### PR TITLE
planner: build secondary index scan ranges from clustered PK predicates

### DIFF
--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
         "rule_cdc_join_reorder_test.go",
         "rule_common_handle_ordering_test.go",
+        "rule_common_handle_range_test.go",
         "rule_correlate_test.go",
         "rule_derive_topn_from_window_test.go",
         "rule_eliminate_empty_selection_test.go",
@@ -21,7 +22,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
+++ b/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommonHandleIndexRanges verifies that predicates on clustered (common handle)
+// primary key columns are turned into scan ranges on non-unique secondary indexes,
+// mirroring the long-standing behavior for int handles. The physical key of a
+// non-unique secondary index on a clustered table ends with the full common handle,
+// so ranger can seek directly instead of scanning and filtering.
+func TestCommonHandleIndexRanges(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t_chr")
+		tk.MustExec(`CREATE TABLE t_chr (
+			tenant int,
+			seq bigint,
+			a int,
+			b int,
+			c int,
+			PRIMARY KEY(tenant, seq) CLUSTERED,
+			KEY ia(a),
+			KEY ia_overlap(a, tenant),
+			UNIQUE KEY ub(b)
+		)`)
+		// Several tenants share the same a values so range narrowing is observable.
+		tk.MustExec(`insert into t_chr values
+			(1, 100, 10, 1, 0),
+			(1, 200, 10, 2, 0),
+			(2, 100, 10, 3, 0),
+			(2, 200, 20, 4, 0),
+			(3, 100, 10, 5, 1)`)
+
+		// ---------------------------------------------------------------
+		// Case 1: Equality on all index columns plus the leading PK column
+		// becomes a multi-column point range on the secondary index.
+		// ---------------------------------------------------------------
+		rows := tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia) where a = 10 and tenant = 2",
+		).Rows()
+		require.True(t, explainHas(rows, "range:[10 2,10 2]"),
+			"case 1: expected the tenant predicate to appear in the index range")
+		tk.MustQuery(
+			"select * from t_chr use index(ia) where a = 10 and tenant = 2",
+		).Check(testkit.Rows("2 100 10 3 0"))
+
+		// ---------------------------------------------------------------
+		// Case 2: The full PK suffix participates: eq on tenant plus a
+		// range on seq extends the index range across both PK columns.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia) where a = 10 and tenant = 1 and seq > 100",
+		).Rows()
+		require.True(t, explainHas(rows, "range:(10 1 100,10 1 +inf]"),
+			"case 2: expected both PK columns in the index range")
+		tk.MustQuery(
+			"select * from t_chr use index(ia) where a = 10 and tenant = 1 and seq > 100",
+		).Check(testkit.Rows("1 200 10 2 0"))
+
+		// ---------------------------------------------------------------
+		// Case 3: A non-point range on the leading PK column.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia) where a = 10 and tenant > 1",
+		).Rows()
+		require.True(t, explainHas(rows, "range:(10 1,10 +inf]"),
+			"case 3: expected a non-point range on the tenant column")
+		tk.MustQuery(
+			"select * from t_chr use index(ia) where a = 10 and tenant > 1 order by tenant, seq",
+		).Check(testkit.Rows("2 100 10 3 0", "3 100 10 5 1"))
+
+		// ---------------------------------------------------------------
+		// Case 4: IN list on the index column combines with the PK suffix.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia) where a in (10, 20) and tenant = 2",
+		).Rows()
+		require.True(t, explainHas(rows, "range:[10 2,10 2], [20 2,20 2]"),
+			"case 4: expected the PK suffix in every IN range")
+		tk.MustQuery(
+			"select * from t_chr use index(ia) where a in (10, 20) and tenant = 2 order by tenant, seq",
+		).Check(testkit.Rows("2 100 10 3 0", "2 200 20 4 0"))
+
+		// ---------------------------------------------------------------
+		// Case 5: A predicate on a later PK column without binding the
+		// earlier one cannot extend the range and stays a filter.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia) where a = 10 and seq = 100",
+		).Rows()
+		require.True(t, explainHas(rows, "range:[10,10]"),
+			"case 5: expected the range to stop at the index column")
+		tk.MustQuery(
+			"select * from t_chr use index(ia) where a = 10 and seq = 100 order by tenant, seq",
+		).Check(testkit.Rows("1 100 10 1 0", "2 100 10 3 0", "3 100 10 5 1"))
+
+		// ---------------------------------------------------------------
+		// Case 6: Overlap — ia_overlap(a, tenant) already contains a PK
+		// column, so the physical key holds tenant twice and the PK suffix
+		// must NOT be appended. The seq predicate stays a filter and the
+		// range ends at the declared index columns.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ia_overlap) where a = 10 and tenant = 1 and seq > 100",
+		).Rows()
+		require.True(t, explainHas(rows, "range:[10 1,10 1]"),
+			"case 6: expected the range to stop at the declared index columns")
+		require.False(t, explainHas(rows, "range:[10 1 100"),
+			"case 6: PK suffix must not extend the range of an overlapping index")
+		tk.MustQuery(
+			"select * from t_chr use index(ia_overlap) where a = 10 and tenant = 1 and seq > 100",
+		).Check(testkit.Rows("1 200 10 2 0"))
+
+		// ---------------------------------------------------------------
+		// Case 7: Unique secondary index — the handle lives in the index
+		// value, not the key, so the PK suffix must NOT be appended.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr use index(ub) where b > 0 and tenant = 2",
+		).Rows()
+		require.False(t, explainHas(rows, "range:(0 2"),
+			"case 7: PK suffix must not extend the range of a unique index")
+		tk.MustQuery(
+			"select * from t_chr use index(ub) where b > 0 and tenant = 2 order by tenant, seq",
+		).Check(testkit.Rows("2 100 10 3 0", "2 200 20 4 0"))
+
+		// ---------------------------------------------------------------
+		// Case 8: Covering read — the appended PK columns are readable from
+		// the index without a duplicated schema (IndexReader, no lookup).
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select tenant, seq, a from t_chr use index(ia) where a = 10 and tenant = 2",
+		).Rows()
+		require.True(t, explainHas(rows, "IndexReader"),
+			"case 8: expected a single-scan IndexReader")
+		require.True(t, explainHas(rows, "range:[10 2,10 2]"),
+			"case 8: expected the tenant predicate in the index range")
+		tk.MustQuery(
+			"select tenant, seq, a from t_chr use index(ia) where a = 10 and tenant = 2",
+		).Check(testkit.Rows("2 100 10"))
+
+		// ---------------------------------------------------------------
+		// Case 9: String PK column with a case-insensitive collation — the
+		// range must honor collation equality (sortKey-encoded seek).
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_chr_ci")
+		tk.MustExec(`CREATE TABLE t_chr_ci (
+			tenant varchar(32) COLLATE utf8mb4_general_ci,
+			seq int,
+			a int,
+			PRIMARY KEY(tenant, seq) CLUSTERED,
+			KEY ia(a)
+		)`)
+		tk.MustExec(`insert into t_chr_ci values
+			('abc', 1, 10),
+			('ABC', 2, 10),
+			('xyz', 1, 10),
+			('abc', 3, 20)`)
+		tk.MustQuery(
+			"select * from t_chr_ci use index(ia) where a = 10 and tenant = 'AbC' order by seq",
+		).Check(testkit.Rows("abc 1 10", "ABC 2 10"))
+		tk.MustQuery(
+			"select * from t_chr_ci use index(ia) where a = 10 and tenant = 'abc' and seq >= 2",
+		).Check(testkit.Rows("ABC 2 10"))
+
+		// ---------------------------------------------------------------
+		// Case 10: Prefixed clustered PK — the handle stores a truncated
+		// prefix of p1, so the range uses prefix semantics and the full
+		// predicate is re-checked as a filter. Results must stay exact.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_chr_prefix")
+		tk.MustExec(`CREATE TABLE t_chr_prefix (
+			p1 varchar(64),
+			p2 int,
+			c int,
+			PRIMARY KEY(p1(2), p2) CLUSTERED,
+			KEY ic(c)
+		)`)
+		tk.MustExec(`insert into t_chr_prefix values ('abz', 1, 0), ('abc', 2, 0), ('axy', 3, 0), ('abc', 4, 1)`)
+		tk.MustQuery(
+			"select * from t_chr_prefix use index(ic) where c = 0 and p1 = 'abc'",
+		).Check(testkit.Rows("abc 2 0"))
+		tk.MustQuery(
+			"select * from t_chr_prefix use index(ic) where c = 0 and p1 = 'abz' and p2 = 1",
+		).Check(testkit.Rows("abz 1 0"))
+	})
+}

--- a/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
+++ b/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
@@ -201,5 +201,66 @@ func TestCommonHandleIndexRanges(t *testing.T) {
 		tk.MustQuery(
 			"select * from t_chr_prefix use index(ic) where c = 0 and p1 = 'abz' and p2 = 1",
 		).Check(testkit.Rows("abz 1 0"))
+
+		// ---------------------------------------------------------------
+		// Case 11: Single-column string common handle — a single non-int
+		// clustered PK is also a common handle, so the same range
+		// extension applies with a one-column suffix.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_chr_single")
+		tk.MustExec(`CREATE TABLE t_chr_single (
+			pk varchar(32),
+			a int,
+			b int,
+			PRIMARY KEY(pk) CLUSTERED,
+			KEY ia(a)
+		)`)
+		tk.MustExec(`insert into t_chr_single values
+			('u1', 10, 1),
+			('u2', 10, 2),
+			('u3', 10, 3),
+			('u4', 20, 4)`)
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr_single use index(ia) where a = 10 and pk = 'u2'",
+		).Rows()
+		require.True(t, explainHas(rows, `range:[10 "u2",10 "u2"]`),
+			"case 11: expected the PK predicate to appear in the index range")
+		tk.MustQuery(
+			"select * from t_chr_single use index(ia) where a = 10 and pk = 'u2'",
+		).Check(testkit.Rows("u2 10 2"))
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr_single use index(ia) where a = 10 and pk > 'u1'",
+		).Rows()
+		require.True(t, explainHas(rows, `range:(10 "u1",10 +inf]`),
+			"case 11: expected a non-point range on the PK column")
+		tk.MustQuery(
+			"select * from t_chr_single use index(ia) where a = 10 and pk > 'u1' order by pk",
+		).Check(testkit.Rows("u2 10 2", "u3 10 3"))
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select pk, a from t_chr_single use index(ia) where a = 10 and pk = 'u2'",
+		).Rows()
+		require.True(t, explainHas(rows, "IndexReader"),
+			"case 11: expected a single-scan IndexReader for the covering read")
+
+		// ---------------------------------------------------------------
+		// Case 12: Single-column decimal common handle — non-int, non-string
+		// handle types take the same path.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_chr_dec")
+		tk.MustExec(`CREATE TABLE t_chr_dec (
+			pk decimal(10,2),
+			a int,
+			PRIMARY KEY(pk) CLUSTERED,
+			KEY ia(a)
+		)`)
+		tk.MustExec(`insert into t_chr_dec values (1.50, 10), (2.50, 10), (3.50, 20)`)
+		rows = tk.MustQuery(
+			"explain format = 'plan_tree' select * from t_chr_dec use index(ia) where a = 10 and pk = 2.50",
+		).Rows()
+		require.True(t, explainHas(rows, "range:[10 2.50,10 2.50]"),
+			"case 12: expected the decimal PK predicate to appear in the index range")
+		tk.MustQuery(
+			"select * from t_chr_dec use index(ia) where a = 10 and pk = 2.50",
+		).Check(testkit.Rows("2.50 10"))
 	})
 }

--- a/pkg/planner/core/operator/physicalop/physical_index_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_scan.go
@@ -361,7 +361,9 @@ func (p *PhysicalIndexScan) GetScanRowSize() float64 {
 //	PhysicalIndexScan.IdxCols       []*expression.Column
 //	PhysicalIndexScan.Columns       []*model.ColumnInfo
 func (p *PhysicalIndexScan) InitSchema(idxExprCols []*expression.Column, isDoubleRead bool) {
-	indexCols := make([]*expression.Column, len(p.IdxCols), len(p.Index.Columns)+1)
+	// IdxCols may exceed the declared index columns when handle columns were appended
+	// (one for an int handle, possibly several for a common handle).
+	indexCols := make([]*expression.Column, len(p.IdxCols), max(len(p.IdxCols), len(p.Index.Columns))+1)
 	copy(indexCols, p.IdxCols)
 
 	for i := len(p.IdxCols); i < len(p.Index.Columns); i++ {
@@ -378,7 +380,13 @@ func (p *PhysicalIndexScan) InitSchema(idxExprCols []*expression.Column, isDoubl
 	}
 	p.NeedCommonHandle = p.Table.IsCommonHandle
 
-	if p.NeedCommonHandle {
+	// fillIndexPath may have appended the full common-handle suffix to IdxCols for
+	// non-unique indexes, in which case indexCols already ends with the handle columns
+	// and appending idxExprCols' handle segment would duplicate them. Otherwise append
+	// the segment verbatim — it must stay complete even when a handle column repeats a
+	// declared index column, because the executor addresses the handle at the offsets
+	// right after the declared index columns (see buildIndexScanOutputOffsets).
+	if p.NeedCommonHandle && len(p.IdxCols) <= len(p.Index.Columns) {
 		for i := len(p.Index.Columns); i < len(idxExprCols); i++ {
 			indexCols = append(indexCols, idxExprCols[i])
 		}

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -195,9 +195,59 @@ func fillIndexPath(ds *logicalop.DataSource, path *util.AccessPath, conds []expr
 				}
 			}
 		}
+		tryAppendCommonHandleColsToIndexPath(ds, path)
 	}
 	err := detachCondAndBuildRangeForPath(ds.SCtx(), path, conds, ds.TableStats.HistColl)
 	return err
+}
+
+// tryAppendCommonHandleColsToIndexPath is the common-handle counterpart of the int-handle
+// append in fillIndexPath. The key of a non-unique secondary index on a clustered table
+// physically ends with the full common handle, so appending the primary key columns to the
+// path lets ranger turn predicates on them into tighter scan ranges instead of filters.
+// The caller must have checked that the index is non-unique, non-primary, and that all
+// declared index columns are resolved (len(path.Index.Columns) == len(path.IdxCols)).
+func tryAppendCommonHandleColsToIndexPath(ds *logicalop.DataSource, path *util.AccessPath) {
+	if !ds.TableInfo.IsCommonHandle || len(ds.CommonHandleCols) == 0 ||
+		len(ds.CommonHandleLens) != len(ds.CommonHandleCols) {
+		return
+	}
+	// Global indexes (V1+) encode the partition ID between the index columns and the handle,
+	// and MV/columnar indexes build their ranges specially, so appended columns would not
+	// align with the physical key layout.
+	if path.Index.Global || path.Index.MVIndex || path.Index.IsColumnarIndex() {
+		return
+	}
+	// In CommonHandleVersion 0 with new collation, string handle columns are stored as
+	// collation sortKey bytes without restored data. Skip them to stay consistent with the
+	// coverage check (indexCoveringColumn) and the ordering check (matchProperty).
+	if hasV0NewCollationStringHandle(ds) {
+		return
+	}
+	for _, handleCol := range ds.CommonHandleCols {
+		if handleCol == nil {
+			return
+		}
+		// If a primary key column is already among the declared index columns, the physical
+		// key contains it twice: once in the index columns and once in the handle suffix.
+		// Appending only the missing columns would misalign the ranges with the key layout,
+		// and repeating a column breaks range building, so skip the append entirely.
+		for _, col := range path.IdxCols {
+			if col.EqualColumn(handleCol) {
+				return
+			}
+		}
+	}
+	path.FullIdxCols = append(path.FullIdxCols, ds.CommonHandleCols...)
+	path.FullIdxColLens = append(path.FullIdxColLens, ds.CommonHandleLens...)
+	path.IdxCols = append(path.IdxCols, ds.CommonHandleCols...)
+	path.IdxColLens = append(path.IdxColLens, ds.CommonHandleLens...)
+	// Also updates the map that maps the index id to its prefix column ids.
+	if len(ds.TableStats.HistColl.Idx2ColUniqueIDs[path.Index.ID]) == len(path.Index.Columns) {
+		for _, handleCol := range ds.CommonHandleCols {
+			ds.TableStats.HistColl.Idx2ColUniqueIDs[path.Index.ID] = append(ds.TableStats.HistColl.Idx2ColUniqueIDs[path.Index.ID], handleCol.UniqueID)
+		}
+	}
 }
 
 // adjustCountAfterAccess adjusts the CountAfterAccess when it's less than the estimated table row count.
@@ -503,7 +553,9 @@ func getGroupNDVs(ds *logicalop.DataSource) []property.GroupNDV {
 		if colsLen < len(idx.Info.Columns) {
 			return false
 		} else if colsLen > len(idx.Info.Columns) {
-			colsLen--
+			// Ignore the appended handle columns: one column for an int handle, and
+			// possibly several for a common handle.
+			colsLen = len(idx.Info.Columns)
 		}
 		idxCols := make([]int64, colsLen)
 		copy(idxCols, tbl.Idx2ColUniqueIDs[idxID])


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69744

Problem Summary:

For a non-unique secondary index on a clustered (common handle) table, the physical index key ends with the full common handle, but `fillIndexPath` only appends the handle column for **int** handles. Predicates on the clustered primary key columns therefore stay filters instead of becoming access ranges, so TiKV scans every index entry matching the declared index columns and filters afterwards — a large penalty for multi-tenant schemas with a composite clustered primary key such as `(tenant_id, seq)`.

### What changed and how does it work?

`fillIndexPath` now appends the common handle columns to non-unique secondary index paths (`tryAppendCommonHandleColsToIndexPath`), mirroring the long-standing int-handle behavior, so ranger turns primary key predicates into tighter scan ranges. For `PRIMARY KEY(tenant_id, seq) CLUSTERED` with `KEY ia(a)`:

```sql
EXPLAIN SELECT * FROM t USE INDEX(ia) WHERE a = 10 AND tenant_id = 2;
-- before: range:[10,10], tenant_id = 2 as an index-side filter (scans all tenants)
-- after:  range:[10 2,10 2] (seeks one tenant's slice of the index)
```

The append is skipped when the physical key layout would not align with the range columns:

- unique indexes — the handle lives in the index value, not the key
- global indexes — V1+ encodes the partition ID between the index columns and the handle
- MV and columnar indexes — their ranges are built specially
- `CommonHandleVersion == 0` with new-collation string handle columns — handle bytes are collation sortKeys without restored data (same guard as the coverage and ordering checks)
- indexes already containing a primary key column — the key stores that column twice (once declared, once in the handle suffix), so appended range columns would misalign

String handle columns are safe to use in ranges otherwise: the handle bytes are written with the same collation-aware `codec.EncodeKey` that `distsql.EncodeIndexKey` uses to encode range boundaries, so seek keys align byte-for-byte (covered by a case-insensitive collation test case).

Two latent single-appended-column assumptions exposed by the multi-column append are fixed as well:

- `PhysicalIndexScan.InitSchema`: the schema slice capacity assumed at most one appended column, and the common-handle suffix append is now skipped when `fillIndexPath` already put the suffix in `IdxCols`. In the overlap case the verbatim (duplicated) handle segment is kept, because the executor addresses handle columns at the offsets right after the declared index columns (`buildIndexScanOutputOffsets`).
- `getGroupNDVs`: the prefix-length trim assumed exactly one appended handle column (`colsLen--`); it now trims to the declared index column count.

Estimation continues to use only the declared index columns (`pruneEstimateRange`), matching the existing int-handle behavior; the improvement is execution-side scan volume.

This is the range-building counterpart of #66645, which made the common-handle suffix visible to ordering.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New regression test `TestCommonHandleIndexRanges` (`pkg/planner/core/casetest/rule`) covers point/range/IN ranges including the PK suffix, gap-in-prefix, overlap and unique-index exclusions, covering IndexReader reads, case-insensitive-collation string PKs, and prefixed clustered PKs; it fails without the fix and passes with it, under both cascades modes. The full `pkg/planner/core/casetest` tree (failpoints enabled), `pkg/util/ranger`, targeted `pkg/executor` IndexLookUp/cluster-index tests, and the full `tests/integrationtest` suite pass with no result-file changes.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve the performance of non-unique secondary index scans on clustered tables: predicates on the clustered primary key columns are now used as index scan ranges instead of filters, reducing the number of index entries scanned in TiKV.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index scan planning for clustered primary keys and common-handle primary keys to avoid incorrect range extension and duplicated suffix handling.
  * Improved statistics/group matching for non-unique, non-primary indexes involving appended common-handle columns.
* **Tests**
  * Added expanded test coverage for common-handle index range generation, including equality/range/`IN` patterns, collation-aware behavior, and covering-read plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->