### PR TITLE
dxf: batch cleanup for IMPORT INTO tasks

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -68,7 +68,7 @@
 - `pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go` - dxf/framework/scheduler: Tests manager scheduler ordering and batched cleanup dispatch.
 - `pkg/dxf/framework/scheduler/scheduler_manager_test.go` - dxf/framework/scheduler: Tests cleanup routine and bounded cleanup-batch draining.
 - `pkg/dxf/framework/scheduler/scheduler_nokit_test.go` - dxf/framework/scheduler: Tests scheduler on next stage.
-- `pkg/dxf/framework/scheduler/scheduler_test.go` - dxf/framework/scheduler: Tests task fail in manager and exported batch-cleanup capability conformance.
+- `pkg/dxf/framework/scheduler/scheduler_test.go` - dxf/framework/scheduler: Tests task fail in manager.
 - `pkg/dxf/framework/scheduler/slots_test.go` - dxf/framework/scheduler: Tests slot manager reserve next-gen.
 
 ## pkg/dxf/framework/schstatus
@@ -102,7 +102,7 @@
 ## pkg/dxf/importinto
 
 ### Tests
-- `pkg/dxf/importinto/clean_up_test.go` - dxf/importinto: Tests batch cleanup groups task files into one scan per storage URI, uses live credentials, and redacts persisted task metadata.
+- `pkg/dxf/importinto/clean_up_test.go` - dxf/importinto: Tests batch cleanup groups task files into one scan per storage URI, uses live credentials, and redacts task metadata.
 - `pkg/dxf/importinto/collect_conflicts_test.go` - dxf/importinto: Tests collect conflicts step executor.
 - `pkg/dxf/importinto/conflict_resolution_test.go` - dxf/importinto: Tests conflict resolution step executor.
 - `pkg/dxf/importinto/encode_and_sort_operator_test.go` - dxf/importinto: Tests encode and sort operator.

--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -102,7 +102,7 @@
 ## pkg/dxf/importinto
 
 ### Tests
-- `pkg/dxf/importinto/clean_up_test.go` - dxf/importinto: Tests batch cleanup uses live storage credentials while redacting persisted task metadata.
+- `pkg/dxf/importinto/clean_up_test.go` - dxf/importinto: Tests batch cleanup groups task files into one scan per storage URI, uses live credentials, and redacts persisted task metadata.
 - `pkg/dxf/importinto/collect_conflicts_test.go` - dxf/importinto: Tests collect conflicts step executor.
 - `pkg/dxf/importinto/conflict_resolution_test.go` - dxf/importinto: Tests conflict resolution step executor.
 - `pkg/dxf/importinto/encode_and_sort_operator_test.go` - dxf/importinto: Tests encode and sort operator.

--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -102,6 +102,7 @@
 ## pkg/dxf/importinto
 
 ### Tests
+- `pkg/dxf/importinto/clean_up_test.go` - dxf/importinto: Tests batch cleanup uses live storage credentials while redacting persisted task metadata.
 - `pkg/dxf/importinto/collect_conflicts_test.go` - dxf/importinto: Tests collect conflicts step executor.
 - `pkg/dxf/importinto/conflict_resolution_test.go` - dxf/importinto: Tests conflict resolution step executor.
 - `pkg/dxf/importinto/encode_and_sort_operator_test.go` - dxf/importinto: Tests encode and sort operator.

--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -65,7 +65,7 @@
 - `pkg/dxf/framework/scheduler/balancer_test.go` - dxf/framework/scheduler: Tests balance one task.
 - `pkg/dxf/framework/scheduler/main_test.go` - Configures default goleak settings and registers testdata.
 - `pkg/dxf/framework/scheduler/nodes_test.go` - dxf/framework/scheduler: Tests maintain live nodes.
-- `pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go` - dxf/framework/scheduler: Tests manager schedulers ordered.
+- `pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go` - dxf/framework/scheduler: Tests manager scheduler ordering and batched cleanup dispatch.
 - `pkg/dxf/framework/scheduler/scheduler_manager_test.go` - dxf/framework/scheduler: Tests cleanup routine and bounded cleanup-batch draining.
 - `pkg/dxf/framework/scheduler/scheduler_nokit_test.go` - dxf/framework/scheduler: Tests scheduler on next stage.
 - `pkg/dxf/framework/scheduler/scheduler_test.go` - dxf/framework/scheduler: Tests task fail in manager.

--- a/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/dxf-case-map.md
@@ -68,7 +68,7 @@
 - `pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go` - dxf/framework/scheduler: Tests manager scheduler ordering and batched cleanup dispatch.
 - `pkg/dxf/framework/scheduler/scheduler_manager_test.go` - dxf/framework/scheduler: Tests cleanup routine and bounded cleanup-batch draining.
 - `pkg/dxf/framework/scheduler/scheduler_nokit_test.go` - dxf/framework/scheduler: Tests scheduler on next stage.
-- `pkg/dxf/framework/scheduler/scheduler_test.go` - dxf/framework/scheduler: Tests task fail in manager.
+- `pkg/dxf/framework/scheduler/scheduler_test.go` - dxf/framework/scheduler: Tests task fail in manager and exported batch-cleanup capability conformance.
 - `pkg/dxf/framework/scheduler/slots_test.go` - dxf/framework/scheduler: Tests slot manager reserve next-gen.
 
 ## pkg/dxf/framework/schstatus

--- a/.agents/skills/tidb-test-guidelines/references/lightning-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/lightning-case-map.md
@@ -27,7 +27,7 @@
 - `pkg/ingestor/globalsort/reader_test.go` - ingestor/globalsort: Tests read all data basic.
 - `pkg/ingestor/globalsort/sort_test.go` - ingestor/globalsort: Tests global sort local basic.
 - `pkg/ingestor/globalsort/split_test.go` - ingestor/globalsort: Tests general properties.
-- `pkg/ingestor/globalsort/util_test.go` - ingestor/globalsort: Tests seek props offsets.
+- `pkg/ingestor/globalsort/util_test.go` - ingestor/globalsort: Tests property seeking and batched cleanup file discovery.
 - `pkg/ingestor/globalsort/writer_test.go` - ingestor/globalsort: Tests writer.
 
 ## pkg/lightning/backend/kv

--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/dxf/framework/scheduler/BUILD.bazel
+++ b/pkg/dxf/framework/scheduler/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     embed = [":scheduler"],
     flaky = True,
     race = "off",
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/dxf/framework/scheduler/interface.go
+++ b/pkg/dxf/framework/scheduler/interface.go
@@ -246,6 +246,24 @@ type CleanUpRoutine interface {
 	// task.Meta can be updated here, such as redacting some sensitive info.
 	CleanUp(ctx context.Context, task *proto.Task) error
 }
+
+// BatchCleanUpRoutine optionally extends CleanUpRoutine with batched cleanup.
+// For these routines, the scheduler calls CleanUpBatch instead of CleanUp. In
+// each cleanup pass, it calls one routine instance with a non-empty group of
+// tasks that all have the same task type. When CleanUpBatch returns nil, the
+// scheduler submits every task in the group together in the subsequent
+// history-table transfer. When it returns an error, no task in the group is
+// transferred in that pass.
+//
+// The scheduler provides no atomicity or rollback across cleanup side effects
+// and the history-table transfer. Implementations must be idempotent and safe
+// to retry after a partial cleanup failure or after cleanup succeeds but the
+// history-table transfer fails.
+type BatchCleanUpRoutine interface {
+	CleanUpRoutine
+	CleanUpBatch(ctx context.Context, tasks []*proto.Task) error
+}
+
 type cleanUpFactoryFn func() CleanUpRoutine
 
 var cleanUpFactoryMap = struct {

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -449,36 +449,65 @@ func (sm *Manager) doCleanupTask() {
 }
 
 func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
-	cleanedTasks := make([]*proto.Task, 0)
-	var firstErr error
-	importIntoTasks := make([]*proto.Task, 0)
-	cleanUpImportIntoTasks := func() error {
-		if len(importIntoTasks) == 0 {
-			return nil
-		}
-		cleanedImportIntoTasks, err := sm.cleanupImportIntoTasks(importIntoTasks)
-		cleanedTasks = append(cleanedTasks, cleanedImportIntoTasks...)
-		importIntoTasks = importIntoTasks[:0]
-		return err
+	type singleCleanUpTask struct {
+		task    *proto.Task
+		cleanUp CleanUpRoutine
 	}
+	type batchCleanUpTaskGroup struct {
+		cleanUp batchCleanUpRoutine
+		tasks   []*proto.Task
+	}
+
+	singleCleanUpTasks := make([]singleCleanUpTask, 0)
+	batchCleanUpTaskGroups := make([]batchCleanUpTaskGroup, 0)
+	batchCleanUpTaskGroupIndexes := make(map[proto.TaskType]int)
+	cleanedTaskSet := make(map[*proto.Task]struct{}, len(tasks))
+	var firstErr error
 	for _, task := range tasks {
 		sm.logger.Info("cleanup task", zap.Int64("task-id", task.ID), zap.String("task-key", task.Key))
-		if task.Type == proto.ImportInto {
-			importIntoTasks = append(importIntoTasks, task)
+		if groupIndex, ok := batchCleanUpTaskGroupIndexes[task.Type]; ok {
+			group := &batchCleanUpTaskGroups[groupIndex]
+			group.tasks = append(group.tasks, task)
 			continue
 		}
-		if err := cleanUpImportIntoTasks(); err != nil {
+
+		cleanUpFactory := getSchedulerCleanUpFactory(task.Type)
+		if cleanUpFactory == nil {
+			cleanedTaskSet[task] = struct{}{}
+			continue
+		}
+		cleanUp := cleanUpFactory()
+		if batchCleanUp, ok := cleanUp.(batchCleanUpRoutine); ok {
+			batchCleanUpTaskGroupIndexes[task.Type] = len(batchCleanUpTaskGroups)
+			batchCleanUpTaskGroups = append(batchCleanUpTaskGroups, batchCleanUpTaskGroup{
+				cleanUp: batchCleanUp,
+				tasks:   []*proto.Task{task},
+			})
+			continue
+		}
+		singleCleanUpTasks = append(singleCleanUpTasks, singleCleanUpTask{
+			task:    task,
+			cleanUp: cleanUp,
+		})
+	}
+
+	for _, cleanUpTask := range singleCleanUpTasks {
+		if err := cleanUpTask.cleanUp.CleanUp(sm.ctx, cleanUpTask.task); err != nil {
 			firstErr = err
 			break
 		}
-		if err := sm.cleanupSingleTask(task); err != nil {
-			firstErr = err
-			break
-		}
-		cleanedTasks = append(cleanedTasks, task)
+		cleanedTaskSet[cleanUpTask.task] = struct{}{}
 	}
 	if firstErr == nil {
-		firstErr = cleanUpImportIntoTasks()
+		for _, group := range batchCleanUpTaskGroups {
+			if err := group.cleanUp.CleanUpBatch(sm.ctx, group.tasks); err != nil {
+				firstErr = err
+				break
+			}
+			for _, task := range group.tasks {
+				cleanedTaskSet[task] = struct{}{}
+			}
+		}
 	}
 	if firstErr != nil {
 		// normally ScheduleEventCounter requires a task ID, but since scheduler
@@ -492,42 +521,11 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 		failpoint.Return(errors.New("transfer err"))
 	})
 
-	return sm.taskMgr.TransferTasks2History(sm.ctx, cleanedTasks)
-}
-
-func (sm *Manager) cleanupImportIntoTasks(tasks []*proto.Task) ([]*proto.Task, error) {
-	cleanupFactory := getSchedulerCleanUpFactory(proto.ImportInto)
-	if cleanupFactory == nil {
-		// if task doesn't register cleanup function, mark it as cleaned.
-		return tasks, nil
-	}
-	cleanup := cleanupFactory()
-	if batchCleanup, ok := cleanup.(batchCleanUpRoutine); ok {
-		if err := batchCleanup.CleanUpBatch(sm.ctx, tasks); err != nil {
-			return nil, err
-		}
-		return tasks, nil
-	}
-
-	cleanedTasks := make([]*proto.Task, 0, len(tasks))
-	for i, task := range tasks {
-		if i > 0 {
-			cleanup = cleanupFactory()
-		}
-		if err := cleanup.CleanUp(sm.ctx, task); err != nil {
-			return cleanedTasks, err
-		}
+	cleanedTasks := make([]*proto.Task, 0, len(cleanedTaskSet))
+	for task := range cleanedTaskSet {
 		cleanedTasks = append(cleanedTasks, task)
 	}
-	return cleanedTasks, nil
-}
-
-func (sm *Manager) cleanupSingleTask(task *proto.Task) error {
-	cleanupFactory := getSchedulerCleanUpFactory(task.Type)
-	if cleanupFactory == nil {
-		return nil
-	}
-	return cleanupFactory().CleanUp(sm.ctx, task)
+	return sm.taskMgr.TransferTasks2History(sm.ctx, cleanedTasks)
 }
 
 func (sm *Manager) collectLoop() {

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -51,6 +51,10 @@ var (
 	defaultCollectMetricsInterval = 15 * time.Second
 )
 
+type batchCleanUpRoutine interface {
+	CleanUpBatch(ctx context.Context, tasks []*proto.Task) error
+}
+
 func (sm *Manager) getSchedulerCount() int {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
@@ -447,21 +451,34 @@ func (sm *Manager) doCleanupTask() {
 func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 	cleanedTasks := make([]*proto.Task, 0)
 	var firstErr error
+	importIntoTasks := make([]*proto.Task, 0)
+	cleanUpImportIntoTasks := func() error {
+		if len(importIntoTasks) == 0 {
+			return nil
+		}
+		cleanedImportIntoTasks, err := sm.cleanupImportIntoTasks(importIntoTasks)
+		cleanedTasks = append(cleanedTasks, cleanedImportIntoTasks...)
+		importIntoTasks = importIntoTasks[:0]
+		return err
+	}
 	for _, task := range tasks {
 		sm.logger.Info("cleanup task", zap.Int64("task-id", task.ID), zap.String("task-key", task.Key))
-		cleanupFactory := getSchedulerCleanUpFactory(task.Type)
-		if cleanupFactory != nil {
-			cleanup := cleanupFactory()
-			err := cleanup.CleanUp(sm.ctx, task)
-			if err != nil {
-				firstErr = err
-				break
-			}
-			cleanedTasks = append(cleanedTasks, task)
-		} else {
-			// if task doesn't register cleanup function, mark it as cleaned.
-			cleanedTasks = append(cleanedTasks, task)
+		if task.Type == proto.ImportInto {
+			importIntoTasks = append(importIntoTasks, task)
+			continue
 		}
+		if err := cleanUpImportIntoTasks(); err != nil {
+			firstErr = err
+			break
+		}
+		if err := sm.cleanupSingleTask(task); err != nil {
+			firstErr = err
+			break
+		}
+		cleanedTasks = append(cleanedTasks, task)
+	}
+	if firstErr == nil {
+		firstErr = cleanUpImportIntoTasks()
 	}
 	if firstErr != nil {
 		// normally ScheduleEventCounter requires a task ID, but since scheduler
@@ -476,6 +493,41 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 	})
 
 	return sm.taskMgr.TransferTasks2History(sm.ctx, cleanedTasks)
+}
+
+func (sm *Manager) cleanupImportIntoTasks(tasks []*proto.Task) ([]*proto.Task, error) {
+	cleanupFactory := getSchedulerCleanUpFactory(proto.ImportInto)
+	if cleanupFactory == nil {
+		// if task doesn't register cleanup function, mark it as cleaned.
+		return tasks, nil
+	}
+	cleanup := cleanupFactory()
+	if batchCleanup, ok := cleanup.(batchCleanUpRoutine); ok {
+		if err := batchCleanup.CleanUpBatch(sm.ctx, tasks); err != nil {
+			return nil, err
+		}
+		return tasks, nil
+	}
+
+	cleanedTasks := make([]*proto.Task, 0, len(tasks))
+	for i, task := range tasks {
+		if i > 0 {
+			cleanup = cleanupFactory()
+		}
+		if err := cleanup.CleanUp(sm.ctx, task); err != nil {
+			return cleanedTasks, err
+		}
+		cleanedTasks = append(cleanedTasks, task)
+	}
+	return cleanedTasks, nil
+}
+
+func (sm *Manager) cleanupSingleTask(task *proto.Task) error {
+	cleanupFactory := getSchedulerCleanUpFactory(task.Type)
+	if cleanupFactory == nil {
+		return nil
+	}
+	return cleanupFactory().CleanUp(sm.ctx, task)
 }
 
 func (sm *Manager) collectLoop() {

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -459,14 +459,12 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 	}
 
 	singleCleanUpTasks := make([]singleCleanUpTask, 0)
-	batchCleanUpTaskGroups := make([]batchCleanUpTaskGroup, 0)
-	batchCleanUpTaskGroupIndexes := make(map[proto.TaskType]int)
+	batchCleanUpTaskGroups := make(map[proto.TaskType]*batchCleanUpTaskGroup)
 	cleanedTaskSet := make(map[*proto.Task]struct{}, len(tasks))
 	var firstErr error
 	for _, task := range tasks {
 		sm.logger.Info("cleanup task", zap.Int64("task-id", task.ID), zap.String("task-key", task.Key))
-		if groupIndex, ok := batchCleanUpTaskGroupIndexes[task.Type]; ok {
-			group := &batchCleanUpTaskGroups[groupIndex]
+		if group, ok := batchCleanUpTaskGroups[task.Type]; ok {
 			group.tasks = append(group.tasks, task)
 			continue
 		}
@@ -478,11 +476,10 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 		}
 		cleanUp := cleanUpFactory()
 		if batchCleanUp, ok := cleanUp.(batchCleanUpRoutine); ok {
-			batchCleanUpTaskGroupIndexes[task.Type] = len(batchCleanUpTaskGroups)
-			batchCleanUpTaskGroups = append(batchCleanUpTaskGroups, batchCleanUpTaskGroup{
+			batchCleanUpTaskGroups[task.Type] = &batchCleanUpTaskGroup{
 				cleanUp: batchCleanUp,
 				tasks:   []*proto.Task{task},
-			})
+			}
 			continue
 		}
 		singleCleanUpTasks = append(singleCleanUpTasks, singleCleanUpTask{

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -51,13 +51,6 @@ var (
 	defaultCollectMetricsInterval = 15 * time.Second
 )
 
-type batchCleanUpRoutine interface {
-	// CleanUpBatch cleans up tasks as a single unit. All tasks in the batch must
-	// be cleaned up successfully before any of them are transferred to the
-	// history table.
-	CleanUpBatch(ctx context.Context, tasks []*proto.Task) error
-}
-
 func (sm *Manager) getSchedulerCount() int {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
@@ -457,7 +450,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 		cleanUp CleanUpRoutine
 	}
 	type batchCleanUpTaskGroup struct {
-		cleanUp batchCleanUpRoutine
+		cleanUp BatchCleanUpRoutine
 		tasks   []*proto.Task
 	}
 
@@ -478,7 +471,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 			continue
 		}
 		cleanUp := cleanUpFactory()
-		if batchCleanUp, ok := cleanUp.(batchCleanUpRoutine); ok {
+		if batchCleanUp, ok := cleanUp.(BatchCleanUpRoutine); ok {
 			batchCleanUpTaskGroups[task.Type] = &batchCleanUpTaskGroup{
 				cleanUp: batchCleanUp,
 				tasks:   []*proto.Task{task},

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -52,6 +52,9 @@ var (
 )
 
 type batchCleanUpRoutine interface {
+	// CleanUpBatch cleans up tasks as a single unit. All tasks in the batch must
+	// be cleaned up successfully before any of them are transferred to the
+	// history table.
 	CleanUpBatch(ctx context.Context, tasks []*proto.Task) error
 }
 
@@ -460,7 +463,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 
 	singleCleanUpTasks := make([]singleCleanUpTask, 0)
 	batchCleanUpTaskGroups := make(map[proto.TaskType]*batchCleanUpTaskGroup)
-	cleanedTaskSet := make(map[*proto.Task]struct{}, len(tasks))
+	cleanedTasks := make([]*proto.Task, 0, len(tasks))
 	var firstErr error
 	for _, task := range tasks {
 		sm.logger.Info("cleanup task", zap.Int64("task-id", task.ID), zap.String("task-key", task.Key))
@@ -471,7 +474,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 
 		cleanUpFactory := getSchedulerCleanUpFactory(task.Type)
 		if cleanUpFactory == nil {
-			cleanedTaskSet[task] = struct{}{}
+			cleanedTasks = append(cleanedTasks, task)
 			continue
 		}
 		cleanUp := cleanUpFactory()
@@ -493,7 +496,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 			firstErr = err
 			break
 		}
-		cleanedTaskSet[cleanUpTask.task] = struct{}{}
+		cleanedTasks = append(cleanedTasks, cleanUpTask.task)
 	}
 	if firstErr == nil {
 		for _, group := range batchCleanUpTaskGroups {
@@ -501,9 +504,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 				firstErr = err
 				break
 			}
-			for _, task := range group.tasks {
-				cleanedTaskSet[task] = struct{}{}
-			}
+			cleanedTasks = append(cleanedTasks, group.tasks...)
 		}
 	}
 	if firstErr != nil {
@@ -518,10 +519,6 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 		failpoint.Return(errors.New("transfer err"))
 	})
 
-	cleanedTasks := make([]*proto.Task, 0, len(cleanedTaskSet))
-	for task := range cleanedTaskSet {
-		cleanedTasks = append(cleanedTasks, task)
-	}
 	return sm.taskMgr.TransferTasks2History(sm.ctx, cleanedTasks)
 }
 

--- a/pkg/dxf/framework/scheduler/scheduler_manager.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager.go
@@ -486,6 +486,7 @@ func (sm *Manager) cleanupFinishedTasks(tasks []*proto.Task) error {
 
 	for _, cleanUpTask := range singleCleanUpTasks {
 		if err := cleanUpTask.cleanUp.CleanUp(sm.ctx, cleanUpTask.task); err != nil {
+			// maybe consider continue cleaning other tasks on error later.
 			firstErr = err
 			break
 		}

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -42,6 +42,34 @@ type storeWithKS struct {
 	ks string
 }
 
+type cleanUpCallRecorder struct {
+	cleanUpCalls []int64
+	batchCalls   [][]int64
+}
+
+func (r *cleanUpCallRecorder) CleanUp(_ context.Context, task *proto.Task) error {
+	r.cleanUpCalls = append(r.cleanUpCalls, task.ID)
+	return nil
+}
+
+func (r *cleanUpCallRecorder) CleanUpBatch(_ context.Context, tasks []*proto.Task) error {
+	taskIDs := make([]int64, 0, len(tasks))
+	for _, task := range tasks {
+		taskIDs = append(taskIDs, task.ID)
+	}
+	r.batchCalls = append(r.batchCalls, taskIDs)
+	return nil
+}
+
+type singleCleanUpCallRecorder struct {
+	cleanUpCalls []int64
+}
+
+func (r *singleCleanUpCallRecorder) CleanUp(_ context.Context, task *proto.Task) error {
+	r.cleanUpCalls = append(r.cleanUpCalls, task.ID)
+	return nil
+}
+
 func (s *storeWithKS) GetKeyspace() string {
 	return s.ks
 }
@@ -176,6 +204,38 @@ func TestSchedulerCleanupTask(t *testing.T) {
 	taskMgr.EXPECT().TransferTasks2History(mgr.ctx, tasks).Return(nil)
 	mgr.doCleanupTask()
 	require.True(t, ctrl.Satisfied())
+}
+
+func TestSchedulerCleanupImportIntoTasksInBatch(t *testing.T) {
+	ClearSchedulerCleanUpFactory()
+	t.Cleanup(ClearSchedulerCleanUpFactory)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	taskMgr := mock.NewMockTaskManager(ctrl)
+	mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
+	importCleanUp := &cleanUpCallRecorder{}
+	exampleCleanUp := &singleCleanUpCallRecorder{}
+	RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
+		return importCleanUp
+	})
+	RegisterSchedulerCleanUpFactory(proto.TaskTypeExample, func() CleanUpRoutine {
+		return exampleCleanUp
+	})
+
+	tasks := []*proto.Task{
+		{TaskBase: proto.TaskBase{ID: 1, Type: proto.ImportInto}},
+		{TaskBase: proto.TaskBase{ID: 2, Type: proto.ImportInto}},
+		{TaskBase: proto.TaskBase{ID: 3, Type: proto.TaskTypeExample}},
+		{TaskBase: proto.TaskBase{ID: 4, Type: proto.ImportInto}},
+		{TaskBase: proto.TaskBase{ID: 5, Type: proto.TaskType("NoCleanUp")}},
+	}
+	taskMgr.EXPECT().TransferTasks2History(mgr.ctx, tasks).Return(nil)
+
+	require.NoError(t, mgr.cleanupFinishedTasks(tasks))
+	require.Equal(t, [][]int64{{1, 2}, {4}}, importCleanUp.batchCalls)
+	require.Empty(t, importCleanUp.cleanUpCalls)
+	require.Equal(t, []int64{3}, exampleCleanUp.cleanUpCalls)
 }
 
 func TestManagerSchedulerNotAllocateSlots(t *testing.T) {

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -295,7 +295,7 @@ func TestSchedulerCleanupFinishedTasks(t *testing.T) {
 		cleanUpErr := errors.New("batch cleanup failed")
 		taskMgr := mock.NewMockTaskManager(ctrl)
 		mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
-		importCleanUp := &cleanUpCallRecorder{}
+		importCleanUp := &cleanUpCallRecorder{batchErr: cleanUpErr}
 		otherBatchCleanUp := &cleanUpCallRecorder{batchErr: cleanUpErr}
 		singleCleanUp := &singleCleanUpCallRecorder{}
 		RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
@@ -316,13 +316,12 @@ func TestSchedulerCleanupFinishedTasks(t *testing.T) {
 			{TaskBase: proto.TaskBase{ID: 5, Type: otherBatchTaskType}},
 			{TaskBase: proto.TaskBase{ID: 6, Type: noCleanUpTaskType}},
 		}
-		cleanedTasks := []*proto.Task{tasks[0], tasks[2], tasks[3], tasks[5]}
+		cleanedTasks := []*proto.Task{tasks[2], tasks[5]}
 		taskMgr.EXPECT().TransferTasks2History(mgr.ctx, gomock.InAnyOrder(cleanedTasks)).Return(nil)
 
 		require.NoError(t, mgr.cleanupFinishedTasks(tasks))
 		require.Equal(t, []int64{3}, singleCleanUp.cleanUpCalls)
-		require.Equal(t, [][]int64{{1, 4}}, importCleanUp.batchCalls)
-		require.Equal(t, [][]int64{{2, 5}}, otherBatchCleanUp.batchCalls)
+		require.Equal(t, 1, len(importCleanUp.batchCalls)+len(otherBatchCleanUp.batchCalls))
 	})
 
 	t.Run("history transfer failure", func(t *testing.T) {

--- a/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_manager_nokit_test.go
@@ -45,6 +45,7 @@ type storeWithKS struct {
 type cleanUpCallRecorder struct {
 	cleanUpCalls []int64
 	batchCalls   [][]int64
+	batchErr     error
 }
 
 func (r *cleanUpCallRecorder) CleanUp(_ context.Context, task *proto.Task) error {
@@ -58,15 +59,20 @@ func (r *cleanUpCallRecorder) CleanUpBatch(_ context.Context, tasks []*proto.Tas
 		taskIDs = append(taskIDs, task.ID)
 	}
 	r.batchCalls = append(r.batchCalls, taskIDs)
-	return nil
+	return r.batchErr
 }
 
 type singleCleanUpCallRecorder struct {
 	cleanUpCalls []int64
+	failTaskID   int64
+	cleanUpErr   error
 }
 
 func (r *singleCleanUpCallRecorder) CleanUp(_ context.Context, task *proto.Task) error {
 	r.cleanUpCalls = append(r.cleanUpCalls, task.ID)
+	if task.ID == r.failTaskID {
+		return r.cleanUpErr
+	}
 	return nil
 }
 
@@ -206,36 +212,132 @@ func TestSchedulerCleanupTask(t *testing.T) {
 	require.True(t, ctrl.Satisfied())
 }
 
-func TestSchedulerCleanupImportIntoTasksInBatch(t *testing.T) {
-	ClearSchedulerCleanUpFactory()
-	t.Cleanup(ClearSchedulerCleanUpFactory)
+func TestSchedulerCleanupFinishedTasks(t *testing.T) {
+	otherBatchTaskType := proto.TaskType("OtherBatch")
+	noCleanUpTaskType := proto.TaskType("NoCleanUp")
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	taskMgr := mock.NewMockTaskManager(ctrl)
-	mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
-	importCleanUp := &cleanUpCallRecorder{}
-	exampleCleanUp := &singleCleanUpCallRecorder{}
-	RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
-		return importCleanUp
+	t.Run("batch cleanup by capability", func(t *testing.T) {
+		ClearSchedulerCleanUpFactory()
+		t.Cleanup(ClearSchedulerCleanUpFactory)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		taskMgr := mock.NewMockTaskManager(ctrl)
+		mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
+		importCleanUp := &cleanUpCallRecorder{}
+		otherBatchCleanUp := &cleanUpCallRecorder{}
+		exampleCleanUp := &singleCleanUpCallRecorder{}
+		RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
+			return importCleanUp
+		})
+		RegisterSchedulerCleanUpFactory(otherBatchTaskType, func() CleanUpRoutine {
+			return otherBatchCleanUp
+		})
+		RegisterSchedulerCleanUpFactory(proto.TaskTypeExample, func() CleanUpRoutine {
+			return exampleCleanUp
+		})
+
+		tasks := []*proto.Task{
+			{TaskBase: proto.TaskBase{ID: 1, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 2, Type: otherBatchTaskType}},
+			{TaskBase: proto.TaskBase{ID: 3, Type: proto.TaskTypeExample}},
+			{TaskBase: proto.TaskBase{ID: 4, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 5, Type: otherBatchTaskType}},
+			{TaskBase: proto.TaskBase{ID: 6, Type: noCleanUpTaskType}},
+		}
+		taskMgr.EXPECT().TransferTasks2History(mgr.ctx, gomock.InAnyOrder(tasks)).Return(nil)
+
+		require.NoError(t, mgr.cleanupFinishedTasks(tasks))
+		require.Equal(t, [][]int64{{1, 4}}, importCleanUp.batchCalls)
+		require.Empty(t, importCleanUp.cleanUpCalls)
+		require.Equal(t, [][]int64{{2, 5}}, otherBatchCleanUp.batchCalls)
+		require.Empty(t, otherBatchCleanUp.cleanUpCalls)
+		require.Equal(t, []int64{3}, exampleCleanUp.cleanUpCalls)
 	})
-	RegisterSchedulerCleanUpFactory(proto.TaskTypeExample, func() CleanUpRoutine {
-		return exampleCleanUp
+
+	t.Run("single cleanup failure", func(t *testing.T) {
+		ClearSchedulerCleanUpFactory()
+		t.Cleanup(ClearSchedulerCleanUpFactory)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cleanUpErr := errors.New("single cleanup failed")
+		taskMgr := mock.NewMockTaskManager(ctrl)
+		mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
+		batchCleanUp := &cleanUpCallRecorder{}
+		singleCleanUp := &singleCleanUpCallRecorder{failTaskID: 4, cleanUpErr: cleanUpErr}
+		RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
+			return batchCleanUp
+		})
+		RegisterSchedulerCleanUpFactory(proto.TaskTypeExample, func() CleanUpRoutine {
+			return singleCleanUp
+		})
+
+		tasks := []*proto.Task{
+			{TaskBase: proto.TaskBase{ID: 1, Type: noCleanUpTaskType}},
+			{TaskBase: proto.TaskBase{ID: 2, Type: proto.TaskTypeExample}},
+			{TaskBase: proto.TaskBase{ID: 3, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 4, Type: proto.TaskTypeExample}},
+			{TaskBase: proto.TaskBase{ID: 5, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 6, Type: noCleanUpTaskType}},
+		}
+		cleanedTasks := []*proto.Task{tasks[0], tasks[1], tasks[5]}
+		taskMgr.EXPECT().TransferTasks2History(mgr.ctx, gomock.InAnyOrder(cleanedTasks)).Return(nil)
+
+		require.NoError(t, mgr.cleanupFinishedTasks(tasks))
+		require.Equal(t, []int64{2, 4}, singleCleanUp.cleanUpCalls)
+		require.Empty(t, batchCleanUp.batchCalls)
 	})
 
-	tasks := []*proto.Task{
-		{TaskBase: proto.TaskBase{ID: 1, Type: proto.ImportInto}},
-		{TaskBase: proto.TaskBase{ID: 2, Type: proto.ImportInto}},
-		{TaskBase: proto.TaskBase{ID: 3, Type: proto.TaskTypeExample}},
-		{TaskBase: proto.TaskBase{ID: 4, Type: proto.ImportInto}},
-		{TaskBase: proto.TaskBase{ID: 5, Type: proto.TaskType("NoCleanUp")}},
-	}
-	taskMgr.EXPECT().TransferTasks2History(mgr.ctx, tasks).Return(nil)
+	t.Run("batch cleanup failure", func(t *testing.T) {
+		ClearSchedulerCleanUpFactory()
+		t.Cleanup(ClearSchedulerCleanUpFactory)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cleanUpErr := errors.New("batch cleanup failed")
+		taskMgr := mock.NewMockTaskManager(ctrl)
+		mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
+		importCleanUp := &cleanUpCallRecorder{}
+		otherBatchCleanUp := &cleanUpCallRecorder{batchErr: cleanUpErr}
+		singleCleanUp := &singleCleanUpCallRecorder{}
+		RegisterSchedulerCleanUpFactory(proto.ImportInto, func() CleanUpRoutine {
+			return importCleanUp
+		})
+		RegisterSchedulerCleanUpFactory(otherBatchTaskType, func() CleanUpRoutine {
+			return otherBatchCleanUp
+		})
+		RegisterSchedulerCleanUpFactory(proto.TaskTypeExample, func() CleanUpRoutine {
+			return singleCleanUp
+		})
 
-	require.NoError(t, mgr.cleanupFinishedTasks(tasks))
-	require.Equal(t, [][]int64{{1, 2}, {4}}, importCleanUp.batchCalls)
-	require.Empty(t, importCleanUp.cleanUpCalls)
-	require.Equal(t, []int64{3}, exampleCleanUp.cleanUpCalls)
+		tasks := []*proto.Task{
+			{TaskBase: proto.TaskBase{ID: 1, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 2, Type: otherBatchTaskType}},
+			{TaskBase: proto.TaskBase{ID: 3, Type: proto.TaskTypeExample}},
+			{TaskBase: proto.TaskBase{ID: 4, Type: proto.ImportInto}},
+			{TaskBase: proto.TaskBase{ID: 5, Type: otherBatchTaskType}},
+			{TaskBase: proto.TaskBase{ID: 6, Type: noCleanUpTaskType}},
+		}
+		cleanedTasks := []*proto.Task{tasks[0], tasks[2], tasks[3], tasks[5]}
+		taskMgr.EXPECT().TransferTasks2History(mgr.ctx, gomock.InAnyOrder(cleanedTasks)).Return(nil)
+
+		require.NoError(t, mgr.cleanupFinishedTasks(tasks))
+		require.Equal(t, []int64{3}, singleCleanUp.cleanUpCalls)
+		require.Equal(t, [][]int64{{1, 4}}, importCleanUp.batchCalls)
+		require.Equal(t, [][]int64{{2, 5}}, otherBatchCleanUp.batchCalls)
+	})
+
+	t.Run("history transfer failure", func(t *testing.T) {
+		ClearSchedulerCleanUpFactory()
+		t.Cleanup(ClearSchedulerCleanUpFactory)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		transferErr := errors.New("transfer failed")
+		taskMgr := mock.NewMockTaskManager(ctrl)
+		mgr := NewManager(context.Background(), nil, taskMgr, "1", proto.NodeResourceForTest)
+		tasks := []*proto.Task{{TaskBase: proto.TaskBase{ID: 1, Type: noCleanUpTaskType}}}
+		taskMgr.EXPECT().TransferTasks2History(mgr.ctx, tasks).Return(transferErr)
+
+		require.ErrorIs(t, mgr.cleanupFinishedTasks(tasks), transferErr)
+	})
 }
 
 func TestManagerSchedulerNotAllocateSlots(t *testing.T) {

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
     name = "importinto_test",
     timeout = "short",
     srcs = [
+        "clean_up_test.go",
         "collect_conflicts_test.go",
         "conflict_resolution_test.go",
         "encode_and_sort_operator_test.go",
@@ -112,7 +113,7 @@ go_test(
     ],
     embed = [":importinto"],
     flaky = True,
-    shard_count = 29,
+    shard_count = 30,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",
@@ -165,6 +166,8 @@ go_test(
         "//pkg/util/mock",
         "@com_github_docker_go_units//:go-units",
         "@com_github_fsouza_fake_gcs_server//fakestorage",
+        "@com_github_johannesboyne_gofakes3//:gofakes3",
+        "@com_github_johannesboyne_gofakes3//backend/s3mem",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/dxf/importinto/clean_up.go
+++ b/pkg/dxf/importinto/clean_up.go
@@ -77,6 +77,8 @@ func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) err
 		if err != nil {
 			return err
 		}
+		cloudStorageURI := taskMeta.Plan.CloudStorageURI
+		isGlobalSort := taskMeta.Plan.IsGlobalSort()
 		redactSensitiveInfo(task, taskMeta)
 
 		if err = cleanUpTableMode(ctx, taskMeta); err != nil {
@@ -87,13 +89,13 @@ func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) err
 			return err
 		}
 
-		if taskMeta.Plan.IsGlobalSort() {
-			fileGroup, ok := fileGroups[taskMeta.Plan.CloudStorageURI]
+		if isGlobalSort {
+			fileGroup, ok := fileGroups[cloudStorageURI]
 			if !ok {
 				fileGroup = &cleanUpFileGroup{
-					cloudStorageURI: taskMeta.Plan.CloudStorageURI,
+					cloudStorageURI: cloudStorageURI,
 				}
-				fileGroups[taskMeta.Plan.CloudStorageURI] = fileGroup
+				fileGroups[cloudStorageURI] = fileGroup
 			}
 			fileGroup.nonPartitionedDirs = append(fileGroup.nonPartitionedDirs, strconv.Itoa(int(task.ID)))
 			fileGroup.taskIDs = append(fileGroup.taskIDs, task.ID)

--- a/pkg/dxf/importinto/clean_up.go
+++ b/pkg/dxf/importinto/clean_up.go
@@ -51,67 +51,129 @@ func newImportCleanUpS3() scheduler.CleanUpRoutine {
 }
 
 // CleanUp implements the CleanUpRoutine.CleanUp interface.
-func (*ImportCleanUp) CleanUp(ctx context.Context, task *proto.Task) error {
+func (c *ImportCleanUp) CleanUp(ctx context.Context, task *proto.Task) error {
+	return c.CleanUpBatch(ctx, []*proto.Task{task})
+}
+
+type cleanUpTaskInfo struct {
+	task            *proto.Task
+	needFileCleanUp bool
+}
+
+type cleanUpFileGroup struct {
+	cloudStorageURI    string
+	nonPartitionedDirs []string
+	taskIDs            []int64
+}
+
+// CleanUpBatch cleans up multiple import tasks in batch.
+func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+
 	// we can only clean up files after all write&ingest subtasks are finished,
 	// since they might share the same file.
-	taskMeta := &TaskMeta{}
-	err := json.Unmarshal(task.Meta, taskMeta)
-	if err != nil {
-		return err
-	}
-	defer redactSensitiveInfo(task, taskMeta)
-
-	if kerneltype.IsClassic() {
-		taskManager, err := storage.GetTaskManager()
+	cleanUpTasks := make([]cleanUpTaskInfo, 0, len(tasks))
+	fileGroupIdx := make(map[string]int)
+	fileGroups := make([]cleanUpFileGroup, 0, len(tasks))
+	for _, task := range tasks {
+		taskMeta := &TaskMeta{}
+		err := json.Unmarshal(task.Meta, taskMeta)
 		if err != nil {
 			return err
 		}
-		if err = taskManager.WithNewTxn(ctx, func(se sessionctx.Context) error {
-			return ddl.AlterTableMode(domain.GetDomain(se).DDLExecutor(), se, model.TableModeNormal, taskMeta.Plan.DBID, taskMeta.Plan.TableInfo.ID)
-		}); err != nil {
-			// If the table is not found, it means the table has been either
-			// dropped or truncated. In such cases, the table mode has already
-			// been reset to normal, so we can ignore this error.
-			if !goerrors.Is(err, infoschema.ErrTableNotExists) {
-				return err
-			}
+		defer redactSensitiveInfo(task, taskMeta)
 
-			logutil.BgLogger().Warn(
-				"table not found during import cleanup, skip altering table mode",
-				zap.Int64("tableID", taskMeta.Plan.TableInfo.ID),
-			)
+		if err = cleanUpTableMode(ctx, taskMeta); err != nil {
+			return err
+		}
+
+		failpoint.InjectCall("mockCleanupError", &err)
+		if err != nil {
+			return err
+		}
+
+		// Not use cloud storage, no need to cleanUp.
+		needFileCleanUp := taskMeta.Plan.CloudStorageURI != ""
+		cleanUpTasks = append(cleanUpTasks, cleanUpTaskInfo{
+			task:            task,
+			needFileCleanUp: needFileCleanUp,
+		})
+		if !needFileCleanUp {
+			continue
+		}
+		idx, ok := fileGroupIdx[taskMeta.Plan.CloudStorageURI]
+		if !ok {
+			idx = len(fileGroups)
+			fileGroupIdx[taskMeta.Plan.CloudStorageURI] = idx
+			fileGroups = append(fileGroups, cleanUpFileGroup{
+				cloudStorageURI: taskMeta.Plan.CloudStorageURI,
+			})
+		}
+		fileGroups[idx].nonPartitionedDirs = append(fileGroups[idx].nonPartitionedDirs, strconv.Itoa(int(task.ID)))
+		fileGroups[idx].taskIDs = append(fileGroups[idx].taskIDs, task.ID)
+	}
+
+	for _, fileGroup := range fileGroups {
+		if err := cleanUpExternalFiles(ctx, fileGroup); err != nil {
+			return err
 		}
 	}
 
-	failpoint.InjectCall("mockCleanupError", &err)
+	for _, cleanUpTask := range cleanUpTasks {
+		// send metering data for nextgen kernel, only for succeed tasks
+		if cleanUpTask.needFileCleanUp && kerneltype.IsNextGen() && cleanUpTask.task.State == proto.TaskStateSucceed {
+			logger := logutil.BgLogger().With(zap.Int64("task-id", cleanUpTask.task.ID))
+			if err := sendMeterOnCleanUp(ctx, cleanUpTask.task, logger); err != nil {
+				logger.Warn("failed to send metering data on cleanup", zap.Error(err))
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func cleanUpTableMode(ctx context.Context, taskMeta *TaskMeta) error {
+	if !kerneltype.IsClassic() {
+		return nil
+	}
+	taskManager, err := storage.GetTaskManager()
 	if err != nil {
 		return err
 	}
+	if err = taskManager.WithNewTxn(ctx, func(se sessionctx.Context) error {
+		return ddl.AlterTableMode(domain.GetDomain(se).DDLExecutor(), se, model.TableModeNormal, taskMeta.Plan.DBID, taskMeta.Plan.TableInfo.ID)
+	}); err != nil {
+		// If the table is not found, it means the table has been either
+		// dropped or truncated. In such cases, the table mode has already
+		// been reset to normal, so we can ignore this error.
+		if !goerrors.Is(err, infoschema.ErrTableNotExists) {
+			return err
+		}
 
-	// Not use cloud storage, no need to cleanUp.
-	if taskMeta.Plan.CloudStorageURI == "" {
-		return nil
+		logutil.BgLogger().Warn(
+			"table not found during import cleanup, skip altering table mode",
+			zap.Int64("tableID", taskMeta.Plan.TableInfo.ID),
+		)
 	}
-	logger := logutil.BgLogger().With(zap.Int64("task-id", task.ID))
+	return nil
+}
+
+func cleanUpExternalFiles(ctx context.Context, fileGroup cleanUpFileGroup) error {
+	logger := logutil.BgLogger().With(zap.Int64s("task-ids", fileGroup.taskIDs))
 	callLog := log.BeginTask(logger, "cleanup global sorted data")
 	defer callLog.End(zap.InfoLevel, nil)
 
-	store, err := importer.GetSortStore(ctx, taskMeta.Plan.CloudStorageURI)
+	store, err := importer.GetSortStore(ctx, fileGroup.cloudStorageURI)
 	if err != nil {
 		logger.Warn("failed to create store", zap.Error(err))
 		return err
 	}
 	defer store.Close()
-	if err = globalsort.CleanUpFiles(ctx, store, strconv.Itoa(int(task.ID))); err != nil {
-		logger.Warn("failed to clean up files of task", zap.Error(err))
+	if err = globalsort.CleanUpFiles(ctx, store, fileGroup.nonPartitionedDirs...); err != nil {
+		logger.Warn("failed to clean up files of tasks", zap.Error(err))
 		return err
-	}
-	// send metering data for nextgen kernel, only for succeed tasks
-	if kerneltype.IsNextGen() && task.State == proto.TaskStateSucceed {
-		if err = sendMeterOnCleanUp(ctx, task, logger); err != nil {
-			logger.Warn("failed to send metering data on cleanup", zap.Error(err))
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/dxf/importinto/clean_up.go
+++ b/pkg/dxf/importinto/clean_up.go
@@ -55,11 +55,6 @@ func (c *ImportCleanUp) CleanUp(ctx context.Context, task *proto.Task) error {
 	return c.CleanUpBatch(ctx, []*proto.Task{task})
 }
 
-type cleanUpTaskInfo struct {
-	task            *proto.Task
-	needFileCleanUp bool
-}
-
 type cleanUpFileGroup struct {
 	cloudStorageURI    string
 	nonPartitionedDirs []string
@@ -74,61 +69,51 @@ func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) err
 
 	// we can only clean up files after all write&ingest subtasks are finished,
 	// since they might share the same file.
-	cleanUpTasks := make([]cleanUpTaskInfo, 0, len(tasks))
-	fileGroupIdx := make(map[string]int)
-	fileGroups := make([]cleanUpFileGroup, 0, len(tasks))
+	meterTasks := make([]*proto.Task, 0, len(tasks))
+	fileGroups := make(map[string]*cleanUpFileGroup, len(tasks))
 	for _, task := range tasks {
 		taskMeta := &TaskMeta{}
 		err := json.Unmarshal(task.Meta, taskMeta)
 		if err != nil {
 			return err
 		}
-		defer redactSensitiveInfo(task, taskMeta)
+		redactSensitiveInfo(task, taskMeta)
 
 		if err = cleanUpTableMode(ctx, taskMeta); err != nil {
 			return err
 		}
-
 		failpoint.InjectCall("mockCleanupError", &err)
 		if err != nil {
 			return err
 		}
 
-		// Not use cloud storage, no need to cleanUp.
-		needFileCleanUp := taskMeta.Plan.CloudStorageURI != ""
-		cleanUpTasks = append(cleanUpTasks, cleanUpTaskInfo{
-			task:            task,
-			needFileCleanUp: needFileCleanUp,
-		})
-		if !needFileCleanUp {
-			continue
+		if taskMeta.Plan.IsGlobalSort() {
+			fileGroup, ok := fileGroups[taskMeta.Plan.CloudStorageURI]
+			if !ok {
+				fileGroup = &cleanUpFileGroup{
+					cloudStorageURI: taskMeta.Plan.CloudStorageURI,
+				}
+				fileGroups[taskMeta.Plan.CloudStorageURI] = fileGroup
+			}
+			fileGroup.nonPartitionedDirs = append(fileGroup.nonPartitionedDirs, strconv.Itoa(int(task.ID)))
+			fileGroup.taskIDs = append(fileGroup.taskIDs, task.ID)
+			if kerneltype.IsNextGen() && task.State == proto.TaskStateSucceed {
+				meterTasks = append(meterTasks, task)
+			}
 		}
-		idx, ok := fileGroupIdx[taskMeta.Plan.CloudStorageURI]
-		if !ok {
-			idx = len(fileGroups)
-			fileGroupIdx[taskMeta.Plan.CloudStorageURI] = idx
-			fileGroups = append(fileGroups, cleanUpFileGroup{
-				cloudStorageURI: taskMeta.Plan.CloudStorageURI,
-			})
-		}
-		fileGroups[idx].nonPartitionedDirs = append(fileGroups[idx].nonPartitionedDirs, strconv.Itoa(int(task.ID)))
-		fileGroups[idx].taskIDs = append(fileGroups[idx].taskIDs, task.ID)
 	}
 
 	for _, fileGroup := range fileGroups {
-		if err := cleanUpExternalFiles(ctx, fileGroup); err != nil {
+		if err := cleanUpExternalFiles(ctx, *fileGroup); err != nil {
 			return err
 		}
 	}
 
-	for _, cleanUpTask := range cleanUpTasks {
-		// send metering data for nextgen kernel, only for succeed tasks
-		if cleanUpTask.needFileCleanUp && kerneltype.IsNextGen() && cleanUpTask.task.State == proto.TaskStateSucceed {
-			logger := logutil.BgLogger().With(zap.Int64("task-id", cleanUpTask.task.ID))
-			if err := sendMeterOnCleanUp(ctx, cleanUpTask.task, logger); err != nil {
-				logger.Warn("failed to send metering data on cleanup", zap.Error(err))
-				return err
-			}
+	for _, task := range meterTasks {
+		logger := logutil.BgLogger().With(zap.Int64("task-id", task.ID))
+		if err := sendMeterOnCleanUp(ctx, task, logger); err != nil {
+			logger.Warn("failed to send metering data on cleanup", zap.Error(err))
+			return err
 		}
 	}
 	return nil

--- a/pkg/dxf/importinto/clean_up.go
+++ b/pkg/dxf/importinto/clean_up.go
@@ -61,7 +61,15 @@ type cleanUpFileGroup struct {
 	taskIDs            []int64
 }
 
-// CleanUpBatch cleans up multiple import tasks in batch.
+// CleanUpBatch cleans up multiple import tasks together.
+// Global-sort files are partitioned by task ID, but finding them requires a scan
+// of the shared object store. Batching lets cleanup scan each store once instead
+// of once per task. The scheduler moves the tasks to history only after this
+// method succeeds, but the cleanup side effects themselves are not atomic: a
+// retry may repeat work that completed before an earlier failure.
+//
+// TODO: Move global-sort file management into DXF so task cleanup can remain
+// independent without giving up batched object-store scans.
 func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) error {
 	if len(tasks) == 0 {
 		return nil
@@ -90,6 +98,8 @@ func (*ImportCleanUp) CleanUpBatch(ctx context.Context, tasks []*proto.Task) err
 		}
 
 		if isGlobalSort {
+			// in next-gen, and most cases of classic kernel, all tasks share the
+			// same cloud storage uri.
 			fileGroup, ok := fileGroups[cloudStorageURI]
 			if !ok {
 				fileGroup = &cleanUpFileGroup{

--- a/pkg/dxf/importinto/clean_up.go
+++ b/pkg/dxf/importinto/clean_up.go
@@ -40,9 +40,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var _ scheduler.CleanUpRoutine = (*ImportCleanUp)(nil)
+var (
+	_ scheduler.CleanUpRoutine      = (*ImportCleanUp)(nil)
+	_ scheduler.BatchCleanUpRoutine = (*ImportCleanUp)(nil)
+)
 
-// ImportCleanUp implements scheduler.CleanUpRoutine.
+// ImportCleanUp implements scheduler.BatchCleanUpRoutine.
 type ImportCleanUp struct {
 }
 
@@ -61,7 +64,7 @@ type cleanUpFileGroup struct {
 	taskIDs            []int64
 }
 
-// CleanUpBatch cleans up multiple import tasks together.
+// CleanUpBatch implements scheduler.BatchCleanUpRoutine.
 // Global-sort files are partitioned by task ID, but finding them requires a scan
 // of the shared object store. Batching lets cleanup scan each store once instead
 // of once per task. The scheduler moves the tasks to history only after this

--- a/pkg/dxf/importinto/clean_up_test.go
+++ b/pkg/dxf/importinto/clean_up_test.go
@@ -37,35 +37,48 @@ func TestImportCleanUpBatchUsesUnredactedStorageCredentials(t *testing.T) {
 	}
 
 	const accessKey = "cleanup-access-key"
-	taskIDs := []int64{42, 43}
+	taskIDs := []int64{42, 43, 44}
+	buckets := []string{"cleanup-bucket", "cleanup-bucket", "other-cleanup-bucket"}
 	backend := s3mem.New()
 	require.NoError(t, backend.CreateBucket("cleanup-bucket"))
+	require.NoError(t, backend.CreateBucket("other-cleanup-bucket"))
 	fakeS3 := gofakes3.New(backend).Server()
+	listRequests := make(chan string, len(taskIDs))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Authorization"), "Credential="+accessKey+"/") {
 			http.Error(w, "unexpected access key", http.StatusForbidden)
 			return
+		}
+		if r.Method == http.MethodGet && r.URL.Query().Has("list-type") {
+			listRequests <- strings.TrimSuffix(r.URL.Path, "/")
 		}
 		fakeS3.ServeHTTP(w, r)
 	}))
 	t.Cleanup(server.Close)
 
 	ctx := context.Background()
-	cloudStorageURI := fmt.Sprintf(
-		"s3://cleanup-bucket/import?region=us-east-1&endpoint=%s&access-key=%s&secret-access-key=cleanup-secret&force-path-style=true",
-		server.URL,
-		accessKey,
-	)
-	store, err := importer.GetSortStore(ctx, cloudStorageURI)
-	require.NoError(t, err)
-	for _, taskID := range taskIDs {
+	cloudStorageURIs := make([]string, 0, len(buckets))
+	for i, bucket := range buckets {
+		cloudStorageURI := fmt.Sprintf(
+			"s3://%s/import?region=us-east-1&endpoint=%s&access-key=%s&secret-access-key=cleanup-secret&force-path-style=true",
+			bucket,
+			server.URL,
+			accessKey,
+		)
+		cloudStorageURIs = append(cloudStorageURIs, cloudStorageURI)
+		store, err := importer.GetSortStore(ctx, cloudStorageURI)
+		require.NoError(t, err)
+		taskID := taskIDs[i]
 		require.NoError(t, store.WriteFile(ctx, fmt.Sprintf("%d/data", taskID), []byte("data")))
+		if i == 0 || i == 2 {
+			require.NoError(t, store.WriteFile(ctx, "kept/data", []byte("data")))
+		}
+		store.Close()
 	}
-	store.Close()
 
 	tasks := make([]*proto.Task, 0, len(taskIDs))
-	for _, taskID := range taskIDs {
-		taskMeta, err := json.Marshal(TaskMeta{Plan: importer.Plan{CloudStorageURI: cloudStorageURI}})
+	for i, taskID := range taskIDs {
+		taskMeta, err := json.Marshal(TaskMeta{Plan: importer.Plan{CloudStorageURI: cloudStorageURIs[i]}})
 		require.NoError(t, err)
 		tasks = append(tasks, &proto.Task{
 			TaskBase: proto.TaskBase{ID: taskID, State: proto.TaskStateFailed},
@@ -74,14 +87,22 @@ func TestImportCleanUpBatchUsesUnredactedStorageCredentials(t *testing.T) {
 	}
 
 	require.NoError(t, (&ImportCleanUp{}).CleanUpBatch(ctx, tasks))
+	require.Equal(t, 2, len(listRequests))
+	listedBuckets := []string{<-listRequests, <-listRequests}
+	require.ElementsMatch(t, []string{"/cleanup-bucket", "/other-cleanup-bucket"}, listedBuckets)
 
-	store, err = importer.GetSortStore(ctx, cloudStorageURI)
-	require.NoError(t, err)
-	t.Cleanup(store.Close)
-	for _, task := range tasks {
+	for i, task := range tasks {
+		store, err := importer.GetSortStore(ctx, cloudStorageURIs[i])
+		require.NoError(t, err)
 		exists, err := store.FileExists(ctx, fmt.Sprintf("%d/data", task.ID))
 		require.NoError(t, err)
 		require.False(t, exists)
+		if i == 0 || i == 2 {
+			exists, err = store.FileExists(ctx, "kept/data")
+			require.NoError(t, err)
+			require.True(t, exists)
+		}
+		store.Close()
 		require.NotContains(t, string(task.Meta), accessKey)
 		require.Contains(t, string(task.Meta), "access-key=xxxxxx")
 	}

--- a/pkg/dxf/importinto/clean_up_test.go
+++ b/pkg/dxf/importinto/clean_up_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importinto
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportCleanUpBatchUsesUnredactedStorageCredentials(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("this test is for nextgen kernel only")
+	}
+
+	const accessKey = "cleanup-access-key"
+	taskIDs := []int64{42, 43}
+	backend := s3mem.New()
+	require.NoError(t, backend.CreateBucket("cleanup-bucket"))
+	fakeS3 := gofakes3.New(backend).Server()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Authorization"), "Credential="+accessKey+"/") {
+			http.Error(w, "unexpected access key", http.StatusForbidden)
+			return
+		}
+		fakeS3.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	cloudStorageURI := fmt.Sprintf(
+		"s3://cleanup-bucket/import?region=us-east-1&endpoint=%s&access-key=%s&secret-access-key=cleanup-secret&force-path-style=true",
+		server.URL,
+		accessKey,
+	)
+	store, err := importer.GetSortStore(ctx, cloudStorageURI)
+	require.NoError(t, err)
+	for _, taskID := range taskIDs {
+		require.NoError(t, store.WriteFile(ctx, fmt.Sprintf("%d/data", taskID), []byte("data")))
+	}
+	store.Close()
+
+	tasks := make([]*proto.Task, 0, len(taskIDs))
+	for _, taskID := range taskIDs {
+		taskMeta, err := json.Marshal(TaskMeta{Plan: importer.Plan{CloudStorageURI: cloudStorageURI}})
+		require.NoError(t, err)
+		tasks = append(tasks, &proto.Task{
+			TaskBase: proto.TaskBase{ID: taskID, State: proto.TaskStateFailed},
+			Meta:     taskMeta,
+		})
+	}
+
+	require.NoError(t, (&ImportCleanUp{}).CleanUpBatch(ctx, tasks))
+
+	store, err = importer.GetSortStore(ctx, cloudStorageURI)
+	require.NoError(t, err)
+	t.Cleanup(store.Close)
+	for _, task := range tasks {
+		exists, err := store.FileExists(ctx, fmt.Sprintf("%d/data", task.ID))
+		require.NoError(t, err)
+		require.False(t, exists)
+		require.NotContains(t, string(task.Meta), accessKey)
+		require.Contains(t, string(task.Meta), "access-key=xxxxxx")
+	}
+}

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -34,13 +34,16 @@ const (
 	metaName = "meta.json"
 )
 
-// CleanUpFiles delete all data and stat files under the same non-partitioned dir.
+// CleanUpFiles delete all data and stat files under the same non-partitioned dirs.
 // see randPartitionedPrefix for how we partition the files.
-func CleanUpFiles(ctx context.Context, store storeapi.Storage, nonPartitionedDir string) error {
+func CleanUpFiles(ctx context.Context, store storeapi.Storage, nonPartitionedDirs ...string) error {
 	failpoint.Inject("skipCleanUpFiles", func() {
 		failpoint.Return(nil)
 	})
-	names, err := simplesst.GetAllFileNames(ctx, store, nonPartitionedDir)
+	if len(nonPartitionedDirs) == 0 {
+		return nil
+	}
+	names, err := simplesst.GetAllFileNames(ctx, store, nonPartitionedDirs...)
 	if err != nil {
 		return err
 	}

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -43,6 +43,9 @@ func CleanUpFiles(ctx context.Context, store storeapi.Storage, nonPartitionedDir
 	if len(nonPartitionedDirs) == 0 {
 		return nil
 	}
+	// TODO: GetAllFileNames accumulates every matching file name in memory before
+	// deletion. Large imports can therefore consume excessive memory or cause an
+	// OOM. List and delete files in bounded batches to keep memory usage bounded.
 	names, err := simplesst.GetAllFileNames(ctx, store, nonPartitionedDirs...)
 	if err != nil {
 		return err

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -19,13 +19,29 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
 	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/stretchr/testify/require"
 )
+
+type walkCountingStorage struct {
+	storeapi.Storage
+	count atomic.Int32
+}
+
+func (s *walkCountingStorage) WalkDir(
+	ctx context.Context,
+	opt *storeapi.WalkOption,
+	fn func(path string, size int64) error,
+) error {
+	s.count.Add(1)
+	return s.Storage.WalkDir(ctx, opt, fn)
+}
 
 func TestGetAllFileNames(t *testing.T) {
 	ctx := context.Background()
@@ -91,15 +107,13 @@ func TestGetAllFileNames(t *testing.T) {
 	}, filenames)
 }
 
-func TestCleanUpFiles(t *testing.T) {
-	ctx := context.Background()
-	store := objstore.NewMemStorage()
+func writeCleanupTestFiles(ctx context.Context, t *testing.T, store storeapi.Storage, dir string) {
 	w := simplesst.NewWriterBuilder().
 		SetMemorySizeLimit(10*(simplesst.LengthBytes*2+2)).
 		SetBlockSize(10*(simplesst.LengthBytes*2+2)).
 		SetPropSizeDistance(5).
 		SetPropKeysDistance(3).
-		Build(store, "/subtask", "0")
+		Build(store, dir, "0")
 	keys := make([][]byte, 0, 30)
 	values := make([][]byte, 0, 30)
 	for i := range 30 {
@@ -110,22 +124,38 @@ func TestCleanUpFiles(t *testing.T) {
 		err := w.WriteRow(ctx, key, values[i], nil)
 		require.NoError(t, err)
 	}
-	err := w.Close(ctx)
-	require.NoError(t, err)
+	require.NoError(t, w.Close(ctx))
+}
 
-	filenames, err := simplesst.GetAllFileNames(ctx, store, "subtask")
+func TestCleanUpFiles(t *testing.T) {
+	ctx := context.Background()
+	baseStore := objstore.NewMemStorage()
+	store := &walkCountingStorage{Storage: baseStore}
+	writeCleanupTestFiles(ctx, t, store, "/subtask")
+	writeCleanupTestFiles(ctx, t, store, "/subtask2")
+	writeCleanupTestFiles(ctx, t, store, "/kept")
+
+	filenames, err := simplesst.GetAllFileNames(ctx, store, "subtask", "subtask2")
 	require.NoError(t, err)
 	filenames = removePartitionPrefix(t, filenames)
 	require.Equal(t, []string{
 		"/subtask/0/0", "/subtask/0/1", "/subtask/0/2",
 		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
+		"/subtask2/0/0", "/subtask2/0/1", "/subtask2/0/2",
+		"/subtask2/0_stat/0", "/subtask2/0_stat/1", "/subtask2/0_stat/2",
 	}, filenames)
+	require.Equal(t, int32(1), store.count.Load())
 
-	require.NoError(t, CleanUpFiles(ctx, store, "subtask"))
+	store.count.Store(0)
+	require.NoError(t, CleanUpFiles(ctx, store, "subtask", "subtask2"))
+	require.Equal(t, int32(1), store.count.Load())
 
-	filenames, err = simplesst.GetAllFileNames(ctx, store, "subtask")
+	filenames, err = simplesst.GetAllFileNames(ctx, baseStore, "subtask", "subtask2")
 	require.NoError(t, err)
 	require.Equal(t, []string(nil), filenames)
+	filenames, err = simplesst.GetAllFileNames(ctx, baseStore, "kept")
+	require.NoError(t, err)
+	require.Len(t, filenames, 6)
 }
 
 func TestSortedKVMeta(t *testing.T) {

--- a/pkg/ingestor/simplesst/util.go
+++ b/pkg/ingestor/simplesst/util.go
@@ -245,12 +245,12 @@ func GetReadRangeFromProps(
 	return readRangesPerKey, nil
 }
 
-// GetAllFileNames returns files with the same non-partitioned dir.
+// GetAllFileNames returns files with the same non-partitioned dirs.
 //   - for intermediate KV/stat files we store them with a partitioned way to mitigate
 //     limitation on Cloud, see randPartitionedPrefix for how we partition the files.
 //   - for meta files, we store them directly under the non-partitioned dir.
 //
-// for example, if nonPartitionedDir is '30001', the files returned might be
+// for example, if nonPartitionedDirs contains '30001', the files returned might be
 //   - 30001/6/meta.json
 //   - 30001/7/meta.json
 //   - 30001/plan/ingest/1/meta.json
@@ -260,8 +260,16 @@ func GetReadRangeFromProps(
 func GetAllFileNames(
 	ctx context.Context,
 	store storeapi.Storage,
-	nonPartitionedDir string,
+	nonPartitionedDirs ...string,
 ) ([]string, error) {
+	if len(nonPartitionedDirs) == 0 {
+		return nil, nil
+	}
+	nonPartitionedDirSet := make(map[string]struct{}, len(nonPartitionedDirs))
+	for _, dir := range nonPartitionedDirs {
+		nonPartitionedDirSet[dir] = struct{}{}
+	}
+
 	var data []string
 
 	err := store.WalkDir(ctx,
@@ -275,7 +283,7 @@ func GetAllFileNames(
 			}
 
 			firstDir := bs[:firstIdx]
-			if string(firstDir) == nonPartitionedDir {
+			if _, ok := nonPartitionedDirSet[string(firstDir)]; ok {
 				data = append(data, path)
 				return nil
 			}
@@ -289,7 +297,7 @@ func GetAllFileNames(
 			}
 			secondDir := path[firstIdx+1 : firstIdx+1+secondIdx]
 
-			if secondDir == nonPartitionedDir {
+			if _, ok := nonPartitionedDirSet[secondDir]; ok {
 				data = append(data, path)
 			}
 			return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69788

Problem Summary:

Cleaning completed `IMPORT INTO` tasks one at a time scans the same global-sort object storage once per task. When many small imports finish together, cleanup can fall behind task execution and delay moving those tasks to history.

### What changed and how does it work?

- Add an optional batch-cleanup capability to DXF and group finished tasks by task type when their cleanup routine supports it. Existing cleanup routines continue to run one task at a time, and only successfully cleaned tasks are transferred to history.
- Make `IMPORT INTO` cleanup process multiple tasks together. It restores table modes and redacts task metadata per task, groups global-sort directories by cloud storage URI, deletes each group with one object-store scan, and sends metering data after file cleanup.
- Keep each live cloud storage URI available for authenticated cleanup while persisting only the redacted URI in task history.
- Extend the global-sort file discovery and deletion helpers to accept multiple task directories in one walk.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run '^TestSchedulerCleanupFinishedTasks$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/dxf/importinto -tags=intest,deadlock,nextgen -run '^TestImportCleanUpBatchUsesUnredactedStorageCredentials$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run '^(TestGetAllFileNames|TestCleanUpFiles)$' -count=1`
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Tested locally with 100, 1,000, and 10,000 files in the global-sort bucket. The speedup comes primarily from replacing one object-store listing per task with one listing per cleanup group:

```
10 tasks: 1.37x to 1.99x faster, saving 27% to 50%.
100 tasks: 4.29x to 18.12x faster, saving 77% to 94%.
1 task: no meaningful change, as expected.
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve `IMPORT INTO` task cleanup performance by batching global-sort file discovery and deletion.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added batch-capable scheduler cleanup that groups work by task type when supported (with batched vs single execution).
  - Enhanced import cleanup with `CleanUpBatch`, batching shared external-file cleanup per storage URI and redacting persisted task metadata.

- **Bug Fixes**
  - Improved cleanup error handling and ensured cleanup/history transfer failures propagate correctly.

- **Tests**
  - Added scheduler cleanup scenario coverage (batch/single selection, failure cases, transfer failures).
  - Added credential-redaction verification and expanded cleanup file discovery/deletion tests.

- **Documentation / Chores**
  - Updated internal test-case reference mappings and adjusted test sharding; improved cleanup file discovery to support multiple non-partitioned directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
