### PR TITLE
session: revert enabling ANALYZE background resource control by default

### DIFF
--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -64,19 +64,19 @@ func TestResourceGroupBasic(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control = 'on'")
 
 	// test default resource group.
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED MEDIUM UNLIMITED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED MEDIUM UNLIMITED <nil> <nil>"))
 	tk.MustExec("alter resource group `default` PRIORITY=LOW")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED LOW UNLIMITED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default UNLIMITED LOW UNLIMITED <nil> <nil>"))
 	tk.MustExec("alter resource group `default` ru_per_sec=1000")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> <nil>"))
 	tk.MustExec("alter resource group `default` BURSTABLE")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> <nil>"))
 	tk.MustExec("alter resource group `default` BURSTABLE=OFF")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW OFF <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW OFF <nil> <nil>"))
 	tk.MustExec("alter resource group `default` BURSTABLE=MODERATED")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW MODERATED <nil> <nil>"))
 	tk.MustExec("alter resource group `default` BURSTABLE=UNLIMITED")
-	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> TASK_TYPES='stats'"))
+	tk.MustQuery("select * from information_schema.resource_groups where name = 'default'").Check(testkit.Rows("default 1000 LOW UNLIMITED <nil> <nil>"))
 
 	tk.MustContainErrMsg("drop resource group `default`", "can't drop reserved resource group")
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -44,7 +44,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
-	"github.com/pingcap/tidb/pkg/resourcegroup"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -416,10 +415,6 @@ func doDDLWorks(s sessionapi.Session) {
 	mustExecute(s, metadef.CreateSchemaUnusedIndexesView)
 	// Create a test database.
 	mustExecute(s, "CREATE DATABASE IF NOT EXISTS test")
-	// Only mark stats requests as background here; the effective background CPU cap is controlled
-	// by bg-cpu-throttle-threshold and fg-cpu-throttle-threshold.
-	mustExecute(s, "ALTER RESOURCE GROUP %n BACKGROUND=(TASK_TYPES=%?)",
-		resourcegroup.DefaultResourceGroupName, kv.InternalTxnStats)
 }
 
 func checkSystemTableConstraint(tblInfo *model.TableInfo) error {

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 45,
+    shard_count = 44,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1486,38 +1486,3 @@ func TestUpgradeVersion256PlanCacheSkipStatsOnBinding(t *testing.T) {
 	row := req.GetRow(0)
 	require.Equal(t, "ON", row.GetString(0))
 }
-
-func TestDefaultAnalyzeBackgroundOnlyAffectsFreshBootstrap(t *testing.T) {
-	store, dom := session.CreateStoreAndBootstrap(t)
-	defer func() { require.NoError(t, store.Close()) }()
-
-	defaultGroup, ok := dom.InfoSchema().ResourceGroupByName(ast.NewCIStr("default"))
-	require.True(t, ok)
-	require.NotNil(t, defaultGroup.Background)
-	require.Equal(t, []string{kv.InternalTxnStats}, defaultGroup.Background.JobTypes)
-	require.Zero(t, defaultGroup.Background.ResourceUtilLimit)
-
-	// Next-gen has no upgrade path in its first release; skip the upgrade-only check below.
-	if kerneltype.IsNextGen() {
-		dom.Close()
-		return
-	}
-
-	upgradeFromVersion := session.CurrentBootstrapVersion - 1
-	txn, err := store.Begin()
-	require.NoError(t, err)
-	m := meta.NewMutator(txn)
-	require.NoError(t, m.DropResourceGroup(meta.DefaultGroupMeta4Test().ID))
-	require.NoError(t, m.FinishBootstrap(upgradeFromVersion))
-	require.NoError(t, txn.Commit(context.Background()))
-	store.SetOption(session.StoreBootstrappedKey, nil)
-	dom.Close()
-
-	domUpgraded, err := session.BootstrapSession(store)
-	require.NoError(t, err)
-	defer domUpgraded.Close()
-	defaultGroup, ok = domUpgraded.InfoSchema().ResourceGroupByName(ast.NewCIStr("default"))
-	require.True(t, ok)
-	// The upgrade path should not backfill the fresh-bootstrap background setting.
-	require.Nil(t, defaultGroup.Background)
-}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69741, close #69765, ref #69472

Problem Summary:

#69452 made bootstrap add `stats` to the default resource group's background `TASK_TYPES`. Once any background task type is configured, TiKV routes all requests, including foreground queries, through the priority scheduler, and its per-request overhead causes performance regressions (6.3% in bank, 6.0% in sysbench).

### What changed and how does it work?

Revert only the default-enabling part of #69452: remove `ALTER RESOURCE GROUP default BACKGROUND=(TASK_TYPES='stats')` from fresh-cluster bootstrap and restore the affected test expectations. The request-source refactor from #69452 (`InternalTxnStatsForegroundPriority` and its call sites) is kept.

Notes:

- #69452 had no upgrade-path change, so only freshly bootstrapped clusters are affected by this revert.
- Users can still opt in manually with `ALTER RESOURCE GROUP default BACKGROUND=(TASK_TYPES='stats')`.
- The default can be re-enabled once the scheduler overhead is resolved on the TiKV side.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/resourcegroup/tests -run TestResourceGroupBasic -count=1`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated default resource group behavior so statistics requests are no longer explicitly marked with a background task type.
  - Adjusted resource group information output to reflect the updated configuration.

- **Tests**
  - Updated related expectations and bootstrap test configuration.
  - Removed an outdated upgrade-path test for default analyze settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->