### PR TITLE
executor, ddl: capture collation mode for background encoding

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	decoder "github.com/pingcap/tidb/pkg/util/rowDecoder"
@@ -159,14 +160,15 @@ type backfillTaskContext struct {
 type backfillCtx struct {
 	id int
 	*ddlCtx
-	warnings   contextutil.WarnHandlerExt
-	loc        *time.Location
-	exprCtx    exprctx.BuildContext
-	tblCtx     table.MutateContext
-	schemaName string
-	table      table.Table
-	batchCnt   int
-	jobContext *ReorgContext
+	warnings      contextutil.WarnHandlerExt
+	loc           *time.Location
+	exprCtx       exprctx.BuildContext
+	tblCtx        table.MutateContext
+	schemaName    string
+	table         table.Table
+	batchCnt      int
+	useNewCollate bool
+	jobContext    *ReorgContext
 
 	metricCounter   prometheus.Counter
 	conflictCounter prometheus.Counter
@@ -215,16 +217,17 @@ func newBackfillCtx(id int, rInfo *reorgInfo, schemaName string, tbl table.Table
 	batchCnt := rInfo.ReorgMeta.GetBatchSize()
 	metricTableID := backfillMetricsTableID(rInfo, label)
 	return &backfillCtx{
-		id:         id,
-		ddlCtx:     rInfo.jobCtx.oldDDLCtx,
-		warnings:   warnHandler,
-		exprCtx:    exprCtx,
-		tblCtx:     tblCtx,
-		loc:        exprCtx.GetEvalCtx().Location(),
-		schemaName: schemaName,
-		table:      tbl,
-		batchCnt:   batchCnt,
-		jobContext: jobCtx,
+		id:            id,
+		ddlCtx:        rInfo.jobCtx.oldDDLCtx,
+		warnings:      warnHandler,
+		exprCtx:       exprCtx,
+		tblCtx:        tblCtx,
+		loc:           exprCtx.GetEvalCtx().Location(),
+		schemaName:    schemaName,
+		table:         tbl,
+		batchCnt:      batchCnt,
+		useNewCollate: rInfo.ReorgMeta.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
+		jobContext:    jobCtx,
 		metricCounter: getBackfillTotalByTableID(
 			metricTableID, label, schemaName, tbl.Meta().Name.String(), colOrIdxName),
 		conflictCounter: getBackfillTotalByTableID(
@@ -719,12 +722,12 @@ func sendTasks(
 	return nil
 }
 
-func makeupDecodeColMap(dbName ast.CIStr, t table.Table) (map[int64]decoder.Column, error) {
+func makeupDecodeColMap(dbName ast.CIStr, t table.Table, useNewCollate bool) (map[int64]decoder.Column, error) {
 	writableColInfos := make([]*model.ColumnInfo, 0, len(t.WritableCols()))
 	for _, col := range t.WritableCols() {
 		writableColInfos = append(writableColInfos, col.ColumnInfo)
 	}
-	exprCols, _, err := expression.ColumnInfos2ColumnsAndNames(newReorgExprCtx(), dbName, t.Meta().Name, writableColInfos, t.Meta())
+	exprCols, _, err := expression.ColumnInfos2ColumnsAndNamesWithCollate(newReorgExprCtx(), dbName, t.Meta().Name, writableColInfos, t.Meta(), useNewCollate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
@@ -110,8 +111,9 @@ func NewAddIndexIngestPipeline(
 	collector execute.Collector,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
+	useNewCollate := reorgMeta.GetUseNewCollateOrDefault(collate.NewCollationEnabled())
 	for _, idxInfo := range idxInfos {
-		index, err := tables.NewIndex(tbl.GetPhysicalID(), tbl.Meta(), idxInfo)
+		index, err := tables.NewIndexWithCollate(useNewCollate, tbl.GetPhysicalID(), tbl.Meta(), idxInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -168,8 +170,9 @@ func NewWriteIndexToExternalStoragePipeline(
 	tikvCodec tikv.Codec,
 ) (*operator.AsyncPipeline, error) {
 	indexes := make([]table.Index, 0, len(idxInfos))
+	useNewCollate := reorgMeta.GetUseNewCollateOrDefault(collate.NewCollationEnabled())
 	for _, idxInfo := range idxInfos {
-		index, err := tables.NewIndex(tbl.GetPhysicalID(), tbl.Meta(), idxInfo)
+		index, err := tables.NewIndexWithCollate(useNewCollate, tbl.GetPhysicalID(), tbl.Meta(), idxInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -914,7 +917,19 @@ func (w *indexIngestWorker) WriteChunk(rs *IndexRecordChunk) (count int, bytes i
 		// skip running the checker in TiDB side.
 		indexConditionCheckers = nil
 	}
-	cnt, kvBytes, err := writeChunk(w.ctx, w.writers, w.indexes, indexConditionCheckers, w.copCtx, sc.TimeZone(), sc.ErrCtx(), vars.GetWriteStmtBufs(), rs.Chunk, w.tbl.Meta())
+	cnt, kvBytes, err := writeChunk(
+		w.ctx,
+		w.writers,
+		w.indexes,
+		indexConditionCheckers,
+		w.reorgMeta.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
+		w.copCtx,
+		sc.TimeZone(),
+		sc.ErrCtx(),
+		vars.GetWriteStmtBufs(),
+		rs.Chunk,
+		w.tbl.Meta(),
+	)
 	if err != nil || cnt == 0 {
 		return 0, 0, err
 	}

--- a/pkg/ddl/backfilling_txn_executor.go
+++ b/pkg/ddl/backfilling_txn_executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -82,7 +83,8 @@ type txnBackfillExecutor struct {
 func newTxnBackfillExecutor(ctx context.Context, info *reorgInfo, sessPool *sess.Pool,
 	tp backfillerType, tbl table.PhysicalTable,
 	jobCtx *ReorgContext) (backfillExecutor, error) {
-	decColMap, err := makeupDecodeColMap(info.dbInfo.Name, tbl)
+	useNewCollate := info.ReorgMeta.GetUseNewCollateOrDefault(collate.NewCollationEnabled())
+	decColMap, err := makeupDecodeColMap(info.dbInfo.Name, tbl, useNewCollate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -7501,7 +7501,7 @@ func getJobCheckInterval(action model.ActionType, i int) (time.Duration, bool) {
 // NewDDLReorgMeta create a DDL ReorgMeta.
 func NewDDLReorgMeta(ctx sessionctx.Context) *model.DDLReorgMeta {
 	tzName, tzOffset := ddlutil.GetTimeZone(ctx)
-	return &model.DDLReorgMeta{
+	reorgMeta := &model.DDLReorgMeta{
 		SQLMode:           ctx.GetSessionVars().SQLMode,
 		Warnings:          make(map[errors.ErrorID]*terror.Error),
 		WarningsCount:     make(map[errors.ErrorID]int64),
@@ -7509,6 +7509,8 @@ func NewDDLReorgMeta(ctx sessionctx.Context) *model.DDLReorgMeta {
 		ResourceGroupName: ctx.GetSessionVars().StmtCtx.ResourceGroupName,
 		Version:           model.CurrentReorgMetaVersion,
 	}
+	reorgMeta.SetUseNewCollate(collate.NewCollationEnabled())
+	return reorgMeta
 }
 
 // RefreshMeta is a internal DDL job. In some cases, BR log restore will EXCHANGE

--- a/pkg/ddl/export_test.go
+++ b/pkg/ddl/export_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
@@ -80,6 +81,6 @@ func ConvertRowToHandleAndIndexDatum(
 	c := copCtx.GetBase()
 	idxData := ddl.ExtractDatumByOffsets(ctx, row, copCtx.IndexColumnOutputOffsets(idxID), c.ExprColumnInfos, idxDataBuf)
 	handleData := ddl.ExtractDatumByOffsets(ctx, row, c.HandleOutputOffsets, c.ExprColumnInfos, handleDataBuf)
-	handle, err := ddl.BuildHandle(handleData, c.TableInfo, c.PrimaryKeyInfo, time.Local, errctx.StrictNoWarningContext)
+	handle, err := ddl.BuildHandle(collate.NewCollationEnabled(), handleData, c.TableInfo, c.PrimaryKeyInfo, time.Local, errctx.StrictNoWarningContext)
 	return handle, idxData, err
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2752,7 +2752,7 @@ func writeChunk(
 				restoreDataBuf[i] = *datum.Clone()
 			}
 		}
-		h, err := BuildHandle(handleDataBuf, c.TableInfo, c.PrimaryKeyInfo, loc, errCtx)
+		h, err := BuildHandle(useNewCollate, handleDataBuf, c.TableInfo, c.PrimaryKeyInfo, loc, errCtx)
 		if err != nil {
 			return 0, totalBytes, errors.Trace(err)
 		}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2477,7 +2477,7 @@ func (w *baseIndexWorker) getIndexRecord(idxInfo *model.IndexInfo, handle kv.Han
 		idxVal[j] = idxColumnVal
 	}
 
-	rsData := tables.TryGetHandleRestoredDataWrapperWithCollate(w.useNewCollate, w.table.Meta(), nil, w.rowMap, idxInfo)
+	rsData := tables.TryGetHandleRestoredDataWrapper(w.table, nil, w.rowMap, idxInfo)
 	idxRecord := &indexRecord{handle: handle, key: recordKey, vals: idxVal, rsData: rsData}
 	return idxRecord, nil
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2404,7 +2404,7 @@ func newAddIndexTxnWorker(
 			continue
 		}
 		indexInfo := model.FindIndexInfoByID(t.Meta().Indices, elem.ID)
-		index, err := tables.NewIndex(t.GetPhysicalID(), t.Meta(), indexInfo)
+		index, err := tables.NewIndexWithCollate(bfCtx.useNewCollate, t.GetPhysicalID(), t.Meta(), indexInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -2477,7 +2477,7 @@ func (w *baseIndexWorker) getIndexRecord(idxInfo *model.IndexInfo, handle kv.Han
 		idxVal[j] = idxColumnVal
 	}
 
-	rsData := tables.TryGetHandleRestoredDataWrapper(w.table.Meta(), nil, w.rowMap, idxInfo)
+	rsData := tables.TryGetHandleRestoredDataWrapperWithCollate(w.useNewCollate, w.table.Meta(), nil, w.rowMap, idxInfo)
 	idxRecord := &indexRecord{handle: handle, key: recordKey, vals: idxVal, rsData: rsData}
 	return idxRecord, nil
 }
@@ -2701,6 +2701,7 @@ func writeChunk(
 	writers []ingest.Writer,
 	indexes []table.Index,
 	indexConditionCheckers []func(row chunk.Row) (bool, error),
+	useNewCollate bool,
 	copCtx copr.CopContext,
 	loc *time.Location,
 	errCtx errctx.Context,
@@ -2732,10 +2733,10 @@ func writeChunk(
 	needRestoreForIndexes := make([]bool, len(indexes))
 	restore, pkNeedRestore := false, false
 	if c.PrimaryKeyInfo != nil && c.TableInfo.IsCommonHandle && c.TableInfo.CommonHandleVersion != 0 {
-		pkNeedRestore = tables.NeedRestoredData(c.PrimaryKeyInfo.Columns, c.TableInfo.Columns)
+		pkNeedRestore = tables.NeedRestoredDataWithCollate(useNewCollate, c.PrimaryKeyInfo.Columns, c.TableInfo.Columns)
 	}
 	for i, index := range indexes {
-		needRestore := pkNeedRestore || tables.NeedRestoredData(index.Meta().Columns, c.TableInfo.Columns)
+		needRestore := pkNeedRestore || tables.NeedRestoredDataWithCollate(useNewCollate, index.Meta().Columns, c.TableInfo.Columns)
 		needRestoreForIndexes[i] = needRestore
 		restore = restore || needRestore
 	}

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -257,11 +257,11 @@ func ExtractDatumByOffsets(ctx expression.EvalContext, row chunk.Row, offsets []
 }
 
 // BuildHandle is exported for test.
-func BuildHandle(pkDts []types.Datum, tblInfo *model.TableInfo,
+func BuildHandle(useNewCollate bool, pkDts []types.Datum, tblInfo *model.TableInfo,
 	pkInfo *model.IndexInfo, loc *time.Location, errCtx errctx.Context) (kv.Handle, error) {
 	if tblInfo.IsCommonHandle {
 		tablecodec.TruncateIndexValues(tblInfo, pkInfo, pkDts)
-		handleBytes, err := codec.EncodeKey(loc, nil, pkDts...)
+		handleBytes, err := codec.EncodeKeyWithCollate(useNewCollate, loc, nil, pkDts...)
 		err = errCtx.HandleError(err)
 		if err != nil {
 			return nil, err

--- a/pkg/ddl/index_merge_tmp.go
+++ b/pkg/ddl/index_merge_tmp.go
@@ -148,7 +148,7 @@ func newMergeTempIndexWorker(bfCtx *backfillCtx, t table.PhysicalTable, elements
 	allIndexes := make([]table.Index, 0, len(elements))
 	for _, elem := range elements {
 		indexInfo := model.FindIndexInfoByID(t.Meta().Indices, elem.ID)
-		index, err := tables.NewIndex(t.GetPhysicalID(), t.Meta(), indexInfo)
+		index, err := tables.NewIndexWithCollate(bfCtx.useNewCollate, t.GetPhysicalID(), t.Meta(), indexInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dxf/importinto/planner.go
+++ b/pkg/dxf/importinto/planner.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/table/tables"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
 )
@@ -351,7 +352,7 @@ func (*PostProcessSpec) ToSubtaskMeta(planCtx planner.PlanCtx) ([]byte, error) {
 func buildControllerForPlan(p *LogicalPlan) (*importer.LoadDataController, error) {
 	plan, stmt := &p.Plan, p.Stmt
 	idAlloc := kv.NewPanickingAllocators(plan.TableInfo.SepAutoInc())
-	tbl, err := tables.TableFromMeta(idAlloc, plan.TableInfo)
+	tbl, err := tables.TableFromMetaWithCollate(plan.GetUseNewCollateOrDefault(collate.NewCollationEnabled()), idAlloc, plan.TableInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dxf/importinto/task_executor.go
+++ b/pkg/dxf/importinto/task_executor.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/resourcemanager/pool/workerpool"
 	"github.com/pingcap/tidb/pkg/table/tables"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
@@ -106,7 +107,11 @@ func getTableImporter(
 	logger *zap.Logger,
 ) (*importer.TableImporter, error) {
 	idAlloc := kv.NewPanickingAllocators(taskMeta.Plan.TableInfo.SepAutoInc())
-	tbl, err := tables.TableFromMeta(idAlloc, taskMeta.Plan.TableInfo)
+	tbl, err := tables.TableFromMetaWithCollate(
+		taskMeta.Plan.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
+		idAlloc,
+		taskMeta.Plan.TableInfo,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/admin.go
+++ b/pkg/executor/admin.go
@@ -404,7 +404,7 @@ func (e *RecoverIndexExec) fetchRecoverRows(ctx context.Context, srcResult dists
 				return nil, err
 			}
 			e.idxValsBufs[result.scanRowCount] = idxVals
-			rsData := tables.TryGetHandleRestoredDataWrapper(e.table.Meta(), plannercore.GetCommonHandleDatum(e.handleCols, row), nil, e.index.Meta())
+			rsData := tables.TryGetHandleRestoredDataWrapper(e.table, plannercore.GetCommonHandleDatum(e.handleCols, row), nil, e.index.Meta())
 			e.recoverRows = append(e.recoverRows, recoverRows{handle: handle, idxVals: idxVals, rsData: rsData, skip: true})
 			result.scanRowCount++
 			result.currentHandle = handle

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -65,6 +65,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/cpu"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
@@ -335,6 +336,8 @@ type Plan struct {
 	ManualRecovery bool
 	// the keyspace name when submitting this job, only for import-into
 	Keyspace string
+	// UseNewCollate is the new-collation mode captured when the import task is created.
+	UseNewCollate *bool `json:"use_new_collate,omitempty"`
 }
 
 // GetOnDupKeyMode returns the conflict handling mode.
@@ -347,6 +350,20 @@ func (p *Plan) GetOnDupKeyMode() OnDupKeyMode {
 		return OnDupKeyModeError
 	}
 	return p.OnDupKey
+}
+
+// GetUseNewCollateOrDefault returns the captured new-collation mode, or
+// defaultVal when the field is absent in old tasks.
+func (p *Plan) GetUseNewCollateOrDefault(defaultVal bool) bool {
+	if p == nil || p.UseNewCollate == nil {
+		return defaultVal
+	}
+	return *p.UseNewCollate
+}
+
+// SetUseNewCollate records the new-collation mode for this import task.
+func (p *Plan) SetUseNewCollate(useNewCollate bool) {
+	p.UseNewCollate = &useNewCollate
 }
 
 // ASTArgs is the arguments for ast.LoadDataStmt.
@@ -553,6 +570,7 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 		User:                   userSctx.GetSessionVars().User.String(),
 		Keyspace:               userSctx.GetStore().GetKeyspace(),
 	}
+	p.SetUseNewCollate(collate.NewCollationEnabled())
 	if err := p.initOptions(ctx, userSctx, plan.Options); err != nil {
 		return nil, err
 	}
@@ -1924,6 +1942,7 @@ func createColAssignSimpleExprs(
 	assignments []*ast.Assignment,
 	ctx expression.BuildContext,
 	mu *sync.Mutex,
+	useNewCollate bool,
 ) (_ []expression.Expression, _ []contextutil.SQLWarn, retErr error) {
 	if mu != nil {
 		mu.Lock()
@@ -1932,7 +1951,7 @@ func createColAssignSimpleExprs(
 	res := make([]expression.Expression, 0, len(assignments))
 	var allWarnings []contextutil.SQLWarn
 	for _, assign := range assignments {
-		newExpr, err := expression.BuildSimpleExpr(ctx, assign.Expr)
+		newExpr, err := expression.BuildSimpleExpr(ctx, assign.Expr, expression.WithUseNewCollate(useNewCollate))
 		// col assign expr warnings is static, we should generate it for each row processed.
 		// so we save it and clear it here.
 		if ctx.GetEvalCtx().WarningCount() > 0 {
@@ -1948,7 +1967,8 @@ func createColAssignSimpleExprs(
 
 // CreateColAssignSimpleExprs creates the column assignment expressions using `expression.BuildContext`.
 func (e *LoadDataController) CreateColAssignSimpleExprs(ctx expression.BuildContext) (_ []expression.Expression, _ []contextutil.SQLWarn, retErr error) {
-	return createColAssignSimpleExprs(e.ColumnAssignments, ctx, &e.colAssignMu)
+	return createColAssignSimpleExprs(e.ColumnAssignments, ctx, &e.colAssignMu,
+		e.GetUseNewCollateOrDefault(collate.NewCollationEnabled()))
 }
 
 func (e *LoadDataController) getLocalBackendCfg(keyspace, pdAddr, dataDir string) ingestctrl.BackendConfig {

--- a/pkg/executor/importer/sampler.go
+++ b/pkg/executor/importer/sampler.go
@@ -39,6 +39,7 @@ import (
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"go.uber.org/zap"
@@ -82,6 +83,7 @@ type KVSizeSampleConfig struct {
 	FieldNullDef     []string
 	LineFieldsInfo   plannercore.LineFieldsInfo
 	IgnoreLines      uint64
+	UseNewCollate    bool
 
 	ColumnsAndUserVars []*ast.ColumnNameOrUserVar
 	ColumnAssignments  []*ast.Assignment
@@ -155,6 +157,7 @@ func (e *LoadDataController) buildKVSizeSampleConfig() *KVSizeSampleConfig {
 		FieldNullDef:       append([]string(nil), e.FieldNullDef...),
 		LineFieldsInfo:     e.LineFieldsInfo,
 		IgnoreLines:        e.IgnoreLines,
+		UseNewCollate:      e.Plan.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
 		ColumnsAndUserVars: e.ColumnsAndUserVars,
 		ColumnAssignments:  e.ColumnAssignments,
 	}
@@ -209,7 +212,7 @@ func validateKVSizeSampleConfig(cfg *KVSizeSampleConfig) error {
 func (s *kvSizeSampler) CreateColAssignSimpleExprs(
 	ctx expression.BuildContext,
 ) (_ []expression.Expression, _ []contextutil.SQLWarn, retErr error) {
-	return createColAssignSimpleExprs(s.cfg.ColumnAssignments, ctx, &s.colAssignMu)
+	return createColAssignSimpleExprs(s.cfg.ColumnAssignments, ctx, &s.colAssignMu, s.cfg.UseNewCollate)
 }
 
 func (s *kvSizeSampler) generateCSVConfig() *config.CSVConfig {
@@ -281,9 +284,10 @@ func (s *kvSizeSampler) getKVEncoder(
 			SysVars:        s.cfg.ImportantSysVars,
 			AutoRandomSeed: chunk.PrevRowIDMax,
 		},
-		Path:   chunk.Path,
-		Table:  encTable,
-		Logger: log.Logger{Logger: logger.With(zap.String("path", chunk.Path))},
+		Path:          chunk.Path,
+		Table:         encTable,
+		Logger:        log.Logger{Logger: logger.With(zap.String("path", chunk.Path))},
+		UseNewCollate: &s.cfg.UseNewCollate,
 	}
 	return newTableKVEncoderInner(cfg, s, s.fieldMappings, s.insertColumns)
 }
@@ -331,7 +335,7 @@ func (s *kvSizeSampler) sampleOneFile(
 		ParquetMeta: file.ParquetMeta,
 	}
 	idAlloc := kv.NewPanickingAllocators(s.table.Meta().SepAutoInc())
-	tbl, err := tables.TableFromMeta(idAlloc, s.table.Meta())
+	tbl, err := tables.TableFromMetaWithCollate(s.cfg.UseNewCollate, idAlloc, s.table.Meta())
 	if err != nil {
 		return 0, 0, 0, errors.Annotatef(err, "failed to tables.TableFromMeta %s", s.table.Meta().Name)
 	}

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/etcd"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/promutil"
@@ -190,7 +191,11 @@ func NewTableImporter(
 	kvStore tidbkv.Storage,
 ) (ti *TableImporter, err error) {
 	idAlloc := kv.NewPanickingAllocators(e.Table.Meta().SepAutoInc())
-	tbl, err := tables.TableFromMeta(idAlloc, e.Table.Meta())
+	tbl, err := tables.TableFromMetaWithCollate(
+		e.Plan.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
+		idAlloc,
+		e.Table.Meta(),
+	)
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to tables.TableFromMeta %s", e.Table.Meta().Name)
 	}
@@ -287,7 +292,11 @@ var _ ingestctrl.StoreHelper = (*storeHelper)(nil)
 func NewTableImporterForTest(ctx context.Context, e *LoadDataController, id string, kvStore tidbkv.Storage) (*TableImporter, error) {
 	helper := &storeHelper{kvStore: kvStore}
 	idAlloc := kv.NewPanickingAllocators(e.Table.Meta().SepAutoInc())
-	tbl, err := tables.TableFromMeta(idAlloc, e.Table.Meta())
+	tbl, err := tables.TableFromMetaWithCollate(
+		e.Plan.GetUseNewCollateOrDefault(collate.NewCollationEnabled()),
+		idAlloc,
+		e.Table.Meta(),
+	)
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to tables.TableFromMeta %s", e.Table.Meta().Name)
 	}
@@ -386,6 +395,7 @@ func (ti *TableImporter) getKVEncoder(chunk *Chunk) (*TableKVEncoder, error) {
 }
 
 func (e *LoadDataController) getKVEncoder(logger *zap.Logger, chunk *Chunk, encTable table.Table) (*TableKVEncoder, error) {
+	useNewCollate := e.GetUseNewCollateOrDefault(collate.NewCollationEnabled())
 	cfg := &encode.EncodingConfig{
 		SessionOptions: encode.SessionOptions{
 			SQLMode:        e.SQLMode,
@@ -393,15 +403,17 @@ func (e *LoadDataController) getKVEncoder(logger *zap.Logger, chunk *Chunk, encT
 			SysVars:        e.ImportantSysVars,
 			AutoRandomSeed: chunk.PrevRowIDMax,
 		},
-		Path:   chunk.Path,
-		Table:  encTable,
-		Logger: log.Logger{Logger: logger.With(zap.String("path", chunk.Path))},
+		Path:          chunk.Path,
+		Table:         encTable,
+		Logger:        log.Logger{Logger: logger.With(zap.String("path", chunk.Path))},
+		UseNewCollate: &useNewCollate,
 	}
 	return NewTableKVEncoder(cfg, e)
 }
 
 // GetKVEncoderForDupResolve get the KV encoder for duplicate resolution.
 func (ti *TableImporter) GetKVEncoderForDupResolve() (*TableKVEncoder, error) {
+	useNewCollate := ti.GetUseNewCollateOrDefault(collate.NewCollationEnabled())
 	cfg := &encode.EncodingConfig{
 		SessionOptions: encode.SessionOptions{
 			SQLMode: ti.SQLMode,
@@ -410,6 +422,7 @@ func (ti *TableImporter) GetKVEncoderForDupResolve() (*TableKVEncoder, error) {
 		Table:                ti.encTable,
 		Logger:               log.Logger{Logger: ti.logger},
 		UseIdentityAutoRowID: true,
+		UseNewCollate:        &useNewCollate,
 	}
 	return NewTableKVEncoderForDupResolve(cfg, ti.LoadDataController)
 }

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/cascades/base"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/generatedexpr"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/pingcap/tidb/pkg/util/zeropool"
@@ -64,6 +65,8 @@ type BuildOptions struct {
 	AllowCastArray bool
 	// TargetFieldType indicates to cast the expression to the target field type if it is not nil
 	TargetFieldType *types.FieldType
+	// UseNewCollate indicates whether the expression should be built with new collation enabled.
+	UseNewCollate bool
 }
 
 // BuildOption is a function to apply optional settings
@@ -98,6 +101,13 @@ func WithAllowCastArray(allow bool) BuildOption {
 func WithCastExprTo(targetFt *types.FieldType) BuildOption {
 	return func(options *BuildOptions) {
 		options.TargetFieldType = targetFt
+	}
+}
+
+// WithUseNewCollate fixes the new-collation mode used while building an expression.
+func WithUseNewCollate(useNewCollate bool) BuildOption {
+	return func(options *BuildOptions) {
+		options.UseNewCollate = useNewCollate
 	}
 }
 
@@ -1096,6 +1106,12 @@ func TableInfo2SchemaAndNames(ctx BuildContext, dbName ast.CIStr, tbl *model.Tab
 
 // ColumnInfos2ColumnsAndNames converts the ColumnInfo to the *Column and NameSlice.
 func ColumnInfos2ColumnsAndNames(ctx BuildContext, dbName, tblName ast.CIStr, colInfos []*model.ColumnInfo, tblInfo *model.TableInfo) ([]*Column, types.NameSlice, error) {
+	return ColumnInfos2ColumnsAndNamesWithCollate(ctx, dbName, tblName, colInfos, tblInfo, collate.NewCollationEnabled())
+}
+
+// ColumnInfos2ColumnsAndNamesWithCollate converts the ColumnInfo to the
+// *Column and NameSlice using the specified new-collation mode.
+func ColumnInfos2ColumnsAndNamesWithCollate(ctx BuildContext, dbName, tblName ast.CIStr, colInfos []*model.ColumnInfo, tblInfo *model.TableInfo, useNewCollate bool) ([]*Column, types.NameSlice, error) {
 	columns := make([]*Column, 0, len(colInfos))
 	names := make([]*types.FieldName, 0, len(colInfos))
 	for i, col := range colInfos {
@@ -1136,7 +1152,7 @@ func ColumnInfos2ColumnsAndNames(ctx BuildContext, dbName, tblName ast.CIStr, co
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			e, err := BuildSimpleExpr(ctx, expr, WithInputSchemaAndNames(mockSchema, names, tblInfo), WithAllowCastArray(true))
+			e, err := BuildSimpleExpr(ctx, expr, WithInputSchemaAndNames(mockSchema, names, tblInfo), WithAllowCastArray(true), WithUseNewCollate(useNewCollate))
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/deadlockhistory"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -2647,6 +2648,11 @@ func (it *infoschemaTable) Meta() *model.TableInfo {
 	return it.meta
 }
 
+// UseNewCollate implements table.Table UseNewCollate interface.
+func (it *infoschemaTable) UseNewCollate() bool {
+	return collate.NewCollationEnabled()
+}
+
 // GetPhysicalID implements table.Table GetPhysicalID interface.
 func (it *infoschemaTable) GetPhysicalID() int64 {
 	return it.meta.ID
@@ -2743,6 +2749,11 @@ func (vt *VirtualTable) Allocators(_ table.AllocatorContext) autoid.Allocators {
 // Meta implements table.Table Meta interface.
 func (vt *VirtualTable) Meta() *model.TableInfo {
 	return nil
+}
+
+// UseNewCollate implements table.Table UseNewCollate interface.
+func (vt *VirtualTable) UseNewCollate() bool {
+	return collate.NewCollationEnabled()
 }
 
 // GetPhysicalID implements table.Table GetPhysicalID interface.

--- a/pkg/lightning/backend/encode/encode.go
+++ b/pkg/lightning/backend/encode/encode.go
@@ -34,6 +34,9 @@ type EncodingConfig struct {
 	// when encoding.
 	// default false, in this case we will do sharding automatically if needed.
 	UseIdentityAutoRowID bool
+	// UseNewCollate fixes the new-collation mode for expression and key
+	// encoding. Nil means using the current global setting.
+	UseNewCollate *bool
 }
 
 // EncodingBuilder consists of operations to handle encoding backend row data formats from source.

--- a/pkg/lightning/backend/kv/base.go
+++ b/pkg/lightning/backend/kv/base.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/redact"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -167,7 +168,11 @@ func NewBaseKVEncoder(config *encode.EncodingConfig) (*BaseKVEncoder, error) {
 	}
 
 	// collect expressions for evaluating stored generated columns
-	genCols, err := CollectGeneratedColumns(se, meta, cols)
+	useNewCollate := collate.NewCollationEnabled()
+	if config.UseNewCollate != nil {
+		useNewCollate = *config.UseNewCollate
+	}
+	genCols, err := CollectGeneratedColumnsWithCollate(se, meta, cols, useNewCollate)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to parse generated column expressions")
 	}

--- a/pkg/lightning/backend/kv/sql2kv.go
+++ b/pkg/lightning/backend/kv/sql2kv.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/collate"
 )
 
 type tableKVEncoder struct {
@@ -69,6 +70,12 @@ func NewTableKVEncoder(
 // CollectGeneratedColumns collects all expressions required to evaluate the
 // results of all generated columns. The returning slice is in evaluation order.
 func CollectGeneratedColumns(se *Session, meta *model.TableInfo, cols []*table.Column) ([]GeneratedCol, error) {
+	return CollectGeneratedColumnsWithCollate(se, meta, cols, collate.NewCollationEnabled())
+}
+
+// CollectGeneratedColumnsWithCollate collects generated column expressions
+// using the specified new-collation mode.
+func CollectGeneratedColumnsWithCollate(se *Session, meta *model.TableInfo, cols []*table.Column, useNewCollate bool) ([]GeneratedCol, error) {
 	hasGenCol := false
 	for _, col := range cols {
 		if col.GeneratedExpr != nil {
@@ -112,6 +119,7 @@ func CollectGeneratedColumns(se *Session, meta *model.TableInfo, cols []*table.C
 				col.GeneratedExpr.Internal(),
 				expression.WithInputSchemaAndNames(schema, names, meta),
 				expression.WithAllowCastArray(true),
+				expression.WithUseNewCollate(useNewCollate),
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/meta/model/reorg.go
+++ b/pkg/meta/model/reorg.go
@@ -95,6 +95,8 @@ type DDLReorgMeta struct {
 	MaxNodeCount      int                              `json:"max_node_count"`
 	AnalyzeState      int8                             `json:"analyze_state"`
 	Stage             ReorgStage                       `json:"stage"`
+	// UseNewCollate is the new-collation mode captured when the reorg job is created.
+	UseNewCollate *bool `json:"use_new_collate,omitempty"`
 	// These two variables are used to control the concurrency and batch size of the reorganization process.
 	// They can be adjusted dynamically through `admin alter ddl jobs` command.
 	// Note: Don't get or set these two variables directly, use the functions instead.
@@ -149,6 +151,20 @@ func (dm *DDLReorgMeta) GetMaxWriteSpeed() int {
 // SetMaxWriteSpeed sets the max write speed in DDLReorgMeta.
 func (dm *DDLReorgMeta) SetMaxWriteSpeed(maxWriteSpeed int) {
 	dm.MaxWriteSpeed.Store(int64(maxWriteSpeed))
+}
+
+// GetUseNewCollateOrDefault returns the captured new-collation mode, or
+// defaultVal when the field is absent in old jobs.
+func (dm *DDLReorgMeta) GetUseNewCollateOrDefault(defaultVal bool) bool {
+	if dm == nil || dm.UseNewCollate == nil {
+		return defaultVal
+	}
+	return *dm.UseNewCollate
+}
+
+// SetUseNewCollate records the new-collation mode for this reorg job.
+func (dm *DDLReorgMeta) SetUseNewCollate(useNewCollate bool) {
+	dm.UseNewCollate = &useNewCollate
 }
 
 const (

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -112,7 +112,9 @@ func buildSimpleExpr(ctx expression.BuildContext, node ast.ExprNode, opts ...exp
 		return nil, errors.New("expression node should be present")
 	}
 
-	var options expression.BuildOptions
+	options := expression.BuildOptions{
+		UseNewCollate: collate.NewCollationEnabled(),
+	}
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -150,6 +152,7 @@ func buildSimpleExpr(ctx expression.BuildContext, node ast.ExprNode, opts ...exp
 		sourceTable:         options.SourceTable,
 		allowBuildCastArray: options.AllowCastArray,
 		asScalar:            true,
+		useNewCollate:       options.UseNewCollate,
 	}
 
 	if tbl := options.SourceTable; tbl != nil && rewriter.schema == nil {
@@ -257,8 +260,10 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalP
 
 	if len(b.rewriterPool) < b.rewriterCounter {
 		rewriter = &expressionRewriter{
-			sctx: b.ctx.GetExprCtx(), ctx: ctx,
-			planCtx: &exprRewriterPlanCtx{plan: p, builder: b, curClause: b.curClause, rollExpand: b.currentBlockExpand},
+			sctx:          b.ctx.GetExprCtx(),
+			ctx:           ctx,
+			planCtx:       &exprRewriterPlanCtx{plan: p, builder: b, curClause: b.curClause, rollExpand: b.currentBlockExpand},
+			useNewCollate: collate.NewCollationEnabled(),
 		}
 		b.rewriterPool = append(b.rewriterPool, rewriter)
 		return
@@ -273,6 +278,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalP
 	rewriter.ctxNameStk = rewriter.ctxNameStk[:0]
 	rewriter.ctx = ctx
 	rewriter.err = nil
+	rewriter.useNewCollate = collate.NewCollationEnabled()
 	rewriter.planCtx.plan = p
 	rewriter.planCtx.curClause = b.curClause
 	rewriter.planCtx.aggrMap = nil
@@ -375,7 +381,8 @@ type expressionRewriter struct {
 
 	astNodeStack []ast.Node
 
-	planCtx *exprRewriterPlanCtx
+	planCtx       *exprRewriterPlanCtx
+	useNewCollate bool
 }
 
 func (er *expressionRewriter) ctxStackLen() int {
@@ -1847,7 +1854,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		}, types.EmptyName)
 	case *ast.SetCollationExpr:
 		arg := er.ctxStack[len(er.ctxStack)-1]
-		if collate.NewCollationEnabled() {
+		if er.useNewCollate {
 			var collInfo *charset.Collation
 			// TODO(bb7133): use charset.ValidCharsetAndCollation when its bug is fixed.
 			if collInfo, er.err = collate.GetCollationByName(v.Collate); er.err != nil {
@@ -2275,7 +2282,7 @@ func (er *expressionRewriter) castCollationForIn(colLen int, elemCnt int, stkLen
 	if colLen != 1 {
 		return
 	}
-	if !collate.NewCollationEnabled() {
+	if !er.useNewCollate {
 		// See https://github.com/pingcap/tidb/issues/52772
 		// This function will apply CoercibilityExplicit to the casted expression, but some checks(during ColumnSubstituteImpl) is missed when the new
 		// collation is disabled, then lead to panic.
@@ -2393,7 +2400,7 @@ func (er *expressionRewriter) patternLikeOrIlikeToExpression(v *ast.PatternLikeO
 	fieldType := &types.FieldType{}
 	isPatternExactMatch := false
 	// Treat predicate 'like' or 'ilike' the same way as predicate '=' when it is an exact match and new collation is not enabled.
-	if patExpression, ok := er.ctxStack[l-1].(*expression.Constant); ok && !collate.NewCollationEnabled() {
+	if patExpression, ok := er.ctxStack[l-1].(*expression.Constant); ok && !er.useNewCollate {
 		patString, isNull, err := patExpression.EvalString(er.sctx.GetEvalCtx(), chunk.Row{})
 		if err != nil {
 			er.err = err

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -459,6 +459,9 @@ type Table interface {
 	// Meta returns TableInfo.
 	Meta() *model.TableInfo
 
+	// UseNewCollate returns the new-collation mode captured for this table.
+	UseNewCollate() bool
+
 	// Type returns the type of table
 	Type() Type
 

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -62,14 +63,22 @@ type index struct {
 	// the collation global variable is initialized *after* `NewIndex()`.
 	initNeedRestoreData sync.Once
 	needRestoredData    bool
+	useNewCollate       bool
 
 	indexPartialCondition
 }
 
 // NeedRestoredData checks whether the index columns needs restored data.
 func NeedRestoredData(idxCols []*model.IndexColumn, colInfos []*model.ColumnInfo) bool {
+	return NeedRestoredDataWithCollate(collate.NewCollationEnabled(), idxCols, colInfos)
+}
+
+// NeedRestoredDataWithCollate checks whether the index columns need restored
+// data under the specified new-collation mode.
+func NeedRestoredDataWithCollate(useNewCollate bool, idxCols []*model.IndexColumn, colInfos []*model.ColumnInfo) bool {
 	for _, idxCol := range idxCols {
-		if model.ColumnNeedRestoredData(idxCol, colInfos) {
+		col := colInfos[idxCol.Offset]
+		if types.NeedRestoredDataWithCollate(model.GetIdxChangingFieldType(idxCol, col), useNewCollate) {
 			return true
 		}
 	}
@@ -78,16 +87,24 @@ func NeedRestoredData(idxCols []*model.IndexColumn, colInfos []*model.ColumnInfo
 
 // NewIndex builds a new Index object.
 func NewIndex(physicalID int64, tblInfo *model.TableInfo, indexInfo *model.IndexInfo) (table.Index, error) {
+	return NewIndexWithCollate(collate.NewCollationEnabled(), physicalID, tblInfo, indexInfo)
+}
+
+// NewIndexWithCollate builds a new Index object with the specified new-collation mode.
+func NewIndexWithCollate(useNewCollate bool, physicalID int64, tblInfo *model.TableInfo, indexInfo *model.IndexInfo) (table.Index, error) {
 	index := &index{
-		idxInfo:  indexInfo,
-		tblInfo:  tblInfo,
-		phyTblID: physicalID,
+		idxInfo:       indexInfo,
+		tblInfo:       tblInfo,
+		phyTblID:      physicalID,
+		useNewCollate: useNewCollate,
 	}
 
 	conditionString := indexInfo.ConditionExprString
 	if len(conditionString) > 0 {
 		var err error
-		index.conditionExpr, err = expression.ParseSimpleExpr(indexConditionECtx, conditionString, expression.WithTableInfo("", tblInfo))
+		index.conditionExpr, err = expression.ParseSimpleExpr(indexConditionECtx, conditionString,
+			expression.WithTableInfo("", tblInfo),
+			expression.WithUseNewCollate(useNewCollate))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -166,7 +183,7 @@ func (c *index) GenIndexKey(ec errctx.Context, loc *time.Location, indexedValues
 		return
 	}
 
-	key, distinct, err = tablecodec.GenIndexKey(loc, c.tblInfo, c.idxInfo, idxTblID, indexedValues, fullHandle, buf)
+	key, distinct, err = tablecodec.GenIndexKeyWithCollate(c.useNewCollate, loc, c.tblInfo, c.idxInfo, idxTblID, indexedValues, fullHandle, buf)
 	err = ec.HandleError(err)
 	return
 }
@@ -175,14 +192,14 @@ func (c *index) GenIndexKey(ec errctx.Context, loc *time.Location, indexedValues
 func (c *index) GenIndexValue(ec errctx.Context, loc *time.Location, distinct, untouched bool, indexedValues []types.Datum,
 	h kv.Handle, restoredData []types.Datum, buf []byte) ([]byte, error) {
 	c.initNeedRestoreData.Do(func() {
-		c.needRestoredData = NeedRestoredData(c.idxInfo.Columns, c.tblInfo.Columns)
+		c.needRestoredData = NeedRestoredDataWithCollate(c.useNewCollate, c.idxInfo.Columns, c.tblInfo.Columns)
 	})
 
 	if err := c.castIndexValuesToChangingTypes(indexedValues); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	idx, err := tablecodec.GenIndexValuePortal(loc, c.tblInfo, c.idxInfo, c.needRestoredData, distinct, untouched, indexedValues, h, c.phyTblID, restoredData, buf)
+	idx, err := tablecodec.GenIndexValuePortalWithCollate(c.useNewCollate, loc, c.tblInfo, c.idxInfo, c.needRestoredData, distinct, untouched, indexedValues, h, c.phyTblID, restoredData, buf)
 	err = ec.HandleError(err)
 	return idx, err
 }

--- a/pkg/table/tables/mutation_checker.go
+++ b/pkg/table/tables/mutation_checker.go
@@ -251,11 +251,12 @@ func checkIndexKeys(
 		}
 
 		// when we cannot decode the key to get the original value
-		if len(value) == 0 && NeedRestoredData(indexInfo.Columns, t.Meta().Columns) {
+		if len(value) == 0 && NeedRestoredDataWithCollate(t.useNewCollate, indexInfo.Columns, t.Meta().Columns) {
 			continue
 		}
 
-		decodedIndexValues, err := tablecodec.DecodeIndexKV(
+		decodedIndexValues, err := tablecodec.DecodeIndexKVWithCollate(
+			t.useNewCollate,
 			m.key, value, len(indexInfo.Columns), tablecodec.HandleNotNeeded, rowColInfos,
 		)
 		if err != nil {

--- a/pkg/table/tables/mutation_checker_test.go
+++ b/pkg/table/tables/mutation_checker_test.go
@@ -330,7 +330,7 @@ func buildIndexKeyValue(index table.Index, rowToInsert []types.Datum, loc *time.
 	if err != nil {
 		return nil, nil, err
 	}
-	rsData := TryGetHandleRestoredDataWrapper(table.meta, rowToInsert, nil, indexInfo)
+	rsData := TryGetHandleRestoredDataWrapper(table, rowToInsert, nil, indexInfo)
 	value, err := tablecodec.GenIndexValuePortal(
 		loc, &tableInfo, indexInfo, NeedRestoredData(indexInfo.Columns, tableInfo.Columns),
 		distinct, false, indexedValues, handle, 0, rsData, nil,

--- a/pkg/table/tables/partition.go
+++ b/pkg/table/tables/partition.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -181,7 +182,7 @@ func newPartitionedTable(tbl *TableCommon, tblInfo *model.TableInfo) (table.Part
 		} else {
 			tblInfo.Indices = origIndices
 		}
-		err := initTableCommonWithIndices(&t.TableCommon, tblInfo, p.ID, tbl.Columns, tbl.allocs, tbl.Constraints)
+		err := initTableCommonWithIndicesAndCollate(tbl.useNewCollate, &t.TableCommon, tblInfo, p.ID, tbl.Columns, tbl.allocs, tbl.Constraints)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -273,7 +274,7 @@ func newPartitionedTable(tbl *TableCommon, tblInfo *model.TableInfo) (table.Part
 
 func initPartition(t *partitionedTable, def model.PartitionDefinition) (*partition, error) {
 	var newPart partition
-	err := initTableCommonWithIndices(&newPart.TableCommon, t.meta, def.ID, t.Columns, t.allocs, t.Constraints)
+	err := initTableCommonWithIndicesAndCollate(t.useNewCollate, &newPart.TableCommon, t.meta, def.ID, t.Columns, t.allocs, t.Constraints)
 	if err != nil {
 		return nil, err
 	}
@@ -1676,7 +1677,7 @@ func GetReorganizedPartitionedTable(t table.Table) (table.PartitionedTable, erro
 		return nil, err
 	}
 	var tc TableCommon
-	initTableCommon(&tc, tblInfo, tblInfo.ID, t.Cols(), t.Allocators(nil), constraints)
+	initTableCommonWithCollate(collate.NewCollationEnabled(), &tc, tblInfo, tblInfo.ID, t.Cols(), t.Allocators(nil), constraints)
 
 	// and rebuild the partitioning structure
 	return newPartitionedTable(&tc, tblInfo)

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -81,6 +81,8 @@ type TableCommon struct {
 	// recordPrefix and indexPrefix are generated using physicalTableID.
 	recordPrefix kv.Key
 	indexPrefix  kv.Key
+	// useNewCollate is the new-collation mode captured when this table is built.
+	useNewCollate bool
 
 	// skipAssert is used for partitions that are in WriteOnly/DeleteOnly state.
 	skipAssert bool
@@ -140,7 +142,7 @@ func MockTableFromMeta(tblInfo *model.TableInfo) table.Table {
 		return nil
 	}
 	var t TableCommon
-	initTableCommon(&t, tblInfo, tblInfo.ID, columns, autoid.NewAllocators(false), constraints)
+	initTableCommonWithCollate(collate.NewCollationEnabled(), &t, tblInfo, tblInfo.ID, columns, autoid.NewAllocators(false), constraints)
 	if tblInfo.TableCacheStatusType != model.TableCacheStatusDisable {
 		ret, err := newCachedTable(&t)
 		if err != nil {
@@ -164,6 +166,12 @@ func MockTableFromMeta(tblInfo *model.TableInfo) table.Table {
 
 // TableFromMeta creates a Table instance from model.TableInfo.
 func TableFromMeta(allocs autoid.Allocators, tblInfo *model.TableInfo) (table.Table, error) {
+	return TableFromMetaWithCollate(collate.NewCollationEnabled(), allocs, tblInfo)
+}
+
+// TableFromMetaWithCollate creates a Table instance using the specified
+// new-collation mode.
+func TableFromMetaWithCollate(useNewCollate bool, allocs autoid.Allocators, tblInfo *model.TableInfo) (table.Table, error) {
 	if tblInfo.State == model.StateNone {
 		return nil, table.ErrTableStateCantNone.GenWithStackByArgs(tblInfo.Name)
 	}
@@ -214,7 +222,7 @@ func TableFromMeta(allocs autoid.Allocators, tblInfo *model.TableInfo) (table.Ta
 		return nil, err
 	}
 	var t TableCommon
-	initTableCommon(&t, tblInfo, tblInfo.ID, columns, allocs, constraints)
+	initTableCommonWithCollate(useNewCollate, &t, tblInfo, tblInfo.ID, columns, allocs, constraints)
 	if tblInfo.GetPartitionInfo() == nil {
 		if err := initTableIndices(&t); err != nil {
 			return nil, err
@@ -241,6 +249,10 @@ func buildGeneratedExpr(tblInfo *model.TableInfo, genExpr string) (ast.ExprNode,
 
 // initTableCommon initializes a TableCommon struct.
 func initTableCommon(t *TableCommon, tblInfo *model.TableInfo, physicalTableID int64, cols []*table.Column, allocs autoid.Allocators, constraints []*table.Constraint) {
+	initTableCommonWithCollate(collate.NewCollationEnabled(), t, tblInfo, physicalTableID, cols, allocs, constraints)
+}
+
+func initTableCommonWithCollate(useNewCollate bool, t *TableCommon, tblInfo *model.TableInfo, physicalTableID int64, cols []*table.Column, allocs autoid.Allocators, constraints []*table.Constraint) {
 	t.tableID = tblInfo.ID
 	t.physicalTableID = physicalTableID
 	t.allocs = allocs
@@ -249,6 +261,7 @@ func initTableCommon(t *TableCommon, tblInfo *model.TableInfo, physicalTableID i
 	t.Constraints = constraints
 	t.recordPrefix = tablecodec.GenTableRecordPrefix(physicalTableID)
 	t.indexPrefix = tablecodec.GenTableIndexPrefix(physicalTableID)
+	t.useNewCollate = useNewCollate
 	if tblInfo.IsSequence() {
 		t.sequence = &sequenceCommon{meta: tblInfo.Sequence}
 	}
@@ -264,7 +277,7 @@ func initTableIndices(t *TableCommon) error {
 		}
 
 		// Use partition ID for index, because TableCommon may be table or partition.
-		idx, err := NewIndex(t.physicalTableID, tblInfo, idxInfo)
+		idx, err := NewIndexWithCollate(t.useNewCollate, t.physicalTableID, tblInfo, idxInfo)
 		if err != nil {
 			return err
 		}
@@ -308,7 +321,12 @@ func asIndex(idx table.Index) *index {
 }
 
 func initTableCommonWithIndices(t *TableCommon, tblInfo *model.TableInfo, physicalTableID int64, cols []*table.Column, allocs autoid.Allocators, constraints []*table.Constraint) error {
-	initTableCommon(t, tblInfo, physicalTableID, cols, allocs, constraints)
+	initTableCommonWithCollate(collate.NewCollationEnabled(), t, tblInfo, physicalTableID, cols, allocs, constraints)
+	return initTableIndices(t)
+}
+
+func initTableCommonWithIndicesAndCollate(useNewCollate bool, t *TableCommon, tblInfo *model.TableInfo, physicalTableID int64, cols []*table.Column, allocs autoid.Allocators, constraints []*table.Constraint) error {
+	initTableCommonWithCollate(useNewCollate, t, tblInfo, physicalTableID, cols, allocs, constraints)
 	return initTableIndices(t)
 }
 
@@ -788,7 +806,7 @@ func (t *TableCommon) addRecord(sctx table.MutateContext, txn kv.Transaction, r 
 			}
 			tablecodec.TruncateIndexValues(tblInfo, pkIdx, pkDts)
 			var handleBytes []byte
-			handleBytes, err = codec.EncodeKey(tc.Location(), nil, pkDts...)
+			handleBytes, err = codec.EncodeKeyWithCollate(t.useNewCollate, tc.Location(), nil, pkDts...)
 			err = ec.HandleError(err)
 			if err != nil {
 				return
@@ -1031,7 +1049,7 @@ func (t *TableCommon) addIndices(sctx table.MutateContext, recordID kv.Handle, r
 			}
 			dupErr = kv.GenKeyExistsErr(colStrVals, fmt.Sprintf("%s.%s", v.TableMeta().Name.String(), v.Meta().Name.String()))
 		}
-		rsData := TryGetHandleRestoredDataWrapper(t.meta, r, nil, v.Meta())
+		rsData := TryGetHandleRestoredDataWrapperWithCollate(t.useNewCollate, t.meta, r, nil, v.Meta())
 		if dupHandle, err := asIndex(v).create(sctx, txn, indexVals, recordID, rsData, false, opt); err != nil {
 			if kv.ErrKeyExists.Equal(err) {
 				return dupHandle, dupErr
@@ -1311,7 +1329,7 @@ func (t *TableCommon) removeRowIndices(ctx table.MutateContext, txn kv.Transacti
 }
 
 func (t *TableCommon) buildIndexForRow(ctx table.MutateContext, h kv.Handle, vals []types.Datum, newData []types.Datum, idx *index, txn kv.Transaction, untouched bool, opt *table.CreateIdxOpt) error {
-	rsData := TryGetHandleRestoredDataWrapper(t.meta, newData, nil, idx.Meta())
+	rsData := TryGetHandleRestoredDataWrapperWithCollate(t.useNewCollate, t.meta, newData, nil, idx.Meta())
 	if _, err := idx.create(ctx, txn, vals, h, rsData, untouched, opt); err != nil {
 		if kv.ErrKeyExists.Equal(err) {
 			// Make error message consistent with MySQL.
@@ -1518,7 +1536,7 @@ func (t *TableCommon) Type() table.Type {
 }
 
 func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
-	return CanSkip(t.Meta(), col, value)
+	return CanSkipWithCollate(t.useNewCollate, t.Meta(), col, value)
 }
 
 // CanSkip is for these cases, we can skip the columns in encoded row:
@@ -1526,6 +1544,11 @@ func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
 // 2. the column's default value is null, and the value equals to that but has no origin default;
 // 3. the column is virtual generated.
 func CanSkip(info *model.TableInfo, col *table.Column, value *types.Datum) bool {
+	return CanSkipWithCollate(collate.NewCollationEnabled(), info, col, value)
+}
+
+// CanSkipWithCollate is like CanSkip but uses the specified new-collation mode.
+func CanSkipWithCollate(useNewCollate bool, info *model.TableInfo, col *table.Column, value *types.Datum) bool {
 	if col.IsPKHandleColumn(info) {
 		return true
 	}
@@ -1536,7 +1559,7 @@ func CanSkip(info *model.TableInfo, col *table.Column, value *types.Datum) bool 
 				continue
 			}
 			canSkip := idxCol.Length == types.UnspecifiedLength
-			canSkip = canSkip && !types.NeedRestoredData(&col.FieldType)
+			canSkip = canSkip && !types.NeedRestoredDataWithCollate(&col.FieldType, useNewCollate)
 			return canSkip
 		}
 	}
@@ -1774,14 +1797,20 @@ func (t *TableCommon) GetSequenceCommon() *sequenceCommon {
 
 // TryGetHandleRestoredDataWrapper tries to get the restored data for handle if needed. The argument can be a slice or a map.
 func TryGetHandleRestoredDataWrapper(tblInfo *model.TableInfo, row []types.Datum, rowMap map[int64]types.Datum, idx *model.IndexInfo) []types.Datum {
-	if !collate.NewCollationEnabled() || !tblInfo.IsCommonHandle || tblInfo.CommonHandleVersion == 0 {
+	return TryGetHandleRestoredDataWrapperWithCollate(collate.NewCollationEnabled(), tblInfo, row, rowMap, idx)
+}
+
+// TryGetHandleRestoredDataWrapperWithCollate tries to get the restored data for
+// handle under the specified new-collation mode.
+func TryGetHandleRestoredDataWrapperWithCollate(useNewCollate bool, tblInfo *model.TableInfo, row []types.Datum, rowMap map[int64]types.Datum, idx *model.IndexInfo) []types.Datum {
+	if !useNewCollate || !tblInfo.IsCommonHandle || tblInfo.CommonHandleVersion == 0 {
 		return nil
 	}
 	rsData := make([]types.Datum, 0, 4)
 	pkIdx := FindPrimaryIndex(tblInfo)
 	for _, pkIdxCol := range pkIdx.Columns {
 		pkCol := tblInfo.Columns[pkIdxCol.Offset]
-		if !types.NeedRestoredData(&pkCol.FieldType) {
+		if !types.NeedRestoredDataWithCollate(&pkCol.FieldType, useNewCollate) {
 			continue
 		}
 		var datum types.Datum

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1049,7 +1049,7 @@ func (t *TableCommon) addIndices(sctx table.MutateContext, recordID kv.Handle, r
 			}
 			dupErr = kv.GenKeyExistsErr(colStrVals, fmt.Sprintf("%s.%s", v.TableMeta().Name.String(), v.Meta().Name.String()))
 		}
-		rsData := TryGetHandleRestoredDataWrapperWithCollate(t.useNewCollate, t.meta, r, nil, v.Meta())
+		rsData := TryGetHandleRestoredDataWrapper(t, r, nil, v.Meta())
 		if dupHandle, err := asIndex(v).create(sctx, txn, indexVals, recordID, rsData, false, opt); err != nil {
 			if kv.ErrKeyExists.Equal(err) {
 				return dupHandle, dupErr
@@ -1329,7 +1329,7 @@ func (t *TableCommon) removeRowIndices(ctx table.MutateContext, txn kv.Transacti
 }
 
 func (t *TableCommon) buildIndexForRow(ctx table.MutateContext, h kv.Handle, vals []types.Datum, newData []types.Datum, idx *index, txn kv.Transaction, untouched bool, opt *table.CreateIdxOpt) error {
-	rsData := TryGetHandleRestoredDataWrapperWithCollate(t.useNewCollate, t.meta, newData, nil, idx.Meta())
+	rsData := TryGetHandleRestoredDataWrapper(t, newData, nil, idx.Meta())
 	if _, err := idx.create(ctx, txn, vals, h, rsData, untouched, opt); err != nil {
 		if kv.ErrKeyExists.Equal(err) {
 			// Make error message consistent with MySQL.
@@ -1533,6 +1533,11 @@ func (t *TableCommon) Allocators(ctx table.AllocatorContext) autoid.Allocators {
 // Type implements table.Table Type interface.
 func (t *TableCommon) Type() table.Type {
 	return table.NormalTable
+}
+
+// UseNewCollate returns the new-collation mode captured for this table.
+func (t *TableCommon) UseNewCollate() bool {
+	return t.useNewCollate
 }
 
 // canSkip returns whether the column can be omitted from the encoded row:
@@ -1788,13 +1793,9 @@ func (t *TableCommon) GetSequenceCommon() *sequenceCommon {
 }
 
 // TryGetHandleRestoredDataWrapper tries to get the restored data for handle if needed. The argument can be a slice or a map.
-func TryGetHandleRestoredDataWrapper(tblInfo *model.TableInfo, row []types.Datum, rowMap map[int64]types.Datum, idx *model.IndexInfo) []types.Datum {
-	return TryGetHandleRestoredDataWrapperWithCollate(collate.NewCollationEnabled(), tblInfo, row, rowMap, idx)
-}
-
-// TryGetHandleRestoredDataWrapperWithCollate tries to get the restored data for
-// handle under the specified new-collation mode.
-func TryGetHandleRestoredDataWrapperWithCollate(useNewCollate bool, tblInfo *model.TableInfo, row []types.Datum, rowMap map[int64]types.Datum, idx *model.IndexInfo) []types.Datum {
+func TryGetHandleRestoredDataWrapper(tbl table.Table, row []types.Datum, rowMap map[int64]types.Datum, idx *model.IndexInfo) []types.Datum {
+	tblInfo := tbl.Meta()
+	useNewCollate := tbl.UseNewCollate()
 	if !useNewCollate || !tblInfo.IsCommonHandle || tblInfo.CommonHandleVersion == 0 {
 		return nil
 	}

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1535,20 +1535,12 @@ func (t *TableCommon) Type() table.Type {
 	return table.NormalTable
 }
 
-func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
-	return CanSkipWithCollate(t.useNewCollate, t.Meta(), col, value)
-}
-
-// CanSkip is for these cases, we can skip the columns in encoded row:
+// canSkip returns whether the column can be omitted from the encoded row:
 // 1. the column is included in primary key;
 // 2. the column's default value is null, and the value equals to that but has no origin default;
 // 3. the column is virtual generated.
-func CanSkip(info *model.TableInfo, col *table.Column, value *types.Datum) bool {
-	return CanSkipWithCollate(collate.NewCollationEnabled(), info, col, value)
-}
-
-// CanSkipWithCollate is like CanSkip but uses the specified new-collation mode.
-func CanSkipWithCollate(useNewCollate bool, info *model.TableInfo, col *table.Column, value *types.Datum) bool {
+func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {
+	info := t.Meta()
 	if col.IsPKHandleColumn(info) {
 		return true
 	}
@@ -1559,7 +1551,7 @@ func CanSkipWithCollate(useNewCollate bool, info *model.TableInfo, col *table.Co
 				continue
 			}
 			canSkip := idxCol.Length == types.UnspecifiedLength
-			canSkip = canSkip && !types.NeedRestoredDataWithCollate(&col.FieldType, useNewCollate)
+			canSkip = canSkip && !types.NeedRestoredDataWithCollate(&col.FieldType, t.useNewCollate)
 			return canSkip
 		}
 	}

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -831,6 +831,10 @@ func reEncodeHandleTo(handle kv.Handle, unsigned bool, buf []byte, result [][]by
 
 // reEncodeHandleConsiderNewCollation encodes the handle as a Datum so it can be properly decoded later.
 func reEncodeHandleConsiderNewCollation(handle kv.Handle, columns []rowcodec.ColInfo, restoreData []byte) ([][]byte, error) {
+	return reEncodeHandleConsiderNewCollationWithCollate(collate.NewCollationEnabled(), handle, columns, restoreData)
+}
+
+func reEncodeHandleConsiderNewCollationWithCollate(useNewCollate bool, handle kv.Handle, columns []rowcodec.ColInfo, restoreData []byte) ([][]byte, error) {
 	handleColLen := handle.NumCols()
 	cHandleBytes := make([][]byte, 0, handleColLen)
 	for i := range handleColLen {
@@ -845,7 +849,7 @@ func reEncodeHandleConsiderNewCollation(handle kv.Handle, columns []rowcodec.Col
 	for idx > 0 && columns[idx-1].ID < 0 {
 		idx--
 	}
-	return decodeRestoredValuesV5(columns[:idx], cHandleBytes, restoreData)
+	return decodeRestoredValuesV5WithCollate(useNewCollate, columns[:idx], cHandleBytes, restoreData)
 }
 
 func decodeRestoredValues(columns []rowcodec.ColInfo, restoredVal []byte) ([][]byte, error) {
@@ -868,8 +872,12 @@ func decodeRestoredValues(columns []rowcodec.ColInfo, restoredVal []byte) ([][]b
 // 2. If a string column's collation is _bin, then we only write the number of the truncated spaces to value.
 // 3. If a string column is char, not varchar, then we use the sortKey directly.
 func decodeRestoredValuesV5(columns []rowcodec.ColInfo, results [][]byte, restoredVal []byte) ([][]byte, error) {
+	return decodeRestoredValuesV5WithCollate(collate.NewCollationEnabled(), columns, results, restoredVal)
+}
+
+func decodeRestoredValuesV5WithCollate(useNewCollate bool, columns []rowcodec.ColInfo, results [][]byte, restoredVal []byte) ([][]byte, error) {
 	colIDOffsets := buildColumnIDOffsets(columns)
-	colInfosNeedRestore := buildRestoredColumn(columns)
+	colInfosNeedRestore := buildRestoredColumnWithCollate(useNewCollate, columns)
 	rd := rowcodec.NewByteDecoder(colInfosNeedRestore, nil, nil, nil)
 	newResults, err := rd.DecodeToBytesNoHandle(colIDOffsets, restoredVal)
 	if err != nil {
@@ -915,9 +923,13 @@ func buildColumnIDOffsets(allCols []rowcodec.ColInfo) map[int64]int {
 }
 
 func buildRestoredColumn(allCols []rowcodec.ColInfo) []rowcodec.ColInfo {
+	return buildRestoredColumnWithCollate(collate.NewCollationEnabled(), allCols)
+}
+
+func buildRestoredColumnWithCollate(useNewCollate bool, allCols []rowcodec.ColInfo) []rowcodec.ColInfo {
 	restoredColumns := make([]rowcodec.ColInfo, 0, len(allCols))
 	for i, col := range allCols {
-		if !types.NeedRestoredData(col.Ft) {
+		if !types.NeedRestoredDataWithCollate(col.Ft, useNewCollate) {
 			continue
 		}
 		copyColInfo := rowcodec.ColInfo{
@@ -981,11 +993,17 @@ func getIndexVersion(value []byte) int {
 
 // DecodeIndexKVEx looks like DecodeIndexKV, the difference is that it tries to reduce allocations.
 func DecodeIndexKVEx(key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo, buf []byte, preAlloc [][]byte) ([][]byte, error) {
+	return DecodeIndexKVExWithCollate(collate.NewCollationEnabled(), key, value, colsLen, hdStatus, columns, buf, preAlloc)
+}
+
+// DecodeIndexKVExWithCollate is like DecodeIndexKVEx but uses the specified
+// new-collation mode when decoding restored data.
+func DecodeIndexKVExWithCollate(useNewCollate bool, key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo, buf []byte, preAlloc [][]byte) ([][]byte, error) {
 	if len(value) <= MaxOldEncodeValueLen {
 		return decodeIndexKvOldCollation(key, value, hdStatus, buf, preAlloc)
 	}
 	if getIndexVersion(value) == 1 {
-		return decodeIndexKvForClusteredIndexVersion1(key, value, colsLen, hdStatus, columns)
+		return decodeIndexKvForClusteredIndexVersion1WithCollate(useNewCollate, key, value, colsLen, hdStatus, columns)
 	}
 	return decodeIndexKvGeneral(key, value, colsLen, hdStatus, columns)
 }
@@ -995,12 +1013,18 @@ func DecodeIndexKVEx(key, value []byte, colsLen int, hdStatus HandleStatus, colu
 //	`colsLen` is expected to be index columns count.
 //	`columns` is expected to be index columns + handle columns(if hdStatus is not HandleNotNeeded).
 func DecodeIndexKV(key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo) ([][]byte, error) {
+	return DecodeIndexKVWithCollate(collate.NewCollationEnabled(), key, value, colsLen, hdStatus, columns)
+}
+
+// DecodeIndexKVWithCollate is like DecodeIndexKV but uses the specified
+// new-collation mode when decoding restored data.
+func DecodeIndexKVWithCollate(useNewCollate bool, key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo) ([][]byte, error) {
 	if len(value) <= MaxOldEncodeValueLen {
 		preAlloc := make([][]byte, colsLen, colsLen+len(columns))
 		return decodeIndexKvOldCollation(key, value, hdStatus, nil, preAlloc)
 	}
 	if getIndexVersion(value) == 1 {
-		return decodeIndexKvForClusteredIndexVersion1(key, value, colsLen, hdStatus, columns)
+		return decodeIndexKvForClusteredIndexVersion1WithCollate(useNewCollate, key, value, colsLen, hdStatus, columns)
 	}
 	return decodeIndexKvGeneral(key, value, colsLen, hdStatus, columns)
 }
@@ -1229,6 +1253,13 @@ func GetIndexKeyBuf(buf []byte, defaultCap int) []byte {
 // GenIndexKey generates index key using input physical table id
 func GenIndexKey(loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
 	phyTblID int64, indexedValues []types.Datum, h kv.Handle, buf []byte) (key []byte, distinct bool, err error) {
+	return GenIndexKeyWithCollate(collate.NewCollationEnabled(), loc, tblInfo, idxInfo, phyTblID, indexedValues, h, buf)
+}
+
+// GenIndexKeyWithCollate generates an index key using the specified
+// new-collation mode.
+func GenIndexKeyWithCollate(useNewCollate bool, loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
+	phyTblID int64, indexedValues []types.Datum, h kv.Handle, buf []byte) (key []byte, distinct bool, err error) {
 	if idxInfo.Unique {
 		// See https://dev.mysql.com/doc/refman/5.7/en/create-index.html
 		// A UNIQUE index creates a constraint such that all values in the index must be distinct.
@@ -1248,7 +1279,7 @@ func GenIndexKey(loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.In
 	key = GetIndexKeyBuf(buf, RecordRowKeyLen+len(indexedValues)*9+9)
 	key = appendTableIndexPrefix(key, phyTblID)
 	key = codec.EncodeInt(key, idxInfo.ID)
-	key, err = codec.EncodeKey(loc, key, indexedValues...)
+	key, err = codec.EncodeKeyWithCollate(useNewCollate, loc, key, indexedValues...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1636,8 +1667,16 @@ func TempIndexValueIsUntouched(b []byte) bool {
 func GenIndexValuePortal(loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
 	needRestoredData bool, distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle,
 	partitionID int64, restoredData []types.Datum, buf []byte) ([]byte, error) {
+	return GenIndexValuePortalWithCollate(collate.NewCollationEnabled(), loc, tblInfo, idxInfo, needRestoredData, distinct, untouched, indexedValues, h, partitionID, restoredData, buf)
+}
+
+// GenIndexValuePortalWithCollate is like GenIndexValuePortal but uses the
+// specified new-collation mode for restored-data decisions.
+func GenIndexValuePortalWithCollate(useNewCollate bool, loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
+	needRestoredData bool, distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle,
+	partitionID int64, restoredData []types.Datum, buf []byte) ([]byte, error) {
 	if tblInfo.IsCommonHandle && tblInfo.CommonHandleVersion == 1 {
-		return GenIndexValueForClusteredIndexVersion1(loc, tblInfo, idxInfo, needRestoredData, distinct, untouched, indexedValues, h, partitionID, restoredData, buf)
+		return GenIndexValueForClusteredIndexVersion1WithCollate(useNewCollate, loc, tblInfo, idxInfo, needRestoredData, distinct, untouched, indexedValues, h, partitionID, restoredData, buf)
 	}
 	return genIndexValueVersion0(loc, tblInfo, idxInfo, needRestoredData, distinct, untouched, indexedValues, h, partitionID, buf)
 }
@@ -1645,6 +1684,12 @@ func GenIndexValuePortal(loc *time.Location, tblInfo *model.TableInfo, idxInfo *
 // TryGetCommonPkColumnRestoredIds get the IDs of primary key columns which need restored data if the table has common handle.
 // Caller need to make sure the table has common handle.
 func TryGetCommonPkColumnRestoredIds(tbl *model.TableInfo) []int64 {
+	return TryGetCommonPkColumnRestoredIdsWithCollate(collate.NewCollationEnabled(), tbl)
+}
+
+// TryGetCommonPkColumnRestoredIdsWithCollate gets the IDs of primary key
+// columns that need restored data under the specified new-collation mode.
+func TryGetCommonPkColumnRestoredIdsWithCollate(useNewCollate bool, tbl *model.TableInfo) []int64 {
 	var pkColIDs []int64
 	var pkIdx *model.IndexInfo
 	for _, idx := range tbl.Indices {
@@ -1657,7 +1702,7 @@ func TryGetCommonPkColumnRestoredIds(tbl *model.TableInfo) []int64 {
 		return pkColIDs
 	}
 	for _, idxCol := range pkIdx.Columns {
-		if types.NeedRestoredData(&tbl.Columns[idxCol.Offset].FieldType) {
+		if types.NeedRestoredDataWithCollate(&tbl.Columns[idxCol.Offset].FieldType, useNewCollate) {
 			pkColIDs = append(pkColIDs, tbl.Columns[idxCol.Offset].ID)
 		}
 	}
@@ -1666,6 +1711,14 @@ func TryGetCommonPkColumnRestoredIds(tbl *model.TableInfo) []int64 {
 
 // GenIndexValueForClusteredIndexVersion1 generates the index value for the clustered index with version 1(New in v5.0.0).
 func GenIndexValueForClusteredIndexVersion1(loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
+	idxValNeedRestoredData bool, distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle,
+	partitionID int64, handleRestoredData []types.Datum, buf []byte) ([]byte, error) {
+	return GenIndexValueForClusteredIndexVersion1WithCollate(collate.NewCollationEnabled(), loc, tblInfo, idxInfo, idxValNeedRestoredData, distinct, untouched, indexedValues, h, partitionID, handleRestoredData, buf)
+}
+
+// GenIndexValueForClusteredIndexVersion1WithCollate generates the clustered
+// common-handle V1 index value using the specified new-collation mode.
+func GenIndexValueForClusteredIndexVersion1WithCollate(useNewCollate bool, loc *time.Location, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
 	idxValNeedRestoredData bool, distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle,
 	partitionID int64, handleRestoredData []types.Datum, buf []byte) ([]byte, error) {
 	var idxVal []byte
@@ -1696,7 +1749,7 @@ func GenIndexValueForClusteredIndexVersion1(loc *time.Location, tblInfo *model.T
 			if mysql.HasPriKeyFlag(col.GetFlag()) {
 				continue
 			}
-			if model.ColumnNeedRestoredData(idxCol, tblInfo.Columns) {
+			if types.NeedRestoredDataWithCollate(model.GetIdxChangingFieldType(idxCol, col), useNewCollate) {
 				colIds = append(colIds, col.ID)
 				if collate.IsBinCollation(model.GetIdxChangingFieldType(idxCol, col).GetCollate()) {
 					allRestoredData = append(allRestoredData, types.NewUintDatum(uint64(stringutil.GetTailSpaceCount(indexedValues[i].GetString()))))
@@ -1707,7 +1760,7 @@ func GenIndexValueForClusteredIndexVersion1(loc *time.Location, tblInfo *model.T
 		}
 
 		if len(handleRestoredData) > 0 {
-			pkColIDs := TryGetCommonPkColumnRestoredIds(tblInfo)
+			pkColIDs := TryGetCommonPkColumnRestoredIdsWithCollate(useNewCollate, tblInfo)
 			colIds = append(colIds, pkColIDs...)
 			allRestoredData = append(allRestoredData, handleRestoredData...)
 		}
@@ -1943,6 +1996,10 @@ func splitIndexValueForClusteredIndexVersion1(value []byte) (segs IndexValueSegm
 }
 
 func decodeIndexKvForClusteredIndexVersion1(key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo) ([][]byte, error) {
+	return decodeIndexKvForClusteredIndexVersion1WithCollate(collate.NewCollationEnabled(), key, value, colsLen, hdStatus, columns)
+}
+
+func decodeIndexKvForClusteredIndexVersion1WithCollate(useNewCollate bool, key, value []byte, colsLen int, hdStatus HandleStatus, columns []rowcodec.ColInfo) ([][]byte, error) {
 	var resultValues [][]byte
 	var keySuffix []byte
 	var handle kv.Handle
@@ -1953,7 +2010,7 @@ func decodeIndexKvForClusteredIndexVersion1(key, value []byte, colsLen int, hdSt
 		return nil, err
 	}
 	if segs.RestoredValues != nil {
-		resultValues, err = decodeRestoredValuesV5(columns[:colsLen], resultValues, segs.RestoredValues)
+		resultValues, err = decodeRestoredValuesV5WithCollate(useNewCollate, columns[:colsLen], resultValues, segs.RestoredValues)
 		if err != nil {
 			return nil, err
 		}
@@ -1971,7 +2028,7 @@ func decodeIndexKvForClusteredIndexVersion1(key, value []byte, colsLen int, hdSt
 	if err != nil {
 		return nil, err
 	}
-	handleBytes, err := reEncodeHandleConsiderNewCollation(handle, columns[colsLen:], segs.RestoredValues)
+	handleBytes, err := reEncodeHandleConsiderNewCollationWithCollate(useNewCollate, handle, columns[colsLen:], segs.RestoredValues)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/types/etc.go
+++ b/pkg/types/etc.go
@@ -138,7 +138,13 @@ func IsNonBinaryStr(ft *FieldType) bool {
 // NeedRestoredData returns if a type needs restored data.
 // If the type is char and the collation is _bin, NeedRestoredData() returns false.
 func NeedRestoredData(ft *FieldType) bool {
-	if collate.NewCollationEnabled() &&
+	return NeedRestoredDataWithCollate(ft, collate.NewCollationEnabled())
+}
+
+// NeedRestoredDataWithCollate reports whether a type needs restored data under
+// the specified new-collation mode.
+func NeedRestoredDataWithCollate(ft *FieldType, useNewCollate bool) bool {
+	if useNewCollate &&
 		IsNonBinaryStr(ft) &&
 		(!collate.IsBinCollation(ft.GetCollate()) || IsTypeVarchar(ft.GetType())) &&
 		ft.GetCollate() != "utf8mb4_0900_bin" {

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -92,6 +92,10 @@ func preRealloc(b []byte, vals []types.Datum, comparable1 bool) []byte {
 // encode will encode a datum and append it to a byte slice. If comparable1 is true, the encoded bytes can be sorted as it's original order.
 // If hash is true, the encoded bytes can be checked equal as it's original value.
 func encode(loc *time.Location, b []byte, vals []types.Datum, comparable1 bool) (_ []byte, err error) {
+	return encodeWithCollate(collate.NewCollationEnabled(), loc, b, vals, comparable1)
+}
+
+func encodeWithCollate(useNewCollate bool, loc *time.Location, b []byte, vals []types.Datum, comparable1 bool) (_ []byte, err error) {
 	b = preRealloc(b, vals, comparable1)
 	for i, length := 0, len(vals); i < length; i++ {
 		switch vals[i].Kind() {
@@ -103,7 +107,7 @@ func encode(loc *time.Location, b []byte, vals []types.Datum, comparable1 bool) 
 			b = append(b, floatFlag)
 			b = EncodeFloat(b, vals[i].GetFloat64())
 		case types.KindString:
-			b = encodeString(b, vals[i], comparable1)
+			b = encodeString(useNewCollate, b, vals[i], comparable1)
 		case types.KindBytes:
 			b = encodeBytes(b, vals[i].GetBytes(), comparable1)
 		case types.KindMysqlTime:
@@ -215,8 +219,8 @@ func EncodeMySQLTime(loc *time.Location, t types.Time, tp byte, b []byte) (_ []b
 	return b, nil
 }
 
-func encodeString(b []byte, val types.Datum, comparable1 bool) []byte {
-	if collate.NewCollationEnabled() && comparable1 {
+func encodeString(useNewCollate bool, b []byte, val types.Datum, comparable1 bool) []byte {
+	if useNewCollate && comparable1 {
 		return encodeBytes(b, collate.GetCollator(val.Collation()).ImmutableKey(val.GetString()), true)
 	}
 	return encodeBytes(b, val.GetBytes(), comparable1)
@@ -305,6 +309,13 @@ func sizeInt(comparable1 bool) int {
 // For decimal type, datum must set datum's length and frac.
 func EncodeKey(loc *time.Location, b []byte, v ...types.Datum) ([]byte, error) {
 	return encode(loc, b, v, true)
+}
+
+// EncodeKeyWithCollate appends the encoded values to byte slice b using the
+// specified new-collation mode. It is intended for background tasks that must
+// replay work using the collation mode captured when the task was created.
+func EncodeKeyWithCollate(useNewCollate bool, loc *time.Location, b []byte, v ...types.Datum) ([]byte, error) {
+	return encodeWithCollate(useNewCollate, loc, b, v, true)
 }
 
 // EncodeValue appends the encoded values to byte slice b, returning the appended
@@ -1887,7 +1898,7 @@ func HashCode(b []byte, d types.Datum) []byte {
 		b = append(b, floatFlag)
 		b = EncodeFloat(b, d.GetFloat64())
 	case types.KindString:
-		b = encodeString(b, d, false)
+		b = encodeString(collate.NewCollationEnabled(), b, d, false)
 	case types.KindBytes:
 		b = encodeBytes(b, d.GetBytes(), false)
 	case types.KindMysqlTime:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

In next-gen deployments, background tasks can be created from a user keyspace and later executed by workers that observe a different keyspace-level `new_collation_enabled` value. Some row/index encoding paths decide new-collation behavior from process-global state at execution time, so ADD INDEX and IMPORT INTO can encode keys, restored data, or generated/assignment expressions with a mode different from the one used when the task was created.

### What changed and how does it work?

- Keep existing codec, tablecodec, table, and expression APIs using the current default collation mode for live/classic paths.
- Add explicit collation-mode helpers for key encoding, restored-data checks, index value encode/decode, table/index construction, and simple expression building.
- Capture `use_new_collate` in DDL reorg meta and IMPORT INTO task plans.
- Build ADD INDEX backfill indexes, decode maps, and IMPORT INTO table/encoder/expression paths with the captured mode.
- Preserve backward compatibility for old DDL jobs and import tasks by falling back to the current default when the new field is absent.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Passed tests:

- `go test ./pkg/util/codec ./pkg/types ./pkg/tablecodec`
- `go test ./pkg/ddl -run '^$'`
- `go test ./pkg/executor/importer ./pkg/dxf/importinto ./pkg/lightning/backend/kv -run '^$'`
- `go test -tags=intest ./pkg/table/tables -run 'Test(MultiColumnCommonHandle|SingleColumnCommonHandle|GenIndexValueFromIndex|GenIndexValueWithLargePaddingSize|CheckRowInsertionConsistency|CheckIndexKeysAndCheckHandleConsistency|CompareIndexData|AddRecordWithCtx|DupKeyCheckMode)$'`
- `go test ./pkg/planner/core -run 'TestRewriterPool$'`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a potential issue that background ADD INDEX and IMPORT INTO tasks may use an incorrect collation mode when encoding keys.
```