### PR TITLE
planner: avoid semi join rewrite round race

### DIFF
--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -634,11 +634,6 @@ type alternativeRound struct {
 // wrapper. Safe because optimize is single-threaded per session.
 var savedEnableCorrelateSubquery bool
 
-// savedEnableSemiJoinRewrite holds the pre-round value of
-// EnableSemiJoinRewrite so setup/cleanup can restore it after the
-// semi-join-rewrite round. Safe because optimize is single-threaded per session.
-var savedEnableSemiJoinRewrite bool
-
 // savedFTSLikeFallback holds the pre-round value of
 // AlternativeLogicalPlanFTSLikeFallback so the fts-like-fallback round's
 // setup/cleanup can restore it after running with the flag forced on. Safe
@@ -672,11 +667,11 @@ var alternativeRounds = [...]alternativeRound{
 		name:    "semi-join-rewrite",
 		enabled: shouldTrySemiJoinRewriteRound,
 		setup: func(sv *variable.SessionVars) {
-			savedEnableSemiJoinRewrite = sv.EnableSemiJoinRewrite
 			sv.EnableSemiJoinRewrite = true
 		},
 		cleanup: func(sv *variable.SessionVars) {
-			sv.EnableSemiJoinRewrite = savedEnableSemiJoinRewrite
+			// This round is enabled only when the original value is false.
+			sv.EnableSemiJoinRewrite = false
 		},
 	},
 	{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67467

Problem Summary:

This is a follow-up to #69279. The semi-join-rewrite alternative logical-plan round used a package-level variable to save and restore `EnableSemiJoinRewrite`. That mutable state can be shared by concurrent optimizer executions across sessions.

### What changed and how does it work?

Remove the package-level `savedEnableSemiJoinRewrite` state. The semi-join-rewrite alternative round is only enabled when the original `EnableSemiJoinRewrite` value is false, so cleanup can restore the session variable to false directly after the round.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

### Tests

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestSemiJoinRewrite -count=1
make lint
git diff --check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning consistency for cases involving semi-join rewrites.
  * Prevented planner settings from being left in an unintended state after this optimization step, helping avoid inconsistent results across repeated planning rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->