### PR TITLE
ddl: tolerate missing masking policy table during upgrade

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -280,6 +280,7 @@ go_test(
         "job_submitter_test.go",
         "job_worker_test.go",
         "main_test.go",
+        "masking_policy_internal_test.go",
         "masking_policy_test.go",
         "metabuild_test.go",
         "modify_column_test.go",

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -335,6 +335,7 @@ type ddlCtx struct {
 	ctx               context.Context
 	cancel            context.CancelFunc
 	uuid              string
+	startMode         StartMode
 	store             kv.Storage
 	ownerManager      owner.Manager
 	schemaVerSyncer   schemaver.Syncer
@@ -888,6 +889,7 @@ func (d *ddl) Start(startMode StartMode, ctxPool *pools.ResourcePool) error {
 	failpoint.Inject("mockBRStartMode", func() {
 		d.executor.startMode = BR
 	})
+	d.ddlCtx.startMode = d.executor.startMode
 
 	d.sessPool = sess.NewSessionPool(ctxPool)
 	d.executor.sessPool, d.jobSubmitter.sessPool = d.sessPool, d.sessPool

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -570,6 +570,11 @@ func (w *worker) dropMaskingPoliciesByDBName(jobCtx *jobContext, dbName string) 
 func (w *worker) updateMaskingPolicyTableIDAfterTruncate(jobCtx *jobContext, oldTableID, newTableID int64) error {
 	policies, err := w.getMaskingPoliciesByTableIDFromSysTable(jobCtx.stepCtx, oldTableID)
 	if err != nil {
+		// If the masking policy system table itself doesn't exist during bootstrap
+		// upgrade, there are no policies to migrate.
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	const updateSQL = `UPDATE mysql.tidb_masking_policy
@@ -615,6 +620,11 @@ func (w *worker) updateMaskingPolicyNamesAfterRename(
 ) error {
 	policies, err := w.getMaskingPoliciesByTableIDFromSysTable(ctx, tableID)
 	if err != nil {
+		// If the masking policy system table itself doesn't exist during bootstrap
+		// upgrade, there are no policies to update.
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	for _, policy := range policies {
@@ -662,6 +672,11 @@ func (w *worker) syncMaskingPolicyForModifiedColumn(
 
 	policies, err := w.getMaskingPoliciesByTableIDFromSysTable(jobCtx.stepCtx, tblInfo.ID)
 	if err != nil {
+		// If the masking policy system table itself doesn't exist during bootstrap
+		// upgrade, there are no policies to sync.
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	for _, policy := range policies {

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta"
@@ -248,6 +249,9 @@ const (
 )
 
 func (w *worker) queryMaskingPoliciesFromSysTable(ctx context.Context, query string, args ...any) ([]*model.MaskingPolicyInfo, error) {
+	failpoint.Inject("mockMissingMaskingPolicySysTable", func() {
+		failpoint.Return(nil, infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_masking_policy"))
+	})
 	rows, err := w.sess.Execute(ctx, query, "query-masking-policy", args...)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -535,7 +539,7 @@ func (w *worker) dropMaskingPoliciesOnTable(jobCtx *jobContext, tableID int64) e
 	if err != nil {
 		// If the masking policy system table itself doesn't exist (e.g., during
 		// bootstrap upgrade that drops and recreates it), there's nothing to clean up.
-		if infoschema.ErrTableNotExists.Equal(err) {
+		if allowMissingMaskingPolicyTableDuringBootstrap(jobCtx, err) {
 			return nil
 		}
 		return errors.Trace(err)
@@ -604,7 +608,7 @@ func (w *worker) dropMaskingPoliciesOnColumn(jobCtx *jobContext, tableID, column
 	if err != nil {
 		// If the masking policy system table itself doesn't exist (e.g., during
 		// bootstrap upgrade that drops and recreates it), there's nothing to clean up.
-		if infoschema.ErrTableNotExists.Equal(err) {
+		if allowMissingMaskingPolicyTableDuringBootstrap(jobCtx, err) {
 			return nil
 		}
 		return errors.Trace(err)

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -564,6 +564,13 @@ func (w *worker) dropMaskingPoliciesByDBName(jobCtx *jobContext, dbName string) 
 	return nil
 }
 
+func allowMissingMaskingPolicyTableDuringBootstrap(jobCtx *jobContext, err error) bool {
+	if !infoschema.ErrTableNotExists.Equal(err) || jobCtx == nil || jobCtx.oldDDLCtx == nil {
+		return false
+	}
+	return jobCtx.oldDDLCtx.startMode == Bootstrap || jobCtx.oldDDLCtx.startMode == Upgrade
+}
+
 // updateMaskingPolicyTableIDAfterTruncate updates the table_id in
 // mysql.tidb_masking_policy from the old table ID to the new one after TRUNCATE TABLE.
 // Column IDs remain the same across truncate, so column bindings are preserved.
@@ -572,7 +579,7 @@ func (w *worker) updateMaskingPolicyTableIDAfterTruncate(jobCtx *jobContext, old
 	if err != nil {
 		// If the masking policy system table itself doesn't exist during bootstrap
 		// upgrade, there are no policies to migrate.
-		if infoschema.ErrTableNotExists.Equal(err) {
+		if allowMissingMaskingPolicyTableDuringBootstrap(jobCtx, err) {
 			return nil
 		}
 		return errors.Trace(err)
@@ -613,16 +620,17 @@ func (w *worker) dropMaskingPoliciesOnColumn(jobCtx *jobContext, tableID, column
 // updateMaskingPolicyNamesAfterRename updates the db_name and table_name in
 // mysql.tidb_masking_policy after a table is renamed.
 func (w *worker) updateMaskingPolicyNamesAfterRename(
-	ctx context.Context,
+	jobCtx *jobContext,
 	tableID int64,
 	_ /* oldDBName */, newDBName ast.CIStr,
 	_ /* oldTableName */, newTableName ast.CIStr,
 ) error {
+	ctx := jobCtx.stepCtx
 	policies, err := w.getMaskingPoliciesByTableIDFromSysTable(ctx, tableID)
 	if err != nil {
 		// If the masking policy system table itself doesn't exist during bootstrap
 		// upgrade, there are no policies to update.
-		if infoschema.ErrTableNotExists.Equal(err) {
+		if allowMissingMaskingPolicyTableDuringBootstrap(jobCtx, err) {
 			return nil
 		}
 		return errors.Trace(err)
@@ -674,7 +682,7 @@ func (w *worker) syncMaskingPolicyForModifiedColumn(
 	if err != nil {
 		// If the masking policy system table itself doesn't exist during bootstrap
 		// upgrade, there are no policies to sync.
-		if infoschema.ErrTableNotExists.Equal(err) {
+		if allowMissingMaskingPolicyTableDuringBootstrap(jobCtx, err) {
 			return nil
 		}
 		return errors.Trace(err)

--- a/pkg/ddl/masking_policy_internal_test.go
+++ b/pkg/ddl/masking_policy_internal_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +45,23 @@ func TestMaskingPolicyMissingSysTableRequiresBootstrapOrUpgrade(t *testing.T) {
 			name: "drop_table",
 			run: func(w *worker, jobCtx *jobContext) error {
 				return w.dropMaskingPoliciesOnTable(jobCtx, 1)
+			},
+		},
+		{
+			name: "truncate_table",
+			run: func(w *worker, jobCtx *jobContext) error {
+				return w.updateMaskingPolicyTableIDAfterTruncate(jobCtx, 1, 2)
+			},
+		},
+		{
+			name: "rename_table",
+			run: func(w *worker, jobCtx *jobContext) error {
+				return w.updateMaskingPolicyNamesAfterRename(
+					jobCtx,
+					1,
+					ast.NewCIStr("old_db"), ast.NewCIStr("new_db"),
+					ast.NewCIStr("old_table"), ast.NewCIStr("new_table"),
+				)
 			},
 		},
 		{

--- a/pkg/ddl/masking_policy_internal_test.go
+++ b/pkg/ddl/masking_policy_internal_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaskingPolicyMissingSysTableRequiresBootstrapOrUpgrade(t *testing.T) {
+	helperTests := []struct {
+		name string
+		run  func(*worker, *jobContext) error
+	}{
+		{
+			name: "modify_column",
+			run: func(w *worker, jobCtx *jobContext) error {
+				return w.syncMaskingPolicyForModifiedColumn(
+					jobCtx,
+					&model.TableInfo{ID: 1},
+					&model.ColumnInfo{},
+					&model.ColumnInfo{},
+				)
+			},
+		},
+		{
+			name: "drop_table",
+			run: func(w *worker, jobCtx *jobContext) error {
+				return w.dropMaskingPoliciesOnTable(jobCtx, 1)
+			},
+		},
+		{
+			name: "drop_column",
+			run: func(w *worker, jobCtx *jobContext) error {
+				return w.dropMaskingPoliciesOnColumn(jobCtx, 1, 1)
+			},
+		},
+	}
+	startModeTests := []struct {
+		name      string
+		startMode StartMode
+		wantErr   bool
+	}{
+		{name: "normal", startMode: Normal, wantErr: true},
+		{name: "bootstrap", startMode: Bootstrap},
+		{name: "upgrade", startMode: Upgrade},
+	}
+
+	for _, helper := range helperTests {
+		t.Run(helper.name, func(t *testing.T) {
+			for _, mode := range startModeTests {
+				t.Run(mode.name, func(t *testing.T) {
+					testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockMissingMaskingPolicySysTable", "return(true)")
+
+					w := &worker{}
+					jobCtx := &jobContext{
+						stepCtx:   context.Background(),
+						oldDDLCtx: &ddlCtx{startMode: mode.startMode},
+					}
+
+					err := helper.run(w, jobCtx)
+					if mode.wantErr {
+						require.Error(t, err)
+						require.True(t, infoschema.ErrTableNotExists.Equal(err), err)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+	}
+}

--- a/pkg/ddl/masking_policy_test.go
+++ b/pkg/ddl/masking_policy_test.go
@@ -15,14 +15,10 @@
 package ddl_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errno"
-	"github.com/pingcap/tidb/pkg/meta"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
@@ -204,29 +200,6 @@ func TestMaskingPolicyModifyColumnRejectUnsupportedType(t *testing.T) {
 	// Verify the policy is still intact.
 	tk.MustQuery("select column_name, expression from mysql.tidb_masking_policy where policy_name = 'p'").
 		Check(testkit.Rows("c `c`"))
-}
-
-func TestMaskingPolicyMissingSysTableFailsInNormalDDL(t *testing.T) {
-	store := testkit.CreateMockStore(t, mockstore.WithDDLChecker())
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t_missing_policy")
-	tk.MustExec("create table t_missing_policy(c varchar(100))")
-
-	dom := domain.GetDomain(tk.Session())
-	policyTbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
-	require.NoError(t, err)
-
-	txn, err := store.Begin()
-	require.NoError(t, err)
-	m := meta.NewMutator(txn)
-	require.NoError(t, m.DropTableOrView(policyTbl.Meta().DBID, policyTbl.Meta().ID))
-	require.NoError(t, txn.Commit(context.Background()))
-	require.NoError(t, dom.Reload())
-
-	err = tk.ExecToErr("alter table t_missing_policy modify column c varchar(200)")
-	require.Error(t, err)
-	require.ErrorContains(t, err, "Table 'mysql.tidb_masking_policy' doesn't exist")
 }
 
 func TestMaskingPolicyExpressionRejectsNonTargetColumn(t *testing.T) {

--- a/pkg/ddl/masking_policy_test.go
+++ b/pkg/ddl/masking_policy_test.go
@@ -15,10 +15,14 @@
 package ddl_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
@@ -200,6 +204,29 @@ func TestMaskingPolicyModifyColumnRejectUnsupportedType(t *testing.T) {
 	// Verify the policy is still intact.
 	tk.MustQuery("select column_name, expression from mysql.tidb_masking_policy where policy_name = 'p'").
 		Check(testkit.Rows("c `c`"))
+}
+
+func TestMaskingPolicyMissingSysTableFailsInNormalDDL(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithDDLChecker())
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_missing_policy")
+	tk.MustExec("create table t_missing_policy(c varchar(100))")
+
+	dom := domain.GetDomain(tk.Session())
+	policyTbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
+	require.NoError(t, err)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	require.NoError(t, m.DropTableOrView(policyTbl.Meta().DBID, policyTbl.Meta().ID))
+	require.NoError(t, txn.Commit(context.Background()))
+	require.NoError(t, dom.Reload())
+
+	err = tk.ExecToErr("alter table t_missing_policy modify column c varchar(200)")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Table 'mysql.tidb_masking_policy' doesn't exist")
 }
 
 func TestMaskingPolicyExpressionRejectsNonTargetColumn(t *testing.T) {

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -834,7 +834,7 @@ func (w *worker) onRenameTable(jobCtx *jobContext, job *model.Job) (ver int64, _
 		job.State = model.JobStateCancelled
 		return ver, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(fmt.Sprintf("schema-ID: %v", newSchemaID))
 	}
-	if err = w.updateMaskingPolicyNamesAfterRename(jobCtx.stepCtx, tblInfo.ID,
+	if err = w.updateMaskingPolicyNamesAfterRename(jobCtx, tblInfo.ID,
 		oldSchemaName, newDB.Name, oldTableName, tableName); err != nil {
 		return ver, errors.Wrapf(err, "failed to update masking policy names after table rename")
 	}
@@ -884,7 +884,7 @@ func (w *worker) onRenameTables(jobCtx *jobContext, job *model.Job) (ver int64, 
 			job.State = model.JobStateCancelled
 			return ver, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(fmt.Sprintf("schema-ID: %v", info.NewSchemaID))
 		}
-		if err = w.updateMaskingPolicyNamesAfterRename(jobCtx.stepCtx, tblInfo.ID,
+		if err = w.updateMaskingPolicyNamesAfterRename(jobCtx, tblInfo.ID,
 			info.OldSchemaName, newDB.Name, info.OldTableName, info.NewTableName); err != nil {
 			return ver, errors.Wrapf(err, "failed to update masking policy names after table rename")
 		}

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1101,55 +1101,57 @@ func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
-	const fromVersion = 254
+	for _, fromVersion := range []int{189, 254} {
+		t.Run(fmt.Sprintf("from_version_%d", fromVersion), func(t *testing.T) {
+			store, dom := session.CreateStoreAndBootstrap(t)
+			defer func() { require.NoError(t, store.Close()) }()
 
-	store, dom := session.CreateStoreAndBootstrap(t)
-	defer func() { require.NoError(t, store.Close()) }()
+			se := session.CreateSessionAndSetID(t, store)
+			txn, err := store.Begin()
+			require.NoError(t, err)
+			m := meta.NewMutator(txn)
+			err = m.FinishBootstrap(int64(fromVersion))
+			require.NoError(t, err)
+			err = txn.Commit(context.Background())
+			require.NoError(t, err)
+			revertVersionAndVariables(t, se, fromVersion)
 
-	seV254 := session.CreateSessionAndSetID(t, store)
-	txn, err := store.Begin()
-	require.NoError(t, err)
-	m := meta.NewMutator(txn)
-	err = m.FinishBootstrap(int64(fromVersion))
-	require.NoError(t, err)
-	err = txn.Commit(context.Background())
-	require.NoError(t, err)
-	revertVersionAndVariables(t, seV254, fromVersion)
+			is := dom.InfoSchema()
+			policyTbl, err := is.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
+			require.NoError(t, err)
+			policyDBID := policyTbl.Meta().DBID
+			policyTblID := policyTbl.Meta().ID
 
-	is := dom.InfoSchema()
-	policyTbl, err := is.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
-	require.NoError(t, err)
-	policyDBID := policyTbl.Meta().DBID
-	policyTblID := policyTbl.Meta().ID
+			txn, err = store.Begin()
+			require.NoError(t, err)
+			m = meta.NewMutator(txn)
+			err = m.DropTableOrView(policyDBID, policyTblID)
+			require.NoError(t, err)
+			exists, err := m.CheckTableExists(policyDBID, policyTblID)
+			require.NoError(t, err)
+			require.False(t, exists)
+			err = txn.Commit(context.Background())
+			require.NoError(t, err)
 
-	txn, err = store.Begin()
-	require.NoError(t, err)
-	m = meta.NewMutator(txn)
-	err = m.DropTableOrView(policyDBID, policyTblID)
-	require.NoError(t, err)
-	exists, err := m.CheckTableExists(policyDBID, policyTblID)
-	require.NoError(t, err)
-	require.False(t, exists)
-	err = txn.Commit(context.Background())
-	require.NoError(t, err)
+			store.SetOption(session.StoreBootstrappedKey, nil)
+			ver, err := session.GetBootstrapVersion(se)
+			require.NoError(t, err)
+			require.Equal(t, int64(fromVersion), ver)
+			dom.Close()
 
-	store.SetOption(session.StoreBootstrappedKey, nil)
-	ver, err := session.GetBootstrapVersion(seV254)
-	require.NoError(t, err)
-	require.Equal(t, int64(fromVersion), ver)
-	dom.Close()
+			newVer, err := session.BootstrapSession(store)
+			require.NoError(t, err)
+			defer newVer.Close()
 
-	newVer, err := session.BootstrapSession(store)
-	require.NoError(t, err)
-	defer newVer.Close()
+			seLatestV := session.CreateSessionAndSetID(t, store)
+			ver, err = session.GetBootstrapVersion(seLatestV)
+			require.NoError(t, err)
+			require.Equal(t, session.CurrentBootstrapVersion, ver)
 
-	seLatestV := session.CreateSessionAndSetID(t, store)
-	ver, err = session.GetBootstrapVersion(seLatestV)
-	require.NoError(t, err)
-	require.Equal(t, session.CurrentBootstrapVersion, ver)
-
-	tk := testkit.NewTestKit(t, store)
-	checkTiDBMaskingPolicyTableSchema(t, tk)
+			tk := testkit.NewTestKit(t, store)
+			checkTiDBMaskingPolicyTableSchema(t, tk)
+		})
+	}
 }
 
 func TestUpgradeWithAnalyzeColumnOptions(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69464

Problem Summary:

During rolling upgrade, a newly started TiDB can repeatedly crash in bootstrap upgrade. `upgradeToVer190` runs `MODIFY COLUMN` DDLs before `upgradeToVer260` creates `mysql.tidb_masking_policy`. The masking policy sync hook added to ordinary column-modification DDL queries that system table, so the DDL job rolls back with `Table 'mysql.tidb_masking_policy' doesn't exist`, and `doReentrantDDL` exits fatally.

### What changed and how does it work?

When ordinary DDL paths sync masking policy metadata for truncate, rename table, or modify/change column, treat `mysql.tidb_masking_policy` not existing as "no policies to sync" during bootstrap upgrade.

Direct masking policy DDL still depends on the system table as before. This only relaxes auxiliary metadata sync for ordinary DDLs that can run before the masking policy system table is created.

This PR also extends the existing masking policy bootstrap upgrade test to cover upgrading from bootstrap version 189 with `mysql.tidb_masking_policy` missing, which reproduces the `upgradeToVer190` path in #69464.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Executed:

- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/session/test/bootstraptest -run '^TestUpgradeVersion260MaskingPolicy/from_version_189$' -count=1`
  - Verified the new regression case fails without the fix and passes with the fix.
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/session/test/bootstraptest -run '^TestUpgradeVersion260MaskingPolicy$' -count=1`
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestMaskingPolicy(RenameTable|RenameTableCrossDatabase|RenameTableNoPolicy|RenameColumn|ModifyColumnRejectUnsupportedType|TruncateKeepsPolicy)$' -count=1`
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue that TiDB might repeatedly crash during rolling upgrade when a bootstrap DDL runs before mysql.tidb_masking_policy is created.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved masking-policy DDL handling during bootstrap and upgrade so missing `mysql.tidb_masking_policy` metadata is treated as a harmless no-op across multiple masking-policy operations.
  * Ensured masking-policy name updates during table renames use the correct job context.
* **Tests**
  * Expanded masking-policy upgrade coverage to validate schema initialization from multiple starting bootstrap versions.
  * Added failpoint-driven tests to confirm the expected `ErrTableNotExists` behavior only in normal start mode.
* **Chores**
  * Updated the test target to include the new masking-policy internal test file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->