### PR TITLE
importsdk, importinto: backport fixes to 2603 nextgen

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -396,6 +396,11 @@ error = '''
 checkpoint not found
 '''
 
+["Lightning:Checkpoint:ErrCheckpointTableNotFound"]
+error = '''
+checkpoint for table %s not found
+'''
+
 ["Lightning:Checkpoint:ErrCleanCheckpoint"]
 error = '''
 clean checkpoint error

--- a/lightning/cmd/tidb-lightning-ctl/BUILD.bazel
+++ b/lightning/cmd/tidb-lightning-ctl/BUILD.bazel
@@ -29,4 +29,9 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":tidb-lightning-ctl_lib"],
     flaky = True,
+    deps = [
+        "//pkg/lightning/common",
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/lightning/cmd/tidb-lightning-ctl/main.go
+++ b/lightning/cmd/tidb-lightning-ctl/main.go
@@ -33,13 +33,26 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, errors.ErrorStack(err))
+		fmt.Fprintln(os.Stderr, formatFatalError(err))
 		exit(1)
 	}
 }
 
 // main_test.go override exit to pass unit test.
 var exit = os.Exit
+
+const checkpointTableNotFoundUsage = "valid examples: --checkpoint-error-ignore='`db`.`table`', --checkpoint-error-destroy='`db`.`table`', or 'all'"
+
+func formatFatalError(err error) string {
+	// Keep stack traces for debugging unexpected failures, but avoid stack noise for
+	// the user-facing "checkpoint table not found" guidance error.
+	// If users later need this stack for troubleshooting, we can add a `-v` option
+	// to print verbose output (including stack traces) for this path too.
+	if err != nil && common.ErrCheckpointTableNotFound.Equal(err) {
+		return fmt.Sprintf("%s; %s", err.Error(), checkpointTableNotFoundUsage)
+	}
+	return errors.ErrorStack(err)
+}
 
 func run() error {
 	var (

--- a/lightning/cmd/tidb-lightning-ctl/main_test.go
+++ b/lightning/cmd/tidb-lightning-ctl/main_test.go
@@ -18,31 +18,53 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/lightning/common"
+	"github.com/stretchr/testify/require"
 )
 
-func TestRunMain(_ *testing.T) {
-	if _, isIntegrationTest := os.LookupEnv("INTEGRATION_TEST"); !isIntegrationTest {
-		// override exit to pass unit test.
-		exit = func(code int) {}
-	}
-
-	var args []string
-	for _, arg := range os.Args {
-		switch {
-		case arg == "DEVEL":
-		case strings.HasPrefix(arg, "-test."):
-		default:
-			args = append(args, arg)
+func TestRunMain(t *testing.T) {
+	t.Run("run-main", func(t *testing.T) {
+		if _, isIntegrationTest := os.LookupEnv("INTEGRATION_TEST"); !isIntegrationTest {
+			// override exit to pass unit test.
+			exit = func(code int) {}
 		}
-	}
 
-	waitCh := make(chan struct{}, 1)
+		var args []string
+		for _, arg := range os.Args {
+			switch {
+			case arg == "DEVEL":
+			case strings.HasPrefix(arg, "-test."):
+			default:
+				args = append(args, arg)
+			}
+		}
 
-	os.Args = args
-	go func() {
-		main()
-		close(waitCh)
-	}()
+		waitCh := make(chan struct{}, 1)
 
-	<-waitCh
+		os.Args = args
+		go func() {
+			main()
+			close(waitCh)
+		}()
+
+		<-waitCh
+	})
+
+	t.Run("checkpoint table not found does not print stack", func(t *testing.T) {
+		err := common.ErrCheckpointTableNotFound.GenWithStackByArgs("`db`.`table`")
+		formatted := formatFatalError(err)
+		require.Contains(t, formatted, err.Error())
+		require.NotContains(t, formatted, "main_test.go")
+		require.Contains(t, formatted, "--checkpoint-error-ignore='`db`.`table`'")
+		require.Contains(t, formatted, "--checkpoint-error-destroy='`db`.`table`'")
+	})
+
+	t.Run("generic errors still print stack", func(t *testing.T) {
+		err := errors.New("boom")
+		formatted := formatFatalError(err)
+		require.NotEqual(t, err.Error(), formatted)
+		require.Contains(t, formatted, "main_test.go")
+	})
 }

--- a/lightning/pkg/checkpoints/BUILD.bazel
+++ b/lightning/pkg/checkpoints/BUILD.bazel
@@ -36,10 +36,11 @@ go_test(
     embed = [":checkpoints"],
     flaky = True,
     race = "on",
-    shard_count = 25,
+    shard_count = 29,
     deps = [
         "//br/pkg/version/build",
         "//lightning/pkg/checkpoints/checkpointspb",
+        "//pkg/lightning/common",
         "//pkg/lightning/config",
         "//pkg/lightning/importdef",
         "//pkg/lightning/mydump",

--- a/lightning/pkg/checkpoints/checkpoints.go
+++ b/lightning/pkg/checkpoints/checkpoints.go
@@ -615,7 +615,12 @@ type DB interface {
 	// GetLocalStoringTables returns a map containing tables have engine files stored on local disk.
 	// currently only meaningful for local backend
 	GetLocalStoringTables(ctx context.Context) (map[string][]int32, error)
+	// IgnoreErrorCheckpoint resets failed checkpoints so import can resume.
+	// IgnoreErrorCheckpoint and DestroyErrorCheckpoint accept `all` or
+	// `db`.`table`; table-scoped calls return an error matching
+	// common.ErrCheckpointTableNotFound when the target checkpoint does not exist.
 	IgnoreErrorCheckpoint(ctx context.Context, tableName string) error
+	// DestroyErrorCheckpoint removes failed checkpoints and returns removed tables.
 	DestroyErrorCheckpoint(ctx context.Context, tableName string) ([]DestroyedTableCheckpoint, error)
 	DumpTables(ctx context.Context, csv io.Writer) error
 	DumpEngines(ctx context.Context, csv io.Writer) error
@@ -1677,8 +1682,24 @@ func (cpdb *MySQLCheckpointsDB) IgnoreErrorCheckpoint(ctx context.Context, table
 		if _, e := tx.ExecContext(c, query, args...); e != nil {
 			return errors.Trace(e)
 		}
-		if _, e := tx.ExecContext(c, query2, args...); e != nil {
+		tableResult, e := tx.ExecContext(c, query2, args...)
+		if e != nil {
 			return errors.Trace(e)
+		}
+		if tableName != allTables {
+			affectedRows, e := tableResult.RowsAffected()
+			if e != nil {
+				return errors.Trace(e)
+			}
+			if affectedRows == 0 {
+				found, e := cpdb.hasTableCheckpoint(c, tx, tableName)
+				if e != nil {
+					return errors.Trace(e)
+				}
+				if !found {
+					return common.ErrCheckpointTableNotFound.GenWithStackByArgs(tableName)
+				}
+			}
 		}
 		return nil
 	})
@@ -1760,6 +1781,15 @@ func (cpdb *MySQLCheckpointsDB) DestroyErrorCheckpoint(ctx context.Context, tabl
 		if e := rows.Err(); e != nil {
 			return errors.Trace(e)
 		}
+		if tableName != allTables && len(targetTables) == 0 {
+			found, e := cpdb.hasTableCheckpoint(c, tx, tableName)
+			if e != nil {
+				return errors.Trace(e)
+			}
+			if !found {
+				return common.ErrCheckpointTableNotFound.GenWithStackByArgs(tableName)
+			}
+		}
 
 		// Delete the checkpoints
 		if _, e := tx.ExecContext(c, deleteChunkQuery, args...); e != nil {
@@ -1778,6 +1808,24 @@ func (cpdb *MySQLCheckpointsDB) DestroyErrorCheckpoint(ctx context.Context, tabl
 	}
 
 	return targetTables, nil
+}
+
+func (cpdb *MySQLCheckpointsDB) hasTableCheckpoint(ctx context.Context, tx *sql.Tx, tableName string) (bool, error) {
+	query := common.SprintfWithIdentifiers(
+		"SELECT 1 FROM %s.%s WHERE table_name = ? LIMIT 1",
+		cpdb.schema,
+		CheckpointTableNameTable,
+	)
+
+	var one int
+	err := tx.QueryRowContext(ctx, query, tableName).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return true, nil
 }
 
 // DumpTables implements CheckpointsDB.DumpTables.
@@ -1924,17 +1972,30 @@ func (cpdb *FileCheckpointsDB) IgnoreErrorCheckpoint(_ context.Context, targetTa
 	cpdb.lock.Lock()
 	defer cpdb.lock.Unlock()
 
-	for tableName, tableModel := range cpdb.checkpoints.Checkpoints {
-		if !(targetTableName == allTables || targetTableName == tableName) {
-			continue
-		}
-		if tableModel.Status <= uint32(CheckpointStatusMaxInvalid) {
-			tableModel.Status = uint32(CheckpointStatusLoaded)
-		}
-		for _, engineModel := range tableModel.Engines {
-			if engineModel.Status <= uint32(CheckpointStatusMaxInvalid) {
-				engineModel.Status = uint32(CheckpointStatusLoaded)
+	if targetTableName == allTables {
+		for _, tableModel := range cpdb.checkpoints.Checkpoints {
+			if tableModel.Status <= uint32(CheckpointStatusMaxInvalid) {
+				tableModel.Status = uint32(CheckpointStatusLoaded)
 			}
+			for _, engineModel := range tableModel.Engines {
+				if engineModel.Status <= uint32(CheckpointStatusMaxInvalid) {
+					engineModel.Status = uint32(CheckpointStatusLoaded)
+				}
+			}
+		}
+		return errors.Trace(cpdb.save())
+	}
+
+	tableModel, ok := cpdb.checkpoints.Checkpoints[targetTableName]
+	if !ok {
+		return common.ErrCheckpointTableNotFound.GenWithStackByArgs(targetTableName)
+	}
+	if tableModel.Status <= uint32(CheckpointStatusMaxInvalid) {
+		tableModel.Status = uint32(CheckpointStatusLoaded)
+	}
+	for _, engineModel := range tableModel.Engines {
+		if engineModel.Status <= uint32(CheckpointStatusMaxInvalid) {
+			engineModel.Status = uint32(CheckpointStatusLoaded)
 		}
 	}
 	return errors.Trace(cpdb.save())
@@ -1947,10 +2008,31 @@ func (cpdb *FileCheckpointsDB) DestroyErrorCheckpoint(_ context.Context, targetT
 
 	var targetTables []DestroyedTableCheckpoint
 
-	for tableName, tableModel := range cpdb.checkpoints.Checkpoints {
-		// Obtain the list of tables
-		if !(targetTableName == allTables || targetTableName == tableName) {
-			continue
+	if targetTableName == allTables {
+		for tableName, tableModel := range cpdb.checkpoints.Checkpoints {
+			// Obtain the list of tables
+			if tableModel.Status <= uint32(CheckpointStatusMaxInvalid) {
+				var minEngineID, maxEngineID int32 = math.MaxInt32, math.MinInt32
+				for engineID := range tableModel.Engines {
+					if engineID < minEngineID {
+						minEngineID = engineID
+					}
+					if engineID > maxEngineID {
+						maxEngineID = engineID
+					}
+				}
+
+				targetTables = append(targetTables, DestroyedTableCheckpoint{
+					TableName:   tableName,
+					MinEngineID: minEngineID,
+					MaxEngineID: maxEngineID,
+				})
+			}
+		}
+	} else {
+		tableModel, ok := cpdb.checkpoints.Checkpoints[targetTableName]
+		if !ok {
+			return nil, common.ErrCheckpointTableNotFound.GenWithStackByArgs(targetTableName)
 		}
 		if tableModel.Status <= uint32(CheckpointStatusMaxInvalid) {
 			var minEngineID, maxEngineID int32 = math.MaxInt32, math.MinInt32
@@ -1964,7 +2046,7 @@ func (cpdb *FileCheckpointsDB) DestroyErrorCheckpoint(_ context.Context, targetT
 			}
 
 			targetTables = append(targetTables, DestroyedTableCheckpoint{
-				TableName:   tableName,
+				TableName:   targetTableName,
 				MinEngineID: minEngineID,
 				MaxEngineID: maxEngineID,
 			})

--- a/lightning/pkg/checkpoints/checkpoints_file_test.go
+++ b/lightning/pkg/checkpoints/checkpoints_file_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/lightning/pkg/checkpoints"
+	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/importdef"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
@@ -330,6 +331,25 @@ func TestIgnoreOneErrorCheckpoints(t *testing.T) {
 	require.Equal(t, checkpoints.CheckpointStatusAllWritten/10, cp.Status)
 }
 
+func TestIgnoreOneErrorCheckpointsNotFound(t *testing.T) {
+	ctx := context.Background()
+	cpdb := newFileCheckpointsDB(t, false)
+
+	setInvalidStatus(cpdb)
+
+	err := cpdb.IgnoreErrorCheckpoint(ctx, "db1.t2")
+	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
+	require.True(t, common.ErrCheckpointTableNotFound.Equal(err))
+	require.True(t, common.ErrCheckpointTableNotFound.Equal(errors.Annotate(err, "wrapped")))
+	require.Contains(t, err.Error(), "checkpoint for table db1.t2 not found")
+	require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+	require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
+	require.False(t, common.ErrCheckpointTableNotFound.Equal(errors.NotFoundf(
+		"checkpoint for table `db`.`table` not found",
+	)))
+}
+
 func TestDestroyAllErrorCheckpoints(t *testing.T) {
 	ctx := context.Background()
 	cpdb := newFileCheckpointsDB(t, false)
@@ -386,4 +406,20 @@ func TestDestroyOneErrorCheckpoint(t *testing.T) {
 	cp, err = cpdb.Get(ctx, "`db2`.`t3`")
 	require.NoError(t, err)
 	require.Equal(t, checkpoints.CheckpointStatusAllWritten/10, cp.Status)
+}
+
+func TestDestroyOneErrorCheckpointNotFound(t *testing.T) {
+	ctx := context.Background()
+	cpdb := newFileCheckpointsDB(t, false)
+
+	setInvalidStatus(cpdb)
+
+	dtc, err := cpdb.DestroyErrorCheckpoint(ctx, "db1.t2")
+	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
+	require.True(t, common.ErrCheckpointTableNotFound.Equal(err))
+	require.Nil(t, dtc)
+	require.Contains(t, err.Error(), "checkpoint for table db1.t2 not found")
+	require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+	require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
 }

--- a/lightning/pkg/checkpoints/checkpoints_sql_test.go
+++ b/lightning/pkg/checkpoints/checkpoints_sql_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/version/build"
 	"github.com/pingcap/tidb/lightning/pkg/checkpoints"
+	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/importdef"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/lightning/verification"
@@ -563,6 +564,33 @@ func TestIgnoreOneErrorCheckpoint(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIgnoreOneErrorCheckpointNotFound(t *testing.T) {
+	s := newCPSQLSuite(t)
+
+	s.mock.ExpectBegin()
+	s.mock.
+		ExpectExec("UPDATE `mock-schema`\\.`engine_v\\d+` SET status = \\? WHERE table_name = \\? AND status <= \\?").
+		WithArgs(checkpoints.CheckpointStatusLoaded, "db1.t2", 25).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mock.
+		ExpectExec("UPDATE `mock-schema`\\.`table_v\\d+` SET status = \\? WHERE table_name = \\? AND status <= \\?").
+		WithArgs(checkpoints.CheckpointStatusLoaded, "db1.t2", 25).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mock.
+		ExpectQuery("SELECT 1 FROM `mock-schema`\\.`table_v\\d+` WHERE table_name = \\? LIMIT 1").
+		WithArgs("db1.t2").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+	s.mock.ExpectRollback()
+
+	err := s.cpdb.IgnoreErrorCheckpoint(context.Background(), "db1.t2")
+	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
+	require.True(t, common.ErrCheckpointTableNotFound.Equal(err))
+	require.Contains(t, err.Error(), "checkpoint for table db1.t2 not found")
+	require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+	require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
+}
+
 func TestDestroyAllErrorCheckpoints_SQL(t *testing.T) {
 	s := newCPSQLSuite(t)
 
@@ -629,6 +657,30 @@ func TestDestroyOneErrorCheckpoints(t *testing.T) {
 		MinEngineID: -1,
 		MaxEngineID: 0,
 	}}, dtc)
+}
+
+func TestDestroyOneErrorCheckpointsNotFound(t *testing.T) {
+	s := newCPSQLSuite(t)
+
+	s.mock.ExpectBegin()
+	s.mock.
+		ExpectQuery("SELECT (?s:.+)table_name = \\?").
+		WithArgs("db1.t2", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "__min__", "__max__"}))
+	s.mock.
+		ExpectQuery("SELECT 1 FROM `mock-schema`\\.`table_v\\d+` WHERE table_name = \\? LIMIT 1").
+		WithArgs("db1.t2").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}))
+	s.mock.ExpectRollback()
+
+	dtc, err := s.cpdb.DestroyErrorCheckpoint(context.Background(), "db1.t2")
+	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
+	require.True(t, common.ErrCheckpointTableNotFound.Equal(err))
+	require.Nil(t, dtc)
+	require.Contains(t, err.Error(), "checkpoint for table db1.t2 not found")
+	require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+	require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
 }
 
 func TestDump(t *testing.T) {

--- a/lightning/pkg/importinto/BUILD.bazel
+++ b/lightning/pkg/importinto/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/lightning/config",
         "//pkg/lightning/log",
         "//pkg/objstore",
+        "//pkg/objstore/s3like",
         "//pkg/parser/ast",
         "//pkg/util/mathutil",
         "@com_github_docker_go_units//:go-units",

--- a/lightning/pkg/importinto/checkpoint.go
+++ b/lightning/pkg/importinto/checkpoint.go
@@ -81,7 +81,10 @@ type CheckpointManager interface {
 	Update(ctx context.Context, cp *TableCheckpoint) error
 	// Remove removes the checkpoint for a specific table.
 	Remove(ctx context.Context, tableName string) error
-	// IgnoreError resets the status of a failed checkpoint to Pending.
+	// IgnoreError resets failed checkpoints to Pending.
+	// IgnoreError and DestroyError accept `all` or `db`.`table`; table-scoped
+	// calls return an error matching common.ErrCheckpointTableNotFound when the
+	// target checkpoint does not exist.
 	IgnoreError(ctx context.Context, tableName string) error
 	// DestroyError removes the checkpoint for a specific table if it is in Failed state.
 	// It returns the list of checkpoints that were removed.
@@ -261,7 +264,11 @@ func (m *FileCheckpointManager) IgnoreError(ctx context.Context, tableName strin
 			}
 		}
 	} else {
-		if cp, ok := m.checkpoints[tableName]; ok && cp.Status == CheckpointStatusFailed {
+		cp, ok := m.checkpoints[tableName]
+		if !ok {
+			return common.ErrCheckpointTableNotFound.GenWithStackByArgs(tableName)
+		}
+		if cp.Status == CheckpointStatusFailed {
 			cp.Status = CheckpointStatusPending
 			cp.Message = ""
 			cp.JobID = 0
@@ -284,7 +291,11 @@ func (m *FileCheckpointManager) DestroyError(ctx context.Context, tableName stri
 			}
 		}
 	} else {
-		if cp, ok := m.checkpoints[tableName]; ok && cp.Status == CheckpointStatusFailed {
+		cp, ok := m.checkpoints[tableName]
+		if !ok {
+			return nil, common.ErrCheckpointTableNotFound.GenWithStackByArgs(tableName)
+		}
+		if cp.Status == CheckpointStatusFailed {
 			destroyed = append(destroyed, cp)
 			delete(m.checkpoints, tableName)
 		}
@@ -464,8 +475,31 @@ func (m *MySQLCheckpointManager) IgnoreError(ctx context.Context, tableName stri
 	}
 	query := fmt.Sprintf("UPDATE %s.%s SET status = ?, message = '', job_id = 0 WHERE table_name = ? AND status = ?",
 		common.EscapeIdentifier(m.schemaName), common.EscapeIdentifier(m.tableName))
-	_, err := m.db.ExecContext(ctx, query, CheckpointStatusPending, tableName, CheckpointStatusFailed)
-	return errors.Trace(err)
+	result, err := m.db.ExecContext(ctx, query, CheckpointStatusPending, tableName, CheckpointStatusFailed)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	affectedRows, err := result.RowsAffected()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if affectedRows == 0 {
+		if err := m.ensureTableCheckpointExists(ctx, tableName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MySQLCheckpointManager) ensureTableCheckpointExists(ctx context.Context, tableName string) error {
+	cp, err := m.Get(ctx, tableName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if cp == nil {
+		return common.ErrCheckpointTableNotFound.GenWithStackByArgs(tableName)
+	}
+	return nil
 }
 
 // DestroyError deletes checkpoints that are stuck in failed state.
@@ -522,6 +556,11 @@ func (m *MySQLCheckpointManager) DestroyError(ctx context.Context, tableName str
 
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if tableName != common.AllTables && len(destroyed) == 0 {
+		if err := m.ensureTableCheckpointExists(ctx, tableName); err != nil {
+			return nil, err
+		}
 	}
 	return destroyed, nil
 }

--- a/lightning/pkg/importinto/checkpoint_test.go
+++ b/lightning/pkg/importinto/checkpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/stretchr/testify/require"
 )
@@ -100,6 +101,18 @@ func TestFileCheckpointManager(t *testing.T) {
 			},
 		},
 		{
+			name:  "IgnoreError returns not found for missing table",
+			setup: func(t *testing.T, mgr *FileCheckpointManager, ctx context.Context) {},
+			operation: func(t *testing.T, mgr *FileCheckpointManager, ctx context.Context, filePath string) {
+				err := mgr.IgnoreError(ctx, "db.t404")
+				require.Error(t, err)
+				require.True(t, perrors.IsNotFound(err))
+				require.Contains(t, err.Error(), "checkpoint for table db.t404 not found")
+				require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+				require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
+			},
+		},
+		{
 			name: "DestroyError removes checkpoint",
 			setup: func(t *testing.T, mgr *FileCheckpointManager, ctx context.Context) {
 				cp1 := &TableCheckpoint{
@@ -118,6 +131,19 @@ func TestFileCheckpointManager(t *testing.T) {
 				cp, err := mgr.Get(ctx, "db.t1")
 				require.NoError(t, err)
 				require.Nil(t, cp)
+			},
+		},
+		{
+			name:  "DestroyError returns not found for missing table",
+			setup: func(t *testing.T, mgr *FileCheckpointManager, ctx context.Context) {},
+			operation: func(t *testing.T, mgr *FileCheckpointManager, ctx context.Context, filePath string) {
+				destroyed, err := mgr.DestroyError(ctx, "db.t404")
+				require.Error(t, err)
+				require.True(t, perrors.IsNotFound(err))
+				require.Nil(t, destroyed)
+				require.Contains(t, err.Error(), "checkpoint for table db.t404 not found")
+				require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+				require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
 			},
 		},
 		{
@@ -336,6 +362,25 @@ func TestMySQLCheckpointManager(t *testing.T) {
 			},
 		},
 		{
+			name: "IgnoreError single checkpoint not found",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("UPDATE `test_schema`.`import_into_checkpoints` SET status = \\?, message = '', job_id = 0 WHERE table_name = \\? AND status = \\?").
+					WithArgs(CheckpointStatusPending, "db.t404", CheckpointStatusFailed).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery("SELECT job_id, status, message, group_key FROM `test_schema`.`import_into_checkpoints` WHERE table_name = \\?").
+					WithArgs("db.t404").
+					WillReturnError(sql.ErrNoRows)
+			},
+			operation: func(t *testing.T, mgr *MySQLCheckpointManager, ctx context.Context) {
+				err := mgr.IgnoreError(ctx, "db.t404")
+				require.Error(t, err)
+				require.True(t, perrors.IsNotFound(err))
+				require.Contains(t, err.Error(), "checkpoint for table db.t404 not found")
+				require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+				require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
+			},
+		},
+		{
 			name: "IgnoreError all checkpoints",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("UPDATE `test_schema`.`import_into_checkpoints` SET status = \\?, message = '', job_id = 0 WHERE status = \\?").
@@ -364,6 +409,31 @@ func TestMySQLCheckpointManager(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, destroyed, 1)
 				require.Equal(t, "db.t1", destroyed[0].TableName)
+			},
+		},
+		{
+			name: "DestroyError single checkpoint not found",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT table_name, job_id, status, message, group_key FROM `test_schema`.`import_into_checkpoints` WHERE table_name = \\? AND status = \\?").
+					WithArgs("db.t404", CheckpointStatusFailed).
+					WillReturnRows(sqlmock.NewRows([]string{"table_name", "job_id", "status", "message", "group_key"}))
+				mock.ExpectExec("DELETE FROM `test_schema`.`import_into_checkpoints` WHERE table_name = \\? AND status = \\?").
+					WithArgs("db.t404", CheckpointStatusFailed).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectCommit()
+				mock.ExpectQuery("SELECT job_id, status, message, group_key FROM `test_schema`.`import_into_checkpoints` WHERE table_name = \\?").
+					WithArgs("db.t404").
+					WillReturnError(sql.ErrNoRows)
+			},
+			operation: func(t *testing.T, mgr *MySQLCheckpointManager, ctx context.Context) {
+				destroyed, err := mgr.DestroyError(ctx, "db.t404")
+				require.Error(t, err)
+				require.True(t, perrors.IsNotFound(err))
+				require.Nil(t, destroyed)
+				require.Contains(t, err.Error(), "checkpoint for table db.t404 not found")
+				require.NotContains(t, err.Error(), "--checkpoint-error-ignore")
+				require.NotContains(t, err.Error(), "--checkpoint-error-destroy")
 			},
 		},
 		{

--- a/lightning/pkg/importinto/importer.go
+++ b/lightning/pkg/importinto/importer.go
@@ -75,16 +75,28 @@ func WithOrchestrator(orchestrator JobOrchestrator) ImporterOption {
 	}
 }
 
+// WithStripS3ExternalIDForImportSQL strips explicit S3 external ID from IMPORT INTO
+// SQL resource parameters. The original source directory is kept unchanged for
+// Lightning's own storage access. Enable it only for callers that need to keep
+// compatibility with older IMPORT INTO planners that reject explicit S3 external ID;
+// newer planners can accept an explicit external ID matching the target value.
+func WithStripS3ExternalIDForImportSQL() ImporterOption {
+	return func(i *Importer) {
+		i.stripS3ExternalIDForImportSQL = true
+	}
+}
+
 // Importer is the implementation of LightningImporter for the 'import into' backend.
 type Importer struct {
-	cfg             *config.Config
-	db              *sql.DB
-	sdk             importsdk.SDK
-	logger          log.Logger
-	cpMgr           CheckpointManager
-	orchestrator    JobOrchestrator
-	groupKey        string
-	progressUpdater ProgressUpdater
+	cfg                           *config.Config
+	db                            *sql.DB
+	sdk                           importsdk.SDK
+	logger                        log.Logger
+	cpMgr                         CheckpointManager
+	orchestrator                  JobOrchestrator
+	groupKey                      string
+	progressUpdater               ProgressUpdater
+	stripS3ExternalIDForImportSQL bool
 }
 
 // NewImporter creates a new Importer.
@@ -149,7 +161,11 @@ func NewImporter(
 }
 
 func (i *Importer) buildOrchestrator() JobOrchestrator {
-	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")))
+	jobSubmitterOpts := make([]JobSubmitterOption, 0, 1)
+	if i.stripS3ExternalIDForImportSQL {
+		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL())
+	}
+	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")), jobSubmitterOpts...)
 
 	return NewJobOrchestrator(OrchestratorConfig{
 		Submitter:         submitter,

--- a/lightning/pkg/importinto/importer.go
+++ b/lightning/pkg/importinto/importer.go
@@ -163,7 +163,7 @@ func NewImporter(
 func (i *Importer) buildOrchestrator() JobOrchestrator {
 	jobSubmitterOpts := make([]JobSubmitterOption, 0, 1)
 	if i.stripS3ExternalIDForImportSQL {
-		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL())
+		jobSubmitterOpts = append(jobSubmitterOpts, WithJobSubmitterStripS3ExternalIDForImportSQL(true))
 	}
 	submitter := NewJobSubmitter(i.sdk, i.cfg, i.groupKey, i.logger.With(zap.String("component", "submitter")), jobSubmitterOpts...)
 

--- a/lightning/pkg/importinto/job_submitter.go
+++ b/lightning/pkg/importinto/job_submitter.go
@@ -59,9 +59,9 @@ type JobSubmitterOption func(*DefaultJobSubmitter)
 // that need to keep compatibility with older IMPORT INTO planners that reject
 // explicit S3 external ID; newer planners can accept an explicit external ID
 // matching the target value.
-func WithJobSubmitterStripS3ExternalIDForImportSQL() JobSubmitterOption {
+func WithJobSubmitterStripS3ExternalIDForImportSQL(strip bool) JobSubmitterOption {
 	return func(s *DefaultJobSubmitter) {
-		s.stripS3ExternalIDForImportSQL = true
+		s.stripS3ExternalIDForImportSQL = strip
 	}
 }
 
@@ -73,6 +73,7 @@ func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, log
 		groupKey: groupKey,
 		logger:   logger,
 	}
+	WithJobSubmitterStripS3ExternalIDForImportSQL(cfg.TikvImporter.StripS3ExternalIDForImportSQL)(submitter)
 	for _, opt := range opts {
 		opt(submitter)
 	}

--- a/lightning/pkg/importinto/job_submitter.go
+++ b/lightning/pkg/importinto/job_submitter.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/tidb/pkg/importsdk"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
+	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"go.uber.org/zap"
 )
@@ -41,20 +43,40 @@ type JobSubmitter interface {
 
 // DefaultJobSubmitter is the default implementation of JobSubmitter.
 type DefaultJobSubmitter struct {
-	sdk      importsdk.SDK
-	config   *config.Config
-	groupKey string
-	logger   log.Logger
+	sdk                           importsdk.SDK
+	config                        *config.Config
+	groupKey                      string
+	logger                        log.Logger
+	stripS3ExternalIDForImportSQL bool
+}
+
+// JobSubmitterOption is a function that configures the JobSubmitter.
+type JobSubmitterOption func(*DefaultJobSubmitter)
+
+// WithJobSubmitterStripS3ExternalIDForImportSQL strips explicit S3 external ID
+// from IMPORT INTO SQL resource parameters. The original source directory is
+// kept unchanged for Lightning's own storage access. Enable it only for callers
+// that need to keep compatibility with older IMPORT INTO planners that reject
+// explicit S3 external ID; newer planners can accept an explicit external ID
+// matching the target value.
+func WithJobSubmitterStripS3ExternalIDForImportSQL() JobSubmitterOption {
+	return func(s *DefaultJobSubmitter) {
+		s.stripS3ExternalIDForImportSQL = true
+	}
 }
 
 // NewJobSubmitter creates a new job submitter.
-func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, logger log.Logger) JobSubmitter {
-	return &DefaultJobSubmitter{
+func NewJobSubmitter(sdk importsdk.SDK, cfg *config.Config, groupKey string, logger log.Logger, opts ...JobSubmitterOption) JobSubmitter {
+	submitter := &DefaultJobSubmitter{
 		sdk:      sdk,
 		config:   cfg,
 		groupKey: groupKey,
 		logger:   logger,
 	}
+	for _, opt := range opts {
+		opt(submitter)
+	}
+	return submitter
 }
 
 // SubmitTable submits an import job for a single table.
@@ -128,11 +150,34 @@ func (s *DefaultJobSubmitter) buildImportOptions(tableMeta *importsdk.TableMeta)
 	if cfg.Mydumper.SourceDir != "" {
 		u, err := url.Parse(cfg.Mydumper.SourceDir)
 		if err == nil {
-			opts.ResourceParameters = u.RawQuery
+			opts.ResourceParameters = buildResourceParametersForImportSQL(u, s.stripS3ExternalIDForImportSQL)
 		}
 	}
 
 	return opts
+}
+
+func buildResourceParametersForImportSQL(u *url.URL, stripS3ExternalID bool) string {
+	if !(stripS3ExternalID && objstore.IsS3Like(u)) {
+		return u.RawQuery
+	}
+
+	values := u.Query()
+	if !stripS3ExternalIDResourceParameters(values) {
+		return u.RawQuery
+	}
+	return values.Encode()
+}
+
+func stripS3ExternalIDResourceParameters(values url.Values) bool {
+	stripped := false
+	for key := range values {
+		if objstore.NormalizeQueryParameterKey(key) == s3like.S3ExternalID {
+			delete(values, key)
+			stripped = true
+		}
+	}
+	return stripped
 }
 
 func generateImportSQLForLog(tableMeta *importsdk.TableMeta, options *importsdk.ImportOptions) (string, error) {

--- a/lightning/pkg/importinto/job_submitter_test.go
+++ b/lightning/pkg/importinto/job_submitter_test.go
@@ -39,6 +39,9 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 
 	s3Cfg := config.NewConfig()
 	s3Cfg.Mydumper.SourceDir = s3SourceDirWithExternalID
+	s3CfgWithStrip := config.NewConfig()
+	s3CfgWithStrip.Mydumper.SourceDir = s3SourceDirWithExternalID
+	s3CfgWithStrip.TikvImporter.StripS3ExternalIDForImportSQL = true
 	ossCfg := config.NewConfig()
 	ossCfg.Mydumper.SourceDir = ossSourceDirWithExternalID
 	gcsCfg := config.NewConfig()
@@ -105,7 +108,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 		},
 		{
 			name:                "sanitize s3 external id when enabled for import sql resource parameters",
-			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL(true)},
 			tableMeta: &importsdk.TableMeta{
 				Database: "db",
 				Table:    "t1",
@@ -122,8 +125,25 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 			},
 		},
 		{
+			name: "sanitize s3 external id when config flag is enabled",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3CfgWithStrip,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, s3ResourceParameters, opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3CfgWithStrip.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
 			name:                "sanitize oss external id as s3 like resource parameters",
-			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL(true)},
 			tableMeta: &importsdk.TableMeta{
 				Database: "db",
 				Table:    "t1",

--- a/lightning/pkg/importinto/job_submitter_test.go
+++ b/lightning/pkg/importinto/job_submitter_test.go
@@ -29,11 +29,28 @@ import (
 )
 
 func TestJobSubmitterSubmitTable(t *testing.T) {
+	const (
+		s3SourceDirWithExternalID  = "s3://bucket/path?role-arn=arn&external-id=remove&External_ID=remove-too&external%5Fid=remove-encoded&region=us-east-1&endpoint=http%3A%2F%2Fminio%3A9000"
+		s3ResourceParameters       = "endpoint=http%3A%2F%2Fminio%3A9000&region=us-east-1&role-arn=arn"
+		ossSourceDirWithExternalID = "oss://bucket/path?external-id=remove&role-arn=arn&region=us-east-1"
+		ossResourceParameters      = "region=us-east-1&role-arn=arn"
+		gcsSourceDir               = "gcs://bucket/path?external-id=keep&external_id=keep-too&region=us-east-1"
+	)
+
+	s3Cfg := config.NewConfig()
+	s3Cfg.Mydumper.SourceDir = s3SourceDirWithExternalID
+	ossCfg := config.NewConfig()
+	ossCfg.Mydumper.SourceDir = ossSourceDirWithExternalID
+	gcsCfg := config.NewConfig()
+	gcsCfg.Mydumper.SourceDir = gcsSourceDir
+
 	tests := []struct {
-		name      string
-		tableMeta *importsdk.TableMeta
-		setup     func(mockSDK *sdkmock.MockSDK)
-		wantErr   bool
+		name                string
+		tableMeta           *importsdk.TableMeta
+		cfg                 *config.Config
+		setup               func(t *testing.T, mockSDK *sdkmock.MockSDK)
+		wantErr             bool
+		jobSubmitterOptions []importinto.JobSubmitterOption
 	}{
 		{
 			name: "successful submission",
@@ -41,7 +58,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("IMPORT INTO ...", nil)
 				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
 			},
@@ -52,7 +69,7 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("", errors.New("gen error"))
 			},
 			wantErr: true,
@@ -63,11 +80,81 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 				Database: "db",
 				Table:    "t1",
 			},
-			setup: func(mockSDK *sdkmock.MockSDK) {
+			setup: func(_ *testing.T, mockSDK *sdkmock.MockSDK) {
 				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).Return("IMPORT INTO ...", nil)
 				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(0), errors.New("submit error"))
 			},
 			wantErr: true,
+		},
+		{
+			name: "keep s3 external id unless nextgen sem is enabled",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3Cfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, "role-arn=arn&external-id=remove&External_ID=remove-too&external%5Fid=remove-encoded&region=us-east-1&endpoint=http%3A%2F%2Fminio%3A9000", opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3Cfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name:                "sanitize s3 external id when enabled for import sql resource parameters",
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: s3Cfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, s3ResourceParameters, opts.ResourceParameters)
+						require.Equal(t, s3SourceDirWithExternalID, s3Cfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name:                "sanitize oss external id as s3 like resource parameters",
+			jobSubmitterOptions: []importinto.JobSubmitterOption{importinto.WithJobSubmitterStripS3ExternalIDForImportSQL()},
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: ossCfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, ossResourceParameters, opts.ResourceParameters)
+						require.Equal(t, ossSourceDirWithExternalID, ossCfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
+		},
+		{
+			name: "keep non s3 resource parameters unchanged",
+			tableMeta: &importsdk.TableMeta{
+				Database: "db",
+				Table:    "t1",
+			},
+			cfg: gcsCfg,
+			setup: func(t *testing.T, mockSDK *sdkmock.MockSDK) {
+				mockSDK.EXPECT().GenerateImportSQL(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ *importsdk.TableMeta, opts *importsdk.ImportOptions) (string, error) {
+						require.Equal(t, "external-id=keep&external_id=keep-too&region=us-east-1", opts.ResourceParameters)
+						require.Equal(t, gcsSourceDir, gcsCfg.Mydumper.SourceDir)
+						return "IMPORT INTO ...", nil
+					})
+				mockSDK.EXPECT().SubmitJob(gomock.Any(), "IMPORT INTO ...").Return(int64(123), nil)
+			},
 		},
 	}
 
@@ -77,9 +164,13 @@ func TestJobSubmitterSubmitTable(t *testing.T) {
 			defer ctrl.Finish()
 			mockSDK := sdkmock.NewMockSDK(ctrl)
 			groupKey := "g1"
-			submitter := importinto.NewJobSubmitter(mockSDK, config.NewConfig(), groupKey, log.L())
+			cfg := tt.cfg
+			if cfg == nil {
+				cfg = config.NewConfig()
+			}
+			submitter := importinto.NewJobSubmitter(mockSDK, cfg, groupKey, log.L(), tt.jobSubmitterOptions...)
 
-			tt.setup(mockSDK)
+			tt.setup(t, mockSDK)
 			job, err := submitter.SubmitTable(context.Background(), tt.tableMeta)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/executor/importer/sampler.go
+++ b/pkg/executor/importer/sampler.go
@@ -38,7 +38,6 @@ import (
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
-	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"go.uber.org/zap"
@@ -355,27 +354,30 @@ func (s *kvSizeSampler) sampleOneFile(
 	}()
 
 	var (
-		count        int
-		readRowCache []types.Datum
-		readFn       = parserEncodeReader(parser, chunk.EndOffset, chunk.GetKey())
-		kvBatch      = newEncodedKVGroupBatch(ksCodec, maxRowCount)
+		count   int
+		kvBatch = newEncodedKVGroupBatch(ksCodec, maxRowCount)
 	)
 	for count < maxRowCount {
-		row, closed, readErr := readFn(ctx, readRowCache)
-		if readErr != nil {
-			return 0, 0, 0, readErr
-		}
-		if closed {
+		startPos, _ := parser.Pos()
+		if s.cfg.Format != DataFormatParquet && startPos >= chunk.EndOffset {
 			break
 		}
-		readRowCache = row.row
-		if rowDelta := row.endOffset - row.startPos; rowDelta > 0 {
-			sourceSize += rowDelta
+
+		readErr := parser.ReadRow()
+		if readErr != nil {
+			if errors.Cause(readErr) == io.EOF {
+				break
+			}
+			return 0, 0, 0, common.ErrEncodeKV.Wrap(readErr).GenWithStackByArgs(chunk.GetKey(), startPos)
 		}
-		kvs, encodeErr := encoder.Encode(row.row, row.rowID)
-		row.resetFn()
+
+		lastRow := parser.LastRow()
+		sourceSize += s.sampledRowSourceSize(parser, startPos, lastRow)
+
+		kvs, encodeErr := encoder.Encode(lastRow.Row, lastRow.RowID)
+		parser.RecycleRow(lastRow)
 		if encodeErr != nil {
-			return 0, 0, 0, common.ErrEncodeKV.Wrap(encodeErr).GenWithStackByArgs(chunk.GetKey(), row.startPos)
+			return 0, 0, 0, common.ErrEncodeKV.Wrap(encodeErr).GenWithStackByArgs(chunk.GetKey(), startPos)
 		}
 		if _, err = kvBatch.add(kvs); err != nil {
 			return 0, 0, 0, err
@@ -384,4 +386,20 @@ func (s *kvSizeSampler) sampleOneFile(
 	}
 	dataKVSize, indexKVSize = kvBatch.groupChecksum.DataAndIndexSumSize()
 	return sourceSize, dataKVSize, indexKVSize, nil
+}
+
+func (s *kvSizeSampler) sampledRowSourceSize(parser mydump.Parser, startPos int64, row mydump.Row) int64 {
+	// Sampling needs per-row source bytes, not buffered reader progress.
+	// SQL/CSV parsers expose byte offsets through Pos(), including compressed
+	// input where Pos() tracks uncompressed bytes and stays aligned with the
+	// RealSize-based source totals. Parquet Pos() is row-count based and must
+	// fall back to the row-size estimate.
+	if s.cfg.Format == DataFormatParquet {
+		return int64(row.Length)
+	}
+	endPos, _ := parser.Pos()
+	if rowDelta := endPos - startPos; rowDelta > 0 {
+		return rowDelta
+	}
+	return int64(row.Length)
 }

--- a/pkg/executor/importer/sampler_test.go
+++ b/pkg/executor/importer/sampler_test.go
@@ -232,6 +232,57 @@ func TestSampleIndexSizeRatio(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, reader.closed)
 	})
+
+	t.Run("sql_source_size_uses_consumed_bytes_not_buffered_progress", func(t *testing.T) {
+		dir := t.TempDir()
+		var fileSB strings.Builder
+		fileSB.WriteString("INSERT INTO t VALUES\n")
+		for i := 0; i < 20; i++ {
+			_, err := fmt.Fprintf(&fileSB, "(%d,'v%d','w%d','x%d')", i, i, i, i)
+			require.NoError(t, err)
+			if i < 19 {
+				fileSB.WriteString(",\n")
+				continue
+			}
+			fileSB.WriteString(";\n")
+		}
+		content := fileSB.String()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "001.sql"), []byte(content), 0o644))
+
+		p := parser.New()
+		node, err := p.ParseOneStmt(`create table t (a int, b text, c text, d text, index idx(a));`, "", "")
+		require.NoError(t, err)
+		sctx := utilmock.NewContext()
+		tblInfo, err := ddl.MockTableInfo(sctx, node.(*ast.CreateTableStmt), 1)
+		require.NoError(t, err)
+		tblInfo.State = model.StatePublic
+		table := tables.MockTableFromMeta(tblInfo)
+
+		ctrl, err := NewLoadDataController(&Plan{
+			Path:         filepath.Join(dir, "*.sql"),
+			Format:       DataFormatSQL,
+			InImportInto: true,
+		}, table, &ASTArgs{})
+		require.NoError(t, err)
+		ctrl.logger = zap.Must(zap.NewDevelopment())
+		ctx := context.Background()
+		require.NoError(t, ctrl.InitDataFiles(ctx))
+
+		sampled, err := SampleFileImportKVSize(
+			ctx,
+			ctrl.buildKVSizeSampleConfig(),
+			table,
+			ctrl.dataStore,
+			ctrl.dataFiles,
+			nil,
+			ctrl.logger,
+		)
+		require.NoError(t, err)
+		require.Positive(t, sampled.SourceSize)
+		require.Positive(t, sampled.TotalKVSize())
+		require.Greater(t, sampled.SourceSize, int64(len(content)/2))
+		require.Less(t, sampled.SourceSize, int64(len(content)*2))
+	})
 }
 func TestSampleIndexSizeRatioVeryLongRows(t *testing.T) {
 	simpleTbl := `create table t (a int, b text, c text, d text, index idx(a));`

--- a/pkg/importsdk/BUILD.bazel
+++ b/pkg/importsdk/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/util/table-filter",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_ngaut_pools//:pools",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -393,19 +393,62 @@ func (s *fileScanner) buildEstimateTableInfo(ctx context.Context, tblMeta *mydum
 	}
 	p := parser.New()
 	p.SetSQLMode(s.config.sqlMode)
-	stmt, err := p.ParseOneStmt(schemaSQL, "", "")
+	stmts, _, err := p.ParseSQL(schemaSQL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	createStmt, ok := stmt.(*ast.CreateTableStmt)
-	if !ok {
-		return nil, errors.Errorf("schema file %s does not contain a CREATE TABLE statement", tblMeta.SchemaFile.FileMeta.Path)
+	createStmt, err := buildEstimateCreateTableStmt(stmts, tblMeta)
+	if err != nil {
+		return nil, err
 	}
 	tableInfo, err := ddl.BuildTableInfoFromAST(metabuild.NewContext(), createStmt)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return tableInfo, nil
+}
+
+func buildEstimateCreateTableStmt(stmts []ast.StmtNode, tblMeta *mydump.MDTableMeta) (*ast.CreateTableStmt, error) {
+	var (
+		firstCreateStmt *ast.CreateTableStmt
+		createStmtCount int
+	)
+	for _, stmt := range stmts {
+		createStmt, ok := stmt.(*ast.CreateTableStmt)
+		if !ok {
+			continue
+		}
+		if firstCreateStmt == nil {
+			firstCreateStmt = createStmt
+		}
+		createStmtCount++
+		if estimateCreateTableStmtMatchesMeta(createStmt, tblMeta) {
+			return createStmt, nil
+		}
+	}
+	if createStmtCount == 1 {
+		return firstCreateStmt, nil
+	}
+	if createStmtCount == 0 {
+		return nil, errors.Errorf("schema file %s does not contain a CREATE TABLE statement", tblMeta.SchemaFile.FileMeta.Path)
+	}
+	return nil, errors.Errorf(
+		"schema file %s contains %d CREATE TABLE statements but none match table %s.%s",
+		tblMeta.SchemaFile.FileMeta.Path,
+		createStmtCount,
+		tblMeta.DB,
+		tblMeta.Name,
+	)
+}
+
+func estimateCreateTableStmtMatchesMeta(createStmt *ast.CreateTableStmt, tblMeta *mydump.MDTableMeta) bool {
+	if !strings.EqualFold(createStmt.Table.Name.String(), tblMeta.Name) {
+		return false
+	}
+	if createStmt.Table.Schema.String() == "" {
+		return true
+	}
+	return strings.EqualFold(createStmt.Table.Schema.String(), tblMeta.DB)
 }
 
 func sourceTypeToImportFormat(tp mydump.SourceType) (string, error) {

--- a/pkg/importsdk/file_scanner.go
+++ b/pkg/importsdk/file_scanner.go
@@ -48,23 +48,32 @@ type FileScanner interface {
 }
 
 type fileScanner struct {
-	sourcePath string
-	db         *sql.DB
-	store      storeapi.Storage
-	loader     *mydump.MDLoader
-	logger     log.Logger
-	config     *SDKConfig
+	redactedSourcePath string
+	db                 *sql.DB
+	store              storeapi.Storage
+	loader             *mydump.MDLoader
+	logger             log.Logger
+	config             *SDKConfig
 }
+
+const redactedInvalidSourcePath = "<redacted-invalid-source>"
 
 // NewFileScanner creates a new FileScanner
 func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDKConfig) (FileScanner, error) {
+	redactedSourcePath := ast.RedactURL(sourcePath)
+	parseErrorSourcePath := redactedSourcePath
+	if parseErrorSourcePath == sourcePath {
+		// ast.RedactURL leaves malformed or unsupported URLs unchanged.
+		// Avoid exposing the original source in outward-facing parse errors.
+		parseErrorSourcePath = redactedInvalidSourcePath
+	}
 	u, err := objstore.ParseBackend(sourcePath, nil)
 	if err != nil {
-		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s, err=%v", sourcePath, err)
+		return nil, errors.Annotatef(ErrParseStorageURL, "source=%s", parseErrorSourcePath)
 	}
 	store, err := objstore.New(ctx, u, &storeapi.Options{})
 	if err != nil {
-		return nil, errors.Annotatef(ErrCreateExternalStorage, "source=%s, err=%v", sourcePath, err)
+		return nil, errors.Annotatef(ErrCreateExternalStorage, "source=%s, err=%v", redactedSourcePath, err)
 	}
 
 	ldrCfg := mydump.LoaderConfig{
@@ -90,24 +99,24 @@ func NewFileScanner(ctx context.Context, sourcePath string, db *sql.DB, cfg *SDK
 	loader, err := mydump.NewLoaderWithStore(ctx, ldrCfg, store, loaderOptions...)
 	if err != nil {
 		if loader == nil || !errors.ErrorEqual(err, common.ErrTooManySourceFiles) {
-			return nil, errors.Annotatef(ErrCreateLoader, "source=%s, charset=%s, err=%v", sourcePath, cfg.charset, err)
+			return nil, errors.Annotatef(ErrCreateLoader, "source=%s, charset=%s, err=%v", redactedSourcePath, cfg.charset, err)
 		}
 	}
 
 	return &fileScanner{
-		sourcePath: sourcePath,
-		db:         db,
-		store:      store,
-		loader:     loader,
-		logger:     cfg.logger,
-		config:     cfg,
+		redactedSourcePath: redactedSourcePath,
+		db:                 db,
+		store:              store,
+		loader:             loader,
+		logger:             cfg.logger,
+		config:             cfg,
 	}, nil
 }
 
 func (s *fileScanner) CreateSchemasAndTables(ctx context.Context) error {
 	dbMetas := s.loader.GetDatabases()
 	if len(dbMetas) == 0 {
-		return errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.sourcePath)
+		return errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.redactedSourcePath)
 	}
 
 	// Create all schemas and tables
@@ -121,7 +130,7 @@ func (s *fileScanner) CreateSchemasAndTables(ctx context.Context) error {
 
 	err := importer.Run(ctx, dbMetas)
 	if err != nil {
-		return errors.Annotatef(ErrCreateSchema, "source=%s, db_count=%d, err=%v", s.sourcePath, len(dbMetas), err)
+		return errors.Annotatef(ErrCreateSchema, "source=%s, db_count=%d, err=%v", s.redactedSourcePath, len(dbMetas), err)
 	}
 
 	return nil
@@ -155,7 +164,7 @@ func (s *fileScanner) CreateSchemaAndTableByName(ctx context.Context, schema, ta
 				Tables:     []*mydump.MDTableMeta{tblMeta},
 			}})
 			if err != nil {
-				return errors.Annotatef(ErrCreateSchema, "source=%s, schema=%s, table=%s, err=%v", s.sourcePath, schema, table, err)
+				return errors.Annotatef(ErrCreateSchema, "source=%s, schema=%s, table=%s, err=%v", s.redactedSourcePath, schema, table, err)
 			}
 
 			return nil
@@ -202,7 +211,7 @@ func (s *fileScanner) GetTotalSize(ctx context.Context) int64 {
 func (s *fileScanner) EstimateImportDataSize(ctx context.Context) (*ImportDataSizeEstimate, error) {
 	dbMetas := s.loader.GetDatabases()
 	if len(dbMetas) == 0 {
-		return nil, errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.sourcePath)
+		return nil, errors.Annotatef(ErrNoDatabasesFound, "source=%s", s.redactedSourcePath)
 	}
 
 	result := &ImportDataSizeEstimate{

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -130,6 +130,32 @@ func TestFileScanner(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("CreateSchemasAndTablesIgnoresDropTableInSchemaFile", func(t *testing.T) {
+		dropDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dropDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dropDir, "db1.t_drop-schema.sql"),
+			[]byte("DROP TABLE t_drop; CREATE TABLE t_drop (id INT);"),
+			0o644,
+		))
+
+		dropDB, dropMock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer dropDB.Close()
+
+		dropScanner, err := NewFileScanner(ctx, "file://"+dropDir, dropDB, defaultSDKConfig())
+		require.NoError(t, err)
+		defer dropScanner.Close()
+
+		dropMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+		dropMock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE IF NOT EXISTS `db1`")).WillReturnResult(sqlmock.NewResult(0, 0))
+		dropMock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS `db1`.`t_drop`")).WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err = dropScanner.CreateSchemasAndTables(ctx)
+		require.NoError(t, err)
+		require.NoError(t, dropMock.ExpectationsWereMet())
+	})
+
 	t.Run("EstimateImportDataSize", func(t *testing.T) {
 		estimateDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(estimateDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -266,6 +266,41 @@ func TestFileScanner(t *testing.T) {
 		require.Equal(t, estimate.Tables[0].SourceSize, estimate.TotalSourceSize)
 		require.Equal(t, estimate.Tables[0].TiKVSize, estimate.TotalTiKVSize)
 	})
+
+	t.Run("EstimateImportDataSizeMultiStatementSchema", func(t *testing.T) {
+		estimateDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(estimateDir, "test_db-schema-create.sql"), []byte("CREATE DATABASE test_db;"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(estimateDir, "test_db.users-schema.sql"),
+			[]byte(strings.Join([]string{
+				"CREATE DATABASE IF NOT EXISTS test_db;",
+				"USE test_db;",
+				"DROP TABLE IF EXISTS users;",
+				"CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255), KEY idx_name (name));",
+			}, "\n")),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(estimateDir, "test_db.users.001.csv"),
+			[]byte("1,alice\n2,bob\n"),
+			0o644,
+		))
+
+		cfg := defaultSDKConfig()
+		cfg.skipInvalidFiles = true
+		estimateScanner, err := NewFileScanner(ctx, "file://"+estimateDir, db, cfg)
+		require.NoError(t, err)
+		defer estimateScanner.Close()
+
+		estimate, err := estimateScanner.EstimateImportDataSize(ctx)
+		require.NoError(t, err)
+		require.Len(t, estimate.Tables, 1)
+		require.Equal(t, "users", estimate.Tables[0].Table)
+		require.Positive(t, estimate.Tables[0].SourceSize)
+		require.Positive(t, estimate.Tables[0].TiKVSize)
+		require.Equal(t, estimate.Tables[0].SourceSize, estimate.TotalSourceSize)
+		require.Equal(t, estimate.Tables[0].TiKVSize, estimate.TotalTiKVSize)
+	})
 }
 
 func TestFileScannerWithEstimateRealSize(t *testing.T) {

--- a/pkg/importsdk/file_scanner_test.go
+++ b/pkg/importsdk/file_scanner_test.go
@@ -26,8 +26,11 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/mydump"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +71,16 @@ func TestProcessDataFiles(t *testing.T) {
 func TestFileScanner(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := context.Background()
+	assertSecretsRedacted := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "access-key=xxxxxx")
+		require.ErrorContains(t, err, "secret-access-key=xxxxxx")
+		require.ErrorContains(t, err, "session-token=xxxxxx")
+		require.NotContains(t, err.Error(), "access-key=ak")
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
+		require.NotContains(t, err.Error(), "session-token=token")
+	}
 
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "db1.t1-schema.sql"), []byte("CREATE TABLE t1 (id INT);"), 0644))
@@ -115,6 +128,59 @@ func TestFileScanner(t *testing.T) {
 		err := scanner.CreateSchemasAndTables(ctx)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("NewFileScannerRedactsSensitiveSourcePathInParseErrors", func(t *testing.T) {
+		_, err := NewFileScanner(
+			ctx,
+			"s3://?access-key=ak&secret-access-key=sk&session-token=token",
+			db,
+			cfg,
+		)
+		assertSecretsRedacted(t, err)
+	})
+
+	t.Run("NewFileScannerHidesMalformedSensitiveSourcePathInParseErrors", func(t *testing.T) {
+		_, err := NewFileScanner(
+			ctx,
+			"1invalid:?secret-access-key=sk",
+			db,
+			cfg,
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "source="+redactedInvalidSourcePath)
+		require.NotContains(t, err.Error(), "secret-access-key=sk")
+	})
+
+	t.Run("CreateSchemasAndTablesRedactsSensitiveSourcePathOnError", func(t *testing.T) {
+		invalidDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(invalidDir, "db1-schema-create.sql"), []byte("CREATE DATABASE db1;"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(invalidDir, "db1.t1-schema.sql"),
+			[]byte("CREATE TABLE t1 (id INT,);"),
+			0o644,
+		))
+
+		invalidDB, invalidMock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer invalidDB.Close()
+
+		invalidScanner, err := NewFileScanner(ctx, "file://"+invalidDir, invalidDB, defaultSDKConfig())
+		require.NoError(t, err)
+		defer invalidScanner.Close()
+
+		fs := invalidScanner.(*fileScanner)
+		sourcePath := "s3://bucket/path?access-key=ak&secret-access-key=sk&session-token=token"
+		fs.redactedSourcePath = ast.RedactURL(sourcePath)
+
+		invalidMock.ExpectQuery("SELECT SCHEMA_NAME FROM information_schema.SCHEMATA.*").WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+		invalidMock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE IF NOT EXISTS `db1`")).WillReturnResult(sqlmock.NewResult(0, 0))
+		invalidMock.ExpectQuery("SHOW CREATE TABLE `db1`.`t1`").WillReturnError(&dmysql.MySQLError{Number: tmysql.ErrNoSuchTable})
+
+		err = invalidScanner.CreateSchemasAndTables(ctx)
+		assertSecretsRedacted(t, err)
+		require.ErrorContains(t, err, "invalid schema statement")
+		require.NoError(t, invalidMock.ExpectationsWereMet())
 	})
 
 	t.Run("CreateSchemaAndTableByName", func(t *testing.T) {

--- a/pkg/importsdk/pattern.go
+++ b/pkg/importsdk/pattern.go
@@ -158,13 +158,21 @@ func longestCommonSuffix(strs []string, prefixLen int) string {
 	return suffix
 }
 
-// generatePrefixSuffixPattern returns a wildcard pattern that matches all and only the given paths
-// by finding the longest common prefix and suffix among them, and placing a '*' wildcard in between.
-func generatePrefixSuffixPattern(paths []string) string {
+func generateFlatPrefixSuffixPattern(paths []string) string {
 	if len(paths) == 0 {
 		return ""
 	}
 	if len(paths) == 1 {
+		return paths[0]
+	}
+	allSame := true
+	for _, p := range paths[1:] {
+		if p != paths[0] {
+			allSame = false
+			break
+		}
+	}
+	if allSame {
 		return paths[0]
 	}
 
@@ -172,4 +180,39 @@ func generatePrefixSuffixPattern(paths []string) string {
 	suffix := longestCommonSuffix(paths, len(prefix))
 
 	return prefix + "*" + suffix
+}
+
+// generatePrefixSuffixPattern returns a wildcard pattern that matches all and only the given paths.
+// When all paths have the same number of '/'-separated components, it generates the wildcard
+// component by component so every '*' stays within a single path segment, which is required by
+// filepath.Match.
+func generatePrefixSuffixPattern(paths []string) string {
+	if len(paths) <= 1 {
+		return generateFlatPrefixSuffixPattern(paths)
+	}
+
+	componentCount := -1
+	pathComponents := make([][]string, 0, len(paths))
+	for _, p := range paths {
+		components := strings.Split(p, "/")
+		if componentCount == -1 {
+			componentCount = len(components)
+		} else if len(components) != componentCount {
+			return generateFlatPrefixSuffixPattern(paths)
+		}
+		pathComponents = append(pathComponents, components)
+	}
+	if componentCount <= 1 {
+		return generateFlatPrefixSuffixPattern(paths)
+	}
+
+	componentPatterns := make([]string, 0, componentCount)
+	for componentIdx := range componentCount {
+		componentValues := make([]string, 0, len(pathComponents))
+		for _, components := range pathComponents {
+			componentValues = append(componentValues, components[componentIdx])
+		}
+		componentPatterns = append(componentPatterns, generateFlatPrefixSuffixPattern(componentValues))
+	}
+	return strings.Join(componentPatterns, "/")
 }

--- a/pkg/importsdk/pattern_test.go
+++ b/pkg/importsdk/pattern_test.go
@@ -131,6 +131,16 @@ func TestValidatePattern(t *testing.T) {
 	// If pattern doesn't match our table's file, it's also invalid
 	require.False(t, isValidPattern("*.csv", tableFiles, smallAll))
 
+	subdirTableFiles := map[string]struct{}{
+		"dir/subdir1/a.csv": {},
+		"dir/subdir2/b.csv": {},
+	}
+	subdirAll := map[string]mydump.FileInfo{
+		"dir/subdir1/a.csv": {},
+		"dir/subdir2/b.csv": {},
+	}
+	require.True(t, isValidPattern("dir/subdir*/*.csv", subdirTableFiles, subdirAll))
+
 	// empty pattern => invalid
 	require.False(t, isValidPattern("", tableFiles, smallAll))
 }
@@ -205,4 +215,48 @@ func TestGenerateWildcardPath(t *testing.T) {
 	_, err = generateWildcardPath(files4, allFiles4)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot generate a unique wildcard pattern")
+
+	files5 := []mydump.FileInfo{
+		{
+			TableName: filter.Table{Schema: "db", Name: "tb"},
+			FileMeta: mydump.SourceFileMeta{
+				Path:        "dir/subdir1/a.csv",
+				Type:        mydump.SourceTypeCSV,
+				Compression: mydump.CompressionNone,
+			},
+		},
+		{
+			TableName: filter.Table{Schema: "db", Name: "tb"},
+			FileMeta: mydump.SourceFileMeta{
+				Path:        "dir/subdir1/b.csv",
+				Type:        mydump.SourceTypeCSV,
+				Compression: mydump.CompressionNone,
+			},
+		},
+		{
+			TableName: filter.Table{Schema: "db", Name: "tb"},
+			FileMeta: mydump.SourceFileMeta{
+				Path:        "dir/subdir2/c.csv",
+				Type:        mydump.SourceTypeCSV,
+				Compression: mydump.CompressionNone,
+			},
+		},
+		{
+			TableName: filter.Table{Schema: "db", Name: "tb"},
+			FileMeta: mydump.SourceFileMeta{
+				Path:        "dir/subdir2/d.csv",
+				Type:        mydump.SourceTypeCSV,
+				Compression: mydump.CompressionNone,
+			},
+		},
+	}
+	allFiles5 := map[string]mydump.FileInfo{
+		files5[0].FileMeta.Path: files5[0],
+		files5[1].FileMeta.Path: files5[1],
+		files5[2].FileMeta.Path: files5[2],
+		files5[3].FileMeta.Path: files5[3],
+	}
+	path5, err := generateWildcardPath(files5, allFiles5)
+	require.NoError(t, err)
+	require.Equal(t, "dir/subdir*/*.csv", path5)
 }

--- a/pkg/lightning/common/errors.go
+++ b/pkg/lightning/common/errors.go
@@ -61,8 +61,14 @@ var (
 	ErrUnknownCheckpointDriver = errors.Normalize("unknown checkpoint driver '%s'", errors.RFCCodeText("Lightning:Checkpoint:ErrUnknownCheckpointDriver"))
 	ErrInvalidCheckpoint       = errors.Normalize("invalid checkpoint", errors.RFCCodeText("Lightning:Checkpoint:ErrInvalidCheckpoint"))
 	ErrCheckpointNotFound      = errors.Normalize("checkpoint not found", errors.RFCCodeText("Lightning:Checkpoint:ErrCheckpointNotFound"))
-	ErrInitCheckpoint          = errors.Normalize("init checkpoint error", errors.RFCCodeText("Lightning:Checkpoint:ErrInitCheckpoint"))
-	ErrCleanCheckpoint         = errors.Normalize("clean checkpoint error", errors.RFCCodeText("Lightning:Checkpoint:ErrCleanCheckpoint"))
+	// ErrCheckpointTableNotFound is the stable identity for table-scoped
+	// checkpoint operations when the checkpoint row does not exist.
+	ErrCheckpointTableNotFound = errors.Normalize(
+		"checkpoint for table %s not found",
+		errors.RFCCodeText("Lightning:Checkpoint:ErrCheckpointTableNotFound"),
+	)
+	ErrInitCheckpoint  = errors.Normalize("init checkpoint error", errors.RFCCodeText("Lightning:Checkpoint:ErrInitCheckpoint"))
+	ErrCleanCheckpoint = errors.Normalize("clean checkpoint error", errors.RFCCodeText("Lightning:Checkpoint:ErrCleanCheckpoint"))
 
 	ErrMetaMgrUnknown = errors.Normalize("unknown error occur on meta manager", errors.RFCCodeText("Lightning:MetaMgr:ErrMetaMgrUnknown"))
 

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -1117,6 +1117,15 @@ type TikvImporter struct {
 	KeyspaceName      string `toml:"keyspace-name" json:"keyspace-name"`
 	AddIndexBySQL     bool   `toml:"add-index-by-sql" json:"add-index-by-sql"`
 
+	// StripS3ExternalIDForImportSQL strips explicit S3 external ID from
+	// generated IMPORT INTO SQL resource parameters while keeping the original
+	// source path unchanged for Lightning storage access. This compatibility flag
+	// is only for callers that need to work with older IMPORT INTO planners that
+	// reject explicit S3 external ID.
+	// Deprecated: remove this flag after downstream callers no longer need to
+	// keep compatibility with those older planners.
+	StripS3ExternalIDForImportSQL bool `toml:"-" json:"-"`
+
 	EngineMemCacheSize      ByteSize `toml:"engine-mem-cache-size" json:"engine-mem-cache-size"`
 	LocalWriterMemCacheSize ByteSize `toml:"local-writer-mem-cache-size" json:"local-writer-mem-cache-size"`
 	StoreWriteBWLimit       ByteSize `toml:"store-write-bwlimit" json:"store-write-bwlimit"`

--- a/pkg/lightning/mydump/schema_import.go
+++ b/pkg/lightning/mydump/schema_import.go
@@ -256,7 +256,9 @@ func (si *SchemaImporter) importViews(ctx context.Context, dbMetas []*MDDatabase
 }
 
 func (si *SchemaImporter) runCreateTableJob(ctx context.Context, p *parser.Parser, job *schemaJob) error {
-	stmts, err := createIfNotExistsStmt(p, job.sqlStr, job.dbName, job.tblName)
+	// Table schema restore should preserve session directives but must not drop
+	// downstream objects from source schema files.
+	stmts, err := createIfNotExistsStmtWithMode(p, job.sqlStr, job.dbName, job.tblName, true)
 	if err != nil {
 		// if the schema supplied by the user is un-parsable by TiDB, we allow
 		// user to create the table by themselves, then import data.
@@ -375,6 +377,14 @@ func (si *SchemaImporter) getExistingSchemas(ctx context.Context, query string) 
 }
 
 func createIfNotExistsStmt(p *parser.Parser, createTable, dbName, tblName string) ([]string, error) {
+	return createIfNotExistsStmtWithMode(p, createTable, dbName, tblName, false)
+}
+
+func createIfNotExistsStmtWithMode(
+	p *parser.Parser,
+	createTable, dbName, tblName string,
+	ignoreDestructiveDDL bool,
+) ([]string, error) {
 	stmts, _, err := p.ParseSQL(createTable)
 	if err != nil {
 		return []string{}, common.ErrInvalidSchemaStmt.Wrap(err).GenWithStackByArgs(createTable)
@@ -390,6 +400,9 @@ func createIfNotExistsStmt(p *parser.Parser, createTable, dbName, tblName string
 			node.Name = ast.NewCIStr(dbName)
 			node.IfNotExists = true
 		case *ast.DropDatabaseStmt:
+			if ignoreDestructiveDDL {
+				continue
+			}
 			node.Name = ast.NewCIStr(dbName)
 			node.IfExists = true
 		case *ast.CreateTableStmt:
@@ -400,6 +413,9 @@ func createIfNotExistsStmt(p *parser.Parser, createTable, dbName, tblName string
 			node.ViewName.Schema = ast.NewCIStr(dbName)
 			node.ViewName.Name = ast.NewCIStr(tblName)
 		case *ast.DropTableStmt:
+			if ignoreDestructiveDDL {
+				continue
+			}
 			node.Tables[0].Schema = ast.NewCIStr(dbName)
 			node.Tables[0].Name = ast.NewCIStr(tblName)
 			node.IfExists = true

--- a/pkg/lightning/mydump/schema_import_test.go
+++ b/pkg/lightning/mydump/schema_import_test.go
@@ -186,6 +186,48 @@ func TestSchemaImporter(t *testing.T) {
 		require.NoError(t, os.Remove(path.Join(tempDir, fileNameT2)))
 	})
 
+	t.Run("table: ignore drop table in schema file", func(t *testing.T) {
+		mock.ExpectQuery(`information_schema.SCHEMATA`).WillReturnRows(
+			sqlmock.NewRows([]string{"SCHEMA_NAME"}).AddRow("test01"))
+		fileName := "test01.t1-schema.sql"
+		require.NoError(t, os.WriteFile(
+			path.Join(tempDir, fileName),
+			[]byte("DROP TABLE t1; CREATE TABLE t1(a int);"),
+			0o644,
+		))
+		dbMetas := []*MDDatabaseMeta{
+			{Name: "test01", Tables: []*MDTableMeta{
+				{DB: "test01", Name: "t1", charSet: "auto", SchemaFile: FileInfo{FileMeta: SourceFileMeta{Path: fileName}}},
+			}},
+		}
+		mock.ExpectExec("CREATE TABLE IF NOT EXISTS `test01`.`t1`").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		require.NoError(t, importer.Run(ctx, dbMetas))
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.NoError(t, os.Remove(path.Join(tempDir, fileName)))
+	})
+
+	t.Run("table: ignore drop database in schema file", func(t *testing.T) {
+		mock.ExpectQuery(`information_schema.SCHEMATA`).WillReturnRows(
+			sqlmock.NewRows([]string{"SCHEMA_NAME"}).AddRow("test01"))
+		fileName := "test01.t1-schema.sql"
+		require.NoError(t, os.WriteFile(
+			path.Join(tempDir, fileName),
+			[]byte("DROP DATABASE test01; CREATE TABLE t1(a int);"),
+			0o644,
+		))
+		dbMetas := []*MDDatabaseMeta{
+			{Name: "test01", Tables: []*MDTableMeta{
+				{DB: "test01", Name: "t1", charSet: "auto", SchemaFile: FileInfo{FileMeta: SourceFileMeta{Path: fileName}}},
+			}},
+		}
+		mock.ExpectExec("CREATE TABLE IF NOT EXISTS `test01`.`t1`").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		require.NoError(t, importer.Run(ctx, dbMetas))
+		require.NoError(t, mock.ExpectationsWereMet())
+		require.NoError(t, os.Remove(path.Join(tempDir, fileName)))
+	})
+
 	t.Run("view: get existing schema err", func(t *testing.T) {
 		mock.ExpectQuery(`information_schema.SCHEMATA`).WillReturnRows(
 			sqlmock.NewRows([]string{"SCHEMA_NAME"}).AddRow("test01").AddRow("test02"))

--- a/pkg/objstore/parse.go
+++ b/pkg/objstore/parse.go
@@ -182,7 +182,7 @@ func ExtractQueryParameters(u *url.URL, options any) {
 			continue
 		}
 		param := params[0]
-		normalizedKey := strings.ToLower(strings.ReplaceAll(key, "_", "-"))
+		normalizedKey := NormalizeQueryParameterKey(key)
 		if f, ok := tagToField[normalizedKey]; ok {
 			field := o.Field(f.index)
 			switch f.kind {
@@ -200,6 +200,12 @@ func ExtractQueryParameters(u *url.URL, options any) {
 
 	// Clean up the URL finally.
 	u.RawQuery = ""
+}
+
+// NormalizeQueryParameterKey normalizes object storage URL query parameter keys
+// to match backend option tags.
+func NormalizeQueryParameterKey(key string) string {
+	return strings.ToLower(strings.ReplaceAll(key, "_", "-"))
 }
 
 // FormatBackendURL obtains the raw URL which can be used the reconstruct the


### PR DESCRIPTION
### What problem does this PR solve?

Backport import SDK and related IMPORT INTO behavior fixes from master to `release-nextgen-202603`:

- #67472: fix wildcard generation for subdir CSV files.
- #67492: fix sampled source size in import estimate.
- #67554: ignore DROP DDL when restoring table schema.
- #67719: redact sensitive source params in outward-facing errors.
- #67712: return not-found for missing checkpoint table names in lightning-ctl/importinto checkpoint paths.
- #69147: strip S3 external ID from IMPORT INTO SQL resource params while preserving the original source path for Lightning.
- #69193: add external ID compatibility flag for importinto.

Also backports the small `objstore.NormalizeQueryParameterKey` helper required by the S3 external ID stripping path, without pulling unrelated planner changes.

### What changed and how does it work?

- Cherry-picked the import SDK/importinto commits above onto `release-nextgen-202603`.
- Resolved the `pkg/executor/importer/sampler.go` conflict by keeping the 2603 nextgen `Chunk`-based sampler structure and applying the master source-size fix: sample source bytes from parser position deltas for SQL/CSV, with Parquet falling back to row length.
- Did not cherry-pick unrelated add-index/test stabilization changes.

### Check List

Tests:

- [x] `make failpoint-enable && go test -tags intest ./pkg/importsdk ./lightning/pkg/importinto ./pkg/executor/importer ./pkg/lightning/mydump && make failpoint-disable`

Notes:

- A plain `go test ./pkg/importsdk ./lightning/pkg/importinto ./pkg/executor/importer ./pkg/lightning/mydump` was also attempted; TiDB failpoint-dependent tests require the repository failpoint-enable flow to pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved import handling for object storage URLs, including optional stripping of external ID parameters from generated SQL.

* **Bug Fixes**
  * Checkpoint operations now clearly report when a specific table checkpoint cannot be found, with clearer guidance and less noisy error output.
  * Schema import and file scanning now better handle multiple statements, ignore destructive statements in schema files, and redact sensitive connection details in errors.
  * File pattern matching and SQL size sampling were refined for more accurate results across nested paths and SQL sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->