### PR TITLE
executor: fix out-of-bounds write in DATA_LOCK_WAITS SQL-digest batching

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -542,6 +542,7 @@ go_test(
         "@com_github_pingcap_fn//:fn",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/coprocessor",
+        "@com_github_pingcap_kvproto//pkg/deadlock",
         "@com_github_pingcap_kvproto//pkg/diagnosticspb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_pingcap_kvproto//pkg/keyspacepb",

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3208,6 +3208,18 @@ func (r *dataLockWaitsTableRetriever) retrieve(ctx context.Context, sctx session
 	var res [][]types.Datum
 
 	err := r.nextBatch(func(start, end int) error {
+		// data_lock_waits contains both lockWaits (pessimistic lock waiting)
+		// and resolving (optimistic lock "waiting") info. We return the lockWaits
+		// first, then resolving, so compute the batch boundaries within each
+		// slice up front. lockWaitsInBatch is the slice of lockWaits belonging to
+		// this batch; every per-row index below (digests included) is relative to
+		// it.
+		lockWaitsStart := min(start, len(r.lockWaits))
+		resolvingStart := start - lockWaitsStart
+		lockWaitsEnd := min(end, len(r.lockWaits))
+		resolvingEnd := end - lockWaitsEnd
+		lockWaitsInBatch := r.lockWaits[lockWaitsStart:lockWaitsEnd]
+
 		// Before getting rows, collect the SQL digests that needs to be retrieved first.
 		var needDigest bool
 		var needSQLText bool
@@ -3221,8 +3233,13 @@ func (r *dataLockWaitsTableRetriever) retrieve(ctx context.Context, sctx session
 
 		var digests []string
 		if needDigest || needSQLText {
-			digests = make([]string, end-start)
-			for i, lockWait := range r.lockWaits {
+			// digests is indexed by the row offset within lockWaitsInBatch, so it
+			// must be sized and filled from that batch slice. Iterating the whole
+			// r.lockWaits here would write past the end of digests (an index
+			// out-of-range panic) whenever a batch does not contain every lock
+			// wait, and would also misalign digests[rowIdx] in later batches.
+			digests = make([]string, len(lockWaitsInBatch))
+			for i, lockWait := range lockWaitsInBatch {
 				digest, err := resourcegrouptag.DecodeResourceGroupTag(lockWait.ResourceGroupTag)
 				if err != nil {
 					// Ignore the error if failed to decode the digest from resource_group_tag. We still want to show
@@ -3253,15 +3270,7 @@ func (r *dataLockWaitsTableRetriever) retrieve(ctx context.Context, sctx session
 
 		// Calculate rows.
 		res = make([][]types.Datum, 0, end-start)
-		// data_lock_waits contains both lockWaits (pessimistic lock waiting)
-		// and resolving (optimistic lock "waiting") info
-		// first we'll return the lockWaits, and then resolving, so we need to
-		// do some index calculation here
-		lockWaitsStart := min(start, len(r.lockWaits))
-		resolvingStart := start - lockWaitsStart
-		lockWaitsEnd := min(end, len(r.lockWaits))
-		resolvingEnd := end - lockWaitsEnd
-		for rowIdx, lockWait := range r.lockWaits[lockWaitsStart:lockWaitsEnd] {
+		for rowIdx, lockWait := range lockWaitsInBatch {
 			row := make([]types.Datum, 0, len(r.columns))
 
 			for _, col := range r.columns {

--- a/pkg/executor/infoschema_reader_internal_test.go
+++ b/pkg/executor/infoschema_reader_internal_test.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -165,23 +167,38 @@ func TestSetDataFromKeywords(t *testing.T) {
 	require.Equal(t, types.NewIntDatum(1), mt.rows[0][1])        // Reserved: true(1)
 }
 
-// TestDataLockWaitsRetrieverBatchDigests is a regression test for an
-// out-of-bounds write in the DATA_LOCK_WAITS retriever. The per-row SQL-digest
-// slice is sized to the current batch, but the fill loop used to iterate every
-// lock wait, so more than batchSize (1024) waiters overran the slice and
-// panicked with "index out of range". It also verifies all rows are returned
-// across batches.
+// TestDataLockWaitsRetrieverBatchDigests is a regression test for two bugs in
+// the DATA_LOCK_WAITS retriever's SQL-digest handling. The per-row digest slice
+// is sized to the current batch, but the fill loop used to iterate every lock
+// wait: with more than batchSize (1024) waiters it overran the batch-sized
+// slice and panicked with "index out of range", and on later batches it also
+// misaligned digests[rowIdx], attributing digests to the wrong rows.
+//
+// Each lock wait is given a distinct SQL digest so the test can assert the
+// returned digest column matches the expected value for every row across all
+// batches, which is what exercises the alignment fix (not just the row count).
 func TestDataLockWaitsRetrieverBatchDigests(t *testing.T) {
 	const numLockWaits = 1500 // > batchSize (1024) so the fill loop overran the batch-sized slice
+
+	// Give each lock wait a distinct SQL digest, built and encoded with the same
+	// production helpers the KV layer uses, so the test drives the real
+	// encode/decode round trip and can assert per-row digest alignment across
+	// batches (not just the row count).
+	expectedDigests := make([]string, numLockWaits)
 	lockWaits := make([]*deadlock.WaitForEntry, numLockWaits)
 	for i := range lockWaits {
+		digest := parser.NewDigest([]byte{byte(i), byte(i >> 8)})
+		expectedDigests[i] = digest.String()
 		lockWaits[i] = &deadlock.WaitForEntry{
-			Txn:        uint64(i + 1),
-			WaitForTxn: uint64(i + 2),
-			Key:        []byte{byte(i), byte(i >> 8)},
+			Txn:              uint64(i + 1),
+			WaitForTxn:       uint64(i + 2),
+			Key:              []byte{byte(i), byte(i >> 8)},
+			ResourceGroupTag: kv.NewResourceGroupTagBuilder(nil).SetSQLDigest(digest).EncodeTagWithKey(nil),
 		}
 	}
 
+	// Column order below fixes SQL_DIGEST at row index 1.
+	const digestColIdx = 1
 	r := &dataLockWaitsTableRetriever{
 		table: &model.TableInfo{Name: ast.NewCIStr("DATA_LOCK_WAITS")},
 		columns: []*model.ColumnInfo{
@@ -197,11 +214,16 @@ func TestDataLockWaitsRetrieverBatchDigests(t *testing.T) {
 	sctx := mock.NewContext()
 	ctx := context.Background()
 
-	total := 0
+	// Rows are returned batch by batch, lockWaits first and in order, so the
+	// accumulated rows line up 1:1 with lockWaits.
+	var rows [][]types.Datum
 	for !r.retrieved {
-		rows, err := r.retrieve(ctx, sctx)
+		batch, err := r.retrieve(ctx, sctx)
 		require.NoError(t, err)
-		total += len(rows)
+		rows = append(rows, batch...)
 	}
-	require.Equal(t, numLockWaits, total)
+	require.Len(t, rows, numLockWaits)
+	for i, row := range rows {
+		require.Equal(t, expectedDigests[i], row[digestColIdx].GetString(), "digest mismatch at row %d", i)
+	}
 }

--- a/pkg/executor/infoschema_reader_internal_test.go
+++ b/pkg/executor/infoschema_reader_internal_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -161,4 +163,45 @@ func TestSetDataFromKeywords(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.NewStringDatum("ADD"), mt.rows[0][0]) // Keyword: ADD
 	require.Equal(t, types.NewIntDatum(1), mt.rows[0][1])        // Reserved: true(1)
+}
+
+// TestDataLockWaitsRetrieverBatchDigests is a regression test for an
+// out-of-bounds write in the DATA_LOCK_WAITS retriever. The per-row SQL-digest
+// slice is sized to the current batch, but the fill loop used to iterate every
+// lock wait, so more than batchSize (1024) waiters overran the slice and
+// panicked with "index out of range". It also verifies all rows are returned
+// across batches.
+func TestDataLockWaitsRetrieverBatchDigests(t *testing.T) {
+	const numLockWaits = 1500 // > batchSize (1024) so the fill loop overran the batch-sized slice
+	lockWaits := make([]*deadlock.WaitForEntry, numLockWaits)
+	for i := range lockWaits {
+		lockWaits[i] = &deadlock.WaitForEntry{
+			Txn:        uint64(i + 1),
+			WaitForTxn: uint64(i + 2),
+			Key:        []byte{byte(i), byte(i >> 8)},
+		}
+	}
+
+	r := &dataLockWaitsTableRetriever{
+		table: &model.TableInfo{Name: ast.NewCIStr("DATA_LOCK_WAITS")},
+		columns: []*model.ColumnInfo{
+			{Name: ast.NewCIStr(infoschema.DataLockWaitsColumnKey)},
+			{Name: ast.NewCIStr(infoschema.DataLockWaitsColumnSQLDigest)},
+		},
+		lockWaits:   lockWaits,
+		initialized: true, // skip the privilege check and store fetch; drive the batch loop directly
+	}
+	r.batchRetrieverHelper.totalRows = len(lockWaits)
+	r.batchRetrieverHelper.batchSize = 1024
+
+	sctx := mock.NewContext()
+	ctx := context.Background()
+
+	total := 0
+	for !r.retrieved {
+		rows, err := r.retrieve(ctx, sctx)
+		require.NoError(t, err)
+		total += len(rows)
+	}
+	require.Equal(t, numLockWaits, total)
 }


### PR DESCRIPTION
The DATA_LOCK_WAITS retriever sizes the per-row SQL-digest slice to the current batch (end-start, capped at batchSize=1024), but the fill loop iterated the entire r.lockWaits slice. Whenever a batch does not contain every lock wait -- more than 1024 waiters, or resolving locks pushing the wait rows into a later batch -- the loop wrote past the end of the slice and panicked with "index out of range". On batches after the first it also misaligned digests[rowIdx], attributing digests to the wrong rows.

Compute the batch boundaries up front and scope the digest slice to the batch's lockWaits sub-slice (lockWaitsInBatch), so the fill loop and the per-row read share the same indexing. Both bugs are fixed.

This is user-reachable with default settings via
SELECT * FROM information_schema.data_lock_waits (PROCESS privilege) under heavy pessimistic-lock contention; the retriever runs on the main executor path, so the panic surfaces as a query error rather than a crash, but the table becomes unreadable while contention persists.

Add TestDataLockWaitsRetrieverBatchDigests, which drives the retriever with 1500 lock waits and asserts all rows are returned across batches (verified it panics with index out of range without the fix).

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected lock-waits batching for the `DATA_LOCK_WAITS` results, ensuring pessimistic and optimistic portions stay aligned.
  * Fixed SQL-digest reporting to avoid missing or mismatched digest values across batched retrievals and large result sets.

* **Tests**
  * Added a regression test that retrieves a large number of lock-wait rows in multiple batches and verifies that every row (including its SQL digest) is returned accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->