### PR TITLE
 planner/core: fix cloneDataSource to preserve access path invariant for Apply alternative in correlated subqueries

### DIFF
--- a/pkg/planner/core/casetest/rule/rule_correlate_test.go
+++ b/pkg/planner/core/casetest/rule/rule_correlate_test.go
@@ -318,3 +318,65 @@ func TestCorrelateWithCostFactors(tt *testing.T) {
 		}
 	})
 }
+
+// TestCorrelateAlternativeAggInSubqueryNoTableDual is a regression test for the
+// silent-wrong-result issue where cloneDataSource cloned AllPossibleAccessPaths
+// and PossibleAccessPaths independently. That broke the invariant that entries
+// of PossibleAccessPaths are the same *AccessPath objects as the corresponding
+// entries of AllPossibleAccessPaths. As a result, stats derivation filled
+// ranges through the canonical AllPossibleAccessPaths objects while physical
+// planning consumed different (empty-range) clones from PossibleAccessPaths.
+//
+// In the aggregate/IN-subquery shape below, the correlated predicate remains
+// above HashAgg, so resetStatsForCorrelatedDS does not rebuild the leaf
+// DataSource paths, and the active clones retain empty ranges - the inner
+// DataSource is then converted to TableDual(rows:0), silently returning
+// an empty result.
+//
+// The fix clones the canonical paths once and maps every active path to the
+// corresponding canonical clone, restoring the real table/index scan.
+func TestCorrelateAlternativeAggInSubqueryNoTableDual(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists o, i")
+	tk.MustExec("create table o(id int primary key, a int not null)")
+	tk.MustExec("create table i(a int not null, b int not null, key ia(a))")
+	tk.MustExec("insert into o values (1,1),(2,2),(3,3)")
+	tk.MustExec("insert into i values (1,10),(1,11),(2,20),(3,30),(5,50)")
+	tk.MustExec("analyze table o, i")
+
+	// Penalize hash/merge joins so the correlate alternative round wins the
+	// cost comparison, mirroring the reproduction in the bug report.
+	tk.MustExec("set tidb_opt_hash_join_cost_factor = 1")
+	tk.MustExec("set tidb_opt_merge_join_cost_factor = 1")
+
+	sql := "select id from o where id <= 3 and a in (select max(a) from i group by b) order by id"
+
+	// Baseline: without alternative plans, the query returns 1,2,3.
+	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = OFF")
+	tk.MustQuery(sql).Check(testkit.Rows("1", "2", "3"))
+
+	// With alternative plans ON: result must be identical (not empty).
+	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = ON")
+	tk.MustQuery(sql).Check(testkit.Rows("1", "2", "3"))
+
+	// Additionally verify that the inner DataSource in the correlate Apply
+	// alternative is NOT collapsed to TableDual. In the buggy plan the probe
+	// side of the Apply reads:
+	//     Selection -> HashAgg -> TableDual(rows:0)
+	// After the fix, the inner leaf must be a real table/index scan.
+	rows := tk.MustQuery("explain format = 'brief' " + sql).Rows()
+	require.False(t, explainContains(rows, "TableDual"),
+		"inner side of Apply must not be TableDual in plan:\n%s", joinExplainRows(rows))
+
+	// As an adjacent control, the aggregation-less variant must also return
+	// 1,2,3 in both modes (this path already worked before the fix and uses
+	// the correlated IndexRangeScan directly).
+	sql2 := "select id from o where id <= 3 and a in (select a from i) order by id"
+	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = OFF")
+	tk.MustQuery(sql2).Check(testkit.Rows("1", "2", "3"))
+	tk.MustExec("set tidb_opt_enable_alternative_logical_plans = ON")
+	tk.MustQuery(sql2).Check(testkit.Rows("1", "2", "3"))
+}

--- a/pkg/planner/core/plan_clone_utils.go
+++ b/pkg/planner/core/plan_clone_utils.go
@@ -140,13 +140,38 @@ func cloneDataSource(ds *logicalop.DataSource) *logicalop.DataSource {
 	// independent path objects. Stats derivation (fillIndexPath, etc.) mutates
 	// AccessPath fields in place; without deep cloning, costing one alternative
 	// can corrupt the other and destabilize CBO.
+	//
+	// Preserve the original invariant that entries of PossibleAccessPaths are
+	// the same *AccessPath objects as the corresponding entries in
+	// AllPossibleAccessPaths (see logical_plan_builder.go where allPaths is
+	// constructed by copy(allPaths, possiblePaths), and derivePathStatsAndTryHeuristics
+	// which stores paths from AllPossibleAccessPaths back into PossibleAccessPaths).
+	//
+	// If we clone the two slices independently, they end up containing
+	// different objects with the same content. DeriveStats then fills ranges
+	// through AllPossibleAccessPaths, while physical planning consumes the
+	// (unfilled) clones from PossibleAccessPaths — the empty ranges cause
+	// the DataSource to collapse into TableDual and silently drop rows
+	// (see the aggregate/IN-subquery case in the correlate alternative).
+	//
+	// Clone canonical paths once from AllPossibleAccessPaths and map each
+	// active path in PossibleAccessPaths to the corresponding canonical clone.
+	pathMap := make(map[*util.AccessPath]*util.AccessPath, len(ds.AllPossibleAccessPaths))
 	clone.AllPossibleAccessPaths = make([]*util.AccessPath, len(ds.AllPossibleAccessPaths))
 	for i, ap := range ds.AllPossibleAccessPaths {
-		clone.AllPossibleAccessPaths[i] = ap.Clone()
+		cloned := ap.Clone()
+		clone.AllPossibleAccessPaths[i] = cloned
+		pathMap[ap] = cloned
 	}
 	clone.PossibleAccessPaths = make([]*util.AccessPath, len(ds.PossibleAccessPaths))
 	for i, ap := range ds.PossibleAccessPaths {
-		clone.PossibleAccessPaths[i] = ap.Clone()
+		if mapped, ok := pathMap[ap]; ok {
+			clone.PossibleAccessPaths[i] = mapped
+		} else {
+			// Fallback: path only in PossibleAccessPaths (should not happen
+			// under the current invariant, but be defensive).
+			clone.PossibleAccessPaths[i] = ap.Clone()
+		}
 	}
 	// Preserve original stats so DeriveStats returns early for DataSources
 	// that don't receive correlated conditions. Without this, DeriveStats


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69790

Problem Summary:

When `tidb_opt_enable_alternative_logical_plans` is enabled, a correlated
subquery whose inner side contains an aggregation over a correlated predicate
can silently return an empty result set.

Minimal reproduce:

```sql
DROP DATABASE IF EXISTS ai_native_correlate;
CREATE DATABASE ai_native_correlate;
USE ai_native_correlate;

CREATE TABLE o(id INT PRIMARY KEY, a INT NOT NULL);
CREATE TABLE i(a INT NOT NULL, b INT NOT NULL, KEY ia(a));
INSERT INTO o VALUES (1,1),(2,2),(3,3);
INSERT INTO i VALUES (1,10),(1,11),(2,20),(3,30),(5,50);
ANALYZE TABLE o, i;

SET SESSION tidb_opt_hash_join_cost_factor = 1;
SET SESSION tidb_opt_merge_join_cost_factor = 1;

SET SESSION tidb_opt_enable_alternative_logical_plans = ON;
SELECT id
FROM o
WHERE id <= 3
  AND a IN (SELECT MAX(a) FROM i GROUP BY b)
ORDER BY id;
-- Expected: 1, 2, 3
-- Actual (buggy):   empty result
```

The relevant part of the feature-ON plan is:

```text
Apply
  ...
  Limit(Probe)
    Selection(eq(Column#9, o.a))
      HashAgg(group by:i.b, funcs:max(i.a))
        TableDual(rows:0)
```

Root cause:

`cloneDataSource` deep-clones `AllPossibleAccessPaths` and `PossibleAccessPaths`
independently. Stats derivation fills ranges through the canonical
`AllPossibleAccessPaths` objects, while physical planning consumes different
active-path clones from `PossibleAccessPaths`. When the correlated predicate
remains above `HashAgg` (i.e., `resetStatsForCorrelatedDS` does not rebuild
the leaf DataSource paths), the active clones retain empty ranges and are
converted into `TableDual(rows:0)`, producing a wrong empty result.

### What changed and how does it work?

Clone the canonical `AllPossibleAccessPaths` once and map every entry in
`PossibleAccessPaths` to the corresponding canonical clone by pointer identity.
This preserves the original invariant that `PossibleAccessPaths ⊆
AllPossibleAccessPaths` (by pointer) after cloning, so subsequent stats
derivation and physical planning observe consistent path objects. The same
Apply alternative is still chosen, but now the real table scan is used instead
of `TableDual`, and the query returns `1,2,3` as expected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - Added `TestCorrelateAlternativeAggInSubqueryNoTableDual` in
    `pkg/planner/core/casetest/rule/rule_correlate_test.go` to lock down the
    behavior: with the feature ON, the Apply alternative must not degrade the
    non-empty inner side into `TableDual`, and the query must return the
    expected `1,2,3`.
- [x] Manual test
  - Verified the reproduce script in the linked issue returns `1,2,3` in both
    ALT-OFF and ALT-ON modes after the fix.
- [ ] Integration test
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
Fix a wrong-result issue where enabling `tidb_opt_enable_alternative_logical_plans`
could silently return an empty result for a correlated subquery whose inner side
contains an aggregation with a correlated predicate above it. The optimizer no
longer collapses the non-empty inner table into `TableDual` in this shape.
```

---

## Notes for reviewers

- The fix is localized to `cloneDataSource` and does not change the search
  space of the alternative logical plans; it only restores the invariant that
  `PossibleAccessPaths` entries are elements of `AllPossibleAccessPaths` (by
  pointer) after cloning.
- If CI reports failures in `TestNaturalJoinWithCorrelatedSubquery` or the
  `vectorsearch` package, please note these are pre-existing on the base
  branch and unrelated to this PR (verified by reverting this PR's changes
  locally and reproducing the same failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning reliability for correlated `IN` subqueries with aggregation.
  * Prevented incorrect or empty query results caused by inconsistent access-path handling during plan processing.
  * Ensured equivalent query configurations produce consistent, correct results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->