### PR TITLE
ttl: expose terminal job results in metrics

### DIFF
--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -24331,7 +24331,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The TTL job statuses in each worker",
+          "description": "The current TTL job statuses in each worker",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -24402,7 +24402,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "TTL Job Count By Status",
+          "title": "TTL Current Job Count By Status",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -24810,6 +24810,125 @@
           "timeShift": null,
           "title": "TTL Insert/Delete Rows By Day",
           "type": "bargauge"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Finished TTL jobs counted by terminal result.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 111
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "success",
+              "color": "#73BF69"
+            },
+            {
+              "alias": "timeout",
+              "color": "#FA6400"
+            },
+            {
+              "alias": "cancelled",
+              "color": "#F2495C"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\"}[1m])) by (result)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "ALL {{ result }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (result, instance)",
+              "interval": "",
+              "legendFormat": "{{ instance }} {{ result }}",
+              "queryType": "randomWalk",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TTL Job Finish Count By Result",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -287,6 +287,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TTLQueryDuration)
 	prometheus.MustRegister(TTLProcessedExpiredRowsCounter)
 	prometheus.MustRegister(TTLJobStatus)
+	prometheus.MustRegister(TTLJobFinishCounter)
 	prometheus.MustRegister(TTLTaskStatus)
 	prometheus.MustRegister(TTLPhaseTime)
 	prometheus.MustRegister(TTLInsertRowsCount)

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -24055,7 +24055,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The TTL job statuses in each worker",
+          "description": "The current TTL job statuses in each worker",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -24126,7 +24126,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "TTL Job Count By Status",
+          "title": "TTL Current Job Count By Status",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -24534,6 +24534,125 @@
           "timeShift": null,
           "title": "TTL Insert/Delete Rows By Day",
           "type": "bargauge"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Finished TTL jobs counted by terminal result.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 111
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "success",
+              "color": "#73BF69"
+            },
+            {
+              "alias": "timeout",
+              "color": "#FA6400"
+            },
+            {
+              "alias": "cancelled",
+              "color": "#F2495C"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\"}[1m])) by (result)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "ALL {{ result }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\"}[1m])) by (result, instance)",
+              "interval": "",
+              "legendFormat": "{{ instance }} {{ result }}",
+              "queryType": "randomWalk",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TTL Job Finish Count By Result",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -22946,7 +22946,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The TTL job statuses in each worker",
+          "description": "The current TTL job statuses in each worker",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -23017,7 +23017,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "TTL Job Count By Status",
+          "title": "TTL Current Job Count By Status",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -23425,6 +23425,125 @@
           "timeShift": null,
           "title": "TTL Insert/Delete Rows By Day",
           "type": "bargauge"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Finished TTL jobs counted by terminal result.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 111
+          },
+          "hiddenSeries": false,
+          "id": 23763575001,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "success",
+              "color": "#73BF69"
+            },
+            {
+              "alias": "timeout",
+              "color": "#FA6400"
+            },
+            {
+              "alias": "cancelled",
+              "color": "#F2495C"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\"}[1m])) by (result)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "ALL {{ result }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_server_ttl_job_finish_total{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (result, instance)",
+              "interval": "",
+              "legendFormat": "{{ instance }} {{ result }}",
+              "queryType": "randomWalk",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TTL Job Finish Count By Result",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},

--- a/pkg/metrics/ttl.go
+++ b/pkg/metrics/ttl.go
@@ -27,6 +27,8 @@ var (
 
 	TTLJobStatus *prometheus.GaugeVec
 
+	TTLJobFinishCounter *prometheus.CounterVec
+
 	TTLTaskStatus *prometheus.GaugeVec
 
 	TTLPhaseTime *prometheus.CounterVec
@@ -68,6 +70,14 @@ func InitTTLMetrics() {
 			Name:      "ttl_job_status",
 			Help:      "The jobs count in the specified status",
 		}, []string{LblType})
+
+	TTLJobFinishCounter = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "ttl_job_finish_total",
+			Help:      "The count of finished TTL jobs by result.",
+		}, []string{LblResult})
 
 	TTLTaskStatus = metricscommon.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/ttl/metrics/metrics.go
+++ b/pkg/ttl/metrics/metrics.go
@@ -36,6 +36,15 @@ var (
 	PhaseOther     = "other"
 )
 
+const (
+	// JobResultSuccess means a TTL job finished after all scan tasks finished.
+	JobResultSuccess = "success"
+	// JobResultTimeout means a TTL job was finished by the job timeout.
+	JobResultTimeout = "timeout"
+	// JobResultCancelled means a TTL job was finished by a cancellation path.
+	JobResultCancelled = "cancelled"
+)
+
 // TTL metrics
 var (
 	SelectSuccessDuration prometheus.Observer
@@ -91,6 +100,11 @@ var (
 		},
 	}
 )
+
+// RecordJobFinished records metrics when a TTL job reaches a terminal result.
+func RecordJobFinished(result string) {
+	metrics.TTLJobFinishCounter.With(prometheus.Labels{metrics.LblResult: result}).Inc()
+}
 
 func init() {
 	InitMetricsVars()

--- a/pkg/ttl/ttlworker/job.go
+++ b/pkg/ttl/ttlworker/job.go
@@ -92,14 +92,14 @@ func createJobHistorySQL(jobID string, tbl *cache.PhysicalTable, expire time.Tim
 	}
 }
 
-func finishJobHistorySQL(jobID string, finishTime time.Time, summary *TTLSummary) (string, []any) {
+func finishJobHistorySQL(jobID string, finishTime time.Time, summary *TTLSummary, status cache.JobStatus) (string, []any) {
 	return finishJobHistoryTemplate, []any{
 		finishTime.Format(timeFormat),
 		summary.SummaryText,
 		summary.TotalRows,
 		summary.SuccessRows,
 		summary.ErrorRows,
-		string(cache.JobStatusFinished),
+		string(status),
 		jobID,
 	}
 }
@@ -124,6 +124,10 @@ type ttlJob struct {
 
 // finish turns current job into last job, and update the error message and statistics summary
 func (job *ttlJob) finish(se session.Session, now time.Time, summary *TTLSummary) error {
+	return job.finishWithStatus(se, now, summary, cache.JobStatusFinished)
+}
+
+func (job *ttlJob) finishWithStatus(se session.Session, now time.Time, summary *TTLSummary, status cache.JobStatus) error {
 	intest.Assert(se.GetSessionVars().Location().String() == now.Location().String())
 
 	// at this time, the job.ctx may have been canceled (to cancel this job)
@@ -141,7 +145,7 @@ func (job *ttlJob) finish(se session.Session, now time.Time, summary *TTLSummary
 			return errors.Wrapf(err, "execute sql: %s", sql)
 		}
 
-		sql, args = finishJobHistorySQL(job.id, now, summary)
+		sql, args = finishJobHistorySQL(job.id, now, summary, status)
 		_, err = se.ExecuteSQL(context.TODO(), sql, args...)
 		if err != nil {
 			return errors.Wrapf(err, "execute sql: %s", sql)

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -597,11 +597,13 @@ func (m *JobManager) checkFinishedJob(se session.Session) {
 			logger.Info("job has finished", zap.String("summary", summary.SummaryText),
 				zap.Uint64("totalRows", summary.TotalRows), zap.Uint64("successRows", summary.SuccessRows), zap.Uint64("errorRows", summary.ErrorRows),
 				zap.String("scanTaskError", summary.ScanTaskErr))
-			err = job.finish(se, se.Now(), summary)
+			now := se.Now()
+			err = job.finish(se, now, summary)
 			if err != nil {
 				logger.Warn("fail to finish job", zap.Error(err))
 				continue
 			}
+			recordJobFinishedMetrics(metrics.JobResultSuccess)
 			m.removeJob(job)
 		}
 	}
@@ -650,11 +652,12 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 				if err != nil {
 					logger.Warn("fail to summarize job", zap.Error(err))
 				}
-				err = job.finish(se, now, summary)
+				err = job.finishWithStatus(se, now, summary, cache.JobStatusCancelled)
 				if err != nil {
 					logger.Warn("fail to finish job", zap.Error(err))
 					continue
 				}
+				recordJobFinishedMetrics(metrics.JobResultCancelled)
 				m.removeJob(job)
 			}
 		}
@@ -682,11 +685,12 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 		if err != nil {
 			logger.Warn("fail to summarize job", zap.Error(err))
 		}
-		err = job.finish(se, now, summary)
+		err = job.finishWithStatus(se, now, summary, cache.JobStatusCancelled)
 		if err != nil {
 			logger.Warn("fail to finish job", zap.Error(err))
 			continue
 		}
+		recordJobFinishedMetrics(metrics.JobResultCancelled)
 		m.removeJob(job)
 	}
 }
@@ -977,10 +981,11 @@ func (m *JobManager) updateHeartBeatForJob(ctx context.Context, se session.Sessi
 		if err != nil {
 			return errors.Wrapf(err, "fail to summarize job")
 		}
-		err = job.finish(se, now, summary)
+		err = job.finishWithStatus(se, now, summary, cache.JobStatusTimeout)
 		if err != nil {
 			return errors.Wrapf(err, "fail to finish job")
 		}
+		recordJobFinishedMetrics(metrics.JobResultTimeout)
 		m.removeJob(job)
 		return nil
 	}
@@ -1027,6 +1032,10 @@ func (m *JobManager) removeJob(finishedJob *ttlJob) {
 
 func (m *JobManager) appendJob(job *ttlJob) {
 	m.runningJobs = append(m.runningJobs, job)
+}
+
+func recordJobFinishedMetrics(result string) {
+	metrics.RecordJobFinished(result)
 }
 
 // GetCommandCli returns the command client

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -662,6 +662,7 @@ func TestRescheduleJobs(t *testing.T) {
 	tkTZ := tk.Session().GetSessionVars().Location()
 	tk.MustQuery("select last_job_summary->>'$.scan_task_err' from mysql.tidb_ttl_table_status").Check(testkit.Rows("out of TTL job schedule window"))
 	tk.MustQuery("select last_job_finish_time from mysql.tidb_ttl_table_status").Check(testkit.Rows(rescheduleTime.In(tkTZ).Format(time.DateTime)))
+	tk.MustQuery("select status from mysql.tidb_ttl_job_history where job_id = ?", originalJobID).Check(testkit.Rows("cancelled"))
 }
 
 func TestRescheduleJobsAfterTableDropped(t *testing.T) {
@@ -710,6 +711,7 @@ func TestRescheduleJobsAfterTableDropped(t *testing.T) {
 			require.NoError(t, m.TableStatusCache().Update(context.Background(), se))
 			m.RescheduleJobs(se, time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, now.Nanosecond(), now.Location()))
 			tk.MustQuery("select last_job_summary->>'$.scan_task_err' from mysql.tidb_ttl_table_status").Check(testkit.Rows("TTL table has been removed or the TTL on this table has been stopped"))
+			tk.MustQuery("select status from mysql.tidb_ttl_job_history where job_id = ?", fmt.Sprintf("request%d", i)).Check(testkit.Rows("cancelled"))
 
 			// resume the table
 			tk.MustExec(rb.resume)
@@ -789,10 +791,20 @@ func TestJobTimeout(t *testing.T) {
 	// the `CurrentJobStatusUpdateTime` only has `s` precision, so use any format with only `s` precision and a TZ to compare.
 	require.Equal(t, now.Format(time.RFC3339), newTableStatus.CurrentJobStatusUpdateTime.Format(time.RFC3339))
 
+	timeoutFinishCounter := metrics2.TTLJobFinishCounter.With(prometheus.Labels{metrics2.LblResult: metrics.JobResultTimeout})
+	out := &dto.Metric{}
+	require.NoError(t, timeoutFinishCounter.Write(out))
+	timeoutFinishCount := out.GetCounter().GetValue()
+
 	// the timeout will be checked while updating heartbeat
 	require.NoError(t, m2.UpdateHeartBeatForJob(ctx, se, now.Add(7*time.Hour), m2.RunningJobs()[0]))
 	tk.MustQuery("select last_job_summary->>'$.scan_task_err' from mysql.tidb_ttl_table_status").Check(testkit.Rows("job is timeout"))
+	tk.MustQuery("select status from mysql.tidb_ttl_job_history where job_id = ?", tableStatus.CurrentJobID).Check(testkit.Rows("timeout"))
 	tk.MustQuery("select count(*) from mysql.tidb_ttl_task").Check(testkit.Rows("0"))
+
+	out.Reset()
+	require.NoError(t, timeoutFinishCounter.Write(out))
+	require.Equal(t, timeoutFinishCount+1, out.GetCounter().GetValue())
 }
 
 func TestTriggerScanTask(t *testing.T) {
@@ -1827,7 +1839,7 @@ func TestTimerJobAfterDropTable(t *testing.T) {
 
 	// The job should have been removed
 	tk.MustQuery("select current_job_owner_id from mysql.tidb_ttl_table_status").Check(testkit.Rows("<nil>"))
-	tk.MustQuery("select status from mysql.tidb_ttl_job_history").Check(testkit.Rows("finished"))
+	tk.MustQuery("select status from mysql.tidb_ttl_job_history").Check(testkit.Rows("cancelled"))
 
 	// Then it'll be removed by GC
 	m2.DoGC(context.Background(), se, now)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69453

Problem Summary:

TTL jobs that hit the fixed 6-hour timeout are summarized with `summary_text.scan_task_err = "job is timeout"`, but the existing `tidb_server_ttl_job_status` metric only reports current in-memory job states (`running`/`cancelling`). As a result, timeout jobs are not directly visible from Prometheus/Grafana, and the existing Grafana panel can be confusing because `cancelling` remains 0 for timeout jobs.

### What changed and how does it work?

- Preserve terminal status in `mysql.tidb_ttl_job_history`:
  - timeout jobs are written as `status = 'timeout'`
  - cancellation paths are written as `status = 'cancelled'`
  - successful jobs still use `status = 'finished'`
- Add a low-cardinality counter `tidb_server_ttl_job_finish_total{result="success|timeout|cancelled"}`. It intentionally only uses the `result` label, so it adds at most a few series per TiDB instance and does not include high-cardinality job/table labels.
- Rename the existing Grafana panel to `TTL Current Job Count By Status` to clarify that it shows current job state.
- Add `TTL Job Finish Count By Result` to show terminal job results, including timeout jobs.

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Expose TTL job terminal results in Prometheus metrics and Grafana.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard visibility for TTL job finish counts by result, including success, timeout, and cancelled states.
  * Introduced a new metric for tracking finished TTL jobs by outcome.

* **Bug Fixes**
  * Improved TTL job history status handling so cancelled and timed-out jobs are recorded correctly.
  * Updated job status labels and dashboard titles for clearer, more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->