### PR TITLE
ddl: load cloud storage before picking add-index backfill

### DIFF
--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/deeptest"
@@ -109,7 +110,8 @@ func TestPickBackfillType(t *testing.T) {
 		})
 
 		ingest.LitInitialized = true
-		ingest.LitDiskRoot = diskRootWithFailedPreCheck{}
+		ingest.LitDiskRoot = ingest.NewDiskRootImpl(t.TempDir())
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed", "return(true)")
 		vardef.CloudStorageURI.Store("s3://bucket")
 
 		job := &model.Job{
@@ -130,26 +132,6 @@ func TestPickBackfillType(t *testing.T) {
 		require.Equal(t, model.ReorgTypeIngest, job.ReorgMeta.ReorgTp)
 	})
 }
-
-type diskRootWithFailedPreCheck struct{}
-
-func (diskRootWithFailedPreCheck) Add(int64, ingest.ResourceTracker) {}
-
-func (diskRootWithFailedPreCheck) Remove(int64) {}
-
-func (diskRootWithFailedPreCheck) Count() int { return 0 }
-
-func (diskRootWithFailedPreCheck) UpdateUsage() {}
-
-func (diskRootWithFailedPreCheck) ShouldImport() bool { return false }
-
-func (diskRootWithFailedPreCheck) UsageInfo() string { return "" }
-
-func (diskRootWithFailedPreCheck) PreCheckUsage() error {
-	return errors.New("local disk precheck should be skipped when cloud storage is used")
-}
-
-func (diskRootWithFailedPreCheck) StartupCheck() error { return nil }
 
 func assertStaticExprContextEqual(t *testing.T, sctx sessionctx.Context, exprCtx *exprstatic.ExprContext, warnHandler contextutil.WarnHandler) {
 	exprCtxManualCheckFields := []struct {

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -97,7 +97,59 @@ func TestPickBackfillType(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tp, model.ReorgTypeIngest)
 	ingest.LitInitialized = false
+
+	t.Run("cloud storage skips local disk precheck", func(t *testing.T) {
+		oldLitInitialized := ingest.LitInitialized
+		oldLitDiskRoot := ingest.LitDiskRoot
+		oldCloudStorageURI := vardef.CloudStorageURI.Load()
+		t.Cleanup(func() {
+			ingest.LitInitialized = oldLitInitialized
+			ingest.LitDiskRoot = oldLitDiskRoot
+			vardef.CloudStorageURI.Store(oldCloudStorageURI)
+		})
+
+		ingest.LitInitialized = true
+		ingest.LitDiskRoot = diskRootWithFailedPreCheck{}
+		vardef.CloudStorageURI.Store("s3://bucket")
+
+		job := &model.Job{
+			ID: 2,
+			ReorgMeta: &model.DDLReorgMeta{
+				IsFastReorg: true,
+				IsDistReorg: true,
+			},
+		}
+		w := &worker{
+			workCtx: context.Background(),
+			ddlCtx:  &ddlCtx{},
+		}
+
+		err := initForReorgIndexes(w, job, []*model.IndexInfo{{}})
+		require.NoError(t, err)
+		require.True(t, job.ReorgMeta.UseCloudStorage)
+		require.Equal(t, model.ReorgTypeIngest, job.ReorgMeta.ReorgTp)
+	})
 }
+
+type diskRootWithFailedPreCheck struct{}
+
+func (diskRootWithFailedPreCheck) Add(int64, ingest.ResourceTracker) {}
+
+func (diskRootWithFailedPreCheck) Remove(int64) {}
+
+func (diskRootWithFailedPreCheck) Count() int { return 0 }
+
+func (diskRootWithFailedPreCheck) UpdateUsage() {}
+
+func (diskRootWithFailedPreCheck) ShouldImport() bool { return false }
+
+func (diskRootWithFailedPreCheck) UsageInfo() string { return "" }
+
+func (diskRootWithFailedPreCheck) PreCheckUsage() error {
+	return errors.New("local disk precheck should be skipped when cloud storage is used")
+}
+
+func (diskRootWithFailedPreCheck) StartupCheck() error { return nil }
 
 func assertStaticExprContextEqual(t *testing.T, sctx sessionctx.Context, exprCtx *exprstatic.ExprContext, warnHandler contextutil.WarnHandler) {
 	exprCtxManualCheckFields := []struct {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1356,6 +1356,7 @@ func initForReorgIndexes(w *worker, job *model.Job, idxInfos []*model.IndexInfo)
 	if len(idxInfos) == 0 {
 		return nil
 	}
+	loadCloudStorageURI(w, job)
 	reorgTp, err := pickBackfillType(job)
 	if err != nil {
 		return err
@@ -1366,7 +1367,6 @@ func initForReorgIndexes(w *worker, job *model.Job, idxInfos []*model.IndexInfo)
 			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs("add partial index without fast reorg is not supported")
 		}
 	}
-	loadCloudStorageURI(w, job)
 	if reorgTp.NeedMergeProcess() {
 		// Increase telemetryAddIndexIngestUsage
 		telemetryAddIndexIngestUsage.Inc()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69731

Problem Summary:

For distributed fast-reorg ADD INDEX with `tidb_cloud_storage_uri` configured, `initForReorgIndexes` picked the backfill type before `loadCloudStorageURI` populated `job.ReorgMeta.UseCloudStorage`. As a result, the ingest path could run the local disk precheck even though global-sort cloud storage should bypass local disk usage checks.

### What changed and how does it work?

Load the cloud-storage URI before selecting the add-index backfill type during reorg initialization. This keeps `job.ReorgMeta.UseCloudStorage` as the existing source of truth for `pickBackfillType`, so cloud-storage/global-sort jobs select ingest backfill without touching local disk precheck.

A regression case was added to `TestPickBackfillType` with a disk root that fails if local precheck is reached. The test verifies a distributed fast-reorg job with cloud storage configured sets `UseCloudStorage` and selects `ReorgTypeIngest`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
./tools/check/failpoint-go-test.sh pkg/ddl -run TestPickBackfillType -count=1
./tools/check/failpoint-go-test.sh pkg/ddl -run TestPickBackfillType -count=1 -tags=intest,deadlock,nextgen
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that ADD INDEX with global sort could fail due to a local ingest disk precheck before loading cloud storage configuration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index backfill behavior when cloud storage is configured, ensuring the cloud-backed ingest path is selected correctly.
  * Added coverage for cloud storage setups to skip unnecessary local disk prechecks, preventing avoidable test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->