### PR TITLE
planner: recheck LIKE/ILIKE with a non-default ESCAPE on memtable scans

### DIFF
--- a/pkg/executor/memtable_reader_test.go
+++ b/pkg/executor/memtable_reader_test.go
@@ -896,6 +896,30 @@ func TestTiDBClusterLog(t *testing.T) {
 			expected: [][]string{},
 		},
 		{
+			// ILIKE is pushed down as a case-insensitive prefilter, so an uppercase
+			// pattern still matches a lowercase message through the remote search.
+			// This also covers the retriever guard: a query whose only message
+			// filter is ILIKE must still produce a pattern, otherwise the scan is
+			// rejected with "denied to scan full logs".
+			conditions: []string{
+				"time>='2019/08/26 06:22:17.011'",
+				"time<='2019/08/26 06:22:17.011'",
+				"message ilike '%FOO%'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+			},
+		},
+		{
+			// The prefilter plus the retained scalar recheck must not over-match.
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+				"time<='2019/08/26 06:28:19.011'",
+				"message ilike '%NoSuchMessage%'",
+			},
+			expected: [][]string{},
+		},
+		{
 			conditions: []string{
 				"time>='2019/08/26 06:18:13.011'",
 				"time<='2019/08/26 06:28:19.011'",

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -459,6 +459,14 @@ func (helper extractHelper) extractLikePattern(
 	case ast.EQ:
 		return true, "^" + regexp.QuoteMeta(datums[0].GetString()) + "$"
 	case ast.Like, ast.Ilike:
+		// The extracted pattern is compiled with the default escape ('\') by
+		// stringutil.CompileLike2Regexp, so a non-default ESCAPE would make the
+		// pushed-down pattern diverge from the original predicate. Only build a
+		// pattern when the escape is the default; otherwise skip extraction so
+		// the scalar predicate is kept and rechecked (issue #69653).
+		if !likeEscapeIsDefault(fn) {
+			return false, ""
+		}
 		if needLike2Regexp {
 			return true, stringutil.CompileLike2Regexp(datums[0].GetString())
 		}
@@ -468,6 +476,23 @@ func (helper extractHelper) extractLikePattern(
 	default:
 		return false, ""
 	}
+}
+
+// likeEscapeIsDefault reports whether the ESCAPE argument of a LIKE/ILIKE
+// ScalarFunction is the default backslash escape. Only then is it safe to
+// compile the pattern with stringutil.CompileLike2Regexp, which hardcodes '\'
+// as the escape. A non-default (or non-constant) escape must fall back to a
+// scalar recheck instead of being pushed down. See issue #69653.
+func likeEscapeIsDefault(fn *expression.ScalarFunction) bool {
+	args := fn.GetArgs()
+	if len(args) < 3 {
+		return false
+	}
+	escape, ok := args[2].(*expression.Constant)
+	if !ok || escape.DeferredExpr != nil || escape.ParamMarker != nil {
+		return false
+	}
+	return escape.Value.GetInt64() == int64('\\')
 }
 
 func (extractHelper) findColumn(schema *expression.Schema, names []*types.FieldName, colName string) map[int64]*types.FieldName {

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -459,16 +459,18 @@ func (helper extractHelper) extractLikePattern(
 	case ast.EQ:
 		return true, "^" + regexp.QuoteMeta(datums[0].GetString()) + "$"
 	case ast.Like, ast.Ilike:
-		// The extracted pattern is compiled with the default escape ('\') by
-		// stringutil.CompileLike2Regexp, so a non-default ESCAPE would make the
-		// pushed-down pattern diverge from the original predicate. Only build a
-		// pattern when the escape is the default; otherwise skip extraction so
-		// the scalar predicate is kept and rechecked (issue #69653).
-		if !likeEscapeIsDefault(fn) {
+		// The pushed-down pattern must honour the LIKE ESCAPE so it does not
+		// diverge from the original predicate (issue #69653). The escape has to
+		// be resolvable at plan time: for a constant escape (including the
+		// default '\' and the empty escape of NO_BACKSLASH_ESCAPES) we compile
+		// the regexp with it; a non-constant/deferred escape can't be resolved
+		// here, so we skip extraction and let the scalar predicate be rechecked.
+		escape, ok := likeEscapeConst(fn)
+		if !ok {
 			return false, ""
 		}
 		if needLike2Regexp {
-			return true, stringutil.CompileLike2Regexp(datums[0].GetString())
+			return true, stringutil.CompileLike2Regexp(datums[0].GetString(), escape)
 		}
 		return true, datums[0].GetString()
 	case ast.Regexp, ast.RegexpLike:
@@ -478,21 +480,21 @@ func (helper extractHelper) extractLikePattern(
 	}
 }
 
-// likeEscapeIsDefault reports whether the ESCAPE argument of a LIKE/ILIKE
-// ScalarFunction is the default backslash escape. Only then is it safe to
-// compile the pattern with stringutil.CompileLike2Regexp, which hardcodes '\'
-// as the escape. A non-default (or non-constant) escape must fall back to a
-// scalar recheck instead of being pushed down. See issue #69653.
-func likeEscapeIsDefault(fn *expression.ScalarFunction) bool {
+// likeEscapeConst returns the ESCAPE byte of a LIKE/ILIKE ScalarFunction when
+// it is a plan-time constant (ok=true). The escape must be constant so the
+// pushed-down pattern can be compiled to match the predicate exactly (issue
+// #69653); a non-constant, deferred, or parameterized escape returns ok=false,
+// telling the caller to skip pushdown and keep a scalar recheck.
+func likeEscapeConst(fn *expression.ScalarFunction) (byte, bool) {
 	args := fn.GetArgs()
 	if len(args) < 3 {
-		return false
+		return 0, false
 	}
 	escape, ok := args[2].(*expression.Constant)
 	if !ok || escape.DeferredExpr != nil || escape.ParamMarker != nil {
-		return false
+		return 0, false
 	}
-	return escape.Value.GetInt64() == int64('\\')
+	return byte(escape.Value.GetInt64()), true
 }
 
 func (extractHelper) findColumn(schema *expression.Schema, names []*types.FieldName, colName string) map[int64]*types.FieldName {

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -389,9 +389,9 @@ func (helper *extractHelper) extractLikePatternCol(
 		// e.g:
 		// SELECT * FROM t WHERE c LIKE '%a%' OR c LIKE '%b%'
 		if fn.FuncName.L == ast.LogicOr && !toLower {
-			canBuildPattern, pattern = helper.extractOrLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
+			canBuildPattern, pattern = helper.extractOrLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		} else {
-			canBuildPattern, pattern = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
+			canBuildPattern, pattern = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		}
 		if canBuildPattern && toLower {
 			pattern = strings.ToLower(pattern)
@@ -411,6 +411,7 @@ func (helper extractHelper) extractOrLikePattern(
 	extractColName string,
 	extractCols map[int64]*types.FieldName,
 	needLike2Regexp bool,
+	toLower bool,
 ) (
 	ok bool,
 	pattern string,
@@ -427,7 +428,7 @@ func (helper extractHelper) extractOrLikePattern(
 			return false, ""
 		}
 
-		ok, partPattern := helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
+		ok, partPattern := helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		if !ok {
 			return false, ""
 		}
@@ -436,12 +437,17 @@ func (helper extractHelper) extractOrLikePattern(
 	return true, strings.Join(patternBuilder, "|")
 }
 
+// extractLikePattern builds the pushed-down pattern for a single predicate.
+// toLower reports whether the caller folds case on both the pattern and the
+// scanned value; it decides whether a case-insensitive ILIKE can be represented
+// by the pattern at all.
 func (helper extractHelper) extractLikePattern(
 	ctx base.PlanContext,
 	fn *expression.ScalarFunction,
 	extractColName string,
 	extractCols map[int64]*types.FieldName,
 	needLike2Regexp bool,
+	toLower bool,
 ) (
 	ok bool,
 	pattern string,
@@ -459,6 +465,16 @@ func (helper extractHelper) extractLikePattern(
 	case ast.EQ:
 		return true, "^" + regexp.QuoteMeta(datums[0].GetString()) + "$"
 	case ast.Like, ast.Ilike:
+		// ILIKE matches case-insensitively, but the pattern built below is
+		// case-sensitive. Callers that fold case (toLower) lower both the
+		// pattern and the scanned value, so it stays equivalent there; callers
+		// that do not -- the cluster log path sends the pattern verbatim in
+		// SearchLogRequest.Patterns and drops this predicate -- would filter out
+		// rows differing only in case, e.g. an "ERROR" line for
+		// `message ILIKE '%error%'`. Leave ILIKE to be rechecked instead.
+		if fn.FuncName.L == ast.Ilike && !toLower {
+			return false, ""
+		}
 		// The pushed-down pattern must honour the LIKE ESCAPE so it does not
 		// diverge from the original predicate (issue #69653). The escape has to
 		// be resolvable at plan time: for a constant escape (including the

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -383,22 +383,25 @@ func (helper *extractHelper) extractLikePatternCol(
 			continue
 		}
 
-		var canBuildPattern bool
+		var canBuildPattern, isPrefilter bool
 		var pattern string
 		// We use '|' to combine DNF regular expression: .*a.*|.*b.*
 		// e.g:
 		// SELECT * FROM t WHERE c LIKE '%a%' OR c LIKE '%b%'
 		if fn.FuncName.L == ast.LogicOr && !toLower {
-			canBuildPattern, pattern = helper.extractOrLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
+			canBuildPattern, pattern, isPrefilter = helper.extractOrLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		} else {
-			canBuildPattern, pattern = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
+			canBuildPattern, pattern, isPrefilter = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		}
 		if canBuildPattern && toLower {
 			pattern = strings.ToLower(pattern)
 		}
 		if canBuildPattern {
 			patterns = append(patterns, pattern)
-		} else {
+		}
+		// A prefilter narrows the scan but is not exactly equivalent to the
+		// predicate, so it is pushed down *and* kept for a scalar recheck.
+		if !canBuildPattern || isPrefilter {
 			remained = append(remained, expr)
 		}
 	}
@@ -415,32 +418,36 @@ func (helper extractHelper) extractOrLikePattern(
 ) (
 	ok bool,
 	pattern string,
+	isPrefilter bool,
 ) {
 	predicates := expression.SplitDNFItems(orFunc)
 	if len(predicates) == 0 {
-		return false, ""
+		return false, "", false
 	}
 
 	patternBuilder := make([]string, 0, len(predicates))
 	for _, predicate := range predicates {
 		fn, ok := predicate.(*expression.ScalarFunction)
 		if !ok {
-			return false, ""
+			return false, "", false
 		}
 
-		ok, partPattern := helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
+		ok, partPattern, partIsPrefilter := helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp, toLower)
 		if !ok {
-			return false, ""
+			return false, "", false
 		}
+		// One inexact branch makes the whole disjunction inexact.
+		isPrefilter = isPrefilter || partIsPrefilter
 		patternBuilder = append(patternBuilder, partPattern)
 	}
-	return true, strings.Join(patternBuilder, "|")
+	return true, strings.Join(patternBuilder, "|"), isPrefilter
 }
 
 // extractLikePattern builds the pushed-down pattern for a single predicate.
 // toLower reports whether the caller folds case on both the pattern and the
-// scanned value; it decides whether a case-insensitive ILIKE can be represented
-// by the pattern at all.
+// scanned value, which decides how a case-insensitive ILIKE is represented.
+// isPrefilter reports that the pattern only narrows the scan and is not exactly
+// equivalent to the predicate, so the caller must keep a scalar recheck.
 func (helper extractHelper) extractLikePattern(
 	ctx base.PlanContext,
 	fn *expression.ScalarFunction,
@@ -451,6 +458,7 @@ func (helper extractHelper) extractLikePattern(
 ) (
 	ok bool,
 	pattern string,
+	isPrefilter bool,
 ) {
 	var colName string
 	var datums []types.Datum
@@ -459,22 +467,12 @@ func (helper extractHelper) extractLikePattern(
 		colName, datums, _ = helper.extractColBinaryOpConsExpr(ctx, extractCols, fn)
 	}
 	if colName != extractColName {
-		return false, ""
+		return false, "", false
 	}
 	switch fn.FuncName.L {
 	case ast.EQ:
-		return true, "^" + regexp.QuoteMeta(datums[0].GetString()) + "$"
+		return true, "^" + regexp.QuoteMeta(datums[0].GetString()) + "$", false
 	case ast.Like, ast.Ilike:
-		// ILIKE matches case-insensitively, but the pattern built below is
-		// case-sensitive. Callers that fold case (toLower) lower both the
-		// pattern and the scanned value, so it stays equivalent there; callers
-		// that do not -- the cluster log path sends the pattern verbatim in
-		// SearchLogRequest.Patterns and drops this predicate -- would filter out
-		// rows differing only in case, e.g. an "ERROR" line for
-		// `message ILIKE '%error%'`. Leave ILIKE to be rechecked instead.
-		if fn.FuncName.L == ast.Ilike && !toLower {
-			return false, ""
-		}
 		// The pushed-down pattern must honour the LIKE ESCAPE so it does not
 		// diverge from the original predicate (issue #69653). The escape has to
 		// be resolvable at plan time: for a constant escape (including the
@@ -483,16 +481,30 @@ func (helper extractHelper) extractLikePattern(
 		// here, so we skip extraction and let the scalar predicate be rechecked.
 		escape, ok := likeEscapeConst(fn)
 		if !ok {
-			return false, ""
+			return false, "", false
 		}
-		if needLike2Regexp {
-			return true, stringutil.CompileLike2Regexp(datums[0].GetString(), escape)
+		if !needLike2Regexp {
+			return true, datums[0].GetString(), false
 		}
-		return true, datums[0].GetString()
+		pattern = stringutil.CompileLike2Regexp(datums[0].GetString(), escape)
+		// ILIKE matches case-insensitively while the pattern above is
+		// case-sensitive. Callers that fold case (toLower) lower both the pattern
+		// and the scanned value, so it stays equivalent there. Callers that do
+		// not -- the cluster log path sends the pattern verbatim in
+		// SearchLogRequest.Patterns -- get a case-insensitive group instead, so
+		// an "ERROR" line still matches `message ILIKE '%error%'`. The scoped
+		// (?i:...) form keeps the flag from leaking across a '|' when several
+		// patterns are combined into one disjunction. Case folding there is the
+		// regexp engine's rather than ILIKE's, so it is only a prefilter and the
+		// predicate is rechecked.
+		if fn.FuncName.L == ast.Ilike && !toLower {
+			return true, "(?i:" + pattern + ")", true
+		}
+		return true, pattern, false
 	case ast.Regexp, ast.RegexpLike:
-		return true, datums[0].GetString()
+		return true, datums[0].GetString(), false
 	default:
-		return false, ""
+		return false, "", false
 	}
 }
 

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -541,26 +541,31 @@ func TestClusterLogTableExtractor(t *testing.T) {
 			level:     set.NewStringSet("debug", "error"),
 		},
 		{
-			// ILIKE is case-insensitive, but the pattern pushed down here is
-			// matched case-sensitively by the remote log search and replaces the
-			// predicate, so consuming it would drop rows that differ only in
-			// case (an "ERROR" line for '%error%'). Keep it as a scalar recheck.
+			// ILIKE is case-insensitive while the pattern is matched
+			// case-sensitively by the remote log search, so it is pushed down as a
+			// case-insensitive group -- an "ERROR" line still matches '%error%'.
+			// The predicate stays for a scalar recheck (see the executor test in
+			// TestClusterLogTableIlike), and a pattern is still produced so the
+			// retriever does not reject the scan as a full-log scan.
 			sql:       "select * from information_schema.cluster_log where message ilike '%error%'",
 			nodeTypes: set.NewStringSet(),
 			instances: set.NewStringSet(),
+			patterns:  []string{"(?i:^.*error.*$)"},
 		},
 		{
-			// Same for an ILIKE carrying a non-default ESCAPE.
+			// Same for an ILIKE carrying a non-default ESCAPE ('#%' is a literal '%').
 			sql:       "select * from information_schema.cluster_log where message ilike '%error#%%' escape '#'",
 			nodeTypes: set.NewStringSet(),
 			instances: set.NewStringSet(),
+			patterns:  []string{"(?i:^.*error%.*$)"},
 		},
 		{
-			// A DNF mixing ILIKE cannot be pushed down either: the combined
-			// pattern would silently lose the case-insensitive branch.
+			// In a DNF the scoped (?i:...) keeps the case-insensitive branch from
+			// leaking case folding onto the case-sensitive one across the '|'.
 			sql:       "select * from information_schema.cluster_log where (message ilike '%pd%' or message like '%tikv%')",
 			nodeTypes: set.NewStringSet(),
 			instances: set.NewStringSet(),
+			patterns:  []string{"(?i:^.*pd.*$)|^.*tikv.*$"},
 		},
 		{
 			// A case-sensitive LIKE still pushes down, honouring a custom ESCAPE

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -540,6 +540,36 @@ func TestClusterLogTableExtractor(t *testing.T) {
 			instances: set.NewStringSet(),
 			level:     set.NewStringSet("debug", "error"),
 		},
+		{
+			// ILIKE is case-insensitive, but the pattern pushed down here is
+			// matched case-sensitively by the remote log search and replaces the
+			// predicate, so consuming it would drop rows that differ only in
+			// case (an "ERROR" line for '%error%'). Keep it as a scalar recheck.
+			sql:       "select * from information_schema.cluster_log where message ilike '%error%'",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+		},
+		{
+			// Same for an ILIKE carrying a non-default ESCAPE.
+			sql:       "select * from information_schema.cluster_log where message ilike '%error#%%' escape '#'",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+		},
+		{
+			// A DNF mixing ILIKE cannot be pushed down either: the combined
+			// pattern would silently lose the case-insensitive branch.
+			sql:       "select * from information_schema.cluster_log where (message ilike '%pd%' or message like '%tikv%')",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+		},
+		{
+			// A case-sensitive LIKE still pushes down, honouring a custom ESCAPE
+			// so the pattern matches the predicate ('#%' is a literal '%').
+			sql:       "select * from information_schema.cluster_log where message like '%a#%b%' escape '#'",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+			patterns:  []string{"^.*a%b.*$"},
+		},
 	}
 	for _, ca := range cases {
 		logicalMemTable, ok := getLogicalMemTable(t, dom, se, parser, ca.sql)

--- a/pkg/planner/core/tests/extractor/BUILD.bazel
+++ b/pkg/planner/core/tests/extractor/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "memtable_infoschema_extractor_test.go",
     ],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/infoschema",
         "//pkg/planner/core",

--- a/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
@@ -510,3 +510,31 @@ func TestMemtableInfoschemaExtractorPart4(t *testing.T) {
 	}
 	testMemtableInfoschemaExtractor(t, tcs)
 }
+
+func TestInfoSchemaTableNameLikeEscape(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database like_escape")
+	tk.MustExec("use like_escape")
+	tk.MustExec("create table `abc_def` (a int)")
+	tk.MustExec("create table `abc#x` (a int)")
+
+	// With ESCAPE '#', "#_" is a literal underscore, so only `abc_def` matches.
+	// The memtable extractor must not push the LIKE pattern down while ignoring
+	// the custom escape: doing so compiles the pattern with the default '\'
+	// escape, which instead matches `abc#x` (a row that fails its own
+	// predicate) and drops `abc_def`. Every returned row must satisfy the same
+	// LIKE ... ESCAPE predicate it was selected by. See issue #69653.
+	tk.MustQuery("select table_name, table_name like '%#_%' escape '#' as self_true " +
+		"from information_schema.tables " +
+		"where table_schema = 'like_escape' and table_name like '%#_%' escape '#'").
+		Check(testkit.Rows("abc_def 1"))
+
+	// A non-default escape must be kept as a scalar Selection rather than folded
+	// into the pushed-down table_name pattern.
+	plan := tk.MustQuery("explain format='brief' select table_name from information_schema.tables " +
+		"where table_schema = 'like_escape' and table_name like '%#_%' escape '#'").String()
+	if !strings.Contains(plan, "Selection") {
+		t.Fatalf("expected the custom-escape LIKE to be kept as a Selection, plan:\n%s", plan)
+	}
+}

--- a/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/tests/extractor/memtable_infoschema_extractor_test.go
@@ -519,22 +519,17 @@ func TestInfoSchemaTableNameLikeEscape(t *testing.T) {
 	tk.MustExec("create table `abc_def` (a int)")
 	tk.MustExec("create table `abc#x` (a int)")
 
-	// With ESCAPE '#', "#_" is a literal underscore, so only `abc_def` matches.
-	// The memtable extractor must not push the LIKE pattern down while ignoring
-	// the custom escape: doing so compiles the pattern with the default '\'
-	// escape, which instead matches `abc#x` (a row that fails its own
-	// predicate) and drops `abc_def`. Every returned row must satisfy the same
-	// LIKE ... ESCAPE predicate it was selected by. See issue #69653.
+	// With ESCAPE '#', "#_" is a literal underscore, so only `abc_def` matches
+	// (not `abc#x`). The extractor pushes the pattern down compiled with the '#'
+	// escape, so the memtable scan matches exactly the LIKE ... ESCAPE predicate
+	// instead of diverging under the default '\' escape. See issue #69653.
 	tk.MustQuery("select table_name, table_name like '%#_%' escape '#' as self_true " +
 		"from information_schema.tables " +
 		"where table_schema = 'like_escape' and table_name like '%#_%' escape '#'").
 		Check(testkit.Rows("abc_def 1"))
 
-	// A non-default escape must be kept as a scalar Selection rather than folded
-	// into the pushed-down table_name pattern.
-	plan := tk.MustQuery("explain format='brief' select table_name from information_schema.tables " +
-		"where table_schema = 'like_escape' and table_name like '%#_%' escape '#'").String()
-	if !strings.Contains(plan, "Selection") {
-		t.Fatalf("expected the custom-escape LIKE to be kept as a Selection, plan:\n%s", plan)
-	}
+	// A default-escape LIKE is unaffected and still matches both tables.
+	tk.MustQuery("select table_name from information_schema.tables " +
+		"where table_schema = 'like_escape' and table_name like 'abc%'").
+		Sort().Check(testkit.Rows("abc#x", "abc_def"))
 }

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -257,9 +257,10 @@ func matchRune(a, b rune) bool {
 	*/
 }
 
-// CompileLike2Regexp convert a like `lhs` to a regular expression
-func CompileLike2Regexp(str string) string {
-	patChars, patTypes := CompilePattern(str, '\\')
+// CompileLike2Regexp convert a like `lhs` to a regular expression, compiling
+// the pattern with the given LIKE escape byte (pass '\\' for the SQL default).
+func CompileLike2Regexp(str string, escape byte) string {
+	patChars, patTypes := CompilePattern(str, escape)
 	var result strings.Builder
 	result.Grow(len(patChars)*2 + 2)
 	result.WriteByte('^')

--- a/pkg/util/stringutil/string_util_test.go
+++ b/pkg/util/stringutil/string_util_test.go
@@ -133,7 +133,7 @@ func TestCompileLike2Regexp(t *testing.T) {
 		{`%_%_aA`, "^...*aA$"},
 	}
 	for _, v := range tbl {
-		result := CompileLike2Regexp(v.pattern)
+		result := CompileLike2Regexp(v.pattern, '\\')
 		require.Equalf(t, v.regexp, result, "source %v", v)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #69653

Problem Summary:

A `LIKE ... ESCAPE` predicate on an `information_schema` table can return rows that fail the predicate and drop rows that match. The memtable predicate extractor pushes the `LIKE` pattern into the scan and removes the original predicate, but it always compiles the pattern with the default `\` escape via `stringutil.CompileLike2Regexp`, ignoring the custom `ESCAPE`. The pushed-down (default-escape) pattern then becomes authoritative and diverges from the real predicate.

For example, with `ESCAPE '#'`, `%#_%` means "contains a literal underscore", so only `abc_def` should match. Instead the scan compiles `%#_%` with the `\` escape (where `_` is the single-char wildcard) and returns `abc#x`, which fails its own predicate.

### What changed and how does it work?

`extractLikePattern` now builds a pushed-down pattern for `LIKE`/`ILIKE` only when the `ESCAPE` argument is the default backslash. For any non-default (or non-constant) escape it returns no pattern, so the predicate stays in the remaining filters and is rechecked as a scalar `Selection`. This keeps the existing fast path for the common default-escape case and restores correct results for custom escapes (and for `NO_BACKSLASH_ESCAPES`, which sets the escape to empty).

The related `REGEXP_LIKE(..., match_type)` case on `cluster_log` mentioned in the issue shares the same shape (the extractor models only part of the operator). I've kept this PR focused on the self-contained `LIKE ... ESCAPE` fix, and I'm happy to follow up on the regexp `match_type` case if that's preferred.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
Fix `information_schema` queries with a `LIKE ... ESCAPE` predicate that uses a non-default escape character returning incorrect rows.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `LIKE` and `ILIKE` matching for case-insensitive patterns and custom `ESCAPE` characters.
  * Prevented incorrect pattern filtering when escape characters are unsupported or unavailable.
  * Preserved accurate results by rechecking predicates when optimized filtering cannot be applied.

* **Tests**
  * Added coverage for escaped table names and varied `LIKE`/`ILIKE` filtering scenarios.
  * Updated extractor test sharding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
