### PR TITLE
go.mod: update PD client for pd#10997

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6530,13 +6530,13 @@ def go_deps():
         name = "com_github_pingcap_kvproto",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/kvproto",
-        sha256 = "cc6e3b4c81ba781c316c0ea799f2e0c03133b2a27215ecbd6217fb37e923f498",
-        strip_prefix = "github.com/pingcap/kvproto@v0.0.0-20260610100801-904083a187d5",
+        sha256 = "b5f2a6e51a50ee0dab6de6e559a989ec0a0be59adf9ef847c324e11fc6a059f8",
+        strip_prefix = "github.com/pingcap/kvproto@v0.0.0-20260703015547-e800f9e5a427",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260610100801-904083a187d5.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260610100801-904083a187d5.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260610100801-904083a187d5.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260610100801-904083a187d5.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260703015547-e800f9e5a427.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260703015547-e800f9e5a427.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260703015547-e800f9e5a427.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20260703015547-e800f9e5a427.zip",
         ],
     )
     go_repository(
@@ -7819,13 +7819,13 @@ def go_deps():
         build_tags = ["nextgen", "intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "4fc6d3541e5829a7b9baa563ab4fc5edcd150e5ef423bc79ab32188c55aff603",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260611063303-491a11c2f061",
+        sha256 = "7d7fe43ed3100e757742bea37cfd327d1e38f8d8eacb13650c973053b370bf02",
+        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260714045825-19ee324ee9d8",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260611063303-491a11c2f061.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260611063303-491a11c2f061.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260611063303-491a11c2f061.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260611063303-491a11c2f061.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260714045825-19ee324ee9d8.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260714045825-19ee324ee9d8.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260714045825-19ee324ee9d8.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260714045825-19ee324ee9d8.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/fn v1.0.0
-	github.com/pingcap/kvproto v0.0.0-20260610100801-904083a187d5
+	github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
@@ -125,7 +125,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
 	github.com/tikv/client-go/v2 v2.0.8-0.20260617064024-5526ae2a8546
-	github.com/tikv/pd/client v0.0.0-20260611063303-491a11c2f061
+	github.com/tikv/pd/client v0.0.0-20260714045825-19ee324ee9d8
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -730,6 +730,8 @@ github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17Xtb
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20260610100801-904083a187d5 h1:OgjuwE14rgqWIPSMyPvR4fMI9zA3TB7DZ535w/58yk4=
 github.com/pingcap/kvproto v0.0.0-20260610100801-904083a187d5/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427 h1:fnagXtVQTLmi2sLH7QgvH1vHlFohDeQtRASxzXVk2ss=
+github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
@@ -899,6 +901,8 @@ github.com/tikv/client-go/v2 v2.0.8-0.20260617064024-5526ae2a8546 h1:fjOCdCmNgUr
 github.com/tikv/client-go/v2 v2.0.8-0.20260617064024-5526ae2a8546/go.mod h1:WDAIZI2EmfkDX4BP947c5wXJiIM3GgTnaaCp3TqReBE=
 github.com/tikv/pd/client v0.0.0-20260611063303-491a11c2f061 h1:G0s09nW/KYlNi17A5rp2EJ1lBTZsQXcH1qpptejC/5E=
 github.com/tikv/pd/client v0.0.0-20260611063303-491a11c2f061/go.mod h1:/AgomU1MKQ1LV0kYcvfLrTX/Prn1jLekzvtRNCqNiO4=
+github.com/tikv/pd/client v0.0.0-20260714045825-19ee324ee9d8 h1:8oHjHFQea2yL+MUK6Z6d1p0dYI2rHkoCQVjw1Yo6Uss=
+github.com/tikv/pd/client v0.0.0-20260714045825-19ee324ee9d8/go.mod h1:UL+x0aP+9+BDig+LYZFIU1G5r/gH2fEsVKl5MTS1Ud8=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/tjfoc/gmsm v1.3.2/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what is changed
2. *: what is changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref tikv/pd#10997

Problem Summary:

Successful Resource Control token waits can produce excessive TiDB warning logs.

### What changed and how does it work?

- Update the PD client to v0.0.0-20260714045825-19ee324ee9d8, which includes tikv/pd#10997.
- Update kvproto to v0.0.0-20260703015547-e800f9e5a427, required by the PD client affinity backport.
- Regenerate Bazel dependency metadata.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test ./pkg/domain/affinity -tags=intest,deadlock,nextgen -count=1`
- [x] Manual test (add detailed scripts or steps below)
  - `make bazel_prepare`
  - `go mod verify`
  - `bazel build --remote_cache=https://cache.hawkingrei.com/bazelcache --noremote_upload_local_results //pkg/domain/affinity:affinity` was attempted, but the new PD client and kvproto archives have not reached the configured TiDB mirrors yet (404/502).
- [ ] Integration test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reduce excessive TiDB warning logs for successful Resource Control token waits.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions for improved compatibility and access to the latest upstream changes.
  * Synchronized dependency metadata and integrity checks with the updated versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->