### PR TITLE
test: stabilize flaky TestLoadDataOverflowBigintUnsigned

### DIFF
--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -441,8 +441,11 @@ func TestLoadDataOverflowBigintUnsigned(t *testing.T) {
 	loadSQL := "load data local infile '/tmp/nonexistence.csv' into table load_data_test"
 	ctx := tk.Session().(sessionctx.Context)
 	tests := []testCase{
-		{[]byte("-1\n-18446744073709551615\n-18446744073709551616\n"), []string{"0", "0", "0"}, "Records: 3  Deleted: 0  Skipped: 0  Warnings: 3"},
-		{[]byte("-9223372036854775809\n18446744073709551616\n"), []string{"0", "18446744073709551615"}, "Records: 2  Deleted: 0  Skipped: 0  Warnings: 2"},
+		{
+			[]byte("-1\n-18446744073709551615\n-18446744073709551616\n-9223372036854775809\n18446744073709551616\n"),
+			[]string{"0", "0", "0", "0", "18446744073709551615"},
+			"Records: 5  Deleted: 0  Skipped: 0  Warnings: 5",
+		},
 	}
 	deleteSQL := "delete from load_data_test"
 	selectSQL := "select * from load_data_test;"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68287

Problem Summary:
Flaky test `TestLoadDataOverflowBigintUnsigned` in `pkg/executor/test/loaddatatest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Duplicate LOAD DATA executions in one logical overflow test made the case vulnerable to time-threshold flakes under a slowed per-load path.

#### Fix

The patch preserves all five overflow inputs, expected stored values, and total warnings while removing one redundant LOAD DATA setup/commit path.

#### Verification

Spec:
- target: `pkg/executor/test/loaddatatest :: TestLoadDataOverflowBigintUnsigned`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -run '^TestLoadDataOverflowBigintUnsigned$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/executor/test/loaddatatest -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for unsigned bigint boundary-value handling.
  * Updated expected results and warning counts for overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->