### PR TITLE
server: avoid requiring client certificate after TLS reload

### DIFF
--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -325,6 +325,15 @@ func TestTLSVerify(t *testing.T) {
 	// Success: when using a secure connection, the value of "require_secure_transport" can change to "ON"
 	err = cli.RunTestEnableSecureTransport(t, connOverrider)
 	require.NoError(t, err)
+	err = cli.RunReloadTLS(t, connOverrider, false)
+	require.NoError(t, err)
+
+	// A TLS connection without a client certificate should still succeed after
+	// enabling require_secure_transport and reloading the server TLS config.
+	err = cli.RunTestTLSConnection(t, func(config *mysql.Config) {
+		config.TLSConfig = "skip-verify"
+	})
+	require.NoError(t, err)
 
 	// This connection will now fail since the client is not configured to use TLS.
 	err = cli.RunTestTLSConnection(t, nil)

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -51,7 +51,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	tlsutil "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
@@ -409,8 +408,6 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 	cs := &atomic.Pointer[tls.Certificate]{}
 	cs.Store(&certs)
 
-	requireTLS := tlsutil.RequireSecureTransport.Load()
-
 	var minTLSVersion uint16 = tls.VersionTLS12
 	switch tlsver := config.GetGlobalConfig().Security.MinTLSVersion; tlsver {
 	case "TLSv1.2":
@@ -431,9 +428,6 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 
 	// Try loading CA cert.
 	clientAuthPolicy := tls.NoClientCert
-	if requireTLS {
-		clientAuthPolicy = tls.RequestClientCert
-	}
 	var certPool *x509.CertPool
 	if len(ca) > 0 {
 		var caCert []byte
@@ -445,11 +439,7 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 		}
 		certPool = x509.NewCertPool()
 		if certPool.AppendCertsFromPEM(caCert) {
-			if requireTLS {
-				clientAuthPolicy = tls.RequireAndVerifyClientCert
-			} else {
-				clientAuthPolicy = tls.VerifyClientCertIfGiven
-			}
+			clientAuthPolicy = tls.VerifyClientCertIfGiven
 		}
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69870

Problem Summary:

When `require_secure_transport` is enabled and `ssl-ca` is configured, reloading TLS changes the client authentication policy to `tls.RequireAndVerifyClientCert`. This incorrectly rejects encrypted connections that do not provide a client certificate.

### What changed and how does it work?

Keep client certificates optional at the TLS layer by using `tls.VerifyClientCertIfGiven`. `require_secure_transport` continues to reject plaintext connections, while account-level `REQUIRE X509` constraints remain responsible for requiring client certificates.

Add regression coverage that enables `require_secure_transport`, reloads TLS, verifies a TLS connection without a client certificate succeeds, and verifies a plaintext connection is rejected.

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where enabling `require_secure_transport` could unexpectedly require client certificates after TLS reload when `ssl-ca` was configured.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS configuration reload behavior so secure connections without client certificates continue to work when client certificates are optional.
  - Updated TLS certificate handling to apply consistent client-certificate verification behavior when a certificate authority is configured.
  - Added coverage for TLS connections after reloading the server’s TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->