### PR TITLE
planner: fix TPCDS Q64 regression under the new join algorithm

### DIFF
--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -560,7 +560,7 @@ func (j *joinOrderGreedy) optimize() (base.LogicalPlan, error) {
 		return nodeWithHint.p, nil
 	}
 
-	slices.SortFunc(nodes, func(a, b *Node) int {
+	slices.SortStableFunc(nodes, func(a, b *Node) int {
 		return cmp.Compare(a.cumCost, b.cumCost)
 	})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69600

Problem Summary: planner: fix TPCDS Q64 regression under the new CD-C join algorithm

### What changed and how does it work?

In TPCDS Q64, `ib1` and `ib2` have the same row count, but the old join-order implementation is using `SortStableFunc` while the new one is using `SortFunc`, which leads to this join order change.

This PR update the new join-order implementation to also use `SortStableFunc` to keep the prior behavior.

<img width="1394" height="124" alt="image" src="https://github.com/user-attachments/assets/01a3556f-c8e3-4352-aff3-3756e64fe803" />
<img width="1300" height="138" alt="image" src="https://github.com/user-attachments/assets/15c33ae3-d2c0-4105-a43c-a828d1454513" />


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in greedy join ordering when multiple options have the same estimated cost.
  * Tie cases now preserve the existing relative order, reducing unexpected plan changes between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->