### PR TITLE
server, util: make connection alive callback lock-free

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2055,12 +2055,12 @@ func setResourceGroupTaggerForMultiStmtPrefetch(snapshot kv.Snapshot, sqls strin
 func (cc *clientConn) setSQLKillerConnectionAlive() func() {
 	sessVars := cc.ctx.GetSessionVars()
 	isAlive := cc.isConnectionAlive
-	sessVars.SQLKiller.SetConnectionAliveFunc(isAlive)
+	sessVars.SQLKiller.IsConnectionAlive.Store(&isAlive)
 
 	var clearOnce sync.Once
 	return func() {
 		clearOnce.Do(func() {
-			sessVars.SQLKiller.SetConnectionAliveFunc(nil)
+			sessVars.SQLKiller.IsConnectionAlive.CompareAndSwap(&isAlive, nil)
 		})
 	}
 }

--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sqlkiller",
@@ -12,4 +12,10 @@ go_library(
         "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",
     ],
+)
+
+go_test(
+    name = "sqlkiller_test",
+    srcs = ["sqlkiller_test.go"],
+    embed = [":sqlkiller"],
 )

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -54,9 +54,8 @@ type SQLKiller struct {
 	// If the query is in writeResultSet and Finish() can acquire rs.finishLock, we can assume the query is waiting for the client to receive data from the server over network I/O.
 	InWriteResultSet atomic.Bool
 
-	lastCheckTime           atomic.Int64
-	connectionAliveFuncLock sync.RWMutex
-	isConnectionAlive       func() bool
+	lastCheckTime     atomic.Pointer[time.Time]
+	IsConnectionAlive atomic.Pointer[func() bool]
 }
 
 // SendKillSignal sends a kill signal to the query.
@@ -131,20 +130,19 @@ func (killer *SQLKiller) HandleSignal() error {
 
 	// Checks if the connection is alive.
 	// For performance reasons, the check interval should be at least `checkConnectionAliveDur`(1 second).
-	fn := killer.getConnectionAliveFunc()
+	fn := killer.IsConnectionAlive.Load()
+	lastCheckTime := killer.lastCheckTime.Load()
 	if fn != nil {
 		var checkConnectionAliveDur time.Duration = time.Second
 		now := time.Now()
-		nowUnixNano := now.UnixNano()
-		lastCheckTime := killer.lastCheckTime.Load()
 		if intest.InTest {
 			checkConnectionAliveDur = time.Millisecond
 		}
-		if lastCheckTime == 0 {
-			killer.lastCheckTime.Store(nowUnixNano)
-		} else if nowUnixNano-lastCheckTime > int64(checkConnectionAliveDur) {
-			killer.lastCheckTime.Store(nowUnixNano)
-			if !fn() {
+		if lastCheckTime == nil {
+			killer.lastCheckTime.Store(&now)
+		} else if now.Sub(*lastCheckTime) > checkConnectionAliveDur {
+			killer.lastCheckTime.Store(&now)
+			if !(*fn)() {
 				killer.SendKillSignal(QueryInterrupted)
 			}
 		}
@@ -161,23 +159,10 @@ func (killer *SQLKiller) HandleSignal() error {
 
 // CheckConnectionAlive checks whether the connection is alive immediately.
 func (killer *SQLKiller) CheckConnectionAlive() {
-	fn := killer.getConnectionAliveFunc()
-	if fn != nil && !fn() {
+	fn := killer.IsConnectionAlive.Load()
+	if fn != nil && !(*fn)() {
 		killer.SendKillSignal(QueryInterrupted)
 	}
-}
-
-// SetConnectionAliveFunc sets the connection liveness callback.
-func (killer *SQLKiller) SetConnectionAliveFunc(fn func() bool) {
-	killer.connectionAliveFuncLock.Lock()
-	defer killer.connectionAliveFuncLock.Unlock()
-	killer.isConnectionAlive = fn
-}
-
-func (killer *SQLKiller) getConnectionAliveFunc() func() bool {
-	killer.connectionAliveFuncLock.RLock()
-	defer killer.connectionAliveFuncLock.RUnlock()
-	return killer.isConnectionAlive
 }
 
 // Reset resets the SqlKiller.
@@ -186,5 +171,5 @@ func (killer *SQLKiller) Reset() {
 		logutil.BgLogger().Warn("kill finished", zap.Uint64("conn", killer.ConnID.Load()))
 	}
 	atomic.StoreUint32(&killer.Signal, 0)
-	killer.lastCheckTime.Store(0)
+	killer.lastCheckTime.Store(nil)
 }

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlkiller
+
+import "testing"
+
+func TestConnectionAliveCallbackCleanupKeepsNewerCallback(t *testing.T) {
+	var killer SQLKiller
+	var oldCallbackCalls, newCallbackCalls int
+
+	oldCallback := func() bool {
+		oldCallbackCalls++
+		return false
+	}
+	newCallback := func() bool {
+		newCallbackCalls++
+		return true
+	}
+
+	killer.IsConnectionAlive.Store(&oldCallback)
+	killer.IsConnectionAlive.Store(&newCallback)
+
+	killer.IsConnectionAlive.CompareAndSwap(&oldCallback, nil)
+	killer.CheckConnectionAlive()
+
+	if oldCallbackCalls != 0 {
+		t.Fatalf("expected old callback not to be called, got %d calls", oldCallbackCalls)
+	}
+	if newCallbackCalls != 1 {
+		t.Fatalf("expected newer callback to remain installed, got %d calls", newCallbackCalls)
+	}
+	if killer.GetKillSignal() != UnspecifiedKillSignal {
+		t.Fatalf("expected no kill signal from the newer alive callback, got %d", killer.GetKillSignal())
+	}
+
+	killer.IsConnectionAlive.CompareAndSwap(&newCallback, nil)
+	killer.CheckConnectionAlive()
+	if newCallbackCalls != 1 {
+		t.Fatalf("expected newer callback to be cleared, got %d calls", newCallbackCalls)
+	}
+}


### PR DESCRIPTION
> Follow-up: #69579 addresses the remaining OLAP regression by narrowing ordinary read result-set connection-alive checks after this PR was merged.

### What problem does this PR solve?

Issue Number: close #69546

Problem Summary:

The connection-alive callback introduced for disconnect detection is checked from `SQLKiller.HandleSignal()`, which is a shared execution checkpoint used by both read and write paths. On release-8.5, the callback lookup still uses an `RWMutex`, so high-frequency checkpoint callers such as hash join can pay noticeable lock/cache-line overhead even though the actual socket probe is throttled.

Master already has a lock-free SQLKiller connection-alive path: the callback is stored in `atomic.Pointer[func() bool]`, and `lastCheckTime` uses `atomic.Pointer[time.Time]`. During the release-8.5 backports of #68237/#68685, this area diverged and kept the `RWMutex`-based release implementation. This PR aligns the release-8.5 SQLKiller connection-alive fields and cleanup semantics with master.

### What changed and how does it work?

This PR makes the release-8.5 connection-alive callback path match master:

- Replace the `RWMutex`-protected callback with `IsConnectionAlive atomic.Pointer[func() bool]`.
- Align `lastCheckTime` with master by using `atomic.Pointer[time.Time]` for the throttled liveness check.
- Use pointer-identity `CompareAndSwap(&isAlive, nil)` cleanup so an older statement cleanup cannot clear a newer callback installed by a following statement.
- Keep the existing read/result-set and autocommit DML installation points unchanged.
- Add SQLKiller unit coverage for stale cleanup preserving the newer callback.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```sh
GOTOOLCHAIN=go1.25.10 go test ./pkg/util/sqlkiller -tags=intest,deadlock
GOTOOLCHAIN=go1.25.10 go test ./pkg/server/tests/commontest -run 'TestIssue57531|TestClientDisconnectKillsAutocommitInsert' -tags=intest,deadlock
GOTOOLCHAIN=go1.25.10 go test -race ./pkg/util/sqlkiller -tags=intest,deadlock
bazel test //pkg/util/sqlkiller:sqlkiller_test
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a performance regression caused by lock contention in connection-alive checks.
```
