### PR TITLE
executor: recover panics in spawned goroutines to prevent server crashes

### DIFF
--- a/pkg/executor/checksum.go
+++ b/pkg/executor/checksum.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/ranger"
@@ -141,7 +142,17 @@ func (e *ChecksumTableExec) checksumWorker(taskCh <-chan *checksumTask, resultCh
 			physicalTableID: task.physicalTableID,
 			indexID:         task.indexID,
 		}
-		result.response, result.err = e.handleChecksumRequest(task.request)
+		// This worker runs in a bare goroutine, and handleChecksumRequest can
+		// panic deep in the distsql/proto layer. Recover here so a panic becomes
+		// this task's error instead of crashing the whole tidb-server, and keep
+		// serving the remaining tasks so Open's result loop does not block.
+		util.WithRecovery(func() {
+			result.response, result.err = e.handleChecksumRequest(task.request)
+		}, func(r any) {
+			if r != nil {
+				result.err = util.GetRecoverError(r)
+			}
+		})
 		resultCh <- result
 	}
 }

--- a/pkg/executor/compact_table.go
+++ b/pkg/executor/compact_table.go
@@ -362,6 +362,13 @@ func (task *storeCompactTask) sendRequestWithRetry(req *tikvrpc.Request) (*kvrpc
 			return nil, tikverr.ErrBodyMissing
 		}
 
-		return resp.Resp.(*kvrpcpb.CompactResponse), nil
+		// This runs inside an errgroup goroutine, which does not recover panics,
+		// so guard the assertion: an unexpected response type becomes an error
+		// rather than crashing the whole tidb-server.
+		compactResp, ok := resp.Resp.(*kvrpcpb.CompactResponse)
+		if !ok {
+			return nil, tikverr.ErrBodyMissing
+		}
+		return compactResp, nil
 	}
 }

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -864,6 +864,17 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 		defer trace.StartRegion(ctx, "IndexLookUpIndexTask").End()
 		growWorkerStack16K()
 		defer func() {
+			// The closure runs on a workerPool goroutine (workerPool.run does not
+			// recover), and its prologue/merge-sort regions sit outside the inner
+			// fetchHandles/fetchHandlesRolling recovers. Catch any panic here and
+			// route it to resultCh (before the close below) so it surfaces as a
+			// query error instead of crashing the whole tidb-server.
+			if r := recover(); r != nil {
+				logutil.Logger(ctx).Warn("indexWorker in IndexLookUpExecutor panicked", zap.Any("recover", r), zap.Stack("stack"))
+				doneCh := make(chan error, 1)
+				doneCh <- util.GetRecoverError(r)
+				e.resultCh <- &lookupTableTask{doneCh: doneCh}
+			}
 			close(e.resultCh)
 			e.idxWorkerWg.Done()
 		}()

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -507,6 +507,16 @@ func (c *localMppCoordinator) dispatchAll(ctx context.Context) {
 			defer func() {
 				c.wg.Done()
 			}()
+			// handleDispatchReq drives RPC dispatch and stream receiving; only
+			// sendToRespCh recovers today, so a panic elsewhere on this bare
+			// goroutine would crash the whole tidb-server. Recover here and
+			// surface it as a query error instead.
+			defer func() {
+				if r := recover(); r != nil {
+					logutil.BgLogger().Warn("localMppCoordinator dispatch goroutine panic", zap.Stack("stack"), zap.Any("recover", r))
+					c.sendError(util2.GetRecoverError(r))
+				}
+			}()
 			c.handleDispatchReq(ctx, bo, mppTask)
 		}(task)
 	}

--- a/pkg/executor/join/index_lookup_hash_join.go
+++ b/pkg/executor/join/index_lookup_hash_join.go
@@ -233,12 +233,19 @@ func (e *IndexNestedLoopHashJoin) finishJoinWorkers(r any) {
 }
 
 func (e *IndexNestedLoopHashJoin) wait4JoinWorkers() {
+	// Capture the channels before waiting. This goroutine is unrecovered, so a
+	// close(nil) here would crash the whole tidb-server. Close() nils these
+	// fields, and today that is ordered safely only because channel.Clear blocks
+	// until the close below happens; taking local references removes that
+	// implicit dependency so the close always targets a valid channel.
+	resultCh := e.resultCh
+	taskCh := e.taskCh
 	e.WorkerWg.Wait()
-	if e.resultCh != nil {
-		close(e.resultCh)
+	if resultCh != nil {
+		close(resultCh)
 	}
-	if e.taskCh != nil {
-		close(e.taskCh)
+	if taskCh != nil {
+		close(taskCh)
 	}
 }
 

--- a/pkg/executor/join/index_lookup_join.go
+++ b/pkg/executor/join/index_lookup_join.go
@@ -526,8 +526,13 @@ func (iw *innerWorker) run(ctx context.Context, wg *sync.WaitGroup) {
 			iw.lookup.Finished.Store(true)
 			logutil.Logger(ctx).Warn("innerWorker panicked", zap.Any("recover", r), zap.Stack("stack"))
 			err := util.GetRecoverError(r)
-			// "task != nil" is guaranteed when panic happened.
-			task.doneCh <- err
+			// task is normally non-nil when a panic happens (only handleTask
+			// panics today), but guard the send anyway: a panic raised before the
+			// first task is received would otherwise nil-deref here, escape this
+			// recover, and crash the whole tidb-server.
+			if task != nil {
+				task.doneCh <- err
+			}
 		}
 		wg.Done()
 	}()

--- a/pkg/executor/mppcoordmanager/BUILD.bazel
+++ b/pkg/executor/mppcoordmanager/BUILD.bazel
@@ -23,9 +23,11 @@ go_test(
     embed = [":mppcoordmanager"],
     flaky = True,
     race = "on",
+    shard_count = 2,
     deps = [
         "//pkg/kv",
         "//pkg/store/copr",
+        "@com_github_pingcap_kvproto//pkg/mpp",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/executor/mppcoordmanager/mpp_coordinator_manager.go
+++ b/pkg/executor/mppcoordmanager/mpp_coordinator_manager.go
@@ -147,6 +147,13 @@ func (m *MPPCoordinatorManager) GetCoordCount() int {
 
 // ReportStatus reports mpp task execution status to specific coordinator
 func (m *MPPCoordinatorManager) ReportStatus(request *mpp.ReportTaskStatusRequest) *mpp.ReportTaskStatusResponse {
+	// request.Meta is dereferenced below, and this runs directly on the gRPC
+	// handler path (rpcServer.ReportMPPTaskStatus), which has no per-request
+	// panic recovery. Guard a malformed request with nil Meta so a bad peer
+	// cannot crash the whole tidb-server.
+	if request == nil || request.Meta == nil {
+		return &mpp.ReportTaskStatusResponse{Error: &mpp.Error{Msg: "invalid ReportTaskStatusRequest: nil meta"}}
+	}
 	mppQueryID := kv.MPPQueryID{
 		QueryTs:      request.Meta.QueryTs,
 		LocalQueryID: request.Meta.LocalQueryId,

--- a/pkg/executor/mppcoordmanager/mpp_coordinator_manager_test.go
+++ b/pkg/executor/mppcoordmanager/mpp_coordinator_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/mpp"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/store/copr"
 	"github.com/stretchr/testify/require"
@@ -91,4 +92,20 @@ func TestDetectAndDelete(t *testing.T) {
 	for id := range InstanceMPPCoordinatorManager.coordinatorMap {
 		require.True(t, id.GatherID == 2 || id.GatherID == 3)
 	}
+}
+
+// TestReportStatusWithNilMeta verifies that a malformed ReportTaskStatusRequest
+// with a nil Meta returns an error response instead of panicking. ReportStatus
+// runs directly on the gRPC handler goroutine, which has no panic recovery, so a
+// nil-Meta dereference there would crash the whole tidb-server.
+func TestReportStatusWithNilMeta(t *testing.T) {
+	m := newMPPCoordinatorManger()
+
+	resp := m.ReportStatus(&mpp.ReportTaskStatusRequest{Meta: nil})
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+
+	resp = m.ReportStatus(nil)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
 }

--- a/pkg/executor/sample.go
+++ b/pkg/executor/sample.go
@@ -27,11 +27,14 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/channel"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	decoder "github.com/pingcap/tidb/pkg/util/rowDecoder"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/zap"
 )
 
 var _ exec.Executor = &TableSampleExecutor{}
@@ -372,6 +375,16 @@ type sampleFetcher struct {
 
 func (s *sampleFetcher) run() {
 	defer close(s.kvChan)
+	// This goroutine is spawned bare (see scanFirstKVForEachRange), so a panic
+	// here would crash the whole tidb-server. Convert it into s.err, which the
+	// syncer observes after kvChan is closed, turning it into a query error.
+	defer func() {
+		if r := recover(); r != nil {
+			s.err = util.GetRecoverError(r)
+			logutil.BgLogger().Error("panic in the recoverable goroutine of table sample fetcher",
+				zap.Any("r", r), zap.Stack("stack trace"))
+		}
+	}()
 	for i, r := range s.ranges {
 		if i%s.concurrency != s.workerID {
 			continue


### PR DESCRIPTION
The main executor path is recovered at the connection level, so a panic there becomes a query error. Several executor code paths, however, panic on a spawned goroutine (or inside a recovery/cleanup handler) with no recover, so a panic would crash the whole tidb-server instead. Harden the eight such sites found by a panic-risk audit of pkg/executor, converting each panic into a query error using the recovery convention already used elsewhere in the same file:

- sample.go: sampleFetcher.run() records a recovered panic in s.err, which the syncer surfaces after kvChan is closed.
- checksum.go: checksumWorker recovers per task into result.err and keeps serving remaining tasks so Open's result loop cannot block.
- distsql.go: the index-worker workerPool closure recovers and routes the panic to resultCh before closing it (the table-worker submit is already covered by execTableTask's recover).
- internal/mpp/local_mpp_coordinator.go: the per-task dispatch goroutine recovers via sendError, matching sendToRespCh.
- compact_table.go: guard the CompactResponse type assertion, which runs inside an unrecovered errgroup goroutine.
- mppcoordmanager: ReportStatus guards a nil request/Meta on the unrecovered gRPC handler path.
- join/index_lookup_join.go: innerWorker's recover handler guards task != nil before sending, so the handler itself cannot nil-deref.
- join/index_lookup_hash_join.go: wait4JoinWorkers captures the result and task channels into locals before Wait, removing the close(nil) race that was previously avoided only by channel.Clear blocking.

Add TestReportStatusWithNilMeta as a regression test for the nil-Meta guard (verified it panics without the fix).

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query and task stability by handling unexpected errors more gracefully instead of crashing.
  * Added safer handling for worker shutdown and channel cleanup to prevent rare runtime failures.
  * Validated request input for status reporting so invalid or empty requests now return a clear error response.
  * Fixed compact-table request handling to return an error when responses are missing or malformed.

* **Tests**
  * Added coverage for invalid status-report requests to ensure error responses are returned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->