### PR TITLE
test: stabilize flaky TestTopSQLStatementStats

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -1593,15 +1593,17 @@ func (c *mockCollector) CollectStmtStatsMap(data stmtstats.StatementStatsMap) {
 	c.f(data)
 }
 
-func waitCollected(ch chan struct{}) {
+func waitCollected(t *testing.T, ch chan struct{}) {
+	t.Helper()
 	select {
 	case <-ch:
-	case <-time.After(time.Second * 3):
+	case <-time.After(time.Second * 10):
+		require.FailNow(t, "timed out waiting for statement stats collection")
 	}
 }
 
 func TestTopSQLStatementStats(t *testing.T) {
-	ts, total, tagChecker, collectedNotifyCh := setupForTestTopSQLStatementStats(t)
+	ts, _, tagChecker, collectedNotifyCh, withTotal := setupForTestTopSQLStatementStats(t)
 
 	const ExecCountPerSQL = 2
 	// Test for CRUD.
@@ -1819,31 +1821,80 @@ func TestTopSQLStatementStats(t *testing.T) {
 	}()
 
 	wg.Wait()
-	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitTopSQLStatementStats(t, collectedNotifyCh, withTotal, sqlDigests, ExecCountPerSQL)
 
-	found := 0
-	for digest, item := range total {
-		if sqlStr, ok := sqlDigests[digest.SQLDigest]; ok {
-			found++
-			require.Equal(t, uint64(ExecCountPerSQL), item.ExecCount, sqlStr)
-			require.Equal(t, uint64(ExecCountPerSQL), item.DurationCount, sqlStr)
-			require.True(t, item.SumDurationNs > uint64(time.Millisecond*100*ExecCountPerSQL), sqlStr)
-			require.True(t, item.SumDurationNs < uint64(time.Millisecond*300*ExecCountPerSQL), sqlStr)
-			if strings.HasPrefix(sqlStr, "set global") {
-				// set global statement use internal SQL to change global variable, so itself doesn't have KV request.
-				continue
+	withTotal(func(total stmtstats.StatementStatsMap) {
+		found := 0
+		for digest, item := range total {
+			if sqlStr, ok := sqlDigests[digest.SQLDigest]; ok {
+				found++
+				require.Equal(t, uint64(ExecCountPerSQL), item.ExecCount, sqlStr)
+				require.Equal(t, uint64(ExecCountPerSQL), item.DurationCount, sqlStr)
+				require.True(t, item.SumDurationNs > uint64(time.Millisecond*100*ExecCountPerSQL), sqlStr)
+				require.True(t, item.SumDurationNs < uint64(time.Millisecond*300*ExecCountPerSQL), sqlStr)
+				if strings.HasPrefix(sqlStr, "set global") {
+					// set global statement use internal SQL to change global variable, so itself doesn't have KV request.
+					continue
+				}
+				var kvSum uint64
+				for _, kvCount := range item.KvStatsItem.KvExecCount {
+					kvSum += kvCount
+				}
+				require.Equal(t, uint64(ExecCountPerSQL), kvSum)
+				tagChecker.checkExist(t, digest.SQLDigest, sqlStr)
 			}
-			var kvSum uint64
-			for _, kvCount := range item.KvStatsItem.KvExecCount {
-				kvSum += kvCount
-			}
-			require.Equal(t, uint64(ExecCountPerSQL), kvSum)
-			tagChecker.checkExist(t, digest.SQLDigest, sqlStr)
+		}
+		require.Equal(t, len(sqlDigests), found)
+		require.Equal(t, 20, found)
+	})
+}
+
+func waitTopSQLStatementStats(
+	t *testing.T,
+	ch chan struct{},
+	withTotal func(func(stmtstats.StatementStatsMap)),
+	sqlDigests map[stmtstats.BinaryDigest]string,
+	execCountPerSQL uint64,
+) {
+	t.Helper()
+
+	deadline := time.After(time.Second * 10)
+	tick := time.NewTicker(time.Millisecond * 10)
+	defer tick.Stop()
+
+	for {
+		if topSQLStatementStatsCollected(withTotal, sqlDigests, execCountPerSQL) {
+			return
+		}
+
+		select {
+		case <-ch:
+		case <-tick.C:
+		case <-deadline:
+			require.FailNow(t, "timed out waiting for expected statement stats")
 		}
 	}
-	require.Equal(t, len(sqlDigests), found)
-	require.Equal(t, 20, found)
+}
+
+func topSQLStatementStatsCollected(
+	withTotal func(func(stmtstats.StatementStatsMap)),
+	sqlDigests map[stmtstats.BinaryDigest]string,
+	execCountPerSQL uint64,
+) bool {
+	collected := false
+	withTotal(func(total stmtstats.StatementStatsMap) {
+		found := 0
+		for digest, item := range total {
+			if _, ok := sqlDigests[digest.SQLDigest]; ok {
+				if item.ExecCount < execCountPerSQL || item.DurationCount < execCountPerSQL {
+					return
+				}
+				found++
+			}
+		}
+		collected = found >= len(sqlDigests)
+	})
+	return collected
 }
 
 type resourceTagChecker struct {
@@ -1883,7 +1934,7 @@ func (c *resourceTagChecker) checkReqExist(t *testing.T, digest stmtstats.Binary
 	}
 }
 
-func setupForTestTopSQLStatementStats(t *testing.T) (*servertestkit.TidbTestSuite, stmtstats.StatementStatsMap, *resourceTagChecker, chan struct{}) {
+func setupForTestTopSQLStatementStats(t *testing.T) (*servertestkit.TidbTestSuite, stmtstats.StatementStatsMap, *resourceTagChecker, chan struct{}, func(func(stmtstats.StatementStatsMap))) {
 	// Prepare stmt stats.
 	stmtstats.SetupAggregator()
 
@@ -1901,6 +1952,11 @@ func setupForTestTopSQLStatementStats(t *testing.T) (*servertestkit.TidbTestSuit
 		}
 	})
 	stmtstats.RegisterCollector(mockCollector)
+	withTotal := func(fn func(stmtstats.StatementStatsMap)) {
+		mu.Lock()
+		defer mu.Unlock()
+		fn(total)
+	}
 
 	ts := servertestkit.CreateTidbTestSuite(t)
 
@@ -1961,11 +2017,11 @@ func setupForTestTopSQLStatementStats(t *testing.T) (*servertestkit.TidbTestSuit
 		view.Stop()
 	})
 
-	return ts, total, tagChecker, collectedNotifyCh
+	return ts, total, tagChecker, collectedNotifyCh, withTotal
 }
 
 func TestTopSQLStatementStats2(t *testing.T) {
-	ts, total, tagChecker, collectedNotifyCh := setupForTestTopSQLStatementStats(t)
+	ts, total, tagChecker, collectedNotifyCh, _ := setupForTestTopSQLStatementStats(t)
 
 	const ExecCountPerSQL = 3
 	sqlDigests := map[stmtstats.BinaryDigest]string{}
@@ -2064,7 +2120,7 @@ func TestTopSQLStatementStats2(t *testing.T) {
 	}
 
 	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitCollected(t, collectedNotifyCh)
 
 	foundMap := map[stmtstats.BinaryDigest]string{}
 	for digest, item := range total {
@@ -2083,7 +2139,7 @@ func TestTopSQLStatementStats2(t *testing.T) {
 }
 
 func TestTopSQLStatementStats3(t *testing.T) {
-	ts, total, tagChecker, collectedNotifyCh := setupForTestTopSQLStatementStats(t)
+	ts, total, tagChecker, collectedNotifyCh, _ := setupForTestTopSQLStatementStats(t)
 
 	err := failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockSleepInTableReaderNext", "return(2000)")
 	require.NoError(t, err)
@@ -2119,7 +2175,7 @@ func TestTopSQLStatementStats3(t *testing.T) {
 		sqlDigests[stmtstats.BinaryDigest(digest.Bytes())] = ca
 	}
 	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitCollected(t, collectedNotifyCh)
 
 	foundMap := map[stmtstats.BinaryDigest]string{}
 	for digest, item := range total {
@@ -2136,7 +2192,7 @@ func TestTopSQLStatementStats3(t *testing.T) {
 	// wait sql execute finish.
 	wg.Wait()
 	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitCollected(t, collectedNotifyCh)
 
 	for digest, item := range total {
 		if sqlStr, ok := sqlDigests[digest.SQLDigest]; ok {
@@ -2150,7 +2206,7 @@ func TestTopSQLStatementStats3(t *testing.T) {
 }
 
 func TestTopSQLStatementStats4(t *testing.T) {
-	ts, total, tagChecker, collectedNotifyCh := setupForTestTopSQLStatementStats(t)
+	ts, total, tagChecker, collectedNotifyCh, _ := setupForTestTopSQLStatementStats(t)
 
 	err := failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockSleepInTableReaderNext", "return(2000)")
 	require.NoError(t, err)
@@ -2196,7 +2252,7 @@ func TestTopSQLStatementStats4(t *testing.T) {
 		sqlDigests[stmtstats.BinaryDigest(digest.Bytes())] = ca.sql
 	}
 	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitCollected(t, collectedNotifyCh)
 
 	foundMap := map[stmtstats.BinaryDigest]string{}
 	for digest, item := range total {
@@ -2213,7 +2269,7 @@ func TestTopSQLStatementStats4(t *testing.T) {
 	// wait sql execute finish.
 	wg.Wait()
 	// Wait for collect.
-	waitCollected(collectedNotifyCh)
+	waitCollected(t, collectedNotifyCh)
 
 	for digest, item := range total {
 		if sqlStr, ok := sqlDigests[digest.SQLDigest]; ok {
@@ -2231,7 +2287,7 @@ func TestTopSQLResourceTag(t *testing.T) {
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.PessimisticTxn.PessimisticAutoCommit.Store(false)
 	})
-	ts, _, tagChecker, _ := setupForTestTopSQLStatementStats(t)
+	ts, _, tagChecker, _, _ := setupForTestTopSQLStatementStats(t)
 	defer func() {
 		topsqlstate.DisableTopSQL()
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69529

Problem Summary:
Flaky test `TestTopSQLStatementStats` in `pkg/server/tests/commontest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test synchronized on one async collection signal/timeout instead of the semantic condition that all expected statement stats had been collected.

#### Fix

Waiting for expected digest counts and reading under the collector mutex removes the partial-collection assertion window without changing product code.

#### Verification

Spec:
- target: `pkg/server/tests/commontest :: TestTopSQLStatementStats`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `WRAPPED_GO_TEST`
- wrapper: `./tools/check/failpoint-go-test.sh`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_scope: SKIPPED
- build: PASS
- lint: PASS

Commands:
- `./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -json -run '^TestTopSQLStatementStats$' -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of statement statistics checks by waiting longer for data collection and failing clearly on timeouts.
  * Strengthened validation of collected statistics, including execution counts, duration totals, and resource tag coverage.
  * Updated related test cases to use the new shared assertion flow for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->