### PR TITLE
server: reduce packet response buffer copies

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -290,7 +290,10 @@ func (cc *clientConn) authSwitchRequest(ctx context.Context, plugin string) ([]b
 		failpoint.Return([]byte(clientPlugin), nil)
 	})
 	enclen := 1 + len(clientPlugin) + 1 + len(cc.salt) + 1
-	data := cc.alloc.AllocWithLen(4, enclen)
+	data, err := cc.allocPacketBuffer(4, 4+enclen)
+	if err != nil {
+		return nil, err
+	}
 	data = append(data, mysql.AuthSwitchRequest) // switch request
 	data = append(data, []byte(clientPlugin)...)
 	data = append(data, byte(0x00)) // requires null
@@ -302,7 +305,7 @@ func (cc *clientConn) authSwitchRequest(ctx context.Context, plugin string) ([]b
 		data = append(data, cc.salt...)
 		data = append(data, 0)
 	}
-	err := cc.writePacket(data)
+	err = cc.writePacket(data)
 	if err != nil {
 		logutil.Logger(ctx).Debug("write response to client failed", zap.Error(err))
 		return nil, err
@@ -357,7 +360,10 @@ func (cc *clientConn) handshake(ctx context.Context) error {
 		return initErr
 	}
 
-	data := cc.alloc.AllocWithLen(4, 32)
+	data, err := cc.allocPacketBuffer(4, 32)
+	if err != nil {
+		return err
+	}
 	data = append(data, mysql.OKHeader)
 	data = append(data, 0, 0)
 	if cc.capability&mysql.ClientProtocol41 > 0 {
@@ -365,7 +371,7 @@ func (cc *clientConn) handshake(ctx context.Context) error {
 		data = append(data, 0, 0)
 	}
 
-	err := cc.writePacket(data)
+	err = cc.writePacket(data)
 	cc.pkt.SetSequence(0)
 	if err != nil {
 		err = errors.SuspendStack(err)
@@ -1598,7 +1604,10 @@ func (cc *clientConn) writeStats(ctx context.Context) error {
 	}
 	msg := fmt.Appendf(nil, "Uptime: %d  Threads: 0  Questions: 0  Slow queries: 0  Opens: 0  Flush tables: 0  Open tables: 0  Queries per second avg: 0.000",
 		uptime)
-	data := cc.alloc.AllocWithLen(4, len(msg))
+	data, err := cc.allocPacketBuffer(4, 4+len(msg))
+	if err != nil {
+		return err
+	}
 	data = append(data, msg...)
 
 	err = cc.writePacket(data)
@@ -1672,7 +1681,10 @@ func (cc *clientConn) writeOkWith(ctx context.Context, header byte, flush bool, 
 		enclen = util2.LengthEncodedIntSize(uint64(len(msg))) + len(msg)
 	}
 
-	data := cc.alloc.AllocWithLen(4, 32+enclen)
+	data, err := cc.allocPacketBuffer(4, 32+enclen)
+	if err != nil {
+		return err
+	}
 	data = append(data, header)
 	data = dump.LengthEncodedInt(data, affectedRows)
 	data = dump.LengthEncodedInt(data, lastInsertID)
@@ -1686,7 +1698,7 @@ func (cc *clientConn) writeOkWith(ctx context.Context, header byte, flush bool, 
 		data = dump.LengthEncodedString(data, []byte(msg))
 	}
 
-	err := cc.writePacket(data)
+	err = cc.writePacket(data)
 	if err != nil {
 		return err
 	}
@@ -1720,7 +1732,10 @@ func (cc *clientConn) writeError(ctx context.Context, e error) error {
 
 	cc.lastCode = m.Code
 	defer errno.IncrementError(m.Code, cc.user, cc.peerHost)
-	data := cc.alloc.AllocWithLen(4, 16+len(m.Message))
+	data, err := cc.allocPacketBuffer(4, 16+len(m.Message))
+	if err != nil {
+		return err
+	}
 	data = append(data, mysql.ErrHeader)
 	data = append(data, byte(m.Code), byte(m.Code>>8))
 	if cc.capability&mysql.ClientProtocol41 > 0 {
@@ -1730,7 +1745,7 @@ func (cc *clientConn) writeError(ctx context.Context, e error) error {
 
 	data = append(data, m.Message...)
 
-	err := cc.writePacket(data)
+	err = cc.writePacket(data)
 	if err != nil {
 		return err
 	}
@@ -1748,7 +1763,10 @@ func (cc *clientConn) writeEOF(ctx context.Context, serverStatus uint16) error {
 		return cc.writeOkWith(ctx, mysql.EOFHeader, false, serverStatus)
 	}
 
-	data := cc.alloc.AllocWithLen(4, 9)
+	data, err := cc.allocPacketBuffer(4, 9)
+	if err != nil {
+		return err
+	}
 
 	data = append(data, mysql.EOFHeader)
 	if cc.capability&mysql.ClientProtocol41 > 0 {
@@ -1756,21 +1774,40 @@ func (cc *clientConn) writeEOF(ctx context.Context, serverStatus uint16) error {
 		data = dump.Uint16(data, serverStatus)
 	}
 
-	err := cc.writePacket(data)
-	return err
+	return cc.writePacket(data)
 }
 
 func (cc *clientConn) writeReq(ctx context.Context, filePath string) error {
-	data := cc.alloc.AllocWithLen(4, 5+len(filePath))
+	data, err := cc.allocPacketBuffer(4, 5+len(filePath))
+	if err != nil {
+		return err
+	}
 	data = append(data, mysql.LocalInFileHeader)
 	data = append(data, filePath...)
 
-	err := cc.writePacket(data)
+	err = cc.writePacket(data)
 	if err != nil {
 		return err
 	}
 
 	return cc.flush(ctx)
+}
+
+func (cc *clientConn) allocPacketBuffer(length int, capacity int) ([]byte, error) {
+	if capacity < length {
+		capacity = length
+	}
+
+	if cc.pkt != nil {
+		buf, err := cc.pkt.AvailableWriteBuffer(capacity)
+		if err != nil {
+			return nil, err
+		}
+		if buf != nil {
+			return buf[:length], nil
+		}
+	}
+	return cc.alloc.AllocWithLen(length, capacity), nil
 }
 
 // getDataFromPath gets file contents from file path.
@@ -2459,11 +2496,13 @@ func (cc *clientConn) handleFieldList(ctx context.Context, sql string) (err erro
 	if err != nil {
 		return err
 	}
-	data := cc.alloc.AllocWithLen(4, 1024)
 	cc.initResultEncoder(ctx)
 	defer cc.rsEncoder.Clean()
 	for _, column := range columns {
-		data = data[0:4]
+		data, err := cc.allocPacketBuffer(4, 1024)
+		if err != nil {
+			return err
+		}
 		data = column.DumpWithDefault(data, cc.rsEncoder)
 		if err := cc.writePacket(data); err != nil {
 			return err
@@ -2521,13 +2560,19 @@ func (cc *clientConn) writeResultSet(ctx context.Context, rs resultset.ResultSet
 }
 
 func (cc *clientConn) writeColumnInfo(columns []*column.Info) error {
-	data := cc.alloc.AllocWithLen(4, 1024)
+	data, err := cc.allocPacketBuffer(4, 1024)
+	if err != nil {
+		return err
+	}
 	data = dump.LengthEncodedInt(data, uint64(len(columns)))
 	if err := cc.writePacket(data); err != nil {
 		return err
 	}
 	for _, v := range columns {
-		data = data[0:4]
+		data, err = cc.allocPacketBuffer(4, 1024)
+		if err != nil {
+			return err
+		}
 		data = v.Dump(data, cc.rsEncoder)
 		if err := cc.writePacket(data); err != nil {
 			return err
@@ -2541,7 +2586,6 @@ func (cc *clientConn) writeColumnInfo(columns []*column.Info) error {
 // serverStatus, a flag bit represents server information
 // The first return value indicates whether error occurs at the first call of ResultSet.Next.
 func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, binary bool, serverStatus uint16) (bool, error) {
-	data := cc.alloc.AllocWithLen(4, 1024)
 	req := rs.NewChunk(cc.ctx.GetSessionVars().GetChunkAllocator())
 	gotColumnInfo := false
 	var columns []*column.Info
@@ -2624,7 +2668,11 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			start = time.Now()
 		}
 		for i := range rowCount {
-			data = data[0:4]
+			data, err := cc.allocPacketBuffer(4, 1024)
+			if err != nil {
+				reg.End()
+				return false, err
+			}
 			if binary {
 				data, err = column.DumpBinaryRow(data, columns, req.GetRow(i), cc.rsEncoder)
 			} else {
@@ -2669,7 +2717,6 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		err        error
 		start      time.Time
 	)
-	data := cc.alloc.AllocWithLen(4, 1024)
 	writtenRows := 0
 	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
 	if stmtDetailRaw != nil {
@@ -2689,7 +2736,10 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 	for i := 0; i < fetchSize && iter.Current(ctx) != iter.End(); i++ {
 		row := iter.Current(ctx)
 
-		data = data[0:4]
+		data, err := cc.allocPacketBuffer(4, 1024)
+		if err != nil {
+			return err
+		}
 		data, err = column.DumpBinaryRow(data, rs.Columns(), row, cc.rsEncoder)
 		if err != nil {
 			return err

--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -117,6 +117,32 @@ func (p *PacketIO) ResetBufWriter(w io.Writer) {
 	p.bufWriter.Reset(w)
 }
 
+// AvailableWriteBuffer returns bufWriter's remaining buffer when it can hold
+// at least capacity bytes. If the current remaining buffer is insufficient but
+// the writer buffer is large enough, it flushes buffered bytes first and returns
+// a fresh available buffer. The returned slice is only valid until the next
+// write operation on p.bufWriter and must not be reused after WritePacket.
+func (p *PacketIO) AvailableWriteBuffer(capacity int) ([]byte, error) {
+	if p.compressionAlgorithm != mysql.CompressionNone || p.bufWriter == nil {
+		return nil, nil
+	}
+	if capacity < 4 {
+		capacity = 4
+	}
+	if capacity > p.bufWriter.Size() {
+		return nil, nil
+	}
+	if p.bufWriter.Available() < capacity {
+		if err := p.bufWriter.Flush(); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	if p.bufWriter.Available() < capacity {
+		return nil, nil
+	}
+	return p.bufWriter.AvailableBuffer(), nil
+}
+
 // SetCompressionAlgorithm sets the compression algorithm of PacketIO.
 func (p *PacketIO) SetCompressionAlgorithm(ca int) {
 	p.compressionAlgorithm = ca

--- a/pkg/server/internal/packetio_test.go
+++ b/pkg/server/internal/packetio_test.go
@@ -62,6 +62,48 @@ func TestPacketIOWrite(t *testing.T) {
 	require.Equal(t, byte(0), res[3])
 }
 
+func TestPacketIOAvailableWriteBuffer(t *testing.T) {
+	t.Run("write packet from available buffer", func(t *testing.T) {
+		var outBuffer bytes.Buffer
+		pkt := NewPacketIOForTest(bufio.NewWriterSize(&outBuffer, 16))
+
+		buf, err := pkt.AvailableWriteBuffer(8)
+		require.NoError(t, err)
+		require.NotNil(t, buf)
+
+		data := append(buf[:4], 0x01, 0x02, 0x03)
+		err = pkt.WritePacket(data)
+		require.NoError(t, err)
+		err = pkt.Flush()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03}, outBuffer.Bytes())
+	})
+
+	t.Run("flush before returning buffer when remaining space is insufficient", func(t *testing.T) {
+		var outBuffer bytes.Buffer
+		writer := bufio.NewWriterSize(&outBuffer, 8)
+		pkt := NewPacketIOForTest(writer)
+
+		_, err := writer.Write([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
+		require.NoError(t, err)
+
+		buf, err := pkt.AvailableWriteBuffer(4)
+		require.NoError(t, err)
+		require.NotNil(t, buf)
+		require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, outBuffer.Bytes())
+		require.GreaterOrEqual(t, cap(buf), 4)
+	})
+
+	t.Run("return nil when requested capacity is larger than writer size", func(t *testing.T) {
+		var outBuffer bytes.Buffer
+		pkt := NewPacketIOForTest(bufio.NewWriterSize(&outBuffer, 8))
+
+		buf, err := pkt.AvailableWriteBuffer(9)
+		require.NoError(t, err)
+		require.Nil(t, buf)
+	})
+}
+
 func TestPacketIOWriteCompressed(t *testing.T) {
 	var testdata, outBuffer bytes.Buffer
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32097 

Problem Summary:
TiDB builds many MySQL response packets in a temporary allocator buffer and then copies those bytes into the packet writer buffer before flushing them to the client. For hot response paths such as OK/ERR/EOF packets, field metadata, and result rows, this adds an avoidable buffer copy when the underlying writer still has enough free space.

### What changed and how does it work?

- Add `PacketIO.AvailableWriteBuffer(capacity)` to expose the remaining `bufio.Writer` buffer when compression is disabled and the requested packet can fit in the writer buffer.
- Add `clientConn.allocPacketBuffer(length, capacity)` to prefer constructing response packets directly in the packet writer buffer, while falling back to the existing allocator when direct writing is not available.
- Keep the existing `writePacket` behavior for packet headers, sequence handling, and flushing semantics.
  

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test 
- Workloads:
  -  small result: `SELECT 1, 16 threads, 3 rounds x 8s.
  - 1 MiB result: `SELECT REPEAT('x', 1048576)`, 16 threads, 3 rounds x 8s.
  - 17 MiB result: `SELECT REPEAT('x', 17825792)`, 4 threads, 3 rounds x 8s.

raw QPS

| Run | T=32 QPS | T=64 warmup QPS | T=128 profile-load QPS | CPU sample/query |
|---|---:|---:|---:|---:|
| baseline r1 | 32840 | 29239 | 24062 | 113.37 us |
| da358 r1 | 33044 | 28830 | 23138 | 112.02 us |
| baseline r2 | 33062 | 28671 | 23356 | 114.43 us |
| da358 r2 | 33926 | 31238 | 25189 | 108.93 us |
Pairwise comparison:

| Pair | T=32 | T=64 warmup | T=128 profile-load | CPU sample/query |
|---|---:|---:|---:|---:|
| r1 | +0.62% | -1.40% | -3.84% | -1.19% |
| r2 | +2.61% | +8.95% | +7.85% | -4.81% |

Notice： After two rounds of testing, unstable performance improvements were found..
Two-round aggregate:

| Metric | baseline avg | da358 avg | da358 vs baseline |
|---|---:|---:|---:|
| T=32 QPS | 32951 | 33485 | +1.62% |
| T=64 warmup QPS | 28955 | 30034 | +3.73% |
| T=128 profile-load QPS | 23709 | 24163.5 | +1.92% |
| CPU sample/query | 113.90 us | 110.47 us | -3.01% |


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve MySQL response packet writing by reducing unnecessary buffer copies for uncompressed responses.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved packet handling for server responses, with smarter buffer reuse when possible.
* **Bug Fixes**
  * Added more reliable error handling during packet creation and writing, reducing failures under memory pressure.
  * Improved handling for larger or repeated data responses, including row data and field listings.
* **Tests**
  * Added coverage for writable buffer behavior and flush handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->