### PR TITLE
server: fix inaccurate WriteSQLRespDuration

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1630,7 +1630,7 @@ func (cc *clientConn) flush(ctx context.Context) error {
 		startTime  = beginWriteSQLRespDuration(stmtDetail)
 	)
 	defer func() {
-		addWriteSQLRespDuration(stmtDetail, startTime)
+		finishWriteSQLRespDuration(stmtDetail, &startTime)
 		trace.StartRegion(ctx, "FlushClientConn").End()
 		if ctx := cc.getCtx(); ctx != nil && ctx.WarningCount() > 0 {
 			for _, err := range ctx.GetWarnings() {
@@ -1666,9 +1666,10 @@ func beginWriteSQLRespDuration(stmtDetail *execdetails.StmtExecDetails) time.Tim
 	return time.Now()
 }
 
-func addWriteSQLRespDuration(stmtDetail *execdetails.StmtExecDetails, startTime time.Time) {
+func finishWriteSQLRespDuration(stmtDetail *execdetails.StmtExecDetails, startTime *time.Time) {
 	if stmtDetail != nil && !startTime.IsZero() {
-		stmtDetail.WriteSQLRespDuration += time.Since(startTime)
+		stmtDetail.WriteSQLRespDuration += time.Since(*startTime)
+		*startTime = time.Time{}
 	}
 }
 
@@ -2579,6 +2580,9 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			ruv2Metrics.AddResultChunkCells(cells)
 		}
 	}()
+	defer func() {
+		finishWriteSQLRespDuration(stmtDetail, &start)
+	}()
 	for {
 		failpoint.Inject("fetchNextErr", func(value failpoint.Value) {
 			//nolint:forcetypeassert
@@ -2607,17 +2611,15 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			columnCount = len(columns)
 			start = beginWriteSQLRespDuration(stmtDetail)
 			if err = cc.writeColumnInfo(columns); err != nil {
-				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 			if cc.capability&mysql.ClientDeprecateEOF == 0 {
 				// metadata only needs EOF marker for old clients without ClientDeprecateEOF
 				if err = cc.writeEOF(ctx, serverStatus); err != nil {
-					addWriteSQLRespDuration(stmtDetail, start)
 					return false, err
 				}
 			}
-			addWriteSQLRespDuration(stmtDetail, start)
+			finishWriteSQLRespDuration(stmtDetail, &start)
 			gotColumnInfo = true
 		}
 		rowCount := req.NumRows()
@@ -2638,17 +2640,15 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			}
 			if err != nil {
 				reg.End()
-				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 			if err = cc.writePacket(data); err != nil {
 				reg.End()
-				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 		}
 		reg.End()
-		addWriteSQLRespDuration(stmtDetail, start)
+		finishWriteSQLRespDuration(stmtDetail, &start)
 	}
 	if err := rs.Finish(); err != nil {
 		return false, err
@@ -2657,7 +2657,7 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 	start = beginWriteSQLRespDuration(stmtDetail)
 
 	err := cc.writeEOF(ctx, serverStatus)
-	addWriteSQLRespDuration(stmtDetail, start)
+	finishWriteSQLRespDuration(stmtDetail, &start)
 	return false, err
 }
 
@@ -2678,6 +2678,9 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		cells := int64(writtenRows) * int64(len(rs.Columns()))
 		resultset.ReportCursorRUV2Delta(rs, cells)
 	}()
+	defer func() {
+		finishWriteSQLRespDuration(stmtDetail, &start)
+	}()
 	start = beginWriteSQLRespDuration(stmtDetail)
 
 	iter := rs.GetRowIterator()
@@ -2688,11 +2691,9 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		data = data[0:4]
 		data, err = column.DumpBinaryRow(data, rs.Columns(), row, cc.rsEncoder)
 		if err != nil {
-			addWriteSQLRespDuration(stmtDetail, start)
 			return err
 		}
 		if err = cc.writePacket(data); err != nil {
-			addWriteSQLRespDuration(stmtDetail, start)
 			return err
 		}
 		writtenRows++
@@ -2700,7 +2701,6 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		iter.Next(ctx)
 	}
 	if iter.Error() != nil {
-		addWriteSQLRespDuration(stmtDetail, start)
 		return iter.Error()
 	}
 
@@ -2712,7 +2712,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 	}
 
 	// don't include the time consumed by `cl.OnFetchReturned()` in the `WriteSQLRespDuration`
-	addWriteSQLRespDuration(stmtDetail, start)
+	finishWriteSQLRespDuration(stmtDetail, &start)
 
 	if cl, ok := rs.(resultset.FetchNotifier); ok {
 		cl.OnFetchReturned()
@@ -2720,7 +2720,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 
 	start = beginWriteSQLRespDuration(stmtDetail)
 	err = cc.writeEOF(ctx, serverStatus)
-	addWriteSQLRespDuration(stmtDetail, start)
+	finishWriteSQLRespDuration(stmtDetail, &start)
 	return err
 }
 

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1626,18 +1626,11 @@ func (cc *clientConn) useDB(ctx context.Context, db string) (node ast.StmtNode, 
 
 func (cc *clientConn) flush(ctx context.Context) error {
 	var (
-		stmtDetail *execdetails.StmtExecDetails
-		startTime  time.Time
+		stmtDetail = stmtExecDetailsFromContext(ctx)
+		startTime  = beginWriteSQLRespDuration(stmtDetail)
 	)
-	if stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey); stmtDetailRaw != nil {
-		//nolint:forcetypeassert
-		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
-		startTime = time.Now()
-	}
 	defer func() {
-		if stmtDetail != nil {
-			stmtDetail.WriteSQLRespDuration += time.Since(startTime)
-		}
+		addWriteSQLRespDuration(stmtDetail, startTime)
 		trace.StartRegion(ctx, "FlushClientConn").End()
 		if ctx := cc.getCtx(); ctx != nil && ctx.WarningCount() > 0 {
 			for _, err := range ctx.GetWarnings() {
@@ -1655,6 +1648,28 @@ func (cc *clientConn) flush(ctx context.Context) error {
 		}
 	})
 	return cc.pkt.Flush()
+}
+
+func stmtExecDetailsFromContext(ctx context.Context) *execdetails.StmtExecDetails {
+	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw == nil {
+		return nil
+	}
+	//nolint:forcetypeassert
+	return stmtDetailRaw.(*execdetails.StmtExecDetails)
+}
+
+func beginWriteSQLRespDuration(stmtDetail *execdetails.StmtExecDetails) time.Time {
+	if stmtDetail == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func addWriteSQLRespDuration(stmtDetail *execdetails.StmtExecDetails, startTime time.Time) {
+	if stmtDetail != nil && !startTime.IsZero() {
+		stmtDetail.WriteSQLRespDuration += time.Since(startTime)
+	}
 }
 
 func (cc *clientConn) writeOK(ctx context.Context) error {
@@ -2549,12 +2564,7 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 	firstNext := true
 	validNextCount := 0
 	var start time.Time
-	var stmtDetail *execdetails.StmtExecDetails
-	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
-	if stmtDetailRaw != nil {
-		//nolint:forcetypeassert
-		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
-	}
+	stmtDetail := stmtExecDetailsFromContext(ctx)
 	totalRows := 0
 	defer func() {
 		cells := int64(totalRows) * int64(columnCount)
@@ -2595,21 +2605,19 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			// Otherwise, we will get incorrect columns info.
 			columns = rs.Columns()
 			columnCount = len(columns)
-			if stmtDetail != nil {
-				start = time.Now()
-			}
+			start = beginWriteSQLRespDuration(stmtDetail)
 			if err = cc.writeColumnInfo(columns); err != nil {
+				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 			if cc.capability&mysql.ClientDeprecateEOF == 0 {
 				// metadata only needs EOF marker for old clients without ClientDeprecateEOF
 				if err = cc.writeEOF(ctx, serverStatus); err != nil {
+					addWriteSQLRespDuration(stmtDetail, start)
 					return false, err
 				}
 			}
-			if stmtDetail != nil {
-				stmtDetail.WriteSQLRespDuration += time.Since(start)
-			}
+			addWriteSQLRespDuration(stmtDetail, start)
 			gotColumnInfo = true
 		}
 		rowCount := req.NumRows()
@@ -2620,9 +2628,7 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 		validNextCount++
 		firstNext = false
 		reg := trace.StartRegion(ctx, "WriteClientConn")
-		if stmtDetail != nil {
-			start = time.Now()
-		}
+		start = beginWriteSQLRespDuration(stmtDetail)
 		for i := range rowCount {
 			data = data[0:4]
 			if binary {
@@ -2632,30 +2638,26 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, b
 			}
 			if err != nil {
 				reg.End()
+				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 			if err = cc.writePacket(data); err != nil {
 				reg.End()
+				addWriteSQLRespDuration(stmtDetail, start)
 				return false, err
 			}
 		}
 		reg.End()
-		if stmtDetail != nil {
-			stmtDetail.WriteSQLRespDuration += time.Since(start)
-		}
+		addWriteSQLRespDuration(stmtDetail, start)
 	}
 	if err := rs.Finish(); err != nil {
 		return false, err
 	}
 
-	if stmtDetail != nil {
-		start = time.Now()
-	}
+	start = beginWriteSQLRespDuration(stmtDetail)
 
 	err := cc.writeEOF(ctx, serverStatus)
-	if stmtDetail != nil {
-		stmtDetail.WriteSQLRespDuration += time.Since(start)
-	}
+	addWriteSQLRespDuration(stmtDetail, start)
 	return false, err
 }
 
@@ -2671,18 +2673,12 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 	)
 	data := cc.alloc.AllocWithLen(4, 1024)
 	writtenRows := 0
-	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
-	if stmtDetailRaw != nil {
-		//nolint:forcetypeassert
-		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
-	}
+	stmtDetail = stmtExecDetailsFromContext(ctx)
 	defer func() {
 		cells := int64(writtenRows) * int64(len(rs.Columns()))
 		resultset.ReportCursorRUV2Delta(rs, cells)
 	}()
-	if stmtDetail != nil {
-		start = time.Now()
-	}
+	start = beginWriteSQLRespDuration(stmtDetail)
 
 	iter := rs.GetRowIterator()
 	// send the rows to the client according to fetchSize.
@@ -2692,9 +2688,11 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		data = data[0:4]
 		data, err = column.DumpBinaryRow(data, rs.Columns(), row, cc.rsEncoder)
 		if err != nil {
+			addWriteSQLRespDuration(stmtDetail, start)
 			return err
 		}
 		if err = cc.writePacket(data); err != nil {
+			addWriteSQLRespDuration(stmtDetail, start)
 			return err
 		}
 		writtenRows++
@@ -2702,6 +2700,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		iter.Next(ctx)
 	}
 	if iter.Error() != nil {
+		addWriteSQLRespDuration(stmtDetail, start)
 		return iter.Error()
 	}
 
@@ -2713,19 +2712,15 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 	}
 
 	// don't include the time consumed by `cl.OnFetchReturned()` in the `WriteSQLRespDuration`
-	if stmtDetail != nil {
-		stmtDetail.WriteSQLRespDuration += time.Since(start)
-	}
+	addWriteSQLRespDuration(stmtDetail, start)
 
 	if cl, ok := rs.(resultset.FetchNotifier); ok {
 		cl.OnFetchReturned()
 	}
 
-	start = time.Now()
+	start = beginWriteSQLRespDuration(stmtDetail)
 	err = cc.writeEOF(ctx, serverStatus)
-	if stmtDetail != nil {
-		stmtDetail.WriteSQLRespDuration += time.Since(start)
-	}
+	addWriteSQLRespDuration(stmtDetail, start)
 	return err
 }
 

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -118,6 +119,21 @@ func (*singleRowCursorRecordSet) Close() error { return nil }
 
 var _ sqlexec.RecordSet = &singleRowCursorRecordSet{}
 
+type failedWriteResponseWriter struct {
+	delay       time.Duration
+	failOnWrite int
+	writes      int
+}
+
+func (w *failedWriteResponseWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failOnWrite {
+		time.Sleep(w.delay)
+		return 0, mysql.ErrBadConn
+	}
+	return len(p), nil
+}
+
 func TestCursorExistsFlag(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	srv := CreateMockServer(t, store)
@@ -185,6 +201,29 @@ func TestCursorExistsFlag(t *testing.T) {
 
 	// the following FETCH should fail, as the cursor has been automatically closed
 	require.Error(t, c.Dispatch(ctx, appendUint32(appendUint32([]byte{mysql.ComStmtFetch}, uint32(stmt.ID())), 5)))
+}
+
+func TestResultSetWriteSQLRespDurationIncludesFailedRowWrite(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	c := CreateMockConn(t, srv).(*mockConn)
+	c.capability &^= mysql.ClientDeprecateEOF
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values (1)")
+
+	const delay = 50 * time.Millisecond
+	c.pkt.SetBufWriter(bufio.NewWriterSize(&failedWriteResponseWriter{
+		delay:       delay,
+		failOnWrite: 4,
+	}, 1))
+	require.Error(t, c.Dispatch(context.Background(), append([]byte{mysql.ComQuery}, "select * from t"...)))
+
+	require.GreaterOrEqual(t, c.Context().GetSessionVars().CacheStmtExecInfo.WriteSQLRespDuration, delay)
 }
 
 func TestCursorWithParams(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64562 

**Problem Summary**

`WriteSQLRespDuration` may be inaccurate for `SELECT` statements when writing the result set response fails. Some error paths in result set writing returned immediately after `writePacket` / `writeEOF` / related write operations failed, before adding the elapsed response write time to statement execution details.

**What changed and how does it work**

This PR updates the result set response writing paths to always record elapsed write time before returning, including failure paths. It adds small helper functions to start and accumulate `WriteSQLRespDuration`, then uses them in `writeChunks` and `writeChunksWithFetchSize` so `SELECT` result set writes and cursor fetch writes include time spent before a write error. A regression test simulates a failed row packet write for a normal `SELECT` and verifies the delayed write time is reflected in `WriteSQLRespDuration`.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of response-time tracking for SQL result writing by sourcing statement execution details from request context.
  * Refined write-duration metrics for streamed result sets and fetch-size reads, ensuring correct segmentation across row writing, EOF markers, and related error paths.
  * Updated/added coverage to ensure write-duration metrics include failed row-write scenarios as expected (including delayed write failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->