### PR TITLE
server: validate advertise-address is bound locally at startup and lease renewal

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -729,6 +729,18 @@ func overrideConfig(cfg *config.Config, fset *flag.FlagSet) {
 	if len(cfg.AdvertiseAddress) == 0 {
 		cfg.AdvertiseAddress = cfg.Host
 	}
+
+	// Validate that advertise-address is bound to a local interface
+	if len(cfg.AdvertiseAddress) > 0 && cfg.AdvertiseAddress != "0.0.0.0" && cfg.AdvertiseAddress != "::" {
+		if !util.IsIPBoundLocally(cfg.AdvertiseAddress) {
+			terror.MustNil(errors.Errorf(
+				"advertise-address %s is not bound to any local network interface. "+
+					"TiDB will fail to register properly with etcd. "+
+					"Please ensure the IP address is configured on a local interface.",
+				cfg.AdvertiseAddress))
+		}
+	}
+
 	var err error
 	if actualFlags[nmPort] {
 		var p int

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -107,6 +107,24 @@ func (s *Syncer) NewSessionAndStoreServerInfo(ctx context.Context) error {
 	if s.etcdCli == nil {
 		return nil
 	}
+
+	// Validate that the advertise address is still bound to a local interface
+	// before creating/renewing the session. This prevents stale server info entries
+	// when the host IP changes.
+	cfg := config.GetGlobalConfig()
+	advertiseAddr := cfg.AdvertiseAddress
+	if len(advertiseAddr) > 0 && advertiseAddr != "0.0.0.0" && advertiseAddr != "::" {
+		if !tidbutil.IsIPBoundLocally(advertiseAddr) {
+			logutil.BgLogger().Warn("advertise-address is no longer bound to any local interface, refusing to renew session",
+				zap.String("advertise-address", advertiseAddr),
+				zap.String("server-info-path", s.serverInfoPath))
+			return errors.Errorf(
+				"advertise-address %s is not bound to any local network interface. "+
+					"The host IP may have changed. Refusing to renew etcd session to prevent stale entries.",
+				advertiseAddr)
+		}
+	}
+
 	s.cleanupStaleServerAndOwnerInfo(ctx)
 	logPrefix := fmt.Sprintf("[Info-syncer] %s", s.serverInfoPath)
 	session, err := tidbutil.NewSession(ctx, logPrefix, s.etcdCli, tidbutil.NewSessionDefaultRetryCnt, util.SessionTTL)

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	util2 "github.com/pingcap/tidb/pkg/util"
@@ -436,6 +437,25 @@ func (m *ownerManager) closeSession() {
 
 func (m *ownerManager) refreshSession(retryCnt, ttl int) error {
 	m.closeSession()
+
+	// Validate that the advertise address is still bound to a local interface
+	// before creating/renewing the session. This prevents stale entries when
+	// the host IP changes.
+	cfg := config.GetGlobalConfig()
+	advertiseAddr := cfg.AdvertiseAddress
+	if len(advertiseAddr) > 0 && advertiseAddr != "0.0.0.0" && advertiseAddr != "::" {
+		if !util2.IsIPBoundLocally(advertiseAddr) {
+			m.logger.Warn("advertise-address is no longer bound to any local interface, refusing to renew session",
+				zap.String("advertise-address", advertiseAddr),
+				zap.String("manager-id", m.id),
+				zap.String("owner-key", m.key))
+			return errors.Errorf(
+				"advertise-address %s is not bound to any local network interface. "+
+					"The host IP may have changed. Refusing to renew etcd session to prevent stale entries.",
+				advertiseAddr)
+		}
+	}
+
 	// Note: we must use manager's context to create session. If we use campaign
 	// context and the context is cancelled, the created session cannot be closed
 	// as session close depends on the context.

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -550,6 +550,44 @@ func GetLocalIP() string {
 	return ""
 }
 
+// IsIPBoundLocally checks if the given IP address is bound to any local network interface.
+// It returns true if the IP is found on a local interface, false otherwise.
+// Special case: "0.0.0.0" and "::" (bind-all addresses) always return true.
+func IsIPBoundLocally(ipAddr string) bool {
+	// Handle bind-all addresses
+	if ipAddr == "0.0.0.0" || ipAddr == "::" {
+		return true
+	}
+
+	// Parse the input IP
+	targetIP := net.ParseIP(ipAddr)
+	if targetIP == nil {
+		// Invalid IP format
+		return false
+	}
+
+	// Get all network interfaces
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		logutil.BgLogger().Warn("failed to get network interfaces", zap.Error(err))
+		return false
+	}
+
+	// Check each interface address
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		// Compare the IP addresses
+		if ipnet.IP.Equal(targetIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // CreateCertificates creates and writes a cert based on the params.
 func CreateCertificates(certpath string, keypath string, rsaKeySize int, pubKeyAlgo x509.PublicKeyAlgorithm,
 	signAlgo x509.SignatureAlgorithm) error {

--- a/pkg/util/misc_test.go
+++ b/pkg/util/misc_test.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bytes"
 	"crypto/x509/pkix"
+	"net"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/fastrand"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunWithRetry(t *testing.T) {
@@ -187,4 +189,59 @@ func TestComposeURL(t *testing.T) {
 	assert.Equal(t, ComposeURL("https://httpserver.example.com", "/api/test"), "https://httpserver.example.com/api/test")
 	assert.Equal(t, ComposeURL("http://server.example.com", ""), "http://server.example.com")
 	assert.Equal(t, ComposeURL("https://server.example.com", ""), "https://server.example.com")
+}
+
+func TestIsIPBoundLocally(t *testing.T) {
+	// Test bind-all addresses
+	t.Run("bind all ipv4", func(t *testing.T) {
+		assert.True(t, IsIPBoundLocally("0.0.0.0"))
+	})
+
+	t.Run("bind all ipv6", func(t *testing.T) {
+		assert.True(t, IsIPBoundLocally("::"))
+	})
+
+	// Test invalid IP
+	t.Run("invalid ip", func(t *testing.T) {
+		assert.False(t, IsIPBoundLocally("not-an-ip"))
+		assert.False(t, IsIPBoundLocally("999.999.999.999"))
+		assert.False(t, IsIPBoundLocally(""))
+	})
+
+	// Test loopback addresses (should be bound on all systems)
+	t.Run("loopback ipv4", func(t *testing.T) {
+		assert.True(t, IsIPBoundLocally("127.0.0.1"))
+	})
+
+	t.Run("loopback ipv6", func(t *testing.T) {
+		assert.True(t, IsIPBoundLocally("::1"))
+	})
+
+	// Test an IP that is definitely not bound locally
+	t.Run("external ip", func(t *testing.T) {
+		// Use a well-known external IP (Google DNS)
+		assert.False(t, IsIPBoundLocally("8.8.8.8"))
+		assert.False(t, IsIPBoundLocally("2001:4860:4860::8888"))
+	})
+
+	// Test with actual local IPs
+	t.Run("actual local ips", func(t *testing.T) {
+		addrs, err := net.InterfaceAddrs()
+		require.NoError(t, err)
+
+		foundAtLeastOne := false
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ipStr := ipnet.IP.String()
+			// This IP should be bound locally
+			if IsIPBoundLocally(ipStr) {
+				foundAtLeastOne = true
+			}
+		}
+		// We should find at least loopback
+		assert.True(t, foundAtLeastOne, "should find at least one local IP")
+	})
 }


### PR DESCRIPTION
## What problem does this PR solve?

TiDB can register stale entries in etcd when the `--advertise-address` parameter doesn't match the actual IP address bound to local network interfaces. This happens when:
1. The advertised address is misconfigured at startup
2. The host IP address changes after TiDB has started (e.g., DHCP reassignment, interface reconfiguration)

When this occurs, stale etcd entries persist indefinitely because TiDB keeps renewing the lease, even though the advertised IP is no longer valid.

## What is changed and how it works?

This PR adds validation at two critical points:

### 1. Startup Validation
- Validates that `--advertise-address` is bound to a local network interface before server starts
- Fails fast with a clear error message if the IP is not bound locally
- Helps catch configuration errors early

### 2. Runtime Validation During Lease Renewal
- Checks if advertise-address is still bound locally before renewing etcd sessions
- Applied to:
  - Owner manager session refresh (DDL owner, auto-ID service, etc.)
  - Server info syncer session refresh
- If validation fails, lease renewal is refused and the etcd entry naturally expires

### Implementation Details
- Added `IsIPBoundLocally()` utility function in `pkg/util/misc.go`
- Special handling for bind-all addresses (`0.0.0.0`, `::`)
- Clear error messages and warning logs when validation fails
- Comprehensive unit tests covering various scenarios

## Check List

Tests:
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (TiUP playground)

## Related changes

- N/A

## Release notes

```release-note
server: Validate that advertise-address is bound to local network interfaces at startup and during lease renewal to prevent stale etcd entries
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added checks to prevent server sessions from renewing when the configured advertised IP is no longer available on the host.
  * Validates advertised addresses at startup and skips validation for wildcard bind addresses.
  * Helps avoid stale server information when a machine’s network address changes.

* **Tests**
  * Added coverage for local IP detection across wildcard, loopback, invalid, and externally bound addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->