### PR TITLE
dxf: log canceled subtasks at info level

### DIFF
--- a/pkg/dxf/framework/taskexecutor/BUILD.bazel
+++ b/pkg/dxf/framework/taskexecutor/BUILD.bazel
@@ -83,5 +83,7 @@ go_test(
         "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_mock//gomock",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/dxf/framework/taskexecutor/execute/interface.go
+++ b/pkg/dxf/framework/taskexecutor/execute/interface.go
@@ -44,10 +44,6 @@ type StepExecutor interface {
 	// RunSubtask is used to run the subtask.
 	// The subtask meta can be updated in place, if no error returned, the subtask
 	// meta will be updated in the task table.
-	// Returning taskexecutor.ErrCancelSubtask directly, for example by propagating
-	// context.Cause(ctx), or returning a context cancellation error indicates an
-	// expected cancellation. The framework logs these returns at info level instead
-	// of treating them as subtask failures.
 	RunSubtask(ctx context.Context, subtask *proto.Subtask) error
 
 	// RealtimeSummary returns the realtime summary of the running subtask by this executor.

--- a/pkg/dxf/framework/taskexecutor/execute/interface.go
+++ b/pkg/dxf/framework/taskexecutor/execute/interface.go
@@ -44,6 +44,10 @@ type StepExecutor interface {
 	// RunSubtask is used to run the subtask.
 	// The subtask meta can be updated in place, if no error returned, the subtask
 	// meta will be updated in the task table.
+	// Returning taskexecutor.ErrCancelSubtask directly, for example by propagating
+	// context.Cause(ctx), or returning a context cancellation error indicates an
+	// expected cancellation. The framework logs these returns at info level instead
+	// of treating them as subtask failures.
 	RunSubtask(ctx context.Context, subtask *proto.Subtask) error
 
 	// RealtimeSummary returns the realtime summary of the running subtask by this executor.

--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -62,6 +62,9 @@ var (
 
 var (
 	// ErrCancelSubtask is the cancel cause when cancelling subtasks.
+	// Step executors may also return this error directly from RunSubtask, for
+	// example when propagating context.Cause(ctx). The framework treats it as an
+	// expected cancellation instead of a subtask failure.
 	ErrCancelSubtask = errors.New("cancel subtasks")
 	// ErrNonIdempotentSubtask means the subtask is left in running state and is not idempotent,
 	// so cannot be run again.

--- a/pkg/dxf/framework/taskexecutor/task_executor.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor.go
@@ -392,10 +392,10 @@ func (e *BaseTaskExecutor) Run() {
 			// task executor keeps running its subtasks even though some subtask
 			// might have failed, we rely on scheduler to detect the error, and
 			// notify task executor or manager to cancel.
-			if llog.IsContextCanceledError(err) {
-				// Context canceled is expected when scheduler/manager cancels executor,
-				// so log as info instead of a subtask failure.
-				e.sampleLogger.Info("subtask run canceled by context", llog.ShortError(err))
+			if goerrors.Is(err, ErrCancelSubtask) || llog.IsContextCanceledError(err) {
+				// Cancellation is expected when scheduler/manager cancels executor or
+				// the task enters reverting, so log as info instead of a subtask failure.
+				e.sampleLogger.Info("subtask run canceled", llog.ShortError(err))
 			} else {
 				e.sampleLogger.Error("run subtask failed", zap.Error(err))
 			}

--- a/pkg/dxf/framework/taskexecutor/task_executor_test.go
+++ b/pkg/dxf/framework/taskexecutor/task_executor_test.go
@@ -33,6 +33,8 @@ import (
 	utilmock "github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var (
@@ -577,6 +579,8 @@ func TestTaskExecutorRun(t *testing.T) {
 
 	t.Run("subtask cancelled during running", func(t *testing.T) {
 		e := newTaskExecutorRunEnv(t)
+		core, logs := observer.New(zap.InfoLevel)
+		e.taskExecutor.sampleLogger = zap.New(core)
 		e.mockForCheckBalanceSubtask()
 		e.taskTable.EXPECT().GetTaskByID(gomock.Any(), e.task1.ID).Return(e.task1, nil)
 		e.taskTable.EXPECT().GetFirstSubtaskInStates(gomock.Any(), "id", e.task1.ID, proto.StepOne,
@@ -592,6 +596,8 @@ func TestTaskExecutorRun(t *testing.T) {
 		e.taskTable.EXPECT().GetTaskByID(gomock.Any(), e.task1.ID).Return(nil, storage.ErrTaskNotFound)
 		e.stepExecutor.EXPECT().Cleanup(gomock.Any()).Return(nil)
 		e.taskExecutor.Run()
+		require.Empty(t, logs.FilterMessage("run subtask failed").All())
+		require.Len(t, logs.FilterMessage("subtask run canceled").All(), 1)
 		require.True(t, e.ctrl.Satisfied())
 	})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

DXF task executors currently report `ErrCancelSubtask` from a canceled running subtask through the sampled `run subtask failed` error log. That cancellation can be expected when a task enters reverting, either from explicit user cancellation or after another subtask failure starts the revert flow.

### What changed and how does it work?

This PR classifies `ErrCancelSubtask` the same way as context cancellation in the task executor run loop:

- log canceled subtask runs at info level with `subtask run canceled`;
- keep real subtask errors on the existing `run subtask failed` error path;
- add a regression assertion for the `ErrCancelSubtask` path to ensure the sampled error log is not emitted and the info log is retained.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/taskexecutor -run 'TestTaskExecutorRun/subtask cancelled during running' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled subtasks: cancellation is now treated as an expected outcome rather than a subtask failure.
  * Reduced noisy logging by emitting a cancellation notice instead of an error when a running subtask is stopped.
* **Tests**
  * Added/updated tests to verify that canceled subtasks produce the correct single cancellation log entry and do not produce failure logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->