### PR TITLE
planner: keep pruned index estimation ranges valid

### DIFF
--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1713,6 +1713,55 @@ func TestIndexRangeEstimationWithAppendedHandleColumn(t *testing.T) {
 	})
 }
 
+// TestIndexRangeEstimationWithTruncatedHandleRange verifies that estimation ranges pruned
+// back to the declared index columns keep valid bounds. Truncating the appended handle
+// dimensions widens a bound to the whole prefix, so an exclusive bound from a dropped
+// dimension must become inclusive (otherwise (5 10, 5 +inf] collapses to the empty (5, 5]
+// and estimates ~0 rows), and ranges collapsing to the same prefix must be merged instead
+// of each contributing the full prefix row count.
+func TestIndexRangeEstimationWithTruncatedHandleRange(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(id bigint primary key clustered, a int, key ia(a))")
+	vals := make([]string, 0, 100)
+	for i := 1; i <= 100; i++ {
+		vals = append(vals, fmt.Sprintf("(%d, %d)", i, i%10))
+	}
+	tk.MustExec("insert into t values " + strings.Join(vals, ","))
+	tk.MustExec("analyze table t all columns")
+
+	// Returns the estRows and operator info of the IndexRangeScan in the plan.
+	indexScanRow := func(sql string) (estRows, operatorInfo string) {
+		rows := tk.MustQuery("explain format='brief' " + sql).Rows()
+		for _, row := range rows {
+			if strings.Contains(row[0].(string), "IndexRangeScan") {
+				return row[1].(string), row[4].(string)
+			}
+		}
+		t.Fatalf("no IndexRangeScan in plan for %q", sql)
+		return "", ""
+	}
+
+	// Each distinct value of a has 10 rows; the handle predicates below must estimate as if
+	// the handle dimension were absent, i.e. the 10 rows of a = 5.
+
+	// Handle range with an exclusive low bound.
+	estRows, opInfo := indexScanRow("select * from t use index(ia) where a = 5 and id > 10")
+	require.Contains(t, opInfo, "range:(5 10,5 +inf]", "execution range must keep the handle dimension")
+	require.Equal(t, "10.00", estRows)
+
+	// Handle range with an exclusive high bound.
+	estRows, opInfo = indexScanRow("select * from t use index(ia) where a = 5 and id < 10")
+	require.Contains(t, opInfo, "range:[5 -inf,5 10)", "execution range must keep the handle dimension")
+	require.Equal(t, "10.00", estRows)
+
+	// Multiple handle points under the same prefix must not double count.
+	estRows, opInfo = indexScanRow("select * from t use index(ia) where a = 5 and id in (11, 22)")
+	require.Contains(t, opInfo, "range:[5 11,5 11], [5 22,5 22]", "execution range must keep the handle dimension")
+	require.Equal(t, "10.00", estRows)
+}
+
 func TestDeriveTablePathStatsNoAccessConds(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -185,6 +185,7 @@ go_library(
         "//pkg/util/parser",
         "//pkg/util/plancodec",
         "//pkg/util/ranger",
+        "//pkg/util/ranger/context",
         "//pkg/util/rowcodec",
         "//pkg/util/sem",
         "//pkg/util/sem/compat",

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -473,11 +473,7 @@ func pruneEstimateRange(rctx *rangerctx.RangerContext, ranges []*ranger.Range, k
 		}
 		estimateRanges = append(estimateRanges, newRange)
 	}
-merged, err := ranger.UnionRanges(rctx, estimateRanges, false)
-if err != nil {
-	return nil, err
-}
-return ([]*ranger.Range)(merged), nil
+	return ranger.UnionRanges(rctx, estimateRanges, false)
 }
 
 func getGeneralAttributesFromPaths(paths []*util.AccessPath, totalRowCount float64) (float64, bool) {

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -473,7 +473,11 @@ func pruneEstimateRange(rctx *rangerctx.RangerContext, ranges []*ranger.Range, k
 		}
 		estimateRanges = append(estimateRanges, newRange)
 	}
-	return ranger.UnionRanges(rctx, estimateRanges, false)
+merged, err := ranger.UnionRanges(rctx, estimateRanges, false)
+if err != nil {
+	return nil, err
+}
+return ([]*ranger.Range)(merged), nil
 }
 
 func getGeneralAttributesFromPaths(paths []*util.AccessPath, totalRowCount float64) (float64, bool) {

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -40,6 +40,7 @@ import (
 	h "github.com/pingcap/tidb/pkg/util/hint"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/ranger"
+	rangerctx "github.com/pingcap/tidb/pkg/util/ranger/context"
 	"go.uber.org/zap"
 )
 
@@ -435,28 +436,35 @@ func detachCondAndBuildRangeForPath(
 			}
 		}
 	}
-	var estimateRanges []*ranger.Range
+	estimateRanges := path.Ranges
 	if needPruneEstimateRange {
 		// Non-unique index paths may append handle columns in `path.IdxCols` for execution ranges.
 		// Rebuild estimation ranges with the same column set used in row-count estimation.
-		estimateRanges = pruneEstimateRange(path.Ranges, len(indexCols))
-	} else {
-		estimateRanges = path.Ranges
+		estimateRanges, err = pruneEstimateRange(sctx.GetRangerCtx(), path.Ranges, len(indexCols))
+		if err != nil {
+			return err
+		}
 	}
 	count, err := cardinality.GetRowCountByIndexRanges(sctx, histColl, path.Index.ID, estimateRanges, indexCols)
 	path.CountAfterAccess, path.MinCountAfterAccess, path.MaxCountAfterAccess = count.Est, count.MinEst, count.MaxEst
 	return err
 }
 
-func pruneEstimateRange(ranges []*ranger.Range, keepColCnt int) []*ranger.Range {
-	estimateRanges := make([]*ranger.Range, 0, len(ranges))
+// pruneEstimateRange truncates ranges built over the index columns plus the appended handle
+// columns down to keepColCnt columns, so that they align with the index statistics, which
+// only cover the declared index columns. Truncating a bound widens it to the whole prefix:
+// a bound that lost values must become inclusive (otherwise a range like (10 1, 10 +inf]
+// would collapse to the empty (10, 10]), and ranges that collapse to the same prefix must
+// be merged so the prefix rows are not counted once per pruned range.
+func pruneEstimateRange(rctx *rangerctx.RangerContext, ranges []*ranger.Range, keepColCnt int) ([]*ranger.Range, error) {
+	estimateRanges := make(ranger.Ranges, 0, len(ranges))
 	for _, ran := range ranges {
 		newRange := &ranger.Range{
 			LowVal:      make([]types.Datum, 0, keepColCnt),
 			HighVal:     make([]types.Datum, 0, keepColCnt),
 			Collators:   make([]collate.Collator, 0, keepColCnt),
-			LowExclude:  ran.LowExclude,
-			HighExclude: ran.HighExclude,
+			LowExclude:  ran.LowExclude && len(ran.LowVal) <= keepColCnt,
+			HighExclude: ran.HighExclude && len(ran.HighVal) <= keepColCnt,
 		}
 		for idx := range min(keepColCnt, len(ran.LowVal)) {
 			newRange.LowVal = append(newRange.LowVal, ran.LowVal[idx])
@@ -465,7 +473,7 @@ func pruneEstimateRange(ranges []*ranger.Range, keepColCnt int) []*ranger.Range 
 		}
 		estimateRanges = append(estimateRanges, newRange)
 	}
-	return estimateRanges
+	return ranger.UnionRanges(rctx, estimateRanges, false)
 }
 
 func getGeneralAttributesFromPaths(paths []*util.AccessPath, totalRowCount float64) (float64, bool) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69746

Problem Summary:

For a non-unique secondary index, the planner appends the int handle column to the execution ranges. `pruneEstimateRange` truncates those ranges back to the declared index columns before row-count estimation (index statistics only cover the declared columns), but the truncation is wrong in two ways:

1. It keeps the original `LowExclude`/`HighExclude` flags. A bound that lost its handle values must become inclusive because truncation widens it to the whole prefix; keeping the flag collapses `(5 10, 5 +inf]` (from `a = 5 AND id > 10`) into the empty range `(5, 5]`, which estimates ~0 rows. The result no longer scales with the actual selectivity of the prefix.
2. It estimates each pruned range independently, so multiple handle points under one prefix double count: `a = 5 AND id IN (11, 22)` prunes `[5 11,5 11], [5 22,5 22]` to `[5,5], [5,5]` and counts the `a = 5` rows twice.

### What changed and how does it work?

In `pruneEstimateRange`:

- A bound whose values were truncated becomes inclusive, since dropping the trailing handle dimensions widens it to the whole prefix.
- The pruned ranges are merged with `ranger.UnionRanges` so ranges that collapse to the same or overlapping prefixes are counted once.

Execution ranges (`path.Ranges`) are untouched; only the copy passed to `GetRowCountByIndexRanges` changes. With the fix, all three query shapes above estimate the row count of the `a = 5` prefix (10 rows in the regression test), instead of 12.50/12.50/20.00 before.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the row count estimation of a non-unique secondary index was too low or double counted when predicates on an integer primary key extended the index scan range.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row-count estimation for non-unique index scans when handle-range dimensions are appended and later truncated.
  * Fixed exclusive bound truncation to avoid collapsing ranges into empty results.
  * Enhanced merging of equivalent/overlapping prefix ranges to prevent double-counted estimates.
* **Tests**
  * Added a planner test covering truncated handle-range behavior, exclusive-to-inclusive bound handling, and merged range estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->