### PR TITLE
statistics: avoid creating pseudo stats table when dumping stats delta (#64565)

### DIFF
--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -202,33 +202,6 @@ func (h *Handle) getStatsByPhysicalID(physicalTableID int64, tblInfo *model.Tabl
 	return nil, false
 }
 
-// GetPartitionStatsByID retrieves the partition stats from cache by partition ID.
-func (h *Handle) GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table {
-	return h.getPartitionStatsByID(is, pid)
-}
-
-func (h *Handle) getPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table {
-	var statsTbl *statistics.Table
-	intest.Assert(h != nil, "stats handle is nil")
-	tbl, ok := h.Get(pid)
-	if !ok {
-		tbl, ok := h.TableInfoByID(is, pid)
-		if !ok {
-			return nil
-		}
-		// TODO: it's possible don't rely on the full table meta to do it here.
-		statsTbl = statistics.PseudoTable(tbl.Meta(), false, true)
-		statsTbl.PhysicalID = pid
-		if tbl.Meta().GetPartitionInfo() == nil || h.Len() < 64 {
-			h.UpdateStatsCache(types.CacheUpdate{
-				Updated: []*statistics.Table{statsTbl},
-			})
-		}
-		return nil
-	}
-	return tbl
-}
-
 // FlushStats flushes the cached stats update into store.
 func (h *Handle) FlushStats() {
 	if err := h.DumpStatsDeltaToKV(true); err != nil {

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -548,10 +548,6 @@ type StatsHandle interface {
 	// Note: this function may return nil if the table is not found in the cache.
 	GetNonPseudoPhysicalTableStats(physicalTableID int64) (*statistics.Table, bool)
 
-	// GetPartitionStatsByID retrieves the partition stats from cache by partition ID.
-	// TODO: remove this function and use GetPhysicalTableStats instead.
-	GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table
-
 	// StatsGC is used to do the GC job.
 	StatsGC
 

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -81,8 +81,10 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 		// Dump the stats to kv at least once 5 minutes.
 		return true
 	}
-	statsTbl := s.statsHandle.GetPartitionStatsByID(is, id)
-	if statsTbl == nil || statsTbl.Pseudo || statsTbl.RealtimeCount == 0 || float64(item.Count)/float64(statsTbl.RealtimeCount) > DumpStatsDeltaRatio {
+	// use GetNonPseudoPhysicalTableStats to avoid creating pseudo tables and dropping instantly
+	statsTable, found := s.statsHandle.GetNonPseudoPhysicalTableStats(id)
+	if !found || statsTable == nil || statsTable.RealtimeCount == 0 ||
+		float64(item.Count)/float64(statsTable.RealtimeCount) > DumpStatsDeltaRatio {
 		// Dump the stats when there are many modifications.
 		return true
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Backport #64565 / #62887 to `release-8.5-20251125-v8.5.4`.

When dumping stats delta, `needDumpStatsDelta` only needs to check whether cached real stats exist and whether the delta ratio reaches the threshold. The old release branch path called `GetPartitionStatsByID`, which creates a pseudo stats table as a side effect when the stats cache misses. This can pollute the stats cache for tables that are created and dropped quickly.

### What changed?

- Use `GetNonPseudoPhysicalTableStats` in stats-delta dump decision.
- Remove the now-unused `GetPartitionStatsByID` implementation and interface method.

### Check List

Tests:

- `git diff --check upstream/release-8.5-20251125-v8.5.4...HEAD`
- `gofmt -l pkg/statistics/handle/handle.go pkg/statistics/handle/types/interfaces.go pkg/statistics/handle/usage/session_stats_collect.go`
- `go test --tags=intest ./pkg/statistics/handle/usage -run 'TestDumpStatsDelta|TestDumpColStatsUsage' -count=1`
- `go test ./pkg/statistics/handle -run '^$' -count=1`
- `go test ./pkg/statistics/handle/types -run '^$' -count=1`
