### PR TITLE
planner: guard empty Idx2ColUniqueIDs in out-of-range estimation

### DIFF
--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -302,8 +302,12 @@ func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index,
 			// Exclude the TopN in Stats Version 2
 			if idx.StatsVer == statistics.Version2 {
 				colIDs := coll.Idx2ColUniqueIDs[idx.Histogram.ID]
-				// Retrieve column statistics for the 1st index column
-				c := coll.GetCol(colIDs[0])
+				// Retrieve column statistics for the 1st index column.
+				// colIDs may be empty if the index-to-column mapping is not populated, so guard the access.
+				var c *statistics.Column
+				if len(colIDs) > 0 {
+					c = coll.GetCol(colIDs[0])
+				}
 				// If this is single column predicate - use the column's information rather than index.
 				// Index histograms are converted to string. Column uses original type - which can be more accurate for out of range
 				isSingleColRange := len(indexRange.LowVal) == len(indexRange.HighVal) && len(indexRange.LowVal) == 1

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -650,6 +650,56 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 		"exclusive lower bound on NULL must drop the NULL row, estimate must be < RealtimeCount")
 }
 
+// TestOutOfRangeEstimationWithoutIdx2ColMapping verifies that the StatsVer2 out-of-range
+// estimation does not panic when the index-to-column mapping (Idx2ColUniqueIDs) is empty.
+// getIndexRowCountForStatsV2 reads Idx2ColUniqueIDs[idx.ID][0] to prefer the leading
+// column's histogram for single-column ranges; if that mapping is not populated the
+// access must be guarded and the estimation must fall back to the index histogram.
+func TestOutOfRangeEstimationWithoutIdx2ColMapping(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int, key idx(a))")
+	is := dom.InfoSchema()
+	tb, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tb.Meta()
+
+	// A fully-loaded StatsVer2 index whose histogram covers the encoded values [0, nonNullCount).
+	const nonNullCount = 50
+	statsTbl := mockStatsTable(tblInfo, nonNullCount)
+	idxValues := make([]types.Datum, nonNullCount)
+	for i := range idxValues {
+		enc, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(int64(i)))
+		require.NoError(t, err)
+		idxValues[i].SetBytes(enc)
+	}
+	idxHist := mockStatsHistogram(tblInfo.Indices[0].ID, idxValues, 1, types.NewFieldType(mysql.TypeBlob))
+	statsTbl.SetIdx(tblInfo.Indices[0].ID, &statistics.Index{
+		Histogram:         *idxHist,
+		Info:              tblInfo.Indices[0],
+		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
+		StatsVer:          2,
+	})
+	// Intentionally do NOT populate Idx2ColUniqueIDs: it stays empty, simulating a HistColl
+	// where the index-to-column mapping was not built. Before the guard, the out-of-range
+	// path indexed colIDs[0] on this empty slice and panicked.
+
+	idxID := tblInfo.Indices[0].ID
+	sctx := tk.Session().GetPlanCtx()
+
+	// An interval range fully above the histogram max forces the StatsVer2 out-of-range
+	// branch (a point range would short-circuit earlier). This must not panic and must
+	// return a small, positive estimate from the index histogram fallback.
+	require.NotPanics(t, func() {
+		countResult, err := cardinality.GetRowCountByIndexRanges(sctx, &statsTbl.HistColl, idxID, getRange(1000, 2000), nil)
+		require.NoError(t, err)
+		require.Greater(t, countResult.Est, 0.0)
+		require.Less(t, countResult.Est, float64(nonNullCount))
+	})
+}
+
 func TestEstimationForUnknownValuesAfterModify(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -652,7 +652,7 @@ func TestCanSkipIndexEstimation(t *testing.T) {
 
 // TestOutOfRangeEstimationWithoutIdx2ColMapping verifies that the StatsVer2 out-of-range
 // estimation does not panic when the index-to-column mapping (Idx2ColUniqueIDs) is empty.
-// getIndexRowCountForStatsV2 reads Idx2ColUniqueIDs[idx.ID][0] to prefer the leading
+// getIndexRowCountForStatsV2 reads Idx2ColUniqueIDs[idx.Histogram.ID][0] to prefer the leading
 // column's histogram for single-column ranges; if that mapping is not populated the
 // access must be guarded and the estimation must fall back to the index histogram.
 func TestOutOfRangeEstimationWithoutIdx2ColMapping(t *testing.T) {


### PR DESCRIPTION
getIndexRowCountForStatsV2 read Idx2ColUniqueIDs[idx.ID][0] to prefer the leading column's histogram for single-column ranges. When the index-to-column mapping is not populated, that slice is empty and the access panicked with "index out of range [0] with length 0". Guard the access and fall back to the index histogram, matching the defensive pattern already used in the V1 path.

Add a regression test that reaches the StatsVer2 out-of-range branch with an empty Idx2ColUniqueIDs; it panics before the fix and passes after.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50080

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain index range estimates could fail when leading-column mapping data was unavailable.
  * Improved handling of out-of-range cardinality estimation so it no longer panics in this case.

* **Tests**
  * Added coverage for index estimation with missing mapping data to verify stable behavior and reasonable row-count results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->