### PR TITLE
planner: switch to RWLock to improve binding cache performance

### DIFF
--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -291,7 +291,7 @@ type BindingCache interface {
 // The key of the LRU cache is original sql, the value is a slice of Bindings.
 // Note: The bindingCache should be accessed with lock.
 type bindingCache struct {
-	lock        sync.Mutex
+	lock        sync.RWMutex
 	cache       *kvcache.SimpleLRUCache
 	memCapacity int64
 	memTracker  *memory.Tracker // track memory usage.
@@ -379,8 +379,8 @@ func (c *bindingCache) delete(key bindingCacheKey) bool {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.get(bindingCacheKey(sqlDigest))
 }
 
@@ -388,8 +388,8 @@ func (c *bindingCache) GetBinding(sqlDigest string) Bindings {
 // The return value is not read-only, but it shouldn't be changed in the caller functions.
 // The function is thread-safe.
 func (c *bindingCache) GetAllBindings() Bindings {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	values := c.cache.Values()
 	bindings := make(Bindings, 0, len(values))
 	for _, vals := range values {
@@ -428,16 +428,16 @@ func (c *bindingCache) SetMemCapacity(capacity int64) {
 // GetMemUsage get the memory Usage for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemUsage() int64 {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.memTracker.BytesConsumed()
 }
 
 // GetMemCapacity get the memory capacity for the cache.
 // The function is thread-safe.
 func (c *bindingCache) GetMemCapacity() int64 {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.memCapacity
 }
 
@@ -463,7 +463,7 @@ func (c *bindingCache) CopyBindingCache() (BindingCache, error) {
 }
 
 func (c *bindingCache) Size() int {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.cache.Size()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65412

Problem Summary:

Binding cache read paths currently use an exclusive mutex, so concurrent sessions serialize on cache lookups and metadata reads.

### What changed and how does it work?

- Change bindingCache.lock from sync.Mutex to sync.RWMutex.
- Use RLock/RUnlock in GetBinding, GetAllBindings, GetMemUsage, GetMemCapacity, and Size.
- Keep SetBinding, RemoveBinding, SetMemCapacity, and CopyBindingCache under the exclusive lock.

Review focus: verify that each read-locked path is truly read-only with the underlying SimpleLRUCache implementation.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test

Tests have not been run yet; this draft is being opened for code review first.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved concurrent access efficiency for binding and memory cache read operations.
  * Reduced contention when multiple read requests occur simultaneously.
* **Bug Fixes**
  * Preserved existing cache behavior while improving synchronization for read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->