### PR TITLE
planner: plan replayer supports hypo tiflash

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -401,16 +401,25 @@ func loadSetTiFlashReplica(ctx sessionctx.Context, z *zip.Reader) error {
 				}
 				dbName := r[0]
 				tableName := r[1]
+				replicaCount := strings.TrimSpace(r[2])
 				c := context.Background()
-				// Though we record tiflash replica in txt, we only set 1 hypothetical
-				// TiFlash replica as it's enough for reproducing the plan.
-				sql := fmt.Sprintf("alter table %s.%s set hypo tiflash replica 1", dbName, tableName)
+				sql := fmt.Sprintf("alter table %s.%s set tiflash replica %s", dbName, tableName, replicaCount)
 				_, err = ctx.GetSQLExecutor().Execute(c, sql)
+				if err != nil && isNoTiFlashStoreErr(err) {
+					// Without TiFlash stores, use one hypothetical replica so the
+					// optimizer can still reproduce TiFlash access paths.
+					sql = fmt.Sprintf("alter table %s.%s set hypo tiflash replica 1", dbName, tableName)
+					_, err = ctx.GetSQLExecutor().Execute(c, sql)
+				}
 				logutil.BgLogger().Debug("plan replayer: skip error", zap.Error(err))
 			}
 		}
 	}
 	return nil
+}
+
+func isNoTiFlashStoreErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "total tiflash server count: 0")
 }
 
 func loadAllBindings(ctx sessionctx.Context, z *zip.Reader, databaseSets map[string]struct{}) error {

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -402,8 +402,9 @@ func loadSetTiFlashReplica(ctx sessionctx.Context, z *zip.Reader) error {
 				dbName := r[0]
 				tableName := r[1]
 				c := context.Background()
-				// Though we record tiflash replica in txt, we only set 1 tiflash replica as it's enough for reproduce the plan
-				sql := fmt.Sprintf("alter table %s.%s set tiflash replica 1", dbName, tableName)
+				// Though we record tiflash replica in txt, we only set 1 hypothetical
+				// TiFlash replica as it's enough for reproducing the plan.
+				sql := fmt.Sprintf("alter table %s.%s set hypo tiflash replica 1", dbName, tableName)
 				_, err = ctx.GetSQLExecutor().Execute(c, sql)
 				logutil.BgLogger().Debug("plan replayer: skip error", zap.Error(err))
 			}
@@ -581,6 +582,11 @@ func loadStats(ctx sessionctx.Context, f *zip.File) error {
 	}
 	if err := json.Unmarshal(buf.Bytes(), jsonTbl); err != nil {
 		ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Join(fmt.Errorf("fail to unmarshal stats JSON for file %s", f.Name), err))
+		return nil
+	}
+	// Keep plan replayer consistent with LOAD STATS: a dumped stats file can be
+	// null when the source table has no stats, and loading it should be a no-op.
+	if jsonTbl.TableName == "" && jsonTbl.Version == 0 {
 		return nil
 	}
 	do := domain.GetDomain(ctx)

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "plan_replayer_test.go",
     ],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/planreplayer/BUILD.bazel
+++ b/pkg/executor/test/planreplayer/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     shard_count = 9,
     deps = [
         "//pkg/config",
+        "//pkg/executor",
         "//pkg/meta/autoid",
         "//pkg/objstore/storeapi",
         "//pkg/planner/extstore",

--- a/pkg/executor/test/planreplayer/plan_replayer_test.go
+++ b/pkg/executor/test/planreplayer/plan_replayer_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/planner/extstore"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -78,6 +79,33 @@ func requirePlanReplayerFileToken(t *testing.T, rows [][]any) string {
 	return token
 }
 
+func hasTiFlashTask(rows [][]any) bool {
+	for _, row := range rows {
+		if len(row) > 2 && strings.Contains(fmt.Sprint(row[2]), "tiflash") {
+			return true
+		}
+	}
+	return false
+}
+
+func requireZipFileContains(t *testing.T, content []byte, fileName, expected string) {
+	reader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+	for _, file := range reader.File {
+		if file.Name != fileName {
+			continue
+		}
+		r, err := file.Open()
+		require.NoError(t, err)
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		require.Contains(t, string(data), expected)
+		return
+	}
+	require.FailNowf(t, "missing file in zip", "file %s not found", fileName)
+}
+
 func TestPlanReplayer(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := context.Background()
@@ -118,6 +146,56 @@ func TestPlanReplayer(t *testing.T) {
 	token := tk.Session().GetSessionVars().LastPlanReplayerToken
 	rows := tk.MustQuery(fmt.Sprintf("select * from mysql.plan_replayer_status where token = '%v'", token)).Rows()
 	require.Len(t, rows, 1)
+}
+
+func TestPlanReplayerLoadTiFlashPlanWithHypoReplica(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+	storage, err := extstore.NewExtStorage(ctx, "file://"+tempDir, "")
+	require.NoError(t, err)
+	extstore.SetGlobalExtStorageForTest(storage)
+	defer func() {
+		extstore.SetGlobalExtStorageForTest(nil)
+		storage.Close()
+	}()
+
+	const mockTiFlashStoreCount = "github.com/pingcap/tidb/pkg/infoschema/mockTiFlashStoreCount"
+	require.NoError(t, failpoint.Enable(mockTiFlashStoreCount, `return(true)`))
+	defer func() {
+		_ = failpoint.Disable(mockTiFlashStoreCount)
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_load_tiflash(a int, b int, index idx_a(a))")
+	tk.MustExec("alter table t_load_tiflash set tiflash replica 1")
+	testkit.SetTiFlashReplica(t, dom, "test", "t_load_tiflash")
+	res := tk.MustQuery("plan replayer dump explain select /*+ read_from_storage(tiflash[t_load_tiflash]) */ * from t_load_tiflash")
+	tiflashFileName := requirePlanReplayerFileToken(t, res.Rows())
+	filePath := filepath.Join(replayer.GetPlanReplayerDirName(), tiflashFileName)
+
+	fileReader, err := storage.Open(ctx, filePath, nil)
+	require.NoError(t, err)
+	content, err := io.ReadAll(fileReader)
+	require.NoError(t, err)
+	require.NoError(t, fileReader.Close())
+	requireZipFileContains(t, content, "explain.txt", "tiflash")
+
+	require.NoError(t, failpoint.Disable(mockTiFlashStoreCount))
+	loadStore := testkit.CreateMockStore(t)
+	loadTK := testkit.NewTestKit(t, loadStore)
+	loadTK.MustExec(fmt.Sprintf("plan replayer load '%s'", strings.ReplaceAll(filepath.Join(tempDir, filePath), "'", "''")))
+	// TestKit executes the SQL marker; clientConn normally completes the local-file
+	// transfer and calls Update, so feed the dumped bytes directly here.
+	loadInfo, ok := loadTK.Session().Value(executor.PlanReplayerLoadVarKey).(*executor.PlanReplayerLoadInfo)
+	require.True(t, ok)
+	defer loadTK.Session().ClearValue(executor.PlanReplayerLoadVarKey)
+	require.NoError(t, loadInfo.Update(content))
+
+	loadTK.MustExec("use test")
+	rows := loadTK.MustQuery("explain select /*+ read_from_storage(tiflash[t_load_tiflash]) */ * from t_load_tiflash").Rows()
+	require.True(t, hasTiFlashTask(rows), rows)
 }
 
 func TestPlanReplayerCaptureSEM(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69641

Problem Summary: planner: plan replayer supports hypo tiflash

### What changed and how does it work?

planner: plan replayer supports hypo tiflash

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan replay for TiFlash replica scenarios by honoring saved replica metadata and adding a fallback when TiFlash resources are missing.
  * Updated stats loading to safely ignore null/empty dumped stats files, aligning with expected “LOAD STATS” behavior.
  * Enhances the reliability of TiFlash-related plan details after restoring saved plans.
* **Tests**
  * Added coverage for TiFlash plan replay with fallback behavior using archived plan replays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->