### PR TITLE
ddl: observe TiKV capacity and ingested SST for add index

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -168,7 +168,8 @@ func (s *backfillDistExecutor) newBackfillStepExecutor(
 		jc := ddlObj.jobContext(jobMeta.ID, jobMeta.ReorgMeta)
 		ddlObj.attachTopProfilingInfo(jobMeta.ID, jobMeta.Query)
 		ddlObj.setDDLSourceForDiagnosis(jobMeta.ID, jobMeta.Type)
-		return newReadIndexExecutor(store, sessPool, ddlObj.etcdCli, jobMeta, indexInfos, tbl, jc, cloudStorageURI, estRowSize)
+		return newReadIndexExecutor(store, sessPool, ddlObj.etcdCli, jobMeta, indexInfos, tbl, jc,
+			cloudStorageURI, estRowSize)
 	case proto.BackfillStepMergeSort:
 		return newMergeSortExecutor(&s.task.TaskBase, store, jobMeta.ID, indexInfos, tbl, cloudStorageURI)
 	case proto.BackfillStepWriteAndIngest:

--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	goerrors "errors"
+	"sync"
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
@@ -41,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
 )
 
 type cloudImportExecutor struct {
@@ -55,6 +57,7 @@ type cloudImportExecutor struct {
 	metric        *lightningmetric.Common
 	engine        atomic.Pointer[globalsort.Engine]
 	summary       *execute.SubtaskSummary
+	ingestedSSTs  *ingestedSSTRecorder
 }
 
 func newCloudImportExecutor(
@@ -64,14 +67,17 @@ func newCloudImportExecutor(
 	ptbl table.PhysicalTable,
 	cloudStoreURI string,
 ) (*cloudImportExecutor, error) {
-	return &cloudImportExecutor{
+	summary := &execute.SubtaskSummary{}
+	executor := &cloudImportExecutor{
 		job:           job,
 		store:         store,
 		indexes:       indexes,
 		ptbl:          ptbl,
 		cloudStoreURI: cloudStoreURI,
-		summary:       &execute.SubtaskSummary{},
-	}, nil
+		summary:       summary,
+		ingestedSSTs:  newIngestedSSTRecorder(),
+	}
+	return executor, nil
 }
 
 func (e *cloudImportExecutor) Init(ctx context.Context) error {
@@ -95,6 +101,7 @@ func (e *cloudImportExecutor) Init(ctx context.Context) error {
 
 func (e *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) error {
 	logutil.Logger(ctx).Info("cloud import executor run subtask")
+	e.ingestedSSTs.Reset()
 
 	accessRec, objStore, err := handle.NewObjStoreWithRecording(ctx, e.cloudStoreURI)
 	if err != nil {
@@ -117,7 +124,8 @@ func (e *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 	}
 
 	localBackend.SetCollector(&ingestCollector{
-		meterRec: meterRec,
+		meterRec:     meterRec,
+		ingestedSSTs: e.ingestedSSTs,
 	})
 
 	currentIdx, idxID, err := getIndexInfoAndID(sm.EleIDs, e.indexes)
@@ -170,6 +178,7 @@ func (e *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 		err = context.DeadlineExceeded
 	})
 	if err == nil {
+		logIngestedSSTObservation(ctx, e.job.ID, subtask.TaskID, subtask.ID, subtask.Step, e.ingestedSSTs.Snapshot())
 		return nil
 	}
 
@@ -214,6 +223,7 @@ func (e *cloudImportExecutor) RealtimeSummary() *execute.SubtaskSummary {
 
 // ResetSummary resets the summary stored in the executor.
 func (e *cloudImportExecutor) ResetSummary() {
+	e.ingestedSSTs.Reset()
 	e.summary.Reset()
 }
 
@@ -257,15 +267,118 @@ func (e *cloudImportExecutor) ResourceModified(ctx context.Context, newResource 
 	return nil
 }
 
+// ingestCollector is shared with ingest worker callbacks. Its SST observation
+// path delegates to ingestedSSTRecorder, which protects mutable state.
 type ingestCollector struct {
 	execute.NoopCollector
-	meterRec *metering.Recorder
+	meterRec     *metering.Recorder
+	ingestedSSTs *ingestedSSTRecorder
 }
 
 func (c *ingestCollector) Processed(bytes, _ int64) {
 	// since the region job might be retried, this value might be larger than
 	// the total KV size.
 	c.meterRec.IncClusterWriteBytes(uint64(bytes))
+}
+
+func (c *ingestCollector) RecordIngestedSST(identity string, size uint64) {
+	if c.ingestedSSTs != nil {
+		c.ingestedSSTs.RecordIngestedSST(identity, size)
+	}
+}
+
+// ingestedSSTRecorder protects SST observation state because RecordIngestedSST
+// can be called concurrently by ingest workers. Reset is called before subtask
+// execution, and Snapshot is called after the ingest path finishes.
+type ingestedSSTRecorder struct {
+	execute.NoopCollector
+
+	mu                   sync.Mutex
+	seen                 map[string]struct{}
+	bytes                uint64
+	count                uint64
+	zeroSizeCount        uint64
+	invalidIdentityCount uint64
+}
+
+func newIngestedSSTRecorder() *ingestedSSTRecorder {
+	return &ingestedSSTRecorder{
+		seen: make(map[string]struct{}),
+	}
+}
+
+func (r *ingestedSSTRecorder) RecordIngestedSST(identity string, size uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if identity == "" {
+		r.invalidIdentityCount++
+		return
+	}
+	if _, ok := r.seen[identity]; ok {
+		return
+	}
+	r.seen[identity] = struct{}{}
+	r.count++
+	r.bytes += size
+	if size == 0 {
+		r.zeroSizeCount++
+	}
+}
+
+func (r *ingestedSSTRecorder) Reset() {
+	r.mu.Lock()
+	clear(r.seen)
+	r.bytes = 0
+	r.count = 0
+	r.zeroSizeCount = 0
+	r.invalidIdentityCount = 0
+	r.mu.Unlock()
+}
+
+func (r *ingestedSSTRecorder) Snapshot() ingestedSSTBytesObservation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	observation := ingestedSSTBytesObservation{
+		bytes:                r.bytes,
+		count:                r.count,
+		zeroSizeCount:        r.zeroSizeCount,
+		invalidIdentityCount: r.invalidIdentityCount,
+		reliable:             true,
+		reason:               "ok",
+	}
+	switch {
+	case observation.invalidIdentityCount > 0:
+		observation.reliable = false
+		observation.reason = "ingested_sst_identity_unavailable"
+	case observation.zeroSizeCount > 0:
+		observation.reliable = false
+		observation.reason = "ingested_sst_size_unavailable"
+	}
+	return observation
+}
+
+func logIngestedSSTObservation(
+	ctx context.Context,
+	jobID int64,
+	taskID int64,
+	subtaskID int64,
+	step proto.Step,
+	observation ingestedSSTBytesObservation,
+) {
+	if observation.count == 0 && observation.invalidIdentityCount == 0 {
+		return
+	}
+	logutil.Logger(ctx).Info("observed ingested SST bytes for add-index subtask",
+		zap.Int64("jobID", jobID),
+		zap.Int64("taskID", taskID),
+		zap.Int64("subtaskID", subtaskID),
+		zap.Int("step", int(step)),
+		zap.Uint64("ingested_sst_bytes", observation.bytes),
+		zap.Uint64("ingested_sst_count", observation.count),
+		zap.Uint64("ingested_sst_zero_size_count", observation.zeroSizeCount),
+		zap.Uint64("ingested_sst_invalid_identity_count", observation.invalidIdentityCount),
+		zap.Bool("ingested_sst_bytes_reliable", observation.reliable),
+		zap.String("ingested_sst_bytes_reliable_reason", observation.reason))
 }
 
 func getIndexInfoAndID(eleIDs []int64, indexes []*model.IndexInfo) (currentIdx *model.IndexInfo, idxID int64, err error) {

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -65,7 +65,8 @@ type readIndexStepExecutor struct {
 	avgRowSize      int
 	cloudStorageURI string
 
-	summary *execute.SubtaskSummary
+	summary      *execute.SubtaskSummary
+	ingestedSSTs *ingestedSSTRecorder
 
 	summaryMap sync.Map // subtaskID => readIndexSummary
 	backendCfg *ingestctrl.BackendConfig
@@ -92,7 +93,8 @@ func newReadIndexExecutor(
 	cloudStorageURI string,
 	avgRowSize int,
 ) (*readIndexStepExecutor, error) {
-	return &readIndexStepExecutor{
+	summary := &execute.SubtaskSummary{}
+	executor := &readIndexStepExecutor{
 		store:           store,
 		etcdCli:         etcdCli,
 		sessPool:        sessPool,
@@ -102,8 +104,10 @@ func newReadIndexExecutor(
 		jc:              jc,
 		cloudStorageURI: cloudStorageURI,
 		avgRowSize:      avgRowSize,
-		summary:         &execute.SubtaskSummary{},
-	}, nil
+		summary:         summary,
+		ingestedSSTs:    newIngestedSSTRecorder(),
+	}
+	return executor, nil
 }
 
 func (r *readIndexStepExecutor) Init(ctx context.Context) error {
@@ -161,6 +165,10 @@ func (r *readIndexStepExecutor) runLocalPipeline(
 	sm *BackfillSubTaskMeta,
 	concurrency int,
 ) error {
+	if r.ingestedSSTs != nil && r.backend != nil {
+		r.ingestedSSTs.Reset()
+		r.backend.SetCollector(r.ingestedSSTs)
+	}
 	bCtx, err := ingest.NewBackendCtxBuilder(ctx, r.store, r.job).
 		WithImportDistributedLock(r.etcdCli, sm.TS).
 		WithDistTaskCheckpointManagerParam(
@@ -196,6 +204,7 @@ func (r *readIndexStepExecutor) runLocalPipeline(
 	if err = bCtx.FinishAndUnregisterEngines(ingest.OptCleanData | ingest.OptCheckDup); err != nil {
 		return errors.Trace(err)
 	}
+	logIngestedSSTObservation(ctx, r.job.ID, subtask.TaskID, subtask.ID, subtask.Step, r.ingestedSSTs.Snapshot())
 	return r.onFinished(ctx, subtask, sm, nil)
 }
 
@@ -207,6 +216,7 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 		metaGroups: make([]*globalsort.SortedKVMeta, len(r.indexes)),
 	})
 	r.summary.Reset()
+	r.ingestedSSTs.Reset()
 	var err error
 	failpoint.InjectCall("beforeReadIndexStepExecRunSubtask", &err)
 	if err != nil {
@@ -248,6 +258,7 @@ func (r *readIndexStepExecutor) RealtimeSummary() *execute.SubtaskSummary {
 }
 
 func (r *readIndexStepExecutor) ResetSummary() {
+	r.ingestedSSTs.Reset()
 	r.summary.Reset()
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
@@ -104,6 +105,17 @@ const (
 )
 
 var telemetryAddIndexIngestUsage = metrics.TelemetryAddIndexIngestCnt
+
+const (
+	addIndexTiKVCapacityObserveTimeout = 2 * time.Second
+)
+
+// TiKVClusterCapacity is the aggregated TiKV capacity snapshot collected from PD.
+type TiKVClusterCapacity struct {
+	TotalBytes     uint64
+	AvailableBytes uint64
+	StoreCount     int
+}
 
 // DefaultCumulativeTimeout is the default cumulative timeout for analyze operation.
 // exported for testing.
@@ -3249,6 +3261,9 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 			zap.Int("worker-cnt", workerCntLimit), zap.Int("required-slots", requiredSlots),
 			zap.String("task-key", taskKey))
 		rowSize := estimateTableRowSize(w.workCtx, w.store, w.sess.GetRestrictedSQLExecutor(), t)
+		if !reorgInfo.mergingTmpIdx {
+			w.logTiKVCapacityForAddIndexObservation(ctx, job.ID, taskKey)
+		}
 		taskMeta := &BackfillTaskMeta{
 			Job:             *job.Clone(),
 			EleIDs:          extractElemIDs(reorgInfo),
@@ -3525,6 +3540,82 @@ func estimateRowSizeFromRegion(ctx context.Context, store kv.Storage, tbl table.
 		return 0, fmt.Errorf("zero approximate size")
 	}
 	return int(uint64(sizeInMiB)*size.MB) / int(sample.ApproximateKeys), nil
+}
+
+func (w *worker) logTiKVCapacityForAddIndexObservation(
+	ctx context.Context,
+	jobID int64,
+	taskKey string,
+) {
+	observeCtx, cancel := context.WithTimeout(ctx, addIndexTiKVCapacityObserveTimeout)
+	defer cancel()
+	capacity, err := collectTiKVStoreCapacity(observeCtx, w.store)
+	if err != nil {
+		logutil.DDLLogger().Warn("skip TiKV capacity observation for add-index task because TiKV capacity snapshot failed",
+			zap.Int64("jobID", jobID),
+			zap.String("task-key", taskKey),
+			zap.Error(err))
+		return
+	}
+	if capacity == nil || capacity.StoreCount == 0 {
+		logutil.DDLLogger().Warn("skip TiKV capacity observation for add-index task because TiKV capacity snapshot is empty",
+			zap.Int64("jobID", jobID),
+			zap.String("task-key", taskKey))
+		return
+	}
+	logutil.DDLLogger().Info("collected TiKV capacity snapshot for add-index task",
+		zap.Int64("jobID", jobID),
+		zap.String("task-key", taskKey),
+		zap.Uint64("tikv_total_bytes", capacity.TotalBytes),
+		zap.Uint64("tikv_available_bytes", capacity.AvailableBytes),
+		zap.Int("tikv_store_count", capacity.StoreCount))
+}
+
+func collectTiKVStoreCapacity(ctx context.Context, store kv.Storage) (*TiKVClusterCapacity, error) {
+	hStore, ok := store.(helper.Storage)
+	if !ok {
+		return nil, errors.Errorf("store %T does not implement helper.Storage", store)
+	}
+	h := helper.NewHelper(hStore)
+	pdCli, err := h.TryGetPDHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	stores, err := pdCli.GetStores(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if stores == nil {
+		return nil, errors.New("pd stores response is nil")
+	}
+
+	capacity := &TiKVClusterCapacity{}
+	for _, storeInfo := range stores.Stores {
+		if storeInfo.Store.State == int64(metapb.StoreState_Tombstone) || engine.IsTiFlashHTTPResp(&storeInfo.Store) {
+			continue
+		}
+		totalBytes, err := units.RAMInBytes(storeInfo.Status.Capacity)
+		if err != nil {
+			return nil, errors.Annotatef(err, "parse store %d capacity %q", storeInfo.Store.ID, storeInfo.Status.Capacity)
+		}
+		availableBytes, err := units.RAMInBytes(storeInfo.Status.Available)
+		if err != nil {
+			return nil, errors.Annotatef(err, "parse store %d available %q", storeInfo.Store.ID, storeInfo.Status.Available)
+		}
+		capacity.StoreCount++
+		capacity.TotalBytes += uint64(totalBytes)
+		capacity.AvailableBytes += uint64(availableBytes)
+	}
+	return capacity, nil
+}
+
+type ingestedSSTBytesObservation struct {
+	bytes                uint64
+	count                uint64
+	zeroSizeCount        uint64
+	invalidIdentityCount uint64
+	reliable             bool
+	reason               string
 }
 
 func (w *worker) updateDistTaskRowCount(taskKey string, jobID int64) {

--- a/pkg/ddl/reorg_util_test.go
+++ b/pkg/ddl/reorg_util_test.go
@@ -57,6 +57,7 @@ func (mockHelperStorage) GetRegionCache() *tikv.RegionCache {
 type mockPDHTTPClient struct {
 	pdhttp.Client
 	regionInfos []*pdhttp.RegionsInfo
+	storesInfo  *pdhttp.StoresInfo
 	callCount   int
 	firstRange  *pdhttp.KeyRange
 	firstLimit  int
@@ -77,6 +78,10 @@ func (c *mockPDHTTPClient) GetRegionsByKeyRange(_ context.Context, keyRange *pdh
 	info := c.regionInfos[c.callCount]
 	c.callCount++
 	return info, nil
+}
+
+func (c *mockPDHTTPClient) GetStores(context.Context) (*pdhttp.StoresInfo, error) {
+	return c.storesInfo, nil
 }
 
 func expectedRegionRange(tableID int64) ([]byte, []byte) {
@@ -179,4 +184,73 @@ func TestEstimateTableSizeByIDUsesMaxApproximateSizes(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCollectTiKVStoreCapacityFromPDHTTP(t *testing.T) {
+	pdCli := &mockPDHTTPClient{
+		storesInfo: &pdhttp.StoresInfo{
+			Stores: []pdhttp.StoreInfo{
+				{
+					Store:  pdhttp.MetaStore{ID: 1, State: 0},
+					Status: pdhttp.StoreStatus{Capacity: "10 GiB", Available: "4 GiB"},
+				},
+				{
+					Store: pdhttp.MetaStore{
+						ID:     2,
+						State:  0,
+						Labels: []pdhttp.StoreLabel{{Key: "engine", Value: "tiflash"}},
+					},
+					Status: pdhttp.StoreStatus{Capacity: "20 GiB", Available: "8 GiB"},
+				},
+				{
+					Store:  pdhttp.MetaStore{ID: 3, State: 2},
+					Status: pdhttp.StoreStatus{Capacity: "30 GiB", Available: "12 GiB"},
+				},
+			},
+		},
+	}
+
+	capacity, err := collectTiKVStoreCapacity(context.Background(), mockHelperStorage{pdCli: pdCli})
+	require.NoError(t, err)
+	require.EqualValues(t, 10*units.GiB, capacity.TotalBytes)
+	require.EqualValues(t, 4*units.GiB, capacity.AvailableBytes)
+	require.Equal(t, 1, capacity.StoreCount)
+}
+
+func TestIngestedSSTRecorder(t *testing.T) {
+	recorder := newIngestedSSTRecorder()
+	recorder.RecordIngestedSST("classic/uuid/default", 100)
+	recorder.RecordIngestedSST("classic/uuid/default", 100)
+	recorder.RecordIngestedSST("classic/uuid/write", 40)
+	recorder.RecordIngestedSST("classic/zero/default", 0)
+	recorder.RecordIngestedSST("", 10)
+	observation := recorder.Snapshot()
+	require.EqualValues(t, 140, observation.bytes)
+	require.EqualValues(t, 3, observation.count)
+	require.EqualValues(t, 1, observation.zeroSizeCount)
+	require.EqualValues(t, 1, observation.invalidIdentityCount)
+	require.False(t, observation.reliable)
+	require.Equal(t, "ingested_sst_identity_unavailable", observation.reason)
+
+	recorder.Reset()
+	observation = recorder.Snapshot()
+	require.Zero(t, observation.bytes)
+	require.Zero(t, observation.count)
+	require.Zero(t, observation.zeroSizeCount)
+	require.Zero(t, observation.invalidIdentityCount)
+	require.True(t, observation.reliable)
+	require.Equal(t, "ok", observation.reason)
+
+	recorder.RecordIngestedSST("classic/uuid/default", 100)
+	observation = recorder.Snapshot()
+	require.EqualValues(t, 100, observation.bytes)
+	require.EqualValues(t, 1, observation.count)
+	require.True(t, observation.reliable)
+	require.Equal(t, "ok", observation.reason)
+
+	recorder.Reset()
+	recorder.RecordIngestedSST("classic/zero/default", 0)
+	observation = recorder.Snapshot()
+	require.False(t, observation.reliable)
+	require.Equal(t, "ingested_sst_size_unavailable", observation.reason)
 }

--- a/pkg/dxf/framework/taskexecutor/execute/interface.go
+++ b/pkg/dxf/framework/taskexecutor/execute/interface.go
@@ -111,7 +111,6 @@ type SubtaskSummary struct {
 	GetReqCnt atomic.Uint64 `json:"get_request_count,omitempty"`
 	// PutReqCnt is the number of put requests to the external storage.
 	PutReqCnt atomic.Uint64 `json:"put_request_count,omitempty"`
-
 	// Progresses are the history of data processed, which is used to get a
 	// smoother speed for each subtask.
 	// It's updated each time we store the latest summary into subtask table.

--- a/pkg/ingestor/ingestcli/client.go
+++ b/pkg/ingestor/ingestcli/client.go
@@ -61,6 +61,7 @@ type nextGenResp struct {
 
 type nextGenSSTMeta struct {
 	ID         int64         `json:"id"`
+	Size       uint64        `json:"size"`
 	Smallest   jsonByteSlice `json:"smallest"`
 	Biggest    jsonByteSlice `json:"biggest"`
 	MetaOffset int           `json:"meta-offset"`
@@ -68,8 +69,8 @@ type nextGenSSTMeta struct {
 }
 
 func (m *nextGenSSTMeta) String() string {
-	return fmt.Sprintf("{ID: %d, Smallest: %s, Biggest: %s, CommitTs: %d}",
-		m.ID, redact.Key(m.Smallest), redact.Key(m.Biggest), m.CommitTs)
+	return fmt.Sprintf("{ID: %d, Size: %d, Smallest: %s, Biggest: %s, CommitTs: %d}",
+		m.ID, m.Size, redact.Key(m.Smallest), redact.Key(m.Biggest), m.CommitTs)
 }
 
 var _ WriteClient = &writeClient{}

--- a/pkg/ingestor/ingestcli/client_test.go
+++ b/pkg/ingestor/ingestcli/client_test.go
@@ -46,7 +46,7 @@ func TestJsonByteSlice(t *testing.T) {
 }
 
 func TestWriteClientWriteChunk(t *testing.T) {
-	sstMeta := nextGenResp{nextGenSSTMeta{ID: 1, Smallest: []byte{0}, Biggest: []byte{1}, MetaOffset: 1, CommitTs: 1}}
+	sstMeta := nextGenResp{nextGenSSTMeta{ID: 1, Size: 64, Smallest: []byte{0}, Biggest: []byte{1}, MetaOffset: 1, CommitTs: 1}}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -78,6 +78,10 @@ func TestWriteClientWriteChunk(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.EqualValues(t, &sstMeta.SstMeta, resp.nextGenSSTMeta)
+	id, size, ok := resp.GetSSTMeta()
+	require.True(t, ok)
+	require.EqualValues(t, 1, id)
+	require.EqualValues(t, 64, size)
 }
 
 func TestClientWriteServerError(t *testing.T) {

--- a/pkg/ingestor/ingestcli/interface.go
+++ b/pkg/ingestor/ingestcli/interface.go
@@ -31,6 +31,26 @@ type WriteResponse struct {
 	nextGenSSTMeta *nextGenSSTMeta
 }
 
+// NewWriteResponseWithSSTMeta creates a write response carrying next-gen SST
+// metadata. It is intended for mocks that need to emulate a TiKV worker response.
+func NewWriteResponseWithSSTMeta(id int64, size uint64) *WriteResponse {
+	return &WriteResponse{
+		nextGenSSTMeta: &nextGenSSTMeta{
+			ID:   id,
+			Size: size,
+		},
+	}
+}
+
+// GetSSTMeta returns the generated SST ID and size when the next-gen worker
+// reports SST metadata.
+func (r *WriteResponse) GetSSTMeta() (id int64, size uint64, ok bool) {
+	if r == nil || r.nextGenSSTMeta == nil {
+		return 0, 0, false
+	}
+	return r.nextGenSSTMeta.ID, r.nextGenSSTMeta.Size, true
+}
+
 // IngestRequest is the request to ingest SST to storage layer.
 type IngestRequest struct {
 	Region    *split.RegionInfo

--- a/pkg/ingestor/ingestctrl/BUILD.bazel
+++ b/pkg/ingestor/ingestctrl/BUILD.bazel
@@ -146,6 +146,7 @@ go_test(
         "//br/pkg/restore/split",
         "//pkg/config/kerneltype",
         "//pkg/ddl",
+        "//pkg/dxf/framework/taskexecutor/execute",
         "//pkg/errno",
         "//pkg/ingestor/engineapi",
         "//pkg/ingestor/errdef",

--- a/pkg/ingestor/ingestctrl/job_worker.go
+++ b/pkg/ingestor/ingestctrl/job_worker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	goerrors "errors"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -56,6 +57,19 @@ type regionJobWorker interface {
 	HandleTask(job *regionJob, f func(*regionJob)) error
 
 	Close() error
+}
+
+type ingestedSSTCollector interface {
+	RecordIngestedSST(identity string, size uint64)
+}
+
+func recordIngestedSST(collector execute.Collector, identity string, size uint64) {
+	if collector == nil {
+		return
+	}
+	if c, ok := collector.(ingestedSSTCollector); ok {
+		c.RecordIngestedSST(identity, size)
+	}
 }
 
 type regionJobBaseWorker struct {
@@ -457,6 +471,12 @@ func (w *objStoreRegionJobWorker) ingest(ctx context.Context, job *regionJob) er
 	if err != nil {
 		return err
 	}
+	id, size, ok := job.writeResult.nextGenWriteResp.GetSSTMeta()
+	if !ok {
+		recordIngestedSST(w.collector, "", 0)
+		return nil
+	}
+	recordIngestedSST(w.collector, "next-gen/"+strconv.FormatInt(id, 10), size)
 	return nil
 }
 

--- a/pkg/ingestor/ingestctrl/job_worker_test.go
+++ b/pkg/ingestor/ingestctrl/job_worker_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/pingcap/errors"
+	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/br/pkg/restore/split"
+	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/ingestor/ingestcli"
@@ -35,7 +37,48 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
 )
+
+type recordedIngestedSST struct {
+	identity string
+	size     uint64
+}
+
+type recordingIngestedSSTCollector struct {
+	execute.NoopCollector
+	mu      sync.Mutex
+	records []recordedIngestedSST
+}
+
+type partialMultiIngestClient struct {
+	sst.ImportSSTClient
+	callCount int
+}
+
+func (c *partialMultiIngestClient) MultiIngest(
+	context.Context,
+	*sst.MultiIngestRequest,
+	...grpc.CallOption,
+) (*sst.IngestResponse, error) {
+	c.callCount++
+	if c.callCount == 1 {
+		return &sst.IngestResponse{}, nil
+	}
+	return nil, errors.New("injected second-batch ingest error")
+}
+
+func (c *recordingIngestedSSTCollector) RecordIngestedSST(identity string, size uint64) {
+	c.mu.Lock()
+	c.records = append(c.records, recordedIngestedSST{identity: identity, size: size})
+	c.mu.Unlock()
+}
+
+func (c *recordingIngestedSSTCollector) snapshot() []recordedIngestedSST {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]recordedIngestedSST(nil), c.records...)
+}
 
 func newRegionJobWorkerPoolForTest(
 	workerCtx context.Context,
@@ -258,6 +301,77 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		require.Error(t, err)
 		require.Regexp(t, "the remaining storage capacity of TiKV.*", err.Error())
 	})
+
+	t.Run("record classic successful ingests", func(t *testing.T) {
+		store := &metapb.Store{Id: 1}
+		client := newMockImportClient()
+		client.store = store
+		collector := &recordingIngestedSSTCollector{}
+		local := &Backend{
+			collector:          collector,
+			supportMultiIngest: true,
+			importClientFactory: &mockImportClientFactory{
+				stores: []*metapb.Store{store},
+				createClientFn: func(*metapb.Store) sst.ImportSSTClient {
+					return client
+				},
+			},
+		}
+		job := &regionJob{
+			region: &split.RegionInfo{
+				Region: &metapb.Region{Id: 1},
+				Leader: &metapb.Peer{StoreId: 1},
+			},
+			writeResult: &tikvWriteResult{
+				sstMeta: []*sst.SSTMeta{
+					{Uuid: []byte{1}, CfName: "default", Length: 100, RegionId: 1},
+					{Uuid: []byte{1}, CfName: "write", Length: 40, RegionId: 1},
+				},
+			},
+		}
+		_, err := local.doIngest(context.Background(), job)
+		require.NoError(t, err)
+		require.Equal(t, []recordedIngestedSST{
+			{identity: "classic/01/default", size: 100},
+			{identity: "classic/01/write", size: 40},
+		}, collector.snapshot())
+	})
+
+	t.Run("record successful batches before a later ingest failure", func(t *testing.T) {
+		store := &metapb.Store{Id: 1}
+		client := &partialMultiIngestClient{}
+		collector := &recordingIngestedSSTCollector{}
+		local := &Backend{
+			collector:          collector,
+			supportMultiIngest: true,
+			importClientFactory: &mockImportClientFactory{
+				stores: []*metapb.Store{store},
+				createClientFn: func(*metapb.Store) sst.ImportSSTClient {
+					return client
+				},
+			},
+		}
+		local.ingestLimiter.Store(newIngestLimiter(context.Background(), 1, 0))
+		job := &regionJob{
+			region: &split.RegionInfo{
+				Region: &metapb.Region{Id: 1},
+				Leader: &metapb.Peer{StoreId: 1},
+			},
+			writeResult: &tikvWriteResult{
+				sstMeta: []*sst.SSTMeta{
+					{Uuid: []byte{1}, CfName: "default", Length: 100},
+					{Uuid: []byte{2}, CfName: "default", Length: 200},
+				},
+			},
+		}
+		_, err := local.doIngest(context.Background(), job)
+		require.ErrorContains(t, err, "injected second-batch ingest error")
+		require.Equal(t, []recordedIngestedSST{
+			{identity: "classic/01/default", size: 100},
+		}, collector.snapshot())
+		require.Len(t, job.writeResult.sstMeta, 1)
+		require.Equal(t, []byte{2}, job.writeResult.sstMeta[0].GetUuid())
+	})
 }
 
 func TestIsRetryableTiKVWriteError(t *testing.T) {
@@ -395,6 +509,8 @@ func TestCloudRegionJobWorker(t *testing.T) {
 	})
 
 	t.Run("ingest success", func(t *testing.T) {
+		collector := &recordingIngestedSSTCollector{}
+		cloudW.collector = collector
 		job := &regionJob{
 			keyRange:    engineapi.Range{Start: []byte("a"), End: []byte("z")},
 			stage:       wrote,
@@ -404,6 +520,27 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		mockIngestCli.EXPECT().Ingest(gomock.Any(), gomock.Any()).Return(nil)
 		err := cloudW.ingest(context.Background(), job)
 		require.NoError(t, err)
+		require.Equal(t, []recordedIngestedSST{{}}, collector.snapshot())
+		require.True(t, ctrl.Satisfied())
+	})
+
+	t.Run("ingest success records next-gen SST metadata", func(t *testing.T) {
+		collector := &recordingIngestedSSTCollector{}
+		cloudW.collector = collector
+		job := &regionJob{
+			keyRange:   engineapi.Range{Start: []byte("a"), End: []byte("z")},
+			stage:      wrote,
+			ingestData: mockIngestData{},
+			writeResult: &tikvWriteResult{
+				nextGenWriteResp: ingestcli.NewWriteResponseWithSSTMeta(42, 2048),
+			},
+		}
+		mockIngestCli.EXPECT().Ingest(gomock.Any(), gomock.Any()).Return(nil)
+		err := cloudW.ingest(context.Background(), job)
+		require.NoError(t, err)
+		require.Equal(t, []recordedIngestedSST{
+			{identity: "next-gen/42", size: 2048},
+		}, collector.snapshot())
 		require.True(t, ctrl.Satisfied())
 	})
 }

--- a/pkg/ingestor/ingestctrl/region_job.go
+++ b/pkg/ingestor/ingestctrl/region_job.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"container/heap"
 	"context"
+	"encoding/hex"
 	goerrors "errors"
 	"fmt"
 	"io"
@@ -809,6 +810,13 @@ func (local *Backend) doIngest(ctx context.Context, j *regionJob) (*sst.IngestRe
 			// remove finished sstMetas
 			j.writeResult.sstMeta = j.writeResult.sstMeta[start:]
 			return resp, errors.Trace(err)
+		}
+		for _, meta := range ingestMetas {
+			identity := ""
+			if len(meta.GetUuid()) > 0 {
+				identity = "classic/" + hex.EncodeToString(meta.GetUuid()) + "/" + meta.GetCfName()
+			}
+			recordIngestedSST(local.collector, identity, meta.GetLength())
 		}
 	}
 	return resp, nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/68354

Problem Summary:

This PR is split from https://github.com/pingcap/tidb/pull/68490.

Before adding TiKV disk-space prediction and enforcement for add index, we need observability data to know:

- The initial TiKV capacity before add-index execution.
- How many SST bytes are actually ingested after add-index execution.

The observability data for ingested SST bytes should be used only for post-run validation. It should not become part of the add-index execution state, task meta, or subtask summary.

### What changed and how does it work?

This PR adds record-only observability for add-index distributed backfill:

- Collects a TiKV capacity snapshot through PD HTTP before submitting the add-index distributed task, then logs total bytes, available bytes, store count, job ID, and task key.
- Records successfully ingested SST metadata through a local in-memory collector owned by ingest control.
- Logs per-subtask ingested SST bytes, SST count, zero-size count, invalid identity count, reliability state, and reliability reason.
- Deduplicates ingested SST records by identity before logging.
- Supports both classic local ingest SST metadata and next-gen SST metadata.
- Keeps ingested SST and TiKV capacity observability out of task meta and `SubtaskSummary`; there is no task-end aggregation or writeback.

Compared with https://github.com/pingcap/tidb/pull/68490, this PR intentionally makes the following changes:

1. Remove the `InitialTiKVCapacity` task meta field and the ingested SST fields from `SubtaskSummary`. They are changed to pure log observations.
2. Change capacity collection from the PD gRPC path to the PD HTTP path. This can introduce about 0.05% observation error, but it reduces TiDB-to-PD IO, improves performance, and reuses the existing PD HTTP capacity data path.
3. Remove the `source` grouping layer from the diagnostic fields in `ingestedSSTRecorder`. The extra `source` layer does not add much diagnostic value.

This PR does not reject add-index tasks, does not add disk-space prediction, and does not change add-index scheduling behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

```bash
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org make bazel_prepare
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/ddl -run 'TestEstimateTableSizeByIDUsesMaxApproximateSizes|TestCollectTiKVStoreCapacityFromPDHTTP|TestIngestedSSTRecorder' -count=1
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org go test -tags=intest,deadlock ./pkg/ingestor/ingestcli -run 'TestWriteClientWriteChunk|TestClientIngest|TestClientIngestError' -count=1
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run 'TestRegionJobBaseWorker|TestCloudRegionJobWorker' -count=1
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org go test -tags=intest,deadlock ./pkg/dxf/framework/taskexecutor/execute -run '^$' -count=1
GOPATH=/Users/xiaoli/go GOSUMDB=sum.golang.org make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking of ingested SST sizes and counts during index backfill and ingest operations.
  - Added cluster capacity observations during add-index scheduling to improve visibility into available storage.

- **Bug Fixes**
  - Improved handling of missing or zero-size SST metadata by marking observations as unreliable instead of reporting misleading totals.
  - Updated ingest responses and tests to carry SST size information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->