### PR TITLE
mvservice: fix refresh alert checker ownership

### DIFF
--- a/pkg/mvservice/mvservice_test.go
+++ b/pkg/mvservice/mvservice_test.go
@@ -1052,7 +1052,7 @@ func TestMVServiceMaybeLogRefreshAlertTasksSkipsCleanupWhenNotOwner(t *testing.T
 	require.Equal(t, int32(0), helper.syncRefreshAlertCalls.Load())
 }
 
-func TestMVServiceRefreshAlertCheckerKeysScanGlobalTasks(t *testing.T) {
+func TestMVServiceRefreshAlertCheckerOwnersScanGlobalTasks(t *testing.T) {
 	now := mvsNow()
 	newTask := func() *mv {
 		return &mv{
@@ -1077,12 +1077,8 @@ func TestMVServiceRefreshAlertCheckerKeysScanGlobalTasks(t *testing.T) {
 		taskState    string
 	}{
 		{
-			name:   "not_checker_owner",
-			selfID: "nodeA",
-		},
-		{
-			name:         "checker_key1_owner_reports_metrics",
-			selfID:       "nodeB",
+			name:         "first_server_reports_metrics",
+			selfID:       "nodeA",
 			checkerOwner: true,
 			metricsOwner: true,
 			fetchCalls:   1,
@@ -1091,12 +1087,16 @@ func TestMVServiceRefreshAlertCheckerKeysScanGlobalTasks(t *testing.T) {
 			taskState:    mvRefreshAlertTaskStateUnknown,
 		},
 		{
-			name:         "checker_key2_owner_does_not_report_metrics",
-			selfID:       "nodeC",
+			name:         "second_server_does_not_report_metrics",
+			selfID:       "nodeB",
 			checkerOwner: true,
 			fetchCalls:   1,
 			syncCalls:    1,
 			taskState:    mvRefreshAlertTaskStateUnknown,
+		},
+		{
+			name:   "third_server_is_not_checker_owner",
+			selfID: "nodeC",
 		},
 	}
 
@@ -1109,7 +1109,7 @@ func TestMVServiceRefreshAlertCheckerKeysScanGlobalTasks(t *testing.T) {
 			svc := NewMVService(context.Background(), mockSessionPool{}, helper, DefaultMVServiceConfig())
 			defer svc.closeTaskExecutors()
 
-			setThreeNodeRefreshAlertCheckerRingForTest(svc, tc.selfID)
+			setThreeNodeRefreshAlertOwnersForTest(svc, tc.selfID)
 			require.Equal(t, tc.checkerOwner, svc.isRefreshAlertCheckerOwner())
 			require.Equal(t, tc.metricsOwner, svc.isRefreshAlertMetricsOwner())
 			svc.metrics.alertWarningCount.Store(7)
@@ -1140,6 +1140,28 @@ func TestMVServiceRefreshAlertCheckerKeysScanGlobalTasks(t *testing.T) {
 			require.Equal(t, tc.taskState, synced[0].taskState)
 		})
 	}
+}
+
+func TestMVServiceRefreshAlertCheckerOwnerSingleServer(t *testing.T) {
+	svc := NewMVService(context.Background(), mockSessionPool{}, &mockMVServiceHelper{}, DefaultMVServiceConfig())
+	defer svc.closeTaskExecutors()
+
+	svc.sch.mu.Lock()
+	svc.sch.ID = "nodeA"
+	svc.sch.rebuildLocked(map[string]serverInfo{
+		"nodeA": {ID: "nodeA"},
+	})
+	svc.sch.mu.Unlock()
+
+	require.True(t, svc.isRefreshAlertCheckerOwner())
+	require.True(t, svc.isRefreshAlertMetricsOwner())
+
+	svc.sch.mu.Lock()
+	svc.sch.ID = "nodeB"
+	svc.sch.mu.Unlock()
+
+	require.False(t, svc.isRefreshAlertCheckerOwner())
+	require.False(t, svc.isRefreshAlertMetricsOwner())
 }
 
 func TestMVServiceMaybeScanMVLogAccumulationAlertsFiltersUnownedTasks(t *testing.T) {

--- a/pkg/mvservice/server_maintainer.go
+++ b/pkg/mvservice/server_maintainer.go
@@ -17,6 +17,7 @@ package mvservice
 import (
 	"context"
 	"encoding/binary"
+	"sort"
 	"sync"
 	"time"
 
@@ -46,12 +47,13 @@ type ServerDiscovery interface {
 
 // ServerConsistentHash maintains TiDB membership and ownership mapping by exec ID.
 type ServerConsistentHash struct {
-	ctx     context.Context
-	servers map[string]serverInfo
-	chash   ConsistentHash // use consistent hash to reduce task movements after nodes changed
-	mu      sync.RWMutex
-	ID      string // current server exec ID
-	helper  ServerDiscovery
+	ctx       context.Context
+	servers   map[string]serverInfo
+	serverIDs []string
+	chash     ConsistentHash // use consistent hash to reduce task movements after nodes changed
+	mu        sync.RWMutex
+	ID        string // current server exec ID
+	helper    ServerDiscovery
 }
 
 // NewServerConsistentHash creates a server ownership helper backed by consistent hash.
@@ -65,6 +67,18 @@ func NewServerConsistentHash(ctx context.Context, replicas int, helper ServerDis
 		chash:   *NewConsistentHash(replicas),
 		helper:  helper,
 	}
+}
+
+func (sch *ServerConsistentHash) rebuildLocked(servers map[string]serverInfo) {
+	sch.servers = servers
+	sch.serverIDs = make([]string, 0, len(servers))
+	for id := range servers {
+		if id != "" {
+			sch.serverIDs = append(sch.serverIDs, id)
+		}
+	}
+	sort.Strings(sch.serverIDs)
+	sch.chash.Rebuild(sch.servers)
 }
 
 // init loads local server info with retry and initializes local exec ID.
@@ -104,22 +118,6 @@ func (sch *ServerConsistentHash) init() bool {
 			backoff = waitDur * 2
 		}
 	}
-}
-
-// AddServer inserts one server into the member map and hash ring.
-func (sch *ServerConsistentHash) AddServer(srv serverInfo) {
-	sch.mu.Lock()
-	defer sch.mu.Unlock()
-	sch.servers[srv.ID] = srv
-	sch.chash.AddNode(srv.ID)
-}
-
-// RemoveServer removes one server from the member map and hash ring.
-func (sch *ServerConsistentHash) RemoveServer(srvID string) {
-	sch.mu.Lock()
-	defer sch.mu.Unlock()
-	delete(sch.servers, srvID)
-	sch.chash.RemoveNode(srvID)
 }
 
 // refresh reloads server membership and rebuilds the hash ring when changed.
@@ -168,8 +166,7 @@ func (sch *ServerConsistentHash) refresh() (bool, error) {
 	{
 		sch.mu.Lock() // Guard server map and hash-ring rebuild.
 
-		sch.servers = newInfos
-		sch.chash.Rebuild(sch.servers)
+		sch.rebuildLocked(newInfos)
 
 		sch.mu.Unlock() // Release guard after rebuild.
 	}

--- a/pkg/mvservice/server_maintainer_test.go
+++ b/pkg/mvservice/server_maintainer_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"maps"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -71,10 +72,14 @@ func (m *mockServerHelper) getAllServerInfo(_ context.Context) (map[string]serve
 func newServerConsistentHashForTest(mapping map[string]uint32, helper ServerDiscovery, selfID string, serverIDs ...string) *ServerConsistentHash {
 	sch := NewServerConsistentHash(context.Background(), 1, helper)
 	sch.chash.hashFunc = mustHash(mapping)
-	sch.ID = selfID
+	servers := make(map[string]serverInfo, len(serverIDs))
 	for _, id := range serverIDs {
-		sch.AddServer(serverInfo{ID: id})
+		servers[id] = serverInfo{ID: id}
 	}
+	sch.mu.Lock()
+	sch.ID = selfID
+	sch.rebuildLocked(servers)
+	sch.mu.Unlock()
 	return sch
 }
 
@@ -100,7 +105,7 @@ func assertAvailableForNode(t *testing.T, sch *ServerConsistentHash, nodeID stri
 	}
 }
 
-func TestServerConsistentHashAddRemoveAndAvailable(t *testing.T) {
+func TestServerConsistentHashRebuildMaintainsSortedServerIDsAndRing(t *testing.T) {
 	mapping := map[string]uint32{
 		"nodeA#0": 10,
 		"nodeB#0": 20,
@@ -113,20 +118,27 @@ func TestServerConsistentHashAddRemoveAndAvailable(t *testing.T) {
 	if len(sch.servers) != 2 {
 		t.Fatalf("expected 2 servers, got %d", len(sch.servers))
 	}
+	if got := sch.serverIDs; !slices.Equal(got, []string{"nodeA", "nodeB"}) {
+		t.Fatalf("expected sorted server IDs [nodeA nodeB], got %v", got)
+	}
 	assertRingNodeCount(t, sch, 2)
 	assertRingOwner(t, sch, []byte("key-low"), "nodeA")
 	assertRingOwner(t, sch, []byte("key-mid"), "nodeB")
-	assertAvailableForNode(t, sch, "nodeB", "key-low", false)
-	assertAvailableForNode(t, sch, "nodeB", "key-mid", true)
 
-	sch.RemoveServer("nodeB")
+	sch.mu.Lock()
+	sch.rebuildLocked(map[string]serverInfo{
+		"nodeA": {ID: "nodeA"},
+	})
+	sch.mu.Unlock()
 
 	if len(sch.servers) != 1 {
-		t.Fatalf("expected 1 server after remove, got %d", len(sch.servers))
+		t.Fatalf("expected 1 server after rebuild, got %d", len(sch.servers))
+	}
+	if got := sch.serverIDs; !slices.Equal(got, []string{"nodeA"}) {
+		t.Fatalf("expected sorted server IDs [nodeA], got %v", got)
 	}
 	assertRingNodeCount(t, sch, 1)
 	assertRingOwner(t, sch, []byte("key-mid"), "nodeA")
-	assertAvailableForNode(t, sch, "nodeB", "key-mid", false)
 }
 
 func TestServerConsistentHashAvailableSupportsDifferentKeyTypes(t *testing.T) {
@@ -186,8 +198,12 @@ func TestServerConsistentHashAvailableSupportsDifferentKeyTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sch := NewServerConsistentHash(context.Background(), 1, &mockServerHelper{})
 			sch.chash.hashFunc = tc.hashFunc(t)
-			sch.AddServer(serverInfo{ID: "nodeA"})
-			sch.AddServer(serverInfo{ID: "nodeB"})
+			sch.mu.Lock()
+			sch.rebuildLocked(map[string]serverInfo{
+				"nodeA": {ID: "nodeA"},
+				"nodeB": {ID: "nodeB"},
+			})
+			sch.mu.Unlock()
 
 			assertAvailableForNode(t, sch, "nodeB", tc.key, true)
 			assertAvailableForNode(t, sch, "nodeA", tc.key, false)

--- a/pkg/mvservice/service.go
+++ b/pkg/mvservice/service.go
@@ -159,10 +159,6 @@ const (
 	mvRunEventGetTSOErr          = "get_tso_error"
 
 	mvHistoryGCOwnerKey = "gc-mv-op-hist"
-	// Two independent hash-ring keys perform global refresh-alert checks, so one
-	// unhealthy TiDB does not fully suppress warning/overdue alerts.
-	mvRefreshAlertCheckerOwnerKey1 = "check-mv-refresh-alert1"
-	mvRefreshAlertCheckerOwnerKey2 = "check-mv-refresh-alert2"
 	// A single hash-ring owner performs stale refresh-alert cleanup to avoid
 	// repeating the same global delete on every TiDB node.
 	mvRefreshAlertCleanupOwnerKey = "gc-mv-refresh-alert"
@@ -706,21 +702,26 @@ func (t *MVService) cleanupStaleRefreshAlerts() {
 }
 
 func (t *MVService) isRefreshAlertCheckerOwner() bool {
-	return t.ownsRefreshAlertKey(mvRefreshAlertCheckerOwnerKey1) ||
-		t.ownsRefreshAlertKey(mvRefreshAlertCheckerOwnerKey2)
+	t.sch.mu.RLock()
+	defer t.sch.mu.RUnlock()
+
+	n := min(2, len(t.sch.serverIDs))
+	for _, id := range t.sch.serverIDs[:n] {
+		if id == t.sch.ID {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *MVService) isRefreshAlertMetricsOwner() bool {
-	return t.ownsRefreshAlertKey(mvRefreshAlertCheckerOwnerKey1)
-}
-
-func (t *MVService) ownsRefreshAlertKey(key string) bool {
 	t.sch.mu.RLock()
 	defer t.sch.mu.RUnlock()
-	if t.sch.ID == "" || len(t.sch.servers) == 0 {
+
+	if len(t.sch.serverIDs) == 0 {
 		return false
 	}
-	return t.sch.chash.GetNode([]byte(key)) == t.sch.ID
+	return t.sch.serverIDs[0] == t.sch.ID
 }
 
 func (t *MVService) isRefreshAlertCleanupOwner() bool {

--- a/pkg/mvservice/test_helpers_test.go
+++ b/pkg/mvservice/test_helpers_test.go
@@ -113,42 +113,36 @@ func setServiceHashOverridesForTest(svc *MVService, overrides map[string]uint32)
 	svc.sch.ID = "nodeA"
 	svc.sch.chash.replicas = 1
 	mapping := map[string]uint32{
-		"nodeA#0":                      10,
-		"nodeB#0":                      30,
-		mvHistoryGCOwnerKey:            10,
-		mvRefreshAlertCheckerOwnerKey1: 10,
-		mvRefreshAlertCheckerOwnerKey2: 10,
-		mvRefreshAlertCleanupOwnerKey:  10,
+		"nodeA#0":                     10,
+		"nodeB#0":                     30,
+		mvHistoryGCOwnerKey:           10,
+		mvRefreshAlertCleanupOwnerKey: 10,
 	}
 	for key, hash := range overrides {
 		mapping[key] = hash
 	}
 	svc.sch.chash.hashFunc = mustHash(mapping)
-	svc.sch.servers = map[string]serverInfo{
+	svc.sch.rebuildLocked(map[string]serverInfo{
 		"nodeA": {ID: "nodeA"},
 		"nodeB": {ID: "nodeB"},
-	}
-	svc.sch.chash.Rebuild(svc.sch.servers)
+	})
 	svc.sch.mu.Unlock()
 }
 
-func setThreeNodeRefreshAlertCheckerRingForTest(svc *MVService, selfID string) {
+func setThreeNodeRefreshAlertOwnersForTest(svc *MVService, selfID string) {
 	svc.sch.mu.Lock()
 	svc.sch.ID = selfID
 	svc.sch.chash.replicas = 1
 	svc.sch.chash.hashFunc = mustHash(map[string]uint32{
-		"nodeA#0":                      10,
-		"nodeB#0":                      20,
-		"nodeC#0":                      30,
-		mvRefreshAlertCheckerOwnerKey1: 15, // owner: nodeB.
-		mvRefreshAlertCheckerOwnerKey2: 25, // owner: nodeC.
-		mvRefreshAlertCleanupOwnerKey:  25,
+		"nodeA#0":                     10,
+		"nodeB#0":                     20,
+		"nodeC#0":                     30,
+		mvRefreshAlertCleanupOwnerKey: 25,
 	})
-	svc.sch.servers = map[string]serverInfo{
+	svc.sch.rebuildLocked(map[string]serverInfo{
 		"nodeA": {ID: "nodeA"},
 		"nodeB": {ID: "nodeB"},
 		"nodeC": {ID: "nodeC"},
-	}
-	svc.sch.chash.Rebuild(svc.sch.servers)
+	})
 	svc.sch.mu.Unlock()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69835

Problem Summary:

The two materialized-view refresh-alert checker keys can be assigned to the same TiDB instance by the consistent hash ring, so the intended checker redundancy is not guaranteed. If that shared checker or metrics owner fails, refresh-alert metrics can temporarily disappear from surviving instances.

### What changed and how does it work?

This PR changes refresh-alert checker ownership to use a deterministic sorted TiDB server list instead of two independent hash-ring keys.

- The first two sorted TiDB server IDs are refresh-alert checker owners.
- The first sorted TiDB server ID is the refresh-alert metrics owner.
- Stale refresh-alert cleanup still uses the existing hash-ring owner key.
- `ServerConsistentHash` now maintains a sorted `serverIDs` list when rebuilding membership.
- Removed unused `ServerConsistentHash.AddServer` and `RemoveServer`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a materialized-view refresh-alert checker ownership issue that could temporarily hide refresh-alert metrics after a TiDB owner fails.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved refresh-alert ownership across multi-server and single-server deployments.
  - Ensured refresh-alert metrics are assigned consistently to the primary server.

- **Bug Fixes**
  - Made server membership and ownership ordering deterministic.
  - Improved consistent-hash ring rebuilding when servers are added or removed.
  - Updated ownership behavior when service IDs change between servers.

- **Tests**
  - Expanded coverage for refresh-alert ownership, metrics reporting, and server-ring rebuild scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->