### PR TITLE
planner: allow partial indexes for index join

### DIFF
--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 13,
+    shard_count = 12,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -391,6 +391,28 @@ func TestPartialIndexWithPlanCache(t *testing.T) {
 		tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).CheckContain("idx2")
 		tk.MustExec("execute stmt using @a")
 		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+		tk.MustExec("drop table if exists pi_pc_outer, pi_pc_inner")
+		tk.MustExec("create table pi_pc_outer(a int, b int)")
+		tk.MustExec("create table pi_pc_inner(a int, b int, index idx_a(a) where a is not null)")
+		tk.MustExec("insert into pi_pc_outer values (1, 10), (2, 20), (null, 30), (3, 40)")
+		tk.MustExec("insert into pi_pc_inner values (1, 100), (2, 200), (null, 999), (3, 300)")
+		tk.MustExec(`prepare stmt from 'select /* issue:69524 */ /*+ INL_JOIN(pi_pc_inner) */ pi_pc_outer.a, pi_pc_inner.b
+			from pi_pc_outer join pi_pc_inner on pi_pc_outer.a = pi_pc_inner.a
+			where pi_pc_inner.a = ?
+			order by pi_pc_outer.b'`)
+		tk.MustExec("set @a = 1")
+		tk.MustQuery("execute stmt using @a").Check(testkit.Rows("1 100"))
+		tk.MustExec("set @a = 2")
+		tk.MustQuery("execute stmt using @a").Check(testkit.Rows("2 200"))
+		tkProcess = tk.Session().ShowProcess()
+		ps[0] = tkProcess
+		tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
+		tk.MustQuery(fmt.Sprintf("explain format = 'brief' for connection %d", tkProcess.ID)).
+			MultiCheckContain([]string{"IndexJoin", "idx_a"})
+		tk.MustExec("set @a = 3")
+		tk.MustQuery("execute stmt using @a").Check(testkit.Rows("3 300"))
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 	})
 }
 
@@ -448,35 +470,6 @@ func TestPartialIndexWithIndexPrune(t *testing.T) {
 		}))
 		tk.MustQuery("explain format = 'plan_tree' select * from t where a is null").CheckNotContain("idx1")
 		require.NoError(t, failpoint.Disable(fpName))
-	})
-}
-
-func TestPartialIndexWithIndexJoin(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
-		tk.MustExec("use test")
-		tk.MustExec("drop table if exists pi_idxjoin_outer, pi_idxjoin_inner")
-		tk.MustExec("create table pi_idxjoin_outer(a int, b int)")
-		tk.MustExec("create table pi_idxjoin_inner(a int, b int, index idx_a(a) where a is not null)")
-		tk.MustExec("insert into pi_idxjoin_outer values (1, 10), (2, 20), (null, 30)")
-		tk.MustExec("insert into pi_idxjoin_inner values (1, 100), (2, 200), (null, 999)")
-
-		innerJoinSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
-			from pi_idxjoin_outer join pi_idxjoin_inner on pi_idxjoin_outer.a = pi_idxjoin_inner.a
-			order by pi_idxjoin_outer.b`
-		tk.MustQuery("explain format = 'plan_tree' " + innerJoinSQL).MultiCheckContain([]string{"IndexJoin", "idx_a"})
-		tk.MustQuery(innerJoinSQL).Check(testkit.Rows("1 100", "2 200"))
-
-		leftJoinSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
-			from pi_idxjoin_outer left join pi_idxjoin_inner on pi_idxjoin_outer.a = pi_idxjoin_inner.a
-			order by pi_idxjoin_outer.b`
-		tk.MustQuery("explain format = 'plan_tree' " + leftJoinSQL).MultiCheckContain([]string{"IndexJoin", "idx_a"})
-		tk.MustQuery(leftJoinSQL).Check(testkit.Rows("1 100", "2 200", "<nil> <nil>"))
-
-		nullEQSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
-			from pi_idxjoin_outer join pi_idxjoin_inner on pi_idxjoin_outer.a <=> pi_idxjoin_inner.a
-			order by pi_idxjoin_outer.b, pi_idxjoin_inner.b`
-		tk.MustQuery("explain format = 'plan_tree' " + nullEQSQL).CheckNotContain("idx_a")
-		tk.MustQuery(nullEQSQL).Check(testkit.Rows("1 100", "2 200", "<nil> 999"))
 	})
 }
 

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -451,6 +451,35 @@ func TestPartialIndexWithIndexPrune(t *testing.T) {
 	})
 }
 
+func TestPartialIndexWithIndexJoin(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists pi_idxjoin_outer, pi_idxjoin_inner")
+		tk.MustExec("create table pi_idxjoin_outer(a int, b int)")
+		tk.MustExec("create table pi_idxjoin_inner(a int, b int, index idx_a(a) where a is not null)")
+		tk.MustExec("insert into pi_idxjoin_outer values (1, 10), (2, 20), (null, 30)")
+		tk.MustExec("insert into pi_idxjoin_inner values (1, 100), (2, 200), (null, 999)")
+
+		innerJoinSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
+			from pi_idxjoin_outer join pi_idxjoin_inner on pi_idxjoin_outer.a = pi_idxjoin_inner.a
+			order by pi_idxjoin_outer.b`
+		tk.MustQuery("explain format = 'plan_tree' " + innerJoinSQL).MultiCheckContain([]string{"IndexJoin", "idx_a"})
+		tk.MustQuery(innerJoinSQL).Check(testkit.Rows("1 100", "2 200"))
+
+		leftJoinSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
+			from pi_idxjoin_outer left join pi_idxjoin_inner on pi_idxjoin_outer.a = pi_idxjoin_inner.a
+			order by pi_idxjoin_outer.b`
+		tk.MustQuery("explain format = 'plan_tree' " + leftJoinSQL).MultiCheckContain([]string{"IndexJoin", "idx_a"})
+		tk.MustQuery(leftJoinSQL).Check(testkit.Rows("1 100", "2 200", "<nil> <nil>"))
+
+		nullEQSQL := `select /* issue:69524 */ /*+ INL_JOIN(pi_idxjoin_inner) */ pi_idxjoin_outer.a, pi_idxjoin_inner.b
+			from pi_idxjoin_outer join pi_idxjoin_inner on pi_idxjoin_outer.a <=> pi_idxjoin_inner.a
+			order by pi_idxjoin_outer.b, pi_idxjoin_inner.b`
+		tk.MustQuery("explain format = 'plan_tree' " + nullEQSQL).CheckNotContain("idx_a")
+		tk.MustQuery(nullEQSQL).Check(testkit.Rows("1 100", "2 200", "<nil> 999"))
+	})
+}
+
 func TestForceIndexLimit(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec(`use test`)

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -684,13 +684,13 @@ func buildDataSource2IndexScanByIndexJoinProp(
 		if path.IsTablePath() {
 			return false
 		}
-		// if path is index path. index path currently include two kind of, one is normal, and the other is mv index.
-		// for mv index like mvi(a, json, b), if driving condition is a=1, and we build a prefix scan with range [1,1]
-		// on mvi, it will return many index rows which breaks handle-unique attribute here.
+		// If path is an MV index path like mvi(a, json, b), a prefix scan with range [1,1] on mvi can
+		// return many index rows and break the handle-unique attribute here.
 		//
-		// the basic rule is that: mv index can be and can only be accessed by indexMerge operator. (embedded handle duplication)
+		// The basic rule is that MV index can be and can only be accessed by indexMerge operator.
+		// Partial index paths that remain here have already passed predicate checking.
 		if !path.IsIndexJoinUnapplicable() {
-			return true // not a MVIndex path, it can successfully be index join probe side.
+			return true
 		}
 		return false
 	}

--- a/pkg/planner/util/path.go
+++ b/pkg/planner/util/path.go
@@ -564,8 +564,8 @@ func (path *AccessPath) IsUndetermined() bool {
 // on mvi, it will return many index rows which breaks handle-unique attribute here.
 // So we cannot use mv index path for index join.
 // If path is partial index path:
-// We need to first determine whether we already meet the partial index condition.
-// Currently we don't support that, so we conservatively return true here.
+// The partial-index predicate has already been checked against pushed-down conditions before IndexJoin path
+// enumeration. A remaining partial-index path can be used as the IndexJoin inner path.
 func (path *AccessPath) IsIndexJoinUnapplicable() bool {
-	return path.IsUndetermined()
+	return !path.IsTablePath() && path.Index != nil && path.Index.MVIndex
 }

--- a/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
@@ -58,44 +58,67 @@ id	estRows	task	access object	operator info
 TableReader	1.00	root		data:Selection
 └─Selection	1.00	cop[tikv]		eq(planner__core__casetest__index__partialindex.t.c, 1)
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-explain format='brief' select /*+ inl_join(t2) */ * from t t1, t t2 where t1.a=t2.b;
-id	estRows	task	access object	operator info
-HashJoin	12487.50	root		inner join, equal:[eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.b)]
-├─TableReader(Build)	9990.00	root		data:Selection
-│ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.b))
-│   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─TableReader(Probe)	9990.00	root		data:Selection
-  └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.a))
-    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-explain format='brief' select /*+ inl_join(t2) */ * from tt t1, tt t2 where t1.a=t2.b;
-id	estRows	task	access object	operator info
-IndexJoin	12487.50	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__index__partialindex.tt.a, inner key:planner__core__casetest__index__partialindex.tt.b, equal cond:eq(planner__core__casetest__index__partialindex.tt.a, planner__core__casetest__index__partialindex.tt.b)
-├─TableReader(Build)	9990.00	root		data:Selection
-│ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.tt.a))
-│   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	12487.50	root		
-  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.tt.b))
-  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2, index:idx2(b)	range: decided by [eq(planner__core__casetest__index__partialindex.tt.b, planner__core__casetest__index__partialindex.tt.a)], keep order:false, stats:pseudo
-  └─TableRowIDScan(Probe)	12487.50	cop[tikv]	table:t2	keep order:false, stats:pseudo
-explain format='brief' select /*+ inl_join(t2) */ * from t t1, t t2 where t1.b=t2.a;
-id	estRows	task	access object	operator info
-HashJoin	12487.50	root		inner join, equal:[eq(planner__core__casetest__index__partialindex.t.b, planner__core__casetest__index__partialindex.t.a)]
-├─TableReader(Build)	9990.00	root		data:Selection
-│ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.a))
-│   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─TableReader(Probe)	9990.00	root		data:Selection
-  └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.b))
-    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-explain format='brief' select /*+ inl_join(t2) */ * from tt t1, tt t2 where t1.b=t2.a;
-id	estRows	task	access object	operator info
-IndexJoin	12487.50	root		inner join, inner:IndexLookUp, outer key:planner__core__casetest__index__partialindex.tt.b, inner key:planner__core__casetest__index__partialindex.tt.a, equal cond:eq(planner__core__casetest__index__partialindex.tt.b, planner__core__casetest__index__partialindex.tt.a)
-├─TableReader(Build)	9990.00	root		data:Selection
-│ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.tt.b))
-│   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	12487.50	root		
-  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.tt.a))
-  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2, index:idx1(a)	range: decided by [eq(planner__core__casetest__index__partialindex.tt.a, planner__core__casetest__index__partialindex.tt.b)], keep order:false, stats:pseudo
-  └─TableRowIDScan(Probe)	12487.50	cop[tikv]	table:t2	keep order:false, stats:pseudo
+explain format='plan_tree' select /*+ inl_join(t2) */ t1.a, t2.b from t t1, t t2 where t1.a=t2.b;
+id	task	access object	operator info
+HashJoin	root		inner join, equal:[eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.b)]
+├─TableReader(Build)	root		data:Selection
+│ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.b))
+│   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─IndexReader(Probe)	root		index:IndexFullScan
+  └─IndexFullScan	cop[tikv]	table:t1, index:idx1(a)	keep order:false, stats:pseudo
+explain format='plan_tree' select /*+ inl_join(t2) */ t1.a, t2.b from tt t1, tt t2 where t1.a=t2.b;
+id	task	access object	operator info
+IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__index__partialindex.tt.a, inner key:planner__core__casetest__index__partialindex.tt.b, equal cond:eq(planner__core__casetest__index__partialindex.tt.a, planner__core__casetest__index__partialindex.tt.b)
+├─IndexReader(Build)	root		index:IndexFullScan
+│ └─IndexFullScan	cop[tikv]	table:t1, index:idx1(a)	keep order:false, stats:pseudo
+└─IndexReader(Probe)	root		index:Selection
+  └─Selection	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.tt.b))
+    └─IndexRangeScan	cop[tikv]	table:t2, index:idx2(b)	range: decided by [eq(planner__core__casetest__index__partialindex.tt.b, planner__core__casetest__index__partialindex.tt.a)], keep order:false, stats:pseudo
+insert into t values (1, 100, 10), (2, 200, 20), (null, 999, 30);
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a = t2.a order by t1.c;
+id	task	access object	operator info
+Projection	root		planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.b, planner__core__casetest__index__partialindex.t.a
+└─Sort	root		planner__core__casetest__index__partialindex.t.c
+  └─IndexJoin	root		inner join, inner:IndexReader, outer key:planner__core__casetest__index__partialindex.t.a, inner key:planner__core__casetest__index__partialindex.t.a, equal cond:eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.a)
+    ├─TableReader(Build)	root		data:Selection
+    │ └─Selection	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.a))
+    │   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─IndexReader(Probe)	root		index:Selection
+      └─Selection	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.a))
+        └─IndexRangeScan	cop[tikv]	table:t2, index:idx1(a)	range: decided by [eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.a)], keep order:false, stats:pseudo
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a = t2.a order by t1.c;
+a	b	a
+1	100	1
+2	200	2
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 left join t t2 on t1.a = t2.a order by t1.c;
+id	task	access object	operator info
+Projection	root		planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.b, planner__core__casetest__index__partialindex.t.a
+└─Sort	root		planner__core__casetest__index__partialindex.t.c
+  └─IndexJoin	root		left outer join, inner:IndexReader, left side:TableReader, outer key:planner__core__casetest__index__partialindex.t.a, inner key:planner__core__casetest__index__partialindex.t.a, equal cond:eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.a)
+    ├─TableReader(Build)	root		data:TableFullScan
+    │ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─IndexReader(Probe)	root		index:Selection
+      └─Selection	cop[tikv]		not(isnull(planner__core__casetest__index__partialindex.t.a))
+        └─IndexRangeScan	cop[tikv]	table:t2, index:idx1(a)	range: decided by [eq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.a)], keep order:false, stats:pseudo
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 left join t t2 on t1.a = t2.a order by t1.c;
+a	b	a
+1	100	1
+2	200	2
+NULL	999	NULL
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a <=> t2.a order by t1.c, t2.a;
+id	task	access object	operator info
+Projection	root		planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.b, planner__core__casetest__index__partialindex.t.a
+└─Sort	root		planner__core__casetest__index__partialindex.t.c, planner__core__casetest__index__partialindex.t.a
+  └─HashJoin	root		inner join, equal:[nulleq(planner__core__casetest__index__partialindex.t.a, planner__core__casetest__index__partialindex.t.a)]
+    ├─TableReader(Build)	root		data:TableFullScan
+    │ └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+    └─TableReader(Probe)	root		data:TableFullScan
+      └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a <=> t2.a order by t1.c, t2.a;
+a	b	a
+1	100	1
+2	200	2
+NULL	999	NULL
 explain format='brief' select /*+ use_index_merge(t, idx1, idx2) */ * from t where (a > 10) or (b > 10);
 id	estRows	task	access object	operator info
 TableReader	5555.56	root		data:Selection

--- a/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
@@ -26,11 +26,20 @@ explain format='brief' select * from t where c > 20;
 # test the TryFastPath short-circuit.
 explain format='brief' select * from t where c = 1;
 
-# test index join(reject)
-explain format='brief' select /*+ inl_join(t2) */ * from t t1, t t2 where t1.a=t2.b;
-explain format='brief' select /*+ inl_join(t2) */ * from tt t1, tt t2 where t1.a=t2.b;
-explain format='brief' select /*+ inl_join(t2) */ * from t t1, t t2 where t1.b=t2.a;
-explain format='brief' select /*+ inl_join(t2) */ * from tt t1, tt t2 where t1.b=t2.a;
+# test index join rejects a partial index whose predicate is not implied by the join.
+# The same join can use normal idx2(b) on tt, but not partial idx2(b) on t.
+explain format='plan_tree' select /*+ inl_join(t2) */ t1.a, t2.b from t t1, t t2 where t1.a=t2.b;
+explain format='plan_tree' select /*+ inl_join(t2) */ t1.a, t2.b from tt t1, tt t2 where t1.a=t2.b;
+
+# issue 69524. Partial-index predicate proof/pruning must run before IndexJoin
+# path construction: equality joins can use partial idx1(a), but NULL-safe equality must not.
+insert into t values (1, 100, 10), (2, 200, 20), (null, 999, 30);
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a = t2.a order by t1.c;
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a = t2.a order by t1.c;
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 left join t t2 on t1.a = t2.a order by t1.c;
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 left join t t2 on t1.a = t2.a order by t1.c;
+explain format='plan_tree' select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a <=> t2.a order by t1.c, t2.a;
+select /* issue:69524 */ /*+ inl_join(t2) */ t1.a, t1.b, t2.a from t t1 join t t2 on t1.a <=> t2.a order by t1.c, t2.a;
 
 # test index merge(reject)
 explain format='brief' select /*+ use_index_merge(t, idx1, idx2) */ * from t where (a > 10) or (b > 10);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69524

Problem Summary:

IndexJoin rejected every partial index because partial indexes were treated as undetermined paths. As a result, even when the partial-index predicate was already proven by pushed-down join conditions, IndexJoin could not choose that index.

### What changed and how does it work?

This PR allows IndexJoin path construction to consider partial indexes after partial-index predicate checking/pruning has already run. MV indexes remain rejected.

The added tests cover:

- ordinary partial-index rejection when the predicate is not implied by the join condition
- IndexJoin using a safe `a IS NOT NULL` partial index for inner join and left outer join
- NULL-safe equality (`<=>`) not using the partial index
- prepared plan cache correctness with partial index and IndexJoin

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/index -run TestPartialIndexWithPlanCache -count=1
./run-tests.sh -r planner/core/casetest/index/partialindex
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that IndexJoin cannot choose a usable partial index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join planning for queries using partial indexes, including better handling of IndexJoin with prepared statements and cached plans.
  * Fixed planner behavior for cases where partial-index conditions are not proven by the join predicate, while still allowing valid non-partial index use.
  * Added coverage for regular, left, and NULL-safe joins to ensure correct plan selection and query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->