### PR TITLE
dep: update pd client for batched runtime trace regions | tidb-test=release-8.5-20260323-v8.5.5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5646,14 +5646,8 @@ def go_deps():
         name = "com_github_pingcap_kvproto",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/kvproto",
-        sha256 = "f344381790869f7b6654340ec855ee2758abb0be9103d9e9146cad82f90b7d1f",
-        strip_prefix = "github.com/pingcap/kvproto@v0.0.0-20251212013835-ed676560b3b4",
-        urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20251212013835-ed676560b3b4.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20251212013835-ed676560b3b4.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20251212013835-ed676560b3b4.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/kvproto/com_github_pingcap_kvproto-v0.0.0-20251212013835-ed676560b3b4.zip",
-        ],
+        sum = "h1:5zfNwsPoZaugwCdZWTJJcetvXn6teN+CP6HSxrO5O9A=",
+        version = "v0.0.0-20260330040622-13d81884357d",
     )
     go_repository(
         name = "com_github_pingcap_log",
@@ -6907,14 +6901,8 @@ def go_deps():
         name = "com_github_tikv_pd_client",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/pd/client",
-        sha256 = "af89b7a867ec8dd05ceaa0509c38d560d6dd619317aa1e5b1c7c725a7e59f2dc",
-        strip_prefix = "github.com/tikv/pd/client@v0.0.0-20260330105957-ebf9af006aac",
-        urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/pd/client/com_github_tikv_pd_client-v0.0.0-20260330105957-ebf9af006aac.zip",
-        ],
+        sum = "h1:mXRNSFPJRllMjsGdp3KUmvvPPOrEZemNlbsEw2UGv7w=",
+        version = "v0.0.0-20260717021404-4363de83f814",
     )
     go_repository(
         name = "com_github_timakin_bodyclose",

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/fn v1.0.0
-	github.com/pingcap/kvproto v0.0.0-20251212013835-ed676560b3b4
+	github.com/pingcap/kvproto v0.0.0-20260330040622-13d81884357d
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20211011031125-9b13dc409c5e
@@ -111,7 +111,7 @@ require (
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
 	github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8
-	github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac
+	github.com/tikv/pd/client v0.0.0-20260717021404-4363de83f814
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -611,8 +611,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20251212013835-ed676560b3b4 h1:uXlwBh9XoxQVfzI9vDkY6X4AusnuQA3ei1SHJ0484h4=
-github.com/pingcap/kvproto v0.0.0-20251212013835-ed676560b3b4/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260330040622-13d81884357d h1:5zfNwsPoZaugwCdZWTJJcetvXn6teN+CP6HSxrO5O9A=
+github.com/pingcap/kvproto v0.0.0-20260330040622-13d81884357d/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
@@ -762,8 +762,8 @@ github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8 h1:zXvmqjetn+Kvs7PL98PahiIp/IswDlT0G39p95OuSPg=
 github.com/tikv/client-go/v2 v2.0.8-0.20260112052152-1d3c5ec76bf8/go.mod h1:iVLG2tuDVyBd9BN6e9JNFtUeEQarvKN7pTcW+pb3nFw=
-github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac h1:RmpwJKGhY7+PN3IohrwDN5gqmIQ/g5HBgxd7ICPEYNw=
-github.com/tikv/pd/client v0.0.0-20260330105957-ebf9af006aac/go.mod h1:X3T+jK+4bLbDKgupmzvVXuySnCNV4Lfdm/bL8TAw3ik=
+github.com/tikv/pd/client v0.0.0-20260717021404-4363de83f814 h1:mXRNSFPJRllMjsGdp3KUmvvPPOrEZemNlbsEw2UGv7w=
+github.com/tikv/pd/client v0.0.0-20260717021404-4363de83f814/go.mod h1:9ovMzFcQhL05VBSmlp5okPGUNxFJT+CySyU20j+OLVM=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #69743

Problem Summary:

`tikv/pd#10988` has been merged into `tikv/pd` branch `release-8.5-20260323-v8.5.5`. TiDB branch `release-8.5-20260323-v8.5.5` still depends on an older `github.com/tikv/pd/client`, so it does not include the batched TSO runtime trace region fix.

### What changed and how does it work?

Update `github.com/tikv/pd/client` from `v0.0.0-20260330105957-ebf9af006aac` to `4363de83f81485ae2f0b513cd5a2c4620d25b198`, which is from [`tikv/pd#10988`.](https://github.com/tikv/pd/pull/11012).

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

Tests run:

```bash
git diff --check
go test ./pkg/store/gcworker ./pkg/domain/infosync ./pkg/store/copr ./br/pkg/pdutil -run '^$' -count=1
```

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated internal Go dependencies to newer versions used for key/value and placement-driver communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->