### PR TITLE
executor: disable pessimistic retry for LOAD DATA LOCAL INFILE

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1420,6 +1420,14 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 		return nil, lockErr
 	}
 
+	// LOAD DATA LOCAL INFILE reads a one-shot file stream from the client
+	// connection. Rebuilding and reopening its executor would send another
+	// LOCAL_INFILE_REQUEST in the same command and desynchronize the MySQL
+	// packet sequence. Server or remote files can be reopened and retried.
+	if loadData, ok := a.Plan.(*plannercore.LoadData); ok && loadData.FileLocRef == ast.FileLocClient {
+		return nil, lockErr
+	}
+
 	if a.retryCount >= config.GetGlobalConfig().PessimisticTxn.MaxRetryCount {
 		return nil, errors.New("pessimistic lock retry limit reached")
 	}

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -4132,3 +4132,50 @@ func TestLoadDataLocalRetryDesyncExplicitTxn(t *testing.T) {
 		require.Equal(t, 1, val)
 	})
 }
+
+// TestLoadDataLocalPessimisticRetryDesync verifies that a retryable
+// single-statement deadlock does not re-execute LOAD DATA LOCAL INFILE.
+// The client file stream is a one-shot resource, so reopening LoadDataExec
+// would send a second LOCAL_INFILE_REQUEST and desynchronize the connection.
+func TestLoadDataLocalPessimisticRetryDesync(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	ts.RunTests(t, func(c *mysql.Config) {
+		c.AllowAllFiles = true
+	}, func(dbt *testkit.DBTestKit) {
+		ctx := context.Background()
+
+		filePath := filepath.Join(t.TempDir(), "pessimistic_retry_desync.csv")
+		mysql.RegisterLocalFile(filePath)
+		err := os.WriteFile(filePath, []byte("1,one\n"), os.ModePerm)
+		require.NoError(t, err)
+
+		conn, err := dbt.GetDB().Conn(ctx)
+		require.NoError(t, err)
+
+		testserverclient.MustExec(ctx, t, conn, "CREATE TABLE t_pessimistic_retry (id INT PRIMARY KEY, v VARCHAR(16))")
+		testserverclient.MustExec(ctx, t, conn, "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
+		testserverclient.MustExec(ctx, t, conn, "BEGIN PESSIMISTIC")
+
+		// Return a retryable single-statement deadlock for the first LockKeys
+		// request after the local file has been consumed.
+		testfailpoint.Enable(t,
+			"github.com/pingcap/tidb/pkg/store/mockstore/unistore/tikv/pessimisticLockReturnDeadlock",
+			`1*return(true)->return(false)`)
+
+		loadCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		_, loadErr := conn.ExecContext(loadCtx, fmt.Sprintf(
+			"LOAD DATA LOCAL INFILE '%s' REPLACE INTO TABLE t_pessimistic_retry FIELDS TERMINATED BY ','",
+			filePath))
+		require.Error(t, loadErr)
+		var mysqlErr *mysql.MySQLError
+		require.ErrorAs(t, loadErr, &mysqlErr, "the original deadlock should be returned")
+		require.Equal(t, uint16(tmysql.ErrLockDeadlock), mysqlErr.Number)
+
+		// No row is committed and the connection protocol remains synchronized.
+		var count int
+		err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM t_pessimistic_retry").Scan(&count)
+		require.NoError(t, err, "connection should be usable after the deadlock")
+		require.Equal(t, 0, count)
+	})
+}

--- a/pkg/store/mockstore/unistore/tikv/server.go
+++ b/pkg/store/mockstore/unistore/tikv/server.go
@@ -254,6 +254,17 @@ func (svr *Server) KvPessimisticLock(ctx context.Context, req *kvrpcpb.Pessimist
 			failpoint.Return(&kvrpcpb.PessimisticLockResponse{Errors: []*kvrpcpb.KeyError{convertToKeyError(err)}}, nil)
 		}
 	})
+	failpoint.Inject("pessimisticLockReturnDeadlock", func(val failpoint.Value) {
+		if val.(bool) && len(req.Mutations) > 0 {
+			key := req.Mutations[0].Key
+			err := &kverrors.ErrDeadlock{
+				LockKey:         key,
+				LockTS:          req.StartVersion + 1,
+				DeadlockKeyHash: keysToHashVals(key)[0],
+			}
+			failpoint.Return(&kvrpcpb.PessimisticLockResponse{Errors: []*kvrpcpb.KeyError{convertToKeyError(err)}}, nil)
+		}
+	})
 
 	reqCtx, err := newRequestCtx(svr, req.Context, "PessimisticLock")
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69793

Problem Summary:

When `LOAD DATA LOCAL INFILE` encounters a retryable single-statement deadlock in a pessimistic transaction, TiDB rebuilds and reopens `LoadDataExec`. This sends a second `LOCAL_INFILE_REQUEST` for a one-shot client file stream and desynchronizes the MySQL packet sequence, masking the original deadlock with an invalid-sequence error.

### What changed and how does it work?

Return the original pessimistic lock error for `LOAD DATA LOCAL INFILE` instead of internally retrying the statement. Server and remote files remain retryable because their input can be reopened.

Add a Unistore deadlock failpoint and a protocol-level regression test verifying that the client receives error 1213 and the connection remains usable.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where an internal pessimistic transaction retry for `LOAD DATA LOCAL INFILE` could desynchronize the client connection.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `LOAD DATA LOCAL INFILE` handling during pessimistic transaction deadlock retries.
  * Prevented connection desynchronization and repeated file requests after a retryable lock error.
  * Connections now remain usable after the operation fails with a deadlock, with no unintended rows committed.

* **Tests**
  * Added regression coverage for deadlock handling during `LOAD DATA LOCAL INFILE` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->