### PR TITLE
planner: fix three flag-gated user-triggerable panics (non-prepared plan cache, skew-distinct-agg, sequence pushdown)

### DIFF
--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -5,11 +5,12 @@ go_test(
     timeout = "moderate",
     srcs = [
         "main_test.go",
+        "panicrisk_tier2_test.go",
         "planner_issue_test.go",
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 2,
+    shard_count = 5,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/panicrisk_tier2_test.go
+++ b/pkg/planner/core/issuetest/panicrisk_tier2_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issuetest
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+// TestNonPreparedPlanCacheZeroArgDateFunc guards against an out-of-range access
+// on Args[0] when parameterizing a zero-arg date_format/str_to_date/time_format/
+// from_unixtime call for the non-prepared plan cache.
+func TestNonPreparedPlanCacheZeroArgDateFunc(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
+	tk.MustExec("create table t (a datetime, b int)")
+	// The parameterizer visits these funcs before arity is validated; a zero-arg
+	// call in the WHERE clause must not panic. The statement still errors on the
+	// invalid call, but must not crash the server.
+	tk.MustExecToErr("select * from t where a = date_format()")
+	tk.MustExecToErr("select * from t where a = str_to_date()")
+	tk.MustExecToErr("select * from t where b = time_format()")
+	tk.MustExecToErr("select * from t where b = from_unixtime()")
+}
+
+// TestSkewDistinctAggConstantArg guards against an unchecked *Column assertion
+// when the skew-distinct-agg rewrite decomposes a distinct aggregate whose
+// argument is a constant (e.g. count(distinct 1)).
+func TestSkewDistinctAggConstantArg(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_opt_skew_distinct_agg=1")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("insert into t values (1, 10), (2, 10), (3, 20)")
+	tk.MustQuery("select b, count(distinct 1) from t group by b order by b").
+		Check(testkit.Rows("10 1", "20 1"))
+	tk.MustQuery("select b, sum(distinct 2) from t group by b order by b").
+		Check(testkit.Rows("10 2", "20 2"))
+}
+
+// TestPushDownSequenceWithTableDual guards against indexing Children()[0] on a
+// childless operator (a LogicalTableDual from a constant-false predicate) while
+// pushing a sequence down under shared-CTE execution.
+func TestPushDownSequenceWithTableDual(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_opt_enable_mpp_shared_cte_execution=1")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1), (2)")
+	tk.MustQuery("with cte as (select a from t) " +
+		"select * from cte c1 join cte c2 on c1.a = c2.a where 1 = 0").
+		Check(testkit.Rows())
+}

--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -66,6 +66,11 @@ func (pr *paramReplacer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		switch n.FnName.L {
 		case ast.DateFormat, ast.StrToDate, ast.TimeFormat, ast.FromUnixTime:
 			// skip the second format argument: date_format('2020', '%Y') --> date_format(?, '%Y')
+			if len(n.Args) == 0 {
+				// A malformed zero-arg call (wrong arity, rejected later during
+				// type checking); don't index Args here.
+				return in, true
+			}
 			ret, _ := n.Args[0].Accept(pr)
 			n.Args[0] = ret.(ast.ExprNode)
 			return in, true

--- a/pkg/planner/core/rule_aggregation_skew_rewrite.go
+++ b/pkg/planner/core/rule_aggregation_skew_rewrite.go
@@ -127,7 +127,18 @@ func (a *SkewDistinctAggRewriter) rewriteSkewDistinctAgg(agg *logicalop.LogicalA
 					return nil
 				}
 				bottomAggFuncs = append(bottomAggFuncs, firstRow)
-				bottomAggSchema.Append(arg.(*expression.Column))
+				// The distinct argument is usually a column, but isQualifiedAgg
+				// also admits a constant (e.g. count(distinct 1)); in that case
+				// synthesize a schema column for the firstrow output rather than
+				// asserting *Column.
+				if argCol, ok := arg.(*expression.Column); ok {
+					bottomAggSchema.Append(argCol)
+				} else {
+					bottomAggSchema.Append(&expression.Column{
+						UniqueID: agg.SCtx().GetSessionVars().AllocPlanColumnID(),
+						RetType:  firstRow.RetTp,
+					})
+				}
 			}
 
 			// now the distinct is not needed anymore

--- a/pkg/planner/core/rule_push_down_sequence.go
+++ b/pkg/planner/core/rule_push_down_sequence.go
@@ -65,7 +65,11 @@ func (pdss *PushDownSequenceSolver) recursiveOptimize(pushedSequence *logicalop.
 		pushedSequence.SetChild(pushedSequence.ChildLen()-1, pdss.recursiveOptimize(nil, lp))
 		return pushedSequence
 	default:
-		if len(lp.Children()) > 1 {
+		if len(lp.Children()) != 1 {
+			// Operators without exactly one child cannot have the sequence pushed
+			// through them: a multi-child operator (e.g. a join), or a childless
+			// leaf such as a LogicalTableDual produced by a constant-false
+			// predicate. Attach the sequence above and stop descending.
 			pushedSequence.SetChild(pushedSequence.ChildLen()-1, lp)
 			return pushedSequence
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69679

Problem Summary:

Follow-up to #69676. The planner panic-risk audit found three more panics reachable from user SQL when a (non-default) optimizer flag is enabled:

1. With `tidb_enable_non_prepared_plan_cache=1`, the parameterizer indexes `Args[0]` of `date_format`/`str_to_date`/`time_format`/`from_unixtime` before the call's arity is validated, so a zero-arg call in a predicate (`where a = date_format()`) panics with index out of range.
2. With `tidb_opt_skew_distinct_agg=on`, the skew-distinct-agg rewrite asserts the distinct argument is a `*expression.Column`, but `isQualifiedAgg` also admits a constant, so `count(distinct 1)` panics with an interface conversion error.
3. With `tidb_opt_enable_mpp_shared_cte_execution=on`, the sequence-pushdown rule's default branch indexes `Children()[0]`, assuming every operator under a `LogicalSequence` has a child; a constant-false predicate (`where 1=0`) leaves a childless `LogicalTableDual`, so the query panics during logical optimization.

### What changed and how does it work?

- `plan_cache_param.go`: `paramReplacer.Enter` returns early for a zero-arg date/time function instead of indexing `Args[0]`; the malformed call is still rejected later during type checking.
- `rule_aggregation_skew_rewrite.go`: when the distinct argument is not a column, synthesize a schema column for the firstrow output (matching how the non-distinct branch already handles constants) instead of asserting `*Column`. The constant flows into the bottom aggregate's group-by, so the rewrite stays correct.
- `rule_push_down_sequence.go`: the default branch now treats any operator without exactly one child (a multi-child operator, or a childless leaf such as `LogicalTableDual`) as a place to attach the sequence and stop descending, rather than indexing `Children()[0]`.

Each fix has a regression test in `pkg/planner/core/issuetest`; every test panics with its fix reverted.

The audit also flagged two lower-severity latent issues (a nil FD hashcode map for a join over a UNION ALL, and a scalar-subquery rewriter stack desync under non-eval-subquery EXPLAIN). Those are normally shielded by an intervening projection / do not reliably reproduce, so they are deferred to a later PR rather than shipped without a failing regression test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fixed three planner panics that could be triggered by user SQL when a non-default optimizer flag was enabled: a zero-argument date function under non-prepared plan cache, count(distinct <constant>) under tidb_opt_skew_distinct_agg, and a constant-false predicate in a shared-CTE query under tidb_opt_enable_mpp_shared_cte_execution.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash risk in query planning for certain date/time function calls with no arguments.
  * Improved handling of distinct aggregation so constant values work correctly in more query patterns.
  * Prevented a panic in sequence pushdown for edge cases involving empty-result queries and shared execution.

* **Tests**
  * Added regression coverage for the above planning and execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->