### PR TITLE
dxf: expose history task errors in HTTP API

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -785,7 +785,241 @@ curl -X POST "http://{TiDBIP}:10080/test/delete/indexkey/{db}/{table}/{index}?{i
 
 ## APIs unique to TiDB-X SYSTEM keyspace
 
-These APIs are registered only on TiDB instances running in the TiDB-X SYSTEM keyspace.
+These APIs are registered only on TiDB instances running in the TiDB-X SYSTEM keyspace. All examples in this section assume `{TiDBIP}:10080` belongs to a TiDB process in that SYSTEM keyspace.
+
+The `/dxf/...` APIs are for DXF (Distributed eXecution Framework) operator observability and emergency runtime tuning. In TiDB-X, DXF runs as a shared SYSTEM-keyspace service for resource-intensive work such as IMPORT INTO and distributed add index, so some APIs are called on a SYSTEM-keyspace TiDB process but target a user keyspace parameter.
+
+### Get the DXF schedule status
+
+This API returns the scheduler view used by cluster controllers to decide how many DXF worker nodes are needed. It includes the number of scheduled tasks, current and required TiDB/TiKV worker counts, busy DXF nodes, and temporary scheduler flags such as `pause_scale_in`.
+
+Usage:
+
+```shell
+curl http://{TiDBIP}:10080/dxf/schedule/status
+```
+
+Parameters: none.
+
+Example response:
+
+```json
+{
+ "version": 1,
+ "task_queue": {
+  "scheduled_count": 2
+ },
+ "tidb_worker": {
+  "cpu_count": 10,
+  "required_count": 2,
+  "current_count": 3,
+  "busy_nodes": [
+   {
+    "id": "192.168.1.10:5000",
+    "is_owner": true
+   }
+  ]
+ },
+ "tikv_worker": {
+  "required_count": 2
+ },
+ "flags": {
+  "pause_scale_in": {
+   "enabled": true,
+   "ttl": 3600000000000,
+   "expire_time": "2025-08-22T16:58:23.092864+08:00"
+  }
+ }
+}
+```
+
+### Pause or resume DXF worker scale-in
+
+This API writes a temporary DXF schedule flag. Use it when scale-in conflicts with DXF subtask scheduling, for example when subtasks keep being moved away from nodes selected for scale-in and task completion becomes slower. `pause_scale_in` asks the cluster controller to stop scaling in DXF workers for a limited time. `resume_scale_in` clears that request.
+
+Usage:
+
+```shell
+curl -X POST "http://{TiDBIP}:10080/dxf/schedule?action=pause_scale_in"
+curl -X POST "http://{TiDBIP}:10080/dxf/schedule?action=pause_scale_in&ttl=5h"
+curl -X POST "http://{TiDBIP}:10080/dxf/schedule?action=resume_scale_in"
+```
+
+Parameters:
+
+- `action`: Required. Valid values are `pause_scale_in` and `resume_scale_in`.
+- `ttl`: Optional for `pause_scale_in`. Uses Go duration syntax such as `10m`, `1h`, or `2h45m`. The default is `1h`. Ignored by `resume_scale_in`.
+
+Example response for `pause_scale_in`:
+
+```json
+{
+ "enabled": true,
+ "ttl": 18000000000000,
+ "expire_time": "2025-08-22T21:13:01.276282+08:00"
+}
+```
+
+Example response for `resume_scale_in`:
+
+```json
+{
+ "expire_time": "0001-01-01T00:00:00Z"
+}
+```
+
+### Get or update DXF schedule tuning factors
+
+This API gets or updates the resource tuning factors for a target keyspace. The scheduler uses these factors when calculating resource-related parameters for new DXF tasks such as IMPORT INTO and distributed add index tasks. Updating `amplify_factor` can make the scheduler reserve more resources for newly planned work in that keyspace.
+
+Usage:
+
+```shell
+curl "http://{TiDBIP}:10080/dxf/schedule/tune?keyspace={keyspace}"
+curl -X POST "http://{TiDBIP}:10080/dxf/schedule/tune?keyspace={keyspace}&amplify_factor={number}&ttl={duration}"
+```
+
+Parameters:
+
+- `keyspace`: Required for both `GET` and `POST`. The target keyspace whose DXF resource calculation should be read or tuned.
+- `amplify_factor`: Required for `POST`. A floating-point number in the range `[1.0, 10.0]`.
+- `ttl`: Optional for `POST`. Uses Go duration syntax such as `10m`, `1h`, or `2h45m`. The default is `1h`. After the TTL expires, `GET` returns the default tuning factor.
+
+Example `GET` response:
+
+```json
+{
+ "amplify_factor": 1
+}
+```
+
+Example `POST` response:
+
+```json
+{
+ "ttl": 7200000000000,
+ "expire_time": "2025-09-15T22:36:24.591155+08:00",
+ "amplify_factor": 2
+}
+```
+
+### Get active DXF task counts
+
+This API returns the number of active DXF tasks in `mysql.tidb_global_task`, grouped by keyspace. It is useful before maintenance or upgrades because it shows tasks that have not yet finished or moved to history. This differs from `/dxf/schedule/status`, which only counts tasks currently considered schedulable by the scheduler.
+
+Usage:
+
+```shell
+curl http://{TiDBIP}:10080/dxf/task/active
+```
+
+Parameters: none.
+
+Example response:
+
+```json
+{
+ "total": 3,
+ "per_keyspace": {
+  "SYSTEM": 1,
+  "keyspace1": 2
+ }
+}
+```
+
+### List DXF history tasks
+
+This API lists rows from `mysql.tidb_global_task_history` in descending task ID order. Use it to inspect completed, reverted, or failed DXF tasks across keyspaces. The API uses keyset pagination: pass the previous response's `NextPageToken` as the next request's `page_token`.
+
+Usage:
+
+```shell
+curl "http://{TiDBIP}:10080/dxf/task/history"
+curl "http://{TiDBIP}:10080/dxf/task/history?keyspace={keyspace}&page_size=50"
+curl "http://{TiDBIP}:10080/dxf/task/history?keyspace={keyspace}&page_size=50&page_token={NextPageToken}"
+```
+
+Parameters:
+
+- `keyspace`: Optional. If set, only returns history tasks from that keyspace.
+- `page_size`: Optional. Default is `20`. Valid range is `[1, 200]`.
+- `page_token`: Optional. Must be a positive task ID returned as `NextPageToken` by the previous page.
+
+Example response:
+
+```json
+{
+ "Items": [
+  {
+   "ID": 30001,
+   "Key": "keyspace1/ddl/backfill/9",
+   "Type": "backfill",
+   "State": "succeed",
+   "Step": -2,
+   "Priority": 512,
+   "RequiredSlots": 1,
+   "TargetScope": "dxf_service",
+   "CreateTime": "2026-04-13T11:30:10+08:00",
+   "MaxNodeCount": 1,
+   "ExtraParams": {},
+   "Keyspace": "keyspace1",
+   "StartTime": "2026-04-13T11:30:13+08:00",
+   "StateUpdateTime": "2026-04-13T11:30:17+08:00",
+   "EndTime": "2026-04-13T11:30:16+08:00"
+  }
+ ],
+ "HasMore": false,
+ "NextPageToken": 0,
+ "ApproxTotalCount": 1
+}
+```
+
+### Get IMPORT INTO history job details
+
+This API returns detailed history for one completed IMPORT INTO job in a target keyspace. It reads DXF history tables and returns task status, resource settings, file and KV sizes, speeds, row counts, and per-step durations. It returns `404 Not Found` if the matching history task is not found.
+
+Usage:
+
+```shell
+curl http://{TiDBIP}:10080/dxf/import-into/history/job/{keyspace}/{job_id}
+```
+
+Parameters:
+
+- `keyspace`: Required path parameter. The keyspace where the IMPORT INTO job ran.
+- `job_id`: Required path parameter. The positive integer IMPORT INTO job ID.
+
+Example response:
+
+```json
+{
+ "job_id": 2,
+ "keyspace": "SYSTEM",
+ "task_id": 2,
+ "state": "succeed",
+ "concurrency": 1,
+ "max_node_count": 1,
+ "distsql_scan_concurrency": 15,
+ "index_count": 4,
+ "column_count": 12,
+ "file_size": "241.4MiB",
+ "data_kv_size": "249.4MiB",
+ "index_kv_size": "40.05MiB",
+ "per_core_speed": "24.97GiB/core/hour",
+ "overall_speed": "24.97GiB/hour",
+ "row_count": 250000,
+ "row_length": 1013,
+ "duration": {
+  "total": "34s",
+  "encode": "2s",
+  "merge_sort": "",
+  "ingest": "25s",
+  "collect_conflicts": "",
+  "resolve_conflicts": "",
+  "post_process": "4s"
+ }
+}
+```
 
 ### Get or update the DXF max concurrent task limit
 
@@ -818,5 +1052,58 @@ curl -X POST "http://{TiDBIP}:10080/dxf/schedule/max_concurrent_task?value={numb
 {
  "max_concurrent_task": 128,
  "persistence": "memory_only"
+}
+```
+
+### Update a DXF task's max runtime slots
+
+This API updates the `MaxRuntimeSlots` extra parameter for one DXF task. Use it as an emergency task-level throttle, for example when a task step causes TiDB memory pressure or repeated restarts. The new value takes effect when the task executor reads the updated task metadata, commonly after the related TiDB node restarts or the task step is retried.
+
+Usage:
+
+```shell
+curl -X POST "http://{TiDBIP}:10080/dxf/task/{taskID}/max_runtime_slots?value={number}"
+curl -X POST "http://{TiDBIP}:10080/dxf/task/{taskID}/max_runtime_slots?value={number}&target_step={step}&target_step={step}"
+```
+
+Parameters:
+
+- `taskID`: Required path parameter. The positive integer DXF task ID.
+- `value`: Required. A positive integer lower than the task's `required_slots`.
+- `target_step`: Optional and repeatable. A numeric business step for the task type. If omitted, the limit applies to all business steps of the task.
+
+For IMPORT INTO tasks, common `target_step` values are:
+
+| Value | Step |
+| --- | --- |
+| `1` | `import` |
+| `2` | `post-process` |
+| `3` | `encode` |
+| `4` | `merge-sort` |
+| `5` | `ingest` |
+| `6` | `collect-conflicts` |
+| `7` | `conflict-resolution` |
+
+For distributed add index backfill tasks, common `target_step` values are:
+
+| Value | Step |
+| --- | --- |
+| `1` | `read-index` |
+| `2` | `merge-sort` |
+| `3` | `ingest` |
+| `4` | `merge-temp-index` |
+
+Example response:
+
+```json
+{
+ "task_id": 2,
+ "task_key": "SYSTEM/ImportInto/2",
+ "required_slots": 7,
+ "max_runtime_slots": 5,
+ "target_steps": [
+  "post-process",
+  "encode"
+ ]
 }
 ```

--- a/pkg/dxf/framework/storage/converter.go
+++ b/pkg/dxf/framework/storage/converter.go
@@ -52,6 +52,19 @@ func row2TaskBasic(r chunk.Row) *proto.TaskBase {
 	return task
 }
 
+func row2TaskError(r chunk.Row, idx int) error {
+	if r.IsNull(idx) {
+		return nil
+	}
+	errBytes := r.GetBytes(idx)
+	stdErr := errors.Normalize("")
+	if err := stdErr.UnmarshalJSON(errBytes); err != nil {
+		logutil.BgLogger().Error("unmarshal task error", zap.Error(err))
+		return errors.New(string(errBytes))
+	}
+	return stdErr
+}
+
 // Row2Task converts a row to a task.
 func Row2Task(r chunk.Row) *proto.Task {
 	taskBase := row2TaskBasic(r)
@@ -67,17 +80,7 @@ func Row2Task(r chunk.Row) *proto.Task {
 	task.StateUpdateTime = updateTime
 	task.Meta = r.GetBytes(14)
 	task.SchedulerID = r.GetString(15)
-	if !r.IsNull(16) {
-		errBytes := r.GetBytes(16)
-		stdErr := errors.Normalize("")
-		err := stdErr.UnmarshalJSON(errBytes)
-		if err != nil {
-			logutil.BgLogger().Error("unmarshal task error", zap.Error(err))
-			task.Error = errors.New(string(errBytes))
-		} else {
-			task.Error = stdErr
-		}
-	}
+	task.Error = row2TaskError(r, 16)
 	if !r.IsNull(17) {
 		str := r.GetJSON(17).String()
 		if err := json.Unmarshal([]byte(str), &task.ModifyParam); err != nil {

--- a/pkg/dxf/framework/storage/history.go
+++ b/pkg/dxf/framework/storage/history.go
@@ -35,7 +35,7 @@ const (
 	MinHistoryTaskPageSize = 1
 	// MaxHistoryTaskPageSize is the maximum page size for history task listing.
 	MaxHistoryTaskPageSize    = 200
-	historyTaskSummaryColumns = basicTaskColumns + `, t.start_time, t.state_update_time, t.end_time`
+	historyTaskSummaryColumns = basicTaskColumns + `, t.error, t.start_time, t.state_update_time, t.end_time`
 )
 
 // TransferSubtasks2HistoryWithSession transfer the selected subtasks into tidb_background_subtask_history table by taskID.
@@ -99,6 +99,7 @@ func (mgr *TaskManager) TransferTasks2History(ctx context.Context, tasks []*prot
 // HistoryTaskSummary contains summary fields for one history task.
 type HistoryTaskSummary struct {
 	*proto.TaskBase
+	Error           string
 	StartTime       time.Time
 	StateUpdateTime time.Time
 	EndTime         time.Time
@@ -190,14 +191,17 @@ func row2HistoryTaskSummary(r chunk.Row) *HistoryTaskSummary {
 	item := &HistoryTaskSummary{
 		TaskBase: row2TaskBasic(r),
 	}
-	if !r.IsNull(12) {
-		item.StartTime, _ = r.GetTime(12).GoTime(time.Local)
+	if taskErr := row2TaskError(r, 12); taskErr != nil {
+		item.Error = taskErr.Error()
 	}
 	if !r.IsNull(13) {
-		item.StateUpdateTime, _ = r.GetTime(13).GoTime(time.Local)
+		item.StartTime, _ = r.GetTime(13).GoTime(time.Local)
 	}
 	if !r.IsNull(14) {
-		item.EndTime, _ = r.GetTime(14).GoTime(time.Local)
+		item.StateUpdateTime, _ = r.GetTime(14).GoTime(time.Local)
+	}
+	if !r.IsNull(15) {
+		item.EndTime, _ = r.GetTime(15).GoTime(time.Local)
 	}
 	return item
 }

--- a/pkg/dxf/framework/storage/table_test.go
+++ b/pkg/dxf/framework/storage/table_test.go
@@ -1119,12 +1119,13 @@ func TestTaskHistoryTable(t *testing.T) {
 		taskSpecs := []struct {
 			key      string
 			keyspace string
+			taskErr  error
 		}{
 			{key: "history-task-1", keyspace: "ks1"},
 			{key: "history-task-2", keyspace: "ks2"},
 			{key: "history-task-3", keyspace: "ks1"},
 			{key: "history-task-4", keyspace: "ks3"},
-			{key: "history-task-5", keyspace: "ks1"},
+			{key: "history-task-5", keyspace: "ks1", taskErr: errors.New("history task failed")},
 		}
 		allIDs := make([]int64, 0, len(taskSpecs))
 		tasksToTransfer := make([]*proto.Task, 0, len(taskSpecs))
@@ -1134,7 +1135,11 @@ func TestTaskHistoryTable(t *testing.T) {
 			task, err2 := gm.GetTaskByID(ctx, id)
 			require.NoError(t, err2)
 			require.NoError(t, gm.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepOne, nil))
-			require.NoError(t, gm.SucceedTask(ctx, id))
+			if spec.taskErr != nil {
+				require.NoError(t, gm.FailTask(ctx, id, proto.TaskStateRunning, spec.taskErr))
+			} else {
+				require.NoError(t, gm.SucceedTask(ctx, id))
+			}
 			task, err2 = gm.GetTaskByID(ctx, id)
 			require.NoError(t, err2)
 			allIDs = append(allIDs, id)
@@ -1153,6 +1158,9 @@ func TestTaskHistoryTable(t *testing.T) {
 		require.Equal(t, allIDs[1], firstPage.NextPageToken)
 		require.Equal(t, "history-task-5", firstPage.Items[0].Key)
 		require.Equal(t, "ks1", firstPage.Items[0].Keyspace)
+		require.Equal(t, proto.TaskStateFailed, firstPage.Items[0].State)
+		require.Contains(t, firstPage.Items[0].Error, "history task failed")
+		require.Empty(t, firstPage.Items[1].Error)
 		require.NotZero(t, firstPage.Items[0].CreateTime)
 		require.NotZero(t, firstPage.Items[0].StartTime)
 		require.NotZero(t, firstPage.Items[0].StateUpdateTime)

--- a/pkg/server/AGENTS.md
+++ b/pkg/server/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+This file adds path-specific guidance for TiDB server code under `pkg/server/**`.
+The repository root `AGENTS.md` still applies.
+
+## HTTP API Documentation
+
+- When adding, removing, renaming, or changing the behavior, parameters, or
+  response shape of an HTTP API registered by `pkg/server`, MUST update
+  `docs/tidb_http_api.md` in the same change.
+- Keep the documentation human-readable and include the endpoint purpose,
+  supported method, parameters, usage, and example request or response.
+- If the API is registered only under a runtime gate, such as SYSTEM keyspace,
+  NextGen, failpoint, or test-only registration, document that availability
+  condition explicitly.

--- a/pkg/server/handler/tests/dxf_test.go
+++ b/pkg/server/handler/tests/dxf_test.go
@@ -202,12 +202,13 @@ func TestDXFAPI(t *testing.T) {
 			taskSpecs := []struct {
 				key      string
 				keyspace string
+				taskErr  error
 			}{
 				{key: "history-key-1", keyspace: "ks1"},
 				{key: "history-key-2", keyspace: "ks2"},
 				{key: "history-key-3", keyspace: "ks1"},
 				{key: "history-key-4", keyspace: "ks3"},
-				{key: "history-key-5", keyspace: "ks1"},
+				{key: "history-key-5", keyspace: "ks1", taskErr: fmt.Errorf("history task failed")},
 			}
 			ids := make([]int64, 0, len(taskSpecs))
 			tasksToTransfer := make([]*proto.Task, 0, len(taskSpecs))
@@ -217,7 +218,11 @@ func TestDXFAPI(t *testing.T) {
 				task, err := tm.GetTaskByID(ctx, id)
 				require.NoError(t, err)
 				require.NoError(t, tm.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepOne, nil))
-				require.NoError(t, tm.SucceedTask(ctx, id))
+				if spec.taskErr != nil {
+					require.NoError(t, tm.FailTask(ctx, id, proto.TaskStateRunning, spec.taskErr))
+				} else {
+					require.NoError(t, tm.SucceedTask(ctx, id))
+				}
 				task, err = tm.GetTaskByID(ctx, id)
 				require.NoError(t, err)
 				ids = append(ids, id)
@@ -233,6 +238,7 @@ func TestDXFAPI(t *testing.T) {
 				Key             string
 				Keyspace        string
 				State           string
+				Error           string
 				StartTime       string
 				StateUpdateTime string
 				EndTime         string
@@ -248,6 +254,7 @@ func TestDXFAPI(t *testing.T) {
 					Key             string
 					Keyspace        string
 					State           string
+					Error           string
 					StartTime       string
 					StateUpdateTime string
 					EndTime         string
@@ -298,7 +305,9 @@ func TestDXFAPI(t *testing.T) {
 			require.Equal(t, ids[4], firstPage.Items[0].ID)
 			require.Equal(t, ids[3], firstPage.Items[1].ID)
 			require.Equal(t, "history-key-5", firstPage.Items[0].Key)
-			require.Equal(t, "succeed", firstPage.Items[0].State)
+			require.Equal(t, "failed", firstPage.Items[0].State)
+			require.Contains(t, firstPage.Items[0].Error, "history task failed")
+			require.Empty(t, firstPage.Items[1].Error)
 			require.NotEmpty(t, firstPage.Items[0].StartTime)
 			require.NotEmpty(t, firstPage.Items[0].StateUpdateTime)
 			require.NotEmpty(t, firstPage.Items[0].EndTime)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67640

Problem Summary:

The DXF task history HTTP API lists completed history tasks, but failed history tasks did not expose the persisted `mysql.tidb_global_task_history.error` value. Operators could see that a history task failed, but they could not get the task error from the HTTP API response.

### What changed and how does it work?

`ListHistoryTasks` now selects `t.error` from `mysql.tidb_global_task_history` and maps it into `HistoryTaskSummary.Error` as a string. The mapping reuses the same TiDB error JSON decoding path used by full task loading, so the history summary and full task APIs interpret persisted task errors consistently.

The DXF task history HTTP test now seeds a real failed history task through `FailTask`, verifies that `/dxf/task/history` includes the failed task error string, and verifies that successful history tasks keep an empty error string. The storage test for `ListHistoryTasks` covers the same behavior at the storage boundary.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/server/handler/tests -run 'TestDXFAPI/task_history_api/success' -count=1 -tags=intest,deadlock,nextgen`
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/storage -run TestTaskHistoryTable -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The DXF task history HTTP API now includes task error information for failed history tasks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the TiDB-X SYSTEM keyspace HTTP API docs with DXF schedule, tuning, history, and task-runtime endpoints.
  * Added request/response details, pagination behavior, status fields, and example usage notes.

* **Bug Fixes**
  * History task results now include error details in summaries and API responses.
  * Improved handling of task error values so failures are surfaced more consistently.

* **Tests**
  * Updated DXF API and storage tests to cover failed history tasks and verify returned error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->