### PR TITLE
ddl: prevent partial ADD INDEX plans after transient TSO errors

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
@@ -11,7 +11,7 @@
 ### Tests
 - `pkg/ddl/affinity_test.go` - ddl: Tests affinity build group definitions table.
 - `pkg/ddl/attributes_sql_test.go` - ddl: Tests alter table partition attributes.
-- `pkg/ddl/backfilling_dist_scheduler_test.go` - ddl: Tests backfilling scheduler local mode.
+- `pkg/ddl/backfilling_dist_scheduler_test.go` - ddl: Tests backfilling scheduler local mode and physical-table plan retries.
 - `pkg/ddl/backfilling_test.go` - ddl: Tests done task keeper.
 - `pkg/ddl/backfilling_txn_executor_test.go` - ddl: Tests expected ingest worker count.
 - `pkg/ddl/bdr_test.go` - ddl: Tests denied by BDR when add column.

--- a/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
@@ -11,7 +11,7 @@
 ### Tests
 - `pkg/ddl/affinity_test.go` - ddl: Tests affinity build group definitions table.
 - `pkg/ddl/attributes_sql_test.go` - ddl: Tests alter table partition attributes.
-- `pkg/ddl/backfilling_dist_scheduler_test.go` - ddl: Tests backfilling scheduler local mode and physical-table plan retries.
+- `pkg/ddl/backfilling_dist_scheduler_test.go` - ddl: Tests backfilling scheduler local mode and backfilling plan retries.
 - `pkg/ddl/backfilling_test.go` - ddl: Tests done task keeper.
 - `pkg/ddl/backfilling_txn_executor_test.go` - ddl: Tests expected ingest worker count.
 - `pkg/ddl/bdr_test.go` - ddl: Tests denied by BDR when add column.

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -352,7 +352,7 @@ func generatePlanForPhysicalTable(
 		return nil, errors.Trace(err)
 	}
 
-	subTaskMetas := make([][]byte, 0, 4)
+	var subTaskMetas [][]byte
 	backoffer := backoff.NewExponential(scanRegionBackoffBase, 2, scanRegionBackoffMax)
 	err = handle.RunWithRetry(ctx, 8, backoffer, logutil.DDLLogger(), func(_ context.Context) (bool, error) {
 		regionCache := store.(helper.Storage).GetRegionCache()
@@ -374,11 +374,15 @@ func generatePlanForPhysicalTable(
 			}
 			cur = m
 		}
+		failpoint.Inject("mockPhysicalTableRegionDiscontinuity", func() {
+			shouldRetry = true
+		})
 
 		if shouldRetry {
-			return true, nil
+			return true, errors.New("regions are not continuous")
 		}
 
+		attemptMetas := make([][]byte, 0, 4)
 		regionBatch := CalculateRegionBatch(len(recordRegionMetas), nodeCnt, !useCloud)
 		logger.Info("calculate region batch",
 			zap.Int("totalRegionCnt", len(recordRegionMetas)),
@@ -391,7 +395,7 @@ func generatePlanForPhysicalTable(
 			// It should be different for each subtask to determine if there are duplicate entries.
 			importTS, err := allocNewTS(ctx, store.(kv.StorageWithPD))
 			if err != nil {
-				return true, nil
+				return true, err
 			}
 			end := min(i+regionBatch, len(recordRegionMetas))
 			batch := recordRegionMetas[i:end]
@@ -411,8 +415,9 @@ func generatePlanForPhysicalTable(
 			if err != nil {
 				return false, err
 			}
-			subTaskMetas = append(subTaskMetas, metaBytes)
+			attemptMetas = append(attemptMetas, metaBytes)
 		}
+		subTaskMetas = attemptMetas
 		return false, nil
 	})
 	if err != nil {
@@ -537,6 +542,11 @@ func generateGlobalSortIngestPlan(
 }
 
 func allocNewTS(ctx context.Context, store kv.StorageWithPD) (uint64, error) {
+	failpoint.Inject("mockAllocNewTSError", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(0, errors.New("mock alloc new TS error"))
+		}
+	})
 	pdCli := store.GetPDClient()
 	p, l, err := pdCli.GetTS(ctx)
 	if err != nil {

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -364,7 +364,8 @@ func generatePlanForPhysicalTable(
 			return bytes.Compare(recordRegionMetas[i].StartKey(), recordRegionMetas[j].StartKey()) < 0
 		})
 
-		// Check if regions are continuous.
+		// LoadRegionsInKeyRange can combine multiple PD scans. A concurrent region
+		// split or merge can make those scans discontinuous, so retry the full scan.
 		shouldRetry := false
 		cur := recordRegionMetas[0]
 		for _, m := range recordRegionMetas[1:] {
@@ -900,7 +901,7 @@ func genMergeTempPlanForOneIndex(
 	pid := tbl.GetPhysicalID()
 	start, end := encodeTempIndexRange(pid, idxInfo.ID, idxInfo.ID)
 
-	subTaskMetas := make([][]byte, 0, 4)
+	var subTaskMetas [][]byte
 	backoffer := backoff.NewExponential(scanRegionBackoffBase, 2, scanRegionBackoffMax)
 	err := handle.RunWithRetry(ctx, 8, backoffer, logutil.DDLLogger(), func(_ context.Context) (bool, error) {
 		regionCache := store.(helper.Storage).GetRegionCache()
@@ -912,7 +913,8 @@ func genMergeTempPlanForOneIndex(
 			return bytes.Compare(regionMetas[i].StartKey(), regionMetas[j].StartKey()) < 0
 		})
 
-		// Check if regions are continuous.
+		// LoadRegionsInKeyRange can combine multiple PD scans. A concurrent region
+		// split or merge can make those scans discontinuous, so retry the full scan.
 		shouldRetry := false
 		cur := regionMetas[0]
 		for _, m := range regionMetas[1:] {
@@ -922,11 +924,15 @@ func genMergeTempPlanForOneIndex(
 			}
 			cur = m
 		}
+		failpoint.Inject("mockMergeTempIndexRegionDiscontinuity", func() {
+			shouldRetry = true
+		})
 
 		if shouldRetry {
-			return true, nil
+			return true, errors.New("regions are not continuous")
 		}
 
+		attemptMetas := make([][]byte, 0, 4)
 		regionBatch := calculateTempIndexRegionBatch(len(regionMetas), nodeCnt)
 		logger.Info("calculate temp index region batch",
 			zap.Int64("physicalTableID", pid),
@@ -955,8 +961,9 @@ func genMergeTempPlanForOneIndex(
 			if err != nil {
 				return false, err
 			}
-			subTaskMetas = append(subTaskMetas, metaBytes)
+			attemptMetas = append(attemptMetas, metaBytes)
 		}
+		subTaskMetas = attemptMetas
 		return false, nil
 	})
 	if err != nil {

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -164,7 +164,25 @@ func TestBackfillingSchedulerLocalMode(t *testing.T) {
 		require.Equal(t, expected.RowEnd, actual.RowEnd)
 	}
 
-	// 2.2.4 BackfillStepReadIndex
+	// 2.2.4 transient region discontinuity should also be retried when planning the merge-temp-index step.
+	tk.MustExec("create table t4(id bigint primary key, v bigint, key idx(v))")
+	mergeTask, server := createAddIndexTask(t, dom, "test", "t4", proto.Backfill, false)
+	require.Nil(t, server)
+	mergeTable, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t4"))
+	require.NoError(t, err)
+	var mergeTaskMeta ddl.BackfillTaskMeta
+	require.NoError(t, json.Unmarshal(mergeTask.Meta, &mergeTaskMeta))
+	mergeTaskMeta.EleIDs = []int64{mergeTable.Meta().Indices[0].ID}
+	mergeTaskMeta.MergeTempIndex = true
+	mergeTask.Meta, err = json.Marshal(&mergeTaskMeta)
+	require.NoError(t, err)
+	mergeTask.Step = proto.BackfillStepMergeTempIndex
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockMergeTempIndexRegionDiscontinuity", "1*return()")
+	metas, err = sch.OnNextSubtasksBatch(ctx, nil, mergeTask, execIDs, mergeTask.Step)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+
+	// 2.2.5 BackfillStepReadIndex
 	task.State = proto.TaskStateRunning
 	task.Step = sch.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.StepDone, task.Step)

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/ngaut/pools"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -40,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
@@ -70,8 +70,7 @@ func TestBackfillingSchedulerLocalMode(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockWriterMemSizeInKB", "return(1048576)"))
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockWriterMemSizeInKB")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockWriterMemSizeInKB", "return(1048576)")
 	/// 1. test partition table.
 	tk.MustExec("create table tp1(id int primary key, v int, key idx (id)) PARTITION BY RANGE (id) (\n    " +
 		"PARTITION p0 VALUES LESS THAN (10),\n" +
@@ -133,7 +132,39 @@ func TestBackfillingSchedulerLocalMode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(metas))
 	require.Equal(t, proto.BackfillStepReadIndex, task.Step)
-	// 2.2.2 BackfillStepReadIndex
+
+	// 2.2.2 transient region discontinuity should be retried.
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockPhysicalTableRegionDiscontinuity", "1*return()")
+	metas, err = sch.OnNextSubtasksBatch(ctx, nil, task, execIDs, task.Step)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+
+	// 2.2.3 a retry after allocating some subtask timestamps should not return a partial or duplicate plan.
+	tk.MustExec("create table t3(id bigint primary key)")
+	tk.MustExec("insert into t3 values (1), (9999)")
+	tk.MustQuery("split table t3 by (5000)").Check(testkit.Rows("1 1"))
+	multiRegionTask, server := createAddIndexTask(t, dom, "test", "t3", proto.Backfill, false)
+	require.Nil(t, server)
+	multiRegionTask.Step = sch.GetNextStep(&multiRegionTask.TaskBase)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockRegionBatch", "return(1)")
+	expectedMetas, err := sch.OnNextSubtasksBatch(ctx, nil, multiRegionTask, execIDs, multiRegionTask.Step)
+	require.NoError(t, err)
+	require.Len(t, expectedMetas, 2)
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockAllocNewTSError", "1*return(false)->1*return(true)")
+	metas, err = sch.OnNextSubtasksBatch(ctx, nil, multiRegionTask, execIDs, multiRegionTask.Step)
+	require.NoError(t, err)
+	require.Len(t, metas, len(expectedMetas))
+	for i := range expectedMetas {
+		var expected, actual ddl.BackfillSubTaskMeta
+		require.NoError(t, json.Unmarshal(expectedMetas[i], &expected))
+		require.NoError(t, json.Unmarshal(metas[i], &actual))
+		require.Equal(t, expected.PhysicalTableID, actual.PhysicalTableID)
+		require.Equal(t, expected.RowStart, actual.RowStart)
+		require.Equal(t, expected.RowEnd, actual.RowEnd)
+	}
+
+	// 2.2.4 BackfillStepReadIndex
 	task.State = proto.TaskStateRunning
 	task.Step = sch.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.StepDone, task.Step)
@@ -244,10 +275,7 @@ func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
 		require.NoError(t, mgr.FinishSubtask(ctx, s.ExecID, s.ID, sortStepMetaBytes))
 	}
 	// 2. to merge-sort stage.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/forceMergeSort", `return()`))
-	t.Cleanup(func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/forceMergeSort"))
-	})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/forceMergeSort", `return()`)
 	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
@@ -284,10 +312,7 @@ func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
 		require.NoError(t, mgr.FinishSubtask(ctx, s.ExecID, s.ID, mergeSortStepMetaBytes))
 	}
 	// 3. to write&ingest stage.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockWriteIngest", "return(true)"))
-	t.Cleanup(func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockWriteIngest"))
-	})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockWriteIngest", "return(true)")
 	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69789

Problem Summary:

`generatePlanForPhysicalTable` returned `(retryable=true, err=nil)` when it
detected discontinuous regions or failed to allocate a timestamp for a subtask.
`RunWithRetry` treats a nil error as success, so a timestamp failure after an
earlier region batch had been planned could publish only the retained prefix of
the physical-table plan. Propagating the timestamp error alone was insufficient
because metadata from failed attempts remained in the shared result slice and
would be duplicated by the next attempt.

### What changed and how does it work?

- Return concrete errors for retryable region-discontinuity and timestamp-allocation failures.
- Build subtask metadata in an attempt-local slice and publish it only when the entire retry attempt succeeds.
- Add deterministic failpoints and regression coverage for both transient failures, including a two-region case that proves a retry returns the complete plan exactly once.
- Use `pkg/testkit/testfailpoint` for checked failpoint setup and automatic cleanup in the affected tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands run:

```sh
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestBackfillingScheduler(LocalMode|GlobalSortMode)$' -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where distributed `ADD INDEX` could publish an incomplete index after a transient timestamp allocation error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior during physical-table backfilling when regions become non-continuous, now returning a clear error instead of silently succeeding.
  * Ensured timestamp allocation failures are correctly surfaced during retry processing.
  * Improved consistency of generated subtask metadata across retry attempts.
* **Tests**
  * Expanded retry coverage for both local and physical-table scenarios, including transient region discontinuity and timestamp allocation failures.
* **Documentation**
  * Updated DDL test reference notes to reflect the broader retry coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->