### PR TITLE
security: restrict Bazel workflow token permissions

### DIFF
--- a/.github/workflows/bazel-build-crossbuild.yml
+++ b/.github/workflows/bazel-build-crossbuild.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   master:
     name: Bazel Crossbuild

--- a/.github/workflows/bazel-lint-crossbuild.yml
+++ b/.github/workflows/bazel-lint-crossbuild.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   master:
     name: Bazel Lint

--- a/.github/workflows/update-bazel-files.yml
+++ b/.github/workflows/update-bazel-files.yml
@@ -7,8 +7,7 @@ on:
       - completed
 
 permissions:
-  actions: read
-  contents: write
+  contents: read
 
 concurrency:
   group: update-bazel-files-${{ github.event.workflow_run.id }}
@@ -17,6 +16,10 @@ concurrency:
 jobs:
   update:
     name: Update Bazel Files
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: read
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'


### PR DESCRIPTION
Issue Number: close #69456

### What changed

This PR restricts the `GITHUB_TOKEN` permissions for the Bazel-related GitHub Actions workflows mentioned in #69456.

- `bazel-build-crossbuild.yml`: add top-level `contents: read` because the workflow only checks out code and runs `make bazel_bin`.
- `bazel-lint-crossbuild.yml`: add top-level `contents: read` because the workflow only checks out code and runs `make bazel_lint_changed`.
- `update-bazel-files.yml`: keep the workflow default at `contents: read`, and grant `actions: read`, `contents: write`, and `pull-requests: read` only to the `Update Bazel Files` job that downloads the generated Bazel artifact, resolves PR metadata, and pushes generated Bazel file commits back to same-repository PR branches.

### Workflow usage

- `Bazel Crossbuild for TiDB/Lightning` runs on `push` and `pull_request` to `master`. It verifies Bazel binary builds across macOS, Ubuntu, and Ubuntu ARM runners. It produces a status check only.
- `Bazel Lint Crossbuild` runs on `pull_request` to `master`. It verifies Bazel lint for changed files across macOS and Ubuntu runners. It produces a status check only.
- `Update Bazel Files` runs after `Generate Bazel Files` completes successfully for PR runs. It consumes the uploaded `bazel.patch`; same-repository PRs receive an automatic `chore: update bazel file` commit, while fork PRs get instructions in the step summary.

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [x] No code

Manual checks:

- `git diff --check -- .github/workflows/bazel-build-crossbuild.yml .github/workflows/bazel-lint-crossbuild.yml .github/workflows/update-bazel-files.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/bazel-build-crossbuild.yml .github/workflows/bazel-lint-crossbuild.yml .github/workflows/update-bazel-files.yml`

Not run:

- `workflow_run` fork PR end-to-end behavior, which requires an actual GitHub Actions run.
- OpenSSF Scorecard rescan, which should be checked after the workflow permission change is merged.

## Release note

```release-note
Restrict Bazel GitHub Actions workflow token permissions to least privilege.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to be more explicit and restrictive across several automation jobs.
  * Limited default access to read-only repository contents where possible.
  * Kept necessary write and pull request access only for the step that updates Bazel-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
