### PR TITLE
test: stabilize flaky TestWorkerPool/TwoWorkers

### DIFF
--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -233,6 +233,9 @@ func TestWorkerPool(t *testing.T) {
 				return workers < 2 && tasks > 0
 			},
 		}
+		secondWorkerStarted := make(chan struct{})
+		finishSecondWorker := make(chan struct{})
+		errCh := make(chan string, 1)
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		pool.submit(func() {
@@ -240,15 +243,30 @@ func TestWorkerPool(t *testing.T) {
 			wg.Add(1)
 			pool.submit(func() {
 				push(3)
-				sleep(10)
+				close(secondWorkerStarted)
+				<-finishSecondWorker
 				push(4)
 				wg.Done()
 			})
-			sleep(1)
+			select {
+			case <-secondWorkerStarted:
+			case <-time.After(5 * time.Second):
+				errCh <- "the second worker did not start the queued task"
+				close(finishSecondWorker)
+				wg.Done()
+				return
+			}
 			push(2)
+			close(finishSecondWorker)
 			wg.Done()
 		})
 		wg.Wait()
+		select {
+		case err := <-errCh:
+			require.Fail(t, err)
+			return
+		default:
+		}
 		require.Equal(t, []int{1, 3, 2, 4}, list)
 	})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69730

Problem Summary:
Flaky test `TestWorkerPool/TwoWorkers` in `pkg/executor` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`TwoWorkers` depended on a 1 ms sleep to let worker 2 start; overloaded scheduling could let worker 1 append `2` first.

#### Fix

Channel synchronization observes the intended second-worker start directly and keeps the original `[1,3,2,4]` assertion.

#### Verification

Spec:
- target: `pkg/executor :: TestWorkerPool/TwoWorkers`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_exact passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_exact: PASS
- target_failpoint_harness: SKIPPED
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor -run '^TestWorkerPool/TwoWorkers$' -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved worker pool test reliability by replacing timing-based waits with explicit synchronization.
  * Added coverage to verify queued tasks are picked up by the second worker in the expected execution order.
  * Added timeout-based failure reporting when the second worker does not start as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->