### PR TITLE
server: limit accumulated COM_STMT_SEND_LONG_DATA size

### DIFF
--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -209,7 +209,10 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 			paramValues = data[pos+1:]
 		}
 
-		err = parseBinaryParams(args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues, cc.inputDecoder)
+		err = stmt.CheckLongDataSize()
+		if err == nil {
+			err = parseBinaryParams(args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues, cc.inputDecoder)
+		}
 		// This `.Reset` resets the arguments, so it's fine to just ignore the error (and the it'll be reset again in the following routine)
 		errReset := stmt.Reset()
 		if errReset != nil {

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -598,9 +598,19 @@ func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
 	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 1, bytes.Repeat([]byte{'b'}, 512)))
 
 	err = dispatchSendLongData(c, stmt.ID(), 0, []byte{'c'})
-	require.ErrorIs(t, err, servererr.ErrNetPacketTooLarge)
+	require.NoError(t, err)
 	require.Len(t, stmt.BoundParams()[0], 512)
 	require.Len(t, stmt.BoundParams()[1], 512)
+
+	err = c.Dispatch(context.Background(), append(
+		binary.LittleEndian.AppendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		0x0, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x0,
+	))
+	require.ErrorIs(t, err, servererr.ErrNetPacketTooLarge)
+	require.Nil(t, stmt.BoundParams()[0])
+	require.Nil(t, stmt.BoundParams()[1])
+	require.NoError(t, stmt.CheckLongDataSize())
 }
 
 func TestCursorFetchSendLongData(t *testing.T) {

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -594,13 +594,14 @@ func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
 	require.NoError(t, err)
 
 	c.Context().GetSessionVars().MaxAllowedPacket = 1024
-	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 512)))
-	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 1, bytes.Repeat([]byte{'b'}, 512)))
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 1024)))
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 1, bytes.Repeat([]byte{'b'}, 1024)))
+	require.NoError(t, stmt.CheckLongDataSize())
 
 	err = dispatchSendLongData(c, stmt.ID(), 0, []byte{'c'})
 	require.NoError(t, err)
-	require.Len(t, stmt.BoundParams()[0], 512)
-	require.Len(t, stmt.BoundParams()[1], 512)
+	require.Len(t, stmt.BoundParams()[0], 1024)
+	require.Len(t, stmt.BoundParams()[1], 1024)
 
 	err = c.Dispatch(context.Background(), append(
 		binary.LittleEndian.AppendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	servererr "github.com/pingcap/tidb/pkg/server/err"
 	"github.com/pingcap/tidb/pkg/server/internal"
 	"github.com/pingcap/tidb/pkg/server/internal/column"
 	"github.com/pingcap/tidb/pkg/server/internal/resultset"
@@ -575,6 +576,31 @@ func dispatchSendLongData(c *mockConn, stmtID int, paramIndex uint16, parameter 
 			parameter..., // the parameter
 		),
 	)
+}
+
+func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	c := CreateMockConn(t, srv).(*mockConn)
+	c.capability = mysql.ClientProtocol41
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	stmt, _, _, err := c.Context().Prepare("select ?, ?")
+	require.NoError(t, err)
+
+	c.Context().GetSessionVars().MaxAllowedPacket = 1024
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 512)))
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 1, bytes.Repeat([]byte{'b'}, 512)))
+
+	err = dispatchSendLongData(c, stmt.ID(), 0, []byte{'c'})
+	require.ErrorIs(t, err, servererr.ErrNetPacketTooLarge)
+	require.Len(t, stmt.BoundParams()[0], 512)
+	require.Len(t, stmt.BoundParams()[1], 512)
 }
 
 func TestCursorFetchSendLongData(t *testing.T) {

--- a/pkg/server/driver.go
+++ b/pkg/server/driver.go
@@ -41,6 +41,9 @@ type PreparedStatement interface {
 	// AppendParam appends parameter to the statement.
 	AppendParam(paramID int, data []byte) error
 
+	// CheckLongDataSize checks whether the statement has accumulated too much data through COM_STMT_SEND_LONG_DATA.
+	CheckLongDataSize() error
+
 	// NumParams returns number of parameters.
 	NumParams() int
 

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -69,8 +69,7 @@ type TiDBStatement struct {
 	id          uint32
 	numParams   int
 	boundParams [][]byte
-	// boundParamsBytes tracks the total bytes accumulated by COM_STMT_SEND_LONG_DATA for this statement.
-	boundParamsBytes    uint64
+	// boundParamsTooLarge tracks whether a single COM_STMT_SEND_LONG_DATA parameter has exceeded max_allowed_packet.
 	boundParamsTooLarge bool
 	paramsType          []byte
 	ctx                 *TiDBContext
@@ -111,25 +110,29 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	}
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
-		ts.boundParamsBytes -= uint64(len(ts.boundParams[paramID]))
 		ts.boundParams[paramID] = []byte{}
 	} else {
-		if ts.boundParamsBytes+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
+		if uint64(len(ts.boundParams[paramID]))+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
 			// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
 			// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
 			ts.boundParamsTooLarge = true
 			return nil
 		}
 		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
-		ts.boundParamsBytes += uint64(len(data))
 	}
 	return nil
 }
 
 // CheckLongDataSize implements PreparedStatement CheckLongDataSize method.
 func (ts *TiDBStatement) CheckLongDataSize() error {
-	if ts.boundParamsTooLarge || ts.boundParamsBytes > ts.ctx.GetSessionVars().MaxAllowedPacket {
+	if ts.boundParamsTooLarge {
 		return servererr.ErrNetPacketTooLarge
+	}
+	maxAllowedPacket := ts.ctx.GetSessionVars().MaxAllowedPacket
+	for _, boundParam := range ts.boundParams {
+		if uint64(len(boundParam)) > maxAllowedPacket {
+			return servererr.ErrNetPacketTooLarge
+		}
 	}
 	return nil
 }
@@ -171,7 +174,6 @@ func (ts *TiDBStatement) Reset() error {
 	for i := range ts.boundParams {
 		ts.boundParams[i] = nil
 	}
-	ts.boundParamsBytes = 0
 	ts.boundParamsTooLarge = false
 	ts.hasActiveCursor = false
 

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -69,8 +69,10 @@ type TiDBStatement struct {
 	id          uint32
 	numParams   int
 	boundParams [][]byte
-	paramsType  []byte
-	ctx         *TiDBContext
+	// boundParamsBytes tracks the total bytes accumulated by COM_STMT_SEND_LONG_DATA for this statement.
+	boundParamsBytes uint64
+	paramsType       []byte
+	ctx              *TiDBContext
 	// this result set should have been closed before stored here. Only the `rowIterator` are used here. This field is
 	// not moved out to reuse the logic inside functions `writeResultSet...`
 	// TODO: move the `fetchedRows` into the statement, and remove the `ResultSet` from statement.
@@ -108,9 +110,14 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	}
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
+		ts.boundParamsBytes -= uint64(len(ts.boundParams[paramID]))
 		ts.boundParams[paramID] = []byte{}
 	} else {
+		if ts.boundParamsBytes+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
+			return servererr.ErrNetPacketTooLarge
+		}
 		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+		ts.boundParamsBytes += uint64(len(data))
 	}
 	return nil
 }
@@ -152,6 +159,7 @@ func (ts *TiDBStatement) Reset() error {
 	for i := range ts.boundParams {
 		ts.boundParams[i] = nil
 	}
+	ts.boundParamsBytes = 0
 	ts.hasActiveCursor = false
 
 	resultset.ReportCursorRUV2Delta(ts.rs, 0)

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -70,9 +70,10 @@ type TiDBStatement struct {
 	numParams   int
 	boundParams [][]byte
 	// boundParamsBytes tracks the total bytes accumulated by COM_STMT_SEND_LONG_DATA for this statement.
-	boundParamsBytes uint64
-	paramsType       []byte
-	ctx              *TiDBContext
+	boundParamsBytes    uint64
+	boundParamsTooLarge bool
+	paramsType          []byte
+	ctx                 *TiDBContext
 	// this result set should have been closed before stored here. Only the `rowIterator` are used here. This field is
 	// not moved out to reuse the logic inside functions `writeResultSet...`
 	// TODO: move the `fetchedRows` into the statement, and remove the `ResultSet` from statement.
@@ -114,10 +115,21 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 		ts.boundParams[paramID] = []byte{}
 	} else {
 		if ts.boundParamsBytes+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
-			return servererr.ErrNetPacketTooLarge
+			// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
+			// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
+			ts.boundParamsTooLarge = true
+			return nil
 		}
 		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
 		ts.boundParamsBytes += uint64(len(data))
+	}
+	return nil
+}
+
+// CheckLongDataSize implements PreparedStatement CheckLongDataSize method.
+func (ts *TiDBStatement) CheckLongDataSize() error {
+	if ts.boundParamsTooLarge || ts.boundParamsBytes > ts.ctx.GetSessionVars().MaxAllowedPacket {
+		return servererr.ErrNetPacketTooLarge
 	}
 	return nil
 }
@@ -160,6 +172,7 @@ func (ts *TiDBStatement) Reset() error {
 		ts.boundParams[i] = nil
 	}
 	ts.boundParamsBytes = 0
+	ts.boundParamsTooLarge = false
 	ts.hasActiveCursor = false
 
 	resultset.ReportCursorRUV2Delta(ts.rs, 0)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69693

Problem Summary:

`COM_STMT_SEND_LONG_DATA` appends each payload chunk into the prepared statement's bound parameter buffers. Before this PR, TiDB did not check the cumulative size of those buffers, so an authenticated client could keep sending long-data chunks for a prepared statement and grow connection memory without executing the statement.

### What changed and how does it work?

This PR tracks the total bytes accumulated by `COM_STMT_SEND_LONG_DATA` for each prepared statement. Before appending a new chunk, TiDB checks whether the statement-level accumulated long-data size would exceed the session `max_allowed_packet`. If it would exceed the limit, TiDB returns the existing `ErrNetPacketTooLarge` error and keeps the already buffered data unchanged.

`COM_STMT_RESET` clears both the buffered parameters and the byte counter.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Tested locally:

- `git diff --check`
- `go test ./pkg/server -run '^(TestStmtSendLongDataMaxAllowedPacket|TestCursorFetchSendLongData|TestCursorFetchSendLongDataReset)$' -count=1`
- `go test --tags=intest ./pkg/server -run '^(TestStmtSendLongDataMaxAllowedPacket|TestCursorFetchSendLongData|TestCursorFetchSendLongDataReset)$' -count=1`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
TiDB now limits the accumulated `COM_STMT_SEND_LONG_DATA` size for a prepared statement by `max_allowed_packet`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-execution validation for accumulated `COM_STMT_SEND_LONG_DATA` payload sizes.
  * Execution now fails early when long-data exceeds `MaxAllowedPacket`, instead of proceeding with parameter parsing.
  * After oversized-packet failures, affected bound parameters are cleared and the prepared statement can be safely reused.

* **Tests**
  * Added a regression test covering the `MaxAllowedPacket` boundary and oversized long-data submissions, including post-error buffer clearing and continued validation success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->