### PR TITLE
statistics: persist stats delta init time (#65586) (#66686) | tidb-test=release-8.5-20251125-v8.5.4

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -916,9 +916,9 @@ func addTableNameInTableIDField(ctx context.Context, tableIDField any, is infosc
 func (s *session) updateStatsDeltaToCollector() {
 	mapper := s.GetSessionVars().TxnCtx.TableDeltaMap
 	if s.statsCollector != nil && mapper != nil {
-		for _, item := range mapper {
-			if item.TableID > 0 {
-				s.statsCollector.Update(item.TableID, item.Delta, item.Count)
+		for tableID, item := range mapper {
+			if tableID > 0 {
+				s.statsCollector.Update(tableID, item.Delta, item.Count)
 			}
 		}
 	}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -358,7 +358,6 @@ func (tc *TransactionContext) UpdateDeltaForTable(
 	item := tc.TableDeltaMap[physicalTableID]
 	item.Delta += delta
 	item.Count += count
-	item.TableID = physicalTableID
 	tc.TableDeltaMap[physicalTableID] = item
 }
 
@@ -2982,7 +2981,17 @@ type TableDelta struct {
 	Delta    int64
 	Count    int64
 	InitTime time.Time // InitTime is the time that this delta is generated.
-	TableID  int64
+}
+
+// MergeFrom merges another delta into the receiver and keeps the earliest InitTime.
+func (td *TableDelta) MergeFrom(incoming TableDelta) {
+	td.Delta += incoming.Delta
+	td.Count += incoming.Count
+	if td.InitTime.IsZero() {
+		td.InitTime = incoming.InitTime
+	} else if !incoming.InitTime.IsZero() && incoming.InitTime.Before(td.InitTime) { // This can happen when merges arrive out of order (e.g., overlapping dump/merge runs).
+		td.InitTime = incoming.InitTime
+	}
 }
 
 // Clone returns a cloned TableDelta.
@@ -2991,7 +3000,6 @@ func (td TableDelta) Clone() TableDelta {
 		Delta:    td.Delta,
 		Count:    td.Count,
 		InitTime: td.InitTime,
-		TableID:  td.TableID,
 	}
 }
 

--- a/pkg/sessionctx/variable/session_test.go
+++ b/pkg/sessionctx/variable/session_test.go
@@ -335,7 +335,6 @@ func TestTableDeltaClone(t *testing.T) {
 		Delta:    1,
 		Count:    2,
 		InitTime: time.Now(),
-		TableID:  5,
 	}
 	td1 := td0.Clone()
 	require.Equal(t, td0, td1)
@@ -354,7 +353,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 					Delta:    1,
 					Count:    2,
 					InitTime: time.Now(),
-					TableID:  5,
 				},
 			},
 		},
@@ -375,7 +373,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		Delta:    6,
 		Count:    7,
 		InitTime: time.Now(),
-		TableID:  9,
 	}
 	tc.SetPessimisticLockCache([]byte{'b'}, []byte{'b'})
 	tc.FlushStmtPessimisticLockCache()
@@ -391,7 +388,6 @@ func TestTransactionContextSavepoint(t *testing.T) {
 		Delta:    10,
 		Count:    11,
 		InitTime: time.Now(),
-		TableID:  13,
 	}
 	tc.SetPessimisticLockCache([]byte{'c'}, []byte{'c'})
 	tc.FlushStmtPessimisticLockCache()

--- a/pkg/statistics/handle/usage/BUILD.bazel
+++ b/pkg/statistics/handle/usage/BUILD.bazel
@@ -35,14 +35,15 @@ go_test(
     name = "usage_test",
     timeout = "short",
     srcs = [
+        "export_test.go",
         "index_usage_integration_test.go",
         "predicate_column_test.go",
         "session_stats_collect_test.go",
     ],
+    embed = [":usage"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 15,
     deps = [
-        ":usage",
         "//pkg/meta/model",
         "//pkg/parser/model",
         "//pkg/statistics/handle/usage/indexusage",

--- a/pkg/statistics/handle/usage/export_test.go
+++ b/pkg/statistics/handle/usage/export_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import "time"
+
+// GetDumpStatsMaxDurationForTest exposes dumpStatsMaxDuration for tests.
+func GetDumpStatsMaxDurationForTest() time.Duration {
+	return dumpStatsMaxDuration
+}
+
+// SetDumpStatsMaxDurationForTest updates dumpStatsMaxDuration for tests.
+func SetDumpStatsMaxDurationForTest(d time.Duration) {
+	dumpStatsMaxDuration = d
+}

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -43,7 +43,7 @@ var (
 	// DumpStatsDeltaRatio is the lower bound of `Modify Count / Table Count` for stats delta to be dumped.
 	DumpStatsDeltaRatio = 1 / 10000.0
 	// dumpStatsMaxDuration is the max duration since last update.
-	dumpStatsMaxDuration = 5 * time.Minute
+	dumpStatsMaxDuration = 1 * time.Hour
 
 	// colStatsUsageLastUsedThrottleInterval is the minimum interval to update last_used_at when it already exists (non-NULL).
 	// This throttles frequent timestamp-only updates while allowing immediate NULL-to-value transitions.
@@ -74,11 +74,9 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 	if dumpAll {
 		return true
 	}
-	if item.InitTime.IsZero() {
-		item.InitTime = currentTime
-	}
+	intest.Assert(!item.InitTime.IsZero(), "InitTime should be initialized before evaluating dump conditions")
 	if currentTime.Sub(item.InitTime) > dumpStatsMaxDuration {
-		// Dump the stats to kv at least once 5 minutes.
+		// Dump the stats to kv at least once per hour to make sure the stats can be updated when there are only few modifications.
 		return true
 	}
 	statsTbl := s.statsHandle.GetPartitionStatsByID(is, id)
@@ -137,8 +135,14 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool) error {
 			batchUpdates = make([]*storage.DeltaUpdate, 0, len(batchTableIDs))
 			// Collect all updates in the batch.
 			for _, id := range batchTableIDs {
+				// NOTE: Ensure InitTime is initialized before evaluating dump conditions.
 				item := deltaMap[id]
-				if !s.needDumpStatsDelta(is, dumpAll, id, item, batchStart) {
+				if item.InitTime.IsZero() {
+					item.InitTime = batchStart
+					deltaMap[id] = item
+				}
+				needDump := s.needDumpStatsDelta(is, dumpAll, id, item, batchStart)
+				if !needDump {
 					continue
 				}
 				batchUpdates = append(batchUpdates, storage.NewDeltaUpdate(id, item, false))
@@ -403,14 +407,14 @@ func (s *statsUsageImpl) NewSessionStatsItem() any {
 	return s.SessionStatsList.NewSessionStatsItem()
 }
 
-func merge(s *SessionStatsItem, deltaMap *TableDelta, colMap *StatsUsage) {
+func merge(s *SessionStatsItem, deltaMap *TableDeltaMap, colMap *StatsUsage) {
 	deltaMap.Merge(s.mapper.GetDeltaAndReset())
 	colMap.Merge(s.statsUsage.GetUsageAndReset())
 }
 
 // SessionStatsItem is a list item that holds the delta mapper. If you want to write or read mapper, you must lock it.
 type SessionStatsItem struct {
-	mapper     *TableDelta
+	mapper     *TableDeltaMap
 	statsUsage *StatsUsage
 	next       *SessionStatsItem
 	sync.Mutex
@@ -437,7 +441,7 @@ func (s *SessionStatsItem) Update(id int64, delta int64, count int64) {
 func (s *SessionStatsItem) ClearForTest() {
 	s.Lock()
 	defer s.Unlock()
-	s.mapper = NewTableDelta()
+	s.mapper = NewTableDeltaMap()
 	s.statsUsage = NewStatsUsage()
 	s.next = nil
 	s.deleted = false
@@ -469,7 +473,7 @@ func (s *SessionStatsItem) UpdateColStatsUsage(colItems iter.Seq[model.TableItem
 */
 type SessionStatsList struct {
 	// tableDelta contains all the delta map from collectors when we dump them to KV.
-	tableDelta *TableDelta
+	tableDelta *TableDeltaMap
 
 	// statsUsage contains all the column stats usage information from collectors when we dump them to KV.
 	statsUsage *StatsUsage
@@ -481,10 +485,10 @@ type SessionStatsList struct {
 // NewSessionStatsList initializes a new SessionStatsList.
 func NewSessionStatsList() *SessionStatsList {
 	return &SessionStatsList{
-		tableDelta: NewTableDelta(),
+		tableDelta: NewTableDeltaMap(),
 		statsUsage: NewStatsUsage(),
 		listHead: &SessionStatsItem{
-			mapper:     NewTableDelta(),
+			mapper:     NewTableDeltaMap(),
 			statsUsage: NewStatsUsage(),
 		},
 	}
@@ -495,7 +499,7 @@ func (sl *SessionStatsList) NewSessionStatsItem() *SessionStatsItem {
 	sl.listHead.Lock()
 	defer sl.listHead.Unlock()
 	newCollector := &SessionStatsItem{
-		mapper:     NewTableDelta(),
+		mapper:     NewTableDeltaMap(),
 		next:       sl.listHead.next,
 		statsUsage: NewStatsUsage(),
 	}
@@ -506,7 +510,7 @@ func (sl *SessionStatsList) NewSessionStatsItem() *SessionStatsItem {
 // SweepSessionStatsList will loop over the list, merge each session's local stats into handle
 // and remove closed session's collector.
 func (sl *SessionStatsList) SweepSessionStatsList() {
-	deltaMap := NewTableDelta()
+	deltaMap := NewTableDeltaMap()
 	colMap := NewStatsUsage()
 	prev := sl.listHead
 	prev.Lock()
@@ -529,8 +533,8 @@ func (sl *SessionStatsList) SweepSessionStatsList() {
 	sl.statsUsage.Merge(colMap.GetUsageAndReset())
 }
 
-// SessionTableDelta returns the current *TableDelta.
-func (sl *SessionStatsList) SessionTableDelta() *TableDelta {
+// SessionTableDelta returns the current *TableDeltaMap.
+func (sl *SessionStatsList) SessionTableDelta() *TableDeltaMap {
 	return sl.tableDelta
 }
 
@@ -546,29 +550,29 @@ func (sl *SessionStatsList) ResetSessionStatsList() {
 	sl.statsUsage.Reset()
 }
 
-// TableDelta is used to collect tables' change information.
+// TableDeltaMap is used to collect tables' change information.
 // All methods of it are thread-safe.
-type TableDelta struct {
+type TableDeltaMap struct {
 	delta map[int64]variable.TableDelta // map[tableID]delta
 	lock  sync.Mutex
 }
 
-// NewTableDelta creates a new TableDelta.
-func NewTableDelta() *TableDelta {
-	return &TableDelta{
+// NewTableDeltaMap creates a new TableDeltaMap.
+func NewTableDeltaMap() *TableDeltaMap {
+	return &TableDeltaMap{
 		delta: make(map[int64]variable.TableDelta),
 	}
 }
 
-// Reset resets the TableDelta.
-func (m *TableDelta) Reset() {
+// Reset resets the TableDeltaMap.
+func (m *TableDeltaMap) Reset() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.delta = make(map[int64]variable.TableDelta)
 }
 
-// GetDeltaAndReset gets the delta and resets the TableDelta.
-func (m *TableDelta) GetDeltaAndReset() map[int64]variable.TableDelta {
+// GetDeltaAndReset gets the delta and resets the TableDeltaMap.
+func (m *TableDeltaMap) GetDeltaAndReset() map[int64]variable.TableDelta {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	ret := m.delta
@@ -577,30 +581,28 @@ func (m *TableDelta) GetDeltaAndReset() map[int64]variable.TableDelta {
 }
 
 // Update updates the delta of the table.
-func (m *TableDelta) Update(id int64, delta int64, count int64) {
+func (m *TableDeltaMap) Update(id int64, delta int64, count int64) {
+	intest.Assert(id > 0, "table ID should be greater than 0")
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	UpdateTableDeltaMap(m.delta, id, delta, count)
+	item := m.delta[id]
+	item.Delta += delta
+	item.Count += count
+	m.delta[id] = item
 }
 
-// Merge merges the deltaMap into the TableDelta.
-func (m *TableDelta) Merge(deltaMap map[int64]variable.TableDelta) {
+// Merge merges the deltaMap into the TableDeltaMap.
+func (m *TableDeltaMap) Merge(deltaMap map[int64]variable.TableDelta) {
 	if len(deltaMap) == 0 {
 		return
 	}
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	for id, item := range deltaMap {
-		UpdateTableDeltaMap(m.delta, id, item.Delta, item.Count)
+	for id, incoming := range deltaMap {
+		item := m.delta[id]
+		item.MergeFrom(incoming)
+		m.delta[id] = item
 	}
-}
-
-// UpdateTableDeltaMap updates the delta of the table.
-func UpdateTableDeltaMap(m map[int64]variable.TableDelta, id int64, delta int64, count int64) {
-	item := m[id]
-	item.Delta += delta
-	item.Count += count
-	m[id] = item
 }
 
 // StatsUsage maps (tableID, columnID) to the last time when the column stats are used(needed).

--- a/pkg/statistics/handle/usage/session_stats_collect_test.go
+++ b/pkg/statistics/handle/usage/session_stats_collect_test.go
@@ -17,6 +17,7 @@ package usage_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -49,7 +50,9 @@ func TestPredicateUsage_FirstTouchCreatesRow(t *testing.T) {
 
 	// verify last_used_at is NOT NULL for (tableID, colAID)
 	rows := tk.MustQuery(
-		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+		"select last_used_at from mysql.column_stats_usage where table_id=? and column_id=?",
+		tableID,
+		colAID,
 	).Rows()
 	require.Len(t, rows, 1)
 	require.NotEqual(t, "<nil>", rows[0][0])
@@ -74,7 +77,9 @@ func TestPredicateUsage_NoBumpWithinThrottle(t *testing.T) {
 	colAID := tbl.Meta().Columns[0].ID
 
 	ts1 := tk.MustQuery(
-		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+		"select last_used_at from mysql.column_stats_usage where table_id=? and column_id=?",
+		tableID,
+		colAID,
 	).Rows()[0][0].(string)
 
 	// touch again shortly and dump; throttled path should skip bump
@@ -82,7 +87,9 @@ func TestPredicateUsage_NoBumpWithinThrottle(t *testing.T) {
 	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
 
 	ts2 := tk.MustQuery(
-		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+		"select last_used_at from mysql.column_stats_usage where table_id=? and column_id=?",
+		tableID,
+		colAID,
 	).Rows()[0][0].(string)
 	require.Equal(t, ts1, ts2)
 }
@@ -106,10 +113,12 @@ func TestPredicateUsage_BumpAfterOldStoredValue(t *testing.T) {
 	colAID := tbl.Meta().Columns[0].ID
 
 	// set an ancient last_used_at so the next usage exceeds throttle interval
-	tk.MustExec(fmt.Sprintf(
-		"update mysql.column_stats_usage set last_used_at = timestamp '2000-01-01 00:00:00' where table_id=%d and column_id=%d",
-		tableID, colAID,
-	))
+	tk.MustExec(
+		"update mysql.column_stats_usage set last_used_at = cast(? as datetime) where table_id=? and column_id=?",
+		"2000-01-01 00:00:00",
+		tableID,
+		colAID,
+	)
 
 	// touch again and dump; should bump to a recent timestamp
 	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
@@ -117,7 +126,9 @@ func TestPredicateUsage_BumpAfterOldStoredValue(t *testing.T) {
 
 	// verify last_used_at changed from the ancient value
 	got := tk.MustQuery(
-		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+		"select last_used_at from mysql.column_stats_usage where table_id=? and column_id=?",
+		tableID,
+		colAID,
 	).Rows()[0][0].(string)
 	require.NotEqual(t, "2000-01-01 00:00:00", got)
 }
@@ -243,10 +254,9 @@ func TestDumpColStatsUsageWriter_ConcurrentMultiTables(t *testing.T) {
 	totalUpdated := 0
 	for _, tid := range tableIDs {
 		row := tk.MustQuery(
-			fmt.Sprintf(
-				"select count(*) from mysql.column_stats_usage where table_id=%d and CONVERT_TZ(last_used_at, @@TIME_ZONE, '+00:00') = timestamp '%s'",
-				tid, bumpTSUTC,
-			),
+			"select count(*) from mysql.column_stats_usage where table_id=? and CONVERT_TZ(last_used_at, @@TIME_ZONE, '+00:00') = cast(? as datetime)",
+			tid,
+			bumpTSUTC,
 		).Rows()[0][0].(string)
 		var c int
 		_, _ = fmt.Sscanf(row, "%d", &c)
@@ -259,4 +269,135 @@ func TestDumpColStatsUsageWriter_ConcurrentMultiTables(t *testing.T) {
 	colAvg, colMinVal, colMaxVal := calculateStats(tc.data)
 	tc.mu.Unlock()
 	t.Logf("DumpColStatsUsage concurrent: goroutines=%d tables=%d cols/table=%d per-g: avg=%s min=%s max=%s; updated=%d/%d; batches=%d per-batch: avg=%s min=%s max=%s", goroutines, tableCount, numCols, avg, minVal, maxVal, totalUpdated, tableCount*numCols, batches, colAvg, colMinVal, colMaxVal)
+}
+
+func TestDumpStatsDeltaPersistsInitTime(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)")
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustExec("analyze table t")
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+
+	origMaxDuration := usage.GetDumpStatsMaxDurationForTest()
+	origRatio := usage.DumpStatsDeltaRatio
+	usage.SetDumpStatsMaxDurationForTest(50 * time.Millisecond)
+	usage.DumpStatsDeltaRatio = 0.5
+	t.Cleanup(func() {
+		usage.SetDumpStatsMaxDurationForTest(origMaxDuration)
+		usage.DumpStatsDeltaRatio = origRatio
+	})
+
+	tk.MustExec("insert into t values (11)")
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(false))
+	tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).
+		Check(testkit.Rows("0"))
+
+	time.Sleep(usage.GetDumpStatsMaxDurationForTest() + 100*time.Millisecond)
+
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(false))
+	tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).
+		Check(testkit.Rows("1"))
+}
+
+func TestDumpStatsDeltaMergeKeepsEarliestInitTime(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// Test setup:
+	// 1) Create/analyze t and t_lock so stats_meta has baseline rows.
+	// 2) Lock t_lock's stats_meta row with FOR UPDATE to block the first DumpStatsDeltaToKV.
+	// 3) While blocked, write to t again and run a second dump to produce a later InitTime.
+	// 4) Release the lock, wait past dumpStatsMaxDuration, then dump and verify the earlier InitTime triggers flushing.
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t_lock")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table t_lock (a int)")
+	tk.MustExec("insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)")
+	tk.MustExec("insert into t_lock values (1)")
+	tk.MustExec("analyze table t")
+	tk.MustExec("analyze table t_lock")
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+	lockTbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t_lock"))
+	require.NoError(t, err)
+	lockTableID := lockTbl.Meta().ID
+
+	require.NoError(t, dom.StatsHandle().Update(context.Background(), is))
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
+	tk.MustQuery("select count(*) from mysql.stats_meta where table_id = ?", lockTableID).
+		Check(testkit.Rows("1"))
+
+	origMaxDuration := usage.GetDumpStatsMaxDurationForTest()
+	origRatio := usage.DumpStatsDeltaRatio
+	usage.SetDumpStatsMaxDurationForTest(100 * time.Millisecond)
+	usage.DumpStatsDeltaRatio = 0.5
+	t.Cleanup(func() {
+		usage.SetDumpStatsMaxDurationForTest(origMaxDuration)
+		usage.DumpStatsDeltaRatio = origRatio
+	})
+
+	baseRows := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+	require.Len(t, baseRows, 1)
+	baseCount, err := strconv.Atoi(baseRows[0][0].(string))
+	require.NoError(t, err)
+
+	tk.MustExec("insert into t values (11)")
+	tk.MustExec("insert into t_lock values (2),(3)")
+
+	tkLock := testkit.NewTestKit(t, store)
+	tkLock.MustExec("set @@tidb_txn_mode = 'pessimistic'")
+	tkLock.MustExec("begin")
+	tkLock.MustQuery("select * from mysql.stats_meta where table_id = ? for update", lockTableID)
+
+	dump1Err := make(chan error, 1)
+	dump1Start := time.Now()
+	go func() {
+		dump1Err <- dom.StatsHandle().DumpStatsDeltaToKV(false)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case err := <-dump1Err:
+		t.Fatalf("first dump finished early: %v", err)
+	default:
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	tk.MustExec("insert into t values (12)")
+
+	dump2Start := time.Now()
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(false))
+
+	afterSecond := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+	require.Len(t, afterSecond, 1)
+	afterSecondCount, err := strconv.Atoi(afterSecond[0][0].(string))
+	require.NoError(t, err)
+	require.Equal(t, baseCount, afterSecondCount)
+
+	tkLock.MustExec("rollback")
+	require.NoError(t, <-dump1Err)
+
+	target := dump1Start.Add(usage.GetDumpStatsMaxDurationForTest() + 10*time.Millisecond)
+	if wait := time.Until(target); wait > 0 {
+		time.Sleep(wait)
+	}
+	require.True(t, time.Since(dump2Start) < usage.GetDumpStatsMaxDurationForTest())
+
+	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(false))
+	finalRows := tk.MustQuery("select modify_count from mysql.stats_meta where table_id = ?", tableID).Rows()
+	require.Len(t, finalRows, 1)
+	finalCount, err := strconv.Atoi(finalRows[0][0].(string))
+	require.NoError(t, err)
+	require.Equal(t, baseCount+2, finalCount)
 }

--- a/pkg/table/tblsession/table_test.go
+++ b/pkg/table/tblsession/table_test.go
@@ -107,7 +107,6 @@ func TestSessionMutateContextFields(t *testing.T) {
 	)
 	require.Equal(t, 1, len(txnCtx.TableDeltaMap))
 	deltaMap := txnCtx.TableDeltaMap[12]
-	require.Equal(t, int64(12), deltaMap.TableID)
 	require.Equal(t, int64(1), deltaMap.Delta)
 	require.Equal(t, int64(2), deltaMap.Count)
 	// cached table support


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65426

Problem Summary:
- Backport #66686 to fix small post-ANALYZE modifications staying unflushed when delta InitTime is not persisted.

### What changed and how does it work?

- Persist TableDelta.InitTime across sweeps and write it back when skipping a dump.
- Add regression tests and test-only accessors for the dump duration threshold.
- Remove the unused table ID field from TableDelta.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix stats delta flushing after small modifications by persisting delta init time for time-based dumps.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how session statistics are tracked and merged, making stat updates more reliable during concurrent activity.
  * Fixed dump timing behavior so stats are refreshed only after the expected time window and earlier updates are preserved correctly.
  * Adjusted table-level delta handling to avoid relying on stale table identifiers and better support ordered merges.

* **Tests**
  * Added coverage for stats dump timing, merge behavior, and concurrent update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->