### PR TITLE
build: add bazel_collect invocation to CI unit test scripts

### DIFF
--- a/build/jenkins_unit_test.sh
+++ b/build/jenkins_unit_test.sh
@@ -23,10 +23,9 @@ set -o pipefail
 coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
-go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test
 EXIT_STATUS=$?
-bazel_collect
+go run github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then
     cp "${coverage_report}" ./coverage.dat

--- a/build/jenkins_unit_test.sh
+++ b/build/jenkins_unit_test.sh
@@ -26,6 +26,7 @@ junit_report=./bazel.xml
 go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test
 EXIT_STATUS=$?
+bazel_collect
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then
     cp "${coverage_report}" ./coverage.dat

--- a/build/jenkins_unit_test_ddlargsv1.sh
+++ b/build/jenkins_unit_test_ddlargsv1.sh
@@ -23,10 +23,9 @@ set -o pipefail
 coverage_report=./bazel-out/_coverage/_coverage_report.dat
 junit_report=./bazel.xml
 
-go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test_ddlargsv1
 EXIT_STATUS=$?
-bazel_collect
+go run github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then
     cp "${coverage_report}" ./coverage.dat

--- a/build/jenkins_unit_test_ddlargsv1.sh
+++ b/build/jenkins_unit_test_ddlargsv1.sh
@@ -26,6 +26,7 @@ junit_report=./bazel.xml
 go install github.com/hawkingrei/bazel_collect@89393073f416d5a8106d4393d918c7f6d4d9e308
 make bazel_ci_test_ddlargsv1
 EXIT_STATUS=$?
+bazel_collect
 # collect the junit and coverage report
 if [ -f "${coverage_report}" ]; then
     cp "${coverage_report}" ./coverage.dat


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69479

Problem Summary: CI unit test jobs fail to produce `bazel.xml` junit report file. The `bazel_collect` tool is installed but never invoked after `make bazel_ci_test` completes.

### What changed and how does this work?

Added `bazel_collect` invocation after `make bazel_ci_test` in both:
- `build/jenkins_unit_test.sh`
- `build/jenkins_unit_test_ddlargsv1.sh`

The `bazel_collect` tool processes Bazel's build event protocol output and generates the local `junit.xml` file that CI expects to find.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test scripts to collect build/test artifacts using a newer execution approach.
  * Preserved JUnit and coverage reporting, with the original test exit status still returned at the end.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->