### PR TITLE
ddl: enhance placement rule mismatch error

### DIFF
--- a/pkg/ddl/placement_error.go
+++ b/pkg/ddl/placement_error.go
@@ -1,0 +1,159 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/ddl/placement"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	pd "github.com/tikv/pd/client/http"
+)
+
+var placementRuleErrorRE = regexp.MustCompile(`rule '([^']+)' from rule group '([^']+)'`)
+
+type placementRuleErrorContext struct {
+	SchemaName string
+	TableName  string
+	PolicyName string
+	Bundles    []*placement.Bundle
+}
+
+func placementRuleErrorWithContext(err error, ctx placementRuleErrorContext) error {
+	if !infosync.ErrHTTPServiceError.Equal(err) {
+		return err
+	}
+
+	originalMsg := strings.TrimSpace(placementHTTPServiceErrorMessage(err))
+	ruleID, ruleGroupID, ok := extractPlacementRuleError(originalMsg)
+	if !ok {
+		return err
+	}
+
+	enhancedMsg := originalMsg + "; " + formatPlacementRuleErrorContext(ctx, ruleGroupID, ruleID)
+	if strings.Contains(originalMsg, "can not match any store") {
+		enhancedMsg += ". No store matches the failed rule constraints; check available store labels with SHOW PLACEMENT LABELS."
+	}
+	return infosync.ErrHTTPServiceError.FastGen("%s", enhancedMsg)
+}
+
+func placementHTTPServiceErrorMessage(err error) string {
+	if terr, ok := errors.Cause(err).(*errors.Error); ok {
+		return terr.GetMsg()
+	}
+	return err.Error()
+}
+
+func extractPlacementRuleError(msg string) (ruleID, ruleGroupID string, ok bool) {
+	matches := placementRuleErrorRE.FindStringSubmatch(msg)
+	if len(matches) != 3 {
+		return "", "", false
+	}
+	return matches[1], matches[2], true
+}
+
+func formatPlacementRuleErrorContext(ctx placementRuleErrorContext, ruleGroupID, ruleID string) string {
+	parts := []string{
+		fmt.Sprintf("table=%s", formatPlacementTableName(ctx.SchemaName, ctx.TableName)),
+		fmt.Sprintf("policy=%s", formatPlacementIdentifier(ctx.PolicyName)),
+		fmt.Sprintf("rule_group=%s", formatPlacementIdentifier(ruleGroupID)),
+		fmt.Sprintf("rule=%s", formatPlacementIdentifier(ruleID)),
+	}
+
+	if rule := findPlacementRule(ctx.Bundles, ruleGroupID, ruleID); rule != nil {
+		parts = append(parts,
+			fmt.Sprintf("role=%s", rule.Role),
+			fmt.Sprintf("count=%d", rule.Count),
+			fmt.Sprintf("label_constraints=%s", formatPlacementLabelConstraints(rule.LabelConstraints)),
+		)
+		return "TiDB placement context: " + strings.Join(parts, ", ")
+	}
+
+	return "TiDB placement context: " + strings.Join(parts, ", ") + " (rule detail not found in current TiDB bundle)"
+}
+
+func findPlacementRule(bundles []*placement.Bundle, ruleGroupID, ruleID string) *pd.Rule {
+	for _, bundle := range bundles {
+		if bundle == nil {
+			continue
+		}
+		for _, rule := range bundle.Rules {
+			if rule == nil {
+				continue
+			}
+			if rule.GroupID == ruleGroupID && rule.ID == ruleID {
+				return rule
+			}
+		}
+	}
+	return nil
+}
+
+func formatPlacementTableName(schemaName, tableName string) string {
+	if tableName == "" {
+		return "<unknown>"
+	}
+	if schemaName == "" {
+		return formatPlacementIdentifier(tableName)
+	}
+	return formatPlacementIdentifier(schemaName) + "." + formatPlacementIdentifier(tableName)
+}
+
+func formatPlacementIdentifier(identifier string) string {
+	if identifier == "" {
+		return "<unknown>"
+	}
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
+func formatPlacementLabelConstraints(labelConstraints []pd.LabelConstraint) string {
+	if len(labelConstraints) == 0 {
+		return "[]"
+	}
+	constraints := make([]string, 0, len(labelConstraints))
+	for _, constraint := range labelConstraints {
+		constraints = append(constraints, formatPlacementLabelConstraint(constraint))
+	}
+	return "[" + strings.Join(constraints, ", ") + "]"
+}
+
+func formatPlacementLabelConstraint(constraint pd.LabelConstraint) string {
+	switch constraint.Op {
+	case pd.In:
+		return fmt.Sprintf("%s in (%s)", constraint.Key, strings.Join(constraint.Values, ","))
+	case pd.NotIn:
+		return fmt.Sprintf("%s notIn (%s)", constraint.Key, strings.Join(constraint.Values, ","))
+	case pd.Exists, pd.NotExists:
+		return fmt.Sprintf("%s %s", constraint.Key, constraint.Op)
+	default:
+		if len(constraint.Values) == 0 {
+			return fmt.Sprintf("%s %s", constraint.Key, constraint.Op)
+		}
+		return fmt.Sprintf("%s %s (%s)", constraint.Key, constraint.Op, strings.Join(constraint.Values, ","))
+	}
+}
+
+func placementPolicyRefName(policyRefInfo *model.PolicyRefInfo) string {
+	if policyRefInfo == nil {
+		return ""
+	}
+	if policyRefInfo.Name.O != "" {
+		return policyRefInfo.Name.O
+	}
+	return policyRefInfo.Name.L
+}

--- a/pkg/ddl/placement_error_test.go
+++ b/pkg/ddl/placement_error_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/ddl/placement"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client/http"
+)
+
+func TestEnhancePlacementRuleError(t *testing.T) {
+	pdMsg := "[PD:placement:ErrRuleContent]invalid rule content, rule 'table_rule_100_2' from rule group 'TiDB_DDL_100' can not match any store"
+	err := infosync.ErrHTTPServiceError.FastGen("%s", pdMsg+"\n")
+	bundle := &placement.Bundle{
+		ID: "TiDB_DDL_100",
+		Rules: []*pd.Rule{
+			{
+				GroupID: "TiDB_DDL_100",
+				ID:      "table_rule_100_2",
+				Role:    pd.Voter,
+				Count:   1,
+				LabelConstraints: []pd.LabelConstraint{
+					{Key: "region", Op: pd.In, Values: []string{"us-west"}},
+					{Key: "engine", Op: pd.NotIn, Values: []string{"tiflash"}},
+				},
+			},
+		},
+	}
+
+	enhancedErr := placementRuleErrorWithContext(err, placementRuleErrorContext{
+		SchemaName: "test",
+		TableName:  "t",
+		PolicyName: "mydeploy",
+		Bundles:    []*placement.Bundle{bundle},
+	})
+
+	require.True(t, infosync.ErrHTTPServiceError.Equal(enhancedErr))
+	terrorErr, ok := errors.Cause(enhancedErr).(*errors.Error)
+	require.True(t, ok)
+	sqlErr := terror.ToSQLError(terrorErr)
+	require.Equal(t, uint16(errno.ErrHTTPServiceError), sqlErr.Code)
+	require.Contains(t, sqlErr.Message, pdMsg)
+	require.Contains(t, sqlErr.Message, "table=`test`.`t`")
+	require.Contains(t, sqlErr.Message, "policy=`mydeploy`")
+	require.Contains(t, sqlErr.Message, "rule_group=`TiDB_DDL_100`")
+	require.Contains(t, sqlErr.Message, "rule=`table_rule_100_2`")
+	require.Contains(t, sqlErr.Message, "role=voter")
+	require.Contains(t, sqlErr.Message, "count=1")
+	require.Contains(t, sqlErr.Message, "label_constraints=[region in (us-west), engine notIn (tiflash)]")
+	require.Contains(t, sqlErr.Message, "No store matches the failed rule constraints")
+	require.Contains(t, sqlErr.Message, "SHOW PLACEMENT LABELS")
+}
+
+func TestEnhancePlacementRuleErrorWithoutNoStoreHint(t *testing.T) {
+	pdMsg := "[PD:placement:ErrRuleContent]invalid rule content, rule 'table_rule_100_2' from rule group 'TiDB_DDL_100' is invalid"
+	err := infosync.ErrHTTPServiceError.FastGen("%s", pdMsg)
+	bundle := &placement.Bundle{
+		ID: "TiDB_DDL_100",
+		Rules: []*pd.Rule{
+			{GroupID: "TiDB_DDL_100", ID: "table_rule_100_2", Role: pd.Leader, Count: 1},
+		},
+	}
+
+	enhancedErr := placementRuleErrorWithContext(err, placementRuleErrorContext{
+		SchemaName: "test",
+		TableName:  "t",
+		PolicyName: "mydeploy",
+		Bundles:    []*placement.Bundle{bundle},
+	})
+
+	require.True(t, infosync.ErrHTTPServiceError.Equal(enhancedErr))
+	terrorErr, ok := errors.Cause(enhancedErr).(*errors.Error)
+	require.True(t, ok)
+	require.Contains(t, terrorErr.GetMsg(), "TiDB placement context")
+	require.NotContains(t, terrorErr.GetMsg(), "No store matches the failed rule constraints")
+}
+
+func TestEnhancePlacementRuleErrorRuleNotFound(t *testing.T) {
+	pdMsg := "[PD:placement:ErrRuleContent]invalid rule content, rule 'table_rule_100_2' from rule group 'TiDB_DDL_100' can not match any store"
+	err := infosync.ErrHTTPServiceError.FastGen("%s", pdMsg)
+
+	enhancedErr := placementRuleErrorWithContext(err, placementRuleErrorContext{
+		SchemaName: "test",
+		TableName:  "t",
+		PolicyName: "mydeploy",
+		Bundles: []*placement.Bundle{{
+			ID:    "TiDB_DDL_100",
+			Rules: []*pd.Rule{{GroupID: "TiDB_DDL_100", ID: "table_rule_100_1", Role: pd.Voter, Count: 1}},
+		}},
+	})
+
+	require.True(t, infosync.ErrHTTPServiceError.Equal(enhancedErr))
+	terrorErr, ok := errors.Cause(enhancedErr).(*errors.Error)
+	require.True(t, ok)
+	require.Contains(t, terrorErr.GetMsg(), "rule detail not found in current TiDB bundle")
+	require.Contains(t, terrorErr.GetMsg(), "rule=`table_rule_100_2`")
+}
+
+func TestEnhancePlacementRuleErrorKeepOtherErrors(t *testing.T) {
+	err := stderrors.New("not pd http service error")
+	require.Equal(t, err, placementRuleErrorWithContext(err, placementRuleErrorContext{}))
+
+	pdErr := infosync.ErrHTTPServiceError.FastGen("%s", "pd http service error without rule id")
+	require.Equal(t, pdErr, placementRuleErrorWithContext(pdErr, placementRuleErrorContext{}))
+}

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -1641,13 +1641,19 @@ func onAlterTablePlacement(jobCtx *jobContext, job *model.Job) (ver int64, err e
 	}
 
 	// Send the placement bundle to PD.
+	bundles := []*placement.Bundle{bundle}
 	if bundle != nil {
-		err = infosync.PutRuleBundlesWithDefaultRetry(context.TODO(), []*placement.Bundle{bundle})
+		err = infosync.PutRuleBundlesWithDefaultRetry(context.TODO(), bundles)
 	}
 
 	if err != nil {
 		job.State = model.JobStateCancelled
-		return ver, errors.Trace(err)
+		return ver, errors.Trace(placementRuleErrorWithContext(err, placementRuleErrorContext{
+			SchemaName: job.SchemaName,
+			TableName:  tblInfo.Name.O,
+			PolicyName: placementPolicyRefName(policyRefInfo),
+			Bundles:    bundles,
+		}))
 	}
 
 	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #47253

Problem Summary:

When `ALTER TABLE ... PLACEMENT POLICY ...` fails because PD rejects a generated placement rule, TiDB only returns PD's raw error, for example `can not match any store`. The message does not tell users which table, placement policy, rule group, rule, or constraints caused the mismatch, making label/topology issues hard to diagnose.

### What changed and how does it work?

- Add a DDL-layer helper to enhance PD placement rule HTTP errors while preserving `infosync.ErrHTTPServiceError` and MySQL error code 8243.
- In `onAlterTablePlacement`, when `infosync.PutRuleBundlesWithDefaultRetry` fails, parse the PD error's rule group/rule ID and look up the matching rule in the current TiDB placement bundle.
- Append TiDB context to the original PD error message, including table, policy, rule group, rule, role, count, and label constraints.
- Add the `No store matches... SHOW PLACEMENT LABELS` hint only for the `can not match any store` case.
- Trim leading/trailing whitespace from the PD body before appending context so the enhanced message remains readable.

Example enhanced message:

before 
```text
ERROR 8243 (HY000): "[PD:placement:ErrRuleContent]invalid rule content, rule 'table_rule_105_1' from rule group 'TiDB_DDL_105' can not match any store"
```
now
```text
ERROR 8243 (HY000): "[PD:placement:ErrRuleContent]invalid rule content, rule 'table_rule_120_3' from rule group 'TiDB_DDL_120' can not match any store"; TiDB placement context: table=`test47253_e2e`.`t`, policy=`mydeploy`, rule_group=`TiDB_DDL_120`, rule=`table_rule_120_3`, role=voter, count=1, label_constraints=[region in (us-west)]. No store matches the failed rule constraints; check available store labels with SHOW PLACEMENT LABELS.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Unit test:

```bash
go test ./pkg/ddl -run TestEnhancePlacementRuleError -count=1
```

Manual test:

- Started a temporary PD/TiKV topology with store labels matching the issue scenario:
  - 2 stores with `region=us-east-1`
  - 2 stores with `region=us-east-2`
  - 1 store with `region=us-west-1`
- Created `all_in_east` and `mydeploy` placement policies, where `mydeploy` requests missing `+region=us-west`.
- Verified:
  - `ALTER TABLE t PLACEMENT POLICY mydeploy` still returns code 8243.
  - The error message includes table, policy, rule group, rule, role/count, and `label_constraints=[region in (us-west)]`.
  - `SHOW WARNINGS` contains the same enhanced message.
  - Failed DDL leaves the table on the previous placement policy.
  - A normal placement policy path still succeeds.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve the error message for placement rule store-label mismatches by including the affected table, placement policy, failed rule, and label constraints.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved placement-related error messages with clearer context, including schema/table names, policy details, rule information, and label constraints.

* **Bug Fixes**
  * Added a helpful hint for placement failures when no store matches the required rules, including guidance to check placement labels.
  * Preserved existing error behavior for unrelated errors while making placement update failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->