### PR TITLE
planner: fix a nil pointer bug caused by nil TopN (#66251)  | tidb-test=release-8.5-20260116-v8.5.5

### DIFF
--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -419,7 +419,7 @@ func estimateRowCountWithUniformDistribution(
 		// This can happen when sampling collects fewer than all NDV.
 		if histNDV > 0 && modifyCount == 0 {
 			topNMinCount := uint64(0)
-			if len(topN.TopN) > 0 {
+			if topN != nil && len(topN.TopN) > 0 {
 				topNMinCount = topN.TopN[0].Count
 				for _, item := range topN.TopN {
 					topNMinCount = min(topNMinCount, item.Count)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65867

Problem Summary: planner: fix a nil pointer bug caused by nil TopN

### What changed and how does it work?

planner: fix a nil pointer bug caused by nil TopN

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning stability when statistics histograms are empty, preventing potential execution failures.

* **Tests**
  * Added coverage for analyzing table statistics and running filtered, ordered queries to verify they complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->