### PR TITLE
test: stabilize flaky TestInstancePlanCacheConcurrencySysbench

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
@@ -82,12 +82,7 @@ func (w *worker) run() {
 			preparedResult := w.tk.MustQuery(stmt.execStmt)
 			normalResult.Sort().Check(preparedResult.Sort().Rows())
 		} else if isDML(stmt.normalStmt) { // DML
-			// Deadlocks can occur when multiple workers update the same row concurrently.
-			// This is expected database behavior - skip the statement on deadlock.
-			_, err := w.tk.Exec(stmt.normalStmt)
-			if err != nil && strings.Contains(err.Error(), "Deadlock") {
-				continue
-			}
+			w.tk.MustExec(stmt.normalStmt)
 			w.tk.MustExec(stmt.prepStmt)
 			w.tk.MustExec(stmt.setStmt)
 			w.tk.MustExec(stmt.execStmt)
@@ -97,13 +92,16 @@ func (w *worker) run() {
 
 func testWithWorkers(TKs []*testkit.TestKit, stmts []*testStmt) {
 	nStmts := make([][]*testStmt, len(TKs))
+	// Keep writes in one session; worker transaction progress is not synchronized,
+	// so splitting writes across sessions can deadlock and break normal/prepared
+	// symmetry after rollback.
+	dmlWorker := rand.Intn(len(TKs))
 	for _, stmt := range stmts {
 		if stmt == nil {
 			continue
 		}
 		if isDML(stmt.normalStmt) { // avoid duplicate DML
-			x := rand.Intn(len(TKs))
-			nStmts[x] = append(nStmts[x], stmt)
+			nStmts[dmlWorker] = append(nStmts[dmlWorker], stmt)
 		} else {
 			for i := range TKs {
 				nStmts[i] = append(nStmts[i], stmt)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57514

Problem Summary:
Flaky test `TestInstancePlanCacheConcurrencySysbench` in `pkg/planner/core/casetest/instanceplancache` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Unsynchronized multi-worker DML routing made lock deadlocks part of a plan-cache equivalence test.

#### Fix

Single-writer DML removes unrelated lock scheduling while preserving normal-vs-prepared SQL comparison under concurrent sessions.

#### Verification

Spec:
- target: `pkg/planner/core/casetest/instanceplancache :: TestInstancePlanCacheConcurrencySysbench`
- strategy: `tidb.issue_scoped.v2`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target-flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- pressure-repro: SKIPPED
- target-flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/instanceplancache -run '^TestInstancePlanCacheConcurrencySysbench$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/instanceplancache -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #57514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in concurrent write testing so database changes stay within one session, reducing deadlock-related flakiness.
  * Simplified statement execution during DML handling to avoid skipping work after deadlocks, helping tests better reflect real behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->