### PR TITLE
*: slow query skip purge statement

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1673,6 +1673,9 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	if (!enable || costTime < threshold) && !force {
 		return
 	}
+	if shouldSkipSlowLogForInternalMVMaintenance(sessVars) {
+		return
+	}
 	sqlText := a.GetTextToLog(true)
 	if len(sqlText) == 0 {
 		sqlText = restoreStmtTextForSlowLogWhenEmptySQL(a.StmtNode)
@@ -1842,6 +1845,14 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 			Internal:   sessVars.InRestrictedSQL,
 		})
 	}
+}
+
+func shouldSkipSlowLogForInternalMVMaintenance(sessVars *variable.SessionVars) bool {
+	if sessVars == nil {
+		return false
+	}
+	// Controlled by tidb_mlog_log_slow_purge: ON -> log (don't skip), OFF -> skip.
+	return !variable.MLogLogSlowPurge.Load() && sessVars.StmtCtx.StmtType == "PurgeMaterializedViewLog"
 }
 
 func extractMsgFromSQLWarn(sqlWarn *contextutil.SQLWarn) string {

--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -185,7 +185,7 @@ func TestSlowQueryMisc(t *testing.T) {
 	const purgeSQL = "purge materialized view log on test.t_internal_mv_purge_slow_log"
 	tk.MustExec(purgeSQL)
 	tk.MustQuery("select count(*) from information_schema.slow_query where query = '" + purgeSQL + ";'").
-		Check(testkit.Rows("1"))
+		Check(testkit.Rows("0"))
 
 	tk.MustExec("insert into test.t_internal_mv_purge_slow_log values (2, 20)")
 	func() {
@@ -201,7 +201,7 @@ func TestSlowQueryMisc(t *testing.T) {
 	}()
 
 	tk.MustQuery("select count(*) from information_schema.slow_query where query = '" + purgeSQL + ";'").
-		Check(testkit.Rows("1"))
+		Check(testkit.Rows("0"))
 }
 
 func TestLogSlowLogIndex(t *testing.T) {

--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -176,6 +177,31 @@ func TestSlowQueryMisc(t *testing.T) {
 	tk.MustExec("commit")
 	require.Len(t, tk.MustQuery("SELECT query, txn_start_ts  FROM `information_schema`.`slow_query` "+
 		"where (query = 'select a from test.t_stale_read;' or query like 'select a from test.t_stale_read as of timestamp %') and Txn_start_ts > 0").Rows(), 3)
+
+	tk.MustExec("create table test.t_internal_mv_purge_slow_log (id int primary key, v int)")
+	tk.MustExec("create materialized view log on test.t_internal_mv_purge_slow_log (id, v) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("insert into test.t_internal_mv_purge_slow_log values (1, 10)")
+
+	const purgeSQL = "purge materialized view log on test.t_internal_mv_purge_slow_log"
+	tk.MustExec(purgeSQL)
+	tk.MustQuery("select count(*) from information_schema.slow_query where query = '" + purgeSQL + ";'").
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("insert into test.t_internal_mv_purge_slow_log values (2, 20)")
+	func() {
+		vars := tk.Session().GetSessionVars()
+		origRestricted := vars.InRestrictedSQL
+		vars.InRestrictedSQL = true
+		defer func() {
+			vars.InRestrictedSQL = origRestricted
+		}()
+		rs, err := tk.ExecWithContext(kv.WithInternalSourceType(context.Background(), kv.InternalTxnMVMaintenance), purgeSQL)
+		require.NoError(t, err)
+		require.Nil(t, rs)
+	}()
+
+	tk.MustQuery("select count(*) from information_schema.slow_query where query = '" + purgeSQL + ";'").
+		Check(testkit.Rows("1"))
 }
 
 func TestLogSlowLogIndex(t *testing.T) {

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2858,6 +2858,13 @@ var defaultSysVars = []*SysVar{
 		}
 		return nil
 	}},
+	{Scope: ScopeGlobal, Name: TiDBMLogLogSlowPurge, Value: BoolToOnOff(DefTiDBMLogLogSlowPurge), Type: TypeBool,
+		SetGlobal: func(_ context.Context, _ *SessionVars, val string) error {
+			MLogLogSlowPurge.Store(TiDBOptOn(val))
+			return nil
+		}, GetGlobal: func(_ context.Context, _ *SessionVars) (string, error) {
+			return BoolToOnOff(MLogLogSlowPurge.Load()), nil
+		}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBNonTransactionalIgnoreError, Value: BoolToOnOff(DefTiDBBatchDMLIgnoreError), Type: TypeBool,
 		SetSession: func(s *SessionVars, val string) error {
 			s.NonTransactionalIgnoreError = TiDBOptOn(val)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -168,7 +168,7 @@ const (
 	TiDBMViewRefreshHistTime = "tidb_mview_refresh_hist_time"
 	// TiDBMLogPurgeHistTime controls the retention time of mysql.tidb_mlog_purge_hist in hours.
 	TiDBMLogPurgeHistTime = "tidb_mlog_purge_hist_time"
-	// TiDBMLogLogSlowPurge controls whether automatic MLog purge statements are recorded in the slow query log.
+	// TiDBMLogLogSlowPurge controls whether MLog purge statements are recorded in the slow query log.
 	TiDBMLogLogSlowPurge = "tidb_mlog_log_slow_purge"
 	// TiDBMemQuotaApplyCache controls the memory quota of a query.
 	TiDBMemQuotaApplyCache = "tidb_mem_quota_apply_cache"

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -168,6 +168,8 @@ const (
 	TiDBMViewRefreshHistTime = "tidb_mview_refresh_hist_time"
 	// TiDBMLogPurgeHistTime controls the retention time of mysql.tidb_mlog_purge_hist in hours.
 	TiDBMLogPurgeHistTime = "tidb_mlog_purge_hist_time"
+	// TiDBMLogLogSlowPurge controls whether automatic MLog purge statements are recorded in the slow query log.
+	TiDBMLogLogSlowPurge = "tidb_mlog_log_slow_purge"
 	// TiDBMemQuotaApplyCache controls the memory quota of a query.
 	TiDBMemQuotaApplyCache = "tidb_mem_quota_apply_cache"
 
@@ -1370,6 +1372,7 @@ const (
 	DefTiDBMLogPurgeBatchSize               = 10000
 	DefTiDBMLogPurgeMinRate                 = 2000
 	DefTiDBMLogPurgeRateBudgetRatio         = 0.5
+	DefTiDBMLogLogSlowPurge                 = false
 	DefMaxPreparedStmtCount                 = -1
 	DefWaitTimeout                          = 28800
 	DefTiDBMemQuotaApplyCache               = 32 << 20 // 32MB.
@@ -1781,6 +1784,7 @@ var (
 	EnableCheckConstraint           = atomic.NewBool(DefTiDBEnableCheckConstraint)
 	SkipMissingPartitionStats       = atomic.NewBool(DefTiDBSkipMissingPartitionStats)
 	TiFlashEnablePipelineMode       = atomic.NewBool(DefTiDBEnableTiFlashPipelineMode)
+	MLogLogSlowPurge                = atomic.NewBool(DefTiDBMLogLogSlowPurge)
 	ServiceScope                    = atomic.NewString("")
 	SchemaVersionCacheLimit         = atomic.NewInt64(DefTiDBSchemaVersionCacheLimit)
 	CloudStorageURI                 = atomic.NewString("")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/18023

Problem Summary:

### What changed and how does it work?

Due to internal flow control, purge statements often end up as slow queries. A large volume of these purge slow queries can clutter the slow query log, making it harder to analyze other queries. To address this, this PR introduces a toggle to control whether purge statements are recorded in the slow query log, and it is disabled by default
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tidb_mlog_log_slow_purge` to control whether materialized view purge operations are recorded in the slow query log.
* **Bug Fixes**
  * Prevented internal materialized view maintenance purge statements from generating slow-query log entries when the setting is disabled.
* **Tests**
  * Updated slow query coverage to verify purge statements are both omitted (when disabled) and not affected in internal maintenance execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->