### PR TITLE
br: force-rebase autoid service after PiTR log replay for AUTO_ID_CAC…

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -62,6 +62,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/version"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/infoschema/issyncer"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
@@ -1555,6 +1556,58 @@ func (rc *LogClient) SetTableModeToNormal(ctx context.Context, schemaReplace *st
 	}
 	return nil
 }
+
+// RebaseAutoIDAllocatorsForSepAutoIncTables rebases the autoid service's in-memory allocators for tables that use AUTO_ID_CACHE=1
+func (rc *LogClient) RebaseAutoIDAllocatorsForSepAutoIncTables(ctx context.Context, schemaReplace *stream.SchemasReplace) error {
+    infoSchema := rc.dom.InfoSchema()
+    store := rc.dom.Store()
+    for _, dbReplace := range schemaReplace.DbReplaceMap {
+        if dbReplace.FilteredOut {
+            continue
+        }
+        for _, tableReplace := range dbReplace.TableMap {
+            if tableReplace.FilteredOut {
+                continue
+            }
+            tbl, exist := infoSchema.TableByID(ctx, tableReplace.TableID)
+            if !exist {
+                continue
+            }
+            tblInfo := tbl.Meta()
+            if !tblInfo.SepAutoInc() {
+                continue
+            }
+            // Read persisted IID directly from TiKV, bypassing service cache.
+            var currentEnd int64
+            err := kv.RunInNewTxn(ctx, store, false, func(_ context.Context, txn kv.Transaction) error {
+                idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbReplace.DbID, tblInfo.ID).IncrementID(model.TableInfoVersion5)
+                var err1 error
+                currentEnd, err1 = idAcc.Get()
+                return err1
+            })
+            if err != nil {
+                log.Warn("failed to read persisted auto-increment ID for rebase", ...)
+                continue
+            }
+            if currentEnd <= 0 {
+                continue
+            }
+            allocs := tbl.Allocators(nil)
+            for _, alloc := range allocs.Allocs {
+                if alloc.GetType() != autoid.AutoIncrementType {
+                    continue
+                }
+                if err := alloc.ForceRebase(currentEnd); err != nil {
+                    log.Warn("failed to force rebase auto-increment allocator after PiTR", ...)
+                    continue
+                }
+                log.Info("rebased auto-increment allocator after PiTR", ...)
+            }
+        }
+    }
+    return nil
+}
+
 
 // WrapCompactedFilesIterWithSplitHelper applies a splitting strategy to the compacted files iterator.
 // It uses a region splitter to handle the splitting logic based on the provided rules and checkpoint sets.

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1908,6 +1908,13 @@ func restoreStream(
 		return errors.Trace(err)
 	}
 
+	// Force-rebase autoid service allocators for AUTO_ID_CACHE=1 tables so
+	// their in-memory state reflects the PiTR-replayed persisted IID value.
+	if err = client.RebaseAutoIDAllocatorsForSepAutoIncTables(ctx, schemasReplace); err != nil {
+    	return errors.Trace(err)
+	}
+
+
 	if err = client.CleanUpKVFiles(ctx); err != nil {
 		return errors.Annotate(err, "failed to clean up")
 	}


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #69485

Problem Summary:
After PiTR (point-in-time recovery) restore, tables with `AUTO_ID_CACHE=1` can produce
duplicate key errors on INSERT because the autoid service's in-memory allocator is stale.

Root cause: PiTR log replay writes the correct auto-increment ID (e.g., 8000) directly to
TiKV via raw KV writes. However, the autoid service may have already cached the value from
the full snapshot restore (e.g., 4000) and batch-allocated a range [4001, 8000]. After log
replay, the service still thinks it owns that range and allocates IDs that collide with
restored rows.


### What changed and how does it work?

After PiTR log replay completes and schema reload finishes, iterate all restored tables
with `SepAutoInc() == true` (AUTO_ID_CACHE=1). For each, read the persisted IID directly
from TiKV (bypassing the service cache) and call `ForceRebase` to synchronize the service's
in-memory state.

This is safe because:
- `ForceRebase` is idempotent when the persisted value already matches
- It only affects AUTO_ID_CACHE=1 tables; traditional allocators are range-based and
  re-read from TiKV when their local cache is exhausted
- It runs after schema reload ensures the info schema is current, and before table mode
  transitions allow writes

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log restore handling for tables using separate auto-increment IDs, helping restored tables continue with the correct next ID.
  * Added a post-restore step to align in-memory auto-increment state with persisted values before cleanup, reducing the chance of ID conflicts after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->