### PR TITLE
executor: reduce SQLKiller checks in HashJoin V1 probe loop

### DIFF
--- a/pkg/executor/join/hash_join_v1.go
+++ b/pkg/executor/join/hash_join_v1.go
@@ -418,7 +418,7 @@ func (w *ProbeWorkerV1) joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey u
 		}
 		rowIdx += len(outerMatchStatus)
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -462,7 +462,7 @@ func (w *ProbeWorkerV1) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, prob
 					return true, waitTime, joinResult
 				}
 				if joinResult.chk.IsFull() {
-					ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+					ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 					waitTime += oneWaitTime
 					if !ok {
 						return false, waitTime, joinResult
@@ -497,7 +497,7 @@ func (w *ProbeWorkerV1) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, prob
 				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 				waitTime += oneWaitTime
 				if !ok {
 					return false, waitTime, joinResult
@@ -537,7 +537,7 @@ func (w *ProbeWorkerV1) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, prob
 				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 				waitTime += oneWaitTime
 				if !ok {
 					return false, waitTime, joinResult
@@ -572,7 +572,7 @@ func (w *ProbeWorkerV1) joinNAALOSJMatchProbeSideRow2Chunk(probeKey uint64, prob
 			return true, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -618,7 +618,7 @@ func (w *ProbeWorkerV1) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 					return true, waitTime, joinResult
 				}
 				if joinResult.chk.IsFull() {
-					ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+					ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 					waitTime += oneWaitTime
 					if !ok {
 						return false, waitTime, joinResult
@@ -653,7 +653,7 @@ func (w *ProbeWorkerV1) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 				waitTime += oneWaitTime
 				if !ok {
 					return false, waitTime, joinResult
@@ -693,7 +693,7 @@ func (w *ProbeWorkerV1) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 				return true, waitTime, joinResult
 			}
 			if joinResult.chk.IsFull() {
-				ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+				ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 				waitTime += oneWaitTime
 				if !ok {
 					return false, waitTime, joinResult
@@ -728,7 +728,7 @@ func (w *ProbeWorkerV1) joinNAASJMatchProbeSideRow2Chunk(probeKey uint64, probeK
 			return true, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -812,7 +812,7 @@ func (w *ProbeWorkerV1) joinMatchedProbeSideRow2Chunk(probeKey uint64, probeSide
 		hasNull = hasNull || isNull
 
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -882,17 +882,18 @@ func (w *ProbeWorkerV1) join2Chunk(probeSideChk *chunk.Chunk, hCtx *HashContext,
 		}
 	}
 
-	for i := range selected {
-		err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal()
-		failpoint.Inject("killedInJoin2Chunk", func(val failpoint.Value) {
-			if val.(bool) {
-				err = exeerrors.ErrQueryInterrupted
-			}
-		})
-		if err != nil {
-			joinResult.err = err
-			return false, waitTime, joinResult
+	err = w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal()
+	failpoint.Inject("killedInJoin2Chunk", func(val failpoint.Value) {
+		if val.(bool) {
+			err = exeerrors.ErrQueryInterrupted
 		}
+	})
+	if err != nil {
+		joinResult.err = err
+		return false, waitTime, joinResult
+	}
+
+	for i := range selected {
 		if isNAAJ {
 			if !selected[i] {
 				// since this is the case of using inner to build, so for an outer row unselected, we should fill the result when it's outer join.
@@ -930,7 +931,7 @@ func (w *ProbeWorkerV1) join2Chunk(probeSideChk *chunk.Chunk, hCtx *HashContext,
 			}
 		}
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -948,6 +949,18 @@ func (w *ProbeWorkerV1) sendingResult(joinResult *hashjoinWorkerResult) (ok bool
 	return ok, cost, newJoinResult
 }
 
+func (w *ProbeWorkerV1) sendingResultAndCheckSignal(joinResult *hashjoinWorkerResult) (ok bool, cost int64, newJoinResult *hashjoinWorkerResult) {
+	ok, cost, newJoinResult = w.sendingResult(joinResult)
+	if !ok {
+		return false, cost, newJoinResult
+	}
+	if err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal(); err != nil {
+		newJoinResult.err = err
+		return false, cost, newJoinResult
+	}
+	return true, cost, newJoinResult
+}
+
 // join2ChunkForOuterHashJoin joins chunks when using the outer to build a hash table (refer to outer hash join)
 func (w *ProbeWorkerV1) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hCtx *HashContext, joinResult *hashjoinWorkerResult) (ok bool, waitTime int64, _ *hashjoinWorkerResult) {
 	waitTime = 0
@@ -960,17 +973,19 @@ func (w *ProbeWorkerV1) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hC
 			return false, waitTime, joinResult
 		}
 	}
-	for i := range probeSideChk.NumRows() {
-		err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal()
-		failpoint.Inject("killedInJoin2ChunkForOuterHashJoin", func(val failpoint.Value) {
-			if val.(bool) {
-				err = exeerrors.ErrQueryInterrupted
-			}
-		})
-		if err != nil {
-			joinResult.err = err
-			return false, waitTime, joinResult
+
+	err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal()
+	failpoint.Inject("killedInJoin2ChunkForOuterHashJoin", func(val failpoint.Value) {
+		if val.(bool) {
+			err = exeerrors.ErrQueryInterrupted
 		}
+	})
+	if err != nil {
+		joinResult.err = err
+		return false, waitTime, joinResult
+	}
+
+	for i := range probeSideChk.NumRows() {
 		probeKey, probeRow := hCtx.HashVals[i].Sum64(), probeSideChk.GetRow(i)
 		ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2ChunkForOuterHashJoin(probeKey, probeRow, hCtx, joinResult)
 		waitTime += oneWaitTime
@@ -978,7 +993,7 @@ func (w *ProbeWorkerV1) join2ChunkForOuterHashJoin(probeSideChk *chunk.Chunk, hC
 			return false, waitTime, joinResult
 		}
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult

--- a/pkg/executor/join/hash_join_v1.go
+++ b/pkg/executor/join/hash_join_v1.go
@@ -949,16 +949,16 @@ func (w *ProbeWorkerV1) sendingResult(joinResult *hashjoinWorkerResult) (ok bool
 	return ok, cost, newJoinResult
 }
 
-func (w *ProbeWorkerV1) sendingResultAndCheckSignal(joinResult *hashjoinWorkerResult) (ok bool, cost int64, newJoinResult *hashjoinWorkerResult) {
-	ok, cost, newJoinResult = w.sendingResult(joinResult)
+func (w *ProbeWorkerV1) sendingResultAndCheckSignal(joinResult *hashjoinWorkerResult) (ok bool, waitTime int64, newJoinResult *hashjoinWorkerResult) {
+	ok, waitTime, newJoinResult = w.sendingResult(joinResult)
 	if !ok {
-		return false, cost, newJoinResult
+		return false, waitTime, newJoinResult
 	}
 	if err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal(); err != nil {
 		newJoinResult.err = err
-		return false, cost, newJoinResult
+		return false, waitTime, newJoinResult
 	}
-	return true, cost, newJoinResult
+	return true, waitTime, newJoinResult
 }
 
 // join2ChunkForOuterHashJoin joins chunks when using the outer to build a hash table (refer to outer hash join)

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -208,13 +208,13 @@ func (killer *SQLKiller) HandleSignal() error {
 	// Checks if the connection is alive.
 	// For performance reasons, the check interval should be at least `checkConnectionAliveDur`(1 second).
 	fn := killer.IsConnectionAlive.Load()
-	lastCheckTime := killer.lastCheckTime.Load()
 	if fn != nil {
 		var checkConnectionAliveDur time.Duration = time.Second
 		now := time.Now()
 		if intest.InTest {
 			checkConnectionAliveDur = time.Millisecond
 		}
+		lastCheckTime := killer.lastCheckTime.Load()
 		if lastCheckTime == nil {
 			killer.lastCheckTime.Store(&now)
 		} else if now.Sub(*lastCheckTime) > checkConnectionAliveDur {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69582, close https://github.com/pingcap/tidb/issues/69546

Problem Summary:
See https://github.com/pingcap/tidb/issues/69582

### What changed and how does it work?
This PR changes HashJoin V1 to avoid checking the kill signal for every probe row. 
Instead, it checks:
* once before processing a probe chunk
* after an output chunk is produced/sent

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join processing so long-running queries respond to cancellation or kill signals more promptly.
  * Fixed join result flushing to stop work immediately when an interrupt is detected, reducing wasted processing on large outputs.
  * Made connection-alive checks more consistent during signal handling, helping ensure query interruption behaves reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->