### PR TITLE
planner: clone partition info for runtime plan clone

### DIFF
--- a/pkg/executor/partition_table_test.go
+++ b/pkg/executor/partition_table_test.go
@@ -1502,6 +1502,42 @@ func TestSplitRegion(t *testing.T) {
 	tk.MustPartition(`select * from thash where a in (1, 10001, 20001)`, "p1").Sort().Check(result)
 }
 
+func TestParallelApplyWithLimitOnRangeColumnsPartition(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
+	tk.MustExec("set @@tidb_enable_parallel_apply = 1")
+	tk.MustExec("set @@tidb_executor_concurrency = 2")
+	tk.MustExec(`create table t_outer (
+		join_id varchar(32) not null,
+		part_col int not null,
+		payload varchar(32),
+		key idx_outer_join(join_id)
+	)`)
+	tk.MustExec(`create table t_part (
+		part_col int not null,
+		join_id varchar(32) not null,
+		filter_col varchar(32) not null,
+		metric decimal(35,15),
+		seq_id bigint not null,
+		row_key varchar(32) not null,
+		primary key (part_col, seq_id, row_key, filter_col, join_id) nonclustered,
+		key idx_join_filter_part(join_id, filter_col, part_col)
+	) partition by range columns (part_col) (partition p0 values less than (100))`)
+	tk.MustExec("insert into t_outer values ('key1', 10, 'payload1')")
+	tk.MustExec("insert into t_part values (10, 'key1', 'flag1', 0.001, 1, 'row1')")
+
+	sql := `select payload from t_outer o where ifnull((
+		select s.metric from t_part s use index(idx_join_filter_part)
+		where s.join_id = o.join_id and s.part_col = o.part_col and s.filter_col = 'flag1'
+		limit 1), 0) < 0.01`
+	tk.MustHavePlan(sql, "IndexLookUp")
+	tk.MustQuery(sql).Check(testkit.Rows("payload1"))
+}
+
 func TestParallelApply(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
 

--- a/pkg/planner/core/operator/physicalop/physical_index_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_reader.go
@@ -68,6 +68,7 @@ func (p *PhysicalIndexReader) Clone(newCtx base.PlanContext) (base.PhysicalPlan,
 		return nil, err
 	}
 	cloned.OutputColumns = util.CloneCols(p.OutputColumns)
+	cloned.PlanPartInfo = p.PlanPartInfo.Clone()
 	return cloned, err
 }
 

--- a/pkg/planner/core/operator/physicalop/physical_indexlookup_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_indexlookup_reader.go
@@ -93,6 +93,7 @@ func (p *PhysicalIndexLookUpReader) Clone(newCtx base.PlanContext) (base.Physica
 	if cloned.TablePlan, err = p.TablePlan.Clone(newCtx); err != nil {
 		return nil, err
 	}
+	cloned.PlanPartInfo = p.PlanPartInfo.Clone()
 	if p.ExtraHandleCol != nil {
 		cloned.ExtraHandleCol = p.ExtraHandleCol.Clone().(*expression.Column)
 	}

--- a/pkg/planner/core/operator/physicalop/physical_plan_misc.go
+++ b/pkg/planner/core/operator/physicalop/physical_plan_misc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
@@ -115,6 +116,19 @@ func (pi *PhysPlanPartInfo) CloneForPlanCache() *PhysPlanPartInfo {
 	cloned.PartitionNames = pi.PartitionNames
 	cloned.Columns = utilfuncp.CloneColumnsForPlanCache(pi.Columns, nil)
 	cloned.ColumnNames = pi.ColumnNames
+	return cloned
+}
+
+// Clone clones the PhysPlanPartInfo.
+func (pi *PhysPlanPartInfo) Clone() *PhysPlanPartInfo {
+	if pi == nil {
+		return nil
+	}
+	cloned := new(PhysPlanPartInfo)
+	cloned.PruningConds = plannerutil.CloneExprs(pi.PruningConds)
+	cloned.PartitionNames = append([]ast.CIStr(nil), pi.PartitionNames...)
+	cloned.Columns = plannerutil.CloneCols(pi.Columns)
+	cloned.ColumnNames = types.NameSlice(plannerutil.CloneFieldNames(pi.ColumnNames))
 	return cloned
 }
 

--- a/pkg/planner/core/operator/physicalop/physical_table_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_reader.go
@@ -231,6 +231,7 @@ func (p *PhysicalTableReader) Clone(newCtx base.PlanContext) (base.PhysicalPlan,
 	cloned.StoreType = p.StoreType
 	cloned.ReadReqType = p.ReadReqType
 	cloned.IsCommonHandle = p.IsCommonHandle
+	cloned.PlanPartInfo = p.PlanPartInfo.Clone()
 	if cloned.TablePlan, err = p.TablePlan.Clone(newCtx); err != nil {
 		return nil, err
 	}

--- a/pkg/planner/core/operator/physicalop/physical_table_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_scan.go
@@ -307,6 +307,7 @@ func (p *PhysicalTableScan) Clone(newCtx base.PlanContext) (base.PhysicalPlan, e
 	clonedScan.AccessCondition = util.CloneExprs(p.AccessCondition)
 	clonedScan.FilterCondition = util.CloneExprs(p.FilterCondition)
 	clonedScan.LateMaterializationFilterCondition = util.CloneExprs(p.LateMaterializationFilterCondition)
+	clonedScan.PlanPartInfo = p.PlanPartInfo.Clone()
 	if p.Table != nil {
 		clonedScan.Table = p.Table.Clone()
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fixes #69709

Problem Summary:

When `tidb_enable_parallel_apply` and dynamic partition pruning are enabled, a correlated subquery with `LIMIT` may run as a parallel Apply whose inner plan contains an `IndexLookUp` on a `RANGE COLUMNS` partitioned table. Parallel Apply clones the inner physical plan for each worker, but the runtime clone path did not preserve `PlanPartInfo`. As a result, dynamic partition pruning later sees empty partition columns and panics while building the range-columns pruner.

### What changed and how does it work?

- Clone `PlanPartInfo` for runtime physical plan clones of table/index readers and table scan.
- Add a `PhysPlanPartInfo.Clone()` helper for runtime cloning.
- Add a regression test covering parallel Apply + correlated subquery `LIMIT` + dynamic pruning + `RANGE COLUMNS` partition + inner `IndexLookUp`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix a panic that could occur when Parallel Apply and dynamic partition pruning are used with a RANGE COLUMNS partitioned table.
```

### Verification

- `go test -tags=intest ./pkg/executor -run '^TestParallelApplyWithLimitOnRangeColumnsPartition$' -count=1`
- `go test ./pkg/planner/core/operator/physicalop -run '^$' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved partition-aware plan cloning so partition pruning and related partition metadata are preserved correctly across cloned physical plan readers/scans, improving reliability for index-based access and parallel execution.

* **Tests**
  * Added a regression test covering a partitioned table query with a correlated subquery using `LIMIT 1`, validating the optimizer plan includes `IndexLookUp` and the query returns the expected single row under parallel execution settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->