### PR TITLE
server, util: avoid connection alive checks for ordinary reads

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -167,6 +167,8 @@ go_test(
         "//pkg/meta/model",
         "//pkg/metrics",
         "//pkg/param",
+        "//pkg/parser",
+        "//pkg/parser/ast",
         "//pkg/parser/auth",
         "//pkg/parser/charset",
         "//pkg/parser/model",

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2088,12 +2088,9 @@ func shouldInstallConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *vari
 	if !sessVars.IsAutocommit() || sessVars.InTxn() {
 		return false
 	}
-	if executeStmt, ok := stmt.(*ast.ExecuteStmt); ok {
-		prepared, err := plannercore.GetPreparedStmt(executeStmt, sessVars)
-		if err != nil || prepared.PreparedAst == nil {
-			return false
-		}
-		stmt = prepared.PreparedAst.Stmt
+	stmt = resolvePreparedStmtForConnectionAlive(stmt, sessVars)
+	if stmt == nil {
+		return false
 	}
 	switch stmt.(type) {
 	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
@@ -2101,6 +2098,52 @@ func shouldInstallConnectionAliveDuringExecute(stmt ast.StmtNode, sessVars *vari
 	default:
 		return false
 	}
+}
+
+// shouldInstallConnectionAliveDuringResultSet keeps the disconnect probe off
+// ordinary read-result hot paths while preserving `SELECT SLEEP(...)` cleanup.
+func shouldInstallConnectionAliveDuringResultSet(stmt ast.StmtNode, sessVars *variable.SessionVars) bool {
+	stmt = resolvePreparedStmtForConnectionAlive(stmt, sessVars)
+	return stmtHasSleepFunc(stmt)
+}
+
+func resolvePreparedStmtForConnectionAlive(stmt ast.StmtNode, sessVars *variable.SessionVars) ast.StmtNode {
+	if executeStmt, ok := stmt.(*ast.ExecuteStmt); ok {
+		prepared, err := plannercore.GetPreparedStmt(executeStmt, sessVars)
+		if err != nil || prepared.PreparedAst == nil {
+			return nil
+		}
+		return prepared.PreparedAst.Stmt
+	}
+	return stmt
+}
+
+func stmtHasSleepFunc(stmt ast.StmtNode) bool {
+	if stmt == nil {
+		return false
+	}
+	visitor := &sleepFuncVisitor{}
+	stmt.Accept(visitor)
+	return visitor.hasSleep
+}
+
+type sleepFuncVisitor struct {
+	hasSleep bool
+}
+
+func (v *sleepFuncVisitor) Enter(n ast.Node) (ast.Node, bool) {
+	if v.hasSleep {
+		return n, true
+	}
+	if fn, ok := n.(*ast.FuncCallExpr); ok && fn.FnName.L == ast.Sleep {
+		v.hasSleep = true
+		return n, true
+	}
+	return n, false
+}
+
+func (v *sleepFuncVisitor) Leave(n ast.Node) (ast.Node, bool) {
+	return n, !v.hasSleep
 }
 
 // The first return value indicates whether the call of handleStmt has no side effect and can be retried.
@@ -2167,7 +2210,7 @@ func (cc *clientConn) handleStmt(
 		if cc.getStatus() == connStatusShutdown {
 			return false, exeerrors.ErrQueryInterrupted
 		}
-		if !checkingConnectionAlive {
+		if !checkingConnectionAlive && shouldInstallConnectionAliveDuringResultSet(stmt, cc.ctx.GetSessionVars()) {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 			defer clearConnectionAlive()
 		}

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -323,7 +323,8 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 	}
 	var lazy bool
 	if rs != nil {
-		if !checkingConnectionAlive {
+		if !checkingConnectionAlive && planCacheStmt != nil && planCacheStmt.PreparedAst != nil &&
+			shouldInstallConnectionAliveDuringResultSet(planCacheStmt.PreparedAst.Stmt, vars) {
 			clearConnectionAlive = cc.setSQLKillerConnectionAlive()
 			defer clearConnectionAlive()
 		}

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/resourcegroup"
@@ -68,6 +70,36 @@ type Issue33699CheckType struct {
 	defVal            string
 	setVal            string
 	isSessionVariable bool
+}
+
+func TestShouldInstallConnectionAlivePolicy(t *testing.T) {
+	p := parser.New()
+	parseStmt := func(sql string) ast.StmtNode {
+		stmts, _, err := p.ParseSQL(sql)
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+		return stmts[0]
+	}
+
+	sessVars := variable.NewSessionVars(nil)
+	resultSetCases := []struct {
+		sql    string
+		expect bool
+	}{
+		{"select * from t", false},
+		{"select 1", false},
+		{"select sleep(1)", true},
+		{"select if(1, sleep(1), 0)", true},
+	}
+	for _, tc := range resultSetCases {
+		require.Equal(t, tc.expect, shouldInstallConnectionAliveDuringResultSet(parseStmt(tc.sql), sessVars), tc.sql)
+	}
+
+	require.True(t, shouldInstallConnectionAliveDuringExecute(parseStmt("insert into t values (1)"), sessVars))
+	require.False(t, shouldInstallConnectionAliveDuringExecute(parseStmt("select 1"), sessVars))
+
+	sessVars.SetInTxn(true)
+	require.False(t, shouldInstallConnectionAliveDuringExecute(parseStmt("insert into t values (1)"), sessVars))
 }
 
 func (c *Issue33699CheckType) toSetSessionVar() string {

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -54,7 +54,10 @@ type SQLKiller struct {
 	// If the query is in writeResultSet and Finish() can acquire rs.finishLock, we can assume the query is waiting for the client to receive data from the server over network I/O.
 	InWriteResultSet atomic.Bool
 
-	lastCheckTime     atomic.Pointer[time.Time]
+	lastCheckTime atomic.Pointer[time.Time]
+	// IsConnectionAlive stores a statement-scoped callback token. Callers should
+	// clear it with CompareAndSwap using the same token, so cleanup from an older
+	// statement cannot remove a callback installed by a newer statement.
 	IsConnectionAlive atomic.Pointer[func() bool]
 }
 
@@ -131,17 +134,17 @@ func (killer *SQLKiller) HandleSignal() error {
 	// Checks if the connection is alive.
 	// For performance reasons, the check interval should be at least `checkConnectionAliveDur`(1 second).
 	fn := killer.IsConnectionAlive.Load()
-	lastCheckTime := killer.lastCheckTime.Load()
 	if fn != nil {
 		var checkConnectionAliveDur time.Duration = time.Second
 		now := time.Now()
+		lastCheckTime := killer.lastCheckTime.Load()
 		if intest.InTest {
 			checkConnectionAliveDur = time.Millisecond
 		}
 		if lastCheckTime == nil {
-			killer.lastCheckTime.Store(&now)
+			killer.storeLastCheckTime(now)
 		} else if now.Sub(*lastCheckTime) > checkConnectionAliveDur {
-			killer.lastCheckTime.Store(&now)
+			killer.storeLastCheckTime(now)
 			if !(*fn)() {
 				killer.SendKillSignal(QueryInterrupted)
 			}
@@ -155,6 +158,14 @@ func (killer *SQLKiller) HandleSignal() error {
 			zap.Uint64("conn", killer.ConnID.Load()))
 	}
 	return err
+}
+
+// storeLastCheckTime keeps the allocation on the throttled update path instead
+// of the high-frequency HandleSignal fast path.
+func (killer *SQLKiller) storeLastCheckTime(t time.Time) {
+	lastCheckTime := new(time.Time)
+	*lastCheckTime = t
+	killer.lastCheckTime.Store(lastCheckTime)
 }
 
 // CheckConnectionAlive checks whether the connection is alive immediately.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #69546

Problem Summary:

#69553 replaced the release-8.5 `SQLKiller` connection-alive callback lock with the master-style atomic pointer. That removed the `RWMutex` contention, but OLAP release testing still shows a regression because ordinary read result-set statements still install the callback for the whole result draining phase.

`SQLKiller.HandleSignal()` is called from very hot execution checkpoints such as hash join probe. When the callback is non-nil, those hot callers still pay the connection-alive time-check branch even though the actual socket probe is throttled. For normal TPC-H/TPC-DS read queries, this keeps the OLAP hot path slower than before #69553.

This is a follow-up to the already-merged #69553.

### What changed and how does it work?

- Keep the lock-free `IsConnectionAlive atomic.Pointer[func() bool]` infrastructure from #69553.
- Keep pointer-identity cleanup semantics so an older statement cleanup cannot clear a newer callback.
- Move the `lastCheckTime` load behind the non-nil callback check.
- Store `lastCheckTime` through a helper so the allocation happens only on the throttled update path, not on every `HandleSignal()` call.
- Continue installing the callback for autocommit `INSERT`/`UPDATE`/`DELETE`, preserving the slow pre-commit disconnect backstop.
- Continue installing the callback for result-set statements containing `SLEEP()`, preserving the `SELECT SLEEP(...)` disconnect cleanup from #57531.
- Do not install the callback for ordinary read result-set statements, keeping OLAP/TPC-H/TPC-DS execution on the nil-callback fast path.
- Add unit coverage for the narrowed installation policy.
- Add the new parser imports to the `pkg/server:server_test` Bazel target deps.

### Correctness note

This keeps the covered disconnect cases that motivated the release-8.5 backports:

- `SELECT SLEEP(...)` still installs the connection-alive callback while draining the result set.
- Autocommit DML still installs the callback during execution and keeps the existing pre-commit backstop.
- The callback cleanup still uses pointer-token `CompareAndSwap`, so stale cleanup cannot remove a callback from a newer statement.

The change intentionally avoids adding the connection-alive probe to ordinary read result-set execution because that is the path causing the OLAP regression.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```sh
GOTOOLCHAIN=go1.25.10 go test ./pkg/server -run TestShouldInstallConnectionAlivePolicy -tags=intest,deadlock
GOTOOLCHAIN=go1.25.10 go test ./pkg/server/tests/commontest -run 'TestIssue57531|TestClientDisconnectKillsAutocommitInsert' -tags=intest,deadlock
GOTOOLCHAIN=go1.25.10 go test ./pkg/util/sqlkiller -tags=intest,deadlock
GOTOOLCHAIN=go1.25.10 go test -race ./pkg/util/sqlkiller -tags=intest,deadlock
bazel test //pkg/util/sqlkiller:sqlkiller_test
git diff --check
```

Also attempted:

```sh
bazel test //pkg/server:server_test --test_filter=TestShouldInstallConnectionAlivePolicy
```

The local run was interrupted during Bazel external dependency downloads after repeated cache timeouts, before analysis completed. The `pkg/server:server_test` target deps were updated for the new `parser` and `parser/ast` imports.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an OLAP performance regression caused by connection-alive checks on ordinary read query hot paths.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary “connection alive” probes on ordinary read-result paths by enabling them only when the underlying prepared statement indicates blocking/sleep behavior.
  * Improved prepared-statement resolution to safely handle missing prepared ASTs and return the correct policy outcome.
  * Disabled execute-time connection-alive installation when running inside transaction sessions.
* **Tests**
  * Added coverage to validate the connection-alive decision policy across multiple SQL examples.
* **Refactor**
  * Streamlined connection-aliveness throttling timing updates for clearer token ownership and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->