### PR TITLE
Revert "planner: update index advisor commends"

### DIFF
--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -2064,7 +2064,7 @@ func (n *RecommendIndexStmt) Restore(ctx *format.RestoreCtx) error {
 			}
 		}
 	case "show":
-		ctx.WriteKeyWord(" SHOW OPTION")
+		ctx.WriteKeyWord(" SHOW")
 	case "apply":
 		ctx.WriteKeyWord(" APPLY ")
 		ctx.WriteKeyWord(fmt.Sprintf("%d", n.ID))

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -13856,7 +13856,7 @@ ConnectionOptions:
 		for _, option := range $2.([]*ast.ResourceOption) {
 			switch option.Type {
 			case ast.MaxUserConnections:
-			// do nothing.
+				// do nothing.
 			default:
 				needWarning = true
 			}
@@ -14413,7 +14413,7 @@ RecommendIndexStmt:
 
 		$$ = x
 	}
-|	"RECOMMEND" "INDEX" "SHOW" "OPTION"
+|	"RECOMMEND" "INDEX" "SHOW"
 	{
 		x := &ast.RecommendIndexStmt{
 			Action: "show",

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -474,7 +474,7 @@ func TestRecommendIndex(t *testing.T) {
 			"RECOMMEND INDEX RUN FOR 'select * from t where a=1' WITH A = 1"},
 		{"recommend index run for 'select * from t where a=1' with A = 1, B = 2", true,
 			"RECOMMEND INDEX RUN FOR 'select * from t where a=1' WITH A = 1, B = 2"},
-		{"recommend index show option", true, "RECOMMEND INDEX SHOW OPTION"},
+		{"recommend index show", true, "RECOMMEND INDEX SHOW"},
 		{"recommend index apply 1", true, "RECOMMEND INDEX APPLY 1"},
 		{"recommend index ignore 1", true, "RECOMMEND INDEX IGNORE 1"},
 		{"recommend index set A = 1", true, "RECOMMEND INDEX SET A = 1"},

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6342,7 +6342,7 @@ func (*PlanBuilder) buildRecommendIndex(v *ast.RecommendIndexStmt) (base.Plan, e
 		schema.Append(buildColumnWithName("", "table", mysql.TypeVarchar, 64))
 		schema.Append(buildColumnWithName("", "index_name", mysql.TypeVarchar, 64))
 		schema.Append(buildColumnWithName("", "index_columns", mysql.TypeVarchar, 256))
-		schema.Append(buildColumnWithName("", "est_index_size", mysql.TypeVarchar, 256))
+		schema.Append(buildColumnWithName("", "index_size", mysql.TypeVarchar, 256))
 		schema.Append(buildColumnWithName("", "reason", mysql.TypeVarchar, 256))
 		schema.Append(buildColumnWithName("", "top_impacted_query", mysql.TypeBlob, -1))
 		p.setSchemaAndNames(schema.col2Schema(), schema.names)

--- a/pkg/planner/indexadvisor/options_test.go
+++ b/pkg/planner/indexadvisor/options_test.go
@@ -144,28 +144,28 @@ func TestOptionsMultiple(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 3 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 1000 The maximum number of queries to recommend indexes.",
 			"timeout 30s The timeout of index advisor."))
 
 	tk.MustExec(`recommend index set max_num_query=111, max_index_columns=11, timeout='11m'`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 11 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 111 The maximum number of queries to recommend indexes.",
 			"timeout 11m The timeout of index advisor."))
 
 	tk.MustExec(`recommend index set max_num_query=222, max_index_columns=22, timeout='22m'`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 22 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 222 The maximum number of queries to recommend indexes.",
 			"timeout 22m The timeout of index advisor."))
 
 	tk.MustExecToErr(`recommend index set max_num_query=333, max_index_columns=33, timeout='-33m'`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 33 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 333 The maximum number of queries to recommend indexes.",
@@ -211,28 +211,28 @@ func TestOptionShow(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 3 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 1000 The maximum number of queries to recommend indexes.",
 			"timeout 30s The timeout of index advisor."))
 
 	tk.MustExec(`recommend index set max_num_query=1111`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 3 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 1111 The maximum number of queries to recommend indexes.",
 			"timeout 30s The timeout of index advisor."))
 
 	tk.MustExec(`recommend index set max_index_columns=10`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 10 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 1111 The maximum number of queries to recommend indexes.",
 			"timeout 30s The timeout of index advisor."))
 
 	tk.MustExec(`recommend index set timeout='10m'`)
-	tk.MustQuery(`recommend index show option`).Sort().
+	tk.MustQuery(`recommend index show`).Sort().
 		Check(testkit.Rows("max_index_columns 10 The maximum number of columns in an index.",
 			"max_num_index 5 The maximum number of indexes to recommend for a table.",
 			"max_num_query 1111 The maximum number of queries to recommend indexes.",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #12303

Problem Summary: planner: update index advisor commends

### What changed and how does it work?

Temporarily revert this PR since the team is preparing to deliver v8.5.7. To avoid re-running all tests, revert this PR for now and pick it into v8.5 next version.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `RECOMMEND INDEX SHOW` now works without the extra `OPTION` keyword.
  * Index recommendation output now uses `index_size` as the displayed column name.

* **Bug Fixes**
  * Improved handling of connection option parsing for `MAX_USER_CONNECTIONS`.
  * Updated restore behavior and tests to match the new `SHOW` syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->