### PR TITLE
statistics: log auto analyze window times in UTC with explicit offset

### DIFF
--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -379,8 +379,8 @@ func (sa *statsAnalyze) Close() {
 func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (startStr, endStr string, ok bool) {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	start, end, ok := checkAutoAnalyzeWindow(parameters)
-	startStr = start.Format("15:04")
-	endStr = end.Format("15:04")
+	startStr = start.UTC().Format("15:04 -0700")
+	endStr = end.UTC().Format("15:04 -0700")
 	return
 }
 

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -613,3 +613,33 @@ func TestAutoAnalyzeWithVectorIndex(t *testing.T) {
 	// Vector Index can not trigger auto analyze.
 	require.False(t, h.HandleAutoAnalyze())
 }
+
+func TestCheckAutoAnalyzeWindowLogsUTC(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	oriStart := tk.MustQuery("select @@tidb_auto_analyze_start_time").Rows()[0][0].(string)
+	oriEnd := tk.MustQuery("select @@tidb_auto_analyze_end_time").Rows()[0][0].(string)
+	defer func() {
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_start_time='%v'", oriStart))
+		tk.MustExec(fmt.Sprintf("set global tidb_auto_analyze_end_time='%v'", oriEnd))
+	}()
+
+	// Set window in UTC+8: 03:00 to 18:00 in +08:00 = 19:00 to 10:00 UTC
+	tk.MustExec("set time_zone = '+08:00'")
+	tk.MustExec("set global tidb_auto_analyze_start_time = '03:00'")
+	tk.MustExec("set global tidb_auto_analyze_end_time = '18:00'")
+
+	se, err := dom.SysSessionPool().Get()
+	require.NoError(t, err)
+	defer dom.SysSessionPool().Put(se)
+	sctx := se.(sessionctx.Context)
+
+	startStr, endStr, _ := autoanalyze.CheckAutoAnalyzeWindow(sctx)
+
+	// The logged start/end must contain UTC offset so operators can compare with UTC log timestamps.
+	require.Contains(t, startStr, "+0000", "start time should be formatted in UTC")
+	require.Contains(t, endStr, "+0000", "end time should be formatted in UTC")
+	require.Equal(t, "19:00 +0000", startStr)
+	require.Equal(t, "10:00 +0000", endStr)
+}


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #69492

Problem Summary:

When `tidb_auto_analyze_start_time` / `tidb_auto_analyze_end_time` are configured in a
non-UTC timezone, the "Kill auto analyze process because it exceeded the window" warning
logs `start` and `end` as bare wall-clock times (e.g. `03:00`) without timezone context.
Since TiDB emits the `now` field in UTC, operators see a misleading log like:

    now=2026/06/26 10:04:34 +00:00  start=03:00  end=18:00

This appears as if `now` is inside the window, when in reality `start=03:00 +0800` is
`19:00 UTC` and `now` is correctly outside.


### What changed and how does it work?

`CheckAutoAnalyzeWindow` formats the times using `start.Format("15:04")`, which uses the
time value's embedded timezone (the one from the user's session when the variable was SET).
The comparison logic (`WithinDayTimePeriod`) converts to UTC before comparing, but the log
does not reflect this conversion.

## Fix

Format start/end in UTC with an explicit offset so the log is unambiguous:

    now=2026/06/26 10:04:34 +00:00  start=19:00 +0000  end=10:00 +0000

No scheduling behavior is changed — only diagnostic output.

## Test Plan

- `TestCheckAutoAnalyzeWindowLogsUTC`: configures window in +08:00, verifies the returned
  strings are in UTC with `+0000` suffix and correct converted hour values.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time-window output now includes the UTC offset, making auto-analyze schedule times clearer and consistent across time zones.
  * Added coverage to ensure the displayed start and end times are correctly converted and formatted in UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->