### PR TITLE
expression: propagate collation substitution failures

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -660,8 +660,9 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 				tmpArgForCollCheck[idx] = newFuncExpr
 				newCollEt, err := CheckAndDeriveCollationFromExprs(ctx, v.FuncName.L, v.RetType.EvalType(), tmpArgForCollCheck...)
 				if err != nil {
-					logutil.BgLogger().Warn("Unexpected error happened during ColumnSubstitution", zap.Stack("stack"), zap.Error(err))
-					return false, failed, v
+					// The substituted arguments may be invalid under collation rules;
+					// treat it as an unsafe substitution.
+					return false, true, v
 				}
 				if oldCollEt.Collation == newCollEt.Collation {
 					if newFuncExpr.GetType(ctx.GetEvalCtx()).GetCollate() == arg.GetType(ctx.GetEvalCtx()).GetCollate() && newFuncExpr.Coercibility() == arg.Coercibility() {

--- a/tests/integrationtest/r/planner/core/expression_rewriter.result
+++ b/tests/integrationtest/r/planner/core/expression_rewriter.result
@@ -496,3 +496,32 @@ Projection	root		planner__core__expression_rewriter.t1.a
       └─TableReader	root		data:HashAgg
         └─HashAgg	cop[tikv]		group by:planner__core__expression_rewriter.t1.a, 
           └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+drop view if exists v_or_case_collation_ppd;
+drop table if exists t_or_case_collation_a;
+drop table if exists t_or_case_collation_b;
+set names utf8mb4 collate utf8mb4_general_ci;
+create table t_or_case_collation_a (
+is_reimburse varchar(10) character set utf8mb4 collate utf8mb4_general_ci
+);
+create table t_or_case_collation_b (
+travel_type varchar(10) character set utf8mb4 collate utf8mb4_general_ci
+);
+insert into t_or_case_collation_a values ('Y'), ('N'), (null);
+insert into t_or_case_collation_b values ('P'), ('B');
+create view v_or_case_collation_ppd as
+select is_reimburse from t_or_case_collation_a
+union all
+select case when travel_type = _utf8mb4'P' then _utf8mb4'N' else _utf8mb4'Y' end as is_reimburse
+from t_or_case_collation_b;
+set names utf8mb4 collate utf8mb4_0900_ai_ci;
+select count(*), sum(is_reimburse is null), sum(is_reimburse = 'Y')
+from v_or_case_collation_ppd
+where is_reimburse = 'Y' or is_reimburse is null;
+count(*)	sum(is_reimburse is null)	sum(is_reimburse = 'Y')
+3	1	2
+select count(*)
+from v_or_case_collation_ppd
+where is_reimburse is not null or is_reimburse = 'Y';
+count(*)
+4
+set names default;

--- a/tests/integrationtest/t/planner/core/expression_rewriter.test
+++ b/tests/integrationtest/t/planner/core/expression_rewriter.test
@@ -287,3 +287,30 @@ explain format='plan_tree' select * from t1 where t1.a > 1 and t1.a in (select a
 explain format='plan_tree' select t1.a in (select a from t) from t1;
 explain format='plan_tree' select * from t1 where (t1.a in (select a from t)) = 1;
 explain format='plan_tree' select t1.a from t1 group by t1.a having t1.a > 1 or t1.a in (select a from t);
+
+# TestColumnSubstituteFallbackForUnionViewWithCollation
+drop view if exists v_or_case_collation_ppd;
+drop table if exists t_or_case_collation_a;
+drop table if exists t_or_case_collation_b;
+set names utf8mb4 collate utf8mb4_general_ci;
+create table t_or_case_collation_a (
+  is_reimburse varchar(10) character set utf8mb4 collate utf8mb4_general_ci
+);
+create table t_or_case_collation_b (
+  travel_type varchar(10) character set utf8mb4 collate utf8mb4_general_ci
+);
+insert into t_or_case_collation_a values ('Y'), ('N'), (null);
+insert into t_or_case_collation_b values ('P'), ('B');
+create view v_or_case_collation_ppd as
+  select is_reimburse from t_or_case_collation_a
+  union all
+  select case when travel_type = _utf8mb4'P' then _utf8mb4'N' else _utf8mb4'Y' end as is_reimburse
+  from t_or_case_collation_b;
+set names utf8mb4 collate utf8mb4_0900_ai_ci;
+select count(*), sum(is_reimburse is null), sum(is_reimburse = 'Y')
+from v_or_case_collation_ppd
+where is_reimburse = 'Y' or is_reimburse is null;
+select count(*)
+from v_or_case_collation_ppd
+where is_reimburse is not null or is_reimburse = 'Y';
+set names default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69713

Problem Summary:
`ColumnSubstituteImpl` validates collation after replacing a scalar-function argument. If the substituted arguments are invalid under collation rules, the substitution is unsafe and callers that require atomic substitution should fall back.

The old code returned the child recursion failure state for this current-node collation error. When the child itself did not fail, `hasFailed` could remain false. For nested predicates such as `OR`, the parent expression could then keep processing sibling predicates and accept a partial substitution. This may incorrectly push part of a predicate through a `UNION ALL` view and produce wrong results.


### What changed and how does it work?
When collation derivation fails for substituted arguments, return `hasFailed=true` from `ColumnSubstituteImpl`. This tells fail-fast callers, such as predicate pushdown through projections, to reject the whole substitution and keep the original predicate instead of accepting a mixed expression.

A regression integration test was added for a `UNION ALL` view whose second branch contains a `CASE` expression under a different session collation. The test verifies that `OR` predicates involving equality and null checks keep the correct result after substitution fallback.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collation handling during expression substitution so failures are now treated as unsafe instead of being silently downgraded.
  * Fixed query behavior for views and `UNION ALL` cases involving mixed collation settings, helping ensure more consistent results.

* **Tests**
  * Added coverage for collation-sensitive query rewriting with `UNION ALL`, `CASE` expressions, and session collation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->