### PR TITLE
executor: collect stats delta for mlog purge

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -2393,6 +2393,11 @@ func (e *PurgeMaterializedViewLogExec) executePurgeMaterializedViewLog(
 		return err
 	}
 	defer e.ReleaseSysSession(releaseCtx, deleteSctx)
+	if collectorAware, ok := deleteSctx.(interface{ AttachStatsCollectorForInternalSession() func() }); ok {
+		// PURGE MATERIALIZED VIEW LOG deletes real MLOG rows through an internal
+		// session, so attach the stats collector to keep mysql.stats_meta.count in sync.
+		defer collectorAware.AttachStatsCollectorForInternalSession()()
+	}
 	deleteSessVars := deleteSctx.GetSessionVars()
 	restoreDeleteMaintenanceVars, err := applyMVMaintenanceSessionVars(
 		deleteSessVars,

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -2384,6 +2384,31 @@ func TestPurgeMaterializedViewLogWritesState(t *testing.T) {
 		Check(testkit.Rows("2"))
 }
 
+func TestPurgeMaterializedViewLogUpdatesStatsMetaRowCount(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_purge_stats_meta (id int primary key, v int)")
+	tk.MustExec("create materialized view log on t_purge_stats_meta (id, v) purge next date_add(now(), interval 1 hour)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("$mlog$t_purge_stats_meta"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	tk.MustExec("insert into t_purge_stats_meta values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50)")
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustQuery(fmt.Sprintf("select modify_count, count from mysql.stats_meta where table_id = %d", mlogID)).
+		Check(testkit.Rows("5 5"))
+
+	tk.MustExec("purge materialized view log on t_purge_stats_meta")
+	tk.MustQuery("select count(*) from `$mlog$t_purge_stats_meta`").Check(testkit.Rows("0"))
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustQuery(fmt.Sprintf("select modify_count, count from mysql.stats_meta where table_id = %d", mlogID)).
+		Check(testkit.Rows("10 0"))
+}
+
 func TestPurgeMaterializedViewLogNextTimeOnlyUpdatesForInternalSQL(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

Materialized view log writes are attached to foreground base-table DML, so their insert deltas are collected by the foreground session stats collector. However, `PURGE MATERIALIZED VIEW LOG` deletes real MLOG rows through an internal session, and that internal delete session did not attach a stats collector. As a result, `mysql.stats_meta.count` for MLOG tables could keep growing with inserts and miss purge delete deltas when auto analyze is disabled.

### What changed and how does it work?

Attach the internal-session stats collector to the MLOG purge delete session. This lets the normal table mutation path flush the purge delete delta to the stats collector after commit, keeping `mysql.stats_meta.count` in sync with actual MLOG row count.

A regression test verifies that after inserting five base rows, MLOG stats are `modify_count=5,count=5`; after purging the MLOG and dumping stats delta, stats become `modify_count=10,count=0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
GOCACHE=/tmp/tidb-gocache-mv-stats go test ./pkg/executor/test/ddl -run '^TestPurgeMaterializedViewLogUpdatesStatsMetaRowCount$' -tags=intest,deadlock -count=1
GOCACHE=/tmp/tidb-gocache-mv-stats go test ./pkg/executor/test/ddl -run '^TestPurgeMaterializedViewLog(WritesState|UpdatesStatsMetaRowCount)$' -tags=intest,deadlock -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect row count statistics after purging materialized view logs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Materialized view log purges now keep row-count statistics in sync after cleanup.
  * This helps ensure table statistics remain accurate following log removal.
* **Tests**
  * Added coverage confirming materialized view log purges update statistics as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->