### PR TITLE
statistics: skip MV log tables in auto analyze priority queue

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -53,6 +53,10 @@ const slowLogThreshold = 150 * time.Millisecond
 // Every 15 minutes, at most 1 log will be output.
 var queueSamplerLogger = logutil.SampleLoggerFactory(15*time.Minute, 1, zap.String(logutil.LogFieldCategory, "stats"))
 
+func isTableHandledByPriorityQueue(tblInfo *model.TableInfo) bool {
+	return !tblInfo.IsView() && tblInfo.MaterializedViewLog == nil
+}
+
 // pqHeap is an interface that wraps the methods of a priority queue heap.
 type pqHeap interface {
 	// getByKey returns the job by the given table ID.
@@ -271,7 +275,7 @@ func (pq *AnalysisPriorityQueue) fetchAllTablesAndBuildAnalysisJobs(ctx context.
 				continue
 			}
 
-			if tblInfo.IsView() {
+			if !isTableHandledByPriorityQueue(tblInfo) {
 				continue
 			}
 
@@ -495,6 +499,9 @@ func (pq *AnalysisPriorityQueue) tryCreateJob(
 		return nil
 	}
 	tableMeta := tableInfo.Meta()
+	if !isTableHandledByPriorityQueue(tableMeta) {
+		return nil
+	}
 	partitionedTable := tableMeta.GetPartitionInfo()
 	if partitionedTable == nil {
 		// If the table is locked, we do not analyze it.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -130,6 +130,11 @@ func (pq *AnalysisPriorityQueue) recreateAndPushJob(
 // So we need to call this function for each partition.
 // For normal tables and dynamic partitioned tables, we only need to recreate the job for the whole table.
 func (pq *AnalysisPriorityQueue) recreateAndPushJobForTable(sctx sessionctx.Context, tableInfo *model.TableInfo) error {
+	intest.Assert(tableInfo != nil)
+	if !isTableHandledByPriorityQueue(tableInfo) {
+		return pq.getAndDeleteJob(tableInfo.ID)
+	}
+
 	pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	partitionInfo := tableInfo.GetPartitionInfo()
 	lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
@@ -162,6 +167,11 @@ func (pq *AnalysisPriorityQueue) handleAddIndexEvent(
 	event *notifier.SchemaChangeEvent,
 ) error {
 	tableInfo, idxes, analyzed := event.GetAddIndexInfo()
+	intest.Assert(tableInfo != nil)
+	if !isTableHandledByPriorityQueue(tableInfo) {
+		return pq.getAndDeleteJob(tableInfo.ID)
+	}
+
 	if analyzed {
 		// if an added index is already analyzed in ddl, skip it here.
 		return nil

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
@@ -126,6 +126,58 @@ func TestAnalysisPriorityQueue(t *testing.T) {
 	})
 }
 
+func TestAnalysisPriorityQueueSkipsMaterializedViewLog(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	handle := dom.StatsHandle()
+	tk.MustExec("create table t (a int not null, b int not null)")
+	require.NoError(t, statstestutil.HandleNextDDLEventWithTxn(handle))
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	require.NoError(t, statstestutil.HandleNextDDLEventWithTxn(handle))
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+
+	originalAutoAnalyzeMinCnt := statistics.AutoAnalyzeMinCnt
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = originalAutoAnalyzeMinCnt
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	baseTable, err := dom.InfoSchema().TableByName(ctx, pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	mlogTable, err := dom.InfoSchema().TableByName(ctx, pmodel.NewCIStr("test"), model.MaterializedViewLogTableName(pmodel.NewCIStr("t")))
+	require.NoError(t, err)
+	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+	mlogStats, found := handle.GetNonPseudoPhysicalTableStats(mlogTable.Meta().ID)
+	require.True(t, found)
+	require.True(t, mlogStats.IsEligibleForAnalysis())
+
+	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
+	defer pq.Close()
+	require.NoError(t, pq.Initialize(ctx))
+
+	length, err := pq.Len()
+	require.NoError(t, err)
+	require.Equal(t, 1, length)
+
+	job, err := pq.Pop()
+	require.NoError(t, err)
+	require.Equal(t, baseTable.Meta().ID, job.GetTableID())
+	require.NotEqual(t, mlogTable.Meta().ID, job.GetTableID())
+
+	tk.MustExec("insert into t values (3, 30)")
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+	pq.ProcessDMLChanges()
+	length, err = pq.Len()
+	require.NoError(t, err)
+	require.Equal(t, 0, length)
+}
+
 func TestRefreshLastAnalysisDuration(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	handle := dom.StatsHandle()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69516

Problem Summary:
The auto analyze priority queue should not schedule materialized view log tables.

### What changed and how does it work?

Skip materialized view log tables when building or recreating priority queue jobs. The non-priority-queue auto analyze path is unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Auto analyze priority queue no longer schedules materialized view log tables.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Priority queue auto-analyze now skips tables that are views or have a materialized view log, preventing them from being queued for analysis.
  * Table change handling now removes any existing queued priority-queue jobs for tables that are no longer eligible, instead of recreating prune-mode jobs.
* **Tests**
  * Added coverage to ensure only the base table is enqueued (not the materialized view log table) and the queue clears after processing DML changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->