### PR TITLE
dxf: make max concurrent task configurable

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -782,3 +782,41 @@ curl -X POST "http://{TiDBIP}:10080/test/delete/indexkey/{db}/{table}/{index}?{i
  "table": "t"
 }
 ```
+
+## APIs unique to TiDB-X SYSTEM keyspace
+
+These APIs are registered only on TiDB instances running in the TiDB-X SYSTEM keyspace.
+
+### Get or update the DXF max concurrent task limit
+
+This API gets or updates the process-local maximum number of DXF tasks that can be scheduled concurrently. The value is kept in memory only, is not persisted to TiKV, and is reset when the TiDB process restarts. When updating the value, send the request to the current DXF owner.
+
+Get the current value:
+
+```shell
+curl http://{TiDBIP}:10080/dxf/schedule/max_concurrent_task
+```
+
+Example response:
+
+```json
+{
+ "max_concurrent_task": 16,
+ "persistence": "memory_only"
+}
+```
+
+Update the value:
+
+```shell
+curl -X POST "http://{TiDBIP}:10080/dxf/schedule/max_concurrent_task?value={number}"
+```
+
+`value` must be an integer in the range `[16, 1000]`. The response uses the same format as the `GET` request:
+
+```json
+{
+ "max_concurrent_task": 128,
+ "persistence": "memory_only"
+}
+```

--- a/pkg/dxf/framework/integrationtests/bench_test.go
+++ b/pkg/dxf/framework/integrationtests/bench_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	maxConcurrentTask       = flag.Int("max-concurrent-task", proto.MaxConcurrentTask, "max concurrent task")
+	maxConcurrentTask       = flag.Int("max-concurrent-task", proto.GetMaxConcurrentTask(), "max concurrent task")
 	waitDuration            = flag.Duration("task-wait-duration", 2*time.Minute, "task wait duration")
 	schedulerInterval       = flag.Duration("scheduler-interval", scheduler.CheckTaskFinishedInterval, "scheduler interval")
 	taskExecutorMgrInterval = flag.Duration("task-executor-mgr-interval", taskexecutor.TaskCheckInterval, "task executor mgr interval")
@@ -65,43 +65,43 @@ func BenchmarkSchedulerOverhead(b *testing.B) {
 	}()
 	schIntervalBak := scheduler.CheckTaskFinishedInterval
 	exeMgrIntervalBak := taskexecutor.TaskCheckInterval
-	bak := proto.MaxConcurrentTask
+	restoreMaxConcurrentTask := proto.SetMaxConcurrentTaskForTest(*maxConcurrentTask)
 	b.Cleanup(func() {
-		proto.MaxConcurrentTask = bak
+		restoreMaxConcurrentTask()
 		scheduler.CheckTaskFinishedInterval = schIntervalBak
 		taskexecutor.TaskCheckInterval = exeMgrIntervalBak
 	})
-	proto.MaxConcurrentTask = *maxConcurrentTask
 	scheduler.CheckTaskFinishedInterval = *schedulerInterval
 	taskexecutor.TaskCheckInterval = *taskExecutorMgrInterval
 
-	b.Logf("max concurrent task: %d", proto.MaxConcurrentTask)
+	maxConcurrentTaskValue := proto.GetMaxConcurrentTask()
+	b.Logf("max concurrent task: %d", maxConcurrentTaskValue)
 	b.Logf("taks wait duration: %s", *waitDuration)
 	b.Logf("task meta size: %d", *taskMetaSize)
 	b.Logf("scheduler interval: %s", scheduler.CheckTaskFinishedInterval)
 	b.Logf("task executor mgr interval: %s", taskexecutor.TaskCheckInterval)
 
 	prepareForBenchTest(b)
-	c := testutil.NewTestDXFContext(b, 1, 2*proto.MaxConcurrentTask, false)
+	c := testutil.NewTestDXFContext(b, 1, 2*maxConcurrentTaskValue, false)
 
 	registerTaskTypeForBench(c)
 
 	if *noTask {
 		time.Sleep(*waitDuration)
 	} else {
-		// in this test, we will start 4*proto.MaxConcurrentTask tasks, but only
-		// proto.MaxConcurrentTask will be scheduled at the same time, for other
+		// in this test, we will start 4*maxConcurrentTaskValue tasks, but only
+		// maxConcurrentTaskValue will be scheduled at the same time, for other
 		// tasks will be in queue only to check the performance of querying them.
-		for i := range 4 * proto.MaxConcurrentTask {
+		for i := range 4 * maxConcurrentTaskValue {
 			taskKey := fmt.Sprintf("task-%03d", i)
 			taskMeta := make([]byte, *taskMetaSize)
 			_, err := handle.SubmitTask(c.Ctx, taskKey, proto.TaskTypeExample, c.Store.GetKeyspace(), 1, "", 0, taskMeta)
 			require.NoError(c.T, err)
 		}
 		// task has 2 steps, each step has 1 subtask，wait in serial to reduce WaitTask check overhead.
-		// only wait first proto.MaxConcurrentTask and exit
+		// only wait first maxConcurrentTaskValue and exit
 		time.Sleep(2 * *waitDuration)
-		for i := range proto.MaxConcurrentTask {
+		for i := range maxConcurrentTaskValue {
 			taskKey := fmt.Sprintf("task-%03d", i)
 			testutil.WaitTaskDoneOrPaused(c.Ctx, c.T, taskKey)
 		}

--- a/pkg/dxf/framework/proto/BUILD.bazel
+++ b/pkg/dxf/framework/proto/BUILD.bazel
@@ -26,6 +26,6 @@ go_test(
     ],
     embed = [":proto"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/dxf/framework/proto/task.go
+++ b/pkg/dxf/framework/proto/task.go
@@ -17,6 +17,7 @@ package proto
 import (
 	"cmp"
 	"fmt"
+	"sync/atomic"
 	"time"
 )
 
@@ -83,9 +84,44 @@ const (
 	NormalPriority = 512
 )
 
-// MaxConcurrentTask is the max concurrency of task.
-// TODO: remove this limit later.
-var MaxConcurrentTask = 16
+const (
+	// DefaultMaxConcurrentTask is the default max concurrency of task.
+	DefaultMaxConcurrentTask = 16
+	// MinMaxConcurrentTask is the minimum allowed max concurrency of task.
+	MinMaxConcurrentTask = 16
+	// MaxMaxConcurrentTask is the maximum allowed max concurrency of task.
+	MaxMaxConcurrentTask = 1000
+)
+
+var maxConcurrentTask atomic.Int64
+
+func init() {
+	maxConcurrentTask.Store(DefaultMaxConcurrentTask)
+}
+
+// GetMaxConcurrentTask returns the max concurrency of task.
+func GetMaxConcurrentTask() int {
+	return int(maxConcurrentTask.Load())
+}
+
+// SetMaxConcurrentTask updates the max concurrency of task.
+func SetMaxConcurrentTask(value int) error {
+	if value < MinMaxConcurrentTask || value > MaxMaxConcurrentTask {
+		return fmt.Errorf("max_concurrent_task %d is out of range [%d, %d]",
+			value, MinMaxConcurrentTask, MaxMaxConcurrentTask)
+	}
+	maxConcurrentTask.Store(int64(value))
+	return nil
+}
+
+// SetMaxConcurrentTaskForTest updates the max concurrency of task and returns a restore function.
+func SetMaxConcurrentTaskForTest(value int) func() {
+	old := GetMaxConcurrentTask()
+	maxConcurrentTask.Store(int64(value))
+	return func() {
+		maxConcurrentTask.Store(int64(old))
+	}
+}
 
 // ExtraParams is the extra params of task.
 // Note: only store params that's not used for filter or sort in this struct.

--- a/pkg/dxf/framework/proto/task.go
+++ b/pkg/dxf/framework/proto/task.go
@@ -85,14 +85,21 @@ const (
 )
 
 const (
-	// DefaultMaxConcurrentTask is the default max concurrency of task.
-	DefaultMaxConcurrentTask = 16
-	// MinMaxConcurrentTask is the minimum allowed max concurrency of task.
-	MinMaxConcurrentTask = 16
-	// MaxMaxConcurrentTask is the maximum allowed max concurrency of task.
-	MaxMaxConcurrentTask = 1000
+	// maxConcurrentTaskLowerBound is the minimum allowed DXF task concurrency.
+	maxConcurrentTaskLowerBound = 16
+	// MaxConcurrentTaskUpperBound is the current safety cap for DXF task concurrency.
+	// TODO: remove this cap after the DXF scheduler no longer runs all schedulers on the owner node.
+	MaxConcurrentTaskUpperBound = 1000
+	// DefaultMaxConcurrentTask is the default DXF task concurrency.
+	DefaultMaxConcurrentTask = maxConcurrentTaskLowerBound
 )
 
+// maxConcurrentTask is an owner-local emergency tuning knob for DXF scheduling.
+// It is intentionally kept in memory only: it is not persisted to TiKV, is reset
+// on restart, and only affects the TiDB node that receives the update. Operators
+// should change it through the DXF owner node when many small tasks are blocked
+// by the default limit. Raising it increases scheduler overhead and memory usage
+// on the owner, so the owner node may need a larger resource spec first.
 var maxConcurrentTask atomic.Int64
 
 func init() {
@@ -106,9 +113,9 @@ func GetMaxConcurrentTask() int {
 
 // SetMaxConcurrentTask updates the max concurrency of task.
 func SetMaxConcurrentTask(value int) error {
-	if value < MinMaxConcurrentTask || value > MaxMaxConcurrentTask {
+	if value < maxConcurrentTaskLowerBound || value > MaxConcurrentTaskUpperBound {
 		return fmt.Errorf("max_concurrent_task %d is out of range [%d, %d]",
-			value, MinMaxConcurrentTask, MaxMaxConcurrentTask)
+			value, maxConcurrentTaskLowerBound, MaxConcurrentTaskUpperBound)
 	}
 	maxConcurrentTask.Store(int64(value))
 	return nil

--- a/pkg/dxf/framework/proto/task_test.go
+++ b/pkg/dxf/framework/proto/task_test.go
@@ -79,16 +79,16 @@ func TestMaxConcurrentTask(t *testing.T) {
 	defer restore()
 
 	require.Equal(t, DefaultMaxConcurrentTask, GetMaxConcurrentTask())
-	require.Equal(t, 1000, MaxMaxConcurrentTask)
-	for _, value := range []int{MinMaxConcurrentTask - 1, MaxMaxConcurrentTask + 1} {
+	require.Equal(t, 1000, MaxConcurrentTaskUpperBound)
+	for _, value := range []int{maxConcurrentTaskLowerBound - 1, MaxConcurrentTaskUpperBound + 1} {
 		require.Error(t, SetMaxConcurrentTask(value))
 		require.Equal(t, DefaultMaxConcurrentTask, GetMaxConcurrentTask())
 	}
 
 	require.NoError(t, SetMaxConcurrentTask(128))
 	require.Equal(t, 128, GetMaxConcurrentTask())
-	require.NoError(t, SetMaxConcurrentTask(MaxMaxConcurrentTask))
-	require.Equal(t, MaxMaxConcurrentTask, GetMaxConcurrentTask())
+	require.NoError(t, SetMaxConcurrentTask(MaxConcurrentTaskUpperBound))
+	require.Equal(t, MaxConcurrentTaskUpperBound, GetMaxConcurrentTask())
 }
 
 func TestTaskCompare(t *testing.T) {

--- a/pkg/dxf/framework/proto/task_test.go
+++ b/pkg/dxf/framework/proto/task_test.go
@@ -74,6 +74,23 @@ func TestTaskIsDone(t *testing.T) {
 	}
 }
 
+func TestMaxConcurrentTask(t *testing.T) {
+	restore := SetMaxConcurrentTaskForTest(DefaultMaxConcurrentTask)
+	defer restore()
+
+	require.Equal(t, DefaultMaxConcurrentTask, GetMaxConcurrentTask())
+	require.Equal(t, 1000, MaxMaxConcurrentTask)
+	for _, value := range []int{MinMaxConcurrentTask - 1, MaxMaxConcurrentTask + 1} {
+		require.Error(t, SetMaxConcurrentTask(value))
+		require.Equal(t, DefaultMaxConcurrentTask, GetMaxConcurrentTask())
+	}
+
+	require.NoError(t, SetMaxConcurrentTask(128))
+	require.Equal(t, 128, GetMaxConcurrentTask())
+	require.NoError(t, SetMaxConcurrentTask(MaxMaxConcurrentTask))
+	require.Equal(t, MaxMaxConcurrentTask, GetMaxConcurrentTask())
+}
+
 func TestTaskCompare(t *testing.T) {
 	taskA := Task{TaskBase: TaskBase{
 		ID:         100,

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -27,7 +27,7 @@ import (
 
 // TaskManager defines the interface to access task table.
 type TaskManager interface {
-	// GetTopUnfinishedTasks returns unfinished tasks, limited by MaxConcurrentTask*2,
+	// GetTopUnfinishedTasks returns unfinished tasks, limited by GetMaxConcurrentTask()*2,
 	// to make sure low ranking tasks can be scheduled if resource is enough.
 	// The returned tasks are sorted by task order, see proto.Task.
 	GetTopUnfinishedTasks(ctx context.Context) ([]*proto.TaskBase, error)

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -154,8 +154,11 @@ func NewManager(ctx context.Context, store kv.Storage, taskMgr TaskManager, serv
 			slotMgr:  slotMgr,
 			serverID: serverID,
 		}),
-		logger:   logger,
-		finishCh: make(chan struct{}, proto.MaxMaxConcurrentTask),
+		logger: logger,
+		// finishCh must be able to buffer finish signals for the largest runtime
+		// value of maxConcurrentTask. Otherwise, raising the limit after startup
+		// can make non-blocking sends drop signals until the periodic cleanup loop runs.
+		finishCh: make(chan struct{}, proto.MaxConcurrentTaskUpperBound),
 		nodeRes:  nodeRes,
 	}
 	schedulerManager.mu.schedulerMap = make(map[int64]Scheduler)

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -155,7 +155,7 @@ func NewManager(ctx context.Context, store kv.Storage, taskMgr TaskManager, serv
 			serverID: serverID,
 		}),
 		logger:   logger,
-		finishCh: make(chan struct{}, proto.MaxConcurrentTask),
+		finishCh: make(chan struct{}, proto.MaxMaxConcurrentTask),
 		nodeRes:  nodeRes,
 	}
 	schedulerManager.mu.schedulerMap = make(map[int64]Scheduler)
@@ -244,7 +244,8 @@ func (sm *Manager) getSchedulableTasks(ctx context.Context) ([]*proto.TaskBase, 
 	defer r.End()
 	getTasksFn := sm.taskMgr.GetTopUnfinishedTasks
 	taskCnt := sm.getSchedulerCount()
-	if taskCnt >= proto.MaxConcurrentTask {
+	maxConcurrentTask := proto.GetMaxConcurrentTask()
+	if taskCnt >= maxConcurrentTask {
 		// when we have reached the limit of concurrent tasks, we only handle
 		// tasks in states that don't need resources, e.g. reverting/cancelling/
 		// pausing/modifying.
@@ -291,7 +292,7 @@ func (sm *Manager) startSchedulers(schedulableTasks []*proto.TaskBase) error {
 		switch task.State {
 		case proto.TaskStatePending, proto.TaskStateRunning, proto.TaskStateResuming:
 			taskCnt := sm.getSchedulerCount()
-			if taskCnt >= proto.MaxConcurrentTask {
+			if taskCnt >= proto.GetMaxConcurrentTask() {
 				continue
 			}
 			reservedExecID, ok = sm.slotMgr.canReserve(task)

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -363,11 +363,7 @@ func TestStartSchedulerCrossKeyspaceRuntime(t *testing.T) {
 }
 
 func TestFastRespondNoNeedResourceTaskWhenSchedulersReachLimit(t *testing.T) {
-	bak := proto.MaxConcurrentTask
-	t.Cleanup(func() {
-		proto.MaxConcurrentTask = bak
-	})
-	proto.MaxConcurrentTask = 1
+	t.Cleanup(proto.SetMaxConcurrentTaskForTest(1))
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/dxf/framework/scheduler/scheduler_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_test.go
@@ -166,10 +166,9 @@ func checkSchedule(t *testing.T, taskCnt int, isSucc, isCancel, isSubtaskCancel,
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
 	// test scheduleTaskLoop
 	// test parallelism control
-	var originalConcurrency int
+	restoreMaxConcurrentTask := func() {}
 	if taskCnt == 1 {
-		originalConcurrency = proto.MaxConcurrentTask
-		proto.MaxConcurrentTask = 1
+		restoreMaxConcurrentTask = proto.SetMaxConcurrentTaskForTest(1)
 	}
 
 	store := testkit.CreateMockStore(t)
@@ -190,10 +189,7 @@ func checkSchedule(t *testing.T, taskCnt int, isSucc, isCancel, isSubtaskCancel,
 	sch.Start()
 	defer func() {
 		sch.Stop()
-		// make data race happy
-		if taskCnt == 1 {
-			proto.MaxConcurrentTask = originalConcurrency
-		}
+		restoreMaxConcurrentTask()
 	}()
 
 	// 3s

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -550,21 +550,24 @@ func TestGetTopUnfinishedTasks(t *testing.T) {
 	require.Len(t, tasks, 8)
 	require.Equal(t, []string{"key/6", "key/5", "key/1", "key/2", "key/3", "key/4", "key/8", "key/9"}, getTaskKeys(tasks))
 
-	proto.SetMaxConcurrentTaskForTest(6)
+	restoreMaxConcurrentTask := proto.SetMaxConcurrentTaskForTest(6)
 	tasks, err = gm.GetTopUnfinishedTasks(ctx)
 	require.NoError(t, err)
 	require.Len(t, tasks, 11)
 	require.Equal(t, []string{"key/6", "key/5", "key/1", "key/2", "key/3", "key/4", "key/8", "key/9", "key/10", "key/11", "key/12"}, getTaskKeys(tasks))
+	restoreMaxConcurrentTask()
 
-	proto.SetMaxConcurrentTaskForTest(3)
+	restoreMaxConcurrentTask = proto.SetMaxConcurrentTaskForTest(3)
 	tasks, err = gm.GetTopNoNeedResourceTasks(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"key/5", "key/3", "key/4", "key/12"}, getTaskKeys(tasks))
+	restoreMaxConcurrentTask()
 
-	proto.SetMaxConcurrentTaskForTest(1)
+	restoreMaxConcurrentTask = proto.SetMaxConcurrentTaskForTest(1)
 	tasks, err = gm.GetTopNoNeedResourceTasks(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"key/5", "key/3"}, getTaskKeys(tasks))
+	restoreMaxConcurrentTask()
 }
 
 func TestGetUsedSlotsOnNodesAndBusyNodes(t *testing.T) {

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -485,11 +485,7 @@ func TestSwitchTaskStepInBatch(t *testing.T) {
 func TestGetTopUnfinishedTasks(t *testing.T) {
 	_, gm, ctx := testutil.InitTableTest(t)
 
-	bak := proto.MaxConcurrentTask
-	t.Cleanup(func() {
-		proto.MaxConcurrentTask = bak
-	})
-	proto.MaxConcurrentTask = 4
+	t.Cleanup(proto.SetMaxConcurrentTaskForTest(4))
 	require.NoError(t, gm.InitMeta(ctx, ":4000", ""))
 	taskStates := []proto.TaskState{
 		proto.TaskStateSucceed,
@@ -554,18 +550,18 @@ func TestGetTopUnfinishedTasks(t *testing.T) {
 	require.Len(t, tasks, 8)
 	require.Equal(t, []string{"key/6", "key/5", "key/1", "key/2", "key/3", "key/4", "key/8", "key/9"}, getTaskKeys(tasks))
 
-	proto.MaxConcurrentTask = 6
+	proto.SetMaxConcurrentTaskForTest(6)
 	tasks, err = gm.GetTopUnfinishedTasks(ctx)
 	require.NoError(t, err)
 	require.Len(t, tasks, 11)
 	require.Equal(t, []string{"key/6", "key/5", "key/1", "key/2", "key/3", "key/4", "key/8", "key/9", "key/10", "key/11", "key/12"}, getTaskKeys(tasks))
 
-	proto.MaxConcurrentTask = 3
+	proto.SetMaxConcurrentTaskForTest(3)
 	tasks, err = gm.GetTopNoNeedResourceTasks(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"key/5", "key/3", "key/4", "key/12"}, getTaskKeys(tasks))
 
-	proto.MaxConcurrentTask = 1
+	proto.SetMaxConcurrentTaskForTest(1)
 	tasks, err = gm.GetTopNoNeedResourceTasks(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"key/5", "key/3"}, getTaskKeys(tasks))

--- a/pkg/dxf/framework/storage/task_table.go
+++ b/pkg/dxf/framework/storage/task_table.go
@@ -364,7 +364,7 @@ func (mgr *TaskManager) getTopTasks(ctx context.Context, states ...proto.TaskSta
 	for _, s := range states {
 		args = append(args, s)
 	}
-	args = append(args, proto.MaxConcurrentTask*2)
+	args = append(args, proto.GetMaxConcurrentTask()*2)
 	rs, err := mgr.ExecuteSQLWithNewSession(ctx, sql, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/server/handler/tests/dxf_test.go
+++ b/pkg/server/handler/tests/dxf_test.go
@@ -149,17 +149,28 @@ func TestDXFAPI(t *testing.T) {
 	t.Run("max concurrent task api", func(t *testing.T) {
 		restore := proto.SetMaxConcurrentTaskForTest(proto.DefaultMaxConcurrentTask)
 		defer restore()
+		const maxConcurrentTaskPath = "/dxf/schedule/max_concurrent_task"
+		checkMaxConcurrentTaskOutput := func(body []byte, expected int) {
+			out := struct {
+				MaxConcurrentTask int    `json:"max_concurrent_task"`
+				Persistence       string `json:"persistence"`
+			}{}
+			require.NoError(t, json.Unmarshal(body, &out))
+			require.Equal(t, expected, out.MaxConcurrentTask)
+			require.Equal(t, "memory_only", out.Persistence)
+			require.NotContains(t, string(body), "scope")
+		}
 
 		runAndCheckReqFn(t, http.StatusBadRequest, "This api only support GET and POST method", func() (*http.Response, error) {
-			req, err := http.NewRequest(http.MethodDelete, ts.StatusURL("/dxf/task/max_concurrent"), nil)
+			req, err := http.NewRequest(http.MethodDelete, ts.StatusURL(maxConcurrentTaskPath), nil)
 			require.NoError(t, err)
 			return http.DefaultClient.Do(req)
 		})
 		for _, c := range [][2]string{
-			{"/dxf/task/max_concurrent", "invalid value "},
-			{"/dxf/task/max_concurrent?value=aa", "invalid value "},
-			{"/dxf/task/max_concurrent?value=15", "out of range"},
-			{fmt.Sprintf("/dxf/task/max_concurrent?value=%d", proto.MaxMaxConcurrentTask+1), "out of range"},
+			{maxConcurrentTaskPath, "invalid value "},
+			{maxConcurrentTaskPath + "?value=aa", "invalid value "},
+			{maxConcurrentTaskPath + "?value=15", "out of range"},
+			{fmt.Sprintf("%s?value=%d", maxConcurrentTaskPath, proto.MaxConcurrentTaskUpperBound+1), "out of range"},
 		} {
 			path, errMsg := c[0], c[1]
 			runAndCheckReqFn(t, http.StatusBadRequest, errMsg, func() (*http.Response, error) {
@@ -168,26 +179,20 @@ func TestDXFAPI(t *testing.T) {
 		}
 
 		body := runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
-			return ts.FetchStatus("/dxf/task/max_concurrent")
+			return ts.FetchStatus(maxConcurrentTaskPath)
 		})
-		out := struct {
-			MaxConcurrentTask int `json:"max_concurrent_task"`
-		}{}
-		require.NoError(t, json.Unmarshal(body, &out))
-		require.Equal(t, proto.DefaultMaxConcurrentTask, out.MaxConcurrentTask)
+		checkMaxConcurrentTaskOutput(body, proto.DefaultMaxConcurrentTask)
 
 		body = runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
-			return ts.PostStatus("/dxf/task/max_concurrent?value=128", "", bytes.NewBuffer([]byte("")))
+			return ts.PostStatus(maxConcurrentTaskPath+"?value=128", "", bytes.NewBuffer([]byte("")))
 		})
-		require.NoError(t, json.Unmarshal(body, &out))
-		require.Equal(t, 128, out.MaxConcurrentTask)
+		checkMaxConcurrentTaskOutput(body, 128)
 		require.Equal(t, 128, proto.GetMaxConcurrentTask())
 
 		body = runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
-			return ts.FetchStatus("/dxf/task/max_concurrent")
+			return ts.FetchStatus(maxConcurrentTaskPath)
 		})
-		require.NoError(t, json.Unmarshal(body, &out))
-		require.Equal(t, 128, out.MaxConcurrentTask)
+		checkMaxConcurrentTaskOutput(body, 128)
 	})
 
 	t.Run("task history api", func(t *testing.T) {

--- a/pkg/server/handler/tests/dxf_test.go
+++ b/pkg/server/handler/tests/dxf_test.go
@@ -146,6 +146,50 @@ func TestDXFAPI(t *testing.T) {
 		require.EqualValues(t, 2, out.PerKeyspace["ks1"])
 	})
 
+	t.Run("max concurrent task api", func(t *testing.T) {
+		restore := proto.SetMaxConcurrentTaskForTest(proto.DefaultMaxConcurrentTask)
+		defer restore()
+
+		runAndCheckReqFn(t, http.StatusBadRequest, "This api only support GET and POST method", func() (*http.Response, error) {
+			req, err := http.NewRequest(http.MethodDelete, ts.StatusURL("/dxf/task/max_concurrent"), nil)
+			require.NoError(t, err)
+			return http.DefaultClient.Do(req)
+		})
+		for _, c := range [][2]string{
+			{"/dxf/task/max_concurrent", "invalid value "},
+			{"/dxf/task/max_concurrent?value=aa", "invalid value "},
+			{"/dxf/task/max_concurrent?value=15", "out of range"},
+			{fmt.Sprintf("/dxf/task/max_concurrent?value=%d", proto.MaxMaxConcurrentTask+1), "out of range"},
+		} {
+			path, errMsg := c[0], c[1]
+			runAndCheckReqFn(t, http.StatusBadRequest, errMsg, func() (*http.Response, error) {
+				return ts.PostStatus(path, "", bytes.NewBuffer([]byte("")))
+			})
+		}
+
+		body := runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
+			return ts.FetchStatus("/dxf/task/max_concurrent")
+		})
+		out := struct {
+			MaxConcurrentTask int `json:"max_concurrent_task"`
+		}{}
+		require.NoError(t, json.Unmarshal(body, &out))
+		require.Equal(t, proto.DefaultMaxConcurrentTask, out.MaxConcurrentTask)
+
+		body = runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
+			return ts.PostStatus("/dxf/task/max_concurrent?value=128", "", bytes.NewBuffer([]byte("")))
+		})
+		require.NoError(t, json.Unmarshal(body, &out))
+		require.Equal(t, 128, out.MaxConcurrentTask)
+		require.Equal(t, 128, proto.GetMaxConcurrentTask())
+
+		body = runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
+			return ts.FetchStatus("/dxf/task/max_concurrent")
+		})
+		require.NoError(t, json.Unmarshal(body, &out))
+		require.Equal(t, 128, out.MaxConcurrentTask)
+	})
+
 	t.Run("task history api", func(t *testing.T) {
 		seedHistoryTasks := func(t *testing.T) []int64 {
 			t.Helper()

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -352,12 +352,15 @@ func NewDXFTaskMaxConcurrentHandler() *DXFTaskMaxConcurrentHandler {
 	return &DXFTaskMaxConcurrentHandler{}
 }
 
+// ServeHTTP implements http.Handler interface.
+//
+// The configured value is local to the TiDB process that handles the request
+// and is kept in memory only. Send the request to the current DXF owner when
+// tuning scheduler concurrency.
 func (*DXFTaskMaxConcurrentHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodGet:
-		handler.WriteData(w, map[string]any{
-			"max_concurrent_task": proto.GetMaxConcurrentTask(),
-		})
+		writeMaxConcurrentTask(w)
 	case http.MethodPost:
 		valueStr := req.FormValue("value")
 		value, err := strconv.Atoi(valueStr)
@@ -369,13 +372,18 @@ func (*DXFTaskMaxConcurrentHandler) ServeHTTP(w http.ResponseWriter, req *http.R
 			handler.WriteError(w, err)
 			return
 		}
-		logutil.BgLogger().Info("set DXF max concurrent task", zap.Int("maxConcurrentTask", value))
-		handler.WriteData(w, map[string]any{
-			"max_concurrent_task": proto.GetMaxConcurrentTask(),
-		})
+		logutil.BgLogger().Info("set in-memory DXF max concurrent task", zap.Int("maxConcurrentTask", value))
+		writeMaxConcurrentTask(w)
 	default:
 		handler.WriteError(w, errors.Errorf("This api only support GET and POST method"))
 	}
+}
+
+func writeMaxConcurrentTask(w http.ResponseWriter) {
+	handler.WriteData(w, map[string]any{
+		"max_concurrent_task": proto.GetMaxConcurrentTask(),
+		"persistence":         "memory_only",
+	})
 }
 
 // DXFTaskMaxRuntimeSlotsHandler handles changing max runtime slots of DXF task.

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -344,6 +344,40 @@ func (h *DXFScheduleTuneHandler) ServeHTTP(w http.ResponseWriter, req *http.Requ
 	}
 }
 
+// DXFTaskMaxConcurrentHandler handles the in-memory DXF task concurrency limit.
+type DXFTaskMaxConcurrentHandler struct{}
+
+// NewDXFTaskMaxConcurrentHandler creates a new DXFTaskMaxConcurrentHandler.
+func NewDXFTaskMaxConcurrentHandler() *DXFTaskMaxConcurrentHandler {
+	return &DXFTaskMaxConcurrentHandler{}
+}
+
+func (*DXFTaskMaxConcurrentHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case http.MethodGet:
+		handler.WriteData(w, map[string]any{
+			"max_concurrent_task": proto.GetMaxConcurrentTask(),
+		})
+	case http.MethodPost:
+		valueStr := req.FormValue("value")
+		value, err := strconv.Atoi(valueStr)
+		if err != nil {
+			handler.WriteError(w, errors.Errorf("invalid value %s, error %v", valueStr, err))
+			return
+		}
+		if err := proto.SetMaxConcurrentTask(value); err != nil {
+			handler.WriteError(w, err)
+			return
+		}
+		logutil.BgLogger().Info("set DXF max concurrent task", zap.Int("maxConcurrentTask", value))
+		handler.WriteData(w, map[string]any{
+			"max_concurrent_task": proto.GetMaxConcurrentTask(),
+		})
+	default:
+		handler.WriteError(w, errors.Errorf("This api only support GET and POST method"))
+	}
+}
+
 // DXFTaskMaxRuntimeSlotsHandler handles changing max runtime slots of DXF task.
 type DXFTaskMaxRuntimeSlotsHandler struct{}
 

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -255,7 +255,8 @@ func (s *Server) startHTTPServer() {
 		router.Handle("/dxf/schedule/tune", tikvhandler.NewDXFScheduleTuneHandler(tikvHandlerTool.Store.(kv.Storage))).Name("DXF_Schedule_Tune")
 		router.Handle("/dxf/task/active", tikvhandler.NewDXFActiveTaskHandler()).Name("DXF_Task_Active")
 		router.Handle("/dxf/task/history", tikvhandler.NewDXFTaskHistoryHandler()).Name("DXF_Task_History")
-		router.Handle("/dxf/task/max_concurrent", tikvhandler.NewDXFTaskMaxConcurrentHandler()).Name("DXF_Task_Max_Concurrent")
+		// This API updates only the TiDB process that handles the request and is not persisted.
+		router.Handle("/dxf/schedule/max_concurrent_task", tikvhandler.NewDXFTaskMaxConcurrentHandler()).Name("DXF_Schedule_Max_Concurrent_Task")
 		router.Handle("/dxf/import-into/history/job/{keyspace}/{job_id}", tikvhandler.NewDXFImportIntoHistoryJobInfoHandler()).Name("DXF_Import_Into_History_Job_Info")
 		router.Handle("/dxf/task/{taskID}/max_runtime_slots", tikvhandler.NewDXFTaskMaxRuntimeSlotsHandler()).Name("DXF_Task_Max_Runtime_Slots")
 	}

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -255,6 +255,7 @@ func (s *Server) startHTTPServer() {
 		router.Handle("/dxf/schedule/tune", tikvhandler.NewDXFScheduleTuneHandler(tikvHandlerTool.Store.(kv.Storage))).Name("DXF_Schedule_Tune")
 		router.Handle("/dxf/task/active", tikvhandler.NewDXFActiveTaskHandler()).Name("DXF_Task_Active")
 		router.Handle("/dxf/task/history", tikvhandler.NewDXFTaskHistoryHandler()).Name("DXF_Task_History")
+		router.Handle("/dxf/task/max_concurrent", tikvhandler.NewDXFTaskMaxConcurrentHandler()).Name("DXF_Task_Max_Concurrent")
 		router.Handle("/dxf/import-into/history/job/{keyspace}/{job_id}", tikvhandler.NewDXFImportIntoHistoryJobInfoHandler()).Name("DXF_Import_Into_History_Job_Info")
 		router.Handle("/dxf/task/{taskID}/max_runtime_slots", tikvhandler.NewDXFTaskMaxRuntimeSlotsHandler()).Name("DXF_Task_Max_Runtime_Slots")
 	}

--- a/tests/realtikvtest/addindextest1/disttask_test.go
+++ b/tests/realtikvtest/addindextest1/disttask_test.go
@@ -590,7 +590,7 @@ func TestAddIndexScheduleAway(t *testing.T) {
 }
 
 func TestAddIndexDistCleanUpBlock(t *testing.T) {
-	proto.MaxConcurrentTask = 1
+	t.Cleanup(proto.SetMaxConcurrentTaskForTest(1))
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", `return(1)`)
 	ch := make(chan struct{})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/dxf/framework/scheduler/doCleanupTask", func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702, #67640

Problem Summary:

DXF service runs in the SYSTEM keyspace for nextgen clusters and shares a resource pool across user keyspaces. The framework-wide max concurrent task limit was a fixed in-memory package variable, which made the limit hard to tune when many small tasks were blocked by the default scheduler concurrency.

### What changed and how does it work?

This PR makes the DXF max concurrent task limit atomically configurable in memory:

- Replaces the plain `proto.MaxConcurrentTask` global with atomic-backed helpers.
- Keeps the default and lower bound at `16`, caps runtime updates at `1000`, and keeps the upper cap available for scheduler buffer sizing.
- Adds `GET /dxf/schedule/max_concurrent_task` and `POST /dxf/schedule/max_concurrent_task?value=<n>` under the existing SYSTEM-keyspace DXF HTTP route block.
- Returns the current value with `persistence: "memory_only"` so callers know the update is not persisted.
- Updates scheduler and storage paths to read the limit through atomic loads.
- Documents the process-local tuning contract and the `finishCh` capacity invariant.
- Keeps test-only override support for existing low-limit scheduler tests and avoids discard-only restore calls in storage tests.

The value is intentionally not persisted in this first version; it only changes the in-memory value of the TiDB process receiving the HTTP request. Operators should send the request to the current DXF owner when tuning scheduler concurrency.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test details:

- `go test -run TestMaxConcurrentTask -tags=intest,deadlock -count=1 ./pkg/dxf/framework/proto`
- `./tools/check/failpoint-go-test.sh pkg/server/handler/tests -run 'TestDXFAPI/max.*concurrent.*task.*api' -count=1 -tags=intest,deadlock,nextgen`
- `./tools/check/failpoint-go-test.sh pkg/dxf/framework/storage -run TestGetTopUnfinishedTasks -count=1`
- `./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run '^$' -count=1`
- `make lint`
- `git diff --check`
- `git diff --cached --check`
- `make bazel_prepare` was not required: no Go files were added, removed, renamed, or moved; no Go import sections changed; no Bazel or module files changed; and no new top-level Go test function was added.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add `/dxf/schedule/max_concurrent_task` to configure the process-local, in-memory DXF max concurrent task limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to view and update the maximum number of concurrent tasks at runtime.
  * Exposed an HTTP endpoint to manage the concurrency limit.
* **Bug Fixes**
  * Scheduler and task queries now consistently use the current concurrency setting.
  * Enforced validated bounds when updating the limit.
* **Documentation**
  * Documented the TiDB-X SYSTEM keyspace HTTP endpoints for getting and setting the max-concurrent task limit.
* **Tests**
  * Expanded unit and API tests to cover default values, validation errors, and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
