### PR TITLE
tablecodec: skip common-handle-v1 untouched index values

### DIFF
--- a/pkg/table/tables/tables_test.go
+++ b/pkg/table/tables/tables_test.go
@@ -997,6 +997,136 @@ func TestSkipWriteUntouchedIndices(t *testing.T) {
 		checkIndexWrittenInMemBuf(0, types.NewIntDatum(12), true, false)
 		checkIndexWrittenInMemBuf(1, types.NewIntDatum(3), !c.isSkip, false)
 	}
+
+	collectIndexValues := func(r kv.Retriever, tbl table.PhysicalTable) [][]byte {
+		idxPrefix := indexPrefix(tbl)
+		it, err := r.Iter(idxPrefix, idxPrefix.PrefixNext())
+		require.NoError(t, err)
+		defer it.Close()
+		values := make([][]byte, 0, 1)
+		for it.Valid() {
+			values = append(values, append([]byte(nil), it.Value()...))
+			require.NoError(t, it.Next())
+		}
+		return values
+	}
+
+	type untouchedIndexStorageCase struct {
+		name             string
+		tableName        string
+		createTable      string
+		insertRow        string
+		updateUntouched  string
+		checkTable       func(table.Table)
+		checkCommitted   func([]byte)
+		checkUncommitted func([]byte)
+	}
+
+	checkUntouchedIndexNotStored := func(c untouchedIndexStorageCase) {
+		tk.MustExec("rollback")
+		tk.MustExec("drop table if exists " + c.tableName)
+		tk.MustExec(c.createTable)
+		tk.MustExec(c.insertRow)
+
+		tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(c.tableName))
+		require.NoError(t, err, c.name)
+		if c.checkTable != nil {
+			c.checkTable(tbl)
+		}
+		physicalTbl, ok := tbl.(table.PhysicalTable)
+		require.True(t, ok, c.name)
+
+		committedBefore := collectIndexValues(store.GetSnapshot(kv.MaxVersion), physicalTbl)
+		require.Len(t, committedBefore, 1, c.name)
+		c.checkCommitted(committedBefore[0])
+
+		tk.MustExec("begin")
+		tk.MustExec(c.updateUntouched)
+		txn, err := tk.Session().Txn(true)
+		require.NoError(t, err, c.name)
+		uncommitted := collectIndexValues(txn.GetMemBuffer(), physicalTbl)
+		require.Len(t, uncommitted, 1, c.name)
+		c.checkUncommitted(uncommitted[0])
+		require.NotEqual(t, committedBefore, uncommitted, c.name)
+
+		tk.MustExec("commit")
+		committedAfter := collectIndexValues(store.GetSnapshot(kv.MaxVersion), physicalTbl)
+		require.Equal(t, committedBefore, committedAfter, c.name)
+	}
+
+	for _, c := range []untouchedIndexStorageCase{
+		{
+			name:            "legacy non-unique index value",
+			tableName:       "t_legacy_non_unique",
+			createTable:     "create table t_legacy_non_unique(id int primary key, v int, k int, key idx_k(k))",
+			insertRow:       "insert into t_legacy_non_unique values(1, 10, 100)",
+			updateUntouched: "update t_legacy_non_unique set v = v + 1 where id = 1",
+			checkCommitted: func(value []byte) {
+				require.Equal(t, []byte{'0'}, value)
+			},
+			checkUncommitted: func(value []byte) {
+				require.Equal(t, []byte{kv.UnCommitIndexKVFlag}, value)
+			},
+		},
+		{
+			name:            "index-value-v0 with restored data",
+			tableName:       "t_index_value_v0",
+			createTable:     "create table t_index_value_v0(id int primary key, v int, k varchar(20) character set utf8mb4 collate utf8mb4_general_ci, key idx_k(k))",
+			insertRow:       "insert into t_index_value_v0 values(1, 10, 'abc')",
+			updateUntouched: "update t_index_value_v0 set v = v + 1 where id = 1",
+			checkCommitted: func(value []byte) {
+				require.Greater(t, len(value), tablecodec.MaxOldEncodeValueLen)
+				require.NotEqual(t, tablecodec.IndexVersionFlag, value[1])
+			},
+			checkUncommitted: func(value []byte) {
+				require.Greater(t, len(value), tablecodec.MaxOldEncodeValueLen)
+				require.Equal(t, kv.UnCommitIndexKVFlag, value[len(value)-1])
+			},
+		},
+		{
+			name:            "issue 69466 common-handle-v1 non-unique index value",
+			tableName:       "t_common_handle_v1",
+			createTable:     "create table t_common_handle_v1(id1 int, id2 int, v int, k int, primary key(id1, id2) clustered, key idx_k(k))",
+			insertRow:       "insert into t_common_handle_v1 values(1, 2, 10, 100)",
+			updateUntouched: "update t_common_handle_v1 set v = v + 1 where id1 = 1 and id2 = 2",
+			checkTable: func(tbl table.Table) {
+				require.True(t, tbl.Meta().IsCommonHandle)
+				require.Equal(t, uint16(1), tbl.Meta().CommonHandleVersion)
+			},
+			checkCommitted: func(value []byte) {
+				require.Equal(t, []byte{0, tablecodec.IndexVersionFlag, 1}, value)
+			},
+			checkUncommitted: func(value []byte) {
+				require.Equal(t, []byte{1, tablecodec.IndexVersionFlag, 1, kv.UnCommitIndexKVFlag}, value)
+			},
+		},
+		{
+			name:            "common-handle-v1 index value with restored data",
+			tableName:       "t_common_handle_v1_restored",
+			createTable:     "create table t_common_handle_v1_restored(id1 int, id2 int, v int, k varchar(20) character set utf8mb4 collate utf8mb4_general_ci, primary key(id1, id2) clustered, key idx_k(k))",
+			insertRow:       "insert into t_common_handle_v1_restored values(1, 2, 10, 'abc')",
+			updateUntouched: "update t_common_handle_v1_restored set v = v + 1 where id1 = 1 and id2 = 2",
+			checkTable: func(tbl table.Table) {
+				require.True(t, tbl.Meta().IsCommonHandle)
+				require.Equal(t, uint16(1), tbl.Meta().CommonHandleVersion)
+			},
+			checkCommitted: func(value []byte) {
+				require.Greater(t, len(value), tablecodec.MaxOldEncodeValueLen)
+				require.Equal(t, byte(0), value[0])
+				require.Equal(t, tablecodec.IndexVersionFlag, value[1])
+				require.Equal(t, byte(1), value[2])
+			},
+			checkUncommitted: func(value []byte) {
+				require.Greater(t, len(value), tablecodec.MaxOldEncodeValueLen)
+				require.Equal(t, byte(1), value[0])
+				require.Equal(t, tablecodec.IndexVersionFlag, value[1])
+				require.Equal(t, byte(1), value[2])
+				require.Equal(t, kv.UnCommitIndexKVFlag, value[len(value)-1])
+			},
+		},
+	} {
+		checkUntouchedIndexNotStored(c)
+	}
 }
 
 func TestDupKeyCheckMode(t *testing.T) {

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -1175,7 +1175,8 @@ func IsUntouchedIndexKValue(k, v []byte) bool {
 		return vLen > 0 && v[vLen-1] == kv.UnCommitIndexKVFlag
 	}
 	if vLen <= MaxOldEncodeValueLen {
-		return (vLen == 1 || vLen == 9) && v[vLen-1] == kv.UnCommitIndexKVFlag
+		// vLen = 1/9 for legacy layout, 4 for common-handle-v1 layout
+		return (vLen == 1 || vLen == 9 || vLen == 4) && v[vLen-1] == kv.UnCommitIndexKVFlag
 	}
 	// New index value format
 	tailLen := int(v[0])
@@ -1545,7 +1546,45 @@ func TempIndexValueIsUntouched(b []byte) bool {
 }
 
 // GenIndexValuePortal is the portal for generating index value.
-// Value layout:
+// TiDB has several physical index-value layouts. The layout is selected by
+// table/index metadata and the current scenario; it is not a simple version
+// upgrade path. A new cluster can still contain or generate more than one
+// layout. The variants are:
+//
+//  1. Legacy compact layout, also known as "Old Encoding".
+//  2. Extensible layout, used by common-handle unique indexes, global indexes,
+//     and restored-data cases. This is also called IndexValueVersion0.
+//  3. Clustered common-handle V1 layout, used by tables whose
+//     CommonHandleVersion is 1. This is also called IndexValueForClusteredIndexVersion1.
+//
+// These layouts are not a monotonic format-version chain. In particular,
+// eligible indexes still use the legacy and extensible layouts. The
+// selection matrix is:
+//
+//	+------------------+-------------------+------------------+--------------------+
+//	| Row handle type  | Non-unique local, | Unique local,    | Global index or    |
+//	|                  | no restored data  | no restored data | need restored data |
+//	+------------------+-------------------+------------------+--------------------+
+//	| int handle       | legacy            | legacy           | extensible         |
+//	| common handle v0 | legacy            | extensible       | extensible         |
+//	| common handle v1 | common-handle-v1  | common-handle-v1 | common-handle-v1   |
+//	+------------------+-------------------+------------------+--------------------+
+//
+// The generated length ranges and in-band markers are enough to identify the
+// layout without table metadata. The legacy layout has no explicit in-band
+// marker, so it is distinguished from the extensible layout by length.
+// Common-handle-v1 values carry an in-band version marker.
+//
+//	+------------------+-----------------------------------+------------------+
+//	| Layout           | In-band marker                    | Generated length |
+//	+------------------+-----------------------------------+------------------+
+//	| Legacy           | none                              | 1, 8, or 9       |
+//	| Extensible       | none; byte 0 is TailLen           | >= 10            |
+//	| common-handle-v1 | byte 1 == IndexVersionFlag(0x7d); | 3, 4, or >= 10   |
+//	|                  | byte 2 == 1; byte 0 is TailLen    |                  |
+//	+------------------+-----------------------------------+------------------+
+//
+// Details of different layouts:
 //
 //	+-- IndexValueVersion0  (with restore data, or common handle, or index is global)
 //	|

--- a/pkg/tablecodec/tablecodec_test.go
+++ b/pkg/tablecodec/tablecodec_test.go
@@ -595,6 +595,15 @@ func TestUntouchedIndexKValue(t *testing.T) {
 	untouchedIndexKey := []byte("t00000001_i000000001")
 	untouchedIndexValue := []byte{0, 0, 0, 0, 0, 0, 0, 1, 49}
 	require.True(t, IsUntouchedIndexKValue(untouchedIndexKey, untouchedIndexValue))
+	commonHandleV1CommittedValue := []byte{0, IndexVersionFlag, 1}
+	require.False(t, IsUntouchedIndexKValue(untouchedIndexKey, commonHandleV1CommittedValue))
+	commonHandleV1UntouchedValue := []byte{1, IndexVersionFlag, 1, kv.UnCommitIndexKVFlag}
+	require.True(t, IsUntouchedIndexKValue(untouchedIndexKey, commonHandleV1UntouchedValue))
+	legacyUniqueValueWithMarkerLikeBytes := EncodeHandleInUniqueIndexValue(kv.IntHandle(0x017d010000000031), false)
+	require.Len(t, legacyUniqueValueWithMarkerLikeBytes, 8)
+	require.Equal(t, IndexVersionFlag, legacyUniqueValueWithMarkerLikeBytes[1])
+	require.Equal(t, kv.UnCommitIndexKVFlag, legacyUniqueValueWithMarkerLikeBytes[len(legacyUniqueValueWithMarkerLikeBytes)-1])
+	require.False(t, IsUntouchedIndexKValue(untouchedIndexKey, legacyUniqueValueWithMarkerLikeBytes))
 	IndexKey2TempIndexKey(untouchedIndexKey)
 	require.True(t, IsUntouchedIndexKValue(untouchedIndexKey, untouchedIndexValue))
 	elem := TempIndexValueElem{Handle: kv.IntHandle(1), Delete: true, Distinct: true}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69466

Problem Summary:

For common-handle-v1 clustered primary key tables, an update that only changes non-index columns can place a short untouched secondary-index value in the transaction buffer. The commit-time filter did not recognize that short common-handle-v1 layout as untouched, so the unnecessary marker value could be committed to storage.

### What changed and how does it work?

This PR updates `tablecodec.IsUntouchedIndexKValue` to classify the short common-handle-v1 untouched value layout as an untouched index value when it ends with `kv.UnCommitIndexKVFlag`.

It also adds regression coverage for:

- the raw tablecodec classifier, including a legacy marker-like value that must not be treated as untouched;
- the table update path, verifying untouched index values are present in the transaction buffer but are not committed for legacy, extensible, and common-handle-v1 layouts.

The nearby index-value layout comment is expanded to document the physical layouts involved in the classifier decision.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
./tools/check/failpoint-go-test.sh pkg/tablecodec -run TestUntouchedIndexKValue -count=1
./tools/check/failpoint-go-test.sh pkg/table/tables -run TestSkipWriteUntouchedIndices -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that common-handle-v1 untouched secondary index values might be committed when only non-index columns are updated.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of untouched index values across more storage layouts, including common-handle variants and legacy encodings.
  * Preserved committed index values while updating non-indexed fields, with stronger checks for uncommitted/tombstone markers in transaction buffers.

* **Tests**
  * Expanded coverage for untouched index behavior to validate multiple schema and encoding scenarios.
  * Added assertions for both committed and in-memory index value states to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->