### PR TITLE
planner: propagate recursive index estimates in exponential backoff

### DIFF
--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -502,6 +502,7 @@ func expBackoffEstimation(sctx planctx.PlanContext, idx *statistics.Index, coll 
 					continue
 				}
 				countResult, err := GetRowCountByIndexRanges(sctx, coll, idxID, tmpRan, nil)
+				failpoint.InjectCall("afterRecursiveIndexEstimation", idxID, &countResult, &err)
 				if err != nil {
 					continue
 				}

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -501,14 +501,15 @@ func expBackoffEstimation(sctx planctx.PlanContext, idx *statistics.Index, coll 
 				if idxStats == nil || statistics.IndexStatsIsInvalid(sctx, idxStats, coll, idxID) {
 					continue
 				}
-				foundStats = true
 				countResult, err := GetRowCountByIndexRanges(sctx, coll, idxID, tmpRan, nil)
-				if err == nil {
-					break
+				if err != nil {
+					continue
 				}
 				realtimeCnt, _ := coll.GetScaledRealtimeAndModifyCnt(idxStats)
 				selectivity = countResult.Est / float64(realtimeCnt)
-				maxSel = min(maxSel, countResult.MaxEst/float64(coll.RealtimeCount))
+				maxSel = min(maxSel, countResult.MaxEst/float64(realtimeCnt))
+				foundStats = true
+				break
 			}
 		}
 		if !foundStats {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -848,6 +848,42 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 	estRows, err = strconv.ParseFloat(rows[0][1].(string), 64)
 	require.NoError(t, err)
 	require.Greater(t, estRows, 10.0)
+
+	// A virtual column at the beginning of a composite index is mapped back to
+	// that index for single-column estimation. Verify that the recursive index
+	// estimate is propagated into exponential backoff instead of being dropped.
+	tk.MustExec(`create table t3(
+		txn_seq varchar(30) primary key,
+		status varchar(2),
+		flag varchar(1),
+		batch_num varchar(20),
+		txn_suffix varchar(1) as (substr(txn_seq, 30, 1)) virtual,
+		index idx_suffix(txn_suffix, status, flag, batch_num)
+	)`)
+	tk.MustExec(`insert into t3(txn_seq, status, flag, batch_num)
+		select concat(lpad(x.a, 29, '0'), mod(x.a, 10)),
+			if(mod(x.a, 10) = 9, '00', '01'), '1', 'batch'
+		from (with recursive x as (
+			select 1 as a union all select a + 1 from x where a < 500
+		) select a from x) as x`)
+	tk.MustExec("analyze table t3 all columns with 10 topn")
+	// Virtual columns have no column statistics, while idx_suffix has TopN.
+	require.Empty(t, tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't3' and column_name = 'txn_suffix' and is_index = 0").Rows())
+	require.NotEmpty(t, tk.MustQuery("show stats_topn where db_name = 'test' and table_name = 't3' and column_name = 'idx_suffix' and is_index = 1").Rows())
+	tk.MustQuery("select count(*) from t3 where txn_suffix = '9' and status = '00'").Check(testkit.Rows("50"))
+
+	rows = tk.MustQuery("explain format='brief' select * from t3 use index(idx_suffix) where txn_suffix = '9' and status = '00'").Rows()
+	indexScanEstRows := ""
+	for _, row := range rows {
+		if strings.Contains(row[0].(string), "IndexRangeScan") {
+			indexScanEstRows = row[1].(string)
+			break
+		}
+	}
+	require.NotEmpty(t, indexScanEstRows)
+	estRows, err = strconv.ParseFloat(indexScanEstRows, 64)
+	require.NoError(t, err)
+	require.Greater(t, estRows, 1.0)
 }
 
 func TestNewIndexWithColumnStats(t *testing.T) {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -809,7 +809,7 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 	// would skip the most selective column and heavily over-estimate the row
 	// count. Verify that estimation falls back to the index statistics instead.
 	// See https://github.com/pingcap/tidb/issues/69134.
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("set @@global.tidb_enable_auto_analyze='OFF'")
@@ -858,7 +858,8 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 		flag varchar(1),
 		batch_num varchar(20),
 		txn_suffix varchar(1) as (substr(txn_seq, 30, 1)) virtual,
-		index idx_suffix(txn_suffix, status, flag, batch_num)
+		index idx_suffix_first(txn_suffix, status, flag, batch_num),
+		index idx_suffix_second(txn_suffix, status, batch_num, flag)
 	)`)
 	tk.MustExec(`insert into t3(txn_seq, status, flag, batch_num)
 		select concat(lpad(x.a, 29, '0'), mod(x.a, 10)),
@@ -867,23 +868,57 @@ func TestVirtualColumnIndexEstimation(t *testing.T) {
 			select 1 as a union all select a + 1 from x where a < 500
 		) select a from x) as x`)
 	tk.MustExec("analyze table t3 all columns with 10 topn")
-	// Virtual columns have no column statistics, while idx_suffix has TopN.
+	// Virtual columns have no column statistics, while both indexes have TopN.
 	require.Empty(t, tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't3' and column_name = 'txn_suffix' and is_index = 0").Rows())
-	require.NotEmpty(t, tk.MustQuery("show stats_topn where db_name = 'test' and table_name = 't3' and column_name = 'idx_suffix' and is_index = 1").Rows())
+	require.NotEmpty(t, tk.MustQuery("show stats_topn where db_name = 'test' and table_name = 't3' and column_name = 'idx_suffix_first' and is_index = 1").Rows())
+	require.NotEmpty(t, tk.MustQuery("show stats_topn where db_name = 'test' and table_name = 't3' and column_name = 'idx_suffix_second' and is_index = 1").Rows())
 	tk.MustQuery("select count(*) from t3 where txn_suffix = '9' and status = '00'").Check(testkit.Rows("50"))
 
-	rows = tk.MustQuery("explain format='brief' select * from t3 use index(idx_suffix) where txn_suffix = '9' and status = '00'").Rows()
-	indexScanEstRows := ""
-	for _, row := range rows {
-		if strings.Contains(row[0].(string), "IndexRangeScan") {
-			indexScanEstRows = row[1].(string)
-			break
+	getIndexScanEstRows := func(sql string) float64 {
+		rows := tk.MustQuery("explain format='brief' " + sql).Rows()
+		for _, row := range rows {
+			if strings.Contains(row[0].(string), "IndexRangeScan") {
+				estRows, err := strconv.ParseFloat(row[1].(string), 64)
+				require.NoError(t, err)
+				return estRows
+			}
 		}
+		t.Fatalf("no IndexRangeScan in plan for %q", sql)
+		return 0
 	}
-	require.NotEmpty(t, indexScanEstRows)
-	estRows, err = strconv.ParseFloat(indexScanEstRows, 64)
+	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t3"))
 	require.NoError(t, err)
-	require.Greater(t, estRows, 1.0)
+	firstCandidate := table.Meta().FindIndexByName("idx_suffix_first")
+	fallbackCandidate := table.Meta().FindIndexByName("idx_suffix_second")
+	require.NotNil(t, firstCandidate)
+	require.NotNil(t, fallbackCandidate)
+	require.Less(t, firstCandidate.ID, fallbackCandidate.ID)
+
+	func() {
+		var firstCandidateFailed, fallbackCandidateSucceeded bool
+		fpName := "github.com/pingcap/tidb/pkg/planner/cardinality/afterRecursiveIndexEstimation"
+		require.NoError(t, failpoint.EnableCall(fpName, func(idxID int64, countResult *statistics.RowEstimate, recursiveErr *error) {
+			switch idxID {
+			case firstCandidate.ID:
+				firstCandidateFailed = true
+				*countResult = statistics.RowEstimate{}
+				*recursiveErr = fmt.Errorf("injected recursive estimation error for index %d", idxID)
+			case fallbackCandidate.ID:
+				fallbackCandidateSucceeded = firstCandidateFailed && *recursiveErr == nil
+			}
+		}))
+		defer func() {
+			require.NoError(t, failpoint.Disable(fpName))
+		}()
+
+		estRows = getIndexScanEstRows("select * from t3 use index(idx_suffix_second) where txn_suffix = '9' and status = '00'")
+		require.True(t, firstCandidateFailed)
+		require.True(t, fallbackCandidateSucceeded)
+		require.InDelta(t, 50.0, estRows, 0.01)
+	}()
+
+	estRows = getIndexScanEstRows("select * from t3 use index(idx_suffix_first) where txn_suffix = '9' and status = '00'")
+	require.InDelta(t, 50.0, estRows, 0.01)
 }
 
 func TestNewIndexWithColumnStats(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69890

Problem Summary:

### What changed and how does it work?

Continue trying other indexes when recursive index estimation fails.
When it succeeds, convert Est and MaxEst to selectivities using the
scaled realtime row count before marking the statistics as found.

Add a regression case covering a virtual column as the first column of
a composite index with TopN statistics.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/planner/cardinality -run '^TestVirtualColumnIndexEstimation$' -count=1`
  - `GOTOOLCHAIN=go1.25.10 make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix inaccurate cardinality estimation for predicates on a leading virtual column of a composite index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index-based row count estimates when candidate statistics are unavailable or return errors.
  * Corrected selectivity calculations to use the selected index’s current statistics.
  * Added more reliable fallback behavior for alternate indexes.

* **Tests**
  * Expanded coverage for virtual columns, composite-index statistics, and recursive estimation failures.
  * Added validation for more accurate index-scan estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->