### PR TITLE
session: reserve bootstrap versions for release-nextgen-202603

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/session-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/session-case-map.md
@@ -14,6 +14,7 @@
 - `pkg/session/main_test.go` - Configures default goleak settings and registers testdata.
 - `pkg/session/session_test.go` - session: Tests get start mode.
 - `pkg/session/tidb_test.go` - session: Tests do map handle nil.
+- `pkg/session/upgrade_backfill_test.go` - session: Tests bootstrap upgrade backfills.
 - `pkg/session/upgrade_test.go` - session: Tests upgrade to ver functions check.
 
 ## pkg/session/cursor

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(263), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(283), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4192,9 +4192,9 @@ func InitDDLTables(store kv.Storage) error {
 // initBootstrapDependentTables creates system tables that classic kernel upgrade
 // DDL may consult before the ordinary upgrade DDL reaches their creation step.
 func initBootstrapDependentTables(store kv.Storage, ver int64) error {
-	// This is only for classic upgrades from below version260. Fresh bootstrap and
-	// next-gen create the table elsewhere. After version260, the table may have been renamed.
-	if !kerneltype.IsClassic() || ver <= notBootstrapped || ver >= version260 || currentBootstrapVersion < version260 {
+	// This is only for classic upgrades from below version280. Fresh bootstrap and
+	// next-gen create the table elsewhere. After version280, the table may have been renamed.
+	if !kerneltype.IsClassic() || ver <= notBootstrapped || ver >= version280 || currentBootstrapVersion < version280 {
 		return nil
 	}
 

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1097,7 +1097,7 @@ ORDER BY index_name, seq_in_index`).Check(testkit.Rows(
 	))
 }
 
-func TestUpgradeVersion260MaskingPolicy(t *testing.T) {
+func TestUpgradeVersion280MaskingPolicy(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}

--- a/pkg/session/upgrade_backfill_test.go
+++ b/pkg/session/upgrade_backfill_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
+func TestUpgradeToVer279BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
@@ -38,18 +38,18 @@ func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 
-	ver258 := version258
-	seV258 := CreateSessionAndSetID(t, store)
+	ver278 := version278
+	seV278 := CreateSessionAndSetID(t, store)
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	err = m.FinishBootstrap(int64(ver258))
+	err = m.FinishBootstrap(int64(ver278))
 	require.NoError(t, err)
-	RevertVersionAndVariables(t, seV258, ver258)
+	RevertVersionAndVariables(t, seV278, ver278)
 
 	// Simulate a cluster upgraded through the old path where the variable existed in code
 	// but its row was never backfilled into mysql.global_variables.
-	MustExec(t, seV258, fmt.Sprintf(
+	MustExec(t, seV278, fmt.Sprintf(
 		"delete from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 		vardef.TiDBIgnoreInlistPlanDigest,
 	))
@@ -57,7 +57,7 @@ func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	require.NoError(t, err)
 	store.SetOption(StoreBootstrappedKey, nil)
 
-	res := MustExecToRecodeSet(t, seV258, fmt.Sprintf(
+	res := MustExecToRecodeSet(t, seV278, fmt.Sprintf(
 		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 		vardef.TiDBIgnoreInlistPlanDigest,
 	))
@@ -94,7 +94,7 @@ func TestUpgradeToVer259BackfillsIgnoreInlistPlanDigest(t *testing.T) {
 	require.NoError(t, res.Close())
 }
 
-func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
+func TestUpgradeToVer282RefreshesBindingDigest(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
@@ -115,9 +115,9 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start from bootstrap version 250 so the next bootstrap runs through the
-	// later upgrade chain, including upgradeToVer262.
+	// later upgrade chain, including upgradeToVer282.
 	// The test still executes on current code, so rows created below need their
-	// persisted digest fields rewritten to the pre-v262 algorithm explicitly.
+	// persisted digest fields rewritten to the pre-v282 algorithm explicitly.
 	ver, err := GetBootstrapVersion(seV250)
 	require.NoError(t, err)
 	require.Equal(t, int64(ver250), ver)
@@ -130,7 +130,7 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 	issueBindSQL := "select /*+ use_index(t_issue, idx_issue_b) */ * from t_issue where ((a = 1) and (b = 1))"
 	// These extra bindings only differ by redundant parentheses. Before the
 	// issue #67363 digest fix they have different sql_digest values, but after
-	// upgradeToVer262 refreshes the digest they collapse to the same binding key.
+	// upgradeToVer282 refreshes the digest they collapse to the same binding key.
 	// Their timestamps are older than the binding created through SQL above, so
 	// that row remains the deterministic winner and these rows become losers.
 	duplicateIssueBindings := []struct {
@@ -155,25 +155,25 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 	MustExec(t, seV250, "create global binding for select * from t_simple where a = 1 using "+simpleBindSQL)
 	MustExec(t, seV250, "create global binding for select * from t_issue where ((a = 1) and (b = 1)) using "+issueBindSQL)
 
-	issueDigestV262 := getEnabledBindingSQLDigest(t, seV250, "idx_issue_b")
-	issuePlanDigest := "issue-plan-digest-v262"
-	require.NotEmpty(t, issueDigestV262)
-	simpleOriginalPreV262, simpleDigestPreV262 := normalizeBindingDigestBeforeVer262(t, simpleBindSQL, "test")
-	issueOriginalPreV262, issueDigestPreV262 := normalizeBindingDigestBeforeVer262(t, issueBindSQL, "test")
-	// Simulate bindings that were persisted before version 262. The simple
+	issueDigestV282 := getEnabledBindingSQLDigest(t, seV250, "idx_issue_b")
+	issuePlanDigest := "issue-plan-digest-v282"
+	require.NotEmpty(t, issueDigestV282)
+	simpleOriginalPreV282, simpleDigestPreV282 := normalizeBindingDigestBeforeVer282(t, simpleBindSQL, "test")
+	issueOriginalPreV282, issueDigestPreV282 := normalizeBindingDigestBeforeVer282(t, issueBindSQL, "test")
+	// Simulate bindings that were persisted before version 282. The simple
 	// binding should normalize to the same digest after upgrade, while the issue
-	// binding should move from the old parenthesized digest to issueDigestV262.
-	MustExec(t, seV250, "update mysql.bind_info set original_sql = ?, sql_digest = ? where bind_sql like ?", simpleOriginalPreV262, simpleDigestPreV262, "%idx_simple_b%")
-	MustExec(t, seV250, "update mysql.bind_info set original_sql = ?, sql_digest = ?, plan_digest = ? where bind_sql like ?", issueOriginalPreV262, issueDigestPreV262, issuePlanDigest, "%idx_issue_b%")
-	oldIssueDigests := map[string]struct{}{issueDigestPreV262: {}}
+	// binding should move from the old parenthesized digest to issueDigestV282.
+	MustExec(t, seV250, "update mysql.bind_info set original_sql = ?, sql_digest = ? where bind_sql like ?", simpleOriginalPreV282, simpleDigestPreV282, "%idx_simple_b%")
+	MustExec(t, seV250, "update mysql.bind_info set original_sql = ?, sql_digest = ?, plan_digest = ? where bind_sql like ?", issueOriginalPreV282, issueDigestPreV282, issuePlanDigest, "%idx_issue_b%")
+	oldIssueDigests := map[string]struct{}{issueDigestPreV282: {}}
 	for _, duplicate := range duplicateIssueBindings {
 		duplicateDigest := insertBindingWithOldDigest(t, seV250, duplicate.bindSQL, duplicate.createTime, duplicate.updateTime, issuePlanDigest)
 		require.NotContains(t, oldIssueDigests, duplicateDigest)
 		oldIssueDigests[duplicateDigest] = struct{}{}
 	}
-	// Keep one unparsable row on the post-v262 digest pair. Even though it cannot
-	// be refreshed, upgradeToVer262 must clear its plan_digest; otherwise updating
-	// a valid row to issueDigestV262 could hit digest_index.
+	// Keep one unparsable row on the post-v282 digest pair. Even though it cannot
+	// be refreshed, upgradeToVer282 must clear its plan_digest; otherwise updating
+	// a valid row to issueDigestV282 could hit digest_index.
 	invalidBindSQL := "invalid binding"
 	MustExec(t, seV250, `insert into mysql.bind_info
 		(original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest)
@@ -187,15 +187,15 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 		"",
 		"",
 		"manual",
-		issueDigestV262,
+		issueDigestV282,
 		issuePlanDigest,
 	)
 
 	simpleDigestBefore := getBindingSQLDigest(t, seV250, "idx_simple_b")
-	issueDigestBefore := issueDigestPreV262
+	issueDigestBefore := issueDigestPreV282
 
 	// Reboot the store into the current bootstrap version. This is the point
-	// where upgradeToVer262 scans mysql.bind_info and refreshes binding digests.
+	// where upgradeToVer282 scans mysql.bind_info and refreshes binding digests.
 	store.SetOption(StoreBootstrappedKey, nil)
 	seV250.Close()
 	dom.Close()
@@ -223,7 +223,7 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 	for _, duplicate := range duplicateIssueBindings {
 		requireBindingDeletedAndDigestPairCleared(t, seCurVer, duplicate.bindSQL)
 	}
-	requireBindingPlanDigestCleared(t, seCurVer, invalidBindSQL, issueDigestV262)
+	requireBindingPlanDigestCleared(t, seCurVer, invalidBindSQL, issueDigestV282)
 
 	// The deleted duplicates should not matter to query behavior. Every
 	// parenthesis variant now normalizes to the enabled winner and can still take
@@ -244,7 +244,7 @@ func TestUpgradeToVer262RefreshesBindingDigest(t *testing.T) {
 	}
 }
 
-func TestUpgradeToVer261BackfillsDefaultStringMatchSelectivity(t *testing.T) {
+func TestUpgradeToVer281BackfillsDefaultStringMatchSelectivity(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
@@ -253,18 +253,18 @@ func TestUpgradeToVer261BackfillsDefaultStringMatchSelectivity(t *testing.T) {
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 
-	ver260 := version260
-	seV260 := CreateSessionAndSetID(t, store)
+	ver280 := version280
+	seV280 := CreateSessionAndSetID(t, store)
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	err = m.FinishBootstrap(int64(ver260))
+	err = m.FinishBootstrap(int64(ver280))
 	require.NoError(t, err)
-	RevertVersionAndVariables(t, seV260, ver260)
+	RevertVersionAndVariables(t, seV280, ver280)
 
 	// Simulate a cluster upgraded through the old path where the variable existed in code
 	// but its row was never backfilled into mysql.global_variables.
-	MustExec(t, seV260, fmt.Sprintf(
+	MustExec(t, seV280, fmt.Sprintf(
 		"delete from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 		vardef.TiDBDefaultStrMatchSelectivity,
 	))
@@ -272,7 +272,7 @@ func TestUpgradeToVer261BackfillsDefaultStringMatchSelectivity(t *testing.T) {
 	require.NoError(t, err)
 	store.SetOption(StoreBootstrappedKey, nil)
 
-	res := MustExecToRecodeSet(t, seV260, fmt.Sprintf(
+	res := MustExecToRecodeSet(t, seV280, fmt.Sprintf(
 		"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 		vardef.TiDBDefaultStrMatchSelectivity,
 	))
@@ -309,7 +309,7 @@ func TestUpgradeToVer261BackfillsDefaultStringMatchSelectivity(t *testing.T) {
 	require.NoError(t, res.Close())
 }
 
-func TestUpgradeToVer263BackfillsAnalyzeDefaultOptions(t *testing.T) {
+func TestUpgradeToVer283BackfillsAnalyzeDefaultOptions(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
@@ -326,17 +326,17 @@ func TestUpgradeToVer263BackfillsAnalyzeDefaultOptions(t *testing.T) {
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 
-	ver262 := version262
-	seV262 := CreateSessionAndSetID(t, store)
+	ver282 := version282
+	seV282 := CreateSessionAndSetID(t, store)
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	err = m.FinishBootstrap(int64(ver262))
+	err = m.FinishBootstrap(int64(ver282))
 	require.NoError(t, err)
-	RevertVersionAndVariables(t, seV262, ver262)
+	RevertVersionAndVariables(t, seV282, ver282)
 
 	for _, variable := range analyzeDefaults {
-		MustExec(t, seV262, fmt.Sprintf(
+		MustExec(t, seV282, fmt.Sprintf(
 			"delete from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 			variable.name,
 		))
@@ -346,7 +346,7 @@ func TestUpgradeToVer263BackfillsAnalyzeDefaultOptions(t *testing.T) {
 	store.SetOption(StoreBootstrappedKey, nil)
 
 	for _, variable := range analyzeDefaults {
-		res := MustExecToRecodeSet(t, seV262, fmt.Sprintf(
+		res := MustExecToRecodeSet(t, seV282, fmt.Sprintf(
 			"select * from mysql.GLOBAL_VARIABLES where variable_name='%s'",
 			variable.name,
 		))
@@ -387,7 +387,7 @@ func TestUpgradeToVer263BackfillsAnalyzeDefaultOptions(t *testing.T) {
 }
 
 func insertBindingWithOldDigest(t *testing.T, se sessionapi.Session, bindSQL, createTime, updateTime, planDigest string) string {
-	originalSQL, sqlDigest := normalizeBindingDigestBeforeVer262(t, bindSQL, "test")
+	originalSQL, sqlDigest := normalizeBindingDigestBeforeVer282(t, bindSQL, "test")
 	MustExec(t, se, `insert into mysql.bind_info
 		(original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest)
 		values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -406,7 +406,7 @@ func insertBindingWithOldDigest(t *testing.T, se sessionapi.Session, bindSQL, cr
 	return sqlDigest
 }
 
-func normalizeBindingDigestBeforeVer262(t *testing.T, sql, defaultDB string) (string, string) {
+func normalizeBindingDigestBeforeVer282(t *testing.T, sql, defaultDB string) (string, string) {
 	stmt, err := parser.New().ParseOneStmt(sql, "", "")
 	require.NoError(t, err)
 

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -485,36 +485,40 @@ const (
 	// version256 introduces tidb_plan_cache_skip_stats_on_binding.
 	version256 = 256
 
-	// version257
-	// Add tidb_enable_no_backslash_escapes_in_like global variable.
-	version257 = 257
+	// ...
+	// [version257, version276] is the version range reserved for release-nextgen-202603.
+	// ...
 
-	// version258
+	// version277
+	// Add tidb_enable_no_backslash_escapes_in_like global variable.
+	version277 = 277
+
+	// version278
 	// Add the default value management for `tidb_analyze_distsql_scan_concurrency`.
 	// If the cluster is upgraded from a version that has no such variable, we set it to the global.tidb_distsql_scan_concurrency value.
-	version258 = 258
+	version278 = 278
 
-	// version259
+	// version279
 	// Backfill tidb_ignore_inlist_plan_digest for upgraded clusters where the row in
 	// mysql.global_variables was never materialized when the variable was introduced.
 	// Use the current sysvar default when the row is missing.
-	version259 = 259
+	version279 = 279
 
 	// Add mysql.tidb_masking_policy table.
-	version260 = 260
+	version280 = 280
 
-	// version261
+	// version281
 	// Backfill tidb_default_string_match_selectivity for upgraded clusters where the row in
 	// mysql.global_variables was never materialized when the variable was introduced.
-	version261 = 261
+	version281 = 281
 
-	// version262 refreshes mysql.bind_info SQL digests after binding
+	// version282 refreshes mysql.bind_info SQL digests after binding
 	// normalization starts skipping redundant parentheses for
 	// https://github.com/pingcap/tidb/issues/67363.
-	version262 = 262
+	version282 = 282
 
-	// version263 backfills analyze default bucket and TopN global variables.
-	version263 = 263
+	// version283 backfills analyze default bucket and TopN global variables.
+	version283 = 283
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -528,7 +532,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version263
+var currentBootstrapVersion int64 = version283
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -709,13 +713,13 @@ var (
 		{version: version254, fn: upgradeToVer254},
 		{version: version255, fn: upgradeToVer255},
 		{version: version256, fn: upgradeToVer256},
-		{version: version257, fn: upgradeToVer257},
-		{version: version258, fn: upgradeToVer258},
-		{version: version259, fn: upgradeToVer259},
-		{version: version260, fn: upgradeToVer260},
-		{version: version261, fn: upgradeToVer261},
-		{version: version262, fn: upgradeToVer262},
-		{version: version263, fn: upgradeToVer263},
+		{version: version277, fn: upgradeToVer277},
+		{version: version278, fn: upgradeToVer278},
+		{version: version279, fn: upgradeToVer279},
+		{version: version280, fn: upgradeToVer280},
+		{version: version281, fn: upgradeToVer281},
+		{version: version282, fn: upgradeToVer282},
+		{version: version283, fn: upgradeToVer283},
 	}
 )
 
@@ -2122,12 +2126,12 @@ func upgradeToVer256(s sessionapi.Session, _ int64) {
 	initGlobalVariableIfNotExists(s, vardef.TiDBPlanCacheSkipStatsOnBinding, vardef.On)
 }
 
-func upgradeToVer257(s sessionapi.Session, _ int64) {
+func upgradeToVer277(s sessionapi.Session, _ int64) {
 	// Keep old behavior for upgraded clusters.
 	initGlobalVariableIfNotExists(s, vardef.TiDBEnableNoBackslashEscapesInLike, vardef.Off)
 }
 
-func upgradeToVer258(s sessionapi.Session, _ int64) {
+func upgradeToVer278(s sessionapi.Session, _ int64) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	rows, err := sqlexec.ExecSQL(ctx, s, "SELECT VARIABLE_VALUE FROM %n.%n WHERE VARIABLE_NAME=%?;", mysql.SystemDB, mysql.GlobalVariablesTable, vardef.TiDBDistSQLScanConcurrency)
 	terror.MustNil(err)
@@ -2137,15 +2141,15 @@ func upgradeToVer258(s sessionapi.Session, _ int64) {
 	initGlobalVariableIfNotExists(s, vardef.TiDBAnalyzeDistSQLScanConcurrency, rows[0].GetString(0))
 }
 
-func upgradeToVer259(s sessionapi.Session, _ int64) {
+func upgradeToVer279(s sessionapi.Session, _ int64) {
 	initGlobalVariableIfNotExists(s, vardef.TiDBIgnoreInlistPlanDigest, vardef.Off)
 }
 
-func upgradeToVer260(s sessionapi.Session, _ int64) {
+func upgradeToVer280(s sessionapi.Session, _ int64) {
 	mustExecute(s, metadef.CreateTiDBMaskingPolicyTable)
 }
 
-func upgradeToVer261(s sessionapi.Session, _ int64) {
+func upgradeToVer281(s sessionapi.Session, _ int64) {
 	// the prior default behavior is "0.8", keep it for compatibility for old clusters.
 	initGlobalVariableIfNotExists(s, vardef.TiDBDefaultStrMatchSelectivity, "0.8")
 }
@@ -2162,7 +2166,7 @@ type bindingDigestPair struct {
 	planDigest string
 }
 
-func upgradeToVer262(s sessionapi.Session, _ int64) {
+func upgradeToVer282(s sessionapi.Session, _ int64) {
 	// Refresh persisted binding digests after the #67363 normalization change.
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	// Duplicate detection keeps the first row scanned for each target digest
@@ -2172,7 +2176,7 @@ func upgradeToVer262(s sessionapi.Session, _ int64) {
 		WHERE source != 'builtin'
 		ORDER BY update_time DESC, create_time DESC, _tidb_rowid DESC`)
 	if err != nil {
-		logutil.BgLogger().Fatal("upgradeToVer262 error", zap.Error(err))
+		logutil.BgLogger().Fatal("upgradeToVer282 error", zap.Error(err))
 	}
 
 	req := rs.NewChunk(nil)
@@ -2183,7 +2187,7 @@ func upgradeToVer262(s sessionapi.Session, _ int64) {
 	for {
 		err = rs.Next(ctx, req)
 		if err != nil {
-			logutil.BgLogger().Fatal("upgradeToVer262 error", zap.Error(err))
+			logutil.BgLogger().Fatal("upgradeToVer282 error", zap.Error(err))
 		}
 		if req.NumRows() == 0 {
 			break
@@ -2238,7 +2242,7 @@ func upgradeToVer262(s sessionapi.Session, _ int64) {
 		req.Reset()
 	}
 	if closeErr := rs.Close(); closeErr != nil {
-		logutil.BgLogger().Fatal("upgradeToVer262 error", zap.Error(closeErr))
+		logutil.BgLogger().Fatal("upgradeToVer282 error", zap.Error(closeErr))
 	}
 
 	// Update rows independently to avoid one large bootstrap transaction.
@@ -2264,7 +2268,7 @@ func upgradeToVer262(s sessionapi.Session, _ int64) {
 	}
 }
 
-func upgradeToVer263(s sessionapi.Session, _ int64) {
+func upgradeToVer283(s sessionapi.Session, _ int64) {
 	// Fresh clusters materialize these rows during bootstrap, but upgraded clusters can miss them.
 	// Backfill only absent rows so @@global reads use defaults while preserving user-set values.
 	initGlobalVariableIfNotExists(s, vardef.TiDBAnalyzeDefaultNumBuckets, vardef.DefTiDBAnalyzeDefaultNumBuckets)

--- a/pkg/session/upgrade_test.go
+++ b/pkg/session/upgrade_test.go
@@ -51,13 +51,19 @@ func getFunctionName(f func(sessionapi.Session, int64)) (string, error) {
 
 func TestUpgradeToVerFunctionsCheck(t *testing.T) {
 	var lastVer int64
+	var firstVersionAfterReleaseNextGen202603 int64
 	for _, verFn := range upgradeToVerFunctions {
 		require.Greater(t, verFn.version, lastVer, "upgradeToVerFunctions should be in ascending order")
 		lastVer = verFn.version
+		if firstVersionAfterReleaseNextGen202603 == 0 && verFn.version > version256 {
+			firstVersionAfterReleaseNextGen202603 = verFn.version
+		}
 		require.NotNil(t, verFn.fn, "upgradeToVerFunctions should not have nil function")
 		name, err := getFunctionName(verFn.fn)
 		require.NoError(t, err, "getFunctionName should not return an error")
 		require.Regexp(t, fmt.Sprintf(`^upgradeToVer%d$`, verFn.version), name, "function name should match upgradeToVer pattern")
 	}
+	require.Equal(t, int64(277), firstVersionAfterReleaseNextGen202603,
+		"versions 257 through 276 should be reserved for release-nextgen-202603")
 	require.Equal(t, currentBootstrapVersion, lastVer, "last version in upgradeToVerFunctions should match currentBootstrapVersion")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69885

Problem Summary:

`release-nextgen-202603` currently ends at bootstrap version 256, while `master` already uses versions 257 through 263 for different upgrade steps. A future release-branch patch upgrade could reuse one of those IDs and cause a required master upgrade to be skipped when the cluster later moves off the release branch.

### What changed and how does it work?

- Reserve bootstrap versions 257 through 276 for `release-nextgen-202603`.
- Renumber the existing master-only upgrades from 257-263 to 277-283, including version-sensitive guards and tests. **since those versions are only exists in master, no release contains them, so there shouldn't be any compatibility issue**
- Add an invariant requiring the first master upgrade after version 256 to be version 277.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
./tools/check/failpoint-go-test.sh pkg/session -run '^TestUpgradeToVer(FunctionsCheck|279BackfillsIgnoreInlistPlanDigest|281BackfillsDefaultStringMatchSelectivity|282RefreshesBindingDigest|283BackfillsAnalyzeDefaultOptions)$' -count=1
./tools/check/failpoint-go-test.sh pkg/session/test/bootstraptest -run '^TestUpgradeVersion280MaskingPolicy$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reserve bootstrap version IDs for release-nextgen-202603 to prevent later upgrades from skipping master bootstrap steps.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended bootstrap upgrade support through version **283** (including reserved intermediate version handling).
  * Added/updated upgrade-time backfills for newer configuration defaults.
  * Ensures masking-policy system tables are created appropriately during classic upgrade paths.

* **Bug Fixes**
  * Refreshes persisted binding digests to match updated SQL normalization and prevents digest/plan conflicts during upgrade.

* **Tests**
  * Expanded and renumbered upgrade/backfill tests for the newer bootstrap versions.
  * Updated system table restore expectations to reflect the newer bootstrap version baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->