### PR TITLE
planner: support semi join rewrite alternative plan | tidb-test=feature/fts

### DIFF
--- a/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
@@ -79,5 +79,10 @@ func TestSemiJoinRewrite(t *testing.T) {
 		tk.MustHavePlan(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 		tk.MustExec(`delete from t1 where t1.id in (select /*+ semi_join_rewrite() */ cast(id as char) from t2 where k=1)`)
 		tk.MustQuery(`select id from t1 order by id`).Check(testkit.Rows("2", "3"))
+
+		tk.MustExec(`insert into t1 values ("1")`)
+		tk.MustExec(`set @@tidb_opt_enable_alternative_logical_plans=on`)
+		tk.MustExec(`set @@tidb_opt_enable_semi_join_rewrite=off`)
+		tk.MustHavePlan(`delete from t1 where t1.id in (select /* issue:58829 */ cast(id as char) from t2 where k=1)`, "IndexHashJoin")
 	})
 }

--- a/pkg/planner/core/casetest/rule/testdata/correlate_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/correlate_suite_out.json
@@ -274,13 +274,14 @@
         "SQL": "select * from t1 where b = 1 and exists (select 1 from t2 where t2.a = t1.a) limit 1",
         "Plan": [
           "Limit 1.00 root  offset:0, count:1",
-          "└─IndexHashJoin 1.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "  ├─TableReader(Build) 1.27 root  data:Selection",
-          "  │ └─Selection 1.27 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
-          "  │   └─TableFullScan 1271.25 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─IndexReader(Probe) 1.59 root  index:Selection",
-          "    └─Selection 1.59 cop[tikv]  not(isnull(test.t2.a))",
-          "      └─IndexRangeScan 1.59 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "└─IndexJoin 1.00 root  inner join, inner:StreamAgg, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+          "  ├─TableReader(Build) 1.00 root  data:Selection",
+          "  │ └─Selection 1.00 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
+          "  │   └─TableFullScan 1001.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─StreamAgg(Probe) 1.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "    └─IndexReader 1.00 root  index:Selection",
+          "      └─Selection 1.00 cop[tikv]  not(isnull(test.t2.a))",
+          "        └─IndexRangeScan 1.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1"
@@ -327,13 +328,15 @@
       {
         "SQL": "select * from t1 where exists (select 1 from t2 where t2.a = t1.a)",
         "Plan": [
-          "IndexHashJoin 7992.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "├─TableReader(Build) 9990.00 root  data:Selection",
-          "│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
-          "│   └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─IndexReader(Probe) 12487.50 root  index:Selection",
-          "  └─Selection 12487.50 cop[tikv]  not(isnull(test.t2.a))",
-          "    └─IndexRangeScan 12500.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "IndexHashJoin 9990.00 root  inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)",
+          "├─StreamAgg(Build) 7992.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─IndexReader 7992.00 root  index:StreamAgg",
+          "│   └─StreamAgg 7992.00 cop[tikv]  group by:test.t2.a, ",
+          "│     └─IndexFullScan 9990.00 cop[tikv] table:t2, index:a(a) keep order:true, stats:pseudo",
+          "└─IndexLookUp(Probe) 9990.00 root  ",
+          "  ├─Selection(Build) 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+          "  │ └─IndexRangeScan 10000.00 cop[tikv] table:t1, index:a(a) range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",

--- a/pkg/planner/core/casetest/rule/testdata/correlate_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/correlate_suite_xut.json
@@ -274,13 +274,14 @@
         "SQL": "select * from t1 where b = 1 and exists (select 1 from t2 where t2.a = t1.a) limit 1",
         "Plan": [
           "Limit 1.00 root  offset:0, count:1",
-          "└─IndexHashJoin 1.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "  ├─TableReader(Build) 1.27 root  data:Selection",
-          "  │ └─Selection 1.27 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
-          "  │   └─TableFullScan 1271.25 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─IndexReader(Probe) 1.59 root  index:Selection",
-          "    └─Selection 1.59 cop[tikv]  not(isnull(test.t2.a))",
-          "      └─IndexRangeScan 1.59 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "└─IndexJoin 1.00 root  inner join, inner:StreamAgg, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+          "  ├─TableReader(Build) 1.00 root  data:Selection",
+          "  │ └─Selection 1.00 cop[tikv]  eq(test.t1.b, 1), not(isnull(test.t1.a))",
+          "  │   └─TableFullScan 1001.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─StreamAgg(Probe) 1.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "    └─IndexReader 1.00 root  index:Selection",
+          "      └─Selection 1.00 cop[tikv]  not(isnull(test.t2.a))",
+          "        └─IndexRangeScan 1.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:true, stats:pseudo"
         ],
         "Result": [
           "1 1"
@@ -327,13 +328,15 @@
       {
         "SQL": "select * from t1 where exists (select 1 from t2 where t2.a = t1.a)",
         "Plan": [
-          "IndexHashJoin 7992.00 root  semi join, inner:IndexReader, left side:TableReader, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
-          "├─TableReader(Build) 9990.00 root  data:Selection",
-          "│ └─Selection 9990.00 cop[tikv]  not(isnull(test.t1.a))",
-          "│   └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─IndexReader(Probe) 12487.50 root  index:Selection",
-          "  └─Selection 12487.50 cop[tikv]  not(isnull(test.t2.a))",
-          "    └─IndexRangeScan 12500.00 cop[tikv] table:t2, index:a(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
+          "IndexHashJoin 9990.00 root  inner join, inner:IndexLookUp, outer key:test.t2.a, inner key:test.t1.a, equal cond:eq(test.t2.a, test.t1.a)",
+          "├─StreamAgg(Build) 7992.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─IndexReader 7992.00 root  index:StreamAgg",
+          "│   └─StreamAgg 7992.00 cop[tikv]  group by:test.t2.a, ",
+          "│     └─IndexFullScan 9990.00 cop[tikv] table:t2, index:a(a) keep order:true, stats:pseudo",
+          "└─IndexLookUp(Probe) 9990.00 root  ",
+          "  ├─Selection(Build) 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+          "  │ └─IndexRangeScan 10000.00 cop[tikv] table:t1, index:a(a) range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan(Probe) 9990.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Result": [
           "1 1",

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5195,6 +5195,12 @@ func (b *PlanBuilder) buildSemiJoin(outerPlan, innerPlan base.LogicalPlan, onCon
 			joinPlan.JoinType = base.SemiJoin
 		}
 	}
+	if b.ctx.GetSessionVars().EnableAlternativeLogicalPlans &&
+		!forceRewrite &&
+		!b.ctx.GetSessionVars().EnableSemiJoinRewrite &&
+		joinPlan.JoinType == base.SemiJoin {
+		b.ctx.GetSessionVars().StmtCtx.MarkAlternativeLogicalPlanSemiJoinRewrite()
+	}
 	// Apply forces to choose hash join currently, so don't worry the hints will take effect if the semi join is in one apply.
 	joinPlan.SetPreferredJoinTypeAndOrder(b.TableHints())
 	// Make the session variable behave like the hint by setting the same prefer bit.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -629,6 +629,12 @@ func shouldTryCorrelateRound(sessVars *variable.SessionVars) bool {
 		sessVars.StmtCtx.AlternativeLogicalPlanPreferCorrelate
 }
 
+func shouldTrySemiJoinRewriteRound(sessVars *variable.SessionVars) bool {
+	return sessVars.EnableAlternativeLogicalPlans &&
+		sessVars.StmtCtx.AlternativeLogicalPlanSemiJoinRewrite &&
+		!sessVars.EnableSemiJoinRewrite
+}
+
 // alternativeRound describes one alternative logical-plan round.
 // adjustFlag adjusts the optimization flags for the round.
 // enabled returns true when the round should be attempted.
@@ -658,6 +664,13 @@ var alternativeRounds = [...]alternativeRound{
 		enabled:    shouldTryCorrelateRound,
 		setup: func(sv *variable.SessionVars) {
 			sv.EnableCorrelateSubquery = true
+		},
+	},
+	{
+		name:    "semi-join-rewrite",
+		enabled: shouldTrySemiJoinRewriteRound,
+		setup: func(sv *variable.SessionVars) {
+			sv.EnableSemiJoinRewrite = true
 		},
 	},
 	{
@@ -780,7 +793,8 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 	for _, round := range enabledRounds {
 		restoreLogicalPlanBuildCtx(sessVars, initialLogicalPlanCtx)
 		failpoint.Inject("failIfAlternativeLogicalPlanRoundTriggered", func(val failpoint.Value) {
-			if testSQL, ok := val.(string); ok && testSQL == node.Node.OriginalText() {
+			if testRoundAndSQL, ok := val.(string); ok &&
+				testRoundAndSQL == round.name+":"+node.Node.OriginalText() {
 				failpoint.Return(nil, nil, 0, errors.New("unexpected alternative logical plan round"))
 			}
 		})
@@ -792,12 +806,14 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 		func() {
 			if round.setup != nil {
 				prevEnableCorrelateSubquery := sessVars.EnableCorrelateSubquery
+				prevEnableSemiJoinRewrite := sessVars.EnableSemiJoinRewrite
 				prevFTSLikeFallback := sessVars.StmtCtx.AlternativeLogicalPlanFTSLikeFallback
 				defer func() {
 					if round.cleanup != nil {
 						round.cleanup(sessVars)
 					}
 					sessVars.EnableCorrelateSubquery = prevEnableCorrelateSubquery
+					sessVars.EnableSemiJoinRewrite = prevEnableSemiJoinRewrite
 					sessVars.StmtCtx.AlternativeLogicalPlanFTSLikeFallback = prevFTSLikeFallback
 				}()
 				round.setup(sessVars)

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -486,6 +486,9 @@ type StatementContext struct {
 	// build round encountered a non-correlated IN subquery eligible for the
 	// correlate-to-Apply alternative.
 	AlternativeLogicalPlanPreferCorrelate bool
+	// AlternativeLogicalPlanSemiJoinRewrite indicates whether the current logical
+	// build found a semi join that can try an additional SEMI_JOIN_REWRITE round.
+	AlternativeLogicalPlanSemiJoinRewrite bool
 	// AlternativeLogicalPlanFTSLikeFallback is a mode flag controlling how the
 	// expression rewriter handles MATCH...AGAINST in predicate contexts. When
 	// false (the default, matching Alt-disabled behavior) the rewriter emits
@@ -683,6 +686,7 @@ func (sc *StatementContext) ResetAlternativeLogicalPlanSignals() {
 	sc.AlternativeLogicalPlanFTSLikeFallback = false
 	sc.AlternativeLogicalPlanHasPredicateContextMatch = false
 	sc.AlternativeLogicalPlanPreferCorrelate = false
+	sc.AlternativeLogicalPlanSemiJoinRewrite = false
 }
 
 // MarkAlternativeLogicalPlanDecorrelatedApply records that at least one Apply has
@@ -708,6 +712,12 @@ func (sc *StatementContext) MarkAlternativeLogicalPlanOrderAwareJoinReorder() {
 // the correlate-to-Apply alternative.
 func (sc *StatementContext) MarkAlternativeLogicalPlanPreferCorrelate() {
 	sc.AlternativeLogicalPlanPreferCorrelate = true
+}
+
+// MarkAlternativeLogicalPlanSemiJoinRewrite records that the current first round
+// found a semi join that can try an extra SEMI_JOIN_REWRITE-based logical round.
+func (sc *StatementContext) MarkAlternativeLogicalPlanSemiJoinRewrite() {
+	sc.AlternativeLogicalPlanSemiJoinRewrite = true
 }
 
 // CtxID returns the context id of the statement


### PR DESCRIPTION
### What
Cherry-pick PR #69279 onto `feature/fts` to support semi join rewrite as an alternative logical plan.

PR #69459 was also checked, but its race fix is already covered here by closure-local session state snapshots in the alternative round driver, so it was an empty cherry-pick.

### Tests
- `make failpoint-enable`
- `GOCACHE=/tmp/tidb-go-build go test --tags=intest ./pkg/planner/core/casetest/correlated ./pkg/planner/core/casetest/rule -run "^(TestSemiJoinRewrite|TestCorrelate)$"`
- `make failpoint-disable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning for certain `EXISTS`/`IN`-style queries, helping them choose better execution strategies in more cases.
  * Fixed session-setting carryover between optimizer passes so plan selection stays consistent.
  * Updated planner behavior to respect more configuration combinations, including when semi-join rewrite is disabled.

* **Tests**
  * Expanded plan coverage for correlated subqueries and semi-join rewrite scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->