### PR TITLE
executor: update error messages for materialized view log creation privileges

### DIFF
--- a/pkg/executor/test/ddl/mview_log_ddl_test.go
+++ b/pkg/executor/test/ddl/mview_log_ddl_test.go
@@ -456,7 +456,9 @@ func TestCreateMaterializedViewLogPrivilege(t *testing.T) {
 	tkNoCreate := testkit.NewTestKit(t, store)
 	require.NoError(t, tkNoCreate.Session().Auth(&auth.UserIdentity{Username: "u_create_mlog_no_create", Hostname: "%"}, nil, nil, nil))
 	err := tkNoCreate.ExecToErr("create materialized view log on test.t_create_mlog_priv (a)")
-	require.ErrorContains(t, err, "CREATE VIEW command denied")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG command denied")
+	require.ErrorContains(t, err, "t_create_mlog_priv")
+	require.NotContains(t, err.Error(), "$mlog$")
 
 	tk.MustExec("grant create view on test.* to 'u_create_mlog_no_select'@'%'")
 	tkNoSelect := testkit.NewTestKit(t, store)
@@ -475,7 +477,9 @@ func TestCreateMaterializedViewLogPrivilege(t *testing.T) {
 	tkTableCreate := testkit.NewTestKit(t, store)
 	require.NoError(t, tkTableCreate.Session().Auth(&auth.UserIdentity{Username: "u_create_mlog_table_create", Hostname: "%"}, nil, nil, nil))
 	err = tkTableCreate.ExecToErr("create materialized view log on test.t_create_mlog_priv (a)")
-	require.ErrorContains(t, err, "CREATE VIEW command denied")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG command denied")
+	require.ErrorContains(t, err, "t_create_mlog_priv")
+	require.NotContains(t, err.Error(), "$mlog$")
 }
 
 func TestGrantMaterializedViewObjectPrivileges(t *testing.T) {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6292,7 +6292,7 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		mlogName := b.materializedViewLogNameForBaseTable(ctx, dbName, v.Table.Name)
 		var createAuthErr, selectAuthErr error
 		if user := b.ctx.GetSessionVars().User; user != nil {
-			createAuthErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("CREATE VIEW", user.AuthUsername, user.AuthHostname, mlogName.L)
+			createAuthErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("CREATE MATERIALIZED VIEW LOG", user.AuthUsername, user.AuthHostname, v.Table.Name.L)
 			selectAuthErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, v.Table.Name.L)
 		}
 		// Creating a materialized view log creates a view-like maintenance object and

--- a/tests/integrationtest/r/executor/mview_privilege.result
+++ b/tests/integrationtest/r/executor/mview_privilege.result
@@ -280,7 +280,7 @@ Grants for u_create_mlog@%
 GRANT USAGE ON *.* TO 'u_create_mlog'@'%'
 GRANT SELECT ON `mview_privilege_test`.`t_revoke_create_mlog` TO 'u_create_mlog'@'%'
 create materialized view log on t_revoke_create_mlog (id, v);
-Error 1142 (42000): CREATE VIEW command denied to user 'u_create_mlog'@'%' for table '$mlog$t_revoke_create_mlog'
+Error 1142 (42000): CREATE MATERIALIZED VIEW LOG command denied to user 'u_create_mlog'@'%' for table 't_revoke_create_mlog'
 create user 'u_alter_mv'@'%';
 grant alter on mview_privilege_test.mv_revoke_ddl to 'u_alter_mv'@'%';
 revoke alter on mview_privilege_test.mv_revoke_ddl from 'u_alter_mv'@'%';


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #69431

Problem Summary:

`CREATE MATERIALIZED VIEW LOG` checks `CREATE VIEW` privilege on the internal MLog object. When the check fails, the error message exposed the internal `$mlog$...` table name and reported the operation as `CREATE VIEW`, which is confusing for users because MLog is an anonymous view-like maintenance object.

### What changed and how does it work?

This PR keeps the existing privilege model unchanged, but changes the privilege error generated for `CREATE MATERIALIZED VIEW LOG`.

When the `CREATE VIEW` privilege check fails, the error now reports the public operation and the base table name:

```text
CREATE MATERIALIZED VIEW LOG command denied ... for table 't_base'
```

instead of exposing the internal MLog table name:

```text
CREATE VIEW command denied ... for table '$mlog$t_base'
```

The regression test verifies that the error contains the base table name and does not contain `$mlog$`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```text
go test -run TestCreateMaterializedViewLogPrivilege -tags=intest ./pkg/executor/test/ddl
make bazel_lint_changed
git diff --check
```

Also tried:

```text
go test -run TestCreateMaterializedViewLogPrivilege -tags=intest,deadlock ./pkg/executor/test/ddl
```

The test reached the updated assertion path, but failed on an unrelated deadlock detector report in TTL/session shutdown.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fixed an issue that CREATE MATERIALIZED VIEW LOG privilege errors exposed internal MLog table names.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization error messages when creating materialized view logs.
  * Failure messages now reference the correct denied privilege: **CREATE MATERIALIZED VIEW LOG**, along with the related base table name.
  * Removed misleading references to internal materialized view log identifiers from these errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->