### PR TITLE
executor: allow canceling import job without dxf task

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -431,6 +431,7 @@ go_test(
         "//pkg/domain",
         "//pkg/domain/affinity",
         "//pkg/domain/infosync",
+        "//pkg/dxf/framework/storage",
         "//pkg/dxf/importinto",
         "//pkg/errctx",
         "//pkg/errno",

--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -16,6 +16,7 @@ package executor
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -399,11 +400,31 @@ func cancelAndWaitImportJob(ctx context.Context, jobID int64) error {
 	if err != nil {
 		return err
 	}
+	taskKey := importinto.TaskKey(jobID)
 	if err := manager.WithNewTxn(ctx, func(se sessionctx.Context) error {
 		ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
-		return manager.CancelTaskByKeySession(ctx, se, importinto.TaskKey(jobID))
+		return manager.CancelTaskByKeySession(ctx, se, taskKey)
 	}); err != nil {
 		return err
 	}
-	return handle.WaitTaskDoneByKey(ctx, importinto.TaskKey(jobID))
+	if err := handle.WaitTaskDoneByKey(ctx, taskKey); err != nil {
+		if goerrors.Is(err, dxfstorage.ErrTaskNotFound) {
+			logutil.Logger(ctx).Info("cancel import job directly because dxf task is not found",
+				zap.Int64("jobID", jobID),
+				zap.String("taskKey", taskKey))
+			return cancelImportJobOnly(ctx, jobID)
+		}
+		return err
+	}
+	return nil
+}
+
+func cancelImportJobOnly(ctx context.Context, jobID int64) error {
+	manager, err := dxfstorage.GetTaskManager()
+	if err != nil {
+		return err
+	}
+	return manager.WithNewTxn(ctx, func(se sessionctx.Context) error {
+		return importer.CancelJob(ctx, se.GetSQLExecutor(), jobID)
+	})
 }

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -39,6 +40,7 @@ import (
 	semv1 "github.com/pingcap/tidb/pkg/util/sem"
 	semv2 "github.com/pingcap/tidb/pkg/util/sem/v2"
 	"github.com/stretchr/testify/require"
+	tikvutil "github.com/tikv/client-go/v2/util"
 )
 
 var (
@@ -237,6 +239,26 @@ func TestNextGenUnsupportedLocalSortAndOptions(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestCancelImportJobWithoutDXFTask(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	ctx := tikvutil.WithInternalSourceType(context.Background(), kv.InternalDistTask)
+	manager, err := storage.GetTaskManager()
+	require.NoError(t, err)
+	require.NoError(t, manager.InitMeta(ctx, ":4000", ""))
+
+	jobID, err := importer.CreateJob(ctx, tk.Session().GetSQLExecutor(), "test", "t", 1,
+		tk.Session().GetSessionVars().User.String(), "", &importer.ImportParameters{
+			Format: importer.DataFormatCSV,
+		}, 0)
+	require.NoError(t, err)
+
+	tk.MustExec(fmt.Sprintf("cancel import job %d", jobID))
+	tk.MustQuery("select status, error_message from mysql.tidb_import_jobs where id = ?", jobID).
+		Check(testkit.Rows("cancelled cancelled by user"))
 }
 
 func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, initFn func(t *testing.T, tk *testkit.TestKit)) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #61702

Problem Summary:

In nextgen user keyspace, IMPORT INTO creates the import job row before submitting the corresponding DXF task in a separate transaction. If the submission fails after the import job is created but before the DXF task is created, `CANCEL IMPORT JOB` fails with `task not found` and leaves the import job active.

### What changed and how does it work?

When canceling an import job, keep the normal DXF task cancellation path. If waiting by the import task key reports `storage.ErrTaskNotFound`, treat it as the orphaned pre-DXF-submit case and update the import job state directly with `importer.CancelJob`.

A regression test creates an import job without a matching DXF task and verifies `CANCEL IMPORT JOB` marks the job as `cancelled`.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix `CANCEL IMPORT JOB` for import jobs whose DXF task was not submitted successfully.
```

### Tests

```bash
./tools/check/failpoint-go-test.sh pkg/executor -run TestCancelImportJobWithoutDXFTask -count=1
make bazel_prepare
make lint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import job cancellation so it still completes even if the related distributed task is missing.
  * Added a fallback path that cancels the import job directly and reports a clearer cancellation outcome.

* **Tests**
  * Added coverage for cancelling an import job when the related distributed task cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->