### PR TITLE
test: stabilize flaky TestTableTimerStore

### DIFF
--- a/pkg/timer/store_intergartion_test.go
+++ b/pkg/timer/store_intergartion_test.go
@@ -62,7 +62,7 @@ func TestMemTimerStore(t *testing.T) {
 
 	store = api.NewMemoryTimerStore()
 	defer store.Close()
-	runTimerStoreWatchTest(t, store)
+	runTimerStoreWatchTest(t, store, nil)
 }
 
 // createTimerTableSQL returns a SQL to create timer table
@@ -106,7 +106,43 @@ func TestTableTimerStore(t *testing.T) {
 	tk.MustExec(createTimerTableSQL(dbName, tblName))
 	timerStore = tablestore.NewTableTimerStore(1, pool, dbName, tblName, cli)
 	defer timerStore.Close()
-	runTimerStoreWatchTest(t, timerStore)
+	// Watch starts asynchronously in the etcd notifier, so synchronize before producing table events.
+	runTimerStoreWatchTest(t, timerStore, func(ch api.WatchTimerChan) {
+		readyDeadline := time.NewTimer(time.Minute)
+		defer readyDeadline.Stop()
+	retryReady:
+		for {
+			readyID := "watch-ready-" + uuid.NewString()
+			readyKey := fmt.Sprintf("/tidb/timer/cluster/%d/notify/%s", 1, readyID)
+			putCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_, err := cli.Put(putCtx, readyKey, fmt.Sprintf(
+				`{"events":[{"tp":"create","timer_id":%q,"timestamp":%d}]}`,
+				readyID,
+				time.Now().Unix(),
+			))
+			cancel()
+			require.NoError(t, err)
+
+			attemptTimer := time.NewTimer(100 * time.Millisecond)
+			for {
+				select {
+				case resp, ok := <-ch:
+					require.True(t, ok)
+					for _, event := range resp.Events {
+						if event.Tp == api.WatchTimerEventCreate && event.TimerID == readyID {
+							attemptTimer.Stop()
+							return
+						}
+					}
+				case <-attemptTimer.C:
+					continue retryReady
+				case <-readyDeadline.C:
+					attemptTimer.Stop()
+					require.FailNow(t, "watch ready timeout")
+				}
+			}
+		}
+	})
 
 	// check pool
 	require.False(t, pool.inuse.Load())
@@ -577,7 +613,7 @@ func runTimerStoreInsertAndList(ctx context.Context, t *testing.T, store *api.Ti
 	checkList([]*api.TimerRecord{&recordTpl1}, timers)
 }
 
-func runTimerStoreWatchTest(t *testing.T, store *api.TimerStore) {
+func runTimerStoreWatchTest(t *testing.T, store *api.TimerStore, prepareWatch func(api.WatchTimerChan)) {
 	require.True(t, store.WatchSupported())
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
@@ -595,6 +631,9 @@ func runTimerStoreWatchTest(t *testing.T, store *api.TimerStore) {
 	}
 
 	ch := store.Watch(ctx)
+	if prepareWatch != nil {
+		prepareWatch(ch)
+	}
 	assertWatchEvent := func(tp api.WatchTimerEventType, id string) {
 		timeout := time.NewTimer(time.Minute)
 		defer timeout.Stop()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69920

Problem Summary:
Flaky test `TestTableTimerStore` in `pkg/timer` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The table-store watch test had a setup race between Watch returning and the etcd watch subscription becoming active.

#### Fix

The readiness event proves the same watch channel is subscribed before the original real timer create/update/delete assertions run.

#### Verification

Spec:
- target: `pkg/timer :: TestTableTimerStore`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package_surface passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_surface: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/timer -run '^TestTableTimerStore$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/timer -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timer storage watch test reliability by ensuring watch subscriptions are ready before events are generated.
  * Added coverage for consistent notification handling across in-memory and table-backed timer stores.
  * These updates reduce intermittent test failures and improve confidence in timer event delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->