### PR TITLE
br: concurrently read all entries | tidb-test=release-8.5-20251125-v8.5.4 tikv=feature/release-8.5-cr-pitr pd=release-8.5-20251204-v8.5.4

### DIFF
--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -84,12 +84,13 @@ func TestCheckpointMetaForRestore(t *testing.T) {
 	require.Equal(t, checkpointMetaForSnapshotRestore.RestoredTS, checkpointMetaForSnapshotRestore2.RestoredTS)
 
 	checkpointMetaForLogRestore := &checkpoint.CheckpointMetadataForLogRestore{
-		UpstreamClusterID: 123,
-		RestoredTS:        222,
-		StartTS:           111,
-		RewriteTS:         333,
-		GcRatio:           "1.0",
-		TiFlashItems:      map[int64]model.TiFlashReplicaInfo{1: {Count: 1}},
+		UpstreamClusterID:        123,
+		RestoredTS:               222,
+		StartTS:                  111,
+		RewriteTS:                333,
+		GcRatio:                  "1.0",
+		RocksDBMaxBackgroundJobs: "8",
+		TiFlashItems:             map[int64]model.TiFlashReplicaInfo{1: {Count: 1}},
 	}
 	err = checkpoint.SaveCheckpointMetadataForLogRestore(ctx, se, checkpointMetaForLogRestore)
 	require.NoError(t, err)
@@ -100,6 +101,7 @@ func TestCheckpointMetaForRestore(t *testing.T) {
 	require.Equal(t, checkpointMetaForLogRestore.StartTS, checkpointMetaForLogRestore2.StartTS)
 	require.Equal(t, checkpointMetaForLogRestore.RewriteTS, checkpointMetaForLogRestore2.RewriteTS)
 	require.Equal(t, checkpointMetaForLogRestore.GcRatio, checkpointMetaForLogRestore2.GcRatio)
+	require.Equal(t, checkpointMetaForLogRestore.RocksDBMaxBackgroundJobs, checkpointMetaForLogRestore2.RocksDBMaxBackgroundJobs)
 	require.Equal(t, checkpointMetaForLogRestore.TiFlashItems, checkpointMetaForLogRestore2.TiFlashItems)
 
 	exists := checkpoint.ExistsCheckpointProgress(ctx, dom)
@@ -119,6 +121,7 @@ func TestCheckpointMetaForRestore(t *testing.T) {
 	require.Equal(t, uint64(111), taskInfo.Metadata.StartTS)
 	require.Equal(t, uint64(333), taskInfo.Metadata.RewriteTS)
 	require.Equal(t, "1.0", taskInfo.Metadata.GcRatio)
+	require.Equal(t, "8", taskInfo.Metadata.RocksDBMaxBackgroundJobs)
 	require.Equal(t, true, taskInfo.HasSnapshotMetadata)
 	require.Equal(t, checkpoint.InLogRestoreAndIdMapPersist, taskInfo.Progress)
 

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -156,11 +156,13 @@ func LoadCheckpointDataForLogRestore[K KeyType, V ValueType](
 }
 
 type CheckpointMetadataForLogRestore struct {
-	UpstreamClusterID uint64 `json:"upstream-cluster-id"`
-	RestoredTS        uint64 `json:"restored-ts"`
-	StartTS           uint64 `json:"start-ts"`
-	RewriteTS         uint64 `json:"rewrite-ts"`
-	GcRatio           string `json:"gc-ratio"`
+	UpstreamClusterID        uint64 `json:"upstream-cluster-id"`
+	RestoredTS               uint64 `json:"restored-ts"`
+	StartTS                  uint64 `json:"start-ts"`
+	RewriteTS                uint64 `json:"rewrite-ts"`
+	GcRatio                  string `json:"gc-ratio"`
+	RocksDBMaxBackgroundJobs string `json:"rocksdb-max-background-jobs,omitempty"`
+	SnapshotRestoreDataSize  uint64 `json:"snapshot-restore-data-size,omitempty"`
 	// tiflash recorder items with snapshot restore records
 	TiFlashItems map[int64]model.TiFlashReplicaInfo `json:"tiflash-recorder,omitempty"`
 }

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -49,10 +49,10 @@ const (
 	// DefaultMergeRegionKeyCount is the default region key count, 960000.
 	DefaultMergeRegionKeyCount uint64 = 960000
 
-	// DefaultImportNumGoroutines is the default number of threads for import.
-	// use 64 as default value, which is 4 times of the default value of tidb.
-	// we think is proper for IO-bound cases.
-	DefaultImportNumGoroutines uint = 64
+	// DefaultImportNumGoroutines is the default number of goroutines for restore.
+	DefaultImportNumGoroutines uint = 36
+
+	minRestoreConcurrencyOverImportThreads uint = 4
 )
 
 type VersionCheckerType int
@@ -308,7 +308,8 @@ func (mgr *Mgr) GetCurrentTsFromPD(ctx context.Context) (uint64, error) {
 }
 
 // ProcessTiKVConfigs handle the tikv config for region split size, region split keys, and import goroutines in place.
-// It retrieves the config from all alive tikv stores and returns the minimum values.
+// It retrieves the config from all alive tikv stores, keeps conservative split values,
+// and makes restore concurrency no less than import.num-threads plus a small margin.
 // If retrieving the config fails, it returns the default config values.
 func (mgr *Mgr) ProcessTiKVConfigs(ctx context.Context, cfg *kvconfig.KVConfig, client *http.Client) {
 	mergeRegionSize := cfg.MergeRegionSize
@@ -342,9 +343,8 @@ func (mgr *Mgr) ProcessTiKVConfigs(ctx context.Context, cfg *kvconfig.KVConfig, 
 				log.Warn("Failed to parse import num-threads from config", logutil.ShortError(e))
 				return e
 			}
-			// We use 4 times the default value because it's an IO-bound case.
-			if importGoroutines.Value == DefaultImportNumGoroutines || (threads > 0 && threads*8 < importGoroutines.Value) {
-				importGoroutines.Value = threads * 4
+			if threads > 0 {
+				importGoroutines.Value = max(importGoroutines.Value, threads+minRestoreConcurrencyOverImportThreads)
 			}
 		}
 		// replace the value

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -50,9 +50,9 @@ const (
 	DefaultMergeRegionKeyCount uint64 = 960000
 
 	// DefaultImportNumGoroutines is the default number of threads for import.
-	// use 128 as default value, which is 8 times of the default value of tidb.
+	// use 64 as default value, which is 4 times of the default value of tidb.
 	// we think is proper for IO-bound cases.
-	DefaultImportNumGoroutines uint = 128
+	DefaultImportNumGoroutines uint = 64
 )
 
 type VersionCheckerType int
@@ -342,9 +342,9 @@ func (mgr *Mgr) ProcessTiKVConfigs(ctx context.Context, cfg *kvconfig.KVConfig, 
 				log.Warn("Failed to parse import num-threads from config", logutil.ShortError(e))
 				return e
 			}
-			// We use 8 times the default value because it's an IO-bound case.
+			// We use 4 times the default value because it's an IO-bound case.
 			if importGoroutines.Value == DefaultImportNumGoroutines || (threads > 0 && threads*8 < importGoroutines.Value) {
-				importGoroutines.Value = threads * 8
+				importGoroutines.Value = threads * 4
 			}
 		}
 		// replace the value

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -357,8 +357,8 @@ func TestGetMergeRegionSizeAndCount(t *testing.T) {
 			content: []string{
 				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 1, \"region-split-size\": \"1MiB\"}, \"import\": {\"num-threads\": 6}}",
 			},
-			// the number of import goroutines is 8 times than import.num-threads.
-			importNumGoroutines: 48,
+			// the default value already satisfies import.num-threads + 4.
+			importNumGoroutines: conn.DefaultImportNumGoroutines,
 			// one tikv detected in this case we are not update default size and keys because they are too small.
 			regionSplitSize: 1 * units.MiB,
 			regionSplitKeys: 1,
@@ -379,7 +379,7 @@ func TestGetMergeRegionSizeAndCount(t *testing.T) {
 			content: []string{
 				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 10000000, \"region-split-size\": \"1GiB\"}, \"import\": {\"num-threads\": 128}}",
 			},
-			importNumGoroutines: 1024,
+			importNumGoroutines: 132,
 			// one tikv detected in this case and we update with new size and keys.
 			regionSplitSize: 1 * units.GiB,
 			regionSplitKeys: 10000000,
@@ -411,8 +411,7 @@ func TestGetMergeRegionSizeAndCount(t *testing.T) {
 				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 10000000, \"region-split-size\": \"1GiB\"}, \"import\": {\"num-threads\": 128}}",
 				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 12000000, \"region-split-size\": \"900MiB\"}, \"import\": {\"num-threads\": 12}}",
 			},
-			// two tikv detected in this case and we choose the small one.
-			importNumGoroutines: 96,
+			importNumGoroutines: 132,
 			regionSplitSize:     1 * units.GiB,
 			regionSplitKeys:     10000000,
 		},

--- a/br/pkg/restore/log_client/BUILD.bazel
+++ b/br/pkg/restore/log_client/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "client.go",
         "compacted_file_strategy.go",
+        "flow_control.go",
         "import.go",
         "import_retry.go",
         "log_file_manager.go",
@@ -53,6 +54,7 @@ go_library(
         "//pkg/util/sqlescape",
         "//pkg/util/sqlexec",
         "//pkg/util/table-filter",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_fatih_color//:color",
         "@com_github_gogo_protobuf//proto",
         "@com_github_opentracing_opentracing_go//:opentracing-go",

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -139,7 +139,6 @@ type SstRestoreManager struct {
 	restorer         restore.SstRestorer
 	storeCount       uint
 	replicaCount     uint
-	workerPool       *tidbutil.WorkerPool
 	checkpointRunner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]
 }
 
@@ -164,16 +163,16 @@ func NewSstRestoreManager(
 	createCheckpointSessionFn func() (glue.Session, error),
 ) (*SstRestoreManager, error) {
 	var checkpointRunner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]
-	// This poolSize is similar to full restore, as both workflows are comparable.
-	// The poolSize should be greater than concurrencyPerStore multiplied by the number of stores.
-	poolSize := concurrencyPerStore * 32 * storeCount
+	// Keep the global SST restore pool large enough to avoid starving stores when
+	// queued file sets temporarily point to other TiKVs.
+	const sstRestoreWorkerPoolSizePerStore uint = 7186
+	poolSize := sstRestoreWorkerPoolSizePerStore * storeCount
 	log.Info("sst restore worker pool", zap.Uint("size", poolSize))
 	sstWorkerPool := tidbutil.NewWorkerPool(poolSize, "sst file")
 
 	s := &SstRestoreManager{
 		storeCount:   storeCount,
 		replicaCount: replicaCount,
-		workerPool:   tidbutil.NewWorkerPool(poolSize, "log manager worker pool"),
 	}
 	se, err := createCheckpointSessionFn()
 	if err != nil {

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1330,17 +1330,42 @@ func (rc *LogClient) constructIDMap(
 	fs []*backuppb.DataFileInfo,
 	sr *stream.SchemasReplace,
 ) error {
-	for _, f := range fs {
-		entries, _, err := rc.ReadAllEntries(ctx, f, math.MaxUint64)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
+	var rewriteLock sync.Mutex
+	return rc.readMetaKVFiles(ctx, fs, math.MaxUint64, func(entries, _ []*KvEntryWithTS, cf string) error {
+		rewriteLock.Lock()
+		defer rewriteLock.Unlock()
 		for _, entry := range entries {
-			if _, err := sr.RewriteKvEntry(&entry.E, f.GetCf()); err != nil {
+			if _, err := sr.RewriteKvEntry(&entry.E, cf); err != nil {
 				return errors.Trace(err)
 			}
 		}
+		return nil
+	})
+}
+
+func (rc *LogClient) readMetaKVFiles(
+	ctx context.Context,
+	files []*backuppb.DataFileInfo,
+	filterTS uint64,
+	consumeFn func([]*KvEntryWithTS, []*KvEntryWithTS, string) error,
+) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	workerPool := tidbutil.NewWorkerPool(min(uint(len(files)), maxReadMetaKVFilesConcurrency), "read meta kv files")
+	for _, file := range files {
+		workerPool.ApplyOnErrorGroup(eg, func() error {
+			es, nextEs, err := rc.ReadAllEntries(egCtx, file, filterTS)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			return consumeFn(es, nextEs, file.GetCf())
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }
@@ -1462,25 +1487,15 @@ func (rc *LogClient) RestoreBatchMetaKVFiles(
 
 	// read all entries from files.
 	if len(files) > 0 {
-		eg, egCtx := errgroup.WithContext(ctx)
-		workerPool := tidbutil.NewWorkerPool(min(uint(len(files)), maxReadMetaKVFilesConcurrency), "read meta kv files")
 		var entriesLock sync.Mutex
-		for _, f := range files {
-			file := f
-			workerPool.ApplyOnErrorGroup(eg, func() error {
-				es, nextEs, err := rc.ReadAllEntries(egCtx, file, filterTS)
-				if err != nil {
-					return errors.Trace(err)
-				}
-
-				entriesLock.Lock()
-				curKvEntries = append(curKvEntries, es...)
-				nextKvEntries = append(nextKvEntries, nextEs...)
-				entriesLock.Unlock()
-				return nil
-			})
-		}
-		if err := eg.Wait(); err != nil {
+		err := rc.readMetaKVFiles(ctx, files, filterTS, func(es, nextEs []*KvEntryWithTS, _ string) error {
+			entriesLock.Lock()
+			curKvEntries = append(curKvEntries, es...)
+			nextKvEntries = append(nextKvEntries, nextEs...)
+			entriesLock.Unlock()
+			return nil
+		})
+		if err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -137,6 +137,8 @@ func (l *LogRestoreManager) Close(ctx context.Context) {
 // including concurrency management, checkpoint handling, and file importing(splitting) for efficient log processing.
 type SstRestoreManager struct {
 	restorer         restore.SstRestorer
+	storeCount       uint
+	replicaCount     uint
 	workerPool       *tidbutil.WorkerPool
 	checkpointRunner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]
 }
@@ -158,6 +160,7 @@ func NewSstRestoreManager(
 	snapFileImporter *snapclient.SnapFileImporter,
 	concurrencyPerStore uint,
 	storeCount uint,
+	replicaCount uint,
 	createCheckpointSessionFn func() (glue.Session, error),
 ) (*SstRestoreManager, error) {
 	var checkpointRunner *checkpoint.CheckpointRunner[checkpoint.RestoreKeyType, checkpoint.RestoreValueType]
@@ -168,7 +171,9 @@ func NewSstRestoreManager(
 	sstWorkerPool := tidbutil.NewWorkerPool(poolSize, "sst file")
 
 	s := &SstRestoreManager{
-		workerPool: tidbutil.NewWorkerPool(poolSize, "log manager worker pool"),
+		storeCount:   storeCount,
+		replicaCount: replicaCount,
+		workerPool:   tidbutil.NewWorkerPool(poolSize, "log manager worker pool"),
 	}
 	se, err := createCheckpointSessionFn()
 	if err != nil {
@@ -337,6 +342,8 @@ func (rc *LogClient) RestoreSSTFileSets(
 	ctx context.Context,
 	backupFileSets restore.BatchBackupFileSet,
 	importModeSwitcher *restore.ImportModeSwitcher,
+	snapshotRestoreDataSize uint64,
+	checkpointCompactedSSTSize uint64,
 	onProgress func(int64),
 ) error {
 	begin := time.Now()
@@ -344,6 +351,15 @@ func (rc *LogClient) RestoreSSTFileSets(
 		log.Info("[Compacted SST Restore] No SST files found for restoration.")
 		return nil
 	}
+	if err := rc.adjustTiKVFlowControlForCompactedSSTRestore(
+		ctx,
+		backupFileSets,
+		snapshotRestoreDataSize,
+		checkpointCompactedSSTSize,
+	); err != nil {
+		return errors.Trace(err)
+	}
+
 	err := importModeSwitcher.GoSwitchToImportMode(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -500,6 +516,10 @@ func (rc *LogClient) InitClients(
 	if err != nil {
 		log.Fatal("failed to get stores", zap.Error(err))
 	}
+	replicaCount, err := rc.getMaxReplica(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	metaClient := split.NewClient(rc.pdClient, rc.pdHTTPClient, rc.tlsConf, maxSplitKeysOnce, len(stores)+1)
 	importCli := importclient.NewImportClient(metaClient, rc.tlsConf, rc.keepaliveConf)
@@ -547,9 +567,36 @@ func (rc *LogClient) InitClients(
 		fileImporter,
 		concurrencyPerStore,
 		uint(len(stores)),
+		replicaCount,
 		createSessionFn,
 	)
 	return errors.Trace(err)
+}
+
+func (rc *LogClient) getMaxReplica(ctx context.Context) (uint, error) {
+	if rc.pdHTTPClient == nil {
+		return 0, errors.New("PD HTTP client is not initialized")
+	}
+	var resp map[string]any
+	var err error
+	err = utils.WithRetry(ctx, func() error {
+		resp, err = rc.pdHTTPClient.GetReplicateConfig(ctx)
+		return err
+	}, utils.NewPDReqBackoffer())
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+
+	const key = "max-replicas"
+	val, ok := resp[key]
+	if !ok {
+		return 0, errors.Errorf("key %s not found in response %v", key, resp)
+	}
+	replicaCount, ok := val.(float64)
+	if !ok {
+		return 0, errors.Errorf("invalid %s value in response %v", key, resp)
+	}
+	return uint(replicaCount), nil
 }
 
 func (rc *LogClient) InitCheckpointMetadataForCompactedSstRestore(
@@ -580,8 +627,10 @@ func (rc *LogClient) InitCheckpointMetadataForLogRestore(
 	ctx context.Context,
 	startTS, restoredTS uint64,
 	gcRatio string,
+	rocksDBMaxBackgroundJobs string,
 	tiflashRecorder *tiflashrec.TiFlashRecorder,
-) (string, error) {
+	snapshotRestoreDataSize uint64,
+) (string, string, uint64, error) {
 	rc.useCheckpoint = true
 
 	// if the checkpoint metadata exists in the external storage, the restore is not
@@ -590,11 +639,16 @@ func (rc *LogClient) InitCheckpointMetadataForLogRestore(
 		// load the checkpoint since this is not the first time to restore
 		meta, err := checkpoint.LoadCheckpointMetadataForLogRestore(ctx, rc.unsafeSession.GetSessionCtx().GetRestrictedSQLExecutor())
 		if err != nil {
-			return "", errors.Trace(err)
+			return "", "", 0, errors.Trace(err)
 		}
 
-		log.Info("reuse gc ratio from checkpoint metadata", zap.String("gc-ratio", gcRatio))
-		return meta.GcRatio, nil
+		if meta.RocksDBMaxBackgroundJobs != "" {
+			rocksDBMaxBackgroundJobs = meta.RocksDBMaxBackgroundJobs
+		}
+		log.Info("reuse TiKV config from checkpoint metadata",
+			zap.String("gc-ratio", meta.GcRatio),
+			zap.String("rocksdb-max-background-jobs", rocksDBMaxBackgroundJobs))
+		return meta.GcRatio, rocksDBMaxBackgroundJobs, meta.SnapshotRestoreDataSize, nil
 	}
 
 	// initialize the checkpoint metadata since it is the first time to restore.
@@ -602,21 +656,24 @@ func (rc *LogClient) InitCheckpointMetadataForLogRestore(
 	if tiflashRecorder != nil {
 		items = tiflashRecorder.GetItems()
 	}
-	log.Info("save gc ratio into checkpoint metadata",
+	log.Info("save TiKV config into checkpoint metadata",
 		zap.Uint64("start-ts", startTS), zap.Uint64("restored-ts", restoredTS), zap.Uint64("rewrite-ts", rc.currentTS),
-		zap.String("gc-ratio", gcRatio), zap.Int("tiflash-item-count", len(items)))
+		zap.String("gc-ratio", gcRatio), zap.String("rocksdb-max-background-jobs", rocksDBMaxBackgroundJobs),
+		zap.Int("tiflash-item-count", len(items)))
 	if err := checkpoint.SaveCheckpointMetadataForLogRestore(ctx, rc.unsafeSession, &checkpoint.CheckpointMetadataForLogRestore{
-		UpstreamClusterID: rc.upstreamClusterID,
-		RestoredTS:        restoredTS,
-		StartTS:           startTS,
-		RewriteTS:         rc.currentTS,
-		GcRatio:           gcRatio,
-		TiFlashItems:      items,
+		UpstreamClusterID:        rc.upstreamClusterID,
+		RestoredTS:               restoredTS,
+		StartTS:                  startTS,
+		RewriteTS:                rc.currentTS,
+		GcRatio:                  gcRatio,
+		RocksDBMaxBackgroundJobs: rocksDBMaxBackgroundJobs,
+		SnapshotRestoreDataSize:  snapshotRestoreDataSize,
+		TiFlashItems:             items,
 	}); err != nil {
-		return gcRatio, errors.Trace(err)
+		return gcRatio, rocksDBMaxBackgroundJobs, snapshotRestoreDataSize, errors.Trace(err)
 	}
 
-	return gcRatio, nil
+	return gcRatio, rocksDBMaxBackgroundJobs, snapshotRestoreDataSize, nil
 }
 
 type LockedMigrations struct {

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -2082,6 +2082,70 @@ func TestCollectSSTFileSets(t *testing.T) {
 	})
 }
 
+func TestEstimateCompactedSSTFlowControl(t *testing.T) {
+	fileSets := restore.BatchBackupFileSet{
+		{
+			TableID: 1,
+			SSTFiles: []*backuppb.File{
+				{
+					Name:  "file-1",
+					Size_: 16 * units.MiB,
+				},
+				{
+					Name:       "file-2",
+					TotalBytes: 8 * units.MiB,
+				},
+			},
+		},
+	}
+
+	snapshotBytes, compactedSSTBytes, l6BytesPerStore, l5BytesPerStore, pendingBytes :=
+		logclient.TEST_EstimateCompactedSSTFlowControl(fileSets, 5, 3, 120*units.MiB, 6*units.MiB)
+	require.Equal(t, uint64(120*units.MiB), snapshotBytes)
+	require.Equal(t, uint64(30*units.MiB), compactedSSTBytes)
+	require.Equal(t, uint64(72*units.MiB), l6BytesPerStore)
+	require.Equal(t, uint64(18*units.MiB), l5BytesPerStore)
+	require.InDelta(t, 54*float64(units.MiB), float64(pendingBytes), float64(units.KiB))
+}
+
+func TestEstimatePendingCompactionBytes(t *testing.T) {
+	require.Equal(t, uint64(0), logclient.TEST_EstimatePendingCompactionBytes(11*units.TiB, units.TiB))
+	pendingBytes := logclient.TEST_EstimatePendingCompactionBytes(units.TiB, 512*units.GiB)
+	expectedPendingBytes := (512*float64(units.GiB) - float64(units.TiB)/10) * 3
+	require.InDelta(t, expectedPendingBytes, float64(pendingBytes), float64(units.MiB))
+}
+
+func TestCompactedSSTFlowControlTarget(t *testing.T) {
+	soft, hard := logclient.TEST_CompactedSSTFlowControlTarget(
+		[]string{"192GiB"},
+		[]string{"256GiB"},
+		512*units.GiB,
+	)
+	require.Equal(t, uint64(units.TiB), soft)
+	require.Equal(t, uint64(2*units.TiB), hard)
+
+	soft, hard = logclient.TEST_CompactedSSTFlowControlTarget(
+		[]string{"192GiB"},
+		[]string{"256GiB"},
+		3*units.TiB,
+	)
+	require.Equal(t, uint64(3840*units.GiB), soft)
+	require.Equal(t, uint64(7680*units.GiB), hard)
+
+	soft, hard = logclient.TEST_CompactedSSTFlowControlTarget(
+		[]string{"4TiB"},
+		[]string{"9TiB"},
+		512*units.GiB,
+	)
+	require.Equal(t, uint64(4*units.TiB), soft)
+	require.Equal(t, uint64(9*units.TiB), hard)
+
+	require.False(t, logclient.TEST_AllTiKVConfigsAtLeast([]string{"4TiB", "192GiB"}, 4*units.TiB))
+	require.True(t, logclient.TEST_AllTiKVConfigsAtLeast([]string{"4TiB", "5TiB"}, 4*units.TiB))
+	require.Equal(t, "1TiB", logclient.TEST_FormatBytes(units.TiB))
+	require.Equal(t, "1536GiB", logclient.TEST_FormatBytes(1536*units.GiB))
+}
+
 func TestCompactedSplitStrategy(t *testing.T) {
 	ctx := context.Background()
 

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -16,6 +16,7 @@ package logclient_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -45,6 +46,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/utiltest"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
@@ -159,6 +161,69 @@ func MockEmptySchemasReplace() *stream.SchemasReplace {
 	)
 }
 
+func MockEmptySchemasReplaceWithGlobalID() *stream.SchemasReplace {
+	dbMap := make(map[stream.UpstreamID]*stream.DBReplace)
+	nextID := int64(100)
+	return stream.NewSchemasReplace(
+		dbMap,
+		true,
+		nil,
+		1,
+		filter.All(),
+		func(context.Context) (int64, error) {
+			nextID++
+			return nextID, nil
+		},
+		nil,
+		nil,
+	)
+}
+
+func encodeTxnMetaKV(key, field []byte, ts uint64, value []byte) []byte {
+	rawKey := tablecodec.EncodeMetaKey(key, field)
+	txnKey := codec.EncodeBytes(nil, rawKey)
+	txnKey = codec.EncodeUintDesc(txnKey, ts)
+	return stream.EncodeKVEntry(txnKey, value)
+}
+
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
+}
+
+func generateIDMapKVData(t *testing.T) ([]byte, logclient.Log, int64, int64, string, string) {
+	const (
+		dbID       int64  = 101
+		tableID    int64  = 202
+		dbName            = "test_db"
+		tableName         = "test_table"
+		dbEntryTS  uint64 = 40
+		tblEntryTS uint64 = 41
+	)
+
+	dbValue := mustMarshalJSON(t, &model.DBInfo{
+		ID:   dbID,
+		Name: pmodel.NewCIStr(dbName),
+	})
+	tableValue := mustMarshalJSON(t, &model.TableInfo{
+		ID:   tableID,
+		Name: pmodel.NewCIStr(tableName),
+	})
+
+	buff := make([]byte, 0)
+	buff = append(buff, encodeTxnMetaKV([]byte("DBs"), meta.DBkey(dbID), dbEntryTS, dbValue)...)
+	buff = append(buff, encodeTxnMetaKV(meta.DBkey(dbID), meta.TableKey(tableID), tblEntryTS, tableValue)...)
+	checksum := sha256.Sum256(buff)
+	return buff, &backuppb.DataFileInfo{
+		Sha256:      checksum[:],
+		RangeOffset: 0,
+		RangeLength: uint64(len(buff)),
+		Length:      uint64(len(buff)),
+		Cf:          stream.DefaultCF,
+	}, dbID, tableID, dbName, tableName
+}
+
 func TestRestoreBatchMetaKVFiles(t *testing.T) {
 	client := logclient.NewRestoreClient(nil, nil, nil, keepalive.ClientParameters{})
 	files := []*backuppb.DataFileInfo{}
@@ -166,6 +231,47 @@ func TestRestoreBatchMetaKVFiles(t *testing.T) {
 	next, err := client.RestoreBatchMetaKVFiles(context.Background(), files[0:], nil, make([]*logclient.KvEntryWithTS, 0), math.MaxUint64, nil, nil, "")
 	require.NoError(t, err)
 	require.Equal(t, 0, len(next))
+}
+
+func TestConstructIDMapReadsFilesConcurrently(t *testing.T) {
+	ctx := context.Background()
+	data, file, dbID, tableID, dbName, tableName := generateIDMapKVData(t)
+	readGate := make(chan struct{})
+	helper := &logclient.FakeStreamMetadataHelper{Data: data, ReadGate: readGate}
+	fm := logclient.TEST_NewLogFileManager(35, 75, 25, helper)
+	client := logclient.TEST_NewLogClientWithLogFileManager(fm)
+
+	files := make([]*backuppb.DataFileInfo, 0, 4)
+	for i := range 4 {
+		f := *file
+		f.Path = fmt.Sprintf("meta-kv-%d", i)
+		f.Cf = stream.DefaultCF
+		files = append(files, &f)
+	}
+
+	sr := MockEmptySchemasReplaceWithGlobalID()
+	sr.SetPreConstructMapStatus()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.TEST_ConstructIDMap(ctx, files, sr)
+	}()
+
+	require.Eventually(t, func() bool {
+		return helper.ActiveReadCount() == int32(len(files))
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, int32(len(files)), helper.MaxActiveReadCount())
+	close(readGate)
+	require.NoError(t, <-errCh)
+
+	dbReplace := sr.DbMap[dbID]
+	require.NotNil(t, dbReplace)
+	require.Equal(t, dbName, dbReplace.Name)
+	require.NotZero(t, dbReplace.DbID)
+
+	tableReplace := dbReplace.TableMap[tableID]
+	require.NotNil(t, tableReplace)
+	require.Equal(t, tableName, tableReplace.Name)
+	require.NotZero(t, tableReplace.TableID)
 }
 
 func TestRestoreMetaKVFilesWithBatchMethod1(t *testing.T) {

--- a/br/pkg/restore/log_client/export_test.go
+++ b/br/pkg/restore/log_client/export_test.go
@@ -102,12 +102,26 @@ func TEST_NewLogClient(clusterID, startTS, restoreTS, upstreamClusterID uint64, 
 	}
 }
 
+func TEST_NewLogClientWithLogFileManager(fm *LogFileManager) *LogClient {
+	return &LogClient{
+		LogFileManager: fm,
+	}
+}
+
 // TEST_NewLogClientWithStorage returns a minimal LogClient whose only
 // dependency is the storage. It is intended for tests that exercise
 // storage-level behavior (lock acquisition, migration loading) and do
 // not need the full domain / session / checkpoint wiring.
 func TEST_NewLogClientWithStorage(s storage.ExternalStorage) *LogClient {
 	return &LogClient{storage: s}
+}
+
+func (rc *LogClient) TEST_ConstructIDMap(
+	ctx context.Context,
+	fs []*backuppb.DataFileInfo,
+	sr *stream.SchemasReplace,
+) error {
+	return rc.constructIDMap(ctx, fs, sr)
 }
 
 func (rc *LogClient) SetUseCheckpoint() {

--- a/br/pkg/restore/log_client/export_test.go
+++ b/br/pkg/restore/log_client/export_test.go
@@ -22,6 +22,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/stream"
 	"github.com/pingcap/tidb/br/pkg/utils/iter"
@@ -139,6 +140,60 @@ func TEST_NewLogFileManager(startTS, restoreTS, shiftStartTS uint64, helper stre
 
 func TEST_CountReadableMetaKVFiles(files []*backuppb.DataFileInfo) int {
 	return countReadableMetaKVFiles(files)
+}
+
+func TEST_EstimateCompactedSSTFlowControl(
+	backupFileSets restore.BatchBackupFileSet,
+	storeCount uint,
+	replicaCount uint,
+	snapshotRestoreBytes uint64,
+	checkpointCompactedSSTBytes uint64,
+) (uint64, uint64, uint64, uint64, uint64) {
+	estimate := estimateCompactedSSTFlowControl(
+		backupFileSets,
+		snapshotRestoreBytes,
+		checkpointCompactedSSTBytes,
+		storeCount,
+		replicaCount,
+	)
+	return estimate.snapshotRestoreBytes,
+		estimate.compactedSSTBytes,
+		estimate.l6BytesPerStore,
+		estimate.l5BytesPerStore,
+		estimate.pendingBytes
+}
+
+func TEST_EstimatePendingCompactionBytes(l6BytesPerStore, l5BytesPerStore uint64) uint64 {
+	return estimatePendingCompactionBytes(l6BytesPerStore, l5BytesPerStore)
+}
+
+func TEST_CompactedSSTFlowControlTarget(
+	softConfig, hardConfig []string,
+	pendingBytes uint64,
+) (uint64, uint64) {
+	originConfig := &compactedSSTFlowControlConfig{
+		soft: make([]tikvConfigValue, 0, len(softConfig)),
+		hard: make([]tikvConfigValue, 0, len(hardConfig)),
+	}
+	for _, value := range softConfig {
+		originConfig.soft = append(originConfig.soft, tikvConfigValue{value: value})
+	}
+	for _, value := range hardConfig {
+		originConfig.hard = append(originConfig.hard, tikvConfigValue{value: value})
+	}
+	return compactedSSTFlowControlTarget(originConfig, pendingBytes)
+}
+
+func TEST_AllTiKVConfigsAtLeast(values []string, target uint64) bool {
+	configs := make([]tikvConfigValue, 0, len(values))
+	for _, value := range values {
+		configs = append(configs, tikvConfigValue{value: value})
+	}
+	return allTiKVConfigsAtLeast(configs, target)
+}
+
+func TEST_FormatBytes(bytes uint64) string {
+	return formatBytes(bytes)
 }
 
 type FakeStreamMetadataHelper struct {

--- a/br/pkg/restore/log_client/flow_control.go
+++ b/br/pkg/restore/log_client/flow_control.go
@@ -1,0 +1,394 @@
+// Copyright 2026 PingCAP, Inc. Licensed under Apache-2.0.
+
+package logclient
+
+import (
+	"context"
+	"math"
+	"strconv"
+
+	"github.com/docker/go-units"
+	"github.com/pingcap/errors"
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/restore"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"go.uber.org/zap"
+)
+
+const (
+	tikvSoftPendingCompactionBytesLimit = "storage.flow-control.soft-pending-compaction-bytes-limit"
+	tikvHardPendingCompactionBytesLimit = "storage.flow-control.hard-pending-compaction-bytes-limit"
+
+	compactedSSTFlowControlSoftLimitFloor   uint64 = units.TiB
+	compactedSSTFlowControlHardLimitFloor   uint64 = 2 * units.TiB
+	compactedSSTFlowControlPendingThreshold uint64 = 100 * units.GiB
+	compactedSSTMaxBytesForLevelMultiplier  uint64 = 10
+)
+
+type tikvConfigValue struct {
+	instance string
+	value    string
+}
+
+type compactedSSTFlowControlConfig struct {
+	soft []tikvConfigValue
+	hard []tikvConfigValue
+}
+
+type compactedSSTFlowControlEstimate struct {
+	snapshotRestoreBytes uint64
+	compactedSSTBytes    uint64
+	l6BytesPerStore      uint64
+	l5BytesPerStore      uint64
+	pendingBytes         uint64
+	storeCount           uint
+	replicaCount         uint
+}
+
+func (rc *LogClient) adjustTiKVFlowControlForCompactedSSTRestore(
+	ctx context.Context,
+	backupFileSets restore.BatchBackupFileSet,
+	snapshotRestoreBytes uint64,
+	checkpointCompactedSSTBytes uint64,
+) error {
+	if rc.unsafeSession == nil {
+		log.Warn("[Compacted SST Restore] skip adjusting TiKV flow-control configs because session is not initialized")
+		return nil
+	}
+	if rc.sstRestoreManager == nil || rc.sstRestoreManager.storeCount == 0 {
+		log.Warn("[Compacted SST Restore] skip adjusting TiKV flow-control configs because TiKV store count is not initialized")
+		return nil
+	}
+	if rc.sstRestoreManager.replicaCount == 0 {
+		log.Warn("[Compacted SST Restore] skip adjusting TiKV flow-control configs because TiKV replica count is not initialized")
+		return nil
+	}
+
+	execCtx := rc.unsafeSession.GetSessionCtx().GetRestrictedSQLExecutor()
+	originConfig, err := getCompactedSSTFlowControlConfig(ctx, execCtx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if originConfig == nil {
+		log.Warn("[Compacted SST Restore] skip adjusting TiKV flow-control configs because config items are unavailable")
+		return nil
+	}
+
+	estimate := estimateCompactedSSTFlowControl(
+		backupFileSets,
+		snapshotRestoreBytes,
+		checkpointCompactedSSTBytes,
+		rc.sstRestoreManager.storeCount,
+		rc.sstRestoreManager.replicaCount,
+	)
+
+	if estimate.pendingBytes <= compactedSSTFlowControlPendingThreshold {
+		log.Info("[Compacted SST Restore] skip adjusting TiKV flow-control configs because estimated pending compaction bytes is small",
+			zap.String("pending-compaction-bytes", formatBytes(estimate.pendingBytes)),
+			zap.String("threshold", formatBytes(compactedSSTFlowControlPendingThreshold)))
+		return nil
+	}
+	targetSoft, targetHard := compactedSSTFlowControlTarget(originConfig, estimate.pendingBytes)
+	originSoftBytes := maxTiKVConfigBytes(originConfig.soft)
+	originHardBytes := maxTiKVConfigBytes(originConfig.hard)
+	logCompactedSSTFlowControlEstimate(estimate, targetSoft, targetHard)
+
+	if allTiKVConfigsAtLeast(originConfig.soft, targetSoft) &&
+		allTiKVConfigsAtLeast(originConfig.hard, targetHard) {
+		log.Info("[Compacted SST Restore] TiKV flow-control configs are already large enough",
+			zap.String("soft-current", formatBytes(originSoftBytes)),
+			zap.String("hard-current", formatBytes(originHardBytes)))
+		return nil
+	}
+
+	if err := setTiKVConfig(ctx, execCtx, tikvHardPendingCompactionBytesLimit, formatBytes(targetHard)); err != nil {
+		return errors.Trace(err)
+	}
+	if err := setTiKVConfig(ctx, execCtx, tikvSoftPendingCompactionBytesLimit, formatBytes(targetSoft)); err != nil {
+		return errors.Trace(err)
+	}
+
+	log.Warn("[Compacted SST Restore] adjusted TiKV flow-control configs",
+		zap.String("soft", formatBytes(targetSoft)),
+		zap.String("hard", formatBytes(targetHard)))
+	return nil
+}
+
+func estimateCompactedSSTFlowControl(
+	backupFileSets restore.BatchBackupFileSet,
+	snapshotRestoreBytes uint64,
+	checkpointCompactedSSTBytes uint64,
+	storeCount uint,
+	replicaCount uint,
+) compactedSSTFlowControlEstimate {
+	compactedSSTBytes := checkpointCompactedSSTBytes
+	for _, set := range backupFileSets {
+		for _, file := range set.SSTFiles {
+			compactedSSTBytes = saturatingAddUint64(compactedSSTBytes, compactedSSTSizeForFlowControl(file))
+		}
+	}
+	l6BytesPerStore := estimateLevelBytesPerStore(snapshotRestoreBytes, storeCount, replicaCount)
+	l5BytesPerStore := estimateLevelBytesPerStore(compactedSSTBytes, storeCount, replicaCount)
+	return compactedSSTFlowControlEstimate{
+		snapshotRestoreBytes: snapshotRestoreBytes,
+		compactedSSTBytes:    compactedSSTBytes,
+		l6BytesPerStore:      l6BytesPerStore,
+		l5BytesPerStore:      l5BytesPerStore,
+		pendingBytes:         estimatePendingCompactionBytes(l6BytesPerStore, l5BytesPerStore),
+		storeCount:           storeCount,
+		replicaCount:         replicaCount,
+	}
+}
+
+func compactedSSTSizeForFlowControl(file *backuppb.File) uint64 {
+	if file.GetSize_() > 0 {
+		return file.GetSize_()
+	}
+	return file.GetTotalBytes()
+}
+
+func estimateLevelBytesPerStore(totalBytes uint64, storeCount uint, replicaCount uint) uint64 {
+	if storeCount == 0 || replicaCount == 0 || totalBytes == 0 {
+		return 0
+	}
+	effectiveReplicaCount := replicaCount
+	if effectiveReplicaCount > storeCount {
+		effectiveReplicaCount = storeCount
+	}
+	return saturatingMulUint64(
+		ceilDivUint64(totalBytes, uint64(storeCount)),
+		uint64(effectiveReplicaCount),
+	)
+}
+
+func estimatePendingCompactionBytes(l6BytesPerStore, l5BytesPerStore uint64) uint64 {
+	if l5BytesPerStore == 0 {
+		return 0
+	}
+	l6Bytes := float64(l6BytesPerStore)
+	l5Bytes := float64(l5BytesPerStore)
+	ratio := l6Bytes / l5Bytes
+	if ratio > float64(compactedSSTMaxBytesForLevelMultiplier) {
+		return 0
+	}
+	l5TargetBytes := l6Bytes / float64(compactedSSTMaxBytesForLevelMultiplier)
+	if l5Bytes <= l5TargetBytes {
+		return 0
+	}
+	pendingBytes := (l5Bytes - l5TargetBytes) * (ratio + 1)
+	if pendingBytes <= 0 {
+		return 0
+	}
+	if pendingBytes >= float64(math.MaxUint64) {
+		return math.MaxUint64
+	}
+	return uint64(pendingBytes)
+}
+
+func compactedSSTFlowControlTarget(
+	originConfig *compactedSSTFlowControlConfig,
+	pendingBytes uint64,
+) (uint64, uint64) {
+	adjustedPendingBytes := saturatingAddUint64(
+		pendingBytes,
+		ceilDivUint64(pendingBytes, 4),
+	)
+	soft := max(
+		compactedSSTFlowControlSoftLimitFloor,
+		adjustedPendingBytes,
+		maxTiKVConfigBytes(originConfig.soft),
+	)
+	hard := saturatingMulUint64(soft, 2)
+	hard = max(compactedSSTFlowControlHardLimitFloor, hard, maxTiKVConfigBytes(originConfig.hard))
+	return soft, hard
+}
+
+func getCompactedSSTFlowControlConfig(
+	ctx context.Context,
+	execCtx sqlexec.RestrictedSQLExecutor,
+) (*compactedSSTFlowControlConfig, error) {
+	soft, err := getTiKVConfigValues(ctx, execCtx, tikvSoftPendingCompactionBytesLimit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	hard, err := getTiKVConfigValues(ctx, execCtx, tikvHardPendingCompactionBytesLimit)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(soft) == 0 || len(hard) == 0 {
+		return nil, nil
+	}
+	return &compactedSSTFlowControlConfig{
+		soft: soft,
+		hard: hard,
+	}, nil
+}
+
+func getTiKVConfigValues(
+	ctx context.Context,
+	execCtx sqlexec.RestrictedSQLExecutor,
+	name string,
+) ([]tikvConfigValue, error) {
+	rows, fields, errSQL := execCtx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		"show config where name = %? and type = 'tikv'",
+		name,
+	)
+	if errSQL != nil {
+		return nil, errSQL
+	}
+
+	configs := make([]tikvConfigValue, 0, len(rows))
+	for _, row := range rows {
+		d := row.GetDatum(1, &fields[1].Column.FieldType)
+		instance, err := d.ToString()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		d = row.GetDatum(3, &fields[3].Column.FieldType)
+		value, err := d.ToString()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		configs = append(configs, tikvConfigValue{
+			instance: instance,
+			value:    value,
+		})
+	}
+	return configs, nil
+}
+
+func setTiKVConfig(
+	ctx context.Context,
+	execCtx sqlexec.RestrictedSQLExecutor,
+	name string,
+	value string,
+) error {
+	_, _, err := execCtx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		"set config tikv `"+name+"`=%?",
+		value,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to set config `%s`=%s", name, value)
+	}
+	return nil
+}
+
+func maxTiKVConfigBytes(configs []tikvConfigValue) uint64 {
+	maxBytes := uint64(0)
+	for _, config := range configs {
+		value, err := parseByteSizeConfig(config.value)
+		if err != nil {
+			log.Warn("[Compacted SST Restore] failed to parse TiKV flow-control config value",
+				zap.String("instance", config.instance),
+				zap.String("value", config.value),
+				zap.Error(err))
+			continue
+		}
+		maxBytes = max(maxBytes, value)
+	}
+	return maxBytes
+}
+
+func allTiKVConfigsAtLeast(configs []tikvConfigValue, target uint64) bool {
+	if len(configs) == 0 {
+		return false
+	}
+	for _, config := range configs {
+		value, err := parseByteSizeConfig(config.value)
+		if err != nil {
+			log.Warn("[Compacted SST Restore] failed to parse TiKV flow-control config value",
+				zap.String("instance", config.instance),
+				zap.String("value", config.value),
+				zap.Error(err))
+			return false
+		}
+		if value < target {
+			return false
+		}
+	}
+	return true
+}
+
+func parseByteSizeConfig(s string) (uint64, error) {
+	v, err := units.RAMInBytes(s)
+	if err != nil {
+		v, err = units.FromHumanSize(s)
+	}
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if v < 0 {
+		return 0, errors.Errorf("invalid negative byte size: %s", s)
+	}
+	return uint64(v), nil
+}
+
+func formatBytes(bytes uint64) string {
+	for _, unit := range []struct {
+		bytes  uint64
+		suffix string
+	}{
+		{uint64(units.TiB), "TiB"},
+		{uint64(units.GiB), "GiB"},
+		{uint64(units.MiB), "MiB"},
+		{uint64(units.KiB), "KiB"},
+	} {
+		if bytes >= unit.bytes && bytes%unit.bytes == 0 {
+			return strconv.FormatUint(bytes/unit.bytes, 10) + unit.suffix
+		}
+	}
+	return strconv.FormatUint(bytes, 10) + "B"
+}
+
+func saturatingAddUint64(a, b uint64) uint64 {
+	if math.MaxUint64-a < b {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
+func saturatingMulUint64(a uint64, b uint64) uint64 {
+	if b != 0 && a > math.MaxUint64/b {
+		return math.MaxUint64
+	}
+	return a * b
+}
+
+func ceilDivUint64(a, b uint64) uint64 {
+	if b == 0 {
+		return 0
+	}
+	if a == 0 {
+		return 0
+	}
+	return 1 + (a-1)/b
+}
+
+func logCompactedSSTFlowControlEstimate(
+	estimate compactedSSTFlowControlEstimate,
+	targetSoft uint64,
+	targetHard uint64,
+) {
+	log.Info("[Compacted SST Restore] estimated added bytes by TiKV store",
+		zap.Uint64("snapshot-restore-bytes", estimate.snapshotRestoreBytes),
+		zap.String("snapshot-restore-size", formatBytes(estimate.snapshotRestoreBytes)),
+		zap.Uint64("compacted-sst-bytes", estimate.compactedSSTBytes),
+		zap.String("compacted-sst-size", formatBytes(estimate.compactedSSTBytes)),
+		zap.Uint("store-count", estimate.storeCount),
+		zap.Uint("replica-count", estimate.replicaCount),
+		zap.Uint64("l6-bytes-per-store", estimate.l6BytesPerStore),
+		zap.String("l6-size-per-store", formatBytes(estimate.l6BytesPerStore)),
+		zap.Uint64("l5-bytes-per-store", estimate.l5BytesPerStore),
+		zap.String("l5-size-per-store", formatBytes(estimate.l5BytesPerStore)),
+		zap.Uint64("estimated-pending-compaction-bytes", estimate.pendingBytes),
+		zap.String("estimated-pending-compaction-size", formatBytes(estimate.pendingBytes)))
+	log.Info("[Compacted SST Restore] target TiKV flow-control configs",
+		zap.String("soft-pending-compaction-bytes-limit", formatBytes(targetSoft)),
+		zap.String("hard-pending-compaction-bytes-limit", formatBytes(targetHard)))
+}

--- a/br/pkg/restore/log_client/log_file_manager.go
+++ b/br/pkg/restore/log_client/log_file_manager.go
@@ -323,13 +323,16 @@ func (rc *LogFileManager) collectDDLFilesAndPrepareCache(
 	if fs.Err != nil {
 		return nil, errors.Annotatef(fs.Err, "failed to collect from files")
 	}
-	log.Info("finish to collect all ddl files", zap.Duration("take", time.Since(start)), zap.Int("file count", len(fs.Item)))
 
 	dataFileInfos := make([]*backuppb.DataFileInfo, 0)
 	for _, g := range fs.Item {
 		rc.helper.InitCacheEntry(g.Path, countReadableMetaKVFiles(g.FileMetas))
 		dataFileInfos = append(dataFileInfos, g.FileMetas...)
 	}
+	log.Info("finish to collect all ddl files",
+		zap.Duration("take", time.Since(start)),
+		zap.Int("ddl file count", len(dataFileInfos)),
+	)
 
 	return dataFileInfos, nil
 }

--- a/br/pkg/restore/log_client/log_file_manager.go
+++ b/br/pkg/restore/log_client/log_file_manager.go
@@ -323,7 +323,7 @@ func (rc *LogFileManager) collectDDLFilesAndPrepareCache(
 	if fs.Err != nil {
 		return nil, errors.Annotatef(fs.Err, "failed to collect from files")
 	}
-	log.Info("finish to collect all ddl files", zap.Duration("take", time.Since(start)))
+	log.Info("finish to collect all ddl files", zap.Duration("take", time.Since(start)), zap.Int("file count", len(fs.Item)))
 
 	dataFileInfos := make([]*backuppb.DataFileInfo, 0)
 	for _, g := range fs.Item {

--- a/br/pkg/restore/snap_client/client.go
+++ b/br/pkg/restore/snap_client/client.go
@@ -237,11 +237,8 @@ func (rc *SnapClient) GetSupportPolicy() bool {
 }
 
 func (rc *SnapClient) updateConcurrency() {
-	// we believe 32 is large enough for download worker pool.
-	// it won't reach the limit if sst files distribute evenly.
-	// when restore memory usage is still too high, we should reduce concurrencyPerStore
-	// to sarifice some speed to reduce memory usage.
-	count := uint(rc.storeCount) * rc.concurrencyPerStore * 32
+	const downloadWorkerPoolSizePerStore uint = 7186
+	count := uint(rc.storeCount) * downloadWorkerPoolSizePerStore
 	log.Info("download coarse worker pool", zap.Uint("size", count))
 	rc.workerPool = tidbutil.NewWorkerPool(count, "file")
 }

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -23,6 +24,8 @@ import (
 	"github.com/pingcap/tidb/pkg/util/redact"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type EventType int
@@ -73,7 +76,15 @@ type AdvancerExt struct {
 var (
 	// etcd's default periodic watch progress is too sparse for failover, so request it proactively.
 	metadataWatchProgressInterval = 30 * time.Second
+	metadataWatchCreateTimeouts   = []time.Duration{5 * time.Second, 10 * time.Second, 15 * time.Second}
+	metadataRequestTimeouts       = []time.Duration{5 * time.Second, 10 * time.Second, 15 * time.Second}
 	metadataWatchIdleTimeout      = 90 * time.Second
+)
+
+const (
+	metadataWatchCreating int32 = iota
+	metadataWatchCreated
+	metadataWatchCreateTimedOut
 )
 
 func errorEvent(err error) TaskEvent {
@@ -106,6 +117,60 @@ func requestWatchProgress(ctx context.Context, watcher clientv3.Watcher) error {
 func watchIdleTimeoutError(target string) error {
 	return errors.Errorf("watching %s timed out after %s without etcd progress",
 		target, metadataWatchIdleTimeout)
+}
+
+func isRetryableMetadataRequestError(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if errors.Cause(err) == context.DeadlineExceeded {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.DeadlineExceeded, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func runMetadataRequestWithRetry[T any](
+	ctx context.Context,
+	warnMessage string,
+	fields []zap.Field,
+	request func(context.Context) (T, error),
+) (T, error) {
+	var (
+		lastErr error
+		zero    T
+	)
+	for attempt, timeout := range metadataRequestTimeouts {
+		requestCtx, cancel := context.WithTimeout(ctx, timeout)
+		resp, err := request(requestCtx)
+		cancel()
+		if err == nil {
+			return resp, nil
+		}
+
+		lastErr = err
+		retryable := attempt+1 < len(metadataRequestTimeouts) &&
+			isRetryableMetadataRequestError(ctx, err)
+		logFields := make([]zap.Field, 0, len(fields)+7)
+		logFields = append(logFields, zap.String("category", "log backup advancer"))
+		logFields = append(logFields, fields...)
+		logFields = append(logFields,
+			zap.Int("attempt", attempt+1),
+			zap.Int("max-attempts", len(metadataRequestTimeouts)),
+			zap.Bool("retry", retryable),
+			zap.Duration("timeout", timeout),
+			logutil.ShortError(err))
+		log.Warn(warnMessage, logFields...)
+		if retryable {
+			continue
+		}
+		return zero, err
+	}
+	return zero, lastErr
 }
 
 func (t AdvancerExt) toTaskEvent(ctx context.Context, event *clientv3.Event) (TaskEvent, error) {
@@ -170,8 +235,9 @@ func (t AdvancerExt) eventFromWatch(ctx context.Context, resp clientv3.WatchResp
 }
 
 func (t AdvancerExt) startListen(ctx context.Context, rev int64, ch chan<- TaskEvent) {
-	taskCh := t.Client.Watcher.Watch(ctx, PrefixOfTask(), clientv3.WithPrefix(), clientv3.WithRev(rev))
-	pauseCh := t.Client.Watcher.Watch(ctx, PrefixOfPause(), clientv3.WithPrefix(), clientv3.WithRev(rev))
+	watcher := t.getWatcher()
+	taskCh := watcher.Watch(ctx, PrefixOfTask(), clientv3.WithPrefix(), clientv3.WithRev(rev))
+	pauseCh := watcher.Watch(ctx, PrefixOfPause(), clientv3.WithPrefix(), clientv3.WithRev(rev))
 
 	// inner function def
 	handleResponse := func(resp clientv3.WatchResponse) bool {
@@ -312,7 +378,19 @@ func (t MetaDataClient) WaitGlobalCheckpointAdvance(ctx context.Context, taskNam
 
 func (t MetaDataClient) getGlobalCheckpointWithRevision(ctx context.Context, taskName string) (uint64, int64, error) {
 	key := GlobalCheckpointOf(taskName)
-	resp, err := t.KV.Get(ctx, key)
+	redactedKey := redact.Key([]byte(key))
+	resp, err := runMetadataRequestWithRetry(ctx,
+		"failed to get global checkpoint from metadata store",
+		[]zap.Field{
+			zap.String("key", redactedKey),
+			zap.String("task", taskName),
+		},
+		func(requestCtx context.Context) (*clientv3.GetResponse, error) {
+			failpoint.Inject("advancer_get_global_checkpoint_request_timeout", func(val failpoint.Value) {
+				failpoint.Return(nil, context.DeadlineExceeded)
+			})
+			return t.KV.Get(requestCtx, key)
+		})
 	if err != nil {
 		return 0, 0, err
 	}
@@ -326,7 +404,9 @@ func (t MetaDataClient) getGlobalCheckpointWithRevision(ctx context.Context, tas
 	if err != nil {
 		return 0, 0, err
 	}
-	return checkpoint, firstKV.ModRevision, nil
+	// Watch from the response revision rather than the key's ModRevision. The key
+	// can stay unchanged long enough for its ModRevision to be compacted.
+	return checkpoint, resp.Header.Revision, nil
 }
 
 func (t MetaDataClient) waitCheckpointEvent(
@@ -335,9 +415,61 @@ func (t MetaDataClient) waitCheckpointEvent(
 	current uint64,
 	rev int64,
 ) error {
-	watchCtx, cancelWatch := context.WithCancel(clientv3.WithRequireLeader(ctx))
+	redactedKey := redact.Key([]byte(key))
+	var (
+		watchCtx    context.Context
+		cancelWatch context.CancelFunc
+		watcher     clientv3.Watcher
+		watchCh     clientv3.WatchChan
+	)
+	for attempt, timeout := range metadataWatchCreateTimeouts {
+		watchCtx, cancelWatch = context.WithCancel(clientv3.WithRequireLeader(ctx))
+		// etcd Watch may block before returning the watch channel when creating the watch stream.
+		watcher = t.getWatcher()
+		var watchCreateState atomic.Int32
+		watchCreateTimer := time.AfterFunc(timeout, func() {
+			if !watchCreateState.CompareAndSwap(metadataWatchCreating, metadataWatchCreateTimedOut) {
+				return
+			}
+			log.Warn("etcd watch creation timed out, resetting metadata watcher",
+				zap.String("category", "log backup advancer"),
+				zap.String("key", redactedKey),
+				zap.Uint64("current-checkpoint", current),
+				zap.Int64("revision", rev),
+				zap.Int("attempt", attempt+1),
+				zap.Int("max-attempts", len(metadataWatchCreateTimeouts)),
+				zap.Bool("retry", attempt+1 < len(metadataWatchCreateTimeouts)),
+				zap.Duration("timeout", timeout))
+			cancelWatch()
+			t.resetWatcher()
+		})
+		watchCh = watcher.Watch(watchCtx, key, clientv3.WithRev(rev), clientv3.WithProgressNotify())
+		if watchCreateState.CompareAndSwap(metadataWatchCreating, metadataWatchCreated) {
+			watchCreateTimer.Stop()
+		}
+		if watchCreateState.Load() == metadataWatchCreateTimedOut {
+			log.Warn("global checkpoint watch returned after creation timeout",
+				zap.String("category", "log backup advancer"),
+				zap.String("key", redactedKey),
+				zap.Uint64("current-checkpoint", current),
+				zap.Int64("revision", rev),
+				zap.Int("attempt", attempt+1),
+				zap.Int("max-attempts", len(metadataWatchCreateTimeouts)))
+			cancelWatch()
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if attempt+1 < len(metadataWatchCreateTimeouts) {
+				continue
+			}
+			return berrors.ErrPiTRCheckpointWatchRestart.GenWithStackByArgs()
+		}
+		break
+	}
+	if watchCh == nil {
+		return berrors.ErrPiTRCheckpointWatchRestart.GenWithStackByArgs()
+	}
 	defer cancelWatch()
-	watchCh := t.Watcher.Watch(watchCtx, key, clientv3.WithRev(rev), clientv3.WithProgressNotify())
 	progressTicker := time.NewTicker(metadataWatchProgressInterval)
 	defer progressTicker.Stop()
 	idleTimer := time.NewTimer(metadataWatchIdleTimeout)
@@ -345,13 +477,31 @@ func (t MetaDataClient) waitCheckpointEvent(
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("stop waiting for global checkpoint event because context is done",
+				zap.String("category", "log backup advancer"),
+				zap.String("key", redactedKey),
+				zap.Uint64("current-checkpoint", current),
+				zap.Int64("revision", rev),
+				logutil.ShortError(ctx.Err()))
 			return ctx.Err()
 		case resp, ok := <-watchCh:
 			resetWatchIdleTimer(idleTimer)
 			if !ok {
+				log.Warn("global checkpoint watch channel closed",
+					zap.String("category", "log backup advancer"),
+					zap.String("key", redactedKey),
+					zap.Uint64("current-checkpoint", current),
+					zap.Int64("revision", rev))
 				return berrors.ErrPiTRCheckpointWatchRestart.GenWithStackByArgs()
 			}
 			if err := resp.Err(); err != nil {
+				log.Warn("global checkpoint watch response has error",
+					zap.String("category", "log backup advancer"),
+					zap.String("key", redactedKey),
+					zap.Uint64("current-checkpoint", current),
+					zap.Int64("revision", rev),
+					zap.Int64("compact-revision", resp.CompactRevision),
+					logutil.ShortError(err))
 				if resp.CompactRevision != 0 {
 					return berrors.ErrPiTRCheckpointWatchRestart.GenWithStackByArgs()
 				}
@@ -370,10 +520,22 @@ func (t MetaDataClient) waitCheckpointEvent(
 				}
 			}
 		case <-progressTicker.C:
-			if err := requestWatchProgress(watchCtx, t.Watcher); err != nil {
+			if err := requestWatchProgress(watchCtx, watcher); err != nil {
+				log.Warn("failed to request global checkpoint watch progress",
+					zap.String("category", "log backup advancer"),
+					zap.String("key", redactedKey),
+					zap.Uint64("current-checkpoint", current),
+					zap.Int64("revision", rev),
+					logutil.ShortError(err))
 				return err
 			}
 		case <-idleTimer.C:
+			log.Warn("global checkpoint watch idle timeout",
+				zap.String("category", "log backup advancer"),
+				zap.String("key", redactedKey),
+				zap.Uint64("current-checkpoint", current),
+				zap.Int64("revision", rev),
+				zap.Duration("timeout", metadataWatchIdleTimeout))
 			return watchIdleTimeoutError("global checkpoint")
 		}
 	}
@@ -392,6 +554,7 @@ func parseGlobalCheckpointValue(value []byte) (uint64, error) {
 func (t AdvancerExt) UploadV3GlobalCheckpointForTask(ctx context.Context, taskName string, checkpoint uint64) error {
 	key := GlobalCheckpointOf(taskName)
 	value := string(encodeUint64(checkpoint))
+	redactedKey := redact.Key([]byte(key))
 	oldValue, err := t.GetGlobalCheckpointForTask(ctx, taskName)
 	if err != nil {
 		return err
@@ -403,7 +566,26 @@ func (t AdvancerExt) UploadV3GlobalCheckpointForTask(ctx context.Context, taskNa
 		return nil
 	}
 
-	_, err = t.KV.Put(ctx, key, value)
+	_, err = runMetadataRequestWithRetry(ctx,
+		"failed to upload global checkpoint to metadata store",
+		[]zap.Field{
+			zap.String("key", redactedKey),
+			zap.String("task", taskName),
+			zap.Uint64("checkpoint", checkpoint),
+		},
+		func(requestCtx context.Context) (struct{}, error) {
+			failpoint.Inject("advancer_upload_global_checkpoint_request_timeout", func(val failpoint.Value) {
+				failpoint.Return(struct{}{}, context.DeadlineExceeded)
+			})
+			_, err = t.KV.Put(requestCtx, key, value)
+			if err == nil {
+				failpoint.Inject("advancer_upload_global_checkpoint_commit_timeout", func(val failpoint.Value) {
+					err = context.DeadlineExceeded
+				})
+			}
+			return struct{}{}, err
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -386,7 +386,7 @@ func (t MetaDataClient) getGlobalCheckpointWithRevision(ctx context.Context, tas
 			zap.String("task", taskName),
 		},
 		func(requestCtx context.Context) (*clientv3.GetResponse, error) {
-			failpoint.Inject("advancer_get_global_checkpoint_request_timeout", func(val failpoint.Value) {
+			failpoint.Inject("advancer_get_global_checkpoint_request_timeout", func() {
 				failpoint.Return(nil, context.DeadlineExceeded)
 			})
 			return t.KV.Get(requestCtx, key)
@@ -574,12 +574,12 @@ func (t AdvancerExt) UploadV3GlobalCheckpointForTask(ctx context.Context, taskNa
 			zap.Uint64("checkpoint", checkpoint),
 		},
 		func(requestCtx context.Context) (struct{}, error) {
-			failpoint.Inject("advancer_upload_global_checkpoint_request_timeout", func(val failpoint.Value) {
+			failpoint.Inject("advancer_upload_global_checkpoint_request_timeout", func() {
 				failpoint.Return(struct{}{}, context.DeadlineExceeded)
 			})
 			_, err = t.KV.Put(requestCtx, key, value)
 			if err == nil {
-				failpoint.Inject("advancer_upload_global_checkpoint_commit_timeout", func(val failpoint.Value) {
+				failpoint.Inject("advancer_upload_global_checkpoint_commit_timeout", func() {
 					err = context.DeadlineExceeded
 				})
 			}

--- a/br/pkg/streamhelper/client.go
+++ b/br/pkg/streamhelper/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
@@ -65,6 +66,24 @@ type MetaDataClient struct {
 
 func NewMetaDataClient(c *clientv3.Client) *MetaDataClient {
 	return &MetaDataClient{c}
+}
+
+var metadataWatcherMu sync.Mutex
+
+func (c MetaDataClient) getWatcher() clientv3.Watcher {
+	metadataWatcherMu.Lock()
+	defer metadataWatcherMu.Unlock()
+	return c.Client.Watcher
+}
+
+func (c MetaDataClient) resetWatcher() {
+	metadataWatcherMu.Lock()
+	oldWatcher := c.Client.Watcher
+	c.Client.Watcher = clientv3.NewWatcher(c.Client)
+	metadataWatcherMu.Unlock()
+	if oldWatcher != nil {
+		_ = oldWatcher.Close()
+	}
 }
 
 // ParseCheckpoint parses the checkpoint from a key & value pair.

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -99,3 +99,11 @@ func SetMetadataWatchProgressForTest(interval, timeout time.Duration) func() {
 		metadataWatchIdleTimeout = oldTimeout
 	}
 }
+
+func GetGlobalCheckpointWithRevisionForTest(
+	c MetaDataClient,
+	ctx context.Context,
+	taskName string,
+) (uint64, int64, error) {
+	return c.getGlobalCheckpointWithRevision(ctx, taskName)
+}

--- a/br/pkg/streamhelper/export_test.go
+++ b/br/pkg/streamhelper/export_test.go
@@ -101,8 +101,8 @@ func SetMetadataWatchProgressForTest(interval, timeout time.Duration) func() {
 }
 
 func GetGlobalCheckpointWithRevisionForTest(
-	c MetaDataClient,
 	ctx context.Context,
+	c MetaDataClient,
 	taskName string,
 ) (uint64, int64, error) {
 	return c.getGlobalCheckpointWithRevision(ctx, taskName)

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -150,6 +150,18 @@ func TestIntegration(t *testing.T) {
 	t.Run("TestCheckpointWatchProgressTimeout", func(t *testing.T) {
 		testCheckpointWatchProgressTimeout(t, streamhelper.AdvancerExt{MetaDataClient: metaCli})
 	})
+	t.Run("TestGlobalCheckpointRevisionSurvivesCompaction", func(t *testing.T) {
+		testGlobalCheckpointRevisionSurvivesCompaction(t, streamhelper.AdvancerExt{MetaDataClient: metaCli})
+	})
+	t.Run("TestGetGlobalCheckpointRetriesTimeout", func(t *testing.T) {
+		testGetGlobalCheckpointRetriesTimeout(t, streamhelper.AdvancerExt{MetaDataClient: metaCli})
+	})
+	t.Run("TestUploadGlobalCheckpointRetriesTimeout", func(t *testing.T) {
+		testUploadGlobalCheckpointRetriesTimeout(t, streamhelper.AdvancerExt{MetaDataClient: metaCli})
+	})
+	t.Run("TestUploadGlobalCheckpointRetriesCommitTimeout", func(t *testing.T) {
+		testUploadGlobalCheckpointRetriesCommitTimeout(t, streamhelper.AdvancerExt{MetaDataClient: metaCli})
+	})
 }
 
 func TestChecking(t *testing.T) {
@@ -396,6 +408,94 @@ func testStreamCheckpoint(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	ts, err = metaCli.GetGlobalCheckpointForTask(ctx, task)
 	req.NoError(err)
 	req.EqualValues(0, ts)
+}
+
+func testGlobalCheckpointRevisionSurvivesCompaction(t *testing.T, metaCli streamhelper.AdvancerExt) {
+	ctx := context.Background()
+	task := "checkpoint_revision_compaction"
+	req := require.New(t)
+
+	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 100))
+	_, checkpointRev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(metaCli.MetaDataClient, ctx, task)
+	req.NoError(err)
+
+	advanceRevisionPrefix := "/test/advance-revision/" + task + "/"
+	for i := range 5 {
+		_, err := metaCli.KV.Put(ctx, fmt.Sprintf("%s%d", advanceRevisionPrefix, i), "value")
+		req.NoError(err)
+	}
+	resp, err := metaCli.KV.Get(ctx, advanceRevisionPrefix, clientv3.WithPrefix(), clientv3.WithCountOnly())
+	req.NoError(err)
+	compactedRev := resp.Header.Revision
+	req.Greater(compactedRev, checkpointRev)
+	_, err = metaCli.KV.Compact(ctx, compactedRev)
+	req.NoError(err)
+
+	checkpoint, rev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(metaCli.MetaDataClient, ctx, task)
+	req.NoError(err)
+	req.EqualValues(100, checkpoint)
+	req.GreaterOrEqual(rev, compactedRev)
+}
+
+func testGetGlobalCheckpointRetriesTimeout(t *testing.T, metaCli streamhelper.AdvancerExt) {
+	ctx := context.Background()
+	task := "checkpoint_get_retry"
+	req := require.New(t)
+
+	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 200))
+	req.NoError(failpoint.Enable(
+		"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_get_global_checkpoint_request_timeout",
+		"2*return(true)"))
+	defer func() {
+		req.NoError(failpoint.Disable(
+			"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_get_global_checkpoint_request_timeout"))
+	}()
+
+	checkpoint, err := metaCli.GetGlobalCheckpointForTask(ctx, task)
+	req.NoError(err)
+	req.EqualValues(200, checkpoint)
+}
+
+func testUploadGlobalCheckpointRetriesTimeout(t *testing.T, metaCli streamhelper.AdvancerExt) {
+	ctx := context.Background()
+	task := "checkpoint_upload_retry"
+	req := require.New(t)
+
+	req.NoError(failpoint.Enable(
+		"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_upload_global_checkpoint_request_timeout",
+		"2*return(true)"))
+	defer func() {
+		req.NoError(failpoint.Disable(
+			"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_upload_global_checkpoint_request_timeout"))
+	}()
+
+	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 300))
+	checkpoint, err := metaCli.GetGlobalCheckpointForTask(ctx, task)
+	req.NoError(err)
+	req.EqualValues(300, checkpoint)
+}
+
+func testUploadGlobalCheckpointRetriesCommitTimeout(t *testing.T, metaCli streamhelper.AdvancerExt) {
+	ctx := context.Background()
+	task := "checkpoint_upload_commit_retry"
+	req := require.New(t)
+
+	req.NoError(failpoint.Enable(
+		"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_upload_global_checkpoint_commit_timeout",
+		"1*return(true)"))
+	defer func() {
+		req.NoError(failpoint.Disable(
+			"github.com/pingcap/tidb/br/pkg/streamhelper/advancer_upload_global_checkpoint_commit_timeout"))
+	}()
+	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 400))
+
+	checkpoint, err := metaCli.GetGlobalCheckpointForTask(ctx, task)
+	req.NoError(err)
+	req.EqualValues(400, checkpoint)
+	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 350))
+	checkpoint, err = metaCli.GetGlobalCheckpointForTask(ctx, task)
+	req.NoError(err)
+	req.EqualValues(400, checkpoint)
 }
 
 func testStoptask(t *testing.T, metaCli streamhelper.AdvancerExt) {

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -416,7 +416,7 @@ func testGlobalCheckpointRevisionSurvivesCompaction(t *testing.T, metaCli stream
 	req := require.New(t)
 
 	req.NoError(metaCli.UploadV3GlobalCheckpointForTask(ctx, task, 100))
-	_, checkpointRev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(metaCli.MetaDataClient, ctx, task)
+	_, checkpointRev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(ctx, metaCli.MetaDataClient, task)
 	req.NoError(err)
 
 	advanceRevisionPrefix := "/test/advance-revision/" + task + "/"
@@ -431,7 +431,7 @@ func testGlobalCheckpointRevisionSurvivesCompaction(t *testing.T, metaCli stream
 	_, err = metaCli.KV.Compact(ctx, compactedRev)
 	req.NoError(err)
 
-	checkpoint, rev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(metaCli.MetaDataClient, ctx, task)
+	checkpoint, rev, err := streamhelper.GetGlobalCheckpointWithRevisionForTest(ctx, metaCli.MetaDataClient, task)
 	req.NoError(err)
 	req.EqualValues(100, checkpoint)
 	req.GreaterOrEqual(rev, compactedRev)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -169,7 +169,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	// TODO remove experimental tag if it's stable
 	flags.Bool(flagOnline, false, "(experimental) Whether online when restore")
 	flags.String(flagGranularity, string(restore.CoarseGrained), "(deprecated) Whether split & scatter regions using fine-grained way during restore")
-	flags.Uint(flagConcurrencyPerStore, 64, "The size of thread pool on each store that executes tasks")
+	flags.Uint(flagConcurrencyPerStore, conn.DefaultImportNumGoroutines, "The size of thread pool on each store that executes tasks")
 	flags.Uint32(flagConcurrency, 128, "(deprecated) The size of thread pool on BR that executes tasks, "+
 		"where each task restores one SST file to TiKV")
 	flags.Uint64(FlagMergeRegionSizeBytes, conn.DefaultMergeRegionSizeBytes,
@@ -1268,6 +1268,21 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	// Set task summary to success status.
 	summary.SetSuccessStatus(true)
 	return nil
+}
+
+func adjustRestoreConcurrencyPerStoreFromTiKV(ctx context.Context, mgr *conn.Mgr, cfg *RestoreConfig) {
+	kvConfigs := &pconfig.KVConfig{
+		ImportGoroutines: cfg.ConcurrencyPerStore,
+		MergeRegionSize: pconfig.ConfigTerm[uint64]{
+			Modified: true,
+		},
+		MergeRegionKeyCount: pconfig.ConfigTerm[uint64]{
+			Modified: true,
+		},
+	}
+	httpCli := httputil.NewClient(mgr.GetTLSConfig())
+	mgr.ProcessTiKVConfigs(ctx, kvConfigs, httpCli)
+	cfg.ConcurrencyPerStore = kvConfigs.ImportGoroutines
 }
 
 func getMaxReplica(ctx context.Context, mgr *conn.Mgr) (cnt uint64, err error) {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -169,7 +169,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	// TODO remove experimental tag if it's stable
 	flags.Bool(flagOnline, false, "(experimental) Whether online when restore")
 	flags.String(flagGranularity, string(restore.CoarseGrained), "(deprecated) Whether split & scatter regions using fine-grained way during restore")
-	flags.Uint(flagConcurrencyPerStore, 128, "The size of thread pool on each store that executes tasks")
+	flags.Uint(flagConcurrencyPerStore, 64, "The size of thread pool on each store that executes tasks")
 	flags.Uint32(flagConcurrency, 128, "(deprecated) The size of thread pool on BR that executes tasks, "+
 		"where each task restores one SST file to TiKV")
 	flags.Uint64(FlagMergeRegionSizeBytes, conn.DefaultMergeRegionSizeBytes,

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -289,6 +289,8 @@ type RestoreConfig struct {
 	UseCheckpoint     bool   `json:"use-checkpoint" toml:"use-checkpoint"`
 	upstreamClusterID uint64 `json:"-" toml:"-"`
 	WaitTiflashReady  bool   `json:"wait-tiflash-ready" toml:"wait-tiflash-ready"`
+	// snapshotRestoreDataSize records the filtered snapshot files restored before PITR log restore.
+	snapshotRestoreDataSize uint64
 
 	// for phased PITR restore
 	RestorePhase   uint64 `json:"restore-phase" toml:"restore-phase"`
@@ -932,6 +934,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		return err
 	}
 	files, tables, dbs := filterRestoreFiles(client, cfg)
+	cfg.snapshotRestoreDataSize = totalBackupFileSize(files)
 	if len(dbs) == 0 && len(tables) != 0 {
 		return errors.Annotate(berrors.ErrRestoreInvalidBackup, "contain tables but no databases")
 	}
@@ -1309,6 +1312,14 @@ func EstimateTikvUsage(files []*backuppb.File, replicaCnt uint64, storeCnt uint6
 	}
 	log.Info("estimate tikv usage", zap.Uint64("total size", totalSize), zap.Uint64("replicaCnt", replicaCnt), zap.Uint64("store count", storeCnt))
 	return totalSize * replicaCnt / storeCnt
+}
+
+func totalBackupFileSize(files []*backuppb.File) uint64 {
+	totalSize := uint64(0)
+	for _, file := range files {
+		totalSize += file.GetSize_()
+	}
+	return totalSize
 }
 
 func EstimateTiflashUsage(tables []*metautil.Table, storeCnt uint64) uint64 {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1320,6 +1320,7 @@ func RunStreamRestore(
 		}
 	}
 	// restore log.
+	adjustRestoreConcurrencyPerStoreFromTiKV(ctx, mgr, cfg)
 	cfg.adjustRestoreConfigForStreamRestore()
 	if err := restoreStream(ctx, mgr, g, cfg, checkInfo.CheckpointInfo); err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -498,6 +498,38 @@ func KeepGcDisabled(g glue.Glue, store kv.Storage) (RestoreFunc, string, error) 
 	}, oldRatio, nil
 }
 
+// KeepRocksDBMaxBackgroundJobsLow limits RocksDB compaction jobs during restore and returns a restore function.
+func KeepRocksDBMaxBackgroundJobsLow(g glue.Glue, store kv.Storage) (RestoreFunc, string, error) {
+	se, err := g.CreateSession(store)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	execCtx := se.GetSessionCtx().GetRestrictedSQLExecutor()
+	oldJobs, err := utils.GetRocksDBMaxBackgroundJobs(execCtx)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	if oldJobs == "" {
+		log.Warn("skip setting rocksdb.max-background-jobs because config item is unavailable")
+		return func(string) error {
+			return nil
+		}, oldJobs, nil
+	}
+
+	err = utils.SetRocksDBMaxBackgroundJobs(execCtx, utils.RocksDBMaxBackgroundJobsForRestore)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	return func(jobs string) error {
+		if jobs == "" {
+			return nil
+		}
+		return utils.SetRocksDBMaxBackgroundJobs(execCtx, jobs)
+	}, oldJobs, nil
+}
+
 // RunStreamCommand run all kinds of `stream task`
 func RunStreamCommand(
 	ctx context.Context,
@@ -1410,13 +1442,45 @@ func restoreStream(
 		log.Info("finish restoring gc")
 	}()
 
+	restoreRocksDBMaxBackgroundJobs, oldRocksDBMaxBackgroundJobs, err := KeepRocksDBMaxBackgroundJobsLow(g, mgr.GetStorage())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rocksDBMaxBackgroundJobsRestorable := false
+	rocksDBMaxBackgroundJobsCheckpointPersisted := !cfg.UseCheckpoint
+	defer func() {
+		if cfg.UseCheckpoint && rocksDBMaxBackgroundJobsCheckpointPersisted && !rocksDBMaxBackgroundJobsRestorable {
+			log.Info("skip restore the rocksdb.max-background-jobs for next retry")
+			return
+		}
+
+		log.Info("start to restore rocksdb.max-background-jobs", zap.String("jobs", oldRocksDBMaxBackgroundJobs))
+		if err := restoreRocksDBMaxBackgroundJobs(oldRocksDBMaxBackgroundJobs); err != nil {
+			log.Error("failed to restore rocksdb.max-background-jobs", zap.Error(err))
+		}
+		log.Info("finish restoring rocksdb.max-background-jobs")
+	}()
+
 	var sstCheckpointSets map[string]struct{}
 	if cfg.UseCheckpoint {
-		oldRatioFromCheckpoint, err := client.InitCheckpointMetadataForLogRestore(ctx, cfg.StartTS, cfg.RestoreTS, oldRatio, cfg.tiflashRecorder)
+		oldRatioFromCheckpoint, oldRocksDBMaxBackgroundJobsFromCheckpoint, snapshotRestoreDataSize, err := client.InitCheckpointMetadataForLogRestore(
+			ctx,
+			cfg.StartTS,
+			cfg.RestoreTS,
+			oldRatio,
+			oldRocksDBMaxBackgroundJobs,
+			cfg.tiflashRecorder,
+			cfg.snapshotRestoreDataSize,
+		)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		rocksDBMaxBackgroundJobsCheckpointPersisted = true
 		oldRatio = oldRatioFromCheckpoint
+		oldRocksDBMaxBackgroundJobs = oldRocksDBMaxBackgroundJobsFromCheckpoint
+		if snapshotRestoreDataSize > 0 {
+			cfg.snapshotRestoreDataSize = snapshotRestoreDataSize
+		}
 		sstCheckpointSets, err = client.InitCheckpointMetadataForCompactedSstRestore(ctx)
 		if err != nil {
 			return errors.Trace(err)
@@ -1532,6 +1596,7 @@ func restoreStream(
 	compactionIter := client.LogFileManager.GetCompactionIter(ctx)
 
 	var checkpointSSTProgress int64
+	var checkpointSSTSize uint64
 	updateSSTStatsWithCheckpoint := func(kvCount, size uint64) {
 		mu.Lock()
 		defer mu.Unlock()
@@ -1540,6 +1605,7 @@ func restoreStream(
 		checkpointTotalKVCount += kvCount
 		checkpointTotalSize += size
 		checkpointSSTProgress += int64(kvCount)
+		checkpointSSTSize += size
 	}
 	compactedSplitIter, err := client.WrapCompactedFilesIterWithSplitHelper(
 		ctx, compactionIter, rewriteRules, sstCheckpointSets,
@@ -1584,7 +1650,14 @@ func restoreStream(
 			p.IncBy(int64(kvCount))
 		}
 
-		err = client.RestoreSSTFileSets(ctx, sstFileSets, importModeSwitcher, p.IncBy)
+		err = client.RestoreSSTFileSets(
+			ctx,
+			sstFileSets,
+			importModeSwitcher,
+			cfg.snapshotRestoreDataSize,
+			checkpointSSTSize,
+			p.IncBy,
+		)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1675,6 +1748,7 @@ func restoreStream(
 	})
 
 	gcDisabledRestorable = true
+	rocksDBMaxBackgroundJobsRestorable = true
 
 	return nil
 }

--- a/br/pkg/utils/db.go
+++ b/br/pkg/utils/db.go
@@ -113,6 +113,8 @@ func GetGcRatio(ctx sqlexec.RestrictedSQLExecutor) (string, error) {
 const (
 	DefaultGcRatioVal  = "1.1"
 	DisabledGcRatioVal = "-1.0"
+
+	RocksDBMaxBackgroundJobsForRestore = "1"
 )
 
 func SetGcRatio(ctx sqlexec.RestrictedSQLExecutor, ratio string) error {
@@ -126,6 +128,38 @@ func SetGcRatio(ctx sqlexec.RestrictedSQLExecutor, ratio string) error {
 		return errors.Annotatef(err, "failed to set config `gc.ratio-threshold`=%s", ratio)
 	}
 	log.Warn("set config tikv gc.ratio-threshold", zap.String("ratio", ratio))
+	return nil
+}
+
+func GetRocksDBMaxBackgroundJobs(ctx sqlexec.RestrictedSQLExecutor) (string, error) {
+	valStr := "show config where name = 'rocksdb.max-background-jobs' and type = 'tikv'"
+	rows, fields, errSQL := ctx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(context.Background(), kv.InternalTxnBR),
+		nil,
+		valStr,
+	)
+	if errSQL != nil {
+		return "", errSQL
+	}
+	if len(rows) == 0 {
+		return "", nil
+	}
+
+	d := rows[0].GetDatum(3, &fields[3].Column.FieldType)
+	return d.ToString()
+}
+
+func SetRocksDBMaxBackgroundJobs(ctx sqlexec.RestrictedSQLExecutor, jobs string) error {
+	_, _, err := ctx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(context.Background(), kv.InternalTxnBR),
+		nil,
+		"set config tikv `rocksdb.max-background-jobs`=%?",
+		jobs,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to set config `rocksdb.max-background-jobs`=%s", jobs)
+	}
+	log.Warn("set config tikv rocksdb.max-background-jobs", zap.String("jobs", jobs))
 	return nil
 }
 

--- a/br/pkg/utils/db_test.go
+++ b/br/pkg/utils/db_test.go
@@ -40,7 +40,8 @@ func (m *mockRestrictedSQLExecutor) ExecRestrictedSQL(ctx context.Context, opts 
 
 	if strings.Contains(sql, "show config") {
 		return m.rows, m.fields, nil
-	} else if strings.Contains(sql, "set config") && strings.Contains(sql, "gc.ratio-threshold") {
+	} else if strings.Contains(sql, "set config") &&
+		(strings.Contains(sql, "gc.ratio-threshold") || strings.Contains(sql, "rocksdb.max-background-jobs")) {
 		value := args[0].(string)
 
 		for _, r := range m.rows {
@@ -98,6 +99,38 @@ func TestGc(t *testing.T) {
 	ratio, err = utils.GetGcRatio(s)
 	require.Nil(t, err)
 	require.Equal(t, ratio, "-1.0")
+}
+
+func TestRocksDBMaxBackgroundJobs(t *testing.T) {
+	fields := make([]*resolve.ResultField, 4)
+	tps := []*types.FieldType{
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+	}
+	for i := 0; i < len(tps); i++ {
+		rf := new(resolve.ResultField)
+		rf.Column = new(model.ColumnInfo)
+		rf.Column.FieldType = *tps[i]
+		fields[i] = rf
+	}
+	rows := make([]chunk.Row, 0, 2)
+	row := chunk.MutRowFromValues("tikv", " 127.0.0.1:20161", "rocksdb.max-background-jobs", "8").ToRow()
+	rows = append(rows, row)
+	row = chunk.MutRowFromValues("tikv", " 127.0.0.1:20162", "rocksdb.max-background-jobs", "8").ToRow()
+	rows = append(rows, row)
+
+	s := &mockRestrictedSQLExecutor{rows: rows, fields: fields}
+	jobs, err := utils.GetRocksDBMaxBackgroundJobs(s)
+	require.NoError(t, err)
+	require.Equal(t, "8", jobs)
+
+	err = utils.SetRocksDBMaxBackgroundJobs(s, utils.RocksDBMaxBackgroundJobsForRestore)
+	require.NoError(t, err)
+	jobs, err = utils.GetRocksDBMaxBackgroundJobs(s)
+	require.NoError(t, err)
+	require.Equal(t, utils.RocksDBMaxBackgroundJobsForRestore, jobs)
 }
 
 func TestRegionSplitInfo(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69422

Problem Summary:
1. v8.5.5 merge the reading metakv into one function, while v8.5.4 should both optimize the two seperate functions.
2. Too many task will reduce the average bandwidth for each task so that the io operations will increase for each task which is limited by disk iops.
3. Each etcd client request may randomly select one PD, which may be a io delay PD.
4. the tikv configuration `storage.flow-control.soft-pending-compaction-bytes-limit` will make healthy tikv busy and `rocksdb.max-background-jobs` will consume disk resources when log restore.
### What changed and how does it work?
1. optimize reading metakv
2. reduce the default tikv restore concurrency
3. fix etcd stuck when pd io delay by adding context timeout
5. set tikv configuration when log restore
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved restore throughput by reading meta-KV files concurrently with consistent results.
  * Added more robust etcd metadata checkpoint watching and request retry/timeout handling.

* **Bug Fixes**
  * Ensured deterministic restore behavior by serializing concurrent metadata rewrite operations.
  * Increased etcd watcher safety with guarded watcher lifecycle and clearer warning/error logging.
  * Adjusted default restore/import concurrency settings.

* **Tests**
  * Added deterministic meta-KV helpers plus concurrency and checkpoint retry/compaction integration coverage.

* **Documentation**
  * Refreshed restore/watch logs with improved counts and timeout/event details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->