### PR TITLE
Revert "planner: switch to RWLock to improve binding cache performance (#65570)"

### DIFF
--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -291,7 +291,7 @@ type BindingCache interface {
 // The key of the LRU cache is original sql, the value is a slice of Bindings.
 // Note: The bindingCache should be accessed with lock.
 type bindingCache struct {
-	lock        sync.RWMutex
+	lock        sync.Mutex
 	cache       *kvcache.SimpleLRUCache
 	memCapacity int64
 	memTracker  *memory.Tracker // track memory usage.
@@ -379,8 +379,8 @@ func (c *bindingCache) delete(key bindingCacheKey) bool {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.get(bindingCacheKey(sqlDigest))
 }
 
@@ -388,8 +388,8 @@ func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetAllBindings() Bindings {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	values := c.cache.Values()
 	bindings := make(Bindings, 0, len(values))
 	for _, vals := range values {
@@ -428,16 +428,16 @@ func (c *bindingCache) SetMemCapacity(capacity int64) {
 // GetMemUsage get the memory Usage for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemUsage() int64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.memTracker.BytesConsumed()
 }
 
 // GetMemCapacity get the memory capacity for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemCapacity() int64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.memCapacity
 }
 
@@ -463,7 +463,7 @@ func (c *bindingCache) CopyBindingCache() (BindingCache, error) {
 }
 
 func (c *bindingCache) Size() int {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.cache.Size()
 }


### PR DESCRIPTION
### What changed
Cherry-picked the squash commit from pingcap/tidb#68029 onto release-8.5-20260630-v8.5.6.

Source commit: 26e57209853dbd8b3ea162cf0ec5af93c8b29a73
Local cherry-pick commit: 947edef585086c4f33c5ef59f74f4432991c1171

### Validation
- go test ./pkg/bindinfo: failed because the package requires --tags=intest
- go test --tags=intest ./pkg/bindinfo: failed in TestCreateUpdateFuzzyBinding with binding status/result mismatch
- go test --tags=intest ./pkg/bindinfo -run TestCreateUpdateFuzzyBinding -count=3: failed with empty binding result after enable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal cache synchronization to use a single locking approach for all access paths.
  - Improved consistency in how cache reads and metrics are protected during concurrent use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Release note

```release-note
None
```