### PR TITLE
ci: pin bazel-contrib/setup-bazel@0.16.0 to a full commit SHA (match check-bazel-prepare.yml)

### DIFF
--- a/.github/actions/tidb_build/action.yml
+++ b/.github/actions/tidb_build/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Set up bazelisk
-      uses: bazel-contrib/setup-bazel@0.16.0
+      uses: bazel-contrib/setup-bazel@8310a45e30297e76bc8fbae427fb6068efa01eb8 # 0.16.0
       with:
         bazelisk-cache: true
         repository-cache: true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69948

Problem Summary:

The composite action `.github/actions/tidb_build/action.yml` (line 18) uses
`bazel-contrib/setup-bazel@0.16.0` — a mutable tag — and forwards the GCP service-account key into it
(`google-credentials: ${{ inputs.gcp_sa_key }}`, line 24), with the real secret supplied by
`bazel-build-crossbuild.yml` (`gcp_sa_key: ${{ secrets.GCP_SA_KEY }}`, line 31) on push-to-master.

The repository already SHA-pins this exact action, at this exact version, elsewhere —
`.github/workflows/check-bazel-prepare.yml` line 31 uses
`bazel-contrib/setup-bazel@8310a45e30297e76bc8fbae427fb6068efa01eb8 # 0.16.0`. The composite simply did
not get the same treatment, so the credential-forwarding path is the unpinned one.

### What changed and how does it work?

Pins the composite to the same commit `check-bazel-prepare.yml` already references, keeping `0.16.0`
visible as a trailing comment so both places agree:

```yaml
uses: bazel-contrib/setup-bazel@8310a45e30297e76bc8fbae427fb6068efa01eb8 # 0.16.0
```

It is the same version, so behaviour is unchanged; a tag can be repointed to a different commit without
anything changing here, whereas a full commit SHA cannot. Dependabot can bump the SHA as it would the tag.
This follows GitHub's
[hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > This PR changes one line of CI configuration (`.github/actions/tidb_build/action.yml`). No Go or
  > other source files are touched, and the pinned commit is the one the repository already uses for
  > this action at version 0.16.0, so the resolved action code is unchanged.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<sub>For transparency: I used AI assistance to help identify this and draft the change; I verified both
workflow files and the secret path against the current source myself and take responsibility for them.
I will sign the CLA.</sub>
