### PR TITLE
metrics, mvservice: refine MV service metrics by component

### DIFF
--- a/docs/note/materialized_view/mv_log_purge.md
+++ b/docs/note/materialized_view/mv_log_purge.md
@@ -252,7 +252,7 @@ Runtime observability:
 
 - MVService periodically scans every MLog tracked by `mysql.tidb_mlog_purge_info`;
 - for each MLog with alerting enabled, it checks the current physical MLog row count;
-- if the count is greater than the effective threshold, the MLog is reported into metric `tidb_mv_service_task_status{type="mvlog_accumulation"}`.
+- if the count is greater than the effective threshold, the MLog is reported into metric `tidb_mv_service_task_status{component="service", type="mvlog_accumulation"}`.
 
 This metric reports the number of MLogs currently exceeding their configured accumulation threshold, after TiDB-node ownership filtering, so the same MLog is not double-counted by multiple nodes.
 

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -24885,7 +24885,7 @@
                 "aliasColors": {},
                 "dashLength": 10,
                 "datasource": "${DS_TEST-CLUSTER}",
-                "description": "Current MV service and task executor counts by status type.",
+                "description": "Current MV service and task executor counts by component and status type.",
                 "fill": 1,
                 "gridPos": {
                     "h": 6,
@@ -24920,10 +24920,10 @@
                 "spaceLength": 10,
                 "targets": [
                     {
-                        "expr": "sum(tidb_mv_service_task_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (type)",
+                        "expr": "sum(tidb_mv_service_task_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (component, type)",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "{{type}}",
+                        "legendFormat": "{{component}}/{{type}}",
                         "refId": "A"
                     }
                 ],
@@ -24979,7 +24979,7 @@
                 "dashLength": 10,
                 "dashes": false,
                 "datasource": "${DS_TEST-CLUSTER}",
-                "description": "MV service scheduler and task executor events per second by type.",
+                "description": "MV service scheduler and task executor events per second by component and type.",
                 "fill": 1,
                 "fillGradient": 0,
                 "gridPos": {
@@ -25020,10 +25020,10 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "sum(rate(tidb_mv_service_run_event_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+                        "expr": "sum(rate(tidb_mv_service_run_event_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (component, type)",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "{{type}}",
+                        "legendFormat": "{{component}}/{{type}}",
                         "refId": "A"
                     }
                 ],

--- a/pkg/metrics/materialized_view.go
+++ b/pkg/metrics/materialized_view.go
@@ -23,8 +23,6 @@ const (
 
 	mvMetricTaskStatusMVTotal           = "mv_total"
 	mvMetricTaskStatusMVLogTotal        = "mvlog_total"
-	mvMetricTaskStatusMVRefreshRun      = "mv_refresh_running"
-	mvMetricTaskStatusMVLogPurgeRun     = "mvlog_purge_running"
 	mvMetricTaskStatusMVRefreshWarning  = "mv_refresh_warning"
 	mvMetricTaskStatusMVRefreshOverdue  = "mv_refresh_overdue"
 	mvMetricTaskStatusMVLogAccumulation = "mvlog_accumulation"
@@ -41,8 +39,6 @@ var (
 
 	MVServiceMVRefreshTotalGauge    prometheus.Gauge
 	MVServiceMVLogPurgeTotalGauge   prometheus.Gauge
-	MVServiceMVRefreshRunningGauge  prometheus.Gauge
-	MVServiceMVLogPurgeRunningGauge prometheus.Gauge
 	MVServiceMVRefreshWarningGauge  prometheus.Gauge
 	MVServiceMVRefreshOverdueGauge  prometheus.Gauge
 	MVServiceMVLogAccumulationGauge prometheus.Gauge
@@ -78,8 +74,6 @@ func InitMVMetrics() {
 
 	MVServiceMVRefreshTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVTotal)
 	MVServiceMVLogPurgeTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogTotal)
-	MVServiceMVRefreshRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshRun)
-	MVServiceMVLogPurgeRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogPurgeRun)
 	MVServiceMVRefreshWarningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshWarning)
 	MVServiceMVRefreshOverdueGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshOverdue)
 	MVServiceMVLogAccumulationGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogAccumulation)

--- a/pkg/metrics/materialized_view.go
+++ b/pkg/metrics/materialized_view.go
@@ -19,6 +19,8 @@ import (
 )
 
 const (
+	mvMetricLabelComponent = "component"
+
 	mvMetricComponentService = "service"
 
 	mvMetricTaskStatusMVTotal           = "mv_total"
@@ -53,7 +55,7 @@ func InitMVMetrics() {
 			Subsystem: "mv",
 			Name:      "service_task_status",
 			Help:      "Number of MV service and task executor tasks by component and status type.",
-		}, []string{LblComponent, LblType})
+		}, []string{mvMetricLabelComponent, LblType})
 
 	MVServiceOperationDurationHistogramVec = NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -70,7 +72,7 @@ func InitMVMetrics() {
 			Subsystem: "mv",
 			Name:      "service_run_event_total",
 			Help:      "Counter of MV service scheduler and task executor events by component and event type.",
-		}, []string{LblComponent, LblType})
+		}, []string{mvMetricLabelComponent, LblType})
 
 	MVServiceMVRefreshTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVTotal)
 	MVServiceMVLogPurgeTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogTotal)

--- a/pkg/metrics/materialized_view.go
+++ b/pkg/metrics/materialized_view.go
@@ -19,17 +19,7 @@ import (
 )
 
 const (
-	mvMetricRunEventTaskExecSubmitted    = "exec_submitted"
-	mvMetricRunEventTaskExecFinished     = "exec_finished"
-	mvMetricRunEventTaskExecFailed       = "exec_failed"
-	mvMetricRunEventTaskExecTimeout      = "exec_timeout"
-	mvMetricRunEventTaskExecRejected     = "exec_rejected"
-	mvMetricRunEventTaskExecBackpressure = "exec_backpressure"
-
-	mvMetricTaskStatusTaskExecRunning         = "exec_running"
-	mvMetricTaskStatusTaskExecWaiting         = "exec_waiting"
-	mvMetricTaskStatusTaskExecTimedOutRunning = "exec_timed_out_running"
-	mvMetricTaskStatusTaskExecBackpressureBlk = "exec_backpressure_blocked"
+	mvMetricComponentService = "service"
 
 	mvMetricTaskStatusMVTotal           = "mv_total"
 	mvMetricTaskStatusMVLogTotal        = "mvlog_total"
@@ -38,7 +28,7 @@ const (
 	mvMetricTaskStatusMVRefreshWarning  = "mv_refresh_warning"
 	mvMetricTaskStatusMVRefreshOverdue  = "mv_refresh_overdue"
 	mvMetricTaskStatusMVLogAccumulation = "mvlog_accumulation"
-	mvMetricTaskStatusMVServicePanic    = "mv_service_panic"
+	mvMetricTaskStatusMVServicePanic    = "panic"
 )
 
 // Metrics for materialized view service.
@@ -48,18 +38,6 @@ var (
 	MVServiceOperationDurationHistogramVec *prometheus.HistogramVec
 
 	MVServiceRunEventCounterVec *prometheus.CounterVec
-
-	MVTaskExecutorSubmittedCounter    prometheus.Counter
-	MVTaskExecutorFinishedCounter     prometheus.Counter
-	MVTaskExecutorFailedCounter       prometheus.Counter
-	MVTaskExecutorTimeoutCounter      prometheus.Counter
-	MVTaskExecutorRejectedCounter     prometheus.Counter
-	MVTaskExecutorBackpressureCounter prometheus.Counter
-
-	MVTaskExecutorRunningTaskGauge         prometheus.Gauge
-	MVTaskExecutorWaitingTaskGauge         prometheus.Gauge
-	MVTaskExecutorTimedOutRunningTaskGauge prometheus.Gauge
-	MVTaskExecutorBackpressureBlockedGauge prometheus.Gauge
 
 	MVServiceMVRefreshTotalGauge    prometheus.Gauge
 	MVServiceMVLogPurgeTotalGauge   prometheus.Gauge
@@ -78,8 +56,8 @@ func InitMVMetrics() {
 			Namespace: "tidb",
 			Subsystem: "mv",
 			Name:      "service_task_status",
-			Help:      "Number of MV service and task executor tasks by status and role.",
-		}, []string{LblType})
+			Help:      "Number of MV service and task executor tasks by component and status type.",
+		}, []string{LblComponent, LblType})
 
 	MVServiceOperationDurationHistogramVec = NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -95,25 +73,15 @@ func InitMVMetrics() {
 			Namespace: "tidb",
 			Subsystem: "mv",
 			Name:      "service_run_event_total",
-			Help:      "Counter of MV service scheduler and task executor events.",
-		}, []string{LblType})
+			Help:      "Counter of MV service scheduler and task executor events by component and event type.",
+		}, []string{LblComponent, LblType})
 
-	MVTaskExecutorSubmittedCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecSubmitted)
-	MVTaskExecutorFinishedCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecFinished)
-	MVTaskExecutorFailedCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecFailed)
-	MVTaskExecutorTimeoutCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecTimeout)
-	MVTaskExecutorRejectedCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecRejected)
-	MVTaskExecutorBackpressureCounter = MVServiceRunEventCounterVec.WithLabelValues(mvMetricRunEventTaskExecBackpressure)
-	MVTaskExecutorRunningTaskGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusTaskExecRunning)
-	MVTaskExecutorWaitingTaskGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusTaskExecWaiting)
-	MVTaskExecutorTimedOutRunningTaskGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusTaskExecTimedOutRunning)
-	MVTaskExecutorBackpressureBlockedGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusTaskExecBackpressureBlk)
-	MVServiceMVRefreshTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVTotal)
-	MVServiceMVLogPurgeTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogTotal)
-	MVServiceMVRefreshRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshRun)
-	MVServiceMVLogPurgeRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogPurgeRun)
-	MVServiceMVRefreshWarningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshWarning)
-	MVServiceMVRefreshOverdueGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVRefreshOverdue)
-	MVServiceMVLogAccumulationGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVLogAccumulation)
-	MVServicePanicGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricTaskStatusMVServicePanic)
+	MVServiceMVRefreshTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVTotal)
+	MVServiceMVLogPurgeTotalGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogTotal)
+	MVServiceMVRefreshRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshRun)
+	MVServiceMVLogPurgeRunningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogPurgeRun)
+	MVServiceMVRefreshWarningGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshWarning)
+	MVServiceMVRefreshOverdueGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVRefreshOverdue)
+	MVServiceMVLogAccumulationGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVLogAccumulation)
+	MVServicePanicGauge = MVServiceTaskStatusGaugeVec.WithLabelValues(mvMetricComponentService, mvMetricTaskStatusMVServicePanic)
 }

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -239,6 +239,7 @@ const (
 	LblAbort          = "abort"
 	LblRollback       = "rollback"
 	LblType           = "type"
+	LblComponent      = "component"
 	LblDb             = "db"
 	LblResult         = "result"
 	LblSQLType        = "sql_type"

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -239,7 +239,6 @@ const (
 	LblAbort          = "abort"
 	LblRollback       = "rollback"
 	LblType           = "type"
-	LblComponent      = "component"
 	LblDb             = "db"
 	LblResult         = "result"
 	LblSQLType        = "sql_type"

--- a/pkg/mvservice/metrics_reporter.go
+++ b/pkg/mvservice/metrics_reporter.go
@@ -55,8 +55,6 @@ func (h *serviceHelper) reportMetrics(s *MVService) {
 	// MVService metrics
 	tidbmetrics.MVServiceMVRefreshTotalGauge.Set(float64(s.metrics.mvCount.Load()))
 	tidbmetrics.MVServiceMVLogPurgeTotalGauge.Set(float64(s.metrics.mvLogCount.Load()))
-	tidbmetrics.MVServiceMVRefreshRunningGauge.Set(float64(s.metrics.runningMVRefreshCount.Load()))
-	tidbmetrics.MVServiceMVLogPurgeRunningGauge.Set(float64(s.metrics.runningMVLogPurgeCount.Load()))
 	tidbmetrics.MVServiceMVRefreshWarningGauge.Set(float64(s.metrics.alertWarningCount.Load()))
 	tidbmetrics.MVServiceMVRefreshOverdueGauge.Set(float64(s.metrics.alertOverdueCount.Load()))
 	tidbmetrics.MVServiceMVLogAccumulationGauge.Set(float64(s.metrics.mvLogAccumulationCount.Load()))

--- a/pkg/mvservice/metrics_reporter.go
+++ b/pkg/mvservice/metrics_reporter.go
@@ -21,6 +21,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	mvMetricComponentService = "service"
+
+	mvMetricExecutorEventSubmitted    = "submitted"
+	mvMetricExecutorEventFinished     = "finished"
+	mvMetricExecutorEventFailed       = "failed"
+	mvMetricExecutorEventTimeout      = "timeout"
+	mvMetricExecutorEventRejected     = "rejected"
+	mvMetricExecutorEventBackpressure = "backpressure"
+
+	mvMetricExecutorStatusRunning             = "running"
+	mvMetricExecutorStatusWaiting             = "waiting"
+	mvMetricExecutorStatusTimedOutRunning     = "timed_out_running"
+	mvMetricExecutorStatusBackpressureBlocked = "backpressure_blocked"
+)
+
 // reportCounterDelta reports only the positive delta since last flush.
 func reportCounterDelta(counter interface{ Add(float64) }, last *int64, current int64) {
 	if current > *last {
@@ -32,17 +48,9 @@ func reportCounterDelta(counter interface{ Add(float64) }, last *int64, current 
 // reportMetrics flushes MVService runtime metrics into the metrics module.
 func (h *serviceHelper) reportMetrics(s *MVService) {
 	// Executor metrics
-	executorMetrics := s.combinedTaskExecutorMetrics()
-	reportCounterDelta(tidbmetrics.MVTaskExecutorSubmittedCounter, &h.reportCache.submittedCount, executorMetrics.submittedCount)
-	reportCounterDelta(tidbmetrics.MVTaskExecutorFinishedCounter, &h.reportCache.finishedCount, executorMetrics.finishedCount)
-	reportCounterDelta(tidbmetrics.MVTaskExecutorFailedCounter, &h.reportCache.failedCount, executorMetrics.failedCount)
-	reportCounterDelta(tidbmetrics.MVTaskExecutorTimeoutCounter, &h.reportCache.timeoutCount, executorMetrics.timeoutCount)
-	reportCounterDelta(tidbmetrics.MVTaskExecutorRejectedCounter, &h.reportCache.rejectedCount, executorMetrics.rejectedCount)
-	reportCounterDelta(tidbmetrics.MVTaskExecutorBackpressureCounter, &h.reportCache.backpressureCount, executorMetrics.backpressureCount)
-	tidbmetrics.MVTaskExecutorRunningTaskGauge.Set(float64(executorMetrics.runningCount))
-	tidbmetrics.MVTaskExecutorWaitingTaskGauge.Set(float64(executorMetrics.waitingCount))
-	tidbmetrics.MVTaskExecutorTimedOutRunningTaskGauge.Set(float64(executorMetrics.timedOutRunningCount))
-	tidbmetrics.MVTaskExecutorBackpressureBlockedGauge.Set(float64(executorMetrics.backpressureBlocked))
+	h.reportTaskExecutorMetrics(mvTaskDurationTypeRefresh, snapshotTaskExecutorMetrics(s.refreshExecutor), &h.reportCache.refresh)
+	h.reportTaskExecutorMetrics(mvTaskDurationTypePurge, snapshotTaskExecutorMetrics(s.purgeExecutor), &h.reportCache.purge)
+	h.reportTaskExecutorMetrics(mvTaskDurationTypeMLogAnalyze, snapshotTaskExecutorMetrics(s.mlogAnalyzeExecutor), &h.reportCache.mlogAnalyze)
 
 	// MVService metrics
 	tidbmetrics.MVServiceMVRefreshTotalGauge.Set(float64(s.metrics.mvCount.Load()))
@@ -52,6 +60,23 @@ func (h *serviceHelper) reportMetrics(s *MVService) {
 	tidbmetrics.MVServiceMVRefreshWarningGauge.Set(float64(s.metrics.alertWarningCount.Load()))
 	tidbmetrics.MVServiceMVRefreshOverdueGauge.Set(float64(s.metrics.alertOverdueCount.Load()))
 	tidbmetrics.MVServiceMVLogAccumulationGauge.Set(float64(s.metrics.mvLogAccumulationCount.Load()))
+}
+
+func (h *serviceHelper) reportTaskExecutorMetrics(component string, metrics taskExecutorMetricsSnapshot, cache *taskExecutorReportCache) {
+	if cache == nil {
+		return
+	}
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventSubmitted), &cache.submittedCount, metrics.submittedCount)
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventFinished), &cache.finishedCount, metrics.finishedCount)
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventFailed), &cache.failedCount, metrics.failedCount)
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventTimeout), &cache.timeoutCount, metrics.timeoutCount)
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventRejected), &cache.rejectedCount, metrics.rejectedCount)
+	reportCounterDelta(h.getRunEventCounter(component, mvMetricExecutorEventBackpressure), &cache.backpressureCount, metrics.backpressureCount)
+
+	tidbmetrics.MVServiceTaskStatusGaugeVec.WithLabelValues(component, mvMetricExecutorStatusRunning).Set(float64(metrics.runningCount))
+	tidbmetrics.MVServiceTaskStatusGaugeVec.WithLabelValues(component, mvMetricExecutorStatusWaiting).Set(float64(metrics.waitingCount))
+	tidbmetrics.MVServiceTaskStatusGaugeVec.WithLabelValues(component, mvMetricExecutorStatusTimedOutRunning).Set(float64(metrics.timedOutRunningCount))
+	tidbmetrics.MVServiceTaskStatusGaugeVec.WithLabelValues(component, mvMetricExecutorStatusBackpressureBlocked).Set(float64(metrics.backpressureBlocked))
 }
 
 // observeTaskDuration reports one task execution duration sample.
@@ -67,7 +92,7 @@ func (h *serviceHelper) observeRunEvent(eventType string) {
 	if eventType == "" {
 		return
 	}
-	h.getRunEventCounter(eventType).Inc()
+	h.getRunEventCounter(mvMetricComponentService, eventType).Inc()
 }
 
 // getDurationObserver returns a cached observer for (type, result) labels.
@@ -94,12 +119,13 @@ func (h *serviceHelper) getDurationObserver(metricType, result string) prometheu
 }
 
 // getRunEventCounter returns a cached counter for eventType label.
-func (h *serviceHelper) getRunEventCounter(eventType string) prometheus.Counter {
+func (h *serviceHelper) getRunEventCounter(component, eventType string) prometheus.Counter {
 	if h == nil {
-		return tidbmetrics.MVServiceRunEventCounterVec.WithLabelValues(eventType)
+		return tidbmetrics.MVServiceRunEventCounterVec.WithLabelValues(component, eventType)
 	}
+	key := mvMetricComponentTypeKey{component: component, typ: eventType}
 	h.runEventCounterCache.mu.RLock()
-	if counter, ok := h.runEventCounterCache.data[eventType]; ok {
+	if counter, ok := h.runEventCounterCache.data[key]; ok {
 		h.runEventCounterCache.mu.RUnlock()
 		return counter
 	}
@@ -107,10 +133,10 @@ func (h *serviceHelper) getRunEventCounter(eventType string) prometheus.Counter 
 
 	h.runEventCounterCache.mu.Lock()
 	defer h.runEventCounterCache.mu.Unlock()
-	if counter, ok := h.runEventCounterCache.data[eventType]; ok {
+	if counter, ok := h.runEventCounterCache.data[key]; ok {
 		return counter
 	}
-	counter := tidbmetrics.MVServiceRunEventCounterVec.WithLabelValues(eventType)
-	h.runEventCounterCache.data[eventType] = counter
+	counter := tidbmetrics.MVServiceRunEventCounterVec.WithLabelValues(component, eventType)
+	h.runEventCounterCache.data[key] = counter
 	return counter
 }

--- a/pkg/mvservice/service_helper.go
+++ b/pkg/mvservice/service_helper.go
@@ -65,13 +65,19 @@ type serviceHelper struct {
 	sysProcTracker        sysproctrack.Tracker
 
 	reportCache struct {
-		submittedCount    int64
-		finishedCount     int64
-		failedCount       int64
-		timeoutCount      int64
-		rejectedCount     int64
-		backpressureCount int64
+		refresh     taskExecutorReportCache
+		purge       taskExecutorReportCache
+		mlogAnalyze taskExecutorReportCache
 	}
+}
+
+type taskExecutorReportCache struct {
+	submittedCount    int64
+	finishedCount     int64
+	failedCount       int64
+	timeoutCount      int64
+	rejectedCount     int64
+	backpressureCount int64
 }
 
 type mvMetricTypeResultKey struct {
@@ -95,7 +101,7 @@ func newDurationObserverCache(capacity int) durationObserverCache {
 
 type runEventCounterCache struct {
 	mu   sync.RWMutex
-	data map[string]prometheus.Counter
+	data map[mvMetricComponentTypeKey]prometheus.Counter
 }
 
 func newRunEventCounterCache(capacity int) runEventCounterCache {
@@ -103,8 +109,13 @@ func newRunEventCounterCache(capacity int) runEventCounterCache {
 		capacity = 0
 	}
 	return runEventCounterCache{
-		data: make(map[string]prometheus.Counter, capacity),
+		data: make(map[mvMetricComponentTypeKey]prometheus.Counter, capacity),
 	}
+}
+
+type mvMetricComponentTypeKey struct {
+	component string
+	typ       string
 }
 
 // newServiceHelper builds a default helper used by MVService.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18023

Problem Summary:

MV service metrics mix service-level states and task executor states in the same `type` label. This makes Grafana panels and PromQL hard to read, especially after refresh, purge, and MLog analyze tasks all share the same executor metrics.

### What changed and how does it work?

This PR intentionally changes the MV service metrics label schema to make the metrics clearer:

- Change `tidb_mv_service_task_status` from `{type}` to `{component,type}`.
- Change `tidb_mv_service_run_event_total` from `{type}` to `{component,type}`.
- Report service-level series with `component="service"`.
- Report executor series with `component="mv_refresh"`, `component="mvlog_purge"`, and `component="mvlog_analyze"`.
- Replace old executor-specific `exec_*` label values with generic status/event values such as `running`, `waiting`, `submitted`, and `finished`.
- Update the built-in Grafana panels to group by `(component, type)` and use `{{component}}/{{type}}` legends.
- Update the MV log purge note to document the new metric label format.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

- `go test ./pkg/mvservice -run 'TestTaskExecutor|TestMVServiceFullChainSimulation|TestMVServiceMaybeGCMVHistoryReportsMetrics' -tags=intest,deadlock -count=1`\n- `jq empty pkg/metrics/grafana/tidb.json`\n- `git diff --check`\n- `make bazel_lint_changed`\n\nSide effects\n\n- [ ] Performance regression: Consumes more CPU\n- [ ] Performance regression: Consumes more Memory\n- [x] Breaking backward compatibility\n\nThis is a metrics compatibility break. PromQL, alerts, and dashboards that depend on the old single-label MV service metrics need to be updated to use the new `component,type` label schema.\n\nDocumentation\n\n- [x] Affects user behaviors\n- [ ] Contains syntax changes\n- [ ] Contains variable changes\n- [ ] Contains experimental features\n- [ ] Changes MySQL compatibility\n\n### Release note\n\n<!-- compatibility change, improvement, bugfix, and new feature need a release note -->\n\nPlease refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.\n\n```release-note\nRefine MV service metrics to distinguish service, refresh, purge, and MLog analyze components.\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved materialized view alerting and dashboard metrics by adding component-level labels to better distinguish status and event data.
  * Updated metric reporting so task execution activity is tracked separately for each MV service component.
  * Removed obsolete “running” gauges from the reported metrics set.
* **New Features**
  * Added an “MV Refresh Duration Distribution” heatmap panel for refresh latency visibility.
* **Documentation**
  * Updated documentation and Grafana panel descriptions to reflect the new metric labels and legend format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->