### PR TITLE
test: stabilize flaky TestTTLStatusCache/last_job_finish_time

### DIFF
--- a/pkg/ttl/cache/ttlstatus_test.go
+++ b/pkg/ttl/cache/ttlstatus_test.go
@@ -169,13 +169,17 @@ func TestTTLStatusCache(t *testing.T) {
 	}
 	for index, testCase := range testCases {
 		t.Run(testCase.columnName, func(t *testing.T) {
+			tk.MustExec("delete from mysql.tidb_ttl_table_status")
 			sql := fmt.Sprintf(`insert into mysql.tidb_ttl_table_status (table_id, %s) values (%d, %s)`,
 				testCase.columnName, index, testCase.sqlLiteral)
 
 			tk.MustExec(sql)
 			assert.NoError(t, isc.Update(context.Background(), ttlSession))
-			assert.Equal(t, index+1, len(isc.Tables))
-			testCase.assert(isc.Tables[int64(index)])
+			assert.Len(t, isc.Tables, 1)
+			table := isc.Tables[int64(index)]
+			if assert.NotNil(t, table) {
+				testCase.assert(table)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69619

Problem Summary:
Flaky test `TestTTLStatusCache/last_job_finish_time` in `pkg/ttl/cache` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?

#### Root Cause

`TestTTLStatusCache` used `CreateMockStoreAndDomain`, which starts the background TTL job manager in the test environment. After the TTL manager becomes leader, it may immediately run `DoGC()`.

The subtests in `TestTTLStatusCache` insert temporary rows into `mysql.tidb_ttl_table_status` and previously relied on rows from earlier subtests remaining in the table. However, those rows have `current_job_status IS NULL`, so they can be removed by the background TTL table-status GC during the test.

As a result, later subtests may observe fewer rows than expected, making the original cumulative assertion (`len(isc.Tables) == index+1`) flaky.

#### Fix

Clearing the TTL status table inside each field subtest makes each field extraction case self-contained.

#### Verification

Spec:
- target: `pkg/ttl/cache :: TestTTLStatusCache/last_job_finish_time`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_validation passed.
package_validation passed.

Gate checklist:
- native_repro: SKIPPED
- target_flaky_validation: PASS
- package_validation: PASS
- build_safety: BLOCKED
- ready_lint: BLOCKED
- prow_bazel_shard: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ttl/cache -run '^TestTTLStatusCache/last_job_finish_time$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/ttl/cache -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cache test coverage to reset table status data between subtests.
  * Strengthened assertions so each case checks a single cached table consistently, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->