### PR TITLE
test: stabilize flaky TestPartialStatsInExplain

### DIFF
--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -672,6 +672,15 @@ func TestStatsAnalyzedInDDL(t *testing.T) {
 
 func TestPartialStatsInExplain(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, _, _ string) {
+		// The async stats-load queue is process-wide; isolate this test's partial/full stats transitions.
+		clearAsyncLoadHistogramNeededItems := func() {
+			for _, item := range asyncload.AsyncLoadHistogramNeededItems.AllItems() {
+				asyncload.AsyncLoadHistogramNeededItems.Delete(item.TableItemID)
+			}
+		}
+		clearAsyncLoadHistogramNeededItems()
+		t.Cleanup(clearAsyncLoadHistogramNeededItems)
+
 		testKit.MustExec("use test")
 		testKit.MustExec("create table t(a int, b int, c int, primary key(a), key idx(b))")
 		testKit.MustExec("insert into t values (1,1,1),(2,2,2),(3,3,3)")
@@ -696,6 +705,7 @@ func TestPartialStatsInExplain(t *testing.T) {
 		testKit.RequireNoError(dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
 		testKit.MustQuery("explain select * from tp where a = 1")
 		testKit.MustExec("set @@tidb_stats_load_sync_wait = 0")
+		clearAsyncLoadHistogramNeededItems()
 		type explainCase struct {
 			sql         string
 			contains    []string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69571

Problem Summary:
Flaky test `TestPartialStatsInExplain` in `pkg/planner/core/casetest/planstats` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky was caused by process-wide async stats-load queue state leaking into TestPartialStatsInExplain’s expected partial/full stats transition sequence.

#### Fix

Clearing the queue before and after the test isolates only this test’s async stats observations without changing the asserted SQL semantics.

#### Verification

Spec:
- target: `pkg/planner/core/casetest/planstats :: TestPartialStatsInExplain`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
scoped_package passed.
build passed.
lint passed.

Gate checklist:
- seeded_async_queue_repro: SKIPPED
- target_flaky: PASS
- scoped_package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/planstats -run '^TestPartialStatsInExplain$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/planstats -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for statistics-related explain output, making the test suite more reliable and reducing interference from leftover asynchronous state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->