### PR TITLE
server: avoid string-to-byte copies in column dump

### DIFF
--- a/pkg/server/internal/column/column.go
+++ b/pkg/server/internal/column/column.go
@@ -60,17 +60,17 @@ func (column *Info) dump(buffer []byte, d *ResultEncoder, withDefault bool) []by
 	if d == nil {
 		d = NewResultEncoder(charset.CharsetUTF8MB4)
 	}
-	nameDump, orgnameDump := []byte(column.Name), []byte(column.OrgName)
+	nameDump, orgnameDump := hack.Slice(column.Name), hack.Slice(column.OrgName)
 	if len(nameDump) > maxColumnNameSize {
 		nameDump = nameDump[0:maxColumnNameSize]
 	}
 	if len(orgnameDump) > maxColumnNameSize {
 		orgnameDump = orgnameDump[0:maxColumnNameSize]
 	}
-	buffer = dump.LengthEncodedString(buffer, []byte("def"))
-	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta([]byte(column.Schema)))
-	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta([]byte(column.Table)))
-	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta([]byte(column.OrgTable)))
+	buffer = dump.LengthEncodedString(buffer, hack.Slice("def"))
+	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta(hack.Slice(column.Schema)))
+	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta(hack.Slice(column.Table)))
+	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta(hack.Slice(column.OrgTable)))
 	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta(nameDump))
 	buffer = dump.LengthEncodedString(buffer, d.EncodeMeta(orgnameDump))
 
@@ -88,7 +88,7 @@ func (column *Info) dump(buffer []byte, d *ResultEncoder, withDefault bool) []by
 			buffer = append(buffer, 251) // NULL
 		default:
 			defaultValStr := fmt.Sprintf("%v", column.DefaultValue)
-			buffer = dump.LengthEncodedString(buffer, []byte(defaultValStr))
+			buffer = dump.LengthEncodedString(buffer, hack.Slice(defaultValStr))
 		}
 	}
 

--- a/pkg/server/internal/column/column_test.go
+++ b/pkg/server/internal/column/column_test.go
@@ -54,6 +54,30 @@ func TestDumpColumn(t *testing.T) {
 	require.Equal(t, mysql.TypeBit, dumpType(mysql.TypeBit))
 }
 
+func BenchmarkDumpColumn(b *testing.B) {
+	info := Info{
+		Schema:       "testSchema",
+		Table:        "testTable",
+		OrgTable:     "testOrgTable",
+		Name:         "testName",
+		OrgName:      "testOrgName",
+		ColumnLength: 1,
+		Charset:      106,
+		Flag:         0,
+		Decimal:      1,
+		Type:         14,
+		DefaultValue: "test",
+	}
+	encoder := NewResultEncoder(charset.CharsetUTF8MB4)
+	buffer := make([]byte, 0, 1024)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buffer = info.DumpWithDefault(buffer[:0], encoder)
+	}
+}
+
 func TestDumpColumnWithDefault(t *testing.T) {
 	info := Info{
 		Schema:       "testSchema",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32073

Problem Summary:

`Info.dump` in the server column metadata path converted several read-only strings with `[]byte(string)`, which allocates when returning result column metadata.

### What changed and how does it work?

Use `hack.Slice` for read-only string-to-byte conversions in `Info.dump`, including column names, schema/table names, the `"def"` catalog string, and formatted default values.

Add `BenchmarkDumpColumn` to track the allocation and latency cost of dumping column metadata with a reused result encoder and output buffer.

Local benchmark on Apple M3:

```text
before: ~121 ns/op, 80 B/op, 6 allocs/op
after:   ~62 ns/op,  4 B/op, 1 allocs/op
```

End-to-end SQL metadata workload:

```text
workload: SELECT * FROM t LIMIT 0 on a 129-column table, 8 concurrency, 15s x 3 repeats
median QPS: 11335.35 -> 11795.61 (+4.1%)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test commands:

```bash
go test -tags=intest,deadlock ./pkg/server/internal/column -run 'TestDumpColumn|TestDumpColumnWithDefault|TestColumnNameLimit'
go test -tags=intest,deadlock ./pkg/server/internal/column -run '^$' -bench '^BenchmarkDumpColumn$' -benchmem -count 10
go test -tags=intest,deadlock ./pkg/server/internal/column
./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -run 'TestVectorTypeTextProtocol|TestPreparedString|TestPreparedTimestamp'
make lint
```

Manual end-to-end performance test:

SQL metadata workload:
- Query: `SELECT * FROM t LIMIT 0`
- Table width: 129 columns (`id` + 128 `VARCHAR` columns)
- Concurrency: 8
- Duration: 15s per repeat
- Repeats: 3

| version | repeat | qps | avg_us | p95_us | p99_us |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 1 | 11275.09 | 708.73 | 1465 | 3274 |
| baseline | 2 | 11617.36 | 687.87 | 1365 | 2803 |
| baseline | 3 | 11335.35 | 704.96 | 1425 | 2983 |
| after | 1 | 11795.61 | 677.44 | 1401 | 2811 |
| after | 2 | 12179.46 | 656.06 | 1318 | 2605 |
| after | 3 | 11269.73 | 709.08 | 1489 | 3187 |

Summary:
- Median QPS: `11335.35 -> 11795.61`, about `+4.1%`
- Average QPS: `11409.27 -> 11748.27`, about `+3.0%`
- Median average latency: `704.96us -> 677.44us`, about `-3.9%`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve result column metadata encoding performance by avoiding unnecessary string-to-byte copies.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved column metadata encoding efficiency, reducing unnecessary string-to-byte conversions during serialization.
  * Preserved existing behavior for column name truncation and default value handling.

* **Tests**
  * Added a benchmark to measure column dump performance and memory allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->