### PR TITLE
planner: allow json_extract in plan cache

### DIFF
--- a/pkg/expression/function_traits.go
+++ b/pkg/expression/function_traits.go
@@ -33,7 +33,6 @@ var UnCacheableFunctions = map[string]struct{}{
 	ast.Like:                 {},
 
 	// functions below are incompatible with (non-prep) plan cache, we'll fix them one by one later.
-	ast.JSONExtract:      {}, // cannot pass TestFuncJSON
 	ast.JSONObject:       {},
 	ast.JSONArray:        {},
 	ast.Coalesce:         {},

--- a/pkg/planner/core/casetest/plancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/plancache/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//pkg/planner/core:plan_clone_utils.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 48,
     deps = [
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -100,6 +100,99 @@ func TestNonPreparedPlanCachePlanString(t *testing.T) {
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 }
 
+func TestJSONExtractPlanCache(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_json_extract_plan_cache (id int primary key, doc varchar(255))")
+	tk.MustExec(`insert into t_json_extract_plan_cache values (1, '{"a": 1, "b": 2}')`)
+
+	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
+	tk.MustExec(`prepare stmt from 'select id from t_json_extract_plan_cache where json_unquote(json_extract(doc, ?)) = ?'`)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec(`set @path = '$.a', @val = '1'`)
+	tk.MustQuery("execute stmt using @path, @val").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`set @path = '$.b', @val = '2'`)
+	tk.MustQuery("execute stmt using @path, @val").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec(`set @path = '$.missing', @val = '1'`)
+	tk.MustQuery("execute stmt using @path, @val").Check(testkit.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tk.MustExec("set @@tidb_enable_non_prepared_plan_cache=1")
+	tk.MustQuery(`select id from t_json_extract_plan_cache where json_unquote(json_extract(doc, '$.a')) = '1'`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery(`select id from t_json_extract_plan_cache where json_unquote(json_extract(doc, '$.b')) = '2'`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustQuery(`select id from t_json_extract_plan_cache where json_unquote(json_extract(doc, '$.missing')) = '1'`).Check(testkit.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tk.MustExec("create table t_json_extract_plan_cache_json (id int primary key, doc json)")
+	tk.MustExec(`insert into t_json_extract_plan_cache_json values (1, '{"a": 1}')`)
+	tk.MustQuery(`select id from t_json_extract_plan_cache_json where json_extract(doc, '$.a') is not null`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery(`select id from t_json_extract_plan_cache_json where json_extract(doc, '$.a') is not null`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
+func TestJSONExtractPlanCacheWithExpressionIndex(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t_json_extract_expr_idx (
+		id int primary key,
+		doc varchar(255),
+		key idx_a ((cast(json_unquote(json_extract(doc, '$.a')) as char(20))))
+	)`)
+	tk.MustExec(`insert into t_json_extract_expr_idx values
+		(1, '{"a": "match", "b": "no"}'),
+		(2, '{"a": "no", "b": "match"}')`)
+
+	tk.MustExec("set @@tidb_enable_prepared_plan_cache=1")
+	tk.MustExec(`prepare stmt from 'select id from t_json_extract_expr_idx where cast(json_unquote(json_extract(doc, ?)) as char(20)) = ?'`)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec(`set @path = '$.a', @val = 'match'`)
+	tk.MustQuery("execute stmt using @path, @val").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`set @path = '$.b', @val = 'match'`)
+	tk.MustQuery("execute stmt using @path, @val").Check(testkit.Rows("2"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@tidb_enable_non_prepared_plan_cache=1")
+	tk.MustQuery(`select id from t_json_extract_expr_idx where cast(json_unquote(json_extract(doc, '$.a')) as char(20)) = 'match'`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery(`select id from t_json_extract_expr_idx where cast(json_unquote(json_extract(doc, '$.a')) as char(20)) = 'match'`).Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery(`select id from t_json_extract_expr_idx where cast(json_unquote(json_extract(doc, '$.b')) as char(20)) = 'match'`).Check(testkit.Rows("2"))
+
+	tk.MustExec(`create table t_json_extract_expr_idx_group (
+		id int primary key,
+		doc varchar(255),
+		key idx_a ((cast(json_unquote(json_extract(doc, '$.a')) as char(20))))
+	)`)
+	tk.MustExec(`insert into t_json_extract_expr_idx_group values
+		(1, '{"a": "one", "b": "same"}'),
+		(2, '{"a": "two", "b": "same"}')`)
+	tk.MustExec(`prepare stmt_group from 'select count(*) from t_json_extract_expr_idx_group group by cast(json_unquote(json_extract(doc, ?)) as char(20)) order by 1'`)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec(`set @path = '$.a'`)
+	tk.MustQuery("execute stmt_group using @path").Check(testkit.Rows("1", "1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`set @path = '$.b'`)
+	tk.MustQuery("execute stmt_group using @path").Check(testkit.Rows("2"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+	tk.MustExec(`prepare stmt_agg from 'select max(cast(json_unquote(json_extract(doc, ?)) as char(20))) from t_json_extract_expr_idx_group'`)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec(`set @path = '$.a'`)
+	tk.MustQuery("execute stmt_agg using @path").Check(testkit.Rows("two"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec(`set @path = '$.b'`)
+	tk.MustQuery("execute stmt_agg using @path").Check(testkit.Rows("same"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
 func TestNonPreparedPlanCacheInformationSchema(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -1212,6 +1305,7 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t where j is null",                                                  // json
 		"select * from t where j is not null",                                              // json
 		"select * from t where j < 1",                                                      // json
+		"select * from t where json_extract(j, '$.a') is not null",                         // json
 		"select * from t where a > 1 and j < 1",
 		"select * from t where e is null",     // enum
 		"select * from t where e is not null", // enum
@@ -1236,6 +1330,7 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"skip non-prepared plan-cache: queries that have sub-queries are not supported",
 		"skip non-prepared plan-cache: query has some unsupported Node",
 		"skip non-prepared plan-cache: query has some unsupported Node",
+		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",
 		"skip non-prepared plan-cache: query has some filters with JSON, Enum, Set or Bit columns",

--- a/pkg/planner/core/casetest/plancache/plan_cacheable_checker_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cacheable_checker_test.go
@@ -377,6 +377,7 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 	tk.MustExec("create table t1(a int, b int, index idx_b(b)) partition by range(a) ( partition p0 values less than (6), partition p1 values less than (11) )")
 	tk.MustExec("create table t2(a int, b int) partition by hash(a) partitions 11")
 	tk.MustExec("create table t3(a int, b int)")
+	tk.MustExec("create table t_json_guard(id int, j json)")
 	is := tk.Session().GetInfoSchema().(infoschema.InfoSchema)
 
 	p := parser.New()
@@ -443,6 +444,9 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t where a in (select a from test.t where a > t1.a)",
 		// correlated sub-query & partitioned
 		"select * from test.t1 where a in (select a from test.t where a > t1.a)",
+
+		// JSON column filter guard still applies when the filter wraps the column in JSON_EXTRACT.
+		"select * from test.t_json_guard where json_extract(j, '$.a') is not null",
 	}
 
 	supportedDML := []string{

--- a/pkg/planner/core/casetest/plancache/testdata/plan_cache_suite_out.json
+++ b/pkg/planner/core/casetest/plancache/testdata/plan_cache_suite_out.json
@@ -420,7 +420,7 @@
       {
         "SQL": "select @@last_plan_from_cache",
         "Result": [
-          "0"
+          "1"
         ]
       },
       {

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -99,6 +99,9 @@ func tryToSubstituteExpr(expr *expression.Expression, lp base.LogicalPlan, candi
 	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	if (*expr).Equal(ectx, candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
 		schema.ColumnIndex(col) != -1 {
+		if expression.MaybeOverOptimized4PlanCache(lp.SCtx().GetExprCtx(), *expr) {
+			lp.SCtx().GetExprCtx().SetSkipPlanCache("generated column substitution with mutable constants can affect index selection")
+		}
 		*expr = col
 		changed = true
 	}
@@ -197,20 +200,14 @@ func (gc *GcSubstituter) substitute(ctx context.Context, lp base.LogicalPlan, ex
 			for i := range aggFunc.Args {
 				tp = aggFunc.Args[i].GetType(ectx).EvalType()
 				for candidateExpr, column := range exprToColumn {
-					if aggFunc.Args[i].Equal(ectx, candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
-						x.Schema().ColumnIndex(column) != -1 {
-						aggFunc.Args[i] = column
-					}
+					tryToSubstituteExpr(&aggFunc.Args[i], lp, candidateExpr, tp, x.Schema(), column)
 				}
 			}
 		}
 		for i := range x.GroupByItems {
 			tp = x.GroupByItems[i].GetType(ectx).EvalType()
 			for candidateExpr, column := range exprToColumn {
-				if x.GroupByItems[i].Equal(ectx, candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
-					x.Schema().ColumnIndex(column) != -1 {
-					x.GroupByItems[i] = column
-				}
+				tryToSubstituteExpr(&x.GroupByItems[i], lp, candidateExpr, tp, x.Schema(), column)
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69522

Problem Summary:

`JSON_EXTRACT` was globally blocked by `expression.UnCacheableFunctions`, so otherwise cache-safe prepared and non-prepared queries using `json_extract` could not reuse plan cache.

Simply removing the blocklist entry is not enough: generated-column / expression-index substitution can be path-sensitive when the JSON path is a mutable parameter. If such a substitution is cached, a later execution with another path could reuse an access path selected for the previous path.

### What changed and how does it work?

- Remove `ast.JSONExtract` from `expression.UnCacheableFunctions`.
- Keep the existing non-prepared plan-cache guard for filters on TiDB JSON columns, including wrapped forms such as `json_extract(j, '$.a') is not null`.
- When generated-column / expression-index substitution matches an expression containing mutable constants, mark the plan as not cacheable with `SetSkipPlanCache`.
- Route aggregation arguments and group-by items through the same substitution helper so they get the same plan-cache safety guard as selection/projection/order-by substitution.
- Add regression tests for:
  - prepared plan cache reuse with scalar `json_extract`;
  - non-prepared plan cache reuse with scalar `json_extract`;
  - JSON-column filter guard behavior;
  - expression-index path-sensitive substitution in selection, group-by, and aggregation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Executed:

```bash
make bazel_prepare
go test ./pkg/planner/core/casetest/plancache -run 'Test(JSONExtractPlanCache|JSONExtractPlanCacheWithExpressionIndex|NonPreparedPlanExplainWarning|NonPreparedPlanCacheable)$' -tags=intest,deadlock -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Allow JSON_EXTRACT expressions to use plan cache when it is safe.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan cache reuse for prepared statements using JSON extraction predicates with bound JSON path/value parameters.
  * Better handling of JSON filter conditions to ensure cacheability decisions are correct.
  * Refined generated-column substitution so plan cache behavior remains consistent during query planning.
* **Tests**
  * Added and expanded plan cache coverage for JSON extraction (including missing paths) and expression-index scenarios with aggregation/grouping.
  * Updated non-prepared plan cache explain-warning expectations to match new unsupported cases.
* **Chores**
  * Adjusted test sharding configuration for the plan cache test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->