### PR TITLE
statistics, executor, session: integrate analyze resource control

### DIFF
--- a/docs/design/2026-06-22-integrate-analyze-into-background-task-resource-control.md
+++ b/docs/design/2026-06-22-integrate-analyze-into-background-task-resource-control.md
@@ -33,7 +33,7 @@ Over the past year, we have repeatedly encountered issues where `ANALYZE` statis
 
 Additionally, in the current TiDB Resource Control implementation, all statistics-related requests share the same `stats` task type. When users try to use Resource Control to limit the resources used by `ANALYZE`, all statistics-related requests are affected, including sync-load stats requests. This may prevent statistics from being loaded in time and can even increase query latency if a foreground query is blocked by statistics loading.
 
-Therefore, this document introduces a new internal task type, `StatsNormalPriority`, for stats maintenance work other than `ANALYZE`. Under this proposal, the existing `stats` task type continues to represent `ANALYZE` requests, including both automatic and manually triggered `ANALYZE`.
+Therefore, this document introduces a new internal task type, `StatsForegroundPriority`, for stats maintenance work other than `ANALYZE`. Under this proposal, the existing `stats` task type continues to represent `ANALYZE` requests, including both automatic and manually triggered `ANALYZE`.
 
 ## Detailed Design
 
@@ -106,17 +106,17 @@ func Analyze(ctx context.Context, client kv.Client, kvReq *kv.Request, vars any,
 
 This shared classification is a problem because we should not throttle sync-load requests. Although sync load belongs to the stats module, it is not regular background work. It is on the critical path of query optimization, so it must finish in time. Otherwise, the user query may have to wait until the sync-load request [times out](https://github.com/pingcap/docs/blob/42da4252914248472710bc8f9d3bb0546015093e/system-variables.md#tidb_stats_load_sync_wait-new-in-v540) before query optimization can continue.
 
-We can introduce a new task type, `StatsNormalPriority`, for internal stats maintenance work other than `ANALYZE` stats collection.
+We can introduce a new task type, `StatsForegroundPriority`, for internal stats maintenance work other than `ANALYZE` stats collection.
 
-This keeps the behavior backward compatible. In most cases, users who enable this feature to limit stats resource usage are trying to control `ANALYZE` requests. Therefore, instead of introducing a new task type dedicated to `ANALYZE`, we can keep using the existing `stats` task type for `ANALYZE` and move other stats maintenance work to the new `StatsNormalPriority` task type. **`StatsNormalPriority` should not be allowed to be throttled as background work, because these tasks are critical to user query optimization.** To enforce this, Resource Control should not expose `StatsNormalPriority` as a configurable `TASK_TYPES` value.
+This keeps the behavior backward compatible. In most cases, users who enable this feature to limit stats resource usage are trying to control `ANALYZE` requests. Therefore, instead of introducing a new task type dedicated to `ANALYZE`, we can keep using the existing `stats` task type for `ANALYZE` and move other stats maintenance work to the new `StatsForegroundPriority` task type. **`StatsForegroundPriority` should not be allowed to be throttled as background work, because these tasks are critical to user query optimization.** To enforce this, Resource Control should not expose `StatsForegroundPriority` as a configurable `TASK_TYPES` value.
 
 In the future, if we add other heavy stats maintenance work that is not on the critical path of user queries, it can use the same `stats` task type as `ANALYZE`. This keeps the model simple and avoids additional confusion or learning cost for users.
 
-Based on the TiDB code example above, we need to update `StatsCtx` to use the new `StatsNormalPriority` type.
+Based on the TiDB code example above, we need to update `StatsCtx` to use the new `StatsForegroundPriority` type.
 
 ```go
 // For sync and async load
-StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsNormalPriority)
+StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 func ExecRows(sctx sessionctx.Context, sql string, args ...any) (rows []chunk.Row, fields []*resolve.ResultField, err error) {
 	...
 	return ExecRowsWithCtx(StatsCtx, sctx, sql, args...)

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1401,7 +1401,7 @@ func (w *worker) queryAnalyzeStatusSince(startTS uint64, dbName, tblName string)
 	if startTS > 0 {
 		startTimeStr = model.TSConvert2Time(startTS).UTC().Format(time.DateTime)
 	}
-	kctx := kv.WithInternalSourceType(w.ctx, kv.InternalTxnStatsMaintenance)
+	kctx := kv.WithInternalSourceType(w.ctx, kv.InternalTxnStatsForegroundPriority)
 
 	// set session time zone to UTC to match the time format in `startTimeStr`
 	originalTimeZone := sessCtx.GetSessionVars().TimeZone

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1401,6 +1401,8 @@ func (w *worker) queryAnalyzeStatusSince(startTS uint64, dbName, tblName string)
 	if startTS > 0 {
 		startTimeStr = model.TSConvert2Time(startTS).UTC().Format(time.DateTime)
 	}
+	// Deliberately not the analyze source: checking the analyze job state is
+	// lightweight metadata work, not the heavy scan that background throttling targets.
 	kctx := kv.WithInternalSourceType(w.ctx, kv.InternalTxnStatsForegroundPriority)
 
 	// set session time zone to UTC to match the time format in `startTimeStr`

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1401,7 +1401,7 @@ func (w *worker) queryAnalyzeStatusSince(startTS uint64, dbName, tblName string)
 	if startTS > 0 {
 		startTimeStr = model.TSConvert2Time(startTS).UTC().Format(time.DateTime)
 	}
-	kctx := kv.WithInternalSourceType(w.ctx, kv.InternalTxnStats)
+	kctx := kv.WithInternalSourceType(w.ctx, kv.InternalTxnStatsMaintenance)
 
 	// set session time zone to UTC to match the time format in `startTimeStr`
 	originalTimeZone := sessCtx.GetSessionVars().TimeZone

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1706,7 +1706,7 @@ func (do *Domain) TelemetryLoop(ctx sessionctx.Context) {
 
 // SetupPlanReplayerHandle setup plan replayer handle
 func (do *Domain) SetupPlanReplayerHandle(collectorSctx sessionctx.Context, workersSctxs []sessionctx.Context) {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	do.planReplayerHandle = &planReplayerHandle{}
 	do.planReplayerHandle.planReplayerTaskCollectorHandle = &planReplayerTaskCollectorHandle{
 		ctx:  ctx,

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1706,7 +1706,7 @@ func (do *Domain) TelemetryLoop(ctx sessionctx.Context) {
 
 // SetupPlanReplayerHandle setup plan replayer handle
 func (do *Domain) SetupPlanReplayerHandle(collectorSctx sessionctx.Context, workersSctxs []sessionctx.Context) {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	do.planReplayerHandle = &planReplayerHandle{}
 	do.planReplayerHandle.planReplayerTaskCollectorHandle = &planReplayerTaskCollectorHandle{
 		ctx:  ctx,

--- a/pkg/domain/extract.go
+++ b/pkg/domain/extract.go
@@ -165,7 +165,7 @@ func (w *extractWorker) collectRecords(ctx context.Context, task *ExtractTask) (
 	w.Lock()
 	defer w.Unlock()
 	exec := w.sctx.GetRestrictedSQLExecutor()
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	sourceTable := "STATEMENTS_SUMMARY_HISTORY"
 	if !task.UseHistoryView {
 		sourceTable = "STATEMENTS_SUMMARY"
@@ -306,7 +306,7 @@ func (w *extractWorker) handleIsView(ctx context.Context, p *extractPlanPackage)
 
 func (w *extractWorker) decodeBinaryPlan(ctx context.Context, bPlan string) (string, error) {
 	exec := w.sctx.GetRestrictedSQLExecutor()
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	rows, _, err := exec.ExecRestrictedSQL(ctx1, nil, fmt.Sprintf("SELECT tidb_decode_binary_plan('%s')", bPlan))
 	if err != nil {
 		return "", err

--- a/pkg/domain/extract.go
+++ b/pkg/domain/extract.go
@@ -165,7 +165,7 @@ func (w *extractWorker) collectRecords(ctx context.Context, task *ExtractTask) (
 	w.Lock()
 	defer w.Unlock()
 	exec := w.sctx.GetRestrictedSQLExecutor()
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	sourceTable := "STATEMENTS_SUMMARY_HISTORY"
 	if !task.UseHistoryView {
 		sourceTable = "STATEMENTS_SUMMARY"
@@ -306,7 +306,7 @@ func (w *extractWorker) handleIsView(ctx context.Context, p *extractPlanPackage)
 
 func (w *extractWorker) decodeBinaryPlan(ctx context.Context, bPlan string) (string, error) {
 	exec := w.sctx.GetRestrictedSQLExecutor()
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	rows, _, err := exec.ExecRestrictedSQL(ctx1, nil, fmt.Sprintf("SELECT tidb_decode_binary_plan('%s')", bPlan))
 	if err != nil {
 		return "", err

--- a/pkg/domain/plan_replayer.go
+++ b/pkg/domain/plan_replayer.go
@@ -132,7 +132,7 @@ func (p *dumpFileGcChecker) gcDumpFilesByPath(ctx context.Context, path string, 
 }
 
 func deletePlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, token string) {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	exec := sctx.GetRestrictedSQLExecutor()
 	_, _, err := exec.ExecRestrictedSQL(ctx1, nil, "delete from mysql.plan_replayer_status where token = %?", token)
 	if err != nil {
@@ -142,7 +142,7 @@ func deletePlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, toke
 
 // insertPlanReplayerStatus insert mysql.plan_replayer_status record
 func insertPlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, records []PlanReplayerStatusRecord) {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	var instance string
 	serverInfo, err := infosync.GetServerInfo()
 	if err != nil {

--- a/pkg/domain/plan_replayer.go
+++ b/pkg/domain/plan_replayer.go
@@ -132,7 +132,7 @@ func (p *dumpFileGcChecker) gcDumpFilesByPath(ctx context.Context, path string, 
 }
 
 func deletePlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, token string) {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	exec := sctx.GetRestrictedSQLExecutor()
 	_, _, err := exec.ExecRestrictedSQL(ctx1, nil, "delete from mysql.plan_replayer_status where token = %?", token)
 	if err != nil {
@@ -142,7 +142,7 @@ func deletePlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, toke
 
 // insertPlanReplayerStatus insert mysql.plan_replayer_status record
 func insertPlanReplayerStatus(ctx context.Context, sctx sessionctx.Context, records []PlanReplayerStatusRecord) {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	var instance string
 	serverInfo, err := infosync.GetServerInfo()
 	if err != nil {

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1871,7 +1871,10 @@ func (a *ExecStmt) recordLastQueryInfo(err error) {
 }
 
 func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
-	if kv.GetInternalSourceType(a.GoCtx) == kv.InternalTxnStats {
+	source := kv.GetInternalSourceType(a.GoCtx)
+	// Analyze and other statistics maintenance use these request sources.
+	// Filter both so plan replayer capture skips all internal statistics work.
+	if source == kv.InternalTxnStats || source == kv.InternalTxnStatsMaintenance {
 		return
 	}
 	se := a.Ctx

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1872,9 +1872,9 @@ func (a *ExecStmt) recordLastQueryInfo(err error) {
 
 func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
 	source := kv.GetInternalSourceType(a.GoCtx)
-	// Analyze and other statistics maintenance use these request sources.
+	// Analyze and foreground-priority statistics work use these request sources.
 	// Filter both so plan replayer capture skips all internal statistics work.
-	if source == kv.InternalTxnStats || source == kv.InternalTxnStatsMaintenance {
+	if source == kv.InternalTxnStats || source == kv.InternalTxnStatsForegroundPriority {
 		return
 	}
 	se := a.Ctx

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -689,7 +689,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	enableAnalyzeSnapshot := e.Ctx().GetSessionVars().EnableAnalyzeSnapshot
 	for range saveStatsConcurrency {
 		worker := newAnalyzeSaveStatsWorker(saveResultsCh, errCh, &e.Ctx().GetSessionVars().SQLKiller)
-		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 		wg.Run(func() {
 			worker.run(ctx1, statsHandle, enableAnalyzeSnapshot)
 		})

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -689,7 +689,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	enableAnalyzeSnapshot := e.Ctx().GetSessionVars().EnableAnalyzeSnapshot
 	for range saveStatsConcurrency {
 		worker := newAnalyzeSaveStatsWorker(saveResultsCh, errCh, &e.Ctx().GetSessionVars().SQLKiller)
-		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 		wg.Run(func() {
 			worker.run(ctx1, statsHandle, enableAnalyzeSnapshot)
 		})

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -689,6 +689,8 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	enableAnalyzeSnapshot := e.Ctx().GetSessionVars().EnableAnalyzeSnapshot
 	for range saveStatsConcurrency {
 		worker := newAnalyzeSaveStatsWorker(saveResultsCh, errCh, &e.Ctx().GetSessionVars().SQLKiller)
+		// Deliberately not the analyze source: the heavy TiKV scan is already done,
+		// so there is no point in throttling the save-stats writes as background work.
 		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 		wg.Run(func() {
 			worker.run(ctx1, statsHandle, enableAnalyzeSnapshot)

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3324,7 +3324,7 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 	// while constructing column analyze tasks. Flush pending deltas first so the base
 	// values include pre-analyze changes and later delta dumps cannot double count them.
 	intest.Assert(b.ctx != nil, "missing statement context for analyze")
-	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStats), b.sctx, v); err != nil {
+	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStatsMaintenance), b.sctx, v); err != nil {
 		b.err = err
 		return nil
 	}

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3324,7 +3324,7 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 	// while constructing column analyze tasks. Flush pending deltas first so the base
 	// values include pre-analyze changes and later delta dumps cannot double count them.
 	intest.Assert(b.ctx != nil, "missing statement context for analyze")
-	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStatsMaintenance), b.sctx, v); err != nil {
+	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStatsForegroundPriority), b.sctx, v); err != nil {
 		b.err = err
 		return nil
 	}

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3323,6 +3323,8 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) exec.Executor {
 	// buildAnalyzeSamplingPushdown reads base count / modify_count from mysql.stats_meta
 	// while constructing column analyze tasks. Flush pending deltas first so the base
 	// values include pre-analyze changes and later delta dumps cannot double count them.
+	// The flush is deliberately not the analyze source: it is lightweight metadata
+	// work, not the heavy scan that background throttling targets.
 	intest.Assert(b.ctx != nil, "missing statement context for analyze")
 	if err := flushStatsDeltaForAnalyze(kv.WithInternalSourceType(b.ctx, kv.InternalTxnStatsForegroundPriority), b.sctx, v); err != nil {
 		b.err = err

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2531,7 +2531,7 @@ func dataForAnalyzeStatusHelper(ctx context.Context, e *memtableRetriever, sctx 
 	const maxAnalyzeJobs = 30
 	const sql = "SELECT table_schema, table_name, partition_name, job_info, processed_rows, CONVERT_TZ(start_time, @@TIME_ZONE, '+00:00'), CONVERT_TZ(end_time, @@TIME_ZONE, '+00:00'), state, fail_reason, instance, process_id FROM mysql.analyze_jobs ORDER BY update_time DESC LIMIT %?"
 	exec := sctx.GetRestrictedSQLExecutor()
-	kctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	kctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	chunkRows, _, err := exec.ExecRestrictedSQL(kctx, nil, sql, maxAnalyzeJobs)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2531,7 +2531,7 @@ func dataForAnalyzeStatusHelper(ctx context.Context, e *memtableRetriever, sctx 
 	const maxAnalyzeJobs = 30
 	const sql = "SELECT table_schema, table_name, partition_name, job_info, processed_rows, CONVERT_TZ(start_time, @@TIME_ZONE, '+00:00'), CONVERT_TZ(end_time, @@TIME_ZONE, '+00:00'), state, fail_reason, instance, process_id FROM mysql.analyze_jobs ORDER BY update_time DESC LIMIT %?"
 	exec := sctx.GetRestrictedSQLExecutor()
-	kctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	kctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	chunkRows, _, err := exec.ExecRestrictedSQL(kctx, nil, sql, maxAnalyzeJobs)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/internal/pdhelper/pd.go
+++ b/pkg/executor/internal/pdhelper/pd.go
@@ -115,7 +115,7 @@ func getApproximateTableCountFromStorage(
 	if partitionName != "" {
 		sqlescape.MustFormatSQL(sql, " partition(%n)", partitionName)
 	}
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	rows, _, err := sctx.GetRestrictedSQLExecutor().ExecRestrictedSQL(ctx, nil, sql.String())
 	if err != nil {
 		return 0, false

--- a/pkg/executor/internal/pdhelper/pd.go
+++ b/pkg/executor/internal/pdhelper/pd.go
@@ -115,7 +115,7 @@ func getApproximateTableCountFromStorage(
 	if partitionName != "" {
 		sqlescape.MustFormatSQL(sql, " partition(%n)", partitionName)
 	}
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	rows, _, err := sctx.GetRestrictedSQLExecutor().ExecRestrictedSQL(ctx, nil, sql.String())
 	if err != nil {
 		return 0, false

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -164,7 +164,7 @@ func isPlanReplayerDownloadURL(token string) bool {
 }
 
 func (e *PlanReplayerExec) removeCaptureTask(ctx context.Context) error {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	exec := e.Ctx().GetRestrictedSQLExecutor()
 	_, _, err := exec.ExecRestrictedSQL(ctx1, nil, fmt.Sprintf("delete from mysql.plan_replayer_task where sql_digest = '%s' and plan_digest = '%s'",
 		e.CaptureInfo.SQLDigest, e.CaptureInfo.PlanDigest))
@@ -183,7 +183,7 @@ func (e *PlanReplayerExec) removeCaptureTask(ctx context.Context) error {
 }
 
 func (e *PlanReplayerExec) registerCaptureTask(ctx context.Context) error {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	exists, err := domain.CheckPlanReplayerTaskExists(ctx1, e.Ctx(), e.CaptureInfo.SQLDigest, e.CaptureInfo.PlanDigest)
 	if err != nil {
 		return err

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -164,7 +164,7 @@ func isPlanReplayerDownloadURL(token string) bool {
 }
 
 func (e *PlanReplayerExec) removeCaptureTask(ctx context.Context) error {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	exec := e.Ctx().GetRestrictedSQLExecutor()
 	_, _, err := exec.ExecRestrictedSQL(ctx1, nil, fmt.Sprintf("delete from mysql.plan_replayer_task where sql_digest = '%s' and plan_digest = '%s'",
 		e.CaptureInfo.SQLDigest, e.CaptureInfo.PlanDigest))
@@ -183,7 +183,7 @@ func (e *PlanReplayerExec) removeCaptureTask(ctx context.Context) error {
 }
 
 func (e *PlanReplayerExec) registerCaptureTask(ctx context.Context) error {
-	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx1 := kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	exists, err := domain.CheckPlanReplayerTaskExists(ctx1, e.Ctx(), e.CaptureInfo.SQLDigest, e.CaptureInfo.PlanDigest)
 	if err != nil {
 		return err

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -645,7 +645,7 @@ func (e *ShowExec) fetchShowTableStatus(ctx context.Context) error {
 	}
 
 	exec := e.Ctx().GetRestrictedSQLExecutor()
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 
 	var snapshot uint64
 	txn, err := e.Ctx().Txn(false)

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -645,7 +645,7 @@ func (e *ShowExec) fetchShowTableStatus(ctx context.Context) error {
 	}
 
 	exec := e.Ctx().GetRestrictedSQLExecutor()
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 
 	var snapshot uint64
 	txn, err := e.Ctx().Txn(false)

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/executor",
+        "//pkg/kv",
         "//pkg/meta/autoid",
         "//pkg/objstore/storeapi",
         "//pkg/planner/extstore",

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -266,7 +266,7 @@ func TestPlanReplayerCapture(t *testing.T) {
 
 	statsStmt, err := tk.Session().Parse(context.Background(), statsSQL)
 	require.NoError(t, err)
-	statsCtx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	statsCtx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	rs, err := tk.Session().ExecuteStmt(statsCtx, statsStmt[0])
 	require.NoError(t, err)
 	tk.ResultSetToResultWithCtx(statsCtx, rs, statsSQL).Check(testkit.Rows())

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/planner/extstore"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -247,6 +248,32 @@ func TestPlanReplayerCapture(t *testing.T) {
 	tk.MustExec("execute stmt using @number,@number")
 	task := dom.GetPlanReplayerHandle().DrainTask()
 	require.NotNil(t, task)
+
+	statsSQL := "select * from t where id = 1"
+	normalSQL := "select count(*) from t where id = 2"
+	tk.MustQuery(statsSQL)
+	_, statsSQLDigest := tk.Session().GetSessionVars().StmtCtx.SQLDigest()
+	_, statsPlanDigest := tk.Session().GetSessionVars().StmtCtx.GetPlanDigest()
+
+	tk.MustQuery(normalSQL)
+	_, normalSQLDigest := tk.Session().GetSessionVars().StmtCtx.SQLDigest()
+	_, normalPlanDigest := tk.Session().GetSessionVars().StmtCtx.GetPlanDigest()
+
+	tk.MustExec(fmt.Sprintf("plan replayer capture '%v' '%v'", statsSQLDigest.String(), statsPlanDigest.String()))
+	tk.MustExec(fmt.Sprintf("plan replayer capture '%v' '%v'", normalSQLDigest.String(), normalPlanDigest.String()))
+	err = dom.GetPlanReplayerHandle().CollectPlanReplayerTask()
+	require.NoError(t, err)
+
+	statsStmt, err := tk.Session().Parse(context.Background(), statsSQL)
+	require.NoError(t, err)
+	statsCtx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	rs, err := tk.Session().ExecuteStmt(statsCtx, statsStmt[0])
+	require.NoError(t, err)
+	tk.ResultSetToResultWithCtx(statsCtx, rs, statsSQL).Check(testkit.Rows())
+
+	tk.MustQuery(normalSQL)
+	task = dom.GetPlanReplayerHandle().DrainTask()
+	require.Equal(t, normalSQLDigest.String(), task.SQLDigest)
 }
 
 func TestPlanReplayerContinuesCapture(t *testing.T) {

--- a/pkg/kv/option.go
+++ b/pkg/kv/option.go
@@ -194,7 +194,13 @@ const (
 	// InternalTxnCacheTable is the type of cache table usage.
 	InternalTxnCacheTable = InternalTxnOthers
 	// InternalTxnStats is the type of statistics txn.
+	// NOTE: This is only used for analyze requests to provide better resource control.
 	InternalTxnStats = "stats"
+	// InternalTxnStatsMaintenance is the type of statistics maintenance txn.
+	// It separates non-analyze statistics requests, such as sync load, async load,
+	// and init stats, from analyze requests. These requests can affect user query
+	// latency, so resource control should not throttle them.
+	InternalTxnStatsMaintenance = "StatsMaintenance"
 	// InternalTxnBindInfo is the type of bind info txn.
 	InternalTxnBindInfo = InternalTxnOthers
 	// InternalTxnWorkloadLearning is the type of workload-based learning txn.

--- a/pkg/kv/option.go
+++ b/pkg/kv/option.go
@@ -196,11 +196,12 @@ const (
 	// InternalTxnStats is the type of statistics txn.
 	// NOTE: This is only used for analyze requests to provide better resource control.
 	InternalTxnStats = "stats"
-	// InternalTxnStatsMaintenance is the type of statistics maintenance txn.
+	// InternalTxnStatsForegroundPriority is the type of statistics txn that
+	// should run at foreground priority.
 	// It separates non-analyze statistics requests, such as sync load, async load,
 	// and init stats, from analyze requests. These requests can affect user query
 	// latency, so resource control should not throttle them.
-	InternalTxnStatsMaintenance = "StatsMaintenance"
+	InternalTxnStatsForegroundPriority = "StatsForegroundPriority"
 	// InternalTxnBindInfo is the type of bind info txn.
 	InternalTxnBindInfo = InternalTxnOthers
 	// InternalTxnWorkloadLearning is the type of workload-based learning txn.

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2936,7 +2936,7 @@ func (b *PlanBuilder) genV2AnalyzeOptions(
 func (b *PlanBuilder) getSavedAnalyzeOpts(physicalID int64, tblInfo *model.TableInfo) (map[ast.AnalyzeOptionType]uint64, ast.ColumnChoice, []*model.ColumnInfo, error) {
 	analyzeOptions := map[ast.AnalyzeOptionType]uint64{}
 	exec := b.ctx.GetRestrictedSQLExecutor()
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, "select sample_num,sample_rate,buckets,topn,column_choice,column_ids from mysql.analyze_options where table_id = %?", physicalID)
 	if err != nil {
 		return nil, ast.DefaultChoice, nil, err

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2936,7 +2936,7 @@ func (b *PlanBuilder) genV2AnalyzeOptions(
 func (b *PlanBuilder) getSavedAnalyzeOpts(physicalID int64, tblInfo *model.TableInfo) (map[ast.AnalyzeOptionType]uint64, ast.ColumnChoice, []*model.ColumnInfo, error) {
 	analyzeOptions := map[ast.AnalyzeOptionType]uint64{}
 	exec := b.ctx.GetRestrictedSQLExecutor()
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, "select sample_num,sample_rate,buckets,topn,column_choice,column_ids from mysql.analyze_options where table_id = %?", physicalID)
 	if err != nil {
 		return nil, ast.DefaultChoice, nil, err

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2936,6 +2936,8 @@ func (b *PlanBuilder) genV2AnalyzeOptions(
 func (b *PlanBuilder) getSavedAnalyzeOpts(physicalID int64, tblInfo *model.TableInfo) (map[ast.AnalyzeOptionType]uint64, ast.ColumnChoice, []*model.ColumnInfo, error) {
 	analyzeOptions := map[ast.AnalyzeOptionType]uint64{}
 	exec := b.ctx.GetRestrictedSQLExecutor()
+	// Deliberately not the analyze source: reading saved options is lightweight
+	// metadata work, not the heavy scan that background throttling targets.
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, "select sample_num,sample_rate,buckets,topn,column_choice,column_ids from mysql.analyze_options where table_id = %?", physicalID)
 	if err != nil {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6468,6 +6468,11 @@ func (b *PlanBuilder) checkSEMStmt(stmt ast.Node) error {
 
 	activeRoles := b.ctx.GetSessionVars().ActiveRoles
 	checker := privilege.GetPrivilegeManager(b.ctx)
+	if checker == nil {
+		// During bootstrap, the privilege manager is unavailable until the system
+		// privilege tables are initialized, so restricted bootstrap SQL cannot be checked yet.
+		return nil
+	}
 	hasPriv := checker.RequestDynamicVerification(activeRoles, "RESTRICTED_SQL_ADMIN", false)
 
 	if hasPriv {

--- a/pkg/planner/indexadvisor/utils.go
+++ b/pkg/planner/indexadvisor/utils.go
@@ -532,7 +532,7 @@ func evaluateIndexSetCost(
 
 func exec(sctx sessionctx.Context, sql string, args ...any) (ret []chunk.Row, err error) {
 	executor := sctx.(sqlexec.SQLExecutor)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	result, err := executor.ExecuteInternal(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("execute %v failed: %v", sql, err)

--- a/pkg/planner/indexadvisor/utils.go
+++ b/pkg/planner/indexadvisor/utils.go
@@ -532,7 +532,7 @@ func evaluateIndexSetCost(
 
 func exec(sctx sessionctx.Context, sql string, args ...any) (ret []chunk.Row, err error) {
 	executor := sctx.(sqlexec.SQLExecutor)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	result, err := executor.ExecuteInternal(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("execute %v failed: %v", sql, err)

--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -64,19 +64,19 @@ func TestResourceGroupBasic(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control = 'on'")
 
 	// test default resource group.
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED MEDIUM UNLIMITED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED MEDIUM UNLIMITED <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` PRIORITY=LOW")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED LOW UNLIMITED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED LOW UNLIMITED <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` ru_per_sec=1000")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` BURSTABLE")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` BURSTABLE=OFF")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW OFF <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW OFF <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` BURSTABLE=MODERATED")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> TASK_TYPES='stats'"))
 	tk.MustExec("alter resource group `default` BURSTABLE=UNLIMITED")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> <nil>"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> TASK_TYPES='stats'"))
 
 	tk.MustContainErrMsg("drop resource group `default`", "can't drop reserved resource group")
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/resourcegroup"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -415,6 +416,10 @@ func doDDLWorks(s sessionapi.Session) {
 	mustExecute(s, metadef.CreateSchemaUnusedIndexesView)
 	// Create a test database.
 	mustExecute(s, "CREATE DATABASE IF NOT EXISTS test")
+	// Only mark stats requests as background here; the effective background CPU cap is controlled
+	// by bg-cpu-throttle-threshold and fg-cpu-throttle-threshold.
+	mustExecute(s, "ALTER RESOURCE GROUP %n BACKGROUND=(TASK_TYPES=%?)",
+		resourcegroup.DefaultResourceGroupName, kv.InternalTxnStats)
 }
 
 func checkSystemTableConstraint(tblInfo *model.TableInfo) error {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2769,6 +2769,10 @@ func shouldBypass(ctx context.Context, stmtNode ast.StmtNode, sessVars *variable
 	switch kv.GetInternalSourceType(ctx) {
 	case kv.InternalTxnOthers:
 		return true
+	// InternalTxnStats marks ANALYZE KV requests as background work. Since ANALYZE
+	// has no statement-level RU v2 charge yet, bypass TiDB-side RU v2 only for
+	// ANALYZE statements. Client-go still applies request-level bypass by
+	// request source and cop request type.
 	case kv.InternalTxnStats:
 		return isNextGenForRUV2() && isAnalyzeStatementForRUV2(stmtNode, sessVars)
 	default:

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1484,3 +1484,38 @@ func TestUpgradeVersion256PlanCacheSkipStatsOnBinding(t *testing.T) {
 	row := req.GetRow(0)
 	require.Equal(t, "ON", row.GetString(0))
 }
+
+func TestDefaultAnalyzeBackgroundOnlyAffectsFreshBootstrap(t *testing.T) {
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	defaultGroup, ok := dom.InfoSchema().ResourceGroupByName(ast.NewCIStr("default"))
+	require.True(t, ok)
+	require.NotNil(t, defaultGroup.Background)
+	require.Equal(t, []string{kv.InternalTxnStats}, defaultGroup.Background.JobTypes)
+	require.Zero(t, defaultGroup.Background.ResourceUtilLimit)
+
+	// Next-gen has no upgrade path in its first release; skip the upgrade-only check below.
+	if kerneltype.IsNextGen() {
+		dom.Close()
+		return
+	}
+
+	upgradeFromVersion := session.CurrentBootstrapVersion - 1
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.DropResourceGroup(meta.DefaultGroupMeta4Test().ID))
+	require.NoError(t, m.FinishBootstrap(upgradeFromVersion))
+	require.NoError(t, txn.Commit(context.Background()))
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	dom.Close()
+
+	domUpgraded, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer domUpgraded.Close()
+	defaultGroup, ok = domUpgraded.InfoSchema().ResourceGroupByName(ast.NewCIStr("default"))
+	require.True(t, ok)
+	// The upgrade path should not backfill the fresh-bootstrap background setting.
+	require.Nil(t, defaultGroup.Background)
+}

--- a/pkg/session/test/session_test.go
+++ b/pkg/session/test/session_test.go
@@ -643,7 +643,7 @@ func TestRandomBinary(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	allBytes := [][]byte{
 		{4, 0, 0, 0, 0, 0, 0, 4, '2'},
 		{4, 0, 0, 0, 0, 0, 0, 4, '.'},

--- a/pkg/session/test/session_test.go
+++ b/pkg/session/test/session_test.go
@@ -643,7 +643,7 @@ func TestRandomBinary(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	allBytes := [][]byte{
 		{4, 0, 0, 0, 0, 0, 0, 4, '2'},
 		{4, 0, 0, 0, 0, 0, 0, 4, '.'},

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
@@ -456,10 +456,14 @@ func TestProcessDMLChangesWithLockedTables(t *testing.T) {
 	tbl2, err := dom.InfoSchema().TableByName(ctx, schema, ast.NewCIStr("t2"))
 	require.NoError(t, err)
 
-	// Check current jobs.
-	job, err := pq.PeekForTest()
+	// Check current jobs. Tables with the same priority do not have a stable heap order.
+	snapshot, err := pq.Snapshot()
 	require.NoError(t, err)
-	require.Equal(t, tbl1.Meta().ID, job.GetTableID())
+	currentJobIDs := make([]int64, 0, len(snapshot.CurrentJobs))
+	for _, job := range snapshot.CurrentJobs {
+		currentJobIDs = append(currentJobIDs, job.TableID)
+	}
+	require.ElementsMatch(t, []int64{tbl1.Meta().ID, tbl2.Meta().ID}, currentJobIDs)
 
 	// Lock t1.
 	tk.MustExec("lock stats t1")
@@ -469,7 +473,10 @@ func TestProcessDMLChangesWithLockedTables(t *testing.T) {
 	pq.ProcessDMLChanges()
 
 	// Check if the jobs have been updated.
-	job, err = pq.PeekForTest()
+	l, err := pq.Len()
+	require.NoError(t, err)
+	require.Equal(t, 1, l)
+	job, err := pq.PeekForTest()
 	require.NoError(t, err)
 	require.Equal(t, tbl2.Meta().ID, job.GetTableID())
 
@@ -481,7 +488,7 @@ func TestProcessDMLChangesWithLockedTables(t *testing.T) {
 	pq.ProcessDMLChanges()
 
 	// Check if the jobs have been updated.
-	l, err := pq.Len()
+	l, err = pq.Len()
 	require.NoError(t, err)
 	require.Equal(t, 2, l)
 }

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -106,7 +106,7 @@ func genInitStatsMetaSQL(tableIDs ...int64) string {
 }
 
 func (h *Handle) initStatsMeta(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, tableIDs ...int64) (statstypes.StatsCache, int64, error) {
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	sql := genInitStatsMetaSQL(tableIDs...)
 	rc, err := util.Exec(sctx, sql)
 	if err != nil {
@@ -389,7 +389,7 @@ func (h *Handle) initStatsHistogramsLite(ctx context.Context, sctx sessionctx.Co
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -425,7 +425,7 @@ func (h *Handle) initStatsHistogramsByPagingWithSCtx(sctx sessionctx.Context, is
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -599,7 +599,6 @@ func genInitStatsTopNSQLForIndexes(isPaging bool, tableRange [2]int64) string {
 func getTablesWithBucketsInRange(sctx sessionctx.Context, tableRange [2]int64) (map[int64]struct{}, error) {
 	// Query to find table_ids that have buckets in the given range
 	// Keep the USE_INDEX(tbl) hint for upgraded clusters; see genInitStatsHistogramsSQL.
-	// TODO: Figure out if HIGH_PRIORITY is working as intended here.
 	sql := "select /*+ USE_INDEX(stats_buckets, tbl) */ HIGH_PRIORITY distinct table_id from mysql.stats_buckets" +
 		" where is_index = 1" +
 		" and table_id >= " + strconv.FormatInt(tableRange[0], 10) +
@@ -611,7 +610,7 @@ func getTablesWithBucketsInRange(sctx sessionctx.Context, tableRange [2]int64) (
 	}
 	defer terror.Call(rc.Close)
 
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	tablesWithBuckets := make(map[int64]struct{})
@@ -656,7 +655,7 @@ func (h *Handle) initStatsTopNByPagingWithSCtx(sctx sessionctx.Context, cache st
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -789,7 +788,7 @@ func (h *Handle) initStatsBucketsByPagingWithSCtx(sctx sessionctx.Context, cache
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -106,7 +106,7 @@ func genInitStatsMetaSQL(tableIDs ...int64) string {
 }
 
 func (h *Handle) initStatsMeta(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, tableIDs ...int64) (statstypes.StatsCache, int64, error) {
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	sql := genInitStatsMetaSQL(tableIDs...)
 	rc, err := util.Exec(sctx, sql)
 	if err != nil {
@@ -389,7 +389,7 @@ func (h *Handle) initStatsHistogramsLite(ctx context.Context, sctx sessionctx.Co
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsMaintenance)
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStatsForegroundPriority)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -425,7 +425,7 @@ func (h *Handle) initStatsHistogramsByPagingWithSCtx(sctx sessionctx.Context, is
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -610,7 +610,7 @@ func getTablesWithBucketsInRange(sctx sessionctx.Context, tableRange [2]int64) (
 	}
 	defer terror.Call(rc.Close)
 
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	tablesWithBuckets := make(map[int64]struct{})
@@ -655,7 +655,7 @@ func (h *Handle) initStatsTopNByPagingWithSCtx(sctx sessionctx.Context, cache st
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {
@@ -788,7 +788,7 @@ func (h *Handle) initStatsBucketsByPagingWithSCtx(sctx sessionctx.Context, cache
 		return errors.Trace(err)
 	}
 	defer terror.Call(rc.Close)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	req := rc.NewChunk(nil)
 	iter := chunk.NewIterator4Chunk(req)
 	for {

--- a/pkg/statistics/handle/handletest/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/initstats/BUILD.bazel
@@ -11,7 +11,6 @@ go_test(
     shard_count = 8,
     deps = [
         "//pkg/config",
-        "//pkg/config/kerneltype",
         "//pkg/infoschema",
         "//pkg/parser/ast",
         "//pkg/session",

--- a/pkg/statistics/handle/handletest/initstats/init_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/init_stats_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/session"
@@ -289,14 +288,10 @@ func testConcurrentlyInitStats(t *testing.T) {
 			require.False(t, col.IsAllEvicted())
 		}
 	}
+	lastTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t9"))
+	require.NoError(t, err)
 	maxID := maxPhysicalTableID(h, is)
-	if kerneltype.IsClassic() {
-		require.Equal(t, int64(132), maxID)
-	} else {
-		// In next-gen, the table ID is different from classic because the system table IDs and the regular table IDs are different,
-		// so the next-gen table ID will be ahead of the classic table ID.
-		require.Equal(t, int64(23), maxID)
-	}
+	require.Equal(t, lastTable.Meta().ID, maxID)
 }
 
 func TestDropTableBeforeConcurrentlyInitStats(t *testing.T) {

--- a/pkg/statistics/handle/lockstats/query_lock_test.go
+++ b/pkg/statistics/handle/lockstats/query_lock_test.go
@@ -118,11 +118,11 @@ type ctxMatcher struct{}
 func (c *ctxMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 	s := util.RequestSourceFromCtx(ctx)
-	return s == util.InternalRequest+"_"+kv.InternalTxnStatsMaintenance
+	return s == util.InternalRequest+"_"+kv.InternalTxnStatsForegroundPriority
 }
 
 func (c *ctxMatcher) String() string {
-	return "all txns should be internal stats maintenance source"
+	return "all txns should be internal stats foreground priority source"
 }
 
 func executeQueryLockedTables(exec *mock.MockRestrictedSQLExecutor, numRows int, wantErr bool) (map[int64]struct{}, error) {

--- a/pkg/statistics/handle/lockstats/query_lock_test.go
+++ b/pkg/statistics/handle/lockstats/query_lock_test.go
@@ -118,11 +118,11 @@ type ctxMatcher struct{}
 func (c *ctxMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 	s := util.RequestSourceFromCtx(ctx)
-	return s == util.InternalRequest+"_"+kv.InternalTxnStats
+	return s == util.InternalRequest+"_"+kv.InternalTxnStatsMaintenance
 }
 
 func (c *ctxMatcher) String() string {
-	return "all txns should be internal_stats source"
+	return "all txns should be internal stats maintenance source"
 }
 
 func executeQueryLockedTables(exec *mock.MockRestrictedSQLExecutor, numRows int, wantErr bool) (map[int64]struct{}, error) {

--- a/pkg/statistics/handle/util/test/ctx_matcher.go
+++ b/pkg/statistics/handle/util/test/ctx_matcher.go
@@ -24,14 +24,14 @@ import (
 // CtxMatcher is a matcher for context.Context
 type CtxMatcher struct{}
 
-// Matches returns true if the context is internal_stats source.
+// Matches returns true if the context is internal stats maintenance source.
 func (*CtxMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 	s := util.RequestSourceFromCtx(ctx)
-	return s == util.InternalRequest+"_"+kv.InternalTxnStats
+	return s == util.InternalRequest+"_"+kv.InternalTxnStatsMaintenance
 }
 
 // String returns the description of CtxMatcher.
 func (*CtxMatcher) String() string {
-	return "all txns should be internal_stats source"
+	return "all txns should be internal stats maintenance source"
 }

--- a/pkg/statistics/handle/util/test/ctx_matcher.go
+++ b/pkg/statistics/handle/util/test/ctx_matcher.go
@@ -24,14 +24,14 @@ import (
 // CtxMatcher is a matcher for context.Context
 type CtxMatcher struct{}
 
-// Matches returns true if the context is internal stats maintenance source.
+// Matches returns true if the context is internal stats foreground priority source.
 func (*CtxMatcher) Matches(x any) bool {
 	ctx := x.(context.Context)
 	s := util.RequestSourceFromCtx(ctx)
-	return s == util.InternalRequest+"_"+kv.InternalTxnStatsMaintenance
+	return s == util.InternalRequest+"_"+kv.InternalTxnStatsForegroundPriority
 }
 
 // String returns the description of CtxMatcher.
 func (*CtxMatcher) String() string {
-	return "all txns should be internal stats maintenance source"
+	return "all txns should be internal stats foreground priority source"
 }

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -56,8 +56,8 @@ var (
 	// UseCurrentSessionOpt to make sure the sql is executed in current session.
 	UseCurrentSessionOpt = []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}
 
-	// StatsCtx is used to mark the request is from stats module.
-	StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	// StatsCtx is used to mark the request as internal stats maintenance.
+	StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 )
 
 // finishTransaction will execute `commit` when error is nil, otherwise `rollback`.

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -56,8 +56,8 @@ var (
 	// UseCurrentSessionOpt to make sure the sql is executed in current session.
 	UseCurrentSessionOpt = []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession}
 
-	// StatsCtx is used to mark the request as internal stats maintenance.
-	StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	// StatsCtx is used to mark the request as internal stats foreground priority.
+	StatsCtx = kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 )
 
 // finishTransaction will execute `commit` when error is nil, otherwise `rollback`.

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -1549,7 +1549,7 @@ func TestJobHeartBeatFailNotBlockOthers(t *testing.T) {
 	now = now.Add(time.Hour)
 	m.UpdateHeartBeat(ctx, se, now)
 	tkTZ := tk.Session().GetSessionVars().Location()
-	tk.MustQuery("select table_id, current_job_owner_hb_time from mysql.tidb_ttl_table_status").Sort().Check(testkit.Rows(
+	tk.MustQuery("select table_id, current_job_owner_hb_time from mysql.tidb_ttl_table_status order by table_id").Check(testkit.Rows(
 		fmt.Sprintf("%d %s", testTable1.Meta().ID, now.Add(-2*time.Hour).In(tkTZ).Format(time.DateTime)),
 		fmt.Sprintf("%d %s", testTable2.Meta().ID, now.In(tkTZ).Format(time.DateTime))))
 }

--- a/tests/readonlytest/readonly_test.go
+++ b/tests/readonlytest/readonly_test.go
@@ -270,7 +270,7 @@ func TestReplicationWriter(t *testing.T) {
 }
 
 func TestInternalSQL(t *testing.T) {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsForegroundPriority)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 

--- a/tests/readonlytest/readonly_test.go
+++ b/tests/readonlytest/readonly_test.go
@@ -270,7 +270,7 @@ func TestReplicationWriter(t *testing.T) {
 }
 
 func TestInternalSQL(t *testing.T) {
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStatsMaintenance)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/69472

Problem Summary:

ANALYZE Resource Control needs to throttle ANALYZE without throttling unrelated internal statistics work.



### What changed and how does it work?

- Add an internal `StatsForegroundPriority` request source for non-ANALYZE statistics work.


The test result summary: https://github.com/pingcap/tidb/pull/69452#issuecomment-4853445331 I will do more tests once the whole project is finished. Then we can connect all the dots to see what the real performance impact is.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/69452#issuecomment-4853445331)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
New TiDB clusters throttle ANALYZE through Resource Control background task scheduling by default. Existing upgraded clusters keep their current resource group background settings.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate internal request category for statistics processing, improving how stats-related work is tracked and controlled.
  * Auto-analyze and stats initialization now better distinguish between standard analyze requests and background stats processing.
  * Plan replayer and related background operations now use the updated stats-processing path.

* **Bug Fixes**
  * Improved request routing so stats-processing work follows the same bypass behavior as existing stats requests.
  * Updated several stats and analyze flows to use the correct internal source type, making background processing more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


