### PR TITLE
server: keep client certificates optional with require_secure_transport

### DIFF
--- a/pkg/server/tests/tls/tls_test.go
+++ b/pkg/server/tests/tls/tls_test.go
@@ -325,6 +325,15 @@ func TestTLSVerify(t *testing.T) {
 	// Success: when using a secure connection, the value of "require_secure_transport" can change to "ON"
 	err = cli.RunTestEnableSecureTransport(t, connOverrider)
 	require.NoError(t, err)
+	err = cli.RunReloadTLS(t, connOverrider, false)
+	require.NoError(t, err)
+
+	// issue:69870 A TLS connection without a client certificate should still succeed after
+	// enabling require_secure_transport and reloading the server TLS config.
+	err = cli.RunTestTLSConnection(t, func(config *mysql.Config) {
+		config.TLSConfig = "skip-verify"
+	})
+	require.NoError(t, err)
 
 	// This connection will now fail since the client is not configured to use TLS.
 	err = cli.RunTestTLSConnection(t, nil)

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//pkg/util/collate",
         "//pkg/util/intest",
         "//pkg/util/logutil",
-        "//pkg/util/tls",
         "//pkg/util/traceevent",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -51,7 +51,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	tlsutil "github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
@@ -409,8 +408,6 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 	cs := &atomic.Pointer[tls.Certificate]{}
 	cs.Store(&certs)
 
-	requireTLS := tlsutil.RequireSecureTransport.Load()
-
 	var minTLSVersion uint16 = tls.VersionTLS12
 	switch tlsver := config.GetGlobalConfig().Security.MinTLSVersion; tlsver {
 	case "TLSv1.2":
@@ -431,9 +428,6 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 
 	// Try loading CA cert.
 	clientAuthPolicy := tls.NoClientCert
-	if requireTLS {
-		clientAuthPolicy = tls.RequestClientCert
-	}
 	var certPool *x509.CertPool
 	if len(ca) > 0 {
 		var caCert []byte
@@ -445,11 +439,7 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 		}
 		certPool = x509.NewCertPool()
 		if certPool.AppendCertsFromPEM(caCert) {
-			if requireTLS {
-				clientAuthPolicy = tls.RequireAndVerifyClientCert
-			} else {
-				clientAuthPolicy = tls.VerifyClientCertIfGiven
-			}
+			clientAuthPolicy = tls.VerifyClientCertIfGiven
 		}
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69870

Problem Summary:

When `ssl-ca` is configured, enabling `require_secure_transport` and executing `ALTER INSTANCE RELOAD TLS` changes the server-side TLS client authentication policy to `tls.RequireAndVerifyClientCert`. As a result, TiDB requires every TLS client to provide a valid client certificate, even when the account is not configured with `REQUIRE X509` or another certificate constraint.

`require_secure_transport` should only reject insecure transport. It should not turn regular TLS connections into mandatory mutual TLS connections.

### What changed and how does it work?

- Don't consider `require_secure_transport` for `LoadTLSCertificates`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS client-certificate handling to support connections where a certificate is not provided when certificates are optional.
  * Ensured TLS configuration reloads correctly preserve expected secure-transport behavior.
  * Strengthened validation of secure and insecure connection outcomes after TLS settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->