### PR TITLE
session: use resource group runtime state for paging

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3466,12 +3466,8 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			}
 		}
 		pagingSizeBytes := vars.PagingSizeBytes
-		if pagingSizeBytes > 0 {
-			if !vardef.EnableResourceControl.Load() || dom == nil || sc.ResourceGroupName == "" {
-				pagingSizeBytes = 0
-			} else if rg, ok := dom.InfoSchema().ResourceGroupByName(ast.NewCIStr(sc.ResourceGroupName)); !ok || rg.GetBurstLimitAdjusted() < 0 {
-				pagingSizeBytes = 0
-			}
+		if pagingSizeBytes > 0 && (!vardef.EnableResourceControl.Load() || !resourceGroupAllowsPagingSizeBytes(dom, sc.ResourceGroupName)) {
+			pagingSizeBytes = 0
 		}
 		ret := &distsqlctx.DistSQLContext{
 			WarnHandler:     sc.WarnHandler,
@@ -3548,6 +3544,19 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 	}
 
 	return dctx
+}
+
+func resourceGroupAllowsPagingSizeBytes(dom *domain.Domain, resourceGroupName string) bool {
+	if dom == nil || resourceGroupName == "" {
+		return false
+	}
+	if rgCtl := dom.ResourceGroupsController(); rgCtl != nil {
+		if state, ok := rgCtl.GetResourceGroupRuntimeState(resourceGroupName); ok {
+			return state.HasLimitedBurst
+		}
+	}
+	rg, ok := dom.InfoSchema().ResourceGroupByName(ast.NewCIStr(resourceGroupName))
+	return ok && rg.GetBurstLimitAdjusted() >= 0
 }
 
 // GetRangerCtx returns the context used in `ranger` related functions


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #68085, tikv/pd#10612

Problem Summary:

PD resource control now exposes whether the runtime request-unit token bucket has a limited burst. TiDB's `tidb_paging_size_bytes` gate still depended only on the static resource-group metadata in InfoSchema, so it could miss limited-burst settings produced by service-limit override logic.

The required PD/client-go versions and TiDB mock compatibility are already present on master through #67941, so this PR now only changes the session-side paging gate.

### What changed and how does it work?

- Makes `GetDistSQLCtx` prefer `ResourceGroupsController.GetResourceGroupRuntimeState().HasLimitedBurst` when deciding whether `tidb_paging_size_bytes` can be forwarded.
- Falls back to the existing InfoSchema burst-limit check while the runtime state is not available yet.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test and static checks:

```sh
./tools/check/failpoint-go-test.sh pkg/session -run TestDistSQLCtxPagingSizeBytesRequiresHardCappedResourceGroup -count=1
make lint
git diff --check upstream/master...HEAD
```

Real TiKV E2E verification (temporary local regression test):

1. Started a `tiup playground v8.5.4 --mode tikv-slim` cluster with a locally built PD and a real TiKV store.
2. Set PD's keyspace service limit to `100`. InfoSchema still reported the `default` resource group as `BURSTABLE = UNLIMITED`, while the runtime state converged to `HasLimitedBurst = true`.
3. Set `tidb_paging_size_bytes = 4194304` and captured the actual outbound `coprocessor.Request` at `onBeforeSendReqCtx`.
4. Ran the same test against master and this PR:

```sh
./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -run '^TestPagingSizeBytesUsesRuntimeLimitedBurst$' -count=1
```

| Revision | Runtime state | Outbound `PagingSizeBytes` | Result |
| --- | --- | ---: | --- |
| `upstream/master` (`52f7a7a3e6`) | `HasLimitedBurst = true` | `0` | FAIL (expected `4194304`) |
| This PR (`f60f3384cd`) | `HasLimitedBurst = true` | `4194304` | PASS |

This verifies the complete path from PD's runtime service-limit override through TiDB's resource-group runtime state to the outbound Cop RPC. It does not verify TiKV server-side page truncation/resume behavior because the stock TiKV v8.5.4 binary does not implement this request field.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the tidb_paging_size_bytes gating so Resource Control limited-burst state reported by PD is recognized before falling back to static resource-group metadata.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-control paging behavior by consistently applying resource-group burst-limit settings.
  * Prevented paging configuration from being enabled when the associated resource group is unavailable or does not permit it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
