### PR TITLE
ingest: propagate context cancellation from local import

### DIFF
--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1634,9 +1634,12 @@ func (local *Backend) doImport(
 	retryer := newRegionJobRetryer(workerCtx, jobToWorkerCh, &jobWg)
 	workGroup.Go(func() error {
 		retryer.run()
-		// OperatorErr reports only business errors. Its context is also canceled on
+		// below worker pool and job generation routine returns wctx.OperatorErr
+		// which reports only business errors. Its context is also canceled on
 		// normal exit, so reporting parent-context cancellation there would require
-		// distinguishing cancellation sources. Return the parent context error here.
+		// distinguishing cancellation sources. the dispatcher doesn't always
+		// notify parent context error. to make sure the error group can return
+		// context error when parent context canceled, we return it here.
 		return ctx.Err()
 	})
 

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1634,9 +1634,7 @@ func (local *Backend) doImport(
 	retryer := newRegionJobRetryer(workerCtx, jobToWorkerCh, &jobWg)
 	workGroup.Go(func() error {
 		retryer.run()
-		// Use the caller context so workGroup cancellation does not mask the
-		// error that caused it.
-		return ctx.Err()
+		return nil
 	})
 
 	// dispatcher sends done jobs to retryer or marks them done.

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1634,7 +1634,10 @@ func (local *Backend) doImport(
 	retryer := newRegionJobRetryer(workerCtx, jobToWorkerCh, &jobWg)
 	workGroup.Go(func() error {
 		retryer.run()
-		return nil
+		// OperatorErr reports only business errors. Its context is also canceled on
+		// normal exit, so reporting parent-context cancellation there would require
+		// distinguishing cancellation sources. Return the parent context error here.
+		return ctx.Err()
 	})
 
 	// dispatcher sends done jobs to retryer or marks them done.

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1634,7 +1634,9 @@ func (local *Backend) doImport(
 	retryer := newRegionJobRetryer(workerCtx, jobToWorkerCh, &jobWg)
 	workGroup.Go(func() error {
 		retryer.run()
-		return nil
+		// Use the caller context so workGroup cancellation does not mask the
+		// error that caused it.
+		return ctx.Err()
 	})
 
 	// dispatcher sends done jobs to retryer or marks them done.

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2107,6 +2107,83 @@ func TestDoImport(t *testing.T) {
 	}
 	err = l.doImport(ctx, e, initRegionKeys, int64(config.SplitRegionSize), int64(config.SplitRegionKeys))
 	require.ErrorContains(t, err, "fatal error")
+
+	t.Run("context canceled before import completes", func(t *testing.T) {
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ingestor/ingestctrl/skipStartWorker", "return()")
+		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ingestor/ingestctrl/injectVariables", "return()")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		oldJobToWorkerCh := testJobToWorkerCh
+		oldJobWg := testJobWg
+		oldFakeRegionJobs := fakeRegionJobs
+		t.Cleanup(func() {
+			testJobToWorkerCh = oldJobToWorkerCh
+			testJobWg = oldJobWg
+			fakeRegionJobs = oldFakeRegionJobs
+		})
+
+		jobRange := engineapi.Range{Start: []byte{'a'}, End: []byte{'b'}}
+		data := &Engine{}
+		fakeRegionJobs = map[[2]string]struct {
+			jobs []*regionJob
+			err  error
+		}{
+			{"a", "b"}: {
+				jobs: []*regionJob{{
+					keyRange:   jobRange,
+					ingestData: data,
+					region:     dummyRegionInfo,
+				}},
+			},
+		}
+		testJobToWorkerCh = make(chan *regionJob, 1)
+
+		mockEngine := &mockEngineWithData{
+			data:   data,
+			ranges: []engineapi.Range{jobRange},
+		}
+		local := &Backend{
+			BackendConfig: BackendConfig{
+				WorkerConcurrency: toAtomic(1),
+			},
+		}
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- local.doImport(
+				ctx,
+				mockEngine,
+				[][]byte{jobRange.Start, jobRange.End},
+				int64(config.SplitRegionSize),
+				int64(config.SplitRegionKeys),
+			)
+		}()
+
+		var job *regionJob
+		select {
+		case job = <-testJobToWorkerCh:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for a dispatched region job")
+		}
+		cancel()
+		job.done(testJobWg)
+
+		select {
+		case err := <-errCh:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for doImport to return")
+		}
+	})
+
+	t.Run("dispatcher propagates context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		dispatcher := &dispatcher{workerCtx: ctx}
+		require.ErrorIs(t, dispatcher.run(), context.Canceled)
+	})
 }
 
 func TestRegionJobResetRetryCounter(t *testing.T) {

--- a/pkg/ingestor/ingestctrl/region_job.go
+++ b/pkg/ingestor/ingestctrl/region_job.go
@@ -967,7 +967,7 @@ func (d *dispatcher) run() error {
 	for {
 		select {
 		case <-d.workerCtx.Done():
-			return nil
+			return d.workerCtx.Err()
 		case job, ok = <-d.jobFromWorkerCh:
 		}
 		if !ok {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69953

Problem Summary:

When the caller cancels the context during an active local-backend import, every import goroutine can stop while returning `nil`. Since the error group does not automatically return the parent context error, `doImport` can report success for an interrupted import.
then when call `verifyImportedStatistics` inside `ImportEngine`, it might incorrectly return `"imported length mismatch, expected %d, got %d"`

### What changed and how does it work?

- Return the dispatcher context error when cancellation stops dispatching.
- Return the caller context error after the region-job retryer exits. Using the caller context distinguishes external cancellation from the retryer's normal internal shutdown and covers the race where the dispatcher observes a closed result channel instead of the canceled context.
- Add failpoint-backed regression coverage that cancels an import while a region job is outstanding.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run '^TestDoImport$' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run '^TestDoImport$/^context_canceled_before_import_completes$' -count=10
```

`make bazel_prepare` is not required: no Go files, import sections, top-level test functions, Bazel files, or module dependencies were added or changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Propagate caller context cancellation from local-backend imports instead of reporting success for an interrupted import.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling during data imports so canceled operations correctly surface `context.Canceled` instead of completing successfully.
  - Worker shutdown during import now reports the correct cancellation error to callers.
- **Tests**
  - Added new test cases to verify cancellation propagation for both the import workflow and worker execution, including scenarios with already-canceled worker contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->