### PR TITLE
dxf/importinto: dedup handles in BoundedHandleSet.Add to fix bound accounting (close #69803)

### DIFF
--- a/pkg/dxf/importinto/conflictedkv/row_handle.go
+++ b/pkg/dxf/importinto/conflictedkv/row_handle.go
@@ -84,6 +84,10 @@ func (s *BoundedHandleSet) Add(handle tidbkv.Handle) {
 	}
 
 	hdlStr := handle.String()
+	if _, ok := s.handles[hdlStr]; ok {
+		// the handle is already in the set, do not charge the shared size again.
+		return
+	}
 	delta := int64(len(hdlStr)) + handleMapEntryShallowSize
 	newSize := s.sharedSize.Add(delta)
 	s.handles[hdlStr] = true

--- a/pkg/dxf/importinto/conflictedkv/row_handle_test.go
+++ b/pkg/dxf/importinto/conflictedkv/row_handle_test.go
@@ -68,3 +68,17 @@ func TestBoundedHandleSet(t *testing.T) {
 	set2.Merge(set)
 	require.EqualValues(t, set.handles, set2.handles)
 }
+
+func TestBoundedHandleSetDuplicateDoesNotConsumeBudget(t *testing.T) {
+	var sharedSize atomic.Int64
+	handle := tidbkv.IntHandle(1)
+	delta := int64(len(handle.String())) + handleMapEntryShallowSize
+	set := NewBoundedHandleSet(zap.NewNop(), &sharedSize, 2*delta)
+
+	set.Add(handle)
+	set.Add(handle)
+
+	require.Len(t, set.handles, 1)
+	require.Equal(t, delta, sharedSize.Load())
+	require.False(t, set.BoundExceeded())
+}


### PR DESCRIPTION
### What problem does this PR solve?

<!-- Please create an issue first to describe the problem. -->

`BoundedHandleSet.Add` in `pkg/dxf/importinto/conflictedkv/row_handle.go` charges `sharedSize` on every call without checking whether the handle already exists in `s.handles`. Because `s.handles[hdlStr] = true` is an idempotent map assignment, calling `Add` multiple times with the same handle keeps the map at a single entry, but each call still adds `delta = len(hdlStr) + handleMapEntryShallowSize` to the shared counter.

Once the inflated counter reaches `sizeLimit`, `BoundExceeded()` returns true, which causes:

1. `collectConflictsStepExecutor.onFinished` (`collect_conflicts.go`) to set `TooManyConflictsFromIndex`.
2. `planner.go` to propagate the flag into post-process metadata.
3. `subtask_executor.go` to **skip local/remote checksum verification** in the post-process step.

A reachable path is `IMPORT INTO` with a unique multi-valued index where a single row conflicts through several array elements: `Collector.HandleEncodedRow` may call `Add(sameHandle)` more than once on the same worker-local set when the duplicate index entries land in different 256-handle buffers. The retained-handle set is still below its memory budget, but the accounting says otherwise and checksum verification is disabled prematurely.

Issue Number: close #69803

### What is changed and how it works?

`BoundedHandleSet.Add` now checks the map before charging `sharedSize`:

```go
hdlStr := handle.String()
if _, ok := s.handles[hdlStr]; ok {
    // the handle is already in the set, do not charge the shared size again.
    return
}
delta := int64(len(hdlStr)) + handleMapEntryShallowSize
newSize := s.sharedSize.Add(delta)
s.handles[hdlStr] = true
```

Only a genuinely new handle contributes to `sharedSize`, so `BoundExceeded()` and the downstream `TooManyConflictsFromIndex` flag now reflect the real memory footprint of the retained handle set.

Notes on scope:

- This PR fixes only the **set-bound accounting** defect. The separate checksum-deduplication issue (tracked in #69799 / referenced in the report) is intentionally out of scope; simply forcing checksum verification back on could surface an already-inaccurate deleted-row checksum. Fixing the accounting here is a prerequisite for that follow-up.
- No behavior change for the common path where every `Add` is a distinct handle — the map lookup adds only an O(1) probe before the existing hot path.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > Because (please explain why the test is not needed for this PR)

Added regression test `TestBoundedHandleSetDuplicateDoesNotConsumeBudget` in `pkg/dxf/importinto/conflictedkv/row_handle_test.go`:

```go
func TestBoundedHandleSetDuplicateDoesNotConsumeBudget(t *testing.T) {
    var sharedSize atomic.Int64
    handle := tidbkv.IntHandle(1)
    delta := int64(len(handle.String())) + handleMapEntryShallowSize
    set := NewBoundedHandleSet(zap.NewNop(), &sharedSize, 2*delta)

    set.Add(handle)
    set.Add(handle)

    require.Len(t, set.handles, 1)
    require.Equal(t, delta, sharedSize.Load())
    require.False(t, set.BoundExceeded())
}
```

Local run:

```
=== RUN   TestHandleFilter                                       --- PASS
=== RUN   TestBoundedHandleSet                                   --- PASS
=== RUN   TestBoundedHandleSetDuplicateDoesNotConsumeBudget      --- PASS
PASS
ok  github.com/pingcap/tidb/pkg/dxf/importinto/conflictedkv  0.058s
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix inaccurate bound accounting in the IMPORT INTO conflict-handle set. Previously, adding the same row handle multiple times to a `BoundedHandleSet` would repeatedly charge the shared size counter, which could prematurely trigger the "too many conflicts from index" state and cause the post-process step to skip local/remote checksum verification even when the retained handle set was still within its memory budget.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate entries from consuming additional memory budget.
  - Improved handling of repeated items so configured size limits are respected.

- **Tests**
  - Added coverage to verify duplicate entries are stored only once and charged against the budget only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->