### PR TITLE
dxf: classify data errors in finished task metric

### DIFF
--- a/pkg/dxf/framework/scheduler/BUILD.bazel
+++ b/pkg/dxf/framework/scheduler/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/dxf/framework/testutil",
         "//pkg/keyspace",
         "//pkg/kv",
+        "//pkg/lightning/common",
         "//pkg/sessionctx",
         "//pkg/testkit",
         "//pkg/testkit/testfailpoint",

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -800,12 +800,16 @@ func isDataErrorForMetric(taskErr error) bool {
 	// from the DXF scheduler. We can replace this when those error definitions are
 	// split out of the Lightning package.
 	//
-	// Examples:
+	// import-into examples:
 	// [Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk:
 	// encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0
 	// at offset 0: Value conversion failed for column 'event_id'. Expected type:
 	// bigint, received value: ?. Reason: [types:1292]Truncated incorrect DOUBLE value: '?'.
+	//
+	// add-index examples:
 	// [kv:1062]Duplicate entry '1' for key 't.idx'
-	return strings.Contains(errMsg, "ErrEncodeKV") && strings.Contains(errMsg, "Truncated incorrect") ||
-		strings.Contains(errMsg, "[kv:1062]") && strings.Contains(errMsg, "Duplicate entry")
+	isImportDataErr := strings.Contains(errMsg, "ErrEncodeKV") && (strings.Contains(errMsg, "Truncated incorrect") ||
+		strings.Contains(errMsg, "Incorrect datetime value"))
+	isUKDupEntryErr := strings.Contains(errMsg, "[kv:1062]") && strings.Contains(errMsg, "Duplicate entry")
+	return isImportDataErr || isUKDupEntryErr
 }

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -798,7 +798,9 @@ func isDataErrorForMetric(taskErr error) bool {
 	errMsg := taskErr.Error()
 	// Keep these checks string-based to avoid depending on Lightning error definitions
 	// from the DXF scheduler. We can replace this when those error definitions are
-	// split out of the Lightning package.
+	// split out of the Lightning package. DXF error serialization keeps only the
+	// outer error code, so nested data errors must be identified by their canonical
+	// messages.
 	//
 	// import-into examples:
 	// [Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk:
@@ -808,8 +810,13 @@ func isDataErrorForMetric(taskErr error) bool {
 	//
 	// add-index examples:
 	// [kv:1062]Duplicate entry '1' for key 't.idx'
-	isImportDataErr := strings.Contains(errMsg, "ErrEncodeKV") && (strings.Contains(errMsg, "Truncated incorrect") ||
-		strings.Contains(errMsg, "Incorrect datetime value"))
+	isImportDataErr := strings.Contains(errMsg, "ErrEncodeKV") &&
+		(strings.Contains(errMsg, "Value conversion failed for column") ||
+			(strings.Contains(errMsg, "Check constraint '") && strings.Contains(errMsg, "' is violated")) ||
+			strings.Contains(errMsg, "Table has no partition for value"))
+	isImportConflictErr := (strings.Contains(errMsg, "[executor:8167]") && strings.Contains(errMsg, "Duplicate key conflict found")) ||
+		(strings.Contains(errMsg, "ErrFoundDataConflictRecords") && strings.Contains(errMsg, "found data conflict records")) ||
+		(strings.Contains(errMsg, "ErrFoundIndexConflictRecords") && strings.Contains(errMsg, "found index conflict records"))
 	isUKDupEntryErr := strings.Contains(errMsg, "[kv:1062]") && strings.Contains(errMsg, "Duplicate entry")
-	return isImportDataErr || isUKDupEntryErr
+	return isImportDataErr || isImportConflictErr || isUKDupEntryErr
 }

--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -48,6 +48,10 @@ const (
 	// so we use a special error message to indicate that the task is cancelled
 	// by user.
 	taskCancelMsg = "cancelled by user"
+
+	metricStateAll       = "all"
+	metricStateCancelled = "cancelled"
+	metricStateDataError = "data-error"
 )
 
 var (
@@ -760,19 +764,48 @@ func getEligibleNodes(ctx context.Context, sch Scheduler, managedNodes []string)
 }
 
 func onTaskFinished(state proto.TaskState, taskErr error) {
-	// when task finishes, we classify the finished tasks into succeed/failed/cancelled
-	var metricState string
-
-	if state == proto.TaskStateSucceed || state == proto.TaskStateFailed {
-		metricState = state.String()
-	} else if state == proto.TaskStateReverted {
-		metricState = proto.TaskStateFailed.String()
-		if IsCancelledErr(taskErr) {
-			metricState = "cancelled"
-		}
-	}
+	// when task finishes, we classify the finished tasks into succeed/failed/cancelled/data-error.
+	metricState := getMetricState(state, taskErr)
 	if len(metricState) > 0 {
-		dxfmetric.FinishedTaskCounter.WithLabelValues("all").Inc()
+		dxfmetric.FinishedTaskCounter.WithLabelValues(metricStateAll).Inc()
 		dxfmetric.FinishedTaskCounter.WithLabelValues(metricState).Inc()
 	}
+}
+
+func getMetricState(state proto.TaskState, taskErr error) string {
+	switch state {
+	case proto.TaskStateSucceed:
+		return state.String()
+	case proto.TaskStateFailed:
+		return state.String()
+	case proto.TaskStateReverted:
+		if IsCancelledErr(taskErr) {
+			return metricStateCancelled
+		}
+		if isDataErrorForMetric(taskErr) {
+			return metricStateDataError
+		}
+		return proto.TaskStateFailed.String()
+	default:
+		return ""
+	}
+}
+
+func isDataErrorForMetric(taskErr error) bool {
+	if taskErr == nil {
+		return false
+	}
+	errMsg := taskErr.Error()
+	// Keep these checks string-based to avoid depending on Lightning error definitions
+	// from the DXF scheduler. We can replace this when those error definitions are
+	// split out of the Lightning package.
+	//
+	// Examples:
+	// [Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk:
+	// encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0
+	// at offset 0: Value conversion failed for column 'event_id'. Expected type:
+	// bigint, received value: ?. Reason: [types:1292]Truncated incorrect DOUBLE value: '?'.
+	// [kv:1062]Duplicate entry '1' for key 't.idx'
+	return strings.Contains(errMsg, "ErrEncodeKV") && strings.Contains(errMsg, "Truncated incorrect") ||
+		strings.Contains(errMsg, "[kv:1062]") && strings.Contains(errMsg, "Duplicate entry")
 }

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -748,30 +748,38 @@ func TestOnTaskFinished(t *testing.T) {
 		return values
 	}
 	onTaskFinished(proto.TaskStateSucceed, nil)
-	require.EqualValues(t, map[string]int{"all": 1, "succeed": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{metricStateAll: 1, "succeed": 1}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateReverted, nil)
-	require.EqualValues(t, map[string]int{"all": 2, "succeed": 1, "failed": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{metricStateAll: 2, "succeed": 1, "failed": 1}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateReverted, errors.New("some err"))
-	require.EqualValues(t, map[string]int{"all": 3, "succeed": 1, "failed": 2}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{metricStateAll: 3, "succeed": 1, "failed": 2}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateReverted, errors.New(taskCancelMsg))
-	require.EqualValues(t, map[string]int{"all": 4, "succeed": 1, "failed": 2, "cancelled": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{metricStateAll: 4, "succeed": 1, "failed": 2, metricStateCancelled: 1}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateFailed, errors.New("some err"))
-	require.EqualValues(t, map[string]int{"all": 5, "succeed": 1, "failed": 3, "cancelled": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{metricStateAll: 5, "succeed": 1, "failed": 3, metricStateCancelled: 1}, collectMetricsFn())
 	valueConversionErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
 		"encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0 at offset 0: " +
 		"Value conversion failed for column 'event_id'. Expected type: bigint, received value: ?. " +
 		"Reason: [types:1292]Truncated incorrect DOUBLE value: '?'."
 	onTaskFinished(proto.TaskStateReverted, errors.New(valueConversionErr))
-	require.EqualValues(t, map[string]int{"all": 6, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{
+		metricStateAll: 6, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 1,
+	}, collectMetricsFn())
 	datetimeConversionErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
 		"encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0 at offset 0: " +
 		"Value conversion failed for column 'created_at'. Expected type: datetime, received value: invalid. " +
 		"Reason: [types:1292]Incorrect datetime value: 'invalid' for column 'created_at' at row 1."
 	onTaskFinished(proto.TaskStateReverted, errors.New(datetimeConversionErr))
-	require.EqualValues(t, map[string]int{"all": 7, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 2}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{
+		metricStateAll: 7, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 2,
+	}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateReverted, errors.New("[kv:1062]Duplicate entry '1' for key 't.idx'"))
-	require.EqualValues(t, map[string]int{"all": 8, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 3}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{
+		metricStateAll: 8, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 3,
+	}, collectMetricsFn())
 	// noop for non-finished state.
 	onTaskFinished(proto.TaskStateRunning, nil)
-	require.EqualValues(t, map[string]int{"all": 8, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 3}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{
+		metricStateAll: 8, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 3,
+	}, collectMetricsFn())
 }

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -30,6 +30,7 @@ import (
 	schmock "github.com/pingcap/tidb/pkg/dxf/framework/scheduler/mock"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/lightning/common"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	utilmock "github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/prometheus/client_golang/prometheus"
@@ -773,6 +774,44 @@ func TestOnTaskFinished(t *testing.T) {
 	require.EqualValues(t, map[string]int{
 		metricStateAll: 7, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 2,
 	}, collectMetricsFn())
+	roundTripImportCastErr := func(column, columnType, value, reason string) error {
+		castErr := common.ErrCastValue.FastGenByArgs(column, columnType, value, reason)
+		encodeErr := common.ErrEncodeKV.Wrap(castErr).FastGenByArgs("data.csv", 0)
+		serializedErr := errors.Normalize(errors.GetErrStackMsg(encodeErr),
+			errors.RFCCodeText(string(common.ErrEncodeKV.RFCCode())),
+			errors.MySQLErrorCode(int(common.ErrEncodeKV.Code())))
+		errBytes, err := serializedErr.MarshalJSON()
+		require.NoError(t, err)
+		restoredErr := errors.Normalize("")
+		require.NoError(t, restoredErr.UnmarshalJSON(errBytes))
+		return restoredErr
+	}
+	dataTooLongErr := roundTripImportCastErr("name", "varchar(3)", "abcd",
+		"[types:1406]Data Too Long, field len 3, data len 4")
+	require.NotContains(t, dataTooLongErr.Error(), "ErrCastValue")
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted, dataTooLongErr))
+	notNullErr := roundTripImportCastErr("name", "varchar(10)", "NULL",
+		"[table:1048]Column 'name' cannot be null")
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted, notNullErr))
+	checkConstraintErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
+		"encode kv error in file data.csv:0 at offset 0: " +
+		"Check constraint 'positive_id' is violated."
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted, errors.New(checkConstraintErr)))
+	noPartitionErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
+		"encode kv error in file data.csv:0 at offset 0: " +
+		"Table has no partition for value 42"
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted, errors.New(noPartitionErr)))
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted,
+		errors.New("[executor:8167]Duplicate key conflict found. Please resolve conflicts in the input dataset")))
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted,
+		errors.New("[Lightning:Restore:ErrFoundDataConflictRecords]found data conflict records in table t")))
+	require.Equal(t, metricStateDataError, getMetricState(proto.TaskStateReverted,
+		errors.New("[Lightning:Restore:ErrFoundIndexConflictRecords]found index conflict records in table t")))
+	parseErr := "[Lightning:Restore:ErrEncodeKV]encode kv error in file data.csv:0 at offset 0: " +
+		"column count mismatch, expected 3, got 2"
+	require.Equal(t, proto.TaskStateFailed.String(), getMetricState(proto.TaskStateReverted, errors.New(parseErr)))
+	require.Equal(t, proto.TaskStateFailed.String(), getMetricState(proto.TaskStateReverted,
+		errors.New("Value conversion failed for column 'name'")))
 	onTaskFinished(proto.TaskStateReverted, errors.New("[kv:1062]Duplicate entry '1' for key 't.idx'"))
 	require.EqualValues(t, map[string]int{
 		metricStateAll: 8, "succeed": 1, "failed": 3, metricStateCancelled: 1, metricStateDataError: 3,

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -757,7 +757,15 @@ func TestOnTaskFinished(t *testing.T) {
 	require.EqualValues(t, map[string]int{"all": 4, "succeed": 1, "failed": 2, "cancelled": 1}, collectMetricsFn())
 	onTaskFinished(proto.TaskStateFailed, errors.New("some err"))
 	require.EqualValues(t, map[string]int{"all": 5, "succeed": 1, "failed": 3, "cancelled": 1}, collectMetricsFn())
+	valueConversionErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
+		"encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0 at offset 0: " +
+		"Value conversion failed for column 'event_id'. Expected type: bigint, received value: ?. " +
+		"Reason: [types:1292]Truncated incorrect DOUBLE value: '?'."
+	onTaskFinished(proto.TaskStateReverted, errors.New(valueConversionErr))
+	require.EqualValues(t, map[string]int{"all": 6, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 1}, collectMetricsFn())
+	onTaskFinished(proto.TaskStateReverted, errors.New("[kv:1062]Duplicate entry '1' for key 't.idx'"))
+	require.EqualValues(t, map[string]int{"all": 7, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 2}, collectMetricsFn())
 	// noop for non-finished state.
 	onTaskFinished(proto.TaskStateRunning, nil)
-	require.EqualValues(t, map[string]int{"all": 5, "succeed": 1, "failed": 3, "cancelled": 1}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{"all": 7, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 2}, collectMetricsFn())
 }

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -763,9 +763,15 @@ func TestOnTaskFinished(t *testing.T) {
 		"Reason: [types:1292]Truncated incorrect DOUBLE value: '?'."
 	onTaskFinished(proto.TaskStateReverted, errors.New(valueConversionErr))
 	require.EqualValues(t, map[string]int{"all": 6, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 1}, collectMetricsFn())
-	onTaskFinished(proto.TaskStateReverted, errors.New("[kv:1062]Duplicate entry '1' for key 't.idx'"))
+	datetimeConversionErr := "[Lightning:Restore:ErrEncodeKV]when encoding 1-th data row in this chunk: " +
+		"encode kv error in file orderlab/orderlab.shipment_events.000000000.csv.gz:0 at offset 0: " +
+		"Value conversion failed for column 'created_at'. Expected type: datetime, received value: invalid. " +
+		"Reason: [types:1292]Incorrect datetime value: 'invalid' for column 'created_at' at row 1."
+	onTaskFinished(proto.TaskStateReverted, errors.New(datetimeConversionErr))
 	require.EqualValues(t, map[string]int{"all": 7, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 2}, collectMetricsFn())
+	onTaskFinished(proto.TaskStateReverted, errors.New("[kv:1062]Duplicate entry '1' for key 't.idx'"))
+	require.EqualValues(t, map[string]int{"all": 8, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 3}, collectMetricsFn())
 	// noop for non-finished state.
 	onTaskFinished(proto.TaskStateRunning, nil)
-	require.EqualValues(t, map[string]int{"all": 7, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 2}, collectMetricsFn())
+	require.EqualValues(t, map[string]int{"all": 8, "succeed": 1, "failed": 3, "cancelled": 1, "data-error": 3}, collectMetricsFn())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

The DXF finished task metric currently classifies reverted tasks with user data errors as `failed`, which can trigger failure alerts even when the underlying cause is bad input data. Import Into Lightning encode/value conversion errors and add-index duplicate-key errors should be separated from infrastructure or framework failures.

### What changed and how does it work?

Extract the metric label selection from `onTaskFinished` into `getMetricState`.

Add a new `data-error` metric state for reverted tasks whose error text matches known user-data failures:

- Import errors containing `ErrEncodeKV` and canonical conversion, check-constraint, or no-matching-partition messages.
- Import duplicate conflicts from global-sort and local-sort conflict-record paths.
- Add unique index duplicate-key errors containing `[kv:1062]` and `Duplicate entry`.

The matching is intentionally string-based so the DXF scheduler does not depend on Lightning error definitions. A code comment records the real Lightning error example and the add-index duplicate-entry shape for future refactoring when the error definitions can be split out.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

#### Results

| Case | Persisted/runtime error | Metric delta | Verdict |
| --- | --- | --- | --- |
| Successful import | Job `finished`, DXF task `succeed` | `all +1`, `succeed +1` | PASS |
| Malformed numeric | `ErrEncodeKV` plus `Value conversion failed for column` | `all +1`, `data-error +1` | PASS |
| `VARCHAR` too long | `[types:1406] Data Too Long` inside conversion error | `all +1`, `data-error +1` | PASS |
| Invalid datetime | `[types:1292] Incorrect datetime value` inside conversion error | `all +1`, `data-error +1` | PASS |
| Explicit `NULL` | `[table:1048] Column ... cannot be null` inside conversion error | `all +1`, `data-error +1` | PASS |
| Missing required value | `[table:1364] Field ... doesn't have a default value` inside conversion error | `all +1`, `data-error +1` | PASS |
| Enforced `CHECK` | Feature flag was globally disabled; constraint was not enforced | No task | INCONCLUSIVE |
| No matching partition | `ErrEncodeKV ... Table has no partition for value 42` | `all +1`, `data-error +1` | PASS |
| Duplicate primary key | `[executor:8167] Duplicate key conflict found` | `all +1`, `data-error +1` | PASS |
| Duplicate unique key | `[executor:8167] Duplicate key conflict found` | `all +1`, `data-error +1` | PASS |
| Distributed add-unique-index | Persisted RFC code `kv:1062`; DDL rolled back | `all +1`, `data-error +1` | PASS |
| Parser negative control | Non-data `ErrEncodeKV` from unterminated quoted field | `all +1`, `failed +1` | PASS |
| Missing-source control | `[executor:8173]` precheck error created a prepare task | `all +1`, `failed +1` | Control assumption failed; classifier correct |

Final counters: `all=15`, `succeed=4`, `failed=2`, `cancelled=0`, `data-error=9`.


add index
```
create table t(id int); insert into t values(1),(1);
alter table t add unique index(id);

...

tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="all"} 1
tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="data-error"} 1
```
import into
```
create table t(id datetime);
import into t from 's3://mybucket/string.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000';

ERROR 1105 (HY000): when encoding 1-th data row in this chunk: encode kv error in file a.csv:0 at offset 0: Value conversion failed for column 'id'. Expected type: datetime BINARY, received value: "123123123". Reason: [types:1292]Incorrect datetime value: '123123123'.

tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="all"} 1
tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="data-error"} 1

create table t(id int);

ERROR 1105 (HY000): when encoding 1-th data row in this chunk: encode kv error in file string.csv:0 at offset 0: Value conversion failed for column 'id'. Expected type: int, received value: "aaa". Reason: [types:1292]Truncated incorrect DOUBLE value: 'aaa'.

tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="all"} 1
tidb_dxf_finished_task_total{keyspace_name="SYSTEM",state="data-error"} 1
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit and local validation commands:

```bash
./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run TestOnTaskFinished -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

The affected behavior is the label value emitted by the DXF finished task metric for the matched user-data error cases.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
DXF finished task metrics now classify known user-data errors as `data-error` instead of `failed`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved finished-task metrics by classifying reverted tasks into **cancelled**, **data-error**, or **failed** based on the encountered error.
  * User-cancelled tasks are now reported as **cancelled** instead of **failed**.
  * Specific data import and duplicate-entry failures are now tracked separately as **data-error**.
  * Finished-task totals are updated with a clearer breakdown across **all**, **failed**, **cancelled**, and **data-error**.
* **Tests**
  * Expanded metric assertions to cover additional error variants for **data-error** mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
