### PR TITLE
session: ensure masking policy table before old upgrades

### DIFF
--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1101,55 +1101,57 @@ func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
-	const fromVersion = 254
+	for _, fromVersion := range []int{189, 254} {
+		t.Run(fmt.Sprintf("from_version_%d", fromVersion), func(t *testing.T) {
+			store, dom := session.CreateStoreAndBootstrap(t)
+			defer func() { require.NoError(t, store.Close()) }()
 
-	store, dom := session.CreateStoreAndBootstrap(t)
-	defer func() { require.NoError(t, store.Close()) }()
+			se := session.CreateSessionAndSetID(t, store)
+			txn, err := store.Begin()
+			require.NoError(t, err)
+			m := meta.NewMutator(txn)
+			err = m.FinishBootstrap(int64(fromVersion))
+			require.NoError(t, err)
+			err = txn.Commit(context.Background())
+			require.NoError(t, err)
+			revertVersionAndVariables(t, se, fromVersion)
 
-	seV254 := session.CreateSessionAndSetID(t, store)
-	txn, err := store.Begin()
-	require.NoError(t, err)
-	m := meta.NewMutator(txn)
-	err = m.FinishBootstrap(int64(fromVersion))
-	require.NoError(t, err)
-	err = txn.Commit(context.Background())
-	require.NoError(t, err)
-	revertVersionAndVariables(t, seV254, fromVersion)
+			is := dom.InfoSchema()
+			policyTbl, err := is.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
+			require.NoError(t, err)
+			policyDBID := policyTbl.Meta().DBID
+			policyTblID := policyTbl.Meta().ID
 
-	is := dom.InfoSchema()
-	policyTbl, err := is.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb_masking_policy"))
-	require.NoError(t, err)
-	policyDBID := policyTbl.Meta().DBID
-	policyTblID := policyTbl.Meta().ID
+			txn, err = store.Begin()
+			require.NoError(t, err)
+			m = meta.NewMutator(txn)
+			err = m.DropTableOrView(policyDBID, policyTblID)
+			require.NoError(t, err)
+			exists, err := m.CheckTableExists(policyDBID, policyTblID)
+			require.NoError(t, err)
+			require.False(t, exists)
+			err = txn.Commit(context.Background())
+			require.NoError(t, err)
 
-	txn, err = store.Begin()
-	require.NoError(t, err)
-	m = meta.NewMutator(txn)
-	err = m.DropTableOrView(policyDBID, policyTblID)
-	require.NoError(t, err)
-	exists, err := m.CheckTableExists(policyDBID, policyTblID)
-	require.NoError(t, err)
-	require.False(t, exists)
-	err = txn.Commit(context.Background())
-	require.NoError(t, err)
+			store.SetOption(session.StoreBootstrappedKey, nil)
+			ver, err := session.GetBootstrapVersion(se)
+			require.NoError(t, err)
+			require.Equal(t, int64(fromVersion), ver)
+			dom.Close()
 
-	store.SetOption(session.StoreBootstrappedKey, nil)
-	ver, err := session.GetBootstrapVersion(seV254)
-	require.NoError(t, err)
-	require.Equal(t, int64(fromVersion), ver)
-	dom.Close()
+			newVer, err := session.BootstrapSession(store)
+			require.NoError(t, err)
+			defer newVer.Close()
 
-	newVer, err := session.BootstrapSession(store)
-	require.NoError(t, err)
-	defer newVer.Close()
+			seLatestV := session.CreateSessionAndSetID(t, store)
+			ver, err = session.GetBootstrapVersion(seLatestV)
+			require.NoError(t, err)
+			require.Equal(t, session.CurrentBootstrapVersion, ver)
 
-	seLatestV := session.CreateSessionAndSetID(t, store)
-	ver, err = session.GetBootstrapVersion(seLatestV)
-	require.NoError(t, err)
-	require.Equal(t, session.CurrentBootstrapVersion, ver)
-
-	tk := testkit.NewTestKit(t, store)
-	checkTiDBMaskingPolicyTableSchema(t, tk)
+			tk := testkit.NewTestKit(t, store)
+			checkTiDBMaskingPolicyTableSchema(t, tk)
+		})
+	}
 }
 
 func TestUpgradeWithAnalyzeColumnOptions(t *testing.T) {

--- a/pkg/session/upgrade_run.go
+++ b/pkg/session/upgrade_run.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/metadef"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -51,6 +52,8 @@ func upgrade(s sessionapi.Session) {
 	if isNull {
 		upgradeToVer99Before(s)
 	}
+
+	ensureTiDBMaskingPolicyTableBeforeUpgradeDDL(s, ver)
 
 	// It is only used in test.
 	upgradeFns := addMockBootstrapVersionForTest(s)
@@ -90,6 +93,14 @@ func upgrade(s sessionapi.Session) {
 			zap.Int64("to", currentBootstrapVersion),
 			zap.Error(err))
 	}
+}
+
+func ensureTiDBMaskingPolicyTableBeforeUpgradeDDL(s sessionapi.Session, ver int64) {
+	if ver >= version260 {
+		return
+	}
+	// Later DDL code may consult this table while running earlier reentrant upgrade DDLs.
+	mustExecute(s, metadef.CreateTiDBMaskingPolicyTable)
 }
 
 // InitMDLVariableForUpgrade initializes the metadata lock variable.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69464

Problem Summary:

During rolling upgrade, a newly started TiDB may repeatedly crash in bootstrap upgrade when upgrading from an old bootstrap version.

`upgradeToVer190` can run reentrant `MODIFY COLUMN` DDLs before `upgradeToVer260` creates `mysql.tidb_masking_policy`. However, the masking policy sync path used by ordinary DDL may query `mysql.tidb_masking_policy`. If the table does not exist yet, the DDL job fails with `Table 'mysql.tidb_masking_policy' doesn't exist`, and bootstrap upgrade exits fatally.

### What changed and how does it work?

Before running the versioned bootstrap upgrade loop, this PR ensures `mysql.tidb_masking_policy` exists when the stored bootstrap version is older than `version260`.

The table is created with `CREATE TABLE IF NOT EXISTS`, so the operation is idempotent. This keeps the fix local to bootstrap upgrade ordering and avoids adding long-lived DDL context state.

This PR also extends the existing masking policy bootstrap upgrade test to cover upgrading from bootstrap version `189`, which reproduces the actual failing `upgradeToVer190` path. The existing `254` coverage is kept.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Executed:

- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/session/test/bootstraptest -run 'TestUpgradeVersion260MaskingPolicy/from_version_189' -count=1`
  - Verified the new regression case fails without the fix and passes with the fix.
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/session/test/bootstraptest -run TestUpgradeVersion260MaskingPolicy -count=1`
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org ./tools/check/failpoint-go-test.sh pkg/session -run TestForIssue23387 -count=1`
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org make bazel_prepare`
  - No Bazel metadata files were changed.
- `GOPATH="$HOME/go" GOSUMDB=sum.golang.org make lint`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that TiDB might repeatedly crash during rolling upgrade when a bootstrap DDL runs before mysql.tidb_masking_policy is created.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade handling to ensure the masking policy system table is available during older-version bootstrap and upgrade flows.
  * Fixed masking-policy schema verification across multiple upgrade paths, helping confirm consistent behavior after re-bootstrap.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->