### PR TITLE
mvservice: force status indexes for history cleanup

### DIFF
--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -1154,16 +1154,12 @@ func (*serviceHelper) GetCurrentTSO(_ context.Context, sysSessionPool basic.Sess
 	return ver.Ver, nil
 }
 
-// PurgeMVHistoryBeforeTSO removes old records from MV history tables.
-func (*serviceHelper) PurgeMVHistoryBeforeTSO(
-	ctx context.Context,
-	sysSessionPool basic.SessionPool,
-	currentTSO uint64,
-	mviewRefreshRetention time.Duration,
-	mlogPurgeRetention time.Duration,
-) error {
-	markRefreshHistoryRunningRowsOrphanedSQL := fmt.Sprintf(
-		`UPDATE mysql.tidb_mview_refresh_hist
+const countRefreshHistorySQL = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
+const countLogPurgeHistorySQL = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
+
+func buildMarkRefreshHistoryRunningRowsOrphanedSQL() string {
+	return fmt.Sprintf(
+		`UPDATE mysql.tidb_mview_refresh_hist FORCE INDEX (idx_refresh_status)
 SET REFRESH_STATUS = '%s',
 	REFRESH_ENDTIME = IFNULL(REFRESH_ENDTIME, NOW(6)),
 	REFRESH_DURATION_SEC = IFNULL(REFRESH_DURATION_SEC, CASE WHEN REFRESH_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, REFRESH_TIME, NOW(6)) / 1000000.0 END),
@@ -1176,8 +1172,11 @@ LIMIT %d`,
 		mvRefreshHistoryOrphanedReason,
 		historyGCDeleteBatchSize,
 	)
-	markLogPurgeHistoryRunningRowsOrphanedSQL := fmt.Sprintf(
-		`UPDATE mysql.tidb_mlog_purge_hist
+}
+
+func buildMarkLogPurgeHistoryRunningRowsOrphanedSQL() string {
+	return fmt.Sprintf(
+		`UPDATE mysql.tidb_mlog_purge_hist FORCE INDEX (idx_purge_status)
 SET PURGE_STATUS = '%s',
 	PURGE_ENDTIME = IFNULL(PURGE_ENDTIME, NOW(6)),
 	PURGE_DURATION_SEC = IFNULL(PURGE_DURATION_SEC, CASE WHEN PURGE_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, PURGE_TIME, NOW(6)) / 1000000.0 END),
@@ -1190,28 +1189,48 @@ LIMIT %d`,
 		mvLogPurgeHistoryOrphanedReason,
 		historyGCDeleteBatchSize,
 	)
-	deleteRefreshHistoryByCutoffTSOSQL := fmt.Sprintf(
+}
+
+func buildDeleteRefreshHistoryByCutoffTSOSQL() string {
+	return fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
-	deleteLogPurgeHistoryByCutoffTSOSQL := fmt.Sprintf(
+}
+
+func buildDeleteLogPurgeHistoryByCutoffTSOSQL() string {
+	return fmt.Sprintf(
 		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
 		historyGCDeleteBatchSize,
 	)
-	const countRefreshHistorySQL = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
-	const countLogPurgeHistorySQL = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
-	deleteRefreshHistoryByCountLimitSQL := func(limit uint64) string {
-		return fmt.Sprintf(
-			`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
-			limit,
-		)
-	}
-	deleteLogPurgeHistoryByCountLimitSQL := func(limit uint64) string {
-		return fmt.Sprintf(
-			`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
-			limit,
-		)
-	}
+}
+
+func buildDeleteRefreshHistoryByCountLimitSQL(limit uint64) string {
+	return fmt.Sprintf(
+		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
+		limit,
+	)
+}
+
+func buildDeleteLogPurgeHistoryByCountLimitSQL(limit uint64) string {
+	return fmt.Sprintf(
+		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
+		limit,
+	)
+}
+
+// PurgeMVHistoryBeforeTSO removes old records from MV history tables.
+func (*serviceHelper) PurgeMVHistoryBeforeTSO(
+	ctx context.Context,
+	sysSessionPool basic.SessionPool,
+	currentTSO uint64,
+	mviewRefreshRetention time.Duration,
+	mlogPurgeRetention time.Duration,
+) error {
+	markRefreshHistoryRunningRowsOrphanedSQL := buildMarkRefreshHistoryRunningRowsOrphanedSQL()
+	markLogPurgeHistoryRunningRowsOrphanedSQL := buildMarkLogPurgeHistoryRunningRowsOrphanedSQL()
+	deleteRefreshHistoryByCutoffTSOSQL := buildDeleteRefreshHistoryByCutoffTSOSQL()
+	deleteLogPurgeHistoryByCutoffTSOSQL := buildDeleteLogPurgeHistoryByCutoffTSOSQL()
 
 	calcCutoffTSO := func(retention time.Duration) uint64 {
 		cutoffTSO := currentTSO
@@ -1242,7 +1261,7 @@ LIMIT %d`,
 	if err := purgeMVHistoryByCutoffTSOInBatches(ctx, sctx, deleteRefreshHistoryByCutoffTSOSQL, calcCutoffTSO(mviewRefreshRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by retention failed: %w", err))
 	}
-	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countRefreshHistorySQL, deleteRefreshHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
+	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countRefreshHistorySQL, buildDeleteRefreshHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mview refresh history by count limit failed: %w", err))
 	}
 	if err := reconcileMVHistoryRunningRowsInBatches(ctx, sctx, markLogPurgeHistoryRunningRowsOrphanedSQL, calcHeartbeatCutoffTime(mvHistoryHeartbeatTimeout)); err != nil {
@@ -1251,7 +1270,7 @@ LIMIT %d`,
 	if err := purgeMVHistoryByCutoffTSOInBatches(ctx, sctx, deleteLogPurgeHistoryByCutoffTSOSQL, calcCutoffTSO(mlogPurgeRetention)); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by retention failed: %w", err))
 	}
-	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countLogPurgeHistorySQL, deleteLogPurgeHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
+	if err := purgeMVHistoryByCountLimitInBatches(ctx, sctx, countLogPurgeHistorySQL, buildDeleteLogPurgeHistoryByCountLimitSQL, defaultMVHistoryGCMaxRecords); err != nil {
 		purgeErrs = append(purgeErrs, fmt.Errorf("purge mlog purge history by count limit failed: %w", err))
 	}
 	if len(purgeErrs) > 0 {

--- a/pkg/mvservice/task_handler_test.go
+++ b/pkg/mvservice/task_handler_test.go
@@ -61,62 +61,24 @@ const (
 )
 
 var (
-	testSQLMarkStaleMVRefreshHistOrphaned = fmt.Sprintf(
-		`UPDATE mysql.tidb_mview_refresh_hist
-SET REFRESH_STATUS = '%s',
-	REFRESH_ENDTIME = IFNULL(REFRESH_ENDTIME, NOW(6)),
-	REFRESH_DURATION_SEC = IFNULL(REFRESH_DURATION_SEC, CASE WHEN REFRESH_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, REFRESH_TIME, NOW(6)) / 1000000.0 END),
-	REFRESH_FAILED_REASON = IFNULL(REFRESH_FAILED_REASON, '%s')
-WHERE REFRESH_STATUS = 'running'
-  AND COALESCE(LAST_HEARTBEAT_AT, REFRESH_TIME) < %%?
-ORDER BY REFRESH_JOB_ID
-LIMIT %d`,
-		mvHistoryOrphanedStatus,
-		mvRefreshHistoryOrphanedReason,
-		historyGCDeleteBatchSize,
-	)
-	testSQLMarkStaleMVLogPurgeHistOrphaned = fmt.Sprintf(
-		`UPDATE mysql.tidb_mlog_purge_hist
-SET PURGE_STATUS = '%s',
-	PURGE_ENDTIME = IFNULL(PURGE_ENDTIME, NOW(6)),
-	PURGE_DURATION_SEC = IFNULL(PURGE_DURATION_SEC, CASE WHEN PURGE_TIME IS NULL THEN NULL ELSE TIMESTAMPDIFF(MICROSECOND, PURGE_TIME, NOW(6)) / 1000000.0 END),
-	PURGE_FAILED_REASON = IFNULL(PURGE_FAILED_REASON, '%s')
-WHERE PURGE_STATUS = 'running'
-  AND COALESCE(LAST_HEARTBEAT_AT, PURGE_TIME) < %%?
-ORDER BY PURGE_JOB_ID
-LIMIT %d`,
-		mvHistoryOrphanedStatus,
-		mvLogPurgeHistoryOrphanedReason,
-		historyGCDeleteBatchSize,
-	)
-	testSQLDeleteMVRefreshHistBeforeTSO = fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID < %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
-		historyGCDeleteBatchSize,
-	)
-	testSQLDeleteMVLogPurgeHistBeforeTSO = fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID < %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
-		historyGCDeleteBatchSize,
-	)
-	testSQLCountMVRefreshHist  = `SELECT COUNT(*), MIN(REFRESH_JOB_ID) FROM mysql.tidb_mview_refresh_hist`
-	testSQLCountMVLogPurgeHist = `SELECT COUNT(*), MIN(PURGE_JOB_ID) FROM mysql.tidb_mlog_purge_hist`
-	testExpectedPurgeMVLogSQL  = []string{
+	testSQLMarkStaleMVRefreshHistOrphaned  = buildMarkRefreshHistoryRunningRowsOrphanedSQL()
+	testSQLMarkStaleMVLogPurgeHistOrphaned = buildMarkLogPurgeHistoryRunningRowsOrphanedSQL()
+	testSQLDeleteMVRefreshHistBeforeTSO    = buildDeleteRefreshHistoryByCutoffTSOSQL()
+	testSQLDeleteMVLogPurgeHistBeforeTSO   = buildDeleteLogPurgeHistoryByCutoffTSOSQL()
+	testSQLCountMVRefreshHist              = countRefreshHistorySQL
+	testSQLCountMVLogPurgeHist             = countLogPurgeHistorySQL
+	testExpectedPurgeMVLogSQL              = []string{
 		testSQLPurgeMVLog,
 		testSQLFindPurgeNextTime,
 	}
 )
 
 func testSQLDeleteMVRefreshHistByCount(limit uint64) string {
-	return fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mview_refresh_hist WHERE (REFRESH_STATUS IS NULL OR REFRESH_STATUS <> 'running') AND REFRESH_JOB_ID >= %%? ORDER BY REFRESH_JOB_ID LIMIT %d`,
-		limit,
-	)
+	return buildDeleteRefreshHistoryByCountLimitSQL(limit)
 }
 
 func testSQLDeleteMVLogPurgeHistByCount(limit uint64) string {
-	return fmt.Sprintf(
-		`DELETE FROM mysql.tidb_mlog_purge_hist WHERE (PURGE_STATUS IS NULL OR PURGE_STATUS <> 'running') AND PURGE_JOB_ID >= %%? ORDER BY PURGE_JOB_ID LIMIT %d`,
-		limit,
-	)
+	return buildDeleteLogPurgeHistoryByCountLimitSQL(limit)
 }
 
 type mockSessionPool struct{}
@@ -2103,6 +2065,11 @@ func TestServerHelperPurgeMVHistoryBeforeTSOReconcilesStaleRunningHistRows(t *te
 	require.Equal(t, []any{currentTSO}, se.executedRestrictedArg[1])
 	require.Equal(t, []any{expectedCutoffTime}, se.executedRestrictedArg[3])
 	require.Equal(t, []any{currentTSO}, se.executedRestrictedArg[4])
+}
+
+func TestServerHelperPurgeMVHistoryBeforeTSOUsesStatusIndexHints(t *testing.T) {
+	require.Contains(t, buildMarkRefreshHistoryRunningRowsOrphanedSQL(), "FORCE INDEX (idx_refresh_status)")
+	require.Contains(t, buildMarkLogPurgeHistoryRunningRowsOrphanedSQL(), "FORCE INDEX (idx_purge_status)")
 }
 
 func TestServerHelperRefreshMVDeletedWhenMetaNotFound(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

The MV service marks expired running rows in `mysql.tidb_mview_refresh_hist` and `mysql.tidb_mlog_purge_hist` during history cleanup. The internal SQL can choose an unsuitable access path without an explicit index hint.

### What changed and how does it work?

This PR adds `FORCE INDEX` hints to the two stale running history cleanup statements:

- `mysql.tidb_mview_refresh_hist FORCE INDEX (idx_refresh_status)`
- `mysql.tidb_mlog_purge_hist FORCE INDEX (idx_purge_status)`

It also factors the MV history cleanup SQL builders out of `PurgeMVHistoryBeforeTSO` so tests can reuse the same SQL definitions instead of duplicating large SQL strings.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```sh
go test ./pkg/mvservice -run TestTemporaryMVHistoryCleanupPlan -tags=intest -count=1 -v > /tmp/mv_force_plan_check.log 2>&1
rg -A8 "refresh cleanup plan|purge cleanup plan" /tmp/mv_force_plan_check.log
```

The explain plans use `idx_refresh_status` and `idx_purge_status` with `range:["running","running"]`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved maintenance-history cleanup logic for MV services, making the SQL generation more consistent and easier to maintain.
  * Streamlined how stale records are marked and removed during purge operations.

* **Tests**
  * Updated purge-related test fixtures to match the new SQL generation approach.
  * Added coverage to verify the correct index hints are used during stale-history cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->