### PR TITLE
executor: track memory usage of batch point get

### DIFF
--- a/pkg/executor/batch_point_get.go
+++ b/pkg/executor/batch_point_get.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil/consistency"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	tikv "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -82,6 +83,12 @@ type BatchPointGetExec struct {
 
 	snapshot kv.Snapshot
 	stats    *runtimeStatsWithSnapshot
+
+	// memTracker tracks the memory usage of the row values buffered in e.values.
+	// Without it the memory held by a large batch point get (e.g. a big `IN`
+	// list over wide rows) is invisible to the query memory quota and to the
+	// instance memory-limit killer, so such queries cannot be canceled.
+	memTracker *memory.Tracker
 }
 
 // buildVirtualColumnInfo saves virtual column indices and sort them in definition order
@@ -118,6 +125,13 @@ func (e *BatchPointGetExec) Open(context.Context) error {
 		}
 	}
 	e.batchGetter = batchGetter
+
+	if e.memTracker != nil {
+		e.memTracker.Reset()
+	} else {
+		e.memTracker = memory.NewTracker(e.ID(), -1)
+	}
+	e.memTracker.AttachTo(sessVars.StmtCtx.MemTracker)
 	return nil
 }
 
@@ -477,6 +491,10 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 			continue
 		}
 		e.values = append(e.values, val.Value)
+		// Account for the buffered row value so the query can be canceled when it
+		// exceeds tidb_mem_quota_query. This fires incrementally as values are
+		// appended, so an oversized batch is stopped as soon as it crosses the quota.
+		e.memTracker.Consume(int64(len(val.Value)))
 		handles = append(handles, e.handles[i])
 		if e.lock && rc {
 			existKeys = append(existKeys, key)

--- a/pkg/executor/batch_point_get_test.go
+++ b/pkg/executor/batch_point_get_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/tikv"
 )
@@ -230,4 +232,45 @@ func TestPointGetForTemporaryTable(t *testing.T) {
 	// Point get.
 	tk.MustQuery("select * from t1 where id = 1").Check(testkit.Rows("1 1"))
 	tk.MustQuery("select * from t1 where id = 2").Check(testkit.Rows())
+}
+
+func TestBatchPointGetMemoryTracking(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int primary key, v varchar(4096))")
+
+	// Insert rows with sizable values so that a batch point get buffering all of
+	// them uses well over a small per-query memory quota.
+	const rows = 200
+	val := strings.Repeat("x", 4000)
+	var insert strings.Builder
+	insert.WriteString("insert into t values ")
+	ids := make([]string, 0, rows)
+	for i := range rows {
+		if i > 0 {
+			insert.WriteByte(',')
+		}
+		fmt.Fprintf(&insert, "(%d, '%s')", i, val)
+		ids = append(ids, fmt.Sprintf("%d", i))
+	}
+	tk.MustExec(insert.String())
+
+	query := fmt.Sprintf("select * from t where id in (%s)", strings.Join(ids, ","))
+	// Ensure the plan is actually a batch point get.
+	require.Contains(t, tk.MustQuery("explain format='brief' " + query).Rows()[0][0].(string), "Batch_Point_Get")
+
+	tk.MustExec("set global tidb_mem_oom_action = 'CANCEL'")
+	defer tk.MustExec("set global tidb_mem_oom_action = default")
+
+	// With a generous quota the query succeeds.
+	tk.MustExec("set @@tidb_mem_quota_query = 1 << 30")
+	require.NoError(t, tk.QueryToErr(query))
+
+	// With a small quota the buffered row values (~800KB) exceed it and the query
+	// is canceled. Before BatchPointGetExec tracked this memory, the query ran to
+	// completion because its memory usage was invisible to the tracker.
+	tk.MustExec("set @@tidb_mem_quota_query = 128 * 1024")
+	require.True(t, exeerrors.ErrMemoryExceedForQuery.Equal(tk.QueryToErr(query)))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69526

Problem Summary:

`BatchPointGetExec` buffers every fetched row value in `e.values` without registering it with the query memory tracker. A large batch point get (e.g. `SELECT ... WHERE pk IN (<many ids>)` over wide rows or large columns) therefore holds memory that is invisible to both `tidb_mem_quota_query` and the `tidb_server_memory_limit` killer (which selects the session with the highest tracked `BytesConsumed`). Such queries can be neither canceled by the per-query OOM action nor picked by the instance memory-limit killer, so they can drive a tidb-server to OOM while reporting `mem_max: 0` in the OOM `running_sql` record.

### What changed and how does it work?

- Add a `memTracker` to `BatchPointGetExec`, created and attached to the statement memory tracker in `Open()`, mirroring `TableReaderExecutor`.
- In `initialize()`, `Consume` the size of each buffered row value as it is appended to `e.values`. This fires incrementally, so an oversized batch is stopped as soon as it crosses the quota.

This makes the memory held by batch point get visible to `tidb_mem_quota_query` (so it can be canceled) and to the `tidb_server_memory_limit` killer (so it can be selected as the victim). The coprocessor read path already tracks its responses this way; this brings the batch-point-get path in line.

### Check List

Tests

- [x] Unit test

Added `TestBatchPointGetMemoryTracking`: a batch point get over many wide rows succeeds under a large `tidb_mem_quota_query` and is canceled with `ErrMemoryExceedForQuery` under a small one.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where the memory used by batch point get queries (`WHERE pk IN (...)`) was not tracked, so they could not be canceled by the query memory quota or selected by the instance memory limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory handling for batch point lookups so large result sets are tracked more accurately and can stop earlier when query memory limits are reached.
  * Queries now fail more reliably with a clear memory limit error when buffered rows exceed the allowed quota.

* **Tests**
  * Added coverage for memory limit behavior in batch point lookup execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->