### PR TITLE
ddl: do not fill TiKV block cache for reorg coprocessor scans

### DIFF
--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -404,6 +404,17 @@ func assertDistSQLCtxEqual(t *testing.T, expected *distsqlctx.DistSQLContext, ac
 	require.Equal(t, errctx.NewContextWithLevels(expected.ErrCtx.LevelMap(), expected.WarnHandler), actual.ErrCtx)
 }
 
+func TestReorgDistSQLCtxNotFillCache(t *testing.T) {
+	// Reorg coprocessor scans are single-pass bulk reads and must not pollute the TiKV
+	// block cache, so NotFillCache is always set on the reorg DistSQLContext.
+	ctx := newDefaultReorgDistSQLCtx(&mock.Client{}, contextutil.NewStaticWarnHandler(0))
+	require.True(t, ctx.NotFillCache)
+
+	withMeta, err := newReorgDistSQLCtxWithReorgMeta(&mock.Client{}, &model.DDLReorgMeta{}, contextutil.NewStaticWarnHandler(0))
+	require.NoError(t, err)
+	require.True(t, withMeta.NotFillCache)
+}
+
 func TestValidateAndFillRanges(t *testing.T) {
 	mkRange := func(start, end string) kv.KeyRange {
 		return kv.KeyRange{StartKey: []byte(start), EndKey: []byte(end)}

--- a/pkg/ddl/backfilling_txn_executor.go
+++ b/pkg/ddl/backfilling_txn_executor.go
@@ -154,8 +154,13 @@ func newDefaultReorgDistSQLCtx(kvClient kv.Client, warnHandler contextutil.WarnA
 	var execDetails execdetails.SyncExecDetails
 	var cpuUsages ppcpuusage.SQLCPUUsages
 	return &distsqlctx.DistSQLContext{
-		WarnHandler:                          warnHandler,
-		Client:                               kvClient,
+		WarnHandler: warnHandler,
+		Client:      kvClient,
+		// Reorg scans are single-pass bulk reads over the whole table/index range: the blocks
+		// they touch are never re-read by the reorg, so caching them brings no benefit and can
+		// evict the working set that concurrent foreground traffic relies on. Skip filling the
+		// block cache for all reorg coprocessor scans.
+		NotFillCache:                         true,
 		EnableChunkRPC:                       true,
 		EnabledRateLimitAction:               vardef.DefTiDBEnableRateLimitAction,
 		KVVars:                               tikvstore.NewVariables(&sqlKiller.Signal),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69875

Problem Summary:

Reorg coprocessor scans are single-pass bulk reads over the whole table/index
range. They are sent with `NotFillCache = false`, so every scanned block is
inserted into the TiKV block cache. Those blocks are never re-read by the reorg,
so caching them brings no benefit while risking eviction of the working set that
concurrent foreground traffic relies on — regressing foreground read
latency during an online `ADD INDEX` on a large table.

### What changed and how does it work?

Set `NotFillCache = true` on the shared reorg `DistSQLContext`
(`newDefaultReorgDistSQLCtx`). All reorg coprocessor scans are built from this
context (via `SetFromSessionVars`), so they now skip filling the block cache.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
Reduce TiKV block cache pollution during DDL reorg (e.g. `ADD INDEX`) by not filling the block cache for reorg coprocessor scans.
```
