### PR TITLE
planner: make SELECT ... SKIP LOCKED fail loudly instead of silently not locking

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_lock.go
+++ b/pkg/planner/core/operator/logicalop/logical_lock.go
@@ -52,18 +52,11 @@ func (p LogicalLock) Init(ctx base.PlanContext) *LogicalLock {
 // PruneColumns implements base.LogicalPlan.<2nd> interface.
 func (p *LogicalLock) PruneColumns(parentUsedCols []*expression.Column) (base.LogicalPlan, error) {
 	var err error
-	if !IsSupportedSelectLockType(p.Lock.LockType) {
-		// when use .baseLogicalPlan to call the PruneColumns, it means current plan itself has
-		// nothing to pruning or plan change, so they resort to its children's column pruning logic.
-		// so for the returned logical plan here, p is definitely determined, we just need to collect
-		// those extra deeper call error in handling children's column pruning.
-		_, err = p.BaseLogicalPlan.PruneColumns(parentUsedCols)
-		if err != nil {
-			return nil, err
-		}
-		return p, nil
-	}
-
+	// PhysicalLock is built from this operator even when the lock type is unsupported and the
+	// lock degrades to a noop (e.g. FOR SHARE under noop functions), and its ResolveIndices
+	// resolves the TblID2Handle columns against the child schema. So the handle columns (and
+	// the extra physical table ID column for partitioned tables) must survive column pruning
+	// regardless of the lock type.
 	for tblID, cols := range p.TblID2Handle {
 		for _, col := range cols {
 			for c := range col.IterColumns() {

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -267,6 +267,10 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		if node.With != nil {
 			p.preprocessWith.cteStack = append(p.preprocessWith.cteStack, node.With.CTEs)
 		}
+		p.checkSelectLockInfo(node)
+		if p.err != nil {
+			return in, true
+		}
 		p.checkSelectNoopFuncs(node)
 		// SelectStmt.Accept visits FROM before LockInfo, so one per-SELECT context can collect FROM
 		// table refs during traversal and later bind LockInfo targets without re-walking the FROM tree.
@@ -1331,6 +1335,26 @@ func (p *preprocessor) checkConstraintGrammar(stmt *ast.Constraint) {
 	p.err = checkIndexSpecs(stmt.Option, stmt.Keys)
 }
 
+// checkSelectLockInfo rejects lock clauses that are parsed but cannot be executed with their
+// documented semantics yet. Without this check, SKIP LOCKED degrades to a plain read that
+// acquires no lock at all, silently breaking the FOR UPDATE guarantee.
+func (p *preprocessor) checkSelectLockInfo(stmt *ast.SelectStmt) {
+	if stmt.LockInfo == nil {
+		return
+	}
+	switch stmt.LockInfo.LockType {
+	case ast.SelectLockForUpdateSkipLocked:
+		p.err = dbterror.ErrNotSupportedYet.GenWithStackByArgs("SKIP LOCKED")
+	case ast.SelectLockForShareSkipLocked:
+		// Without shared lock promotion, FOR SHARE SKIP LOCKED degrades to the same noop as
+		// FOR SHARE, handled by checkSelectNoopFuncs. With promotion, FOR SHARE executes as
+		// FOR UPDATE and would need real skip-locked support.
+		if p.sctx.GetSessionVars().SharedLockPromotion {
+			p.err = dbterror.ErrNotSupportedYet.GenWithStackByArgs("SKIP LOCKED")
+		}
+	}
+}
+
 func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 	noopFuncsMode := p.sctx.GetSessionVars().NoopFuncsMode
 	if noopFuncsMode == variable.OnInt {
@@ -1338,7 +1362,8 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 		// When `tidb_enable_shared_lock_promotion` is enabled, the `for share` statements would be
 		// executed as `for update` statements despite setting of noop functions.
 		if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
-			stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
+			stmt.LockInfo.LockType == ast.SelectLockForShareNoWait ||
+			stmt.LockInfo.LockType == ast.SelectLockForShareSkipLocked) &&
 			!p.sctx.GetSessionVars().SharedLockPromotion {
 			p.sctx.GetSessionVars().StmtCtx.ForShareLockEnabledByNoop = true
 		}
@@ -1357,7 +1382,8 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 	// When `tidb_enable_shared_lock_promotion` is enabled, the `for share` statements would be
 	// executed as `for update` statements.
 	if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
-		stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
+		stmt.LockInfo.LockType == ast.SelectLockForShareNoWait ||
+		stmt.LockInfo.LockType == ast.SelectLockForShareSkipLocked) &&
 		!p.sctx.GetSessionVars().SharedLockPromotion {
 		err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
 		if noopFuncsMode == variable.OffInt {

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -489,3 +489,42 @@ func TestPreprocessDeleteFromWithAlias(t *testing.T) {
 	tk.MustExec("delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id;")
 	tk.MustExec("create global binding for delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id using delete /*+ MAX_EXECUTION_TIME(10)*/ tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id;")
 }
+
+func TestSelectLockSkipLocked(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// A nonclustered PK makes _tidb_rowid the handle column: the regression shape of
+	// https://github.com/pingcap/tidb/issues/61621.
+	tk.MustExec("create table t (id varchar(10) not null, uid varchar(20), c varchar(20), " +
+		"primary key (id) /*T![clustered_index] NONCLUSTERED */, key idx_n1 (uid, c))")
+	tk.MustExec("insert into t values ('111', 'u1', 'c1')")
+
+	// FOR UPDATE SKIP LOCKED must not degrade to a plain non-locking read (issue #69720).
+	notSupportedErr := "This version of TiDB doesn't yet support 'SKIP LOCKED'"
+	tk.MustContainErrMsg("select * from t for update skip locked", notSupportedErr)
+	// The exact repro of issue #61621.
+	tk.MustContainErrMsg("select id, uid, c from t use index(primary) where id = '111' for update skip locked",
+		notSupportedErr)
+
+	// FOR SHARE SKIP LOCKED follows the FOR SHARE noop handling: rejected unless noop
+	// functions are enabled.
+	tk.MustContainErrMsg("select * from t for share skip locked",
+		"function LOCK IN SHARE MODE has only noop implementation in tidb now")
+
+	tk.MustExec("set session tidb_enable_noop_functions = 1")
+	// The noop lock type must still plan successfully on a nonclustered-PK table:
+	// LogicalLock used to prune the _tidb_rowid handle column for unsupported lock types and
+	// planning failed with "Can't find column ..._tidb_rowid" (issue #61621).
+	tk.MustQuery("select id, uid, c from t where uid = 'u1' for share skip locked").
+		Check(testkit.Rows("111 u1 c1"))
+	tk.MustQuery("select id, uid, c from t use index(primary) where id = '111' for share skip locked").
+		Check(testkit.Rows("111 u1 c1"))
+	tk.MustExec("set session tidb_enable_noop_functions = default")
+
+	// With shared lock promotion, FOR SHARE executes as FOR UPDATE, which would need real
+	// skip-locked support.
+	tk.MustExec("set session tidb_enable_shared_lock_promotion = 1")
+	tk.MustContainErrMsg("select * from t for share skip locked", notSupportedErr)
+	tk.MustExec("set session tidb_enable_shared_lock_promotion = default")
+}

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -520,7 +520,14 @@ func TestSelectLockSkipLocked(t *testing.T) {
 		Check(testkit.Rows("111 u1 c1"))
 	tk.MustQuery("select id, uid, c from t use index(primary) where id = '111' for share skip locked").
 		Check(testkit.Rows("111 u1 c1"))
+	// The pruning condition is not specific to joins or nonclustered PKs: any locked
+	// table whose handle column is not otherwise needed by the parent hits it, e.g. a
+	// clustered-PK table whose PK is not in the projection.
+	tk.MustExec("create table tc (id int primary key, a_id int)")
+	tk.MustExec("insert into tc values (1, 100)")
+	tk.MustQuery("select a_id from tc for share skip locked").Check(testkit.Rows("100"))
 	tk.MustExec("set session tidb_enable_noop_functions = default")
+	tk.MustContainErrMsg("select a_id from tc for update skip locked", notSupportedErr)
 
 	// With shared lock promotion, FOR SHARE executes as FOR UPDATE, which would need real
 	// skip-locked support.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69720, close #61621, close #67715, ref #18207

Problem Summary:

`SELECT ... FOR UPDATE SKIP LOCKED` is parsed, but the lock type is unsupported everywhere downstream:

1. The statement silently degrades to a plain **non-locking** read (#69720): two transactions can "lock" the same row at the same time, which silently breaks the `FOR UPDATE` guarantee.
2. Planning can fail with `Can't find column ... in schema` (#61621, #67715): `buildSelectLock` still builds a `LogicalLock` carrying `TblID2Handle`, but `LogicalLock.PruneColumns` does not preserve the handle columns for unsupported lock types, so `PhysicalLock.ResolveIndices` cannot resolve them against the pruned child schema. The trigger is general: any locked table whose handle column is not otherwise needed by the parent (joins and `_tidb_rowid` on nonclustered-PK tables are just the common ways to get there — a single clustered-PK table whose PK is not projected fails the same way).

### What changed and how does it work?

- Add a `checkSelectLockInfo` validation to preprocess (which also covers the PointGet fast path):
  - `FOR UPDATE SKIP LOCKED` now returns `ErrNotSupportedYet` (1235) `This version of TiDB doesn't yet support 'SKIP LOCKED'` instead of silently not locking.
  - `FOR SHARE SKIP LOCKED` follows the existing `FOR SHARE` noop handling: rejected unless noop functions are enabled, noop-with-warning when they are, and `ErrNotSupportedYet` when `tidb_enable_shared_lock_promotion` is enabled (promotion would execute it as `FOR UPDATE`).
- `LogicalLock.PruneColumns` now keeps the `TblID2Handle`/`TblID2PhysTblIDCol` columns from being pruned for unsupported (noop) lock types as well, since `PhysicalLock` is still built and resolves those columns against the child schema.

This is a preparatory, independently cherry-pickable step for the real SKIP LOCKED support tracked in #18207 (design doc and implementation in follow-up PRs).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

`TestSelectLockSkipLocked` in `pkg/planner/core/preprocess_test.go` covers the exact repro of #61621 (which fails with the `_tidb_rowid` error before this fix), the silent-no-op case of #69720, and the FOR SHARE noop/promotion matrix.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Statements using `FOR UPDATE SKIP LOCKED` that previously (incorrectly) executed as plain reads now return error 1235. This behavior was a correctness bug; applications relying on it were not actually acquiring any locks.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
`SELECT ... FOR UPDATE SKIP LOCKED` now returns an `ErrNotSupportedYet` error instead of silently executing as a non-locking read, and no longer fails with a handle column resolution error when the locked table's handle column is not in the projection (for example `_tidb_rowid` on tables with a nonclustered primary key, or locking joins).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `SKIP LOCKED` clauses, including clearer handling of unsupported lock modes.
  * Ensured lock-related data remains available during query planning, including for tables without clustered primary keys.
  * Aligned `FOR SHARE SKIP LOCKED` behavior with shared-lock promotion and noop-function settings.
* **Tests**
  * Added coverage for supported and unsupported `SKIP LOCKED` scenarios and related error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
