### PR TITLE
executor: avoid exposing materialized view cancel job state

### DIFF
--- a/pkg/executor/materialized_view.go
+++ b/pkg/executor/materialized_view.go
@@ -591,26 +591,24 @@ func checkCancelMaterializedViewJobPrivilege(
 			return err
 		}
 		if !found {
-			return cancelMaterializedViewJobNotRunningUserError(stmt)
+			return cancelMaterializedViewJobUserError(stmt)
 		}
 		if pm.RequestVerification(ctx.GetSessionVars().ActiveRoles, dbName, tableName, "", mysql.OperateViewPriv) {
 			return nil
 		}
-		return cancelMaterializedViewJobPrecheckUserError(stmt,
-			plannererrors.ErrTableaccessDenied.GenWithStackByArgs("OPERATE VIEW", user.AuthUsername, user.AuthHostname, tableName))
+		return plannererrors.ErrTableaccessDenied.GenWithStackByArgs("OPERATE VIEW", user.AuthUsername, user.AuthHostname, tableName)
 	case ast.CancelMaterializedViewJobTypeLogPurge:
 		dbName, tableName, found, err = resolveCancelPurgeJobPrivilegeTarget(kctx, sqlExec, is, uint64(stmt.JobID))
 		if err != nil {
 			return err
 		}
 		if !found {
-			return cancelMaterializedViewJobNotRunningUserError(stmt)
+			return cancelMaterializedViewJobUserError(stmt)
 		}
 		if pm.RequestVerification(ctx.GetSessionVars().ActiveRoles, dbName, tableName, "", mysql.OperateViewPriv) {
 			return nil
 		}
-		return cancelMaterializedViewJobPrecheckUserError(stmt,
-			plannererrors.ErrTableaccessDenied.GenWithStackByArgs("OPERATE VIEW", user.AuthUsername, user.AuthHostname, tableName))
+		return plannererrors.ErrTableaccessDenied.GenWithStackByArgs("OPERATE VIEW", user.AuthUsername, user.AuthHostname, tableName)
 	default:
 		return errors.Errorf("invalid materialized view job cancel type: %d", stmt.Tp)
 	}
@@ -2232,7 +2230,7 @@ func (e *CancelMaterializedViewJobExec) Next(ctx context.Context, _ *chunk.Chunk
 			return err
 		}
 		if !applied {
-			return cancelMaterializedViewJobNotRunningUserError(e.stmt)
+			return cancelMaterializedViewJobUserError(e.stmt)
 		}
 	case ast.CancelMaterializedViewJobTypeLogPurge:
 		applied, err = requestPurgeHistCancel(ctx, sctx, uint64(e.stmt.JobID), requesterArg)
@@ -2240,7 +2238,7 @@ func (e *CancelMaterializedViewJobExec) Next(ctx context.Context, _ *chunk.Chunk
 			return err
 		}
 		if !applied {
-			return cancelMaterializedViewJobNotRunningUserError(e.stmt)
+			return cancelMaterializedViewJobUserError(e.stmt)
 		}
 	default:
 		return errors.Errorf("cancel materialized view job: unsupported type %d", e.stmt.Tp)
@@ -2257,25 +2255,6 @@ func validateCancelMaterializedViewJobStmt(stmt *ast.CancelMaterializedViewJobSt
 		return nil
 	default:
 		return errors.Errorf("invalid materialized view job cancel type: %d", stmt.Tp)
-	}
-}
-
-func cancelMaterializedViewJobPrecheckUserError(stmt *ast.CancelMaterializedViewJobStmt, cause error) error {
-	logutil.BgLogger().Warn("cannot cancel materialized view job because privilege target check failed",
-		zap.Int64("jobID", stmt.JobID),
-		zap.Uint8("type", uint8(stmt.Tp)),
-		zap.Error(cause))
-	return cancelMaterializedViewJobUserError(stmt)
-}
-
-func cancelMaterializedViewJobNotRunningUserError(stmt *ast.CancelMaterializedViewJobStmt) error {
-	switch stmt.Tp {
-	case ast.CancelMaterializedViewJobTypeRefresh:
-		return errors.NewNoStackErrorf("cannot cancel materialized view refresh job %d: job not running, not found, or cancel already requested", stmt.JobID)
-	case ast.CancelMaterializedViewJobTypeLogPurge:
-		return errors.NewNoStackErrorf("cannot cancel materialized view log purge job %d: job not running, not found, or cancel already requested", stmt.JobID)
-	default:
-		return errors.Errorf("cancel materialized view job: unsupported type %d", stmt.Tp)
 	}
 }
 

--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -1601,7 +1601,7 @@ func TestCancelMaterializedViewLogPurgeJob(t *testing.T) {
 	tkCancel := testkit.NewTestKit(t, store)
 	require.NoError(t, tkCancel.Session().Auth(&auth.UserIdentity{Username: "mv_purge_cancel_u", Hostname: "%"}, nil, nil, nil))
 	err = tkCancel.ExecToErr(fmt.Sprintf("cancel materialized view log purge job %s", jobID))
-	require.ErrorContains(t, err, "cannot cancel materialized view log purge job")
+	require.ErrorContains(t, err, "OPERATE VIEW command denied")
 	tk.MustExec("grant operate view on test.`$mlog$t_purge_cancel_job` to 'mv_purge_cancel_u'@'%'")
 	requestedCh := waitMVTaskCancelWatcherRequested(t, "mlog-purge-")
 	tkCancel.MustExec(fmt.Sprintf("cancel materialized view log purge job %s", jobID))

--- a/pkg/executor/test/executor/materialized_view_refresh_test.go
+++ b/pkg/executor/test/executor/materialized_view_refresh_test.go
@@ -4213,7 +4213,7 @@ func TestCancelMaterializedViewRefreshJob(t *testing.T) {
 	tkCancel := testkit.NewTestKit(t, store)
 	require.NoError(t, tkCancel.Session().Auth(&auth.UserIdentity{Username: "mv_refresh_cancel_u", Hostname: "%"}, nil, nil, nil))
 	err = tkCancel.ExecToErr(fmt.Sprintf("cancel materialized view refresh job %s", jobID))
-	require.ErrorContains(t, err, "cannot cancel materialized view refresh job")
+	require.ErrorContains(t, err, "OPERATE VIEW command denied")
 	tk.MustExec("grant operate view on test.mv_refresh_cancel_job to 'mv_refresh_cancel_u'@'%'")
 	requestedCh := waitMVTaskCancelWatcherRequested(t, "refresh-")
 	tkCancel.MustExec(fmt.Sprintf("cancel materialized view refresh job %s", jobID))
@@ -4246,12 +4246,14 @@ func TestCancelMaterializedViewRefreshJob(t *testing.T) {
 	require.Equal(t, "cancelled manually by 'mv_refresh_cancel_u'@'%'", fmt.Sprint(reasonRows[0][0]))
 }
 
-func TestCancelMaterializedViewRefreshJobNotRunning(t *testing.T) {
+func TestCancelMaterializedViewJobNotRunning(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
 	err := tk.ExecToErr("cancel materialized view refresh job 1")
-	require.ErrorContains(t, err, "cannot cancel materialized view refresh job 1: job not running, not found, or cancel already requested")
+	require.ErrorContains(t, err, "cannot cancel materialized view refresh job 1")
+	err = tk.ExecToErr("cancel materialized view log purge job 1")
+	require.ErrorContains(t, err, "cannot cancel materialized view log purge job 1")
 }
 
 func TestMaterializedViewRefreshCancelWatcherStopsAfterTaskFinish(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69432

Problem Summary:

`CANCEL MATERIALIZED VIEW REFRESH JOB` and `CANCEL MATERIALIZED VIEW LOG PURGE JOB` could expose job-state details through user-facing errors when the job was not running, not found, or already had a cancel request.

For users without access to the target MV/MLog, this made the statement usable as a job-state probe.

### What changed and how does it work?

This PR removes the detailed user-facing cancel job state error:

- `job not running, not found, or cancel already requested`

The cancel path now returns a generic cancel failure when no cancellable running job can be resolved or when the cancel update does not apply:

- `cannot cancel materialized view refresh job <id>`
- `cannot cancel materialized view log purge job <id>`

If a running job target can be resolved but the user lacks `OPERATE VIEW` on the target MV/MLog, the statement now returns the normal privilege error, so permission failures are still explicit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- [x] No side effects

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized error messages for cancelling materialized view refresh and purge/log purge jobs when the target job can’t be cancelled or isn’t running.
  * When permissions are insufficient, cancellation now consistently reports an `OPERATE VIEW command denied`-style message.
  * Updated/adjusted related automated tests to reflect the new, consistent error text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->