### PR TITLE
server: add logging for profiling requests

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/server-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/server-case-map.md
@@ -38,7 +38,7 @@
 
 ### Tests
 - `pkg/server/handler/tests/dxf_test.go` - server/handler: Tests DXF API.
-- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests post settings.
+- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests settings and debug route logging.
 - `pkg/server/handler/tests/http_handler_test.go` - server/handler: Tests region index range.
 - `pkg/server/handler/tests/main_test.go` - Configures default goleak settings and registers testdata.
 

--- a/.agents/skills/tidb-test-guidelines/references/server-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/server-case-map.md
@@ -38,8 +38,8 @@
 
 ### Tests
 - `pkg/server/handler/tests/dxf_test.go` - server/handler: Tests DXF API.
-- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests settings and pprof route logging.
-- `pkg/server/handler/tests/http_handler_test.go` - server/handler: Tests HTTP handlers, including debug zip logging.
+- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests serial HTTP handlers, including pprof request logging.
+- `pkg/server/handler/tests/http_handler_test.go` - server/handler: Tests HTTP handlers, including `/debug/zip` request logging.
 - `pkg/server/handler/tests/main_test.go` - Configures default goleak settings and registers testdata.
 
 ## pkg/server/handler/tikvhandler

--- a/.agents/skills/tidb-test-guidelines/references/server-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/server-case-map.md
@@ -38,8 +38,8 @@
 
 ### Tests
 - `pkg/server/handler/tests/dxf_test.go` - server/handler: Tests DXF API.
-- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests settings and debug route logging.
-- `pkg/server/handler/tests/http_handler_test.go` - server/handler: Tests region index range.
+- `pkg/server/handler/tests/http_handler_serial_test.go` - server/handler: Tests settings and pprof route logging.
+- `pkg/server/handler/tests/http_handler_test.go` - server/handler: Tests HTTP handlers, including debug zip logging.
 - `pkg/server/handler/tests/main_test.go` - Configures default goleak settings and registers testdata.
 
 ## pkg/server/handler/tikvhandler

--- a/.agents/skills/tidb-test-guidelines/references/util-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/util-case-map.md
@@ -397,7 +397,7 @@
 ### Tests
 - `pkg/util/profile/flamegraph_test.go` - util/profile: Tests profile to datum.
 - `pkg/util/profile/main_test.go` - Configures default goleak settings and registers testdata.
-- `pkg/util/profile/profile_test.go` - util/profile: Tests profiles.
+- `pkg/util/profile/profile_test.go` - util/profile: Tests profile tables and profiling logs.
 
 ### Testdata
 - `pkg/util/profile/testdata/test.pprof`

--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 26,
+    shard_count = 25,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/infoschema/perfschema/BUILD.bazel
+++ b/pkg/infoschema/perfschema/BUILD.bazel
@@ -27,11 +27,13 @@ go_library(
         "//pkg/table/tables",
         "//pkg/types",
         "//pkg/util",
+        "//pkg/util/logutil",
         "//pkg/util/profile",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_tikv_pd_client//http",
+        "@org_uber_go_zap//:zap",
     ],
 )
 

--- a/pkg/infoschema/perfschema/tables.go
+++ b/pkg/infoschema/perfschema/tables.go
@@ -37,8 +37,10 @@ import (
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/profile"
 	pd "github.com/tikv/pd/client/http"
+	"go.uber.org/zap"
 )
 
 const (
@@ -237,19 +239,40 @@ func initTableIndices(t *perfSchemaTable) error {
 	return nil
 }
 
+func logTiDBProfileRequest(sctx sessionctx.Context, tableName string) {
+	vars := sctx.GetSessionVars()
+	fields := []zap.Field{
+		zap.String("table", "performance_schema."+tableName),
+		zap.Uint64("conn", vars.ConnectionID),
+	}
+	if vars.User != nil {
+		fields = append(fields, zap.String("user", vars.User.LoginString()))
+	}
+	if vars.ConnectionInfo != nil {
+		fields = append(fields, zap.String("client-ip", vars.ConnectionInfo.ClientIP))
+	}
+	logutil.BgLogger().Info("profiling request received", fields...)
+}
+
 func (vt *perfSchemaTable) getRows(ctx context.Context, sctx sessionctx.Context, cols []*table.Column) (fullRows [][]types.Datum, err error) {
 	switch vt.meta.Name.O {
 	case tableNameTiDBProfileCPU:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileCPU)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("cpu")
 	case tableNameTiDBProfileMemory:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileMemory)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("heap")
 	case tableNameTiDBProfileMutex:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileMutex)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("mutex")
 	case tableNameTiDBProfileAllocs:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileAllocs)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("allocs")
 	case tableNameTiDBProfileBlock:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileBlock)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("block")
 	case tableNameTiDBProfileGoroutines:
+		logTiDBProfileRequest(sctx, tableNameTiDBProfileGoroutines)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("goroutine")
 	case tableNameTiKVProfileCPU:
 		interval := fmt.Sprintf("%d", profile.CPUProfileInterval/time.Second)

--- a/pkg/server/handler/tests/BUILD.bazel
+++ b/pkg/server/handler/tests/BUILD.bazel
@@ -78,5 +78,6 @@ go_test(
         "@io_etcd_go_etcd_tests_v3//integration",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/client/clients/gc"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func dummyRecord() *deadlockhistory.DeadlockRecord {
@@ -444,6 +445,12 @@ func TestDebugRoutes(t *testing.T) {
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
+	core, recorded := observer.New(zap.InfoLevel)
+	restore := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{
+		Core:  core,
+		Level: zap.NewAtomicLevelAt(zap.InfoLevel),
+	})
+	defer restore()
 
 	debugRoutes := []string{
 		"/debug/pprof/",
@@ -462,11 +469,28 @@ func TestDebugRoutes(t *testing.T) {
 		// "/debug/zip", // this creates unexpected goroutines which will make goleak complain, so we skip it for now
 		"/debug/ballast-object-sz",
 	}
+	expectedPProfLogs := 0
 	for _, route := range debugRoutes {
+		if strings.HasPrefix(route, "/debug/pprof/") {
+			expectedPProfLogs++
+		}
 		resp, err := ts.FetchStatus(route)
 		require.NoError(t, err, fmt.Sprintf("GET route %s failed", route))
 		require.Equal(t, http.StatusOK, resp.StatusCode, fmt.Sprintf("GET route %s failed", route))
 		require.NoError(t, resp.Body.Close())
+	}
+
+	pprofLogs := recorded.FilterMessage("pprof request received")
+	require.Len(t, pprofLogs.All(), expectedPProfLogs)
+	require.Len(t, pprofLogs.FilterField(zap.String("path", "/debug/pprof/goroutine")).
+		FilterField(zap.String("debug", "2")).All(), 1)
+	require.Len(t, pprofLogs.FilterField(zap.String("path", "/debug/pprof/profile")).
+		FilterField(zap.String("seconds", "5")).All(), 1)
+	for _, entry := range pprofLogs.All() {
+		fields := entry.ContextMap()
+		require.Equal(t, http.MethodGet, fields["method"])
+		require.NotEmpty(t, fields["path"])
+		require.NotEmpty(t, fields["remote-addr"])
 	}
 }
 

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -469,10 +469,10 @@ func TestDebugRoutes(t *testing.T) {
 		// "/debug/zip", // this creates unexpected goroutines which will make goleak complain, so we skip it for now
 		"/debug/ballast-object-sz",
 	}
-	expectedPProfLogs := 0
+	expectedProfilingLogs := 0
 	for _, route := range debugRoutes {
 		if strings.HasPrefix(route, "/debug/pprof/") {
-			expectedPProfLogs++
+			expectedProfilingLogs++
 		}
 		resp, err := ts.FetchStatus(route)
 		require.NoError(t, err, fmt.Sprintf("GET route %s failed", route))
@@ -480,13 +480,13 @@ func TestDebugRoutes(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 	}
 
-	pprofLogs := recorded.FilterMessage("pprof request received")
-	require.Len(t, pprofLogs.All(), expectedPProfLogs)
-	require.Len(t, pprofLogs.FilterField(zap.String("path", "/debug/pprof/goroutine")).
+	profilingLogs := recorded.FilterMessage("profiling request received")
+	require.Len(t, profilingLogs.All(), expectedProfilingLogs)
+	require.Len(t, profilingLogs.FilterField(zap.String("path", "/debug/pprof/goroutine")).
 		FilterField(zap.String("debug", "2")).All(), 1)
-	require.Len(t, pprofLogs.FilterField(zap.String("path", "/debug/pprof/profile")).
+	require.Len(t, profilingLogs.FilterField(zap.String("path", "/debug/pprof/profile")).
 		FilterField(zap.String("seconds", "5")).All(), 1)
-	for _, entry := range pprofLogs.All() {
+	for _, entry := range profilingLogs.All() {
 		fields := entry.ContextMap()
 		require.Equal(t, http.MethodGet, fields["method"])
 		require.NotEmpty(t, fields["path"])

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -85,6 +85,7 @@ import (
 	"github.com/tikv/client-go/v2/tikv"
 	"go.etcd.io/etcd/tests/v3/integration"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type basicHTTPHandlerTestSuite struct {
@@ -1245,6 +1246,13 @@ func TestDebugZip(t *testing.T) {
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
+	core, recorded := observer.New(zap.InfoLevel)
+	restore := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{
+		Core:  core,
+		Level: zap.NewAtomicLevelAt(zap.InfoLevel),
+	})
+	defer restore()
+
 	resp, err := ts.FetchStatus("/debug/zip?seconds=1")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1252,6 +1260,14 @@ func TestDebugZip(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(b), 0)
 	require.NoError(t, resp.Body.Close())
+
+	profilingLogs := recorded.FilterMessage("profiling request received").
+		FilterField(zap.String("path", "/debug/zip")).
+		FilterField(zap.String("seconds", "1"))
+	require.Len(t, profilingLogs.All(), 1)
+	fields := profilingLogs.All()[0].ContextMap()
+	require.Equal(t, http.MethodGet, fields["method"])
+	require.NotEmpty(t, fields["remote-addr"])
 }
 
 func TestCheckCN(t *testing.T) {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -214,6 +214,24 @@ func (b *Ballast) GenHTTPHandler() func(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+func withPProfRequestLog(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fields := []zap.Field{
+			zap.String("method", r.Method),
+			zap.String("path", r.URL.Path),
+			zap.String("remote-addr", r.RemoteAddr),
+		}
+		query := r.URL.Query()
+		for _, key := range []string{"seconds", "debug", "gc"} {
+			if value := query.Get(key); value != "" {
+				fields = append(fields, zap.String(key, value))
+			}
+		}
+		logutil.BgLogger().Info("pprof request received", fields...)
+		next(w, r)
+	}
+}
+
 func (s *Server) startHTTPServer() {
 	router := mux.NewRouter()
 
@@ -343,12 +361,12 @@ func (s *Server) startHTTPServer() {
 		router.PathPrefix(path).Handler(handler)
 	}
 
-	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	router.HandleFunc("/debug/pprof/profile", cpuprofile.ProfileHTTPHandler)
-	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	router.HandleFunc("/debug/pprof/cmdline", withPProfRequestLog(pprof.Cmdline))
+	router.HandleFunc("/debug/pprof/profile", withPProfRequestLog(cpuprofile.ProfileHTTPHandler))
+	router.HandleFunc("/debug/pprof/symbol", withPProfRequestLog(pprof.Symbol))
+	router.HandleFunc("/debug/pprof/trace", withPProfRequestLog(pprof.Trace))
 	// Other /debug/pprof paths not covered above are redirected to pprof.Index.
-	router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
+	router.PathPrefix("/debug/pprof/").HandlerFunc(withPProfRequestLog(pprof.Index))
 	router.HandleFunc("/debug/traceevent", traceeventHandler)
 
 	router.HandleFunc("/covdata", func(writer http.ResponseWriter, _ *http.Request) {

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -214,7 +214,7 @@ func (b *Ballast) GenHTTPHandler() func(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func withPProfRequestLog(next http.HandlerFunc) http.HandlerFunc {
+func withProfilingRequestLog(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		fields := []zap.Field{
 			zap.String("method", r.Method),
@@ -227,7 +227,7 @@ func withPProfRequestLog(next http.HandlerFunc) http.HandlerFunc {
 				fields = append(fields, zap.String(key, value))
 			}
 		}
-		logutil.BgLogger().Info("pprof request received", fields...)
+		logutil.BgLogger().Info("profiling request received", fields...)
 		next(w, r)
 	}
 }
@@ -361,12 +361,12 @@ func (s *Server) startHTTPServer() {
 		router.PathPrefix(path).Handler(handler)
 	}
 
-	router.HandleFunc("/debug/pprof/cmdline", withPProfRequestLog(pprof.Cmdline))
-	router.HandleFunc("/debug/pprof/profile", withPProfRequestLog(cpuprofile.ProfileHTTPHandler))
-	router.HandleFunc("/debug/pprof/symbol", withPProfRequestLog(pprof.Symbol))
-	router.HandleFunc("/debug/pprof/trace", withPProfRequestLog(pprof.Trace))
+	router.HandleFunc("/debug/pprof/cmdline", withProfilingRequestLog(pprof.Cmdline))
+	router.HandleFunc("/debug/pprof/profile", withProfilingRequestLog(cpuprofile.ProfileHTTPHandler))
+	router.HandleFunc("/debug/pprof/symbol", withProfilingRequestLog(pprof.Symbol))
+	router.HandleFunc("/debug/pprof/trace", withProfilingRequestLog(pprof.Trace))
 	// Other /debug/pprof paths not covered above are redirected to pprof.Index.
-	router.PathPrefix("/debug/pprof/").HandlerFunc(withPProfRequestLog(pprof.Index))
+	router.PathPrefix("/debug/pprof/").HandlerFunc(withProfilingRequestLog(pprof.Index))
 	router.HandleFunc("/debug/traceevent", traceeventHandler)
 
 	router.HandleFunc("/covdata", func(writer http.ResponseWriter, _ *http.Request) {
@@ -461,7 +461,7 @@ func (s *Server) startHTTPServer() {
 		}
 	})
 
-	router.HandleFunc("/debug/zip", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/debug/zip", withProfilingRequestLog(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Disposition", `attachment; filename="tidb_debug"`+time.Now().Format("20060102150405")+".zip")
 
 		// dump goroutine/heap/mutex
@@ -543,7 +543,7 @@ func (s *Server) startHTTPServer() {
 
 		err = zw.Close()
 		terror.Log(err)
-	})
+	}))
 
 	// failpoint is enabled only for tests so we can add some http APIs here for tests.
 	failpoint.Inject("enableTestAPI", func() {

--- a/pkg/util/profile/BUILD.bazel
+++ b/pkg/util/profile/BUILD.bazel
@@ -37,9 +37,13 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/types",
         "//pkg/util/collate",
+        "//pkg/util/cpuprofile",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_opencensus_go//stats/view",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/util/profile/profile_test.go
+++ b/pkg/util/profile/profile_test.go
@@ -18,14 +18,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/cpuprofile"
 	"github.com/pingcap/tidb/pkg/util/profile"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestProfiles(t *testing.T) {
@@ -51,12 +55,28 @@ func TestProfiles(t *testing.T) {
 	defer func() {
 		profile.CPUProfileInterval = oldValue
 	}()
+	require.NoError(t, cpuprofile.StartCPUProfiler())
+	defer cpuprofile.StopCPUProfiler()
 
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("select * from performance_schema.tidb_profile_cpu")
-	tk.MustExec("select * from performance_schema.tidb_profile_memory")
-	tk.MustExec("select * from performance_schema.tidb_profile_allocs")
-	tk.MustExec("select * from performance_schema.tidb_profile_mutex")
-	tk.MustExec("select * from performance_schema.tidb_profile_block")
-	tk.MustExec("select * from performance_schema.tidb_profile_goroutines")
+	core, recorded := observer.New(zap.InfoLevel)
+	restore := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{
+		Core:  core,
+		Level: zap.NewAtomicLevelAt(zap.InfoLevel),
+	})
+	defer restore()
+
+	profileTables := []string{
+		"tidb_profile_cpu",
+		"tidb_profile_memory",
+		"tidb_profile_allocs",
+		"tidb_profile_mutex",
+		"tidb_profile_block",
+		"tidb_profile_goroutines",
+	}
+	for _, tableName := range profileTables {
+		tk.MustQuery("select * from performance_schema." + tableName)
+		require.Len(t, recorded.FilterMessage("profiling request received").
+			FilterField(zap.String("table", "performance_schema."+tableName)).All(), 1)
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69896

Problem Summary:
See https://github.com/pingcap/tidb/issues/69896

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```

[2026/07/17 10:46:34.892 +08:00] [INFO] [http_status.go:230] ["profiling request received"] [method=GET] [path=/debug/pprof/mutex] [remote-addr=127.0.0.1:53315] [debug=1]
[2026/07/17 10:46:34.892 +08:00] [INFO] [http_status.go:230] ["profiling request received"] [method=GET] [path=/debug/pprof/profile] [remote-addr=127.0.0.1:53314] [seconds=30]
[2026/07/17 10:46:34.892 +08:00] [INFO] [http_status.go:230] ["profiling request received"] [method=GET] [path=/debug/pprof/heap] [remote-addr=127.0.0.1:53311]
[2026/07/17 10:46:34.892 +08:00] [INFO] [http_status.go:230] ["profiling request received"] [method=GET] [path=/debug/pprof/goroutine] [remote-addr=127.0.0.1:53312] [debug=1]

[2026/07/20 11:53:09.809 +08:00] [INFO] [http_status.go:230] ["profiling request received"] [method=GET] [path=/debug/zip] [remote-addr=127.0.0.1:63746] [seconds=1]

[2026/07/20 11:48:56.409 +08:00] [INFO] [tables.go:254] ["profiling request received"] [table=performance_schema.tidb_profile_goroutines] [conn=2631925766] [user=root@127.0.0.1] [client-ip=127.0.0.1]
[2026/07/20 11:50:03.338 +08:00] [INFO] [tables.go:254] ["profiling request received"] [table=performance_schema.tidb_profile_cpu] [conn=2631925766] [user=root@127.0.0.1] [client-ip=127.0.0.1]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured profiling request logging for `/debug/pprof/` routes, capturing method, path, remote address, and (when present) query parameters like `seconds`, `debug`, and `gc`.
  * Extended the same profiling request logging to `/debug/zip`.
  * Added structured “profiling request received” logging for TiDB performance schema profiling tables.
* **Tests**
  * Updated debug, zip, and profiling-table tests to assert the expected profiling request log entries (including key fields and counts) alongside existing HTTP/table behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->