### PR TITLE
expression: INET6_NTOA returns NULL for non-binary or wrong-length input

### DIFF
--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression/expropt"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -822,12 +823,27 @@ func (b *builtinInet6NtoaSig) Clone() builtinFunc {
 	return newSig
 }
 
+// inet6NtoaArgInvalid reports whether an INET6_NTOA argument violates MySQL's
+// requirement that it be a binary string of exactly 4 or 16 bytes. MySQL keys
+// this on the argument collation being binary, so a non-binary argument such as
+// INET6_NTOA(1234) or INET6_NTOA('abcdefghijklmnop') is rejected even though its
+// length is 4 or 16 bytes; a wrong length is rejected too. Such input yields
+// NULL with warning 1411, see https://github.com/pingcap/tidb/issues/59461.
+func inet6NtoaArgInvalid(argTp *types.FieldType, valLen int) bool {
+	return argTp.GetCharset() != charset.CharsetBin || (valLen != net.IPv4len && valLen != net.IPv6len)
+}
+
 // evalString evals a builtinInet6NtoaSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-ntoa
 func (b *builtinInet6NtoaSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalString(ctx, row)
 	if err != nil || isNull {
 		return "", true, err
+	}
+	if inet6NtoaArgInvalid(b.args[0].GetType(ctx), len(val)) {
+		tc := typeCtx(ctx)
+		tc.AppendWarning(errWrongValueForType.FastGenByArgs("string", val, "inet6_ntoa"))
+		return "", true, nil
 	}
 	ip := net.IP(val).String()
 	if len(val) == net.IPv6len && !strings.Contains(ip, ":") {

--- a/pkg/expression/builtin_miscellaneous_test.go
+++ b/pkg/expression/builtin_miscellaneous_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
@@ -382,31 +383,63 @@ func TestInetNtoa(t *testing.T) {
 	require.True(t, r.IsNull())
 }
 
+// inet6NtoaArg builds an INET6_NTOA argument constant with either a binary or a
+// non-binary (utf8mb4) charset, so the tests can exercise MySQL's rule that only
+// a binary string of 4 or 16 bytes is rendered (see issue #59461).
+func inet6NtoaArg(val []byte, binaryChs bool) Expression {
+	var ft *types.FieldType
+	if binaryChs {
+		ft = types.NewFieldType(mysql.TypeVarString)
+		types.SetBinChsClnFlag(ft)
+	} else {
+		ft = types.NewFieldTypeWithCollation(mysql.TypeVarString, charset.CollationUTF8MB4, types.UnspecifiedLength)
+	}
+	return &Constant{Value: types.NewBytesDatum(val), RetType: ft}
+}
+
+func TestInet6NtoaArgInvalid(t *testing.T) {
+	binTp := types.NewFieldType(mysql.TypeVarString)
+	types.SetBinChsClnFlag(binTp)
+	strTp := types.NewFieldTypeWithCollation(mysql.TypeVarString, charset.CollationUTF8MB4, types.UnspecifiedLength)
+	// A binary string of 4 or 16 bytes is the only valid shape.
+	require.False(t, inet6NtoaArgInvalid(binTp, 4))
+	require.False(t, inet6NtoaArgInvalid(binTp, 16))
+	// A binary string of any other length is rejected.
+	require.True(t, inet6NtoaArgInvalid(binTp, 5))
+	require.True(t, inet6NtoaArgInvalid(binTp, 0))
+	// A non-binary argument is rejected even at a valid length.
+	require.True(t, inet6NtoaArgInvalid(strTp, 4))
+	require.True(t, inet6NtoaArgInvalid(strTp, 16))
+}
+
 func TestInet6NtoA(t *testing.T) {
 	ctx := createContext(t)
 	tests := []struct {
-		ip     []byte
-		expect any
+		ip        []byte
+		binaryChs bool
+		expect    any
 	}{
-		// Success cases
-		{[]byte{0x00, 0x00, 0x00, 0x00}, "0.0.0.0"},
-		{[]byte{0x0A, 0x00, 0x05, 0x09}, "10.0.5.9"},
+		// Success cases: binary strings of 4 or 16 bytes.
+		{[]byte{0x00, 0x00, 0x00, 0x00}, true, "0.0.0.0"},
+		{[]byte{0x0A, 0x00, 0x05, 0x09}, true, "10.0.5.9"},
 		{[]byte{0xFD, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5A, 0x55, 0xCA, 0xFF, 0xFE,
-			0xFA, 0x90, 0x89}, "fdfe::5a55:caff:fefa:9089"},
+			0xFA, 0x90, 0x89}, true, "fdfe::5a55:caff:fefa:9089"},
 		{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x01,
-			0x02, 0x03, 0x04}, "::ffff:1.2.3.4"},
+			0x02, 0x03, 0x04}, true, "::ffff:1.2.3.4"},
 		{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
-			0xFF, 0xFF, 0xFF}, "::ffff:255.255.255.255"},
-		// Fail cases
-		{[]byte{}, nil},                 // missing bytes
-		{[]byte{0x0A, 0x00, 0x05}, nil}, // missing a byte ipv4
+			0xFF, 0xFF, 0xFF}, true, "::ffff:255.255.255.255"},
+		// Fail cases: wrong length, still a binary string.
+		{[]byte{}, true, nil},                 // missing bytes
+		{[]byte{0x0A, 0x00, 0x05}, true, nil}, // missing a byte ipv4
 		{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF,
-			0xFF, 0xFF}, nil}, // missing a byte ipv6
+			0xFF, 0xFF}, true, nil}, // missing a byte ipv6
+		// Fail cases: non-binary argument at a valid length (issue #59461).
+		{[]byte("1234"), false, nil},             // INET6_NTOA(1234) -> "1234", 4 bytes
+		{[]byte("abcdefghijklmnop"), false, nil}, // 16 bytes, non-binary
 	}
 	fc := funcs[ast.Inet6Ntoa]
 	for _, test := range tests {
-		ip := types.NewDatum(test.ip)
-		f, err := fc.getFunction(ctx, datumsToConstants([]types.Datum{ip}))
+		f, err := fc.getFunction(ctx, []Expression{inet6NtoaArg(test.ip, test.binaryChs)})
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, ctx, chunk.Row{})
 		require.NoError(t, err)

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -734,6 +734,8 @@ func (b *builtinInet6NtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err := b.args[0].VecEvalString(ctx, input, val); err != nil {
 		return err
 	}
+	tc := typeCtx(ctx)
+	argTp := b.args[0].GetType(ctx)
 	result.ReserveString(n)
 	for i := range n {
 		if val.IsNull(i) {
@@ -741,6 +743,11 @@ func (b *builtinInet6NtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 			continue
 		}
 		valI := val.GetString(i)
+		if inet6NtoaArgInvalid(argTp, len(valI)) {
+			tc.AppendWarning(errWrongValueForType.FastGenByArgs("string", valI, "inet6_ntoa"))
+			result.AppendNull()
+			continue
+		}
 		ip := net.IP(valI).String()
 		if len(valI) == net.IPv6len && !strings.Contains(ip, ":") {
 			ip = fmt.Sprintf("::ffff:%s", ip)

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "integration_test_test",
     timeout = "short",
     srcs = [
+        "inet6_ntoa_test.go",
         "integration_test.go",
         "main_test.go",
     ],

--- a/pkg/expression/integration_test/inet6_ntoa_test.go
+++ b/pkg/expression/integration_test/inet6_ntoa_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestInet6NtoaInvalidArg(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Invalid arguments: not a binary string of exactly 4 or 16 bytes. MySQL
+	// returns NULL with warning 1411 rather than rendering a bogus address, even
+	// when the byte length is 4 or 16 but the value is not a binary string.
+	// See https://github.com/pingcap/tidb/issues/59461.
+	tk.MustQuery("select inet6_ntoa(1234)").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1411 Incorrect string value: '1234' for function inet6_ntoa"))
+
+	tk.MustQuery("select inet6_ntoa('abcdefghijklmnop')").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1411 Incorrect string value: 'abcdefghijklmnop' for function inet6_ntoa"))
+
+	// A valid binary string produced by inet6_aton / unhex still renders.
+	tk.MustQuery("select inet6_ntoa(inet6_aton('1.2.3.4'))").Check(testkit.Rows("1.2.3.4"))
+	tk.MustQuery("select inet6_ntoa(unhex('0A000509'))").Check(testkit.Rows("10.0.5.9"))
+
+	// A genuinely binary string (unhex) whose length is not 4 or 16 is rejected
+	// too, exercising the length-only failure path (charset is already binary).
+	tk.MustQuery("select inet6_ntoa(unhex('3132333435'))").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1411 Incorrect string value: '12345' for function inet6_ntoa"))
+
+	// Exercise the vectorized path against real column-backed values: a binary
+	// VARBINARY column renders, a non-binary VARCHAR column is rejected to NULL
+	// with the same warning.
+	tk.MustExec("create table t (v varbinary(20), s varchar(20))")
+	tk.MustExec("insert into t values (inet6_aton('10.0.5.9'), 'abcdefghijklmnop')")
+	tk.MustQuery("select inet6_ntoa(v) from t").Check(testkit.Rows("10.0.5.9"))
+	tk.MustQuery("select inet6_ntoa(s) from t").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1411 Incorrect string value: 'abcdefghijklmnop' for function inet6_ntoa"))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59461

Problem Summary:

`INET6_NTOA` rendered any argument that Go's `net.ParseIP` happened to accept, instead of restricting the input to a binary string of 4 or 16 bytes the way MySQL does:

- `SELECT INET6_NTOA(1234)` returned `49.50.51.52` (MySQL returns NULL with warning 1411)
- `SELECT INET6_NTOA('abcdefghijklmnop')` returned a bogus IPv6 address (MySQL returns NULL with warning 1411)

Both reproducers are 4 and 16 bytes, so a length check alone does not catch them. The actual rule is that the argument must be a binary string; MySQL keys on the argument collation being binary.

### What changed and how does it work?

Guard both the scalar `evalString` and the vectorized `vecEvalString` paths of `builtinInet6NtoaSig` on the argument charset being binary and the length being 4 or 16 bytes. When the argument is invalid, append warning 1411 (`ErrWrongValueForType`) and return NULL, matching MySQL. Binary strings produced by `INET6_ATON`, `UNHEX`, or a `VARBINARY` column keep rendering unchanged.

Verified end to end:

- `INET6_NTOA(1234)` and `INET6_NTOA('abcdefghijklmnop')` now return NULL with warning 1411
- `INET6_NTOA(INET6_ATON('1.2.3.4'))` returns `1.2.3.4`, and `INET6_NTOA(UNHEX('0A000509'))` returns `10.0.5.9`

This touches the same function as the in-flight #61998, which fixes the #59483 panic on the vectorized path. The two changes are independent; if #61998 merges first I will rebase the vector-path guard onto its row-by-row loop.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix `INET6_NTOA` to return NULL with warning 1411 for a non-binary or wrong-length argument instead of rendering an incorrect address.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `INET6_NTOA` now applies stricter, MySQL-compatible input validation and returns `NULL` with a warning (`incorrect string value`) for improperly formatted values.
  * Non-binary inputs are rejected even when their length matches 4 or 16 bytes.
  * Vectorized evaluation now validates per row and returns `NULL` for invalid entries while preserving correct results for valid binary inputs.

* **Tests**
  * Added integration tests for invalid arguments, warning emission, and vectorized/column-based scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->