### PR TITLE
planner: fix four user-triggerable panics (batch point-get plan cache, index advisor timeout, tidb_encode_record_key, information_schema)

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -230,6 +230,7 @@ go_test(
         "logical_plans_test.go",
         "main_test.go",
         "optimizer_test.go",
+        "panicrisk_regression_test.go",
         "physical_plan_test.go",
         "plan_cache_instance_test.go",
         "plan_cache_lru_test.go",

--- a/pkg/planner/core/expression_codec_fn.go
+++ b/pkg/planner/core/expression_codec_fn.go
@@ -112,7 +112,7 @@ func (tidbCodecFuncHelper) extractTablePartition(str string) (table, partition s
 		return str, ""
 	}
 	end := strings.IndexByte(str, ')')
-	if end == -1 {
+	if end == -1 || end < start {
 		return str, ""
 	}
 	return str[:start], str[start+1 : end]

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -790,12 +790,7 @@ func findSchemasForTables(
 		}
 	}
 	// Remove nil elements in tableSlice.
-	remains := tableSlice[:0]
-	for _, tbl := range tableSlice {
-		if tbl != nil {
-			remains = append(remains, tbl)
-		}
-	}
+	remains := slices.DeleteFunc(tableSlice, func(tbl *model.TableInfo) bool { return tbl == nil })
 	// Sort schema/table pairs together, keeping the two slices aligned. The
 	// comparator must stay side-effect free, so swap both slices via sort.Sort
 	// rather than mutating inside a sort.Slice less func.

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -766,6 +766,10 @@ func findSchemasForTables(
 		if !ok {
 			logutil.BgLogger().Warn("schema not found for table info",
 				zap.Int64("tableID", tbl.ID), zap.Int64("dbID", tbl.DBID))
+			// Drop this table so schemaSlice and the compacted tableSlice stay
+			// the same length; leaving it in would desync the parallel slices
+			// and make every consumer index out of range.
+			tableSlice[i] = nil
 			continue
 		}
 		if unspecified { // all schemas should be included.
@@ -792,16 +796,33 @@ func findSchemasForTables(
 			remains = append(remains, tbl)
 		}
 	}
-	sort.Slice(schemaSlice, func(i, j int) bool {
-		iSchema, jSchema := schemaSlice[i].L, schemaSlice[j].L
-		less := iSchema < jSchema ||
-			(iSchema == jSchema && remains[i].Name.L < remains[j].Name.L)
-		if less {
-			remains[i], remains[j] = remains[j], remains[i]
-		}
-		return less
-	})
+	// Sort schema/table pairs together, keeping the two slices aligned. The
+	// comparator must stay side-effect free, so swap both slices via sort.Sort
+	// rather than mutating inside a sort.Slice less func.
+	sort.Sort(&schemaTableSorter{schemas: schemaSlice, tables: remains})
 	return schemaSlice, remains, nil
+}
+
+// schemaTableSorter sorts a parallel pair of schema names and table infos
+// together, ordering by schema name and then table name, so that
+// schemas[i] stays paired with tables[i] after sorting.
+type schemaTableSorter struct {
+	schemas []ast.CIStr
+	tables  []*model.TableInfo
+}
+
+func (s *schemaTableSorter) Len() int { return len(s.schemas) }
+
+func (s *schemaTableSorter) Less(i, j int) bool {
+	if s.schemas[i].L != s.schemas[j].L {
+		return s.schemas[i].L < s.schemas[j].L
+	}
+	return s.tables[i].Name.L < s.tables[j].Name.L
+}
+
+func (s *schemaTableSorter) Swap(i, j int) {
+	s.schemas[i], s.schemas[j] = s.schemas[j], s.schemas[i]
+	s.tables[i], s.tables[j] = s.tables[j], s.tables[i]
 }
 
 func parseIDs(ids []ast.CIStr) []int64 {

--- a/pkg/planner/core/panicrisk_regression_test.go
+++ b/pkg/planner/core/panicrisk_regression_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractTablePartitionMalformed guards against an out-of-range slice when
+// the input contains ')' before '(' (e.g. a crafted table-name argument to
+// tidb_encode_record_key). Previously str[start+1:end] panicked with a reversed
+// slice; now it returns the whole string with an empty partition.
+func TestExtractTablePartitionMalformed(t *testing.T) {
+	var h tidbCodecFuncHelper
+	cases := []struct {
+		input     string
+		wantTable string
+		wantPart  string
+	}{
+		{"t)(", "t)(", ""}, // ')' before '(' — the panic trigger
+		{")(", ")(", ""},   // leading ')'
+		{"t(p)", "t", "p"}, // normal partitioned form still works
+		{"t", "t", ""},     // no parens
+		{"t(p", "t(p", ""}, // missing ')'
+		{"tp)", "tp)", ""}, // missing '('
+	}
+	for _, c := range cases {
+		tbl, part := h.extractTablePartition(c.input)
+		require.Equal(t, c.wantTable, tbl, "input=%q", c.input)
+		require.Equal(t, c.wantPart, part, "input=%q", c.input)
+	}
+}
+
+// TestSchemaTableSorterKeepsPairsAligned verifies that sorting schema/table
+// pairs keeps schemas[i] paired with tables[i]. The previous hand-rolled
+// sort.Slice mutated the table slice inside the less func, scrambling the
+// pairing.
+func TestSchemaTableSorterKeepsPairsAligned(t *testing.T) {
+	schemas := []ast.CIStr{
+		ast.NewCIStr("db_b"),
+		ast.NewCIStr("db_a"),
+		ast.NewCIStr("db_a"),
+	}
+	tables := []*model.TableInfo{
+		{Name: ast.NewCIStr("t_in_b")},
+		{Name: ast.NewCIStr("t2_in_a")},
+		{Name: ast.NewCIStr("t1_in_a")},
+	}
+	sort.Sort(&schemaTableSorter{schemas: schemas, tables: tables})
+
+	// Expected order: (db_a, t1_in_a), (db_a, t2_in_a), (db_b, t_in_b).
+	require.Equal(t, "db_a", schemas[0].L)
+	require.Equal(t, "t1_in_a", tables[0].Name.L)
+	require.Equal(t, "db_a", schemas[1].L)
+	require.Equal(t, "t2_in_a", tables[1].Name.L)
+	require.Equal(t, "db_b", schemas[2].L)
+	require.Equal(t, "t_in_b", tables[2].Name.L)
+}

--- a/pkg/planner/core/plan_cache_rebuild.go
+++ b/pkg/planner/core/plan_cache_rebuild.go
@@ -397,6 +397,9 @@ func buildRangesForBatchGet(sctx base.PlanContext, x *physicalop.BatchPointGetPl
 			}
 			for j, param := range params {
 				if param != nil {
+					if j >= len(x.IndexColTypes) || x.IndexColTypes[j] == nil {
+						return errors.New("rebuild to get an unsafe range, missing index column type")
+					}
 					dVal, err := convertConstant2Datum(sctx, param, x.IndexColTypes[j])
 					if err != nil {
 						return err

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -321,6 +321,13 @@ func newBatchPointGetPlan(
 			for index, inner := range x.Values {
 				// permutations is used to match column and value.
 				permIndex := permutations[index]
+				// Record the column type for every position, not just the ones
+				// that are parameter markers in this (the first) row. A later
+				// row may hold a marker where this row holds a literal, and the
+				// plan-cache range rebuild needs a non-nil type for that column.
+				if initTypes {
+					indexTypes[permIndex] = &colInfos[index].FieldType
+				}
 				switch innerX := inner.(type) {
 				case *driver.ValueExpr:
 					dval := getPointGetValue(stmtCtx, colInfos[index], &innerX.Datum)
@@ -343,9 +350,6 @@ func newBatchPointGetPlan(
 					}
 					values[permIndex] = *dval
 					valuesParams[permIndex] = con
-					if initTypes {
-						indexTypes[permIndex] = &colInfos[index].FieldType
-					}
 				default:
 					return nil
 				}

--- a/pkg/planner/core/tests/prepare/BUILD.bazel
+++ b/pkg/planner/core/tests/prepare/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "prepare_test.go",
     ],
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/errno",

--- a/pkg/planner/core/tests/prepare/prepare_test.go
+++ b/pkg/planner/core/tests/prepare/prepare_test.go
@@ -1707,3 +1707,23 @@ func TestHashPartitionAndPlanCache(t *testing.T) {
 	explain = tkExplain.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID))
 	require.Equal(t, "Point_Get_1", explain.Rows()[0][0])
 }
+
+func TestBatchPointGetPlanCacheMixedInList(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (k1 int, k2 int, v int, unique key uk(k1, k2))")
+	tk.MustExec("insert into t values (1, 2, 100), (3, 2, 200), (1, 4, 300)")
+	// The first IN-list row has a literal where the second row has a parameter
+	// marker (and vice versa). The batch-point-get plan-cache range rebuild used
+	// to dereference a nil index-column type for such a column and panic on the
+	// second (cache-hit) execution.
+	tk.MustExec("prepare st from 'select v from t where (k1, k2) in ((1, ?), (?, 2))'")
+	tk.MustExec("set @a = 2, @b = 3")
+	tk.MustQuery("execute st using @a, @b").Sort().Check(testkit.Rows("100", "200"))
+	// Re-execute with new values to hit the plan cache and exercise the rebuild.
+	tk.MustExec("set @a = 4, @b = 3")
+	tk.MustQuery("execute st using @a, @b").Sort().Check(testkit.Rows("200", "300"))
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
+}

--- a/pkg/planner/indexadvisor/options.go
+++ b/pkg/planner/indexadvisor/options.go
@@ -99,7 +99,11 @@ func optionVal(opt string, val ast.ValueExpr) (string, error) {
 		}
 		v = strconv.Itoa(x)
 	case OptTimeout:
-		v = val.GetValue().(string)
+		var ok bool
+		v, ok = val.GetValue().(string)
+		if !ok {
+			return "", errors.Errorf("invalid value type %T for %s, expected a duration string", val.GetValue(), opt)
+		}
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return "", err

--- a/pkg/planner/indexadvisor/options_test.go
+++ b/pkg/planner/indexadvisor/options_test.go
@@ -125,6 +125,10 @@ func TestOptionTimeout(t *testing.T) {
 	tk.MustQuery(`select value from tidb_kernel_options where module='index_advisor' and name='timeout'`).
 		Check(testkit.Rows("1m"))
 	tk.MustExecToErr(`recommend index set timeout='-1s'`)
+	// A non-string literal for timeout must return an error, not panic.
+	tk.MustExecToErr(`recommend index set timeout=30`)
+	tk.MustExecToErr(`recommend index set timeout=3.5`)
+	tk.MustExecToErr(`recommend index set timeout=null`)
 
 	tk.MustExec(`use test`)
 	tk.MustExec(`recommend index set timeout='1m'`)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69675

Problem Summary:

An audit of the planner (excluding cascades) found four code paths that panic on inputs an ordinary authenticated user can send with default settings:

1. `tidb_encode_record_key`/`tidb_encode_index_key` with a malformed table-name argument where `)` precedes `(` (e.g. `SELECT tidb_encode_record_key('test', 't)(', 1)`) — `extractTablePartition` sliced `str[start+1:end]` with reversed bounds.
2. A prepared batch-point-get with a mixed literal/marker IN list (`(k1,k2) IN ((1,?),(?,2))`) panics on the second (cache-hit) execution — the cached plan's index-column type for a column that is a literal in the first row but a marker in a later row is never populated (nil), and the plan-cache range rebuild dereferences it.
3. `RECOMMEND INDEX SET timeout = 30` — the option handler asserted the value is a string, but the grammar accepts numeric/NULL literals and the `SET` path has no recover.
4. `SELECT * FROM information_schema.tables WHERE tidb_table_id = <id>` during a concurrent `DROP DATABASE`/DDL window — `findSchemasForTables` skipped a table whose schema id did not resolve without removing it, desyncing the parallel schema/table slices and causing out-of-range access in every consumer. The same function also mutated the table slice inside a `sort.Slice` comparator, scrambling the schema/table pairing.

### What changed and how does it work?

- `expression_codec_fn.go`: guard `end < start` in `extractTablePartition` and fall back to the whole string with an empty partition.
- `point_get_plan.go`: in `newBatchPointGetPlan`, record the index-column type for every column position on the first IN-list row (not only marker positions). `plan_cache_rebuild.go`: as a backstop, return a "rebuild to get an unsafe range" error (safe plan-cache fallback) instead of dereferencing a missing type.
- `indexadvisor/options.go`: `optionVal` uses the comma-ok form for the `timeout` value and returns a typed error for non-string literals, matching the sibling `intVal`.
- `memtable_infoschema_extractor.go`: `findSchemasForTables` drops a table whose schema id does not resolve so the schema/table slices stay the same length, and sorts the two slices together via a side-effect-free `sort.Sort` (`schemaTableSorter`) instead of mutating inside a comparator.

Regression tests are added for each fix; the batch-point-get test panics with the fix reverted.

This PR addresses only the Tier 1 (default-settings, user-triggerable) findings. Lower-severity findings from the same audit will be addressed in follow-up PRs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fixed several planner panics that could be triggered by user SQL: a malformed argument to `tidb_encode_record_key`/`tidb_encode_index_key`, re-executing a prepared batch point-get with a mixed literal/parameter IN list, `RECOMMEND INDEX SET timeout` with a non-string value, and an `information_schema` query racing schema changes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed table partition strings to avoid crashes.
  * Ensured schema/table pairs remain correctly aligned during sorting.
  * Added error handling for missing index-column type info during plan cache rebuilds and batch point-get planning.
  * Made `recommend index set timeout` reject non-string inputs with clear errors instead of panicking.
* **Tests**
  * Added regression tests for partition parsing, aligned sorting, mixed literal/parameter `IN`-list plan-cache behavior, and invalid timeout inputs.
* **Chores**
  * Updated Bazel test shard and Go test source configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->