### PR TITLE
lightning: disable PD router client for auto-increment rebase

### DIFF
--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -1396,6 +1396,13 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		kvStoreWithPD, ok := kvStore.(tidbkv.StorageWithPD)
+		if !ok {
+			return errors.Errorf("TiKV store does not expose PD client")
+		}
+		if err = kvStoreWithPD.GetPDClient().UpdateOption(opt.EnableRouterClient, false); err != nil {
+			return errors.Trace(err)
+		}
 		etcdCli, err = clientv3.New(clientv3.Config{
 			Endpoints:        urlsWithScheme,
 			AutoSyncInterval: 30 * time.Second,

--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -1396,6 +1396,8 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		// Older PD servers do not support the router client's QueryRegion RPC.
+		// Disable it for the post-process store used by auto-increment rebase.
 		kvStoreWithPD, ok := kvStore.(tidbkv.StorageWithPD)
 		if !ok {
 			return errors.Errorf("TiKV store does not expose PD client")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67923

Problem Summary:

When TiDB Lightning local backend imports an `AUTO_INCREMENT` table into an older TiDB/PD cluster, the post-process auto-increment rebase path can use a PD client with router client enabled.

Older PD versions do not support the router `QueryRegion` RPC, so the rebase may fail with `unknown method QueryRegion for service pdpb.PD` and eventually report `PD server timeout`.

### What changed and how does it work?

Disable the PD router client on the TiKV store opened for Lightning local backend post-process work.

This store is used by the auto-increment rebase path during table post-processing, so disabling its PD router client avoids calling `QueryRegion` against older PD versions.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

- `go test ./lightning/pkg/importer -run 'TestTableRestoreSuite/TestImportKVSuccess' -count=1`

No new unit test was added for the old-PD RPC incompatibility because this regression depends on a real PD client talking to an older PD version that does not support router `QueryRegion`. Existing mockstore/importer unit tests do not exercise that router RPC path.

Manual test:

- Built latest master `tidb-lightning`.
- Used local backend to import an `AUTO_INCREMENT` clustered primary key table into TiDB/PD v6.5.12 and v8.5.6 clusters.
- Both imports completed successfully.
- Follow-up inserts used the next auto-increment value.
- Lightning logs did not contain `QueryRegion`, `PD server timeout`, or `ErrRestoreTable`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix TiDB Lightning compatibility with older PD versions when rebasing auto-increment IDs during local backend import.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local restore/import reliability by validating that the TiKV storage backend exposes the required PD connectivity before continuing.
  * Prevented client-routing conflicts during local backend imports by disabling router client behavior when supported, and returning a clear error when it isn’t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
