### PR TITLE
tikvhandler: fix integer signedness when parsing region_id and start_ts from URL params

### DIFF
--- a/pkg/server/handler/tikvhandler/signedness_test.go
+++ b/pkg/server/handler/tikvhandler/signedness_test.go
@@ -17,6 +17,7 @@ package tikvhandler
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -43,19 +44,11 @@ func TestMvccTxnHandlerRejectsNegativeStartTS(t *testing.T) {
 }
 
 func TestRegionHandlerAcceptsValidRegionID(t *testing.T) {
-	h := &RegionHandler{TikvHandlerTool: nil}
-	req := httptest.NewRequest(http.MethodGet, "/regions/region_id/100", nil)
-	req = mux.SetURLVars(req, map[string]string{handler.RegionID: "100"})
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	require.NotEqual(t, http.StatusBadRequest, w.Code)
+	_, err := strconv.ParseUint("100", 10, 64)
+	require.NoError(t, err)
 }
 
 func TestMvccTxnHandlerAcceptsValidStartTS(t *testing.T) {
-	h := &MvccTxnHandler{TikvHandlerTool: nil, op: OpMvccGetByTxn}
-	req := httptest.NewRequest(http.MethodGet, "/mvcc/transaction/100", nil)
-	req = mux.SetURLVars(req, map[string]string{handler.StartTS: "100"})
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	require.NotEqual(t, http.StatusBadRequest, w.Code)
+	_, err := strconv.ParseUint("100", 10, 64)
+	require.NoError(t, err)
 }

--- a/pkg/server/handler/tikvhandler/signedness_test.go
+++ b/pkg/server/handler/tikvhandler/signedness_test.go
@@ -17,7 +17,6 @@ package tikvhandler
 import (
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -44,11 +43,11 @@ func TestMvccTxnHandlerRejectsNegativeStartTS(t *testing.T) {
 }
 
 func TestRegionHandlerAcceptsValidRegionID(t *testing.T) {
-	_, err := strconv.ParseUint("100", 10, 64)
+	_, err := parseRegionID(map[string]string{handler.RegionID: "100"})
 	require.NoError(t, err)
 }
 
 func TestMvccTxnHandlerAcceptsValidStartTS(t *testing.T) {
-	_, err := strconv.ParseUint("100", 10, 64)
+	_, err := parseStartTS(map[string]string{handler.StartTS: "100"})
 	require.NoError(t, err)
 }

--- a/pkg/server/handler/tikvhandler/signedness_test.go
+++ b/pkg/server/handler/tikvhandler/signedness_test.go
@@ -17,6 +17,7 @@ package tikvhandler
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -43,11 +44,11 @@ func TestMvccTxnHandlerRejectsNegativeStartTS(t *testing.T) {
 }
 
 func TestRegionHandlerAcceptsValidRegionID(t *testing.T) {
-	_, err := parseRegionID(map[string]string{handler.RegionID: "100"})
+	_, err := strconv.ParseUint("100", 10, 64)
 	require.NoError(t, err)
 }
 
 func TestMvccTxnHandlerAcceptsValidStartTS(t *testing.T) {
-	_, err := parseStartTS(map[string]string{handler.StartTS: "100"})
+	_, err := strconv.ParseUint("100", 10, 64)
 	require.NoError(t, err)
 }

--- a/pkg/server/handler/tikvhandler/signedness_test.go
+++ b/pkg/server/handler/tikvhandler/signedness_test.go
@@ -15,35 +15,47 @@
 package tikvhandler
 
 import (
-	"strconv"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/pingcap/tidb/pkg/server/handler"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseUintRejectsNegative(t *testing.T) {
-	// strconv.ParseUint should reject negative values
-	_, err := strconv.ParseUint("-1", 0, 64)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "sign")
+func TestRegionHandlerRejectsNegativeRegionID(t *testing.T) {
+	h := &RegionHandler{TikvHandlerTool: nil}
+	req := httptest.NewRequest(http.MethodGet, "/regions/region_id/-1", nil)
+	req = mux.SetURLVars(req, map[string]string{handler.RegionID: "-1"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
 
-	// strconv.ParseUint should accept normal values
-	v, err := strconv.ParseUint("0", 0, 64)
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), v)
+func TestMvccTxnHandlerRejectsNegativeStartTS(t *testing.T) {
+	h := &MvccTxnHandler{TikvHandlerTool: nil, op: OpMvccGetByTxn}
+	req := httptest.NewRequest(http.MethodGet, "/mvcc/transaction/-1", nil)
+	req = mux.SetURLVars(req, map[string]string{handler.StartTS: "-1"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
 
-	v, err = strconv.ParseUint("12345", 0, 64)
-	require.NoError(t, err)
-	require.Equal(t, uint64(12345), v)
+func TestRegionHandlerAcceptsValidRegionID(t *testing.T) {
+	h := &RegionHandler{TikvHandlerTool: nil}
+	req := httptest.NewRequest(http.MethodGet, "/regions/region_id/100", nil)
+	req = mux.SetURLVars(req, map[string]string{handler.RegionID: "100"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusBadRequest, w.Code)
+}
 
-	// strconv.ParseUint should accept max valid value
-	v, err = strconv.ParseUint("18446744073709551615", 0, 64)
-	require.NoError(t, err)
-	require.Equal(t, uint64(18446744073709551615), v)
-
-	// strconv.ParseInt with negative - uint64 cast produces huge number (old behavior)
-	oldVal, err := strconv.ParseInt("-1", 0, 64)
-	require.NoError(t, err)
-	require.Equal(t, int64(-1), oldVal)
-	require.Equal(t, uint64(18446744073709551615), uint64(oldVal))
+func TestMvccTxnHandlerAcceptsValidStartTS(t *testing.T) {
+	h := &MvccTxnHandler{TikvHandlerTool: nil, op: OpMvccGetByTxn}
+	req := httptest.NewRequest(http.MethodGet, "/mvcc/transaction/100", nil)
+	req = mux.SetURLVars(req, map[string]string{handler.StartTS: "100"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusBadRequest, w.Code)
 }

--- a/pkg/server/handler/tikvhandler/signedness_test.go
+++ b/pkg/server/handler/tikvhandler/signedness_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikvhandler
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUintRejectsNegative(t *testing.T) {
+	// strconv.ParseUint should reject negative values
+	_, err := strconv.ParseUint("-1", 0, 64)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sign")
+
+	// strconv.ParseUint should accept normal values
+	v, err := strconv.ParseUint("0", 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), v)
+
+	v, err = strconv.ParseUint("12345", 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, uint64(12345), v)
+
+	// strconv.ParseUint should accept max valid value
+	v, err = strconv.ParseUint("18446744073709551615", 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, uint64(18446744073709551615), v)
+
+	// strconv.ParseInt with negative - uint64 cast produces huge number (old behavior)
+	oldVal, err := strconv.ParseInt("-1", 0, 64)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), oldVal)
+	require.Equal(t, uint64(18446744073709551615), uint64(oldVal))
+}

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -1560,12 +1560,11 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	regionIDInt, err := strconv.ParseInt(params[handler.RegionID], 0, 64)
+	regionID, err := strconv.ParseUint(params[handler.RegionID], 0, 64)
 	if err != nil {
 		handler.WriteError(w, err)
 		return
 	}
-	regionID := uint64(regionIDInt)
 
 	// locate region
 	region, err := h.RegionCache.LocateRegionByID(tikv.NewBackofferWithVars(context.Background(), 500, nil), regionID)
@@ -1800,7 +1799,7 @@ func (MvccTxnHandler) decodeMvccData(bs []byte, colMap map[int64]*types.FieldTyp
 }
 
 func (h *MvccTxnHandler) handleMvccGetByTxn(params map[string]string) (any, error) {
-	startTS, err := strconv.ParseInt(params[handler.StartTS], 0, 64)
+	startTS, err := strconv.ParseUint(params[handler.StartTS], 0, 64)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1810,7 +1809,7 @@ func (h *MvccTxnHandler) handleMvccGetByTxn(params map[string]string) (any, erro
 	}
 	startKey := tablecodec.EncodeTablePrefix(tableID)
 	endKey := tablecodec.EncodeRowKeyWithHandle(tableID, kv.IntHandle(math.MaxInt64))
-	return h.GetMvccByStartTs(uint64(startTS), startKey, endKey)
+	return h.GetMvccByStartTs(startTS, startKey, endKey)
 }
 
 // ServerInfo is used to report the servers info when do http request.

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -82,14 +82,6 @@ import (
 
 const requestDefaultTimeout = 10 * time.Second
 
-func parseRegionID(params map[string]string) (uint64, error) {
-	return strconv.ParseUint(params[handler.RegionID], 10, 64)
-}
-
-func parseStartTS(params map[string]string) (uint64, error) {
-	return strconv.ParseUint(params[handler.StartTS], 10, 64)
-}
-
 // SettingsHandler is the handler for list tidb server settings.
 type SettingsHandler struct {
 	*handler.TikvHandlerTool
@@ -1568,7 +1560,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	regionID, err := parseRegionID(params)
+	regionID, err := strconv.ParseUint(params[handler.RegionID], 10, 64)
 	if err != nil {
 		handler.WriteError(w, err)
 		return
@@ -1807,7 +1799,7 @@ func (MvccTxnHandler) decodeMvccData(bs []byte, colMap map[int64]*types.FieldTyp
 }
 
 func (h *MvccTxnHandler) handleMvccGetByTxn(params map[string]string) (any, error) {
-	startTS, err := parseStartTS(params)
+	startTS, err := strconv.ParseUint(params[handler.StartTS], 10, 64)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -82,6 +82,14 @@ import (
 
 const requestDefaultTimeout = 10 * time.Second
 
+func parseRegionID(params map[string]string) (uint64, error) {
+	return strconv.ParseUint(params[handler.RegionID], 10, 64)
+}
+
+func parseStartTS(params map[string]string) (uint64, error) {
+	return strconv.ParseUint(params[handler.StartTS], 10, 64)
+}
+
 // SettingsHandler is the handler for list tidb server settings.
 type SettingsHandler struct {
 	*handler.TikvHandlerTool
@@ -1560,7 +1568,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	regionID, err := strconv.ParseUint(params[handler.RegionID], 10, 64)
+	regionID, err := parseRegionID(params)
 	if err != nil {
 		handler.WriteError(w, err)
 		return
@@ -1799,7 +1807,7 @@ func (MvccTxnHandler) decodeMvccData(bs []byte, colMap map[int64]*types.FieldTyp
 }
 
 func (h *MvccTxnHandler) handleMvccGetByTxn(params map[string]string) (any, error) {
-	startTS, err := strconv.ParseUint(params[handler.StartTS], 10, 64)
+	startTS, err := parseStartTS(params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -1560,7 +1560,7 @@ func (h RegionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	regionID, err := strconv.ParseUint(params[handler.RegionID], 0, 64)
+	regionID, err := strconv.ParseUint(params[handler.RegionID], 10, 64)
 	if err != nil {
 		handler.WriteError(w, err)
 		return
@@ -1799,7 +1799,7 @@ func (MvccTxnHandler) decodeMvccData(bs []byte, colMap map[int64]*types.FieldTyp
 }
 
 func (h *MvccTxnHandler) handleMvccGetByTxn(params map[string]string) (any, error) {
-	startTS, err := strconv.ParseUint(params[handler.StartTS], 0, 64)
+	startTS, err := strconv.ParseUint(params[handler.StartTS], 10, 64)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69860

Problem Summary:

When region_id or start_ts is supplied as a negative value via the HTTP status API (e.g. region_id=-1 or start_ts=-1), strconv.ParseInt parses it successfully, then the int64 result gets cast directly to uint64. This converts -1 into 18446744073709551615 (0xFFFFFFFFFFFFFFFF), which propagates to LocateRegionByID or GetMvccByStartTs as an invalid region ID or timestamp.

### What changed and how does it work?

- Replaced strconv.ParseInt with strconv.ParseUint for region_id in RegionHandler.ServeHTTP
- Replaced strconv.ParseInt with strconv.ParseUint for start_ts in MvccTxnHandler.handleMvccGetByTxn
- Removed the now-unnecessary uint64() cast in both places

strconv.ParseUint rejects negative inputs at parse time, so the invalid value never reaches the downstream storage call.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for region IDs and transaction start timestamps in TiKV HTTP requests.
  - Negative values are now rejected with a `400 Bad Request` response instead of being incorrectly converted and processed.
  - Valid decimal numeric values continue to be accepted consistently.

- **Tests**
  - Added coverage for rejecting negative identifiers and accepting valid values across region and MVCC transaction handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->