### PR TITLE
br: prune removed stores from CRR synced progress

### DIFF
--- a/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
+++ b/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":checkpoint"],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "//br/pkg/stream",
         "//br/pkg/streamhelper",

--- a/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
+++ b/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":checkpoint"],
     flaky = True,
-    shard_count = 22,
+    shard_count = 23,
     deps = [
         "//br/pkg/stream",
         "//br/pkg/streamhelper",

--- a/br/pkg/stream/crr/internal/checkpoint/calculator.go
+++ b/br/pkg/stream/crr/internal/checkpoint/calculator.go
@@ -21,8 +21,10 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/streamhelper"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
+	"go.uber.org/zap"
 )
 
 const (
@@ -52,6 +54,7 @@ type CheckpointEvent struct {
 	LoopIteration      uint64
 	UpstreamCheckpoint uint64
 	SyncedTS           uint64
+	SyncedByStore      map[uint64]uint64
 
 	AliveStoreCount  int
 	PendingFileCount int
@@ -251,6 +254,14 @@ func (c *Calculator) RestorePersistentState(state PersistentState) error {
 	if c.state.syncedByStore == nil {
 		c.state.syncedByStore = map[uint64]uint64{}
 	}
+	log.Info(
+		"restore crr checkpoint calculator state",
+		zap.String("category", "crr checkpoint"),
+		zap.String("task", c.cfg.TaskName),
+		zap.Uint64("last-checkpoint", c.state.lastCheckpoint),
+		zap.Uint64("synced-ts", c.state.syncedTS),
+		zap.Any("synced-by-store", c.state.syncedByStore),
+	)
 	return nil
 }
 
@@ -313,6 +324,7 @@ func (c *Calculator) observeCheckpointAdvanced(
 		TaskName:           c.cfg.TaskName,
 		UpstreamCheckpoint: upstreamCheckpoint,
 		SyncedTS:           c.state.syncedTS,
+		SyncedByStore:      maps.Clone(c.state.syncedByStore),
 		AliveStoreCount:    len(aliveStores),
 		Statistic:          statistic,
 	})

--- a/br/pkg/stream/crr/internal/checkpoint/calculator.go
+++ b/br/pkg/stream/crr/internal/checkpoint/calculator.go
@@ -64,6 +64,7 @@ type CheckpointEvent struct {
 // FileStatistic summarizes the files observed in the current calculation round.
 type FileStatistic struct {
 	UpstreamReadMetaFileCount       int
+	SkippedStoreSyncedMetaFileCount int
 	EstimatedSyncLogFileCount       int
 	DownstreamCheckFileCount        int
 	PlannedFileSuffixCounts         map[string]int

--- a/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
+++ b/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
@@ -322,7 +322,7 @@ func TestCheckpointCalculatorPrunesRemovedStoreAfterFilesSynced(t *testing.T) {
 	checkpointTS, err := calculator.ComputeNextCheckpoint(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(20), checkpointTS)
-	require.Equal(t, uint64(20), calculator.SyncedTS())
+	require.Equal(t, uint64(10), calculator.SyncedTS())
 	require.Equal(
 		t,
 		map[uint64]uint64{
@@ -330,6 +330,13 @@ func TestCheckpointCalculatorPrunesRemovedStoreAfterFilesSynced(t *testing.T) {
 		},
 		calculator.StateSnapshot().SyncedByStore,
 	)
+
+	pd.Set(30, 2)
+	checkpointTS, err = calculator.ComputeNextCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(30), checkpointTS)
+	require.Equal(t, uint64(20), calculator.SyncedTS())
+	require.Equal(t, map[uint64]uint64{2: 20}, calculator.StateSnapshot().SyncedByStore)
 }
 
 func TestCheckpointCalculatorPrunesRemovedStoreBeforeAliveStoreBlocksAdvance(t *testing.T) {

--- a/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
+++ b/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
@@ -292,7 +292,7 @@ func TestCheckpointCalculatorWaitsForRemovedStoreFiles(t *testing.T) {
 	require.NotEmpty(t, log1Path)
 }
 
-func TestCheckpointCalculatorObservedRemovedStoreStillBoundsSyncedTS(t *testing.T) {
+func TestCheckpointCalculatorPrunesRemovedStoreAfterFilesSynced(t *testing.T) {
 	ctx := context.Background()
 	upstream, err := objstore.NewLocalStorage(t.TempDir())
 	require.NoError(t, err)
@@ -322,15 +322,48 @@ func TestCheckpointCalculatorObservedRemovedStoreStillBoundsSyncedTS(t *testing.
 	checkpointTS, err := calculator.ComputeNextCheckpoint(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(20), checkpointTS)
-	require.Equal(t, uint64(10), calculator.SyncedTS())
+	require.Equal(t, uint64(20), calculator.SyncedTS())
 	require.Equal(
 		t,
 		map[uint64]uint64{
-			1: 10,
 			2: 20,
 		},
 		calculator.StateSnapshot().SyncedByStore,
 	)
+}
+
+func TestCheckpointCalculatorPrunesRemovedStoreBeforeAliveStoreBlocksAdvance(t *testing.T) {
+	ctx := context.Background()
+	upstream, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	pd := &fakePDMetaReader{}
+	pd.Set(60, 2, 3)
+
+	calculator, err := checkpoint.NewCalculator(
+		checkpoint.CalculatorDeps{
+			PD:       pd,
+			Upstream: upstream,
+			Sync:     checkpoint.NewExistenceSyncChecker(fileExistenceMap{}),
+		},
+		checkpoint.CheckpointCalculatorConfig{TaskName: "drr_test_task"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, calculator.RestorePersistentState(checkpoint.PersistentState{
+		LastCheckpoint: 40,
+		SyncedTS:       50,
+		SyncedByStore: map[uint64]uint64{
+			1: 100,
+			2: 50,
+		},
+	}))
+
+	checkpointTS, err := calculator.ComputeNextCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(60), checkpointTS)
+	require.Equal(t, uint64(50), calculator.SyncedTS())
+	require.Equal(t, map[uint64]uint64{2: 50}, calculator.StateSnapshot().SyncedByStore)
 }
 
 func TestCheckpointCalculatorSkipsMetaSyncedByStoreProgress(t *testing.T) {

--- a/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
+++ b/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
@@ -333,6 +333,62 @@ func TestCheckpointCalculatorObservedRemovedStoreStillBoundsSyncedTS(t *testing.
 	)
 }
 
+func TestCheckpointCalculatorSkipsMetaSyncedByStoreProgress(t *testing.T) {
+	ctx := context.Background()
+	upstream, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	staleMetaPath, staleLogPath := writeCheckpointTestMeta(ctx, t, upstream, 15, 2)
+	syncedFiles := fileExistenceMap{
+		staleMetaPath: true,
+	}
+	require.False(t, syncedFiles[staleLogPath])
+
+	pd := &fakePDMetaReader{}
+	pd.Set(30, 2)
+	observer := &recordingObserver{}
+	calculator, err := checkpoint.NewCalculator(
+		checkpoint.CalculatorDeps{
+			PD:       pd,
+			Upstream: upstream,
+			Sync:     checkpoint.NewExistenceSyncChecker(syncedFiles),
+		},
+		checkpoint.CheckpointCalculatorConfig{
+			TaskName:     "drr_test_task",
+			PollInterval: time.Millisecond,
+		},
+		observer,
+	)
+	require.NoError(t, err)
+	require.NoError(t, calculator.RestorePersistentState(checkpoint.PersistentState{
+		LastCheckpoint: 20,
+		SyncedTS:       10,
+		SyncedByStore: map[uint64]uint64{
+			1: 10,
+			2: 20,
+		},
+	}))
+
+	computeCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+
+	checkpointTS, err := calculator.ComputeNextCheckpoint(computeCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(30), checkpointTS)
+
+	events := observer.Events()
+	require.Len(t, events, 3)
+	require.Equal(t, checkpoint.EventRoundPlanned, events[1].Type)
+	require.NotNil(t, events[1].Statistic)
+	require.Zero(t, events[1].Statistic.UpstreamReadMetaFileCount)
+	require.Equal(t, 1, events[1].Statistic.SkippedStoreSyncedMetaFileCount)
+	require.Zero(t, events[1].PendingFileCount)
+	require.Equal(t, checkpoint.EventCheckpointAdvanced, events[2].Type)
+	require.NotNil(t, events[2].Statistic)
+	require.Equal(t, 1, events[2].Statistic.SkippedStoreSyncedMetaFileCount)
+	require.Zero(t, events[2].Statistic.DownstreamCheckFileCount)
+}
+
 type fakePDMetaReader struct {
 	mu         sync.Mutex
 	checkpoint uint64
@@ -457,9 +513,10 @@ func writeCheckpointTestMeta(
 
 	logPath := fmt.Sprintf("v1/log/store-%d/flush-%016x.log", storeID, flushTS)
 	metaPath := fmt.Sprintf(
-		"%s/%016X-%016X-%016X-%016X.meta",
+		"%s/%016X%016X-d%016Xl%016Xu%016X.meta",
 		stream.GetStreamBackupMetaPrefix(),
 		flushTS,
+		storeID,
 		flushTS,
 		flushTS,
 		flushTS,

--- a/br/pkg/stream/crr/internal/checkpoint/doc.go
+++ b/br/pkg/stream/crr/internal/checkpoint/doc.go
@@ -31,7 +31,7 @@ replicated. `lastCheckpoint` is the last upstream global checkpoint returned by
 the calculator.
 
 The calculator tracks synced progress per store and publishes the global
-`syncedTS` as the minimum synced `flushTS` across all observed stores. This is
+`syncedTS` as the minimum synced `flushTS` across all alive stores. This is
 necessary because meta file names are globally ordered by
 `(flushTS, storeID, extraTags)`, while `flushTS` is only monotonic within each
 individual store.
@@ -39,7 +39,9 @@ individual store.
 The alive-store set is used only as an extra blocker: if PD still reports a
 store as alive but the calculator has not observed any flush progress for that
 store yet, `syncedTS` must not advance. Alive stores must never make
-`syncedTS` move faster than the minimum across observed stores.
+`syncedTS` move faster than the minimum across alive stores. Stores that are no
+longer alive are pruned after a successful round has scanned and waited all
+newly discovered files, so they no longer block future `syncedTS` advancement.
 
 For example:
 
@@ -53,11 +55,13 @@ As an example:
 0672E0E5956C00020000000000000004-<...>.meta
 |flushTS ------||storeID ------|  ->  flushTS = 0x0672E0E5956C0002, storeID = 4
 
-If one observed store is only known synced through `0x0672E0E5956C0002`, while
+If one alive store is only known synced through `0x0672E0E5956C0002`, while
 another is synced through `0x0672E0E5A0000000`, then the global `syncedTS`
 must stay at `min(0x0672E0E5956C0002, 0x0672E0E5A0000000)`. If PD reports an
 additional alive store that has not been observed yet, that missing store must
-block advancement, but it must not raise the minimum.
+block advancement, but it must not raise the minimum. If an observed store is no
+longer alive, its synced progress is removed after the round verifies its
+discovered files.
 
 This algorithm relies on these invariants:
 

--- a/br/pkg/stream/crr/internal/checkpoint/doc.go
+++ b/br/pkg/stream/crr/internal/checkpoint/doc.go
@@ -31,17 +31,18 @@ replicated. `lastCheckpoint` is the last upstream global checkpoint returned by
 the calculator.
 
 The calculator tracks synced progress per store and publishes the global
-`syncedTS` as the minimum synced `flushTS` across all alive stores. This is
-necessary because meta file names are globally ordered by
+`syncedTS` as the minimum synced `flushTS` across the store progress that still
+constrains the current round. This is necessary because meta file names are globally ordered by
 `(flushTS, storeID, extraTags)`, while `flushTS` is only monotonic within each
 individual store.
 
 The alive-store set is used only as an extra blocker: if PD still reports a
 store as alive but the calculator has not observed any flush progress for that
-store yet, `syncedTS` must not advance. Alive stores must never make
-`syncedTS` move faster than the minimum across alive stores. Stores that are no
-longer alive are pruned after a successful round has scanned and waited all
-newly discovered files, so they no longer block future `syncedTS` advancement.
+store yet, `syncedTS` must not advance. Alive stores must never make `syncedTS`
+move faster than the minimum across the current round's synced store progress.
+Stores that are no longer alive are pruned after a successful round has scanned
+and waited all newly discovered files. Their pre-prune progress can still bound
+that successful round's `syncedTS`, but it no longer blocks future rounds.
 
 For example:
 
@@ -60,8 +61,8 @@ another is synced through `0x0672E0E5A0000000`, then the global `syncedTS`
 must stay at `min(0x0672E0E5956C0002, 0x0672E0E5A0000000)`. If PD reports an
 additional alive store that has not been observed yet, that missing store must
 block advancement, but it must not raise the minimum. If an observed store is no
-longer alive, its synced progress is removed after the round verifies its
-discovered files.
+longer alive, its synced progress can bound the current round and is then removed
+after the round verifies its discovered files.
 
 This algorithm relies on these invariants:
 

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -194,6 +194,7 @@ func (c *Calculator) advanceSyncedState(
 		}
 	}
 
+	syncedByStoreBeforePrune := maps.Clone(c.state.syncedByStore)
 	maps.DeleteFunc(c.state.syncedByStore, func(storeID uint64, _ uint64) bool {
 		_, ok := aliveStores[storeID]
 		return !ok
@@ -203,7 +204,7 @@ func (c *Calculator) advanceSyncedState(
 		return
 	}
 
-	storeSyncedTSs := slices.Collect(maps.Values(c.state.syncedByStore))
+	storeSyncedTSs := slices.Collect(maps.Values(syncedByStoreBeforePrune))
 	if len(storeSyncedTSs) == 0 {
 		return
 	}

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
-	"math"
 	"path"
+	"slices"
 	"sync"
 	"time"
 
@@ -188,41 +189,41 @@ func (c *Calculator) advanceSyncedState(
 	aliveStores map[uint64]struct{},
 	maxFlushTSByStore map[uint64]uint64,
 ) {
-	for storeID, flushTS := range maxFlushTSByStore {
-		if flushTS > c.state.syncedByStore[storeID] {
-			c.state.syncedByStore[storeID] = flushTS
+	maps.Insert(c.state.syncedByStore, func(yield func(uint64, uint64) bool) {
+		for storeID, flushTS := range maxFlushTSByStore {
+			if flushTS <= c.state.syncedByStore[storeID] {
+				continue
+			}
+			if !yield(storeID, flushTS) {
+				return
+			}
 		}
-	}
+	})
 
-	missingStores := make([]uint64, 0)
-	for storeID := range aliveStores {
-		if _, ok := c.state.syncedByStore[storeID]; !ok {
-			missingStores = append(missingStores, storeID)
-		}
-	}
+	maps.DeleteFunc(c.state.syncedByStore, func(storeID uint64, _ uint64) bool {
+		_, ok := aliveStores[storeID]
+		return !ok
+	})
+
+	missingStores := slices.DeleteFunc(slices.Collect(maps.Keys(aliveStores)), func(storeID uint64) bool {
+		_, ok := c.state.syncedByStore[storeID]
+		return ok
+	})
 	if len(missingStores) > 0 {
 		c.warnUnsafeSyncedTS(missingStores, "alive store has no observed flush ts yet")
 		return
 	}
 
-	if len(c.state.syncedByStore) == 0 {
+	storeSyncedTSs := slices.Collect(maps.Values(c.state.syncedByStore))
+	if len(storeSyncedTSs) == 0 {
 		return
 	}
 
-	syncedCandidate := uint64(math.MaxUint64)
-	for _, storeSyncedTS := range c.state.syncedByStore {
-		if storeSyncedTS < syncedCandidate {
-			syncedCandidate = storeSyncedTS
-		}
-	}
-
+	syncedCandidate := slices.Min(storeSyncedTSs)
 	if syncedCandidate < c.state.syncedTS {
-		behindStores := make([]uint64, 0)
-		for storeID, storeSyncedTS := range c.state.syncedByStore {
-			if storeSyncedTS < c.state.syncedTS {
-				behindStores = append(behindStores, storeID)
-			}
-		}
+		behindStores := slices.DeleteFunc(slices.Collect(maps.Keys(c.state.syncedByStore)), func(storeID uint64) bool {
+			return c.state.syncedByStore[storeID] >= c.state.syncedTS
+		})
 		c.warnUnsafeSyncedTS(behindStores, "observed store flush ts is behind current synced-ts")
 		return
 	}

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"maps"
 	"path"
 	"slices"

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -188,28 +188,18 @@ func (c *Calculator) advanceSyncedState(
 	aliveStores map[uint64]struct{},
 	maxFlushTSByStore map[uint64]uint64,
 ) {
-	maps.Insert(c.state.syncedByStore, func(yield func(uint64, uint64) bool) {
-		for storeID, flushTS := range maxFlushTSByStore {
-			if flushTS <= c.state.syncedByStore[storeID] {
-				continue
-			}
-			if !yield(storeID, flushTS) {
-				return
-			}
+	for storeID, flushTS := range maxFlushTSByStore {
+		if flushTS > c.state.syncedByStore[storeID] {
+			c.state.syncedByStore[storeID] = flushTS
 		}
-	})
+	}
 
 	maps.DeleteFunc(c.state.syncedByStore, func(storeID uint64, _ uint64) bool {
 		_, ok := aliveStores[storeID]
 		return !ok
 	})
 
-	missingStores := slices.DeleteFunc(slices.Collect(maps.Keys(aliveStores)), func(storeID uint64) bool {
-		_, ok := c.state.syncedByStore[storeID]
-		return ok
-	})
-	if len(missingStores) > 0 {
-		c.warnUnsafeSyncedTS(missingStores, "alive store has no observed flush ts yet")
+	if ok := c.checkMissingStore(aliveStores); !ok {
 		return
 	}
 
@@ -217,35 +207,25 @@ func (c *Calculator) advanceSyncedState(
 	if len(storeSyncedTSs) == 0 {
 		return
 	}
-
 	syncedCandidate := slices.Min(storeSyncedTSs)
-	if syncedCandidate < c.state.syncedTS {
-		behindStores := slices.DeleteFunc(slices.Collect(maps.Keys(c.state.syncedByStore)), func(storeID uint64) bool {
-			return c.state.syncedByStore[storeID] >= c.state.syncedTS
-		})
-		c.warnUnsafeSyncedTS(behindStores, "observed store flush ts is behind current synced-ts")
-		return
-	}
 	if syncedCandidate > c.state.syncedTS {
 		c.state.syncedTS = syncedCandidate
 	}
 }
 
-func (c *Calculator) warnUnsafeSyncedTS(storeIDs []uint64, reason string) {
-	if c.state.syncedTS == 0 {
-		return
+func (c *Calculator) checkMissingStore(aliveStores map[uint64]struct{}) bool {
+	missingStores := slices.DeleteFunc(slices.Collect(maps.Keys(aliveStores)), func(storeID uint64) bool {
+		_, ok := c.state.syncedByStore[storeID]
+		return ok
+	})
+	if len(missingStores) == 0 {
+		return true
 	}
-	if len(storeIDs) == 0 {
-		return
-	}
-	log.Warn(
-		"crr checkpoint calculator cannot safely advance synced-ts",
-		zap.String("category", "crr checkpoint"),
-		zap.String("task", c.cfg.TaskName),
-		zap.Uint64s("store-ids", storeIDs),
-		zap.Uint64("synced-ts", c.state.syncedTS),
-		zap.String("reason", reason),
-	)
+	log.Warn("crr checkpoint calculator cannot safely advance synced-ts",
+		zap.String("category", "crr checkpoint"), zap.String("task", c.cfg.TaskName),
+		zap.Uint64s("store-ids", missingStores), zap.Uint64("synced-ts", c.state.syncedTS),
+		zap.String("reason", "alive store has no observed flush ts yet"))
+	return false
 }
 
 func sleepWithContext(ctx context.Context, d time.Duration) error {

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -122,6 +122,10 @@ func (c *Calculator) planRound(ctx context.Context) (roundPlan, error) {
 			cancel()
 			break
 		}
+		if syncedTS, ok := c.state.syncedByStore[metaFile.storeID]; ok && metaFile.flushTS <= syncedTS {
+			plan.statistic.SkippedStoreSyncedMetaFileCount++
+			continue
+		}
 
 		eg.Go(func() error {
 			failpoint.InjectCall("before-read-meta", metaFile.path)
@@ -258,6 +262,7 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 func (s FileStatistic) snapshot() *FileStatistic {
 	cloned := FileStatistic{
 		UpstreamReadMetaFileCount:       s.UpstreamReadMetaFileCount,
+		SkippedStoreSyncedMetaFileCount: s.SkippedStoreSyncedMetaFileCount,
 		EstimatedSyncLogFileCount:       s.EstimatedSyncLogFileCount,
 		DownstreamCheckFileCount:        s.DownstreamCheckFileCount,
 		PlannedFileSuffixCounts:         maps.Clone(s.PlannedFileSuffixCounts),

--- a/br/pkg/stream/crr/service/BUILD.bazel
+++ b/br/pkg/stream/crr/service/BUILD.bazel
@@ -25,7 +25,7 @@ go_test(
     srcs = ["service_test.go"],
     embed = [":service"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         "//br/pkg/stream/crr/internal/checkpoint",
         "//br/pkg/streamhelper/config",

--- a/br/pkg/stream/crr/service/BUILD.bazel
+++ b/br/pkg/stream/crr/service/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//br/pkg/stream/crr/internal/checkpoint",
         "//br/pkg/streamhelper/config",
         "//br/pkg/utiltest/crr",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/stream/crr/service/metrics.go
+++ b/br/pkg/stream/crr/service/metrics.go
@@ -103,7 +103,8 @@ var (
 		Namespace: "tidb",
 		Subsystem: "br_crr",
 		Name:      "skipped_store_synced_meta_file_count",
-		Help:      "Skipped upstream meta file count because the store is already synced past the meta flush ts in latest round statistic.",
+		Help: "Skipped upstream meta file count because the store is already synced " +
+			"past the meta flush ts in latest round statistic.",
 	}, []string{"task"})
 	estimatedSyncLogFileCount = metricscommon.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tidb",
@@ -175,7 +176,9 @@ func observeStatusMetrics(snapshot *StatusSnapshot) {
 	pendingFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.PendingFileCount))
 	consecutiveFailures.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.ConsecutiveFailures))
 	upstreamReadMetaFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.UpstreamReadMetaFileCount))
-	skippedStoreSyncedMetaFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.SkippedStoreSyncedMetaFileCount))
+	skippedStoreSyncedMetaFileCount.WithLabelValues(snapshot.TaskName).Set(
+		float64(snapshot.Statistic.SkippedStoreSyncedMetaFileCount),
+	)
 	estimatedSyncLogFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.EstimatedSyncLogFileCount))
 	downstreamCheckFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.DownstreamCheckFileCount))
 }

--- a/br/pkg/stream/crr/service/metrics.go
+++ b/br/pkg/stream/crr/service/metrics.go
@@ -73,7 +73,7 @@ var (
 		Namespace: "tidb",
 		Subsystem: "br_crr",
 		Name:      "synced_ts",
-		Help:      "Current synced ts(minimum synced flush ts across all alive stores) of CRR.",
+		Help:      "Current synced ts(replication-complete checkpoint) of CRR.",
 	}, []string{"task"})
 	aliveStoreCount = metricscommon.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tidb",

--- a/br/pkg/stream/crr/service/metrics.go
+++ b/br/pkg/stream/crr/service/metrics.go
@@ -99,6 +99,12 @@ var (
 		Name:      "upstream_read_meta_file_count",
 		Help:      "Read upstream meta file count in latest round statistic.",
 	}, []string{"task"})
+	skippedStoreSyncedMetaFileCount = metricscommon.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tidb",
+		Subsystem: "br_crr",
+		Name:      "skipped_store_synced_meta_file_count",
+		Help:      "Skipped upstream meta file count because the store is already synced past the meta flush ts in latest round statistic.",
+	}, []string{"task"})
 	estimatedSyncLogFileCount = metricscommon.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tidb",
 		Subsystem: "br_crr",
@@ -127,6 +133,7 @@ func init() {
 	prometheus.MustRegister(pendingFileCount)
 	prometheus.MustRegister(consecutiveFailures)
 	prometheus.MustRegister(upstreamReadMetaFileCount)
+	prometheus.MustRegister(skippedStoreSyncedMetaFileCount)
 	prometheus.MustRegister(estimatedSyncLogFileCount)
 	prometheus.MustRegister(downstreamCheckFileCount)
 }
@@ -168,6 +175,7 @@ func observeStatusMetrics(snapshot *StatusSnapshot) {
 	pendingFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.PendingFileCount))
 	consecutiveFailures.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.ConsecutiveFailures))
 	upstreamReadMetaFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.UpstreamReadMetaFileCount))
+	skippedStoreSyncedMetaFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.SkippedStoreSyncedMetaFileCount))
 	estimatedSyncLogFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.EstimatedSyncLogFileCount))
 	downstreamCheckFileCount.WithLabelValues(snapshot.TaskName).Set(float64(snapshot.Statistic.DownstreamCheckFileCount))
 }

--- a/br/pkg/stream/crr/service/service.go
+++ b/br/pkg/stream/crr/service/service.go
@@ -125,63 +125,58 @@ func New(
 func (s *Service) Run(ctx context.Context) error {
 	s.status.start()
 	defer s.status.stop()
+	defer s.flushPendingResumeStateOnShutdown()
 
 	for {
 		if ctx.Err() != nil {
-			s.flushPendingResumeStateOnShutdown()
 			return nil
 		}
-		if err := s.prepareResumeState(ctx); err != nil {
-			if shouldStop(ctx, err) {
-				return nil
-			}
-			s.recordServiceFailure(err)
-			if err := sleepContext(ctx, s.cfg.RetryInterval); err != nil {
+		if err := s.runOnce(ctx); err != nil {
+			if !s.retryAfterRunError(ctx, err) {
 				return nil
 			}
 			continue
-		}
-
-		s.observer.BeginCalculationRound()
-		lastCheckpoint := s.calc.LastCheckpoint()
-		nextCheckpoint, err := s.calc.ComputeNextCheckpoint(ctx)
-		if err == nil {
-			s.queueResumeStateSave(lastCheckpoint, nextCheckpoint)
-			if err := s.flushPendingResumeState(ctx); err != nil {
-				if shouldStop(ctx, err) {
-					s.flushPendingResumeStateOnShutdown()
-					return nil
-				}
-				s.recordServiceFailure(err)
-				if err := sleepContext(ctx, s.cfg.RetryInterval); err != nil {
-					return nil
-				}
-				continue
-			}
-			if nextCheckpoint == lastCheckpoint {
-				if err := s.waitCheckpointAdvance(ctx, lastCheckpoint); err != nil {
-					if shouldStop(ctx, err) {
-						return nil
-					}
-					s.recordServiceFailure(err)
-					if err := sleepContext(ctx, s.cfg.RetryInterval); err != nil {
-						return nil
-					}
-				}
-			}
-			continue
-		}
-		if shouldStop(ctx, err) {
-			return nil
-		}
-		if err := sleepContext(ctx, s.cfg.RetryInterval); err != nil {
-			return nil
 		}
 	}
 }
 
+func (s *Service) runOnce(ctx context.Context) error {
+	if err := s.prepareResumeState(ctx); err != nil {
+		return err
+	}
+
+	s.observer.BeginCalculationRound()
+	lastCheckpoint := s.calc.LastCheckpoint()
+	nextCheckpoint, err := s.calc.ComputeNextCheckpoint(ctx)
+	if err != nil {
+		return observedCalculatorError{err: err}
+	}
+
+	s.queueResumeStateSave(lastCheckpoint, nextCheckpoint)
+	if err := s.flushPendingResumeState(ctx); err != nil {
+		return err
+	}
+
+	if nextCheckpoint == lastCheckpoint {
+		return s.waitCheckpointAdvance(ctx, lastCheckpoint)
+	}
+	return nil
+}
+
 func (s *Service) waitCheckpointAdvance(ctx context.Context, current uint64) error {
 	return s.pd.WaitGlobalCheckpointAdvance(ctx, s.cfg.TaskName, current)
+}
+
+type observedCalculatorError struct {
+	err error
+}
+
+func (e observedCalculatorError) Error() string {
+	return e.err.Error()
+}
+
+func (e observedCalculatorError) Unwrap() error {
+	return e.err
 }
 
 // recordServiceFailure reports failures that happen outside ComputeNextCheckpoint.
@@ -194,13 +189,20 @@ func (s *Service) recordServiceFailure(err error) {
 	})
 }
 
-func shouldStop(ctx context.Context, err error) bool {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		if ctx.Err() != nil {
-			return true
-		}
+func (s *Service) retryAfterRunError(ctx context.Context, err error) bool {
+	if shouldStop(ctx, err) {
+		return false
 	}
-	return false
+	var observed observedCalculatorError
+	if !errors.As(err, &observed) {
+		s.recordServiceFailure(err)
+	}
+	return sleepContext(ctx, s.cfg.RetryInterval) == nil
+}
+
+func shouldStop(ctx context.Context, err error) bool {
+	return ctx.Err() != nil &&
+		(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded))
 }
 
 // Status returns a consistent snapshot of the current service status.

--- a/br/pkg/stream/crr/service/service_test.go
+++ b/br/pkg/stream/crr/service/service_test.go
@@ -419,6 +419,64 @@ func TestServiceRetriesFailedResumeStatePersist(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
+func TestServiceFlushesPendingResumeStateOnShutdownAfterPersistFailure(t *testing.T) {
+	ctx := context.Background()
+	h := newServiceHarness(ctx, t)
+	initialCheckpoint := h.requireInitialCheckpointByTick()
+	stateStore := &inMemoryResumeStateStore{
+		state: &PersistentState{
+			LastCheckpoint: initialCheckpoint,
+			SyncedTS:       initialCheckpoint,
+			SyncedByStore:  map[uint64]uint64{1: initialCheckpoint},
+		},
+		saveFailuresLeft: 1,
+	}
+
+	svc, err := New(
+		Deps{
+			PD:       h.PDSim,
+			Watcher:  h.PDSim,
+			Upstream: h.Upstream,
+			Sync:     checkpoint.NewExistenceSyncChecker(h.Downstream),
+			State:    stateStore,
+		},
+		Config{
+			CalculatorConfig: CalculatorConfig{
+				TaskName:     "drr_test_task",
+				PollInterval: 5 * time.Millisecond,
+			},
+			RetryInterval: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.Run(runCtx)
+	}()
+
+	record, err := h.FlushSim.FlushStore(ctx, 1)
+	require.NoError(t, err)
+	h.requireCheckpointAdvancedByTick(initialCheckpoint, record.CheckpointTS)
+	h.requireReplicateAllPending()
+
+	require.Eventually(t, func() bool {
+		snapshot := svc.Status()
+		return stateStore.saveCount() == 1 &&
+			snapshot.State == stateDegraded &&
+			snapshot.LastError == "save resume state: persist boom"
+	}, 5*time.Second, 20*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+
+	state := stateStore.savedState()
+	require.Equal(t, record.CheckpointTS, state.LastCheckpoint)
+	require.Equal(t, record.FlushTS, state.SyncedTS)
+	require.Equal(t, record.FlushTS, state.SyncedByStore[1])
+}
+
 func TestServiceRetriesFailedResumeStateLoad(t *testing.T) {
 	ctx := context.Background()
 	h := newServiceHarness(ctx, t)

--- a/br/pkg/stream/crr/service/service_test.go
+++ b/br/pkg/stream/crr/service/service_test.go
@@ -347,6 +347,7 @@ func TestServiceLoadsPersistedResumeState(t *testing.T) {
 		snapshot := svc.Status()
 		return snapshot.SafeCheckpoint == firstRecord.CheckpointTS &&
 			snapshot.SyncedTS == firstRecord.FlushTS &&
+			snapshot.SyncedByStore[1] == firstRecord.FlushTS &&
 			snapshot.PendingFileCount > 0 &&
 			snapshot.Statistic.UpstreamReadMetaFileCount == 1 &&
 			snapshot.Statistic.EstimatedSyncLogFileCount == 1
@@ -357,6 +358,7 @@ func TestServiceLoadsPersistedResumeState(t *testing.T) {
 		snapshot := svc.Status()
 		return snapshot.SafeCheckpoint == secondRecord.CheckpointTS &&
 			snapshot.SyncedTS == secondRecord.FlushTS &&
+			snapshot.SyncedByStore[1] == secondRecord.FlushTS &&
 			stateStore.savedState().LastCheckpoint == secondRecord.CheckpointTS &&
 			stateStore.savedState().SyncedTS == secondRecord.FlushTS &&
 			stateStore.savedState().SyncedByStore[1] == secondRecord.FlushTS
@@ -488,6 +490,7 @@ func TestServiceStatusEndpoints(t *testing.T) {
 	status.setPersistentState(PersistentState{
 		LastCheckpoint: 42,
 		SyncedTS:       42,
+		SyncedByStore:  map[uint64]uint64{1: 42},
 	})
 
 	rec = httptest.NewRecorder()
@@ -512,6 +515,7 @@ func TestServiceStatusEndpoints(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &snapshot))
 	require.Equal(t, uint64(42), snapshot.SafeCheckpoint)
 	require.Equal(t, uint64(42), snapshot.SyncedTS)
+	require.Equal(t, map[uint64]uint64{1: 42}, snapshot.SyncedByStore)
 	require.Equal(t, 3, snapshot.Statistic.UpstreamReadMetaFileCount)
 	require.Equal(t, 5, snapshot.Statistic.SkippedStoreSyncedMetaFileCount)
 	require.Equal(t, 7, snapshot.Statistic.EstimatedSyncLogFileCount)
@@ -523,6 +527,11 @@ func TestServiceStatusEndpoints(t *testing.T) {
 func TestStatusStoreTracksFileStatistic(t *testing.T) {
 	status := newStatusStore("task")
 	status.start()
+	status.setPersistentState(PersistentState{
+		LastCheckpoint: 10,
+		SyncedTS:       10,
+		SyncedByStore:  map[uint64]uint64{1: 10},
+	})
 	status.beginRound()
 	status.applyEvent(checkpoint.CheckpointEvent{
 		Type:             checkpoint.EventRoundPlanned,
@@ -558,7 +567,9 @@ func TestStatusStoreTracksFileStatistic(t *testing.T) {
 	require.Equal(t, 4.0, promtest.ToFloat64(skippedStoreSyncedMetaFileCount.WithLabelValues("task")))
 
 	snapshot.Statistic.PlannedFileSuffixCounts[".txt"] = 99
+	snapshot.SyncedByStore[1] = 99
 	require.Equal(t, map[string]int{".log": 1, ".meta": 1}, status.snapshotCopy().Statistic.PlannedFileSuffixCounts)
+	require.Equal(t, map[uint64]uint64{1: 10}, status.snapshotCopy().SyncedByStore)
 }
 
 func TestStatusStorePreservesFailureStoreCountAndTracksZeroAliveStores(t *testing.T) {

--- a/br/pkg/stream/crr/service/service_test.go
+++ b/br/pkg/stream/crr/service/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/stream/crr/internal/checkpoint"
 	streamhelperconfig "github.com/pingcap/tidb/br/pkg/streamhelper/config"
 	testutil "github.com/pingcap/tidb/br/pkg/utiltest/crr"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -477,6 +478,7 @@ func TestServiceStatusEndpoints(t *testing.T) {
 		SyncedTS:           42,
 		Statistic: &checkpoint.FileStatistic{
 			UpstreamReadMetaFileCount:       3,
+			SkippedStoreSyncedMetaFileCount: 5,
 			EstimatedSyncLogFileCount:       7,
 			DownstreamCheckFileCount:        11,
 			PlannedFileSuffixCounts:         map[string]int{".log": 7, ".meta": 3},
@@ -511,6 +513,7 @@ func TestServiceStatusEndpoints(t *testing.T) {
 	require.Equal(t, uint64(42), snapshot.SafeCheckpoint)
 	require.Equal(t, uint64(42), snapshot.SyncedTS)
 	require.Equal(t, 3, snapshot.Statistic.UpstreamReadMetaFileCount)
+	require.Equal(t, 5, snapshot.Statistic.SkippedStoreSyncedMetaFileCount)
 	require.Equal(t, 7, snapshot.Statistic.EstimatedSyncLogFileCount)
 	require.Equal(t, 11, snapshot.Statistic.DownstreamCheckFileCount)
 	require.Equal(t, map[string]int{".log": 7, ".meta": 3}, snapshot.Statistic.PlannedFileSuffixCounts)
@@ -526,9 +529,10 @@ func TestStatusStoreTracksFileStatistic(t *testing.T) {
 		Time:             time.Now(),
 		PendingFileCount: 2,
 		Statistic: &checkpoint.FileStatistic{
-			UpstreamReadMetaFileCount: 1,
-			EstimatedSyncLogFileCount: 1,
-			PlannedFileSuffixCounts:   map[string]int{".log": 1, ".meta": 1},
+			UpstreamReadMetaFileCount:       1,
+			SkippedStoreSyncedMetaFileCount: 3,
+			EstimatedSyncLogFileCount:       1,
+			PlannedFileSuffixCounts:         map[string]int{".log": 1, ".meta": 1},
 		},
 	})
 	status.applyEvent(checkpoint.CheckpointEvent{
@@ -536,6 +540,7 @@ func TestStatusStoreTracksFileStatistic(t *testing.T) {
 		Time: time.Now(),
 		Statistic: &checkpoint.FileStatistic{
 			UpstreamReadMetaFileCount:       1,
+			SkippedStoreSyncedMetaFileCount: 4,
 			EstimatedSyncLogFileCount:       1,
 			DownstreamCheckFileCount:        2,
 			PlannedFileSuffixCounts:         map[string]int{".log": 1, ".meta": 1},
@@ -545,10 +550,12 @@ func TestStatusStoreTracksFileStatistic(t *testing.T) {
 
 	snapshot := status.snapshotCopy()
 	require.Equal(t, 1, snapshot.Statistic.UpstreamReadMetaFileCount)
+	require.Equal(t, 4, snapshot.Statistic.SkippedStoreSyncedMetaFileCount)
 	require.Equal(t, 1, snapshot.Statistic.EstimatedSyncLogFileCount)
 	require.Equal(t, 2, snapshot.Statistic.DownstreamCheckFileCount)
 	require.Equal(t, map[string]int{".log": 1, ".meta": 1}, snapshot.Statistic.PlannedFileSuffixCounts)
 	require.Equal(t, map[string]int{".log": 1, ".meta": 1}, snapshot.Statistic.DownstreamCheckFileSuffixCounts)
+	require.Equal(t, 4.0, promtest.ToFloat64(skippedStoreSyncedMetaFileCount.WithLabelValues("task")))
 
 	snapshot.Statistic.PlannedFileSuffixCounts[".txt"] = 99
 	require.Equal(t, map[string]int{".log": 1, ".meta": 1}, status.snapshotCopy().Statistic.PlannedFileSuffixCounts)

--- a/br/pkg/stream/crr/service/status.go
+++ b/br/pkg/stream/crr/service/status.go
@@ -61,9 +61,10 @@ type StatusSnapshot struct {
 	CurrentRound      uint64 `json:"current_round"`
 	LastLoopIteration uint64 `json:"last_loop_iteration"`
 
-	LastUpstreamCheckpoint uint64 `json:"last_upstream_checkpoint"`
-	SafeCheckpoint         uint64 `json:"safe_checkpoint"`
-	SyncedTS               uint64 `json:"synced_ts"`
+	LastUpstreamCheckpoint uint64            `json:"last_upstream_checkpoint"`
+	SafeCheckpoint         uint64            `json:"safe_checkpoint"`
+	SyncedTS               uint64            `json:"synced_ts"`
+	SyncedByStore          map[uint64]uint64 `json:"synced_by_store,omitempty"`
 
 	AliveStoreCount  int             `json:"alive_store_count"`
 	PendingFileCount int             `json:"pending_file_count"`
@@ -117,6 +118,7 @@ func (s *statusStore) setPersistentState(state PersistentState) {
 	defer s.mu.Unlock()
 	s.snapshot.SafeCheckpoint = state.LastCheckpoint
 	s.snapshot.SyncedTS = state.SyncedTS
+	s.snapshot.SyncedByStore = maps.Clone(state.SyncedByStore)
 	observeStatusMetrics(&s.snapshot)
 }
 
@@ -158,6 +160,9 @@ func (s *statusStore) applyEvent(event checkpoint.CheckpointEvent) {
 	if event.SyncedTS > 0 {
 		s.snapshot.SyncedTS = event.SyncedTS
 	}
+	if event.SyncedByStore != nil {
+		s.snapshot.SyncedByStore = maps.Clone(event.SyncedByStore)
+	}
 	if event.Type == checkpoint.EventRoundPlanned || event.Type == checkpoint.EventCheckpointAdvanced {
 		s.snapshot.AliveStoreCount = event.AliveStoreCount
 	}
@@ -196,6 +201,7 @@ func (s *statusStore) snapshotCopy() StatusSnapshot {
 	defer s.mu.RUnlock()
 
 	snapshot := s.snapshot
+	snapshot.SyncedByStore = maps.Clone(snapshot.SyncedByStore)
 	snapshot.Statistic.PlannedFileSuffixCounts = maps.Clone(snapshot.Statistic.PlannedFileSuffixCounts)
 	snapshot.Statistic.DownstreamCheckFileSuffixCounts = maps.Clone(snapshot.Statistic.DownstreamCheckFileSuffixCounts)
 	return snapshot

--- a/br/pkg/stream/crr/service/status.go
+++ b/br/pkg/stream/crr/service/status.go
@@ -42,6 +42,7 @@ func GetStatusFileName() string {
 // StatusStatistic summarizes the current round's file-related work.
 type StatusStatistic struct {
 	UpstreamReadMetaFileCount       int            `json:"upstream_read_meta_file_count"`
+	SkippedStoreSyncedMetaFileCount int            `json:"skipped_store_synced_meta_file_count"`
 	EstimatedSyncLogFileCount       int            `json:"estimated_sync_log_file_count"`
 	DownstreamCheckFileCount        int            `json:"downstream_check_file_count"`
 	PlannedFileSuffixCounts         map[string]int `json:"planned_file_suffix_counts,omitempty"`
@@ -219,6 +220,7 @@ func (o *statusObserver) OnCheckpointEvent(event checkpoint.CheckpointEvent) {
 func newStatusStatistic(stat checkpoint.FileStatistic) StatusStatistic {
 	return StatusStatistic{
 		UpstreamReadMetaFileCount:       stat.UpstreamReadMetaFileCount,
+		SkippedStoreSyncedMetaFileCount: stat.SkippedStoreSyncedMetaFileCount,
 		EstimatedSyncLogFileCount:       stat.EstimatedSyncLogFileCount,
 		DownstreamCheckFileCount:        stat.DownstreamCheckFileCount,
 		PlannedFileSuffixCounts:         maps.Clone(stat.PlannedFileSuffixCounts),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69567

Problem Summary:

CRR checkpoint calculation keeps removed stores in per-store synced progress. A removed store can continue bounding the global `syncedTS`, so `syncedTS` may stop advancing after store removal.

### What changed and how does it work?

- Prune stores that are no longer alive from CRR per-store synced progress after a successful round has scanned and waited for discovered files.
- Compute global `syncedTS` from alive stores only.
- Keep missing alive stores as blockers so `syncedTS` cannot advance before every live store has observed flush progress.
- Update checkpoint tests and docs for the new alive-store semantics.
- This PR also filters out meta files can be verified synced by `syncedTSByStore`. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

- `./tools/check/failpoint-go-test.sh br/pkg/stream/crr/internal/checkpoint -run 'TestCheckpointCalculator(WaitsForRemovedStoreFiles|PrunesRemovedStoreAfterFilesSynced|PrunesRemovedStoreBeforeAliveStoreBlocksAdvance|DoesNotAdvanceSyncedTSWhenNewAliveStoreHasNoFlush)$' -count=1`
- `./tools/check/failpoint-go-test.sh br/pkg/stream/crr/internal/checkpoint -run TestCheckpointCalculatorRandomizedCRRSimulation -count=5`
- `make bazel_prepare`
- `make lint`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that CRR checkpoint syncedTS might stop advancing after a store is removed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional end-to-end reporting for skipped synced meta-file progress, including new service status fields and checkpoint statistics.
  * Exposed `synced_by_store` in service snapshots and added a Prometheus gauge metric for `skipped_store_synced_meta_file_count`.
* **Bug Fixes**
  * Improved checkpoint progression by pruning removed stores and avoiding redundant meta-file reads when already synced.
  * Prevented mutable synced-by-store state from leaking between persisted snapshots and externally observed status.
* **Documentation**
  * Clarified how `syncedTS` advances using alive-store data.
* **Tests**
  * Expanded coverage for pruning/skip behavior, new metrics, and new snapshot fields (including resume-state persistence on shutdown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->