### PR TITLE
importinto: propagate conflict deletion commit errors

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -113,6 +113,7 @@
 
 ### Tests
 - `pkg/dxf/importinto/conflictedkv/collector_test.go` - dxf/importinto/conflictedkv: Tests collect result merge.
+- `pkg/dxf/importinto/conflictedkv/deleter_internal_test.go` - dxf/importinto/conflictedkv: Tests commit error propagation when deleting buffered keys.
 - `pkg/dxf/importinto/conflictedkv/deleter_test.go` - dxf/importinto/conflictedkv: Tests deleter.
 - `pkg/dxf/importinto/conflictedkv/handler_test.go` - dxf/importinto/conflictedkv: Tests handler.
 - `pkg/dxf/importinto/conflictedkv/row_handle_test.go` - dxf/importinto/conflictedkv: Tests handle filter.

--- a/pkg/dxf/importinto/conflictedkv/BUILD.bazel
+++ b/pkg/dxf/importinto/conflictedkv/BUILD.bazel
@@ -46,13 +46,14 @@ go_test(
     timeout = "short",
     srcs = [
         "collector_test.go",
+        "deleter_internal_test.go",
         "deleter_test.go",
         "handler_test.go",
         "row_handle_test.go",
     ],
     embed = [":conflictedkv"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/dxf/framework/taskexecutor/execute",
@@ -67,6 +68,7 @@ go_test(
         "//pkg/objstore",
         "//pkg/parser/ast",
         "//pkg/session",
+        "//pkg/store/mockstore",
         "//pkg/table",
         "//pkg/tablecodec",
         "//pkg/testkit",

--- a/pkg/dxf/importinto/conflictedkv/deleter.go
+++ b/pkg/dxf/importinto/conflictedkv/deleter.go
@@ -148,7 +148,7 @@ func (d *Deleter) deleteKeysWithRetry(ctx context.Context, keys []tidbkv.Key) er
 	})
 }
 
-func (d *Deleter) deleteBufferedKeys(ctx context.Context, keys []tidbkv.Key) error {
+func (d *Deleter) deleteBufferedKeys(ctx context.Context, keys []tidbkv.Key) (resErr error) {
 	if d.trafficRec != nil {
 		var writeBytes uint64
 		for _, k := range keys {
@@ -162,8 +162,8 @@ func (d *Deleter) deleteBufferedKeys(ctx context.Context, keys []tidbkv.Key) err
 		return errors.Trace(err)
 	}
 	defer func() {
-		if err == nil {
-			err = txn.Commit(ctx)
+		if resErr == nil {
+			resErr = txn.Commit(ctx)
 		} else {
 			if rollbackErr := txn.Rollback(); rollbackErr != nil {
 				d.logger.Warn("failed to rollback transaction", zap.Error(rollbackErr))

--- a/pkg/dxf/importinto/conflictedkv/deleter_internal_test.go
+++ b/pkg/dxf/importinto/conflictedkv/deleter_internal_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conflictedkv
+
+import (
+	"context"
+	goerrors "errors"
+	"testing"
+
+	tidbkv "github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/zap"
+)
+
+type commitErrorStorage struct {
+	tidbkv.Storage
+	err error
+}
+
+func (s *commitErrorStorage) Begin(opts ...tikv.TxnOption) (tidbkv.Transaction, error) {
+	txn, err := s.Storage.Begin(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &commitErrorTxn{Transaction: txn, err: s.err}, nil
+}
+
+type commitErrorTxn struct {
+	tidbkv.Transaction
+	err error
+}
+
+func (txn *commitErrorTxn) Commit(context.Context) error {
+	if err := txn.Transaction.Rollback(); err != nil {
+		return err
+	}
+	return txn.err
+}
+
+func TestDeleteBufferedKeysReturnsCommitError(t *testing.T) {
+	// Regression test for https://github.com/pingcap/tidb/issues/69792.
+	ctx := context.Background()
+	store, err := mockstore.NewMockStore()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	key := tidbkv.Key("commit-error/conflict-key")
+	value := []byte("still-present")
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	require.NoError(t, txn.Set(key, value))
+	require.NoError(t, txn.Commit(ctx))
+
+	commitErr := goerrors.New("injected commit error")
+	deleter := &Deleter{
+		store:  &commitErrorStorage{Storage: store, err: commitErr},
+		logger: zap.NewNop(),
+	}
+	err = deleter.deleteBufferedKeys(ctx, []tidbkv.Key{key})
+	require.ErrorIs(t, err, commitErr)
+
+	readTxn, err := store.Begin()
+	require.NoError(t, err)
+	got, err := readTxn.Get(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, value, got.Value)
+	require.NoError(t, readTxn.Rollback())
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69792

Problem Summary:

During `IMPORT INTO` conflict resolution, `deleteBufferedKeys` committed its transaction in a deferred function. Because the function had an unnamed return value, a commit error assigned by the defer did not change the already-evaluated `nil` return value. The retry loop therefore treated a failed conflict-deletion transaction as successful, which could leave table and index KVs inconsistent while the import reported success.

### What changed and how does it work?

The function now uses a named error result, so the deferred transaction commit can return its error to `deleteKeysWithRetry`. Retryable commit failures are consequently visible to the existing retry mechanism, which retries the complete key batch.

This PR also adds a regression test that injects a commit error after rolling back the transaction. The test verifies that the exact commit error is returned and that the key remains present after the failed commit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validated with:

```bash
./tools/check/failpoint-go-test.sh pkg/dxf/importinto/conflictedkv \
  -run '^TestDeleteBufferedKeysReturnsCommitError$' -count=1
make bazel_prepare
make lint
```

The regression test fails before the production change because `deleteBufferedKeys` returns `nil`, and passes after the change with the injected commit error in the returned error chain.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `IMPORT INTO` could report success with inconsistent indexes after a transient conflict-deletion commit failure.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when deleting buffered keys so storage commit failures are correctly reported.
  * Ensured data remains unchanged when a delete transaction cannot be committed.

* **Tests**
  * Added regression coverage for commit-error propagation during buffered-key deletion.
  * Updated the test mapping and build configuration to include the new coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->