### PR TITLE
bindinfo: skip binding match for insert values

### DIFF
--- a/pkg/bindinfo/BUILD.bazel
+++ b/pkg/bindinfo/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/hack",
+        "//pkg/util/mock",
         "//pkg/util/parser",
         "//pkg/util/stmtsummary",
         "@com_github_ngaut_pools//:pools",

--- a/pkg/bindinfo/binding_match.go
+++ b/pkg/bindinfo/binding_match.go
@@ -97,6 +97,7 @@ func matchSQLBinding(sctx sessionctx.Context, stmtNode ast.StmtNode, info *Bindi
 func mayHaveSQLBinding(stmtNode ast.StmtNode) bool {
 	switch stmt := stmtNode.(type) {
 	case *ast.InsertStmt:
+		// REPLACE also uses InsertStmt with IsReplace set.
 		return stmt.Select != nil
 	case *ast.ExplainStmt:
 		return stmt.Stmt != nil && mayHaveSQLBinding(stmt.Stmt)

--- a/pkg/bindinfo/binding_match.go
+++ b/pkg/bindinfo/binding_match.go
@@ -55,7 +55,7 @@ func MatchSQLBinding(sctx sessionctx.Context, stmtNode ast.StmtNode) (binding Bi
 
 func matchSQLBinding(sctx sessionctx.Context, stmtNode ast.StmtNode, info *BindingMatchInfo) (binding Binding, matched bool, scope string) {
 	useBinding := sctx.GetSessionVars().UsePlanBaselines
-	if !useBinding || stmtNode == nil {
+	if !useBinding || stmtNode == nil || !mayHaveSQLBinding(stmtNode) {
 		return
 	}
 	// When the domain is initializing, the bind will be nil.
@@ -92,6 +92,17 @@ func matchSQLBinding(sctx sessionctx.Context, stmtNode ast.StmtNode, info *Bindi
 	}
 
 	return
+}
+
+func mayHaveSQLBinding(stmtNode ast.StmtNode) bool {
+	switch stmt := stmtNode.(type) {
+	case *ast.InsertStmt:
+		return stmt.Select != nil
+	case *ast.ExplainStmt:
+		return stmt.Stmt != nil && mayHaveSQLBinding(stmt.Stmt)
+	default:
+		return true
+	}
 }
 
 func fuzzyMatchBindingTableName(currentDB string, stmtTableNames, bindingTableNames []*ast.TableName) (numWildcards int, matched bool) {

--- a/pkg/bindinfo/binding_match_test.go
+++ b/pkg/bindinfo/binding_match_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,5 +73,56 @@ func TestExtractTableName(t *testing.T) {
 		rs := CollectTableNames(stmt)
 		result := getTableName(rs)
 		require.Equal(t, tt.tables, result)
+	}
+}
+
+func TestMayHaveSQLBinding(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want bool
+	}{
+		{"insert into t values (1)", false},
+		{"insert into t values (1) on duplicate key update a = values(a)", false},
+		{"replace into t values (1)", false},
+		{"explain insert into t values (1)", false},
+		{"insert into t select * from s", true},
+		{"replace into t select * from s", true},
+		{"explain insert into t select * from s", true},
+		{"select * from t", true},
+		{"update t set a = 1", true},
+		{"delete from t where a = 1", true},
+	}
+
+	p := parser.New()
+	for _, tt := range tests {
+		stmt, err := p.ParseOneStmt(tt.sql, "", "")
+		require.NoError(t, err)
+		require.Equal(t, tt.want, mayHaveSQLBinding(stmt), tt.sql)
+	}
+}
+
+func TestMatchSQLBindingSkipsInsertValues(t *testing.T) {
+	tests := []string{
+		"insert into t values (1)",
+		"insert into t values (1) on duplicate key update a = values(a)",
+		"replace into t values (1)",
+		"explain insert into t values (1)",
+	}
+
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().UsePlanBaselines = true
+	sctx.SetValue(SessionBindInfoKeyType, NewSessionBindingHandle())
+
+	p := parser.New()
+	for _, sql := range tests {
+		stmt, err := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, err)
+
+		info := &BindingMatchInfo{}
+		bindingSQL, ignoreBinding := MatchSQLBindingForPlanCache(sctx, stmt, info)
+		require.Empty(t, bindingSQL, sql)
+		require.False(t, ignoreBinding, sql)
+		require.Empty(t, info.FuzzyDigest, sql)
+		require.Nil(t, info.TableNames, sql)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69928

Problem Summary:

TiDB currently tries to match SQL bindings for `INSERT/REPLACE ... VALUES` during optimization. These statements cannot be created as bindings through the regular `CREATE BINDING` path, because TiDB only supports `INSERT / REPLACE INTO SELECT` for insert bindings.

For large `INSERT ... ON DUPLICATE KEY UPDATE` statements, the current binding match path still restores and normalizes the full AST before proving that there is no applicable binding. This creates unnecessary compile-time CPU overhead.

### What changed and how does it work?

This PR adds an early eligibility check in SQL binding matching:

- Skip binding matching for `INSERT ... VALUES`.
- Skip binding matching for `REPLACE ... VALUES`.
- Skip binding matching for `INSERT ... VALUES ... ON DUPLICATE KEY UPDATE`.
- Keep existing behavior for `INSERT ... SELECT` and `REPLACE ... SELECT`.
- For `EXPLAIN`, decide based on the underlying statement.

This avoids unnecessary SQL normalization for insert-values workloads without changing supported SQL binding semantics.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
make bazel_prepare
make failpoint-enable
GOCACHE=/tmp/go-build go test ./pkg/bindinfo -run 'TestMayHaveSQLBinding|TestMatchSQLBindingSkipsInsertValues' -tags=intest,deadlock -count=1
make failpoint-disable
git diff --check
make bazel_lint_changed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL binding matching logic for `INSERT` and `REPLACE` statements.
  * `INSERT ... VALUES`-style statements (including `ON DUPLICATE KEY UPDATE` and `REPLACE` variants) are now correctly excluded from SQL binding fuzzy matching.
  * Continued support for `INSERT ... SELECT`, and added correct behavior for `EXPLAIN` wrapping `INSERT/SELECT` patterns.
* **Tests**
  * Added unit tests to verify SQL binding eligibility and to confirm `VALUES`-style statements are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->