### PR TITLE
session: reset starter privileges after branch or restore

### DIFF
--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -486,19 +486,22 @@ engines = ["tikv", "tiflash", "tidb"]
 # does not replay the upgrade entries.
 # Each SQL array element must contain exactly one retry-safe statement. `<keyspace>`
 # is the only supported placeholder and is replaced with the current keyspace name.
+# "bootstrap" must use only INSERT, REPLACE, UPDATE, or DELETE statements. When
+# replayed for a privilege reset, it must recreate the `<keyspace>.root`@`%`
+# account. The DML restriction does not apply to "upgrades" migrations.
 #
 # Example /etc/tidb/starter-bootstrap.json:
 # {
 #   "version": 2,
 #   "bootstrap": [
-#     "INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.starter_admin', '', 'mysql_native_password') ON DUPLICATE KEY UPDATE authentication_string = VALUES(authentication_string), plugin = VALUES(plugin)",
-#     "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.starter_admin', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
+#     "INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.root', '', 'mysql_native_password') ON DUPLICATE KEY UPDATE authentication_string = VALUES(authentication_string), plugin = VALUES(plugin)",
+#     "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.root', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
 #   ],
 #   "upgrades": [
 #     {
 #       "version": 2,
 #       "sql": [
-#         "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.starter_admin', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
+#         "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.root', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
 #       ]
 #     }
 #   ]

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -486,9 +486,8 @@ engines = ["tikv", "tiflash", "tidb"]
 # does not replay the upgrade entries.
 # Each SQL array element must contain exactly one retry-safe statement. `<keyspace>`
 # is the only supported placeholder and is replaced with the current keyspace name.
-# "bootstrap" must use only INSERT, REPLACE, UPDATE, or DELETE statements. When
-# replayed for a privilege reset, it must recreate the `<keyspace>.root`@`%`
-# account. The DML restriction does not apply to "upgrades" migrations.
+# "bootstrap" must use only INSERT, REPLACE, UPDATE, or DELETE statements and
+# create the `<keyspace>.root`@`%` account.
 #
 # Example /etc/tidb/starter-bootstrap.json:
 # {

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -491,14 +491,14 @@ engines = ["tikv", "tiflash", "tidb"]
 # {
 #   "version": 2,
 #   "bootstrap": [
-#     "CREATE USER IF NOT EXISTS '<keyspace>.starter_admin'@'%'",
-#     "GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO '<keyspace>.starter_admin'@'%'"
+#     "INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.starter_admin', '', 'mysql_native_password') ON DUPLICATE KEY UPDATE authentication_string = VALUES(authentication_string), plugin = VALUES(plugin)",
+#     "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.starter_admin', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
 #   ],
 #   "upgrades": [
 #     {
 #       "version": 2,
 #       "sql": [
-#         "GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO '<keyspace>.starter_admin'@'%'"
+#         "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES ('<keyspace>.starter_admin', '%', 'SYSTEM_VARIABLES_ADMIN') ON DUPLICATE KEY UPDATE WITH_GRANT_OPTION = 'N'"
 #       ]
 #     }
 #   ]

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -149,6 +149,7 @@ go_library(
         "@com_github_tikv_client_go_v2//trace",
         "@com_github_tikv_client_go_v2//txnkv/transaction",
         "@com_github_tikv_client_go_v2//util",
+        "@com_github_tikv_pd_client//http",
         "@io_etcd_go_etcd_client_v3//:client",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -221,6 +221,8 @@ go_test(
         "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
+        "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//http",
         "@io_etcd_go_etcd_tests_v3//integration",
         "@org_uber_go_atomic//:atomic",  #keep
         "@org_uber_go_goleak//:goleak",

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
+	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/zap"
 )
 
@@ -49,9 +50,23 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
+	starterBranchConfigKey              = "serverless_is_branch"
+	starterBranchResetCompleteKey       = "serverless_is_branch_bootstrapped"
+	starterRestoreResetCompleteKey      = "serverless_is_bootstrapped_for_restore"
+	starterPrivilegeResetCompleteValue  = "True"
 )
 
-var starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
+var (
+	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
+	starterPrivilegeResetSQL      = []string{
+		"DELETE FROM mysql.db",
+		"DELETE FROM mysql.default_roles",
+		"DELETE FROM mysql.global_grants",
+		"DELETE FROM mysql.global_priv",
+		"DELETE FROM mysql.role_edges",
+		"DELETE FROM mysql.user",
+	}
+)
 
 type starterBootstrapFileSpec struct {
 	Version            int64                         `json:"version"`
@@ -64,7 +79,24 @@ type starterBootstrapUpgradeSpec struct {
 	SQLBlocks []string `json:"sql,omitempty"`
 }
 
+type starterPrivilegeResetState struct {
+	keyspaceName  string
+	completionKey string
+	observedValue string
+}
+
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
+	return runStarterBootstrapTransaction(s, bootstrapFile, false)
+}
+
+func runStarterPrivilegeResetLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
+	if len(bootstrapFile.BootstrapSQLBlocks) == 0 {
+		return errors.New("starter bootstrap file must contain bootstrap SQL for privilege reset")
+	}
+	return runStarterBootstrapTransaction(s, bootstrapFile, true)
+}
+
+func runStarterBootstrapTransaction(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec, resetPrivileges bool) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	if _, err := s.ExecuteInternal(ctx, "BEGIN"); err != nil {
 		return errors.Annotate(err, "begin starter bootstrap file")
@@ -78,6 +110,11 @@ func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBoots
 			logutil.BgLogger().Warn("rollback starter bootstrap file failed", zap.Error(err))
 		}
 	}()
+	if resetPrivileges {
+		if err := executeStarterBootstrapSQLBlocks(s, starterPrivilegeResetSQL); err != nil {
+			return errors.Annotate(err, "reset starter privilege tables")
+		}
+	}
 	if err := executeStarterBootstrapSQLBlocks(s, bootstrapFile.BootstrapSQLBlocks); err != nil {
 		return err
 	}
@@ -98,17 +135,42 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 		return err
 	}
 	if bootstrapFile == nil {
+		_, pending, err := readStarterPrivilegeResetState(store, false)
+		if err != nil {
+			return err
+		}
+		if pending {
+			return errors.New("starter bootstrap file is required for pending privilege reset")
+		}
 		return nil
 	}
 	return upgradeStarterBootstrapWithFile(store, bootstrapFile)
 }
 
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
+	return upgradeStarterBootstrapWithFileAndReset(
+		store,
+		bootstrapFile,
+		readStarterPrivilegeResetState,
+		markStarterPrivilegeResetComplete,
+	)
+}
+
+func upgradeStarterBootstrapWithFileAndReset(
+	store kv.Storage,
+	bootstrapFile *starterBootstrapFileSpec,
+	readResetState func(kv.Storage, bool) (starterPrivilegeResetState, bool, error),
+	markResetComplete func(context.Context, starterPrivilegeResetState) error,
+) error {
+	resetState, privilegeResetPending, err := readResetState(store, false)
+	if err != nil {
+		return err
+	}
 	completedVersion, err := getStoreStarterBootstrapVersion(store)
 	if err != nil {
 		return err
 	}
-	if !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -119,11 +181,17 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	}
 	defer releaseFn()
 
+	if privilegeResetPending {
+		resetState, privilegeResetPending, err = readResetState(store, true)
+		if err != nil {
+			return err
+		}
+	}
 	completedVersion, err = getStoreStarterBootstrapVersion(store)
 	if err != nil {
 		return err
 	}
-	if !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -152,6 +220,23 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
+	if privilegeResetPending {
+		if err = runStarterPrivilegeResetLocked(s, bootstrapFile); err != nil {
+			return err
+		}
+		if err = finishStarterBootstrap(store, bootstrapFile.Version); err != nil {
+			return err
+		}
+		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+		if err = markResetComplete(ctx, resetState); err != nil {
+			return errors.Annotate(err, "complete starter privilege reset")
+		}
+		logutil.BgLogger().Info("starter privilege reset finished",
+			zap.String("keyspace", resetState.keyspaceName),
+			zap.Int64("version", bootstrapFile.Version),
+			zap.Duration("cost", time.Since(startTime)))
+		return nil
+	}
 	if !needStarterBootstrapUpgrade(storedVersion, bootstrapFile) {
 		// The SQL version can be ahead after a crash before the completion key is written.
 		return finishStarterBootstrap(store, storedVersion)
@@ -179,6 +264,67 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 		zap.Int64("version", bootstrapFile.Version),
 		zap.Duration("cost", time.Since(startTime)))
 	return nil
+}
+
+func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool) {
+	isBranch, _ := strconv.ParseBool(keyspaceConfig[starterBranchConfigKey])
+	if isBranch {
+		value, ok := keyspaceConfig[starterBranchResetCompleteKey]
+		if !ok || value == "" || value == starterPrivilegeResetCompleteValue {
+			return starterPrivilegeResetState{}, false
+		}
+		return starterPrivilegeResetState{
+			completionKey: starterBranchResetCompleteKey,
+			observedValue: value,
+		}, true
+	}
+
+	value, ok := keyspaceConfig[starterRestoreResetCompleteKey]
+	if !ok || value == "" {
+		return starterPrivilegeResetState{}, false
+	}
+	complete, _ := strconv.ParseBool(value)
+	if complete {
+		return starterPrivilegeResetState{}, false
+	}
+	return starterPrivilegeResetState{
+		completionKey: starterRestoreResetCompleteKey,
+		observedValue: value,
+	}, true
+}
+
+func readStarterPrivilegeResetState(store kv.Storage, refreshFromPD bool) (starterPrivilegeResetState, bool, error) {
+	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
+	if keyspaceMeta == nil {
+		return starterPrivilegeResetState{}, false, nil
+	}
+	if refreshFromPD {
+		if storeWithPD, ok := store.(kv.StorageWithPD); ok && storeWithPD.GetPDClient() != nil {
+			latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
+			if err != nil {
+				return starterPrivilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
+			}
+			if latestMeta != nil {
+				keyspaceMeta = latestMeta
+			}
+		}
+	}
+	state, pending := pendingStarterPrivilegeReset(keyspaceMeta.GetConfig())
+	state.keyspaceName = keyspaceMeta.GetName()
+	return state, pending, nil
+}
+
+func markStarterPrivilegeResetComplete(ctx context.Context, state starterPrivilegeResetState) error {
+	completeValue := starterPrivilegeResetCompleteValue
+	observedValue := state.observedValue
+	return infosync.SetKeyspaceConfig(ctx, state.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
+		Config: map[string]*string{
+			state.completionKey: &completeValue,
+		},
+		Preconditions: map[string]*string{
+			state.completionKey: &observedValue,
+		},
+	})
 }
 
 func getStoreStarterBootstrapVersion(store kv.Storage) (int64, error) {

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -54,7 +54,6 @@ const (
 
 // These values are part of the existing PD keyspace metadata contract.
 const (
-	starterBranchConfigKey         = "serverless_is_branch"
 	starterBranchResetCompleteKey  = "serverless_is_branch_bootstrapped"
 	starterRestoreResetCompleteKey = "serverless_is_bootstrapped_for_restore"
 )
@@ -62,11 +61,14 @@ const (
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
 	starterPrivilegeResetSQL      = []string{
+		"DELETE FROM mysql.columns_priv",
 		"DELETE FROM mysql.db",
 		"DELETE FROM mysql.default_roles",
 		"DELETE FROM mysql.global_grants",
 		"DELETE FROM mysql.global_priv",
+		"DELETE FROM mysql.password_history",
 		"DELETE FROM mysql.role_edges",
+		"DELETE FROM mysql.tables_priv",
 		"DELETE FROM mysql.user",
 	}
 )
@@ -83,9 +85,8 @@ type starterBootstrapUpgradeSpec struct {
 }
 
 type starterPrivilegeResetState struct {
-	keyspaceName  string
-	completionKey string
-	observedValue string
+	keyspaceName   string
+	pendingMarkers map[string]string
 }
 
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
@@ -256,24 +257,22 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 }
 
 func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool) {
-	completionKey := starterRestoreResetCompleteKey
-	isBranch, _ := strconv.ParseBool(keyspaceConfig[starterBranchConfigKey])
-	if isBranch {
-		completionKey = starterBranchResetCompleteKey
+	state := starterPrivilegeResetState{}
+	for _, key := range []string{starterBranchResetCompleteKey, starterRestoreResetCompleteKey} {
+		value, ok := keyspaceConfig[key]
+		if !ok || value == "" {
+			continue
+		}
+		complete, _ := strconv.ParseBool(value)
+		if complete {
+			continue
+		}
+		if state.pendingMarkers == nil {
+			state.pendingMarkers = make(map[string]string)
+		}
+		state.pendingMarkers[key] = value
 	}
-
-	value, ok := keyspaceConfig[completionKey]
-	if !ok || value == "" {
-		return starterPrivilegeResetState{}, false
-	}
-	complete, _ := strconv.ParseBool(value)
-	if complete {
-		return starterPrivilegeResetState{}, false
-	}
-	return starterPrivilegeResetState{
-		completionKey: completionKey,
-		observedValue: value,
-	}, true
+	return state, len(state.pendingMarkers) > 0
 }
 
 func readStarterPrivilegeResetState(store kv.Storage, refreshFromPD bool) (starterPrivilegeResetState, bool, error) {
@@ -299,13 +298,16 @@ func readStarterPrivilegeResetState(store kv.Storage, refreshFromPD bool) (start
 
 func markStarterPrivilegeResetComplete(ctx context.Context, state starterPrivilegeResetState) error {
 	completeValue := "True"
+	config := make(map[string]*string, len(state.pendingMarkers))
+	preconditions := make(map[string]*string, len(state.pendingMarkers))
+	for key, value := range state.pendingMarkers {
+		observedValue := value
+		config[key] = &completeValue
+		preconditions[key] = &observedValue
+	}
 	return infosync.SetKeyspaceConfig(ctx, state.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
-		Config: map[string]*string{
-			state.completionKey: &completeValue,
-		},
-		Preconditions: map[string]*string{
-			state.completionKey: &state.observedValue,
-		},
+		Config:        config,
+		Preconditions: preconditions,
 	})
 }
 

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -61,14 +61,11 @@ const (
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
 	starterPrivilegeResetSQL      = []string{
-		"DELETE FROM mysql.columns_priv",
 		"DELETE FROM mysql.db",
 		"DELETE FROM mysql.default_roles",
 		"DELETE FROM mysql.global_grants",
 		"DELETE FROM mysql.global_priv",
-		"DELETE FROM mysql.password_history",
 		"DELETE FROM mysql.role_edges",
-		"DELETE FROM mysql.tables_priv",
 		"DELETE FROM mysql.user",
 	}
 )

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -87,17 +88,27 @@ type starterPrivilegeResetState struct {
 }
 
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	return runStarterBootstrapTransaction(s, bootstrapFile, false)
+	stmts, err := prepareStarterBootstrapStatements(s, bootstrapFile.BootstrapSQLBlocks)
+	if err != nil {
+		return err
+	}
+	return runStarterBootstrapTransaction(s, bootstrapFile, stmts, false)
 }
 
 func runStarterPrivilegeResetLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	if len(bootstrapFile.BootstrapSQLBlocks) == 0 {
-		return errors.New("starter bootstrap file must contain bootstrap SQL for privilege reset")
+	stmts, err := prepareStarterBootstrapStatements(s, bootstrapFile.BootstrapSQLBlocks)
+	if err != nil {
+		return err
 	}
-	return runStarterBootstrapTransaction(s, bootstrapFile, true)
+	return runStarterBootstrapTransaction(s, bootstrapFile, stmts, true)
 }
 
-func runStarterBootstrapTransaction(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec, resetPrivileges bool) error {
+func runStarterBootstrapTransaction(
+	s sessionapi.Session,
+	bootstrapFile *starterBootstrapFileSpec,
+	bootstrapStmts []ast.StmtNode,
+	resetPrivileges bool,
+) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	if _, err := s.ExecuteInternal(ctx, "BEGIN"); err != nil {
 		return errors.Annotate(err, "begin starter bootstrap file")
@@ -116,8 +127,13 @@ func runStarterBootstrapTransaction(s sessionapi.Session, bootstrapFile *starter
 			return errors.Annotate(err, "reset starter privilege tables")
 		}
 	}
-	if err := executeStarterBootstrapSQLBlocks(s, bootstrapFile.BootstrapSQLBlocks); err != nil {
+	if err := executeStarterBootstrapStatements(s, bootstrapStmts); err != nil {
 		return err
+	}
+	if resetPrivileges {
+		if err := verifyStarterRootUser(s); err != nil {
+			return err
+		}
 	}
 	if err := updateStarterBootstrapVersion(s, bootstrapFile.Version); err != nil {
 		return err
@@ -208,6 +224,10 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 		return err
 	}
 	if privilegeResetPending {
+		copiedVersion := max(completedVersion, storedVersion)
+		if copiedVersion > bootstrapFile.Version {
+			return errors.Errorf("starter bootstrap file version %d is older than copied version %d", bootstrapFile.Version, copiedVersion)
+		}
 		if err = runStarterPrivilegeResetLocked(s, bootstrapFile); err != nil {
 			return err
 		}
@@ -481,9 +501,28 @@ func updateStarterBootstrapVersion(s sessionapi.Session, version int64) error {
 }
 
 func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) error {
-	if len(blocks) == 0 {
-		return nil
+	stmts, err := parseStarterBootstrapSQLBlocks(s, blocks)
+	if err != nil {
+		return err
 	}
+	return executeStarterBootstrapStatements(s, stmts)
+}
+
+func prepareStarterBootstrapStatements(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+	if len(blocks) == 0 {
+		return nil, errors.New("starter bootstrap file must contain bootstrap SQL")
+	}
+	stmts, err := parseStarterBootstrapSQLBlocks(s, blocks)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateStarterBootstrapStatements(stmts); err != nil {
+		return nil, err
+	}
+	return stmts, nil
+}
+
+func parseStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -492,24 +531,77 @@ func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) err
 		sessionVars.InRestrictedSQL = originalInRestrictedSQL
 	}()
 
+	stmts := make([]ast.StmtNode, 0, len(blocks))
 	for blockIdx, block := range blocks {
 		rendered := renderStarterBootstrapSQL(block)
-		stmts, err := s.Parse(ctx, rendered)
+		parsed, err := s.Parse(ctx, rendered)
 		if err != nil {
-			return errors.Annotatef(err, "parse SQL block %d", blockIdx)
+			return nil, errors.Annotatef(err, "parse SQL block %d", blockIdx)
 		}
-		if len(stmts) != 1 {
-			return errors.Errorf("SQL block %d must contain exactly one statement", blockIdx)
+		if len(parsed) != 1 {
+			return nil, errors.Errorf("SQL block %d must contain exactly one statement", blockIdx)
 		}
-		rs, err := s.ExecuteStmt(ctx, stmts[0])
+		stmts = append(stmts, parsed[0])
+	}
+	return stmts, nil
+}
+
+func validateStarterBootstrapStatements(stmts []ast.StmtNode) error {
+	for i, stmt := range stmts {
+		switch stmt.(type) {
+		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+		default:
+			return errors.Errorf("bootstrap SQL block %d must be INSERT, REPLACE, UPDATE, or DELETE", i)
+		}
+	}
+	return nil
+}
+
+func executeStarterBootstrapStatements(s sessionapi.Session, stmts []ast.StmtNode) error {
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	sessionVars := s.GetSessionVars()
+	originalInRestrictedSQL := sessionVars.InRestrictedSQL
+	sessionVars.InRestrictedSQL = true
+	defer func() {
+		sessionVars.InRestrictedSQL = originalInRestrictedSQL
+	}()
+
+	for i, stmt := range stmts {
+		rs, err := s.ExecuteStmt(ctx, stmt)
 		if err != nil {
-			return errors.Annotatef(err, "execute SQL block %d", blockIdx)
+			return errors.Annotatef(err, "execute SQL block %d", i)
 		}
 		if rs != nil {
 			if err := rs.Close(); err != nil {
 				return errors.Annotate(err, "close SQL result")
 			}
 		}
+	}
+	return nil
+}
+
+func verifyStarterRootUser(s sessionapi.Session) error {
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	rootUser := config.GetGlobalKeyspaceName() + ".root"
+	rs, err := s.ExecuteInternal(ctx,
+		"SELECT 1 FROM mysql.user WHERE Host = '%' AND User = %? LIMIT 1", rootUser)
+	if err != nil {
+		return errors.Annotate(err, "verify starter root user")
+	}
+	if rs == nil {
+		return errors.New("verify starter root user returned no result")
+	}
+	req := rs.NewChunk(nil)
+	nextErr := rs.Next(ctx, req)
+	closeErr := rs.Close()
+	if nextErr != nil {
+		return errors.Annotate(nextErr, "verify starter root user")
+	}
+	if closeErr != nil {
+		return errors.Annotate(closeErr, "close starter root verification result")
+	}
+	if req.NumRows() == 0 {
+		return errors.Errorf("starter bootstrap file must create '%s'@'%%' for privilege reset", rootUser)
 	}
 	return nil
 }

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -50,10 +50,13 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
-	starterBranchConfigKey              = "serverless_is_branch"
-	starterBranchResetCompleteKey       = "serverless_is_branch_bootstrapped"
-	starterRestoreResetCompleteKey      = "serverless_is_bootstrapped_for_restore"
-	starterPrivilegeResetCompleteValue  = "True"
+)
+
+// These values are part of the existing PD keyspace metadata contract.
+const (
+	starterBranchConfigKey         = "serverless_is_branch"
+	starterBranchResetCompleteKey  = "serverless_is_branch_bootstrapped"
+	starterRestoreResetCompleteKey = "serverless_is_bootstrapped_for_restore"
 )
 
 var (
@@ -148,21 +151,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 }
 
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
-	return upgradeStarterBootstrapWithFileAndReset(
-		store,
-		bootstrapFile,
-		readStarterPrivilegeResetState,
-		markStarterPrivilegeResetComplete,
-	)
-}
-
-func upgradeStarterBootstrapWithFileAndReset(
-	store kv.Storage,
-	bootstrapFile *starterBootstrapFileSpec,
-	readResetState func(kv.Storage, bool) (starterPrivilegeResetState, bool, error),
-	markResetComplete func(context.Context, starterPrivilegeResetState) error,
-) error {
-	resetState, privilegeResetPending, err := readResetState(store, false)
+	resetState, privilegeResetPending, err := readStarterPrivilegeResetState(store, false)
 	if err != nil {
 		return err
 	}
@@ -182,7 +171,7 @@ func upgradeStarterBootstrapWithFileAndReset(
 	defer releaseFn()
 
 	if privilegeResetPending {
-		resetState, privilegeResetPending, err = readResetState(store, true)
+		resetState, privilegeResetPending, err = readStarterPrivilegeResetState(store, true)
 		if err != nil {
 			return err
 		}
@@ -228,7 +217,7 @@ func upgradeStarterBootstrapWithFileAndReset(
 			return err
 		}
 		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
-		if err = markResetComplete(ctx, resetState); err != nil {
+		if err = markStarterPrivilegeResetComplete(ctx, resetState); err != nil {
 			return errors.Annotate(err, "complete starter privilege reset")
 		}
 		logutil.BgLogger().Info("starter privilege reset finished",
@@ -267,19 +256,13 @@ func upgradeStarterBootstrapWithFileAndReset(
 }
 
 func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool) {
+	completionKey := starterRestoreResetCompleteKey
 	isBranch, _ := strconv.ParseBool(keyspaceConfig[starterBranchConfigKey])
 	if isBranch {
-		value, ok := keyspaceConfig[starterBranchResetCompleteKey]
-		if !ok || value == "" || value == starterPrivilegeResetCompleteValue {
-			return starterPrivilegeResetState{}, false
-		}
-		return starterPrivilegeResetState{
-			completionKey: starterBranchResetCompleteKey,
-			observedValue: value,
-		}, true
+		completionKey = starterBranchResetCompleteKey
 	}
 
-	value, ok := keyspaceConfig[starterRestoreResetCompleteKey]
+	value, ok := keyspaceConfig[completionKey]
 	if !ok || value == "" {
 		return starterPrivilegeResetState{}, false
 	}
@@ -288,7 +271,7 @@ func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPriv
 		return starterPrivilegeResetState{}, false
 	}
 	return starterPrivilegeResetState{
-		completionKey: starterRestoreResetCompleteKey,
+		completionKey: completionKey,
 		observedValue: value,
 	}, true
 }
@@ -315,14 +298,13 @@ func readStarterPrivilegeResetState(store kv.Storage, refreshFromPD bool) (start
 }
 
 func markStarterPrivilegeResetComplete(ctx context.Context, state starterPrivilegeResetState) error {
-	completeValue := starterPrivilegeResetCompleteValue
-	observedValue := state.observedValue
+	completeValue := "True"
 	return infosync.SetKeyspaceConfig(ctx, state.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
 		Config: map[string]*string{
 			state.completionKey: &completeValue,
 		},
 		Preconditions: map[string]*string{
-			state.completionKey: &observedValue,
+			state.completionKey: &state.observedValue,
 		},
 	})
 }

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -165,6 +165,8 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 }
 
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
+	// Reset markers are written before TiDB starts, so the codec snapshot is
+	// sufficient for the no-reset fast path.
 	resetState, privilegeResetPending, err := readStarterPrivilegeResetState(store, false)
 	if err != nil {
 		return err

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -51,18 +51,18 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
-	starterPrivilegeResetBatchSize      = 128
+	privilegeResetBatchSize             = 128
 )
 
 // These values are part of the existing PD keyspace metadata contract.
 const (
-	starterBranchResetCompleteKey  = "serverless_is_branch_bootstrapped"
-	starterRestoreResetCompleteKey = "serverless_is_bootstrapped_for_restore"
+	branchResetDoneKey  = "serverless_is_branch_bootstrapped"
+	restoreResetDoneKey = "serverless_is_bootstrapped_for_restore"
 )
 
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
-	starterPrivilegeResetTables   = []string{
+	privilegeResetTables          = []string{
 		"columns_priv",
 		"db",
 		"default_roles",
@@ -85,31 +85,31 @@ type starterBootstrapUpgradeSpec struct {
 	SQLBlocks []string `json:"sql,omitempty"`
 }
 
-type starterPrivilegeResetState struct {
+type privilegeResetState struct {
 	keyspaceName   string
 	pendingMarkers map[string]string
 }
 
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareStarterBootstrapStatements(s, bootstrapFile.BootstrapSQLBlocks)
+	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	return runStarterBootstrapTransaction(s, bootstrapFile, stmts)
+	return runBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func runStarterPrivilegeResetLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareStarterBootstrapStatements(s, bootstrapFile.BootstrapSQLBlocks)
+func resetPrivilegesLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
+	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	if err := resetStarterPrivilegeTables(s); err != nil {
+	if err := resetPrivilegeTables(s); err != nil {
 		return err
 	}
-	return runStarterBootstrapTransaction(s, bootstrapFile, stmts)
+	return runBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func runStarterBootstrapTransaction(
+func runBootstrapTxn(
 	s sessionapi.Session,
 	bootstrapFile *starterBootstrapFileSpec,
 	bootstrapStmts []ast.StmtNode,
@@ -127,10 +127,10 @@ func runStarterBootstrapTransaction(
 			logutil.BgLogger().Warn("rollback starter bootstrap file failed", zap.Error(err))
 		}
 	}()
-	if err := executeStarterBootstrapStatements(s, bootstrapStmts); err != nil {
+	if err := executeBootstrapStmts(s, bootstrapStmts); err != nil {
 		return err
 	}
-	if err := verifyStarterRootUser(s); err != nil {
+	if err := verifyRootUser(s); err != nil {
 		return err
 	}
 	if err := updateStarterBootstrapVersion(s, bootstrapFile.Version); err != nil {
@@ -143,14 +143,14 @@ func runStarterBootstrapTransaction(
 	return nil
 }
 
-func resetStarterPrivilegeTables(s sessionapi.Session) error {
-	for _, table := range starterPrivilegeResetTables {
+func resetPrivilegeTables(s sessionapi.Session) error {
+	for _, table := range privilegeResetTables {
 		for {
-			affectedRows, err := deleteStarterPrivilegeBatch(s, table)
+			affectedRows, err := deletePrivilegeBatch(s, table)
 			if err != nil {
 				return errors.Annotatef(err, "reset starter privilege table mysql.%s", table)
 			}
-			if affectedRows < starterPrivilegeResetBatchSize {
+			if affectedRows < privilegeResetBatchSize {
 				break
 			}
 		}
@@ -158,7 +158,7 @@ func resetStarterPrivilegeTables(s sessionapi.Session) error {
 	return nil
 }
 
-func deleteStarterPrivilegeBatch(s sessionapi.Session, table string) (uint64, error) {
+func deletePrivilegeBatch(s sessionapi.Session, table string) (uint64, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	if _, err := s.ExecuteInternal(ctx, "BEGIN"); err != nil {
 		return 0, err
@@ -172,7 +172,7 @@ func deleteStarterPrivilegeBatch(s sessionapi.Session, table string) (uint64, er
 		}
 	}()
 
-	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, starterPrivilegeResetBatchSize)
+	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, privilegeResetBatchSize)
 	if err != nil {
 		return 0, err
 	}
@@ -196,7 +196,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 		return err
 	}
 	if bootstrapFile == nil {
-		_, pending, err := readStarterPrivilegeResetStateFromCodec(store)
+		_, pending, err := readPrivilegeResetFromCodec(store)
 		if err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
 	// Reset markers are written before TiDB starts, so the codec snapshot is
 	// sufficient for the no-reset fast path.
-	resetState, privilegeResetPending, err := readStarterPrivilegeResetStateFromCodec(store)
+	resetState, privilegeResetPending, err := readPrivilegeResetFromCodec(store)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	defer releaseFn()
 
 	if privilegeResetPending {
-		resetState, privilegeResetPending, err = loadStarterPrivilegeResetStateFromPD(store)
+		resetState, privilegeResetPending, err = loadPrivilegeResetFromPD(store)
 		if err != nil {
 			return err
 		}
@@ -274,14 +274,14 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 		if copiedVersion > bootstrapFile.Version {
 			return errors.Errorf("starter bootstrap file version %d is older than copied version %d", bootstrapFile.Version, copiedVersion)
 		}
-		if err = runStarterPrivilegeResetLocked(s, bootstrapFile); err != nil {
+		if err = resetPrivilegesLocked(s, bootstrapFile); err != nil {
 			return err
 		}
 		if err = finishStarterBootstrap(store, bootstrapFile.Version); err != nil {
 			return err
 		}
 		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
-		if err = markStarterPrivilegeResetComplete(ctx, resetState); err != nil {
+		if err = markPrivilegeResetComplete(ctx, resetState); err != nil {
 			return errors.Annotate(err, "complete starter privilege reset")
 		}
 		logutil.BgLogger().Info("starter privilege reset finished",
@@ -319,16 +319,16 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	return nil
 }
 
-func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool, error) {
-	state := starterPrivilegeResetState{}
-	for _, key := range []string{starterBranchResetCompleteKey, starterRestoreResetCompleteKey} {
+func parsePrivilegeReset(keyspaceConfig map[string]string) (privilegeResetState, bool, error) {
+	state := privilegeResetState{}
+	for _, key := range []string{branchResetDoneKey, restoreResetDoneKey} {
 		value, ok := keyspaceConfig[key]
 		if !ok || value == "" {
 			continue
 		}
 		complete, err := strconv.ParseBool(value)
 		if err != nil {
-			return starterPrivilegeResetState{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
+			return privilegeResetState{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
 		}
 		if complete {
 			continue
@@ -341,38 +341,38 @@ func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPriv
 	return state, len(state.pendingMarkers) > 0, nil
 }
 
-func readStarterPrivilegeResetStateFromCodec(store kv.Storage) (starterPrivilegeResetState, bool, error) {
+func readPrivilegeResetFromCodec(store kv.Storage) (privilegeResetState, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return starterPrivilegeResetState{}, false, nil
+		return privilegeResetState{}, false, nil
 	}
-	state, pending, err := pendingStarterPrivilegeReset(keyspaceMeta.GetConfig())
+	state, pending, err := parsePrivilegeReset(keyspaceMeta.GetConfig())
 	state.keyspaceName = keyspaceMeta.GetName()
 	return state, pending, err
 }
 
-func loadStarterPrivilegeResetStateFromPD(store kv.Storage) (starterPrivilegeResetState, bool, error) {
+func loadPrivilegeResetFromPD(store kv.Storage) (privilegeResetState, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return starterPrivilegeResetState{}, false, nil
+		return privilegeResetState{}, false, nil
 	}
 	storeWithPD, ok := store.(kv.StorageWithPD)
 	if !ok || storeWithPD.GetPDClient() == nil {
-		return starterPrivilegeResetState{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
+		return privilegeResetState{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
 	}
 	latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
 	if err != nil {
-		return starterPrivilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
+		return privilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
 	}
 	if latestMeta == nil {
-		return starterPrivilegeResetState{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
+		return privilegeResetState{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
 	}
-	state, pending, err := pendingStarterPrivilegeReset(latestMeta.GetConfig())
+	state, pending, err := parsePrivilegeReset(latestMeta.GetConfig())
 	state.keyspaceName = latestMeta.GetName()
 	return state, pending, err
 }
 
-func markStarterPrivilegeResetComplete(ctx context.Context, state starterPrivilegeResetState) error {
+func markPrivilegeResetComplete(ctx context.Context, state privilegeResetState) error {
 	completeValue := "True"
 	config := make(map[string]*string, len(state.pendingMarkers))
 	preconditions := make(map[string]*string, len(state.pendingMarkers))
@@ -590,21 +590,21 @@ func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) err
 	return nil
 }
 
-func prepareStarterBootstrapStatements(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func prepareBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	if len(blocks) == 0 {
 		return nil, errors.New("starter bootstrap file must contain bootstrap SQL")
 	}
-	stmts, err := parseStarterBootstrapSQLBlocks(s, blocks)
+	stmts, err := parseBootstrapBlocks(s, blocks)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateStarterBootstrapStatements(stmts); err != nil {
+	if err := validateBootstrapStmts(stmts); err != nil {
 		return nil, err
 	}
 	return stmts, nil
 }
 
-func parseStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func parseBootstrapBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -628,7 +628,7 @@ func parseStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) ([]as
 	return stmts, nil
 }
 
-func validateStarterBootstrapStatements(stmts []ast.StmtNode) error {
+func validateBootstrapStmts(stmts []ast.StmtNode) error {
 	for i, stmt := range stmts {
 		switch stmt.(type) {
 		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
@@ -639,7 +639,7 @@ func validateStarterBootstrapStatements(stmts []ast.StmtNode) error {
 	return nil
 }
 
-func executeStarterBootstrapStatements(s sessionapi.Session, stmts []ast.StmtNode) error {
+func executeBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -662,7 +662,7 @@ func executeStarterBootstrapStatements(s sessionapi.Session, stmts []ast.StmtNod
 	return nil
 }
 
-func verifyStarterRootUser(s sessionapi.Session) error {
+func verifyRootUser(s sessionapi.Session) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	rootUser := config.GetGlobalKeyspaceName() + ".root"
 	rs, err := s.ExecuteInternal(ctx,

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -51,6 +51,7 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
+	starterPrivilegeResetBatchSize      = 128
 )
 
 // These values are part of the existing PD keyspace metadata contract.
@@ -61,13 +62,15 @@ const (
 
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
-	starterPrivilegeResetSQL      = []string{
-		"DELETE FROM mysql.db",
-		"DELETE FROM mysql.default_roles",
-		"DELETE FROM mysql.global_grants",
-		"DELETE FROM mysql.global_priv",
-		"DELETE FROM mysql.role_edges",
-		"DELETE FROM mysql.user",
+	starterPrivilegeResetTables   = []string{
+		"columns_priv",
+		"db",
+		"default_roles",
+		"global_grants",
+		"global_priv",
+		"role_edges",
+		"tables_priv",
+		"user",
 	}
 )
 
@@ -92,7 +95,7 @@ func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBoots
 	if err != nil {
 		return err
 	}
-	return runStarterBootstrapTransaction(s, bootstrapFile, stmts, false)
+	return runStarterBootstrapTransaction(s, bootstrapFile, stmts)
 }
 
 func runStarterPrivilegeResetLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
@@ -100,14 +103,16 @@ func runStarterPrivilegeResetLocked(s sessionapi.Session, bootstrapFile *starter
 	if err != nil {
 		return err
 	}
-	return runStarterBootstrapTransaction(s, bootstrapFile, stmts, true)
+	if err := resetStarterPrivilegeTables(s); err != nil {
+		return err
+	}
+	return runStarterBootstrapTransaction(s, bootstrapFile, stmts)
 }
 
 func runStarterBootstrapTransaction(
 	s sessionapi.Session,
 	bootstrapFile *starterBootstrapFileSpec,
 	bootstrapStmts []ast.StmtNode,
-	resetPrivileges bool,
 ) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	if _, err := s.ExecuteInternal(ctx, "BEGIN"); err != nil {
@@ -122,18 +127,11 @@ func runStarterBootstrapTransaction(
 			logutil.BgLogger().Warn("rollback starter bootstrap file failed", zap.Error(err))
 		}
 	}()
-	if resetPrivileges {
-		if err := executeStarterBootstrapSQLBlocks(s, starterPrivilegeResetSQL); err != nil {
-			return errors.Annotate(err, "reset starter privilege tables")
-		}
-	}
 	if err := executeStarterBootstrapStatements(s, bootstrapStmts); err != nil {
 		return err
 	}
-	if resetPrivileges {
-		if err := verifyStarterRootUser(s); err != nil {
-			return err
-		}
+	if err := verifyStarterRootUser(s); err != nil {
+		return err
 	}
 	if err := updateStarterBootstrapVersion(s, bootstrapFile.Version); err != nil {
 		return err
@@ -145,6 +143,52 @@ func runStarterBootstrapTransaction(
 	return nil
 }
 
+func resetStarterPrivilegeTables(s sessionapi.Session) error {
+	for _, table := range starterPrivilegeResetTables {
+		for {
+			affectedRows, err := deleteStarterPrivilegeBatch(s, table)
+			if err != nil {
+				return errors.Annotatef(err, "reset starter privilege table mysql.%s", table)
+			}
+			if affectedRows < starterPrivilegeResetBatchSize {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func deleteStarterPrivilegeBatch(s sessionapi.Session, table string) (uint64, error) {
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	if _, err := s.ExecuteInternal(ctx, "BEGIN"); err != nil {
+		return 0, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if _, err := s.ExecuteInternal(ctx, "ROLLBACK"); err != nil {
+				logutil.BgLogger().Warn("rollback starter privilege reset batch failed", zap.Error(err))
+			}
+		}
+	}()
+
+	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, starterPrivilegeResetBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	if rs != nil {
+		if err := rs.Close(); err != nil {
+			return 0, err
+		}
+	}
+	affectedRows := s.AffectedRows()
+	if _, err := s.ExecuteInternal(ctx, "COMMIT"); err != nil {
+		return 0, err
+	}
+	committed = true
+	return affectedRows, nil
+}
+
 // upgradeStarterBootstrap reconciles starter SQL independently of TiDB's core bootstrap lifecycle.
 func upgradeStarterBootstrap(store kv.Storage) error {
 	bootstrapFile, err := loadStarterBootstrapFile()
@@ -152,7 +196,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 		return err
 	}
 	if bootstrapFile == nil {
-		_, pending, err := readStarterPrivilegeResetState(store, false)
+		_, pending, err := readStarterPrivilegeResetStateFromCodec(store)
 		if err != nil {
 			return err
 		}
@@ -167,7 +211,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
 	// Reset markers are written before TiDB starts, so the codec snapshot is
 	// sufficient for the no-reset fast path.
-	resetState, privilegeResetPending, err := readStarterPrivilegeResetState(store, false)
+	resetState, privilegeResetPending, err := readStarterPrivilegeResetStateFromCodec(store)
 	if err != nil {
 		return err
 	}
@@ -187,7 +231,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	defer releaseFn()
 
 	if privilegeResetPending {
-		resetState, privilegeResetPending, err = readStarterPrivilegeResetState(store, true)
+		resetState, privilegeResetPending, err = loadStarterPrivilegeResetStateFromPD(store)
 		if err != nil {
 			return err
 		}
@@ -275,14 +319,17 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	return nil
 }
 
-func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool) {
+func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPrivilegeResetState, bool, error) {
 	state := starterPrivilegeResetState{}
 	for _, key := range []string{starterBranchResetCompleteKey, starterRestoreResetCompleteKey} {
 		value, ok := keyspaceConfig[key]
 		if !ok || value == "" {
 			continue
 		}
-		complete, _ := strconv.ParseBool(value)
+		complete, err := strconv.ParseBool(value)
+		if err != nil {
+			return starterPrivilegeResetState{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
+		}
 		if complete {
 			continue
 		}
@@ -291,28 +338,38 @@ func pendingStarterPrivilegeReset(keyspaceConfig map[string]string) (starterPriv
 		}
 		state.pendingMarkers[key] = value
 	}
-	return state, len(state.pendingMarkers) > 0
+	return state, len(state.pendingMarkers) > 0, nil
 }
 
-func readStarterPrivilegeResetState(store kv.Storage, refreshFromPD bool) (starterPrivilegeResetState, bool, error) {
+func readStarterPrivilegeResetStateFromCodec(store kv.Storage) (starterPrivilegeResetState, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
 		return starterPrivilegeResetState{}, false, nil
 	}
-	if refreshFromPD {
-		if storeWithPD, ok := store.(kv.StorageWithPD); ok && storeWithPD.GetPDClient() != nil {
-			latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
-			if err != nil {
-				return starterPrivilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
-			}
-			if latestMeta != nil {
-				keyspaceMeta = latestMeta
-			}
-		}
-	}
-	state, pending := pendingStarterPrivilegeReset(keyspaceMeta.GetConfig())
+	state, pending, err := pendingStarterPrivilegeReset(keyspaceMeta.GetConfig())
 	state.keyspaceName = keyspaceMeta.GetName()
-	return state, pending, nil
+	return state, pending, err
+}
+
+func loadStarterPrivilegeResetStateFromPD(store kv.Storage) (starterPrivilegeResetState, bool, error) {
+	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
+	if keyspaceMeta == nil {
+		return starterPrivilegeResetState{}, false, nil
+	}
+	storeWithPD, ok := store.(kv.StorageWithPD)
+	if !ok || storeWithPD.GetPDClient() == nil {
+		return starterPrivilegeResetState{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
+	}
+	latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
+	if err != nil {
+		return starterPrivilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
+	}
+	if latestMeta == nil {
+		return starterPrivilegeResetState{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
+	}
+	state, pending, err := pendingStarterPrivilegeReset(latestMeta.GetConfig())
+	state.keyspaceName = latestMeta.GetName()
+	return state, pending, err
 }
 
 func markStarterPrivilegeResetComplete(ctx context.Context, state starterPrivilegeResetState) error {
@@ -503,11 +560,34 @@ func updateStarterBootstrapVersion(s sessionapi.Session, version int64) error {
 }
 
 func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) error {
-	stmts, err := parseStarterBootstrapSQLBlocks(s, blocks)
-	if err != nil {
-		return err
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+	sessionVars := s.GetSessionVars()
+	originalInRestrictedSQL := sessionVars.InRestrictedSQL
+	sessionVars.InRestrictedSQL = true
+	defer func() {
+		sessionVars.InRestrictedSQL = originalInRestrictedSQL
+	}()
+
+	for blockIdx, block := range blocks {
+		rendered := renderStarterBootstrapSQL(block)
+		stmts, err := s.Parse(ctx, rendered)
+		if err != nil {
+			return errors.Annotatef(err, "parse SQL block %d", blockIdx)
+		}
+		if len(stmts) != 1 {
+			return errors.Errorf("SQL block %d must contain exactly one statement", blockIdx)
+		}
+		rs, err := s.ExecuteStmt(ctx, stmts[0])
+		if err != nil {
+			return errors.Annotatef(err, "execute SQL block %d", blockIdx)
+		}
+		if rs != nil {
+			if err := rs.Close(); err != nil {
+				return errors.Annotate(err, "close SQL result")
+			}
+		}
 	}
-	return executeStarterBootstrapStatements(s, stmts)
+	return nil
 }
 
 func prepareStarterBootstrapStatements(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
@@ -603,7 +683,7 @@ func verifyStarterRootUser(s sessionapi.Session) error {
 		return errors.Annotate(closeErr, "close starter root verification result")
 	}
 	if req.NumRows() == 0 {
-		return errors.Errorf("starter bootstrap file must create '%s'@'%%' for privilege reset", rootUser)
+		return errors.Errorf("starter bootstrap file must create '%s'@'%%'", rootUser)
 	}
 	return nil
 }

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -51,18 +51,18 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
-	privilegeResetBatchSize             = 128
+	privilegeDeleteBatchSize            = 128
 )
 
 // These values are part of the existing PD keyspace metadata contract.
 const (
-	branchResetDoneKey  = "serverless_is_branch_bootstrapped"
-	restoreResetDoneKey = "serverless_is_bootstrapped_for_restore"
+	branchBootstrapDoneKey  = "serverless_is_branch_bootstrapped"
+	restoreBootstrapDoneKey = "serverless_is_bootstrapped_for_restore"
 )
 
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
-	privilegeResetTables          = []string{
+	privilegeTablesToClear        = []string{
 		"columns_priv",
 		"db",
 		"default_roles",
@@ -85,31 +85,31 @@ type starterBootstrapUpgradeSpec struct {
 	SQLBlocks []string `json:"sql,omitempty"`
 }
 
-type privilegeResetState struct {
-	keyspaceName   string
-	pendingMarkers map[string]string
+type pendingPrivilegeReset struct {
+	keyspaceName string
+	markers      map[string]string
 }
 
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
+	stmts, err := prepareStarterBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	return runBootstrapTxn(s, bootstrapFile, stmts)
+	return runStarterBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func resetPrivilegesLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
+func resetStarterPrivilegesLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
+	stmts, err := prepareStarterBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	if err := resetPrivilegeTables(s); err != nil {
+	if err := clearPrivilegeTables(s); err != nil {
 		return err
 	}
-	return runBootstrapTxn(s, bootstrapFile, stmts)
+	return runStarterBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func runBootstrapTxn(
+func runStarterBootstrapTxn(
 	s sessionapi.Session,
 	bootstrapFile *starterBootstrapFileSpec,
 	bootstrapStmts []ast.StmtNode,
@@ -127,10 +127,10 @@ func runBootstrapTxn(
 			logutil.BgLogger().Warn("rollback starter bootstrap file failed", zap.Error(err))
 		}
 	}()
-	if err := executeBootstrapStmts(s, bootstrapStmts); err != nil {
+	if err := executeStarterBootstrapStmts(s, bootstrapStmts); err != nil {
 		return err
 	}
-	if err := verifyRootUser(s); err != nil {
+	if err := verifyStarterRootUser(s); err != nil {
 		return err
 	}
 	if err := updateStarterBootstrapVersion(s, bootstrapFile.Version); err != nil {
@@ -143,14 +143,14 @@ func runBootstrapTxn(
 	return nil
 }
 
-func resetPrivilegeTables(s sessionapi.Session) error {
-	for _, table := range privilegeResetTables {
+func clearPrivilegeTables(s sessionapi.Session) error {
+	for _, table := range privilegeTablesToClear {
 		for {
 			affectedRows, err := deletePrivilegeBatch(s, table)
 			if err != nil {
 				return errors.Annotatef(err, "reset starter privilege table mysql.%s", table)
 			}
-			if affectedRows < privilegeResetBatchSize {
+			if affectedRows < privilegeDeleteBatchSize {
 				break
 			}
 		}
@@ -172,7 +172,7 @@ func deletePrivilegeBatch(s sessionapi.Session, table string) (uint64, error) {
 		}
 	}()
 
-	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, privilegeResetBatchSize)
+	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, privilegeDeleteBatchSize)
 	if err != nil {
 		return 0, err
 	}
@@ -211,7 +211,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
 	// Reset markers are written before TiDB starts, so the codec snapshot is
 	// sufficient for the no-reset fast path.
-	resetState, privilegeResetPending, err := readPrivilegeResetFromCodec(store)
+	reset, pending, err := readPrivilegeResetFromCodec(store)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !pending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -230,8 +230,8 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	}
 	defer releaseFn()
 
-	if privilegeResetPending {
-		resetState, privilegeResetPending, err = loadPrivilegeResetFromPD(store)
+	if pending {
+		reset, pending, err = loadPrivilegeResetFromPD(store)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !pending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -269,23 +269,23 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if privilegeResetPending {
+	if pending {
 		copiedVersion := max(completedVersion, storedVersion)
 		if copiedVersion > bootstrapFile.Version {
 			return errors.Errorf("starter bootstrap file version %d is older than copied version %d", bootstrapFile.Version, copiedVersion)
 		}
-		if err = resetPrivilegesLocked(s, bootstrapFile); err != nil {
+		if err = resetStarterPrivilegesLocked(s, bootstrapFile); err != nil {
 			return err
 		}
 		if err = finishStarterBootstrap(store, bootstrapFile.Version); err != nil {
 			return err
 		}
 		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
-		if err = markPrivilegeResetComplete(ctx, resetState); err != nil {
+		if err = markPrivilegeResetComplete(ctx, reset); err != nil {
 			return errors.Annotate(err, "complete starter privilege reset")
 		}
 		logutil.BgLogger().Info("starter privilege reset finished",
-			zap.String("keyspace", resetState.keyspaceName),
+			zap.String("keyspace", reset.keyspaceName),
 			zap.Int64("version", bootstrapFile.Version),
 			zap.Duration("cost", time.Since(startTime)))
 		return nil
@@ -319,69 +319,69 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	return nil
 }
 
-func parsePrivilegeReset(keyspaceConfig map[string]string) (privilegeResetState, bool, error) {
-	state := privilegeResetState{}
-	for _, key := range []string{branchResetDoneKey, restoreResetDoneKey} {
+func parsePrivilegeResetMarkers(keyspaceConfig map[string]string) (pendingPrivilegeReset, bool, error) {
+	reset := pendingPrivilegeReset{}
+	for _, key := range []string{branchBootstrapDoneKey, restoreBootstrapDoneKey} {
 		value, ok := keyspaceConfig[key]
 		if !ok || value == "" {
 			continue
 		}
 		complete, err := strconv.ParseBool(value)
 		if err != nil {
-			return privilegeResetState{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
+			return pendingPrivilegeReset{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
 		}
 		if complete {
 			continue
 		}
-		if state.pendingMarkers == nil {
-			state.pendingMarkers = make(map[string]string)
+		if reset.markers == nil {
+			reset.markers = make(map[string]string)
 		}
-		state.pendingMarkers[key] = value
+		reset.markers[key] = value
 	}
-	return state, len(state.pendingMarkers) > 0, nil
+	return reset, len(reset.markers) > 0, nil
 }
 
-func readPrivilegeResetFromCodec(store kv.Storage) (privilegeResetState, bool, error) {
+func readPrivilegeResetFromCodec(store kv.Storage) (pendingPrivilegeReset, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return privilegeResetState{}, false, nil
+		return pendingPrivilegeReset{}, false, nil
 	}
-	state, pending, err := parsePrivilegeReset(keyspaceMeta.GetConfig())
-	state.keyspaceName = keyspaceMeta.GetName()
-	return state, pending, err
+	reset, pending, err := parsePrivilegeResetMarkers(keyspaceMeta.GetConfig())
+	reset.keyspaceName = keyspaceMeta.GetName()
+	return reset, pending, err
 }
 
-func loadPrivilegeResetFromPD(store kv.Storage) (privilegeResetState, bool, error) {
+func loadPrivilegeResetFromPD(store kv.Storage) (pendingPrivilegeReset, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return privilegeResetState{}, false, nil
+		return pendingPrivilegeReset{}, false, nil
 	}
 	storeWithPD, ok := store.(kv.StorageWithPD)
 	if !ok || storeWithPD.GetPDClient() == nil {
-		return privilegeResetState{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
+		return pendingPrivilegeReset{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
 	}
 	latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
 	if err != nil {
-		return privilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
+		return pendingPrivilegeReset{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
 	}
 	if latestMeta == nil {
-		return privilegeResetState{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
+		return pendingPrivilegeReset{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
 	}
-	state, pending, err := parsePrivilegeReset(latestMeta.GetConfig())
-	state.keyspaceName = latestMeta.GetName()
-	return state, pending, err
+	reset, pending, err := parsePrivilegeResetMarkers(latestMeta.GetConfig())
+	reset.keyspaceName = latestMeta.GetName()
+	return reset, pending, err
 }
 
-func markPrivilegeResetComplete(ctx context.Context, state privilegeResetState) error {
+func markPrivilegeResetComplete(ctx context.Context, reset pendingPrivilegeReset) error {
 	completeValue := "True"
-	config := make(map[string]*string, len(state.pendingMarkers))
-	preconditions := make(map[string]*string, len(state.pendingMarkers))
-	for key, value := range state.pendingMarkers {
+	config := make(map[string]*string, len(reset.markers))
+	preconditions := make(map[string]*string, len(reset.markers))
+	for key, value := range reset.markers {
 		observedValue := value
 		config[key] = &completeValue
 		preconditions[key] = &observedValue
 	}
-	return infosync.SetKeyspaceConfig(ctx, state.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
+	return infosync.SetKeyspaceConfig(ctx, reset.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
 		Config:        config,
 		Preconditions: preconditions,
 	})
@@ -590,21 +590,21 @@ func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) err
 	return nil
 }
 
-func prepareBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func prepareStarterBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	if len(blocks) == 0 {
 		return nil, errors.New("starter bootstrap file must contain bootstrap SQL")
 	}
-	stmts, err := parseBootstrapBlocks(s, blocks)
+	stmts, err := parseStarterBootstrapStmts(s, blocks)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateBootstrapStmts(stmts); err != nil {
+	if err := validateStarterBootstrapStmts(stmts); err != nil {
 		return nil, err
 	}
 	return stmts, nil
 }
 
-func parseBootstrapBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func parseStarterBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -628,7 +628,7 @@ func parseBootstrapBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode
 	return stmts, nil
 }
 
-func validateBootstrapStmts(stmts []ast.StmtNode) error {
+func validateStarterBootstrapStmts(stmts []ast.StmtNode) error {
 	for i, stmt := range stmts {
 		switch stmt.(type) {
 		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
@@ -639,7 +639,7 @@ func validateBootstrapStmts(stmts []ast.StmtNode) error {
 	return nil
 }
 
-func executeBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
+func executeStarterBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -662,7 +662,7 @@ func executeBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
 	return nil
 }
 
-func verifyRootUser(s sessionapi.Session) error {
+func verifyStarterRootUser(s sessionapi.Session) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	rootUser := config.GetGlobalKeyspaceName() + ".root"
 	rs, err := s.ExecuteInternal(ctx,

--- a/pkg/session/starter_bootstrap_file.go
+++ b/pkg/session/starter_bootstrap_file.go
@@ -51,18 +51,18 @@ const (
 	starterBootstrapVersionVar          = "starter_bootstrap_version"
 	starterBootstrapKeyspacePlaceholder = "<keyspace>"
 	starterBootstrapVersionComment      = "Starter bootstrap file version. Do not delete."
-	privilegeDeleteBatchSize            = 128
+	privilegeResetBatchSize             = 128
 )
 
 // These values are part of the existing PD keyspace metadata contract.
 const (
-	branchBootstrapDoneKey  = "serverless_is_branch_bootstrapped"
-	restoreBootstrapDoneKey = "serverless_is_bootstrapped_for_restore"
+	branchResetDoneKey  = "serverless_is_branch_bootstrapped"
+	restoreResetDoneKey = "serverless_is_bootstrapped_for_restore"
 )
 
 var (
 	starterBootstrapPlaceholderRe = regexp.MustCompile(`<[A-Za-z0-9_-]+>`)
-	privilegeTablesToClear        = []string{
+	privilegeResetTables          = []string{
 		"columns_priv",
 		"db",
 		"default_roles",
@@ -85,31 +85,31 @@ type starterBootstrapUpgradeSpec struct {
 	SQLBlocks []string `json:"sql,omitempty"`
 }
 
-type pendingPrivilegeReset struct {
-	keyspaceName string
-	markers      map[string]string
+type privilegeResetState struct {
+	keyspaceName   string
+	pendingMarkers map[string]string
 }
 
 func runStarterBootstrapLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareStarterBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
+	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	return runStarterBootstrapTxn(s, bootstrapFile, stmts)
+	return runBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func resetStarterPrivilegesLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
-	stmts, err := prepareStarterBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
+func resetPrivilegesLocked(s sessionapi.Session, bootstrapFile *starterBootstrapFileSpec) error {
+	stmts, err := prepareBootstrapStmts(s, bootstrapFile.BootstrapSQLBlocks)
 	if err != nil {
 		return err
 	}
-	if err := clearPrivilegeTables(s); err != nil {
+	if err := resetPrivilegeTables(s); err != nil {
 		return err
 	}
-	return runStarterBootstrapTxn(s, bootstrapFile, stmts)
+	return runBootstrapTxn(s, bootstrapFile, stmts)
 }
 
-func runStarterBootstrapTxn(
+func runBootstrapTxn(
 	s sessionapi.Session,
 	bootstrapFile *starterBootstrapFileSpec,
 	bootstrapStmts []ast.StmtNode,
@@ -127,10 +127,10 @@ func runStarterBootstrapTxn(
 			logutil.BgLogger().Warn("rollback starter bootstrap file failed", zap.Error(err))
 		}
 	}()
-	if err := executeStarterBootstrapStmts(s, bootstrapStmts); err != nil {
+	if err := executeBootstrapStmts(s, bootstrapStmts); err != nil {
 		return err
 	}
-	if err := verifyStarterRootUser(s); err != nil {
+	if err := verifyRootUser(s); err != nil {
 		return err
 	}
 	if err := updateStarterBootstrapVersion(s, bootstrapFile.Version); err != nil {
@@ -143,14 +143,14 @@ func runStarterBootstrapTxn(
 	return nil
 }
 
-func clearPrivilegeTables(s sessionapi.Session) error {
-	for _, table := range privilegeTablesToClear {
+func resetPrivilegeTables(s sessionapi.Session) error {
+	for _, table := range privilegeResetTables {
 		for {
 			affectedRows, err := deletePrivilegeBatch(s, table)
 			if err != nil {
 				return errors.Annotatef(err, "reset starter privilege table mysql.%s", table)
 			}
-			if affectedRows < privilegeDeleteBatchSize {
+			if affectedRows < privilegeResetBatchSize {
 				break
 			}
 		}
@@ -172,7 +172,7 @@ func deletePrivilegeBatch(s sessionapi.Session, table string) (uint64, error) {
 		}
 	}()
 
-	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, privilegeDeleteBatchSize)
+	rs, err := s.ExecuteInternal(ctx, "DELETE FROM %n.%n LIMIT %?", mysql.SystemDB, table, privilegeResetBatchSize)
 	if err != nil {
 		return 0, err
 	}
@@ -211,7 +211,7 @@ func upgradeStarterBootstrap(store kv.Storage) error {
 func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBootstrapFileSpec) error {
 	// Reset markers are written before TiDB starts, so the codec snapshot is
 	// sufficient for the no-reset fast path.
-	reset, pending, err := readPrivilegeResetFromCodec(store)
+	resetState, privilegeResetPending, err := readPrivilegeResetFromCodec(store)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if !pending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -230,8 +230,8 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	}
 	defer releaseFn()
 
-	if pending {
-		reset, pending, err = loadPrivilegeResetFromPD(store)
+	if privilegeResetPending {
+		resetState, privilegeResetPending, err = loadPrivilegeResetFromPD(store)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if !pending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
+	if !privilegeResetPending && !needStarterBootstrapUpgrade(completedVersion, bootstrapFile) {
 		return nil
 	}
 
@@ -269,23 +269,23 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	if err != nil {
 		return err
 	}
-	if pending {
+	if privilegeResetPending {
 		copiedVersion := max(completedVersion, storedVersion)
 		if copiedVersion > bootstrapFile.Version {
 			return errors.Errorf("starter bootstrap file version %d is older than copied version %d", bootstrapFile.Version, copiedVersion)
 		}
-		if err = resetStarterPrivilegesLocked(s, bootstrapFile); err != nil {
+		if err = resetPrivilegesLocked(s, bootstrapFile); err != nil {
 			return err
 		}
 		if err = finishStarterBootstrap(store, bootstrapFile.Version); err != nil {
 			return err
 		}
 		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
-		if err = markPrivilegeResetComplete(ctx, reset); err != nil {
+		if err = markPrivilegeResetComplete(ctx, resetState); err != nil {
 			return errors.Annotate(err, "complete starter privilege reset")
 		}
 		logutil.BgLogger().Info("starter privilege reset finished",
-			zap.String("keyspace", reset.keyspaceName),
+			zap.String("keyspace", resetState.keyspaceName),
 			zap.Int64("version", bootstrapFile.Version),
 			zap.Duration("cost", time.Since(startTime)))
 		return nil
@@ -319,69 +319,69 @@ func upgradeStarterBootstrapWithFile(store kv.Storage, bootstrapFile *starterBoo
 	return nil
 }
 
-func parsePrivilegeResetMarkers(keyspaceConfig map[string]string) (pendingPrivilegeReset, bool, error) {
-	reset := pendingPrivilegeReset{}
-	for _, key := range []string{branchBootstrapDoneKey, restoreBootstrapDoneKey} {
+func parsePrivilegeReset(keyspaceConfig map[string]string) (privilegeResetState, bool, error) {
+	state := privilegeResetState{}
+	for _, key := range []string{branchResetDoneKey, restoreResetDoneKey} {
 		value, ok := keyspaceConfig[key]
 		if !ok || value == "" {
 			continue
 		}
 		complete, err := strconv.ParseBool(value)
 		if err != nil {
-			return pendingPrivilegeReset{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
+			return privilegeResetState{}, false, errors.Errorf("invalid starter privilege reset marker %s=%q", key, value)
 		}
 		if complete {
 			continue
 		}
-		if reset.markers == nil {
-			reset.markers = make(map[string]string)
+		if state.pendingMarkers == nil {
+			state.pendingMarkers = make(map[string]string)
 		}
-		reset.markers[key] = value
+		state.pendingMarkers[key] = value
 	}
-	return reset, len(reset.markers) > 0, nil
+	return state, len(state.pendingMarkers) > 0, nil
 }
 
-func readPrivilegeResetFromCodec(store kv.Storage) (pendingPrivilegeReset, bool, error) {
+func readPrivilegeResetFromCodec(store kv.Storage) (privilegeResetState, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return pendingPrivilegeReset{}, false, nil
+		return privilegeResetState{}, false, nil
 	}
-	reset, pending, err := parsePrivilegeResetMarkers(keyspaceMeta.GetConfig())
-	reset.keyspaceName = keyspaceMeta.GetName()
-	return reset, pending, err
+	state, pending, err := parsePrivilegeReset(keyspaceMeta.GetConfig())
+	state.keyspaceName = keyspaceMeta.GetName()
+	return state, pending, err
 }
 
-func loadPrivilegeResetFromPD(store kv.Storage) (pendingPrivilegeReset, bool, error) {
+func loadPrivilegeResetFromPD(store kv.Storage) (privilegeResetState, bool, error) {
 	keyspaceMeta := store.GetCodec().GetKeyspaceMeta()
 	if keyspaceMeta == nil {
-		return pendingPrivilegeReset{}, false, nil
+		return privilegeResetState{}, false, nil
 	}
 	storeWithPD, ok := store.(kv.StorageWithPD)
 	if !ok || storeWithPD.GetPDClient() == nil {
-		return pendingPrivilegeReset{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
+		return privilegeResetState{}, false, errors.New("PD client is required to refresh starter privilege reset metadata")
 	}
 	latestMeta, err := storeWithPD.GetPDClient().LoadKeyspace(context.Background(), keyspaceMeta.GetName())
 	if err != nil {
-		return pendingPrivilegeReset{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
+		return privilegeResetState{}, false, errors.Annotate(err, "refresh starter privilege reset metadata")
 	}
 	if latestMeta == nil {
-		return pendingPrivilegeReset{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
+		return privilegeResetState{}, false, errors.New("refresh starter privilege reset metadata returned no keyspace")
 	}
-	reset, pending, err := parsePrivilegeResetMarkers(latestMeta.GetConfig())
-	reset.keyspaceName = latestMeta.GetName()
-	return reset, pending, err
+	state, pending, err := parsePrivilegeReset(latestMeta.GetConfig())
+	state.keyspaceName = latestMeta.GetName()
+	return state, pending, err
 }
 
-func markPrivilegeResetComplete(ctx context.Context, reset pendingPrivilegeReset) error {
+func markPrivilegeResetComplete(ctx context.Context, state privilegeResetState) error {
 	completeValue := "True"
-	config := make(map[string]*string, len(reset.markers))
-	preconditions := make(map[string]*string, len(reset.markers))
-	for key, value := range reset.markers {
+	config := make(map[string]*string, len(state.pendingMarkers))
+	preconditions := make(map[string]*string, len(state.pendingMarkers))
+	for key, value := range state.pendingMarkers {
 		observedValue := value
 		config[key] = &completeValue
 		preconditions[key] = &observedValue
 	}
-	return infosync.SetKeyspaceConfig(ctx, reset.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
+	return infosync.SetKeyspaceConfig(ctx, state.keyspaceName, pdhttp.UpdateKeyspaceConfigParams{
 		Config:        config,
 		Preconditions: preconditions,
 	})
@@ -590,21 +590,21 @@ func executeStarterBootstrapSQLBlocks(s sessionapi.Session, blocks []string) err
 	return nil
 }
 
-func prepareStarterBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func prepareBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	if len(blocks) == 0 {
 		return nil, errors.New("starter bootstrap file must contain bootstrap SQL")
 	}
-	stmts, err := parseStarterBootstrapStmts(s, blocks)
+	stmts, err := parseBootstrapBlocks(s, blocks)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateStarterBootstrapStmts(stmts); err != nil {
+	if err := validateBootstrapStmts(stmts); err != nil {
 		return nil, err
 	}
 	return stmts, nil
 }
 
-func parseStarterBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
+func parseBootstrapBlocks(s sessionapi.Session, blocks []string) ([]ast.StmtNode, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -628,7 +628,7 @@ func parseStarterBootstrapStmts(s sessionapi.Session, blocks []string) ([]ast.St
 	return stmts, nil
 }
 
-func validateStarterBootstrapStmts(stmts []ast.StmtNode) error {
+func validateBootstrapStmts(stmts []ast.StmtNode) error {
 	for i, stmt := range stmts {
 		switch stmt.(type) {
 		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
@@ -639,7 +639,7 @@ func validateStarterBootstrapStmts(stmts []ast.StmtNode) error {
 	return nil
 }
 
-func executeStarterBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
+func executeBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	sessionVars := s.GetSessionVars()
 	originalInRestrictedSQL := sessionVars.InRestrictedSQL
@@ -662,7 +662,7 @@ func executeStarterBootstrapStmts(s sessionapi.Session, stmts []ast.StmtNode) er
 	return nil
 }
 
-func verifyStarterRootUser(s sessionapi.Session) error {
+func verifyRootUser(s sessionapi.Session) error {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
 	rootUser := config.GetGlobalKeyspaceName() + ".root"
 	rs, err := s.ExecuteInternal(ctx,

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -386,6 +386,192 @@ func TestStarterBootstrapStoreVersionGate(t *testing.T) {
 	require.Equal(t, int64(3), completedVersion)
 }
 
+func TestStarterPrivilegeResetMetadataState(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        map[string]string
+		pending       bool
+		completionKey string
+		observedValue string
+	}{
+		{
+			name: "ordinary keyspace",
+		},
+		{
+			name: "restore pending",
+			config: map[string]string{
+				starterRestoreResetCompleteKey: "False",
+			},
+			pending:       true,
+			completionKey: starterRestoreResetCompleteKey,
+			observedValue: "False",
+		},
+		{
+			name: "restore complete",
+			config: map[string]string{
+				starterRestoreResetCompleteKey: starterPrivilegeResetCompleteValue,
+			},
+		},
+		{
+			name: "branch pending",
+			config: map[string]string{
+				starterBranchConfigKey:        "true",
+				starterBranchResetCompleteKey: "False",
+			},
+			pending:       true,
+			completionKey: starterBranchResetCompleteKey,
+			observedValue: "False",
+		},
+		{
+			name: "branch complete",
+			config: map[string]string{
+				starterBranchConfigKey:        "true",
+				starterBranchResetCompleteKey: starterPrivilegeResetCompleteValue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, pending := pendingStarterPrivilegeReset(tt.config)
+			require.Equal(t, tt.pending, pending)
+			require.Equal(t, tt.completionKey, state.completionKey)
+			require.Equal(t, tt.observedValue, state.observedValue)
+		})
+	}
+}
+
+func TestStarterPrivilegeReset(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("classic mock store is sufficient for starter privilege reset")
+	}
+
+	originConfig := config.GetGlobalConfig()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(originConfig)
+	})
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "restored_keyspace"
+	})
+
+	store, dom := CreateStoreAndBootstrap(t)
+	t.Cleanup(func() {
+		if dom != nil {
+			dom.Close()
+		}
+		require.NoError(t, store.Close())
+	})
+
+	se := CreateSessionAndSetID(t, store)
+	seedStarterPrivilegeRows(t, se, "source_keyspace.user")
+	require.NoError(t, updateStarterBootstrapVersion(se, 3))
+	MustExec(t, se, "COMMIT")
+	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, &starterBootstrapFileSpec{Version: 3}),
+		"must contain bootstrap SQL")
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
+	se.Close()
+	require.NoError(t, finishStarterBootstrap(store, 3))
+
+	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
+		"version": 3,
+		"bootstrap": [
+			"INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.root', '', 'mysql_native_password')"
+		]
+	}`))
+	require.NoError(t, err)
+
+	var completedState starterPrivilegeResetState
+	completionCalls := 0
+	readResetState := func(kv.Storage, bool) (starterPrivilegeResetState, bool, error) {
+		return starterPrivilegeResetState{
+			keyspaceName:  "restored_keyspace",
+			completionKey: starterRestoreResetCompleteKey,
+			observedValue: "False",
+		}, true, nil
+	}
+	markResetComplete := func(_ context.Context, state starterPrivilegeResetState) error {
+		completionCalls++
+		completedState = state
+		return nil
+	}
+
+	dom.Close()
+	dom = nil
+	require.NoError(t, upgradeStarterBootstrapWithFileAndReset(
+		store, bootstrapFile, readResetState, markResetComplete))
+	require.Equal(t, "restored_keyspace", completedState.keyspaceName)
+	require.Equal(t, starterRestoreResetCompleteKey, completedState.completionKey)
+	require.Equal(t, "False", completedState.observedValue)
+	require.Equal(t, 1, completionCalls)
+
+	dom, err = BootstrapSession(store)
+	require.NoError(t, err)
+	checkSe := CreateSessionAndSetID(t, store)
+	for _, table := range []string{"db", "default_roles", "global_grants", "global_priv", "user"} {
+		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
+	}
+	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+		"SELECT COUNT(*) FROM mysql.role_edges WHERE TO_USER = ?", "source_keyspace.user"), "role_edges")
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+		"SELECT COUNT(*) FROM mysql.tables_priv WHERE User = ?", "source_keyspace.user"))
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ? AND authentication_string = ''",
+		"restored_keyspace.root"))
+	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, checkSe, starterBootstrapVersionVar))
+	checkSe.Close()
+	dom.Close()
+	dom = nil
+
+	failingBootstrapFile, err := parseStarterBootstrapFile([]byte(`{
+		"version": 3,
+		"bootstrap": [
+			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')",
+			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')"
+		]
+	}`))
+	require.NoError(t, err)
+	require.Error(t, upgradeStarterBootstrapWithFileAndReset(
+		store, failingBootstrapFile, readResetState, markResetComplete))
+	require.Equal(t, 1, completionCalls)
+
+	dom, err = BootstrapSession(store)
+	require.NoError(t, err)
+	checkSe = CreateSessionAndSetID(t, store)
+	t.Cleanup(func() {
+		checkSe.Close()
+	})
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.root"))
+	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
+}
+
+func seedStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string) {
+	t.Helper()
+	MustExec(t, se, "INSERT INTO mysql.db (Host, DB, User) VALUES ('%', 'test', ?)", user)
+	MustExec(t, se, "INSERT INTO mysql.default_roles (Host, User, DEFAULT_ROLE_HOST, DEFAULT_ROLE_USER) VALUES ('%', ?, '%', 'source_role')", user)
+	MustExec(t, se, "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES (?, '%', 'BACKUP_ADMIN')", user)
+	MustExec(t, se, "INSERT INTO mysql.global_priv (Host, User, Priv) VALUES ('%', ?, '{}')", user)
+	MustExec(t, se, "INSERT INTO mysql.role_edges (FROM_HOST, FROM_USER, TO_HOST, TO_USER) VALUES ('%', 'source_role', '%', ?)", user)
+	MustExec(t, se, "INSERT INTO mysql.user (Host, User) VALUES ('%', ?)", user)
+	MustExec(t, se, "INSERT INTO mysql.tables_priv (Host, DB, User, Table_name) VALUES ('%', 'test', ?, 't')", user)
+}
+
+func mustCountStarterPrivilegeRows(t *testing.T, se sessionapi.Session, sql string, args ...any) int64 {
+	t.Helper()
+	rs := MustExecToRecodeSet(t, se, sql, args...)
+	t.Cleanup(func() {
+		require.NoError(t, rs.Close())
+	})
+	req := rs.NewChunk(nil)
+	err := rs.Next(kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, req.NumRows())
+	return req.GetRow(0).GetInt64(0)
+}
+
 func mustGetTiDBVarForStarterFile(t *testing.T, se sessionapi.Session, name string) string {
 	t.Helper()
 	rs := MustExecToRecodeSet(t, se, "SELECT variable_value FROM mysql.tidb WHERE variable_name = ?", name)

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -372,7 +372,9 @@ func TestStarterBootstrapStoreVersionGate(t *testing.T) {
 	mappedDomain, err := domap.Get(store)
 	require.NoError(t, err)
 	require.Same(t, dom, mappedDomain)
-	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
+	currentBootstrapFile := *bootstrapFile
+	currentBootstrapFile.BootstrapSQLBlocks = []string{"CREATE TABLE mysql.starter_file_noop (id INT)"}
+	require.NoError(t, upgradeStarterBootstrapWithFile(store, &currentBootstrapFile))
 	mappedDomain, err = domap.Get(store)
 	require.NoError(t, err)
 	require.Same(t, dom, mappedDomain)
@@ -488,6 +490,30 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		"must contain bootstrap SQL")
 	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
+
+	nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
+		"version": 3,
+		"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
+	}`))
+	require.NoError(t, err)
+	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, nonTransactionalFile),
+		"must be INSERT, REPLACE, UPDATE, or DELETE")
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
+
+	missingRootFile, err := parseStarterBootstrapFile([]byte(`{
+		"version": 3,
+		"bootstrap": [
+			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.not_root')"
+		]
+	}`))
+	require.NoError(t, err)
+	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, missingRootFile),
+		"must create 'restored_keyspace.root'@'%'")
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
+	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
 
 	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -499,13 +499,10 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 	require.NoError(t, runStarterPrivilegeResetLocked(se, bootstrapFile))
 	for _, table := range []string{
-		"columns_priv",
 		"db",
 		"default_roles",
 		"global_grants",
 		"global_priv",
-		"password_history",
-		"tables_priv",
 		"user",
 	} {
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
@@ -513,6 +510,10 @@ func TestStarterPrivilegeReset(t *testing.T) {
 	}
 	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.role_edges WHERE TO_USER = ?", "source_keyspace.user"), "role_edges")
+	for _, table := range []string{"columns_priv", "password_history", "tables_priv"} {
+		require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
+	}
 	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ? AND authentication_string = ''",
 		"restored_keyspace.root"))

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -409,7 +409,7 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		{
 			name: "restore complete",
 			config: map[string]string{
-				starterRestoreResetCompleteKey: starterPrivilegeResetCompleteValue,
+				starterRestoreResetCompleteKey: "true",
 			},
 		},
 		{
@@ -426,7 +426,7 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 			name: "branch complete",
 			config: map[string]string{
 				starterBranchConfigKey:        "true",
-				starterBranchResetCompleteKey: starterPrivilegeResetCompleteValue,
+				starterBranchResetCompleteKey: "true",
 			},
 		},
 	}
@@ -456,22 +456,22 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 	store, dom := CreateStoreAndBootstrap(t)
 	t.Cleanup(func() {
-		if dom != nil {
-			dom.Close()
-		}
+		dom.Close()
 		require.NoError(t, store.Close())
 	})
 
 	se := CreateSessionAndSetID(t, store)
+	t.Cleanup(func() {
+		se.Close()
+	})
 	seedStarterPrivilegeRows(t, se, "source_keyspace.user")
 	require.NoError(t, updateStarterBootstrapVersion(se, 3))
 	MustExec(t, se, "COMMIT")
+	require.NoError(t, finishStarterBootstrap(store, 3))
 	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, &starterBootstrapFileSpec{Version: 3}),
 		"must contain bootstrap SQL")
 	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
-	se.Close()
-	require.NoError(t, finishStarterBootstrap(store, 3))
 
 	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,
@@ -481,48 +481,19 @@ func TestStarterPrivilegeReset(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	var completedState starterPrivilegeResetState
-	completionCalls := 0
-	readResetState := func(kv.Storage, bool) (starterPrivilegeResetState, bool, error) {
-		return starterPrivilegeResetState{
-			keyspaceName:  "restored_keyspace",
-			completionKey: starterRestoreResetCompleteKey,
-			observedValue: "False",
-		}, true, nil
-	}
-	markResetComplete := func(_ context.Context, state starterPrivilegeResetState) error {
-		completionCalls++
-		completedState = state
-		return nil
-	}
-
-	dom.Close()
-	dom = nil
-	require.NoError(t, upgradeStarterBootstrapWithFileAndReset(
-		store, bootstrapFile, readResetState, markResetComplete))
-	require.Equal(t, "restored_keyspace", completedState.keyspaceName)
-	require.Equal(t, starterRestoreResetCompleteKey, completedState.completionKey)
-	require.Equal(t, "False", completedState.observedValue)
-	require.Equal(t, 1, completionCalls)
-
-	dom, err = BootstrapSession(store)
-	require.NoError(t, err)
-	checkSe := CreateSessionAndSetID(t, store)
+	require.NoError(t, runStarterPrivilegeResetLocked(se, bootstrapFile))
 	for _, table := range []string{"db", "default_roles", "global_grants", "global_priv", "user"} {
-		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
 	}
-	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.role_edges WHERE TO_USER = ?", "source_keyspace.user"), "role_edges")
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.tables_priv WHERE User = ?", "source_keyspace.user"))
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ? AND authentication_string = ''",
 		"restored_keyspace.root"))
-	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, checkSe, starterBootstrapVersionVar))
-	checkSe.Close()
-	dom.Close()
-	dom = nil
+	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, se, starterBootstrapVersionVar))
 
 	failingBootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,
@@ -532,19 +503,10 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		]
 	}`))
 	require.NoError(t, err)
-	require.Error(t, upgradeStarterBootstrapWithFileAndReset(
-		store, failingBootstrapFile, readResetState, markResetComplete))
-	require.Equal(t, 1, completionCalls)
-
-	dom, err = BootstrapSession(store)
-	require.NoError(t, err)
-	checkSe = CreateSessionAndSetID(t, store)
-	t.Cleanup(func() {
-		checkSe.Close()
-	})
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, checkSe,
+	require.Error(t, runStarterPrivilegeResetLocked(se, failingBootstrapFile))
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.root"))
-	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, checkSe,
+	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
 }
 

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -388,11 +388,9 @@ func TestStarterBootstrapStoreVersionGate(t *testing.T) {
 
 func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 	tests := []struct {
-		name          string
-		config        map[string]string
-		pending       bool
-		completionKey string
-		observedValue string
+		name           string
+		config         map[string]string
+		pendingMarkers map[string]string
 	}{
 		{
 			name: "ordinary keyspace",
@@ -402,9 +400,9 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 			config: map[string]string{
 				starterRestoreResetCompleteKey: "False",
 			},
-			pending:       true,
-			completionKey: starterRestoreResetCompleteKey,
-			observedValue: "False",
+			pendingMarkers: map[string]string{
+				starterRestoreResetCompleteKey: "False",
+			},
 		},
 		{
 			name: "restore complete",
@@ -415,18 +413,37 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		{
 			name: "branch pending",
 			config: map[string]string{
-				starterBranchConfigKey:        "true",
 				starterBranchResetCompleteKey: "False",
 			},
-			pending:       true,
-			completionKey: starterBranchResetCompleteKey,
-			observedValue: "False",
+			pendingMarkers: map[string]string{
+				starterBranchResetCompleteKey: "False",
+			},
 		},
 		{
 			name: "branch complete",
 			config: map[string]string{
-				starterBranchConfigKey:        "true",
 				starterBranchResetCompleteKey: "true",
+			},
+		},
+		{
+			name: "branch complete and restore pending",
+			config: map[string]string{
+				starterBranchResetCompleteKey:  "true",
+				starterRestoreResetCompleteKey: "False",
+			},
+			pendingMarkers: map[string]string{
+				starterRestoreResetCompleteKey: "False",
+			},
+		},
+		{
+			name: "branch and restore pending",
+			config: map[string]string{
+				starterBranchResetCompleteKey:  "False",
+				starterRestoreResetCompleteKey: "invalid",
+			},
+			pendingMarkers: map[string]string{
+				starterBranchResetCompleteKey:  "False",
+				starterRestoreResetCompleteKey: "invalid",
 			},
 		},
 	}
@@ -434,9 +451,8 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state, pending := pendingStarterPrivilegeReset(tt.config)
-			require.Equal(t, tt.pending, pending)
-			require.Equal(t, tt.completionKey, state.completionKey)
-			require.Equal(t, tt.observedValue, state.observedValue)
+			require.Equal(t, len(tt.pendingMarkers) > 0, pending)
+			require.Equal(t, tt.pendingMarkers, state.pendingMarkers)
 		})
 	}
 }
@@ -482,14 +498,21 @@ func TestStarterPrivilegeReset(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, runStarterPrivilegeResetLocked(se, bootstrapFile))
-	for _, table := range []string{"db", "default_roles", "global_grants", "global_priv", "user"} {
+	for _, table := range []string{
+		"columns_priv",
+		"db",
+		"default_roles",
+		"global_grants",
+		"global_priv",
+		"password_history",
+		"tables_priv",
+		"user",
+	} {
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
 	}
 	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.role_edges WHERE TO_USER = ?", "source_keyspace.user"), "role_edges")
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.tables_priv WHERE User = ?", "source_keyspace.user"))
 	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ? AND authentication_string = ''",
 		"restored_keyspace.root"))
@@ -512,10 +535,12 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 func seedStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string) {
 	t.Helper()
+	MustExec(t, se, "INSERT INTO mysql.columns_priv (Host, DB, User, Table_name, Column_name) VALUES ('%', 'test', ?, 't', 'c')", user)
 	MustExec(t, se, "INSERT INTO mysql.db (Host, DB, User) VALUES ('%', 'test', ?)", user)
 	MustExec(t, se, "INSERT INTO mysql.default_roles (Host, User, DEFAULT_ROLE_HOST, DEFAULT_ROLE_USER) VALUES ('%', ?, '%', 'source_role')", user)
 	MustExec(t, se, "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES (?, '%', 'BACKUP_ADMIN')", user)
 	MustExec(t, se, "INSERT INTO mysql.global_priv (Host, User, Priv) VALUES ('%', ?, '{}')", user)
+	MustExec(t, se, "INSERT INTO mysql.password_history (Host, User, Password) VALUES ('%', ?, 'hash')", user)
 	MustExec(t, se, "INSERT INTO mysql.role_edges (FROM_HOST, FROM_USER, TO_HOST, TO_USER) VALUES ('%', 'source_role', '%', ?)", user)
 	MustExec(t, se, "INSERT INTO mysql.user (Host, User) VALUES ('%', ?)", user)
 	MustExec(t, se, "INSERT INTO mysql.tables_priv (Host, DB, User, Table_name) VALUES ('%', 'test', ?, 't')", user)

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -16,16 +16,26 @@ package session
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/session/sessionapi"
+	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
+	pd "github.com/tikv/pd/client"
+	pdhttp "github.com/tikv/pd/client/http"
 )
 
 func TestStarterBootstrapFileValidationAndRendering(t *testing.T) {
@@ -205,10 +215,24 @@ func TestStarterBootstrapFileInitialBootstrap(t *testing.T) {
 	t.Cleanup(func() {
 		se.Close()
 	})
+	missingRootFile, err := parseStarterBootstrapFile([]byte(`{
+		"version": 3,
+		"bootstrap": [
+			"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_initial_missing_root', '<keyspace>.boot', 'test')"
+		]
+	}`))
+	require.NoError(t, err)
+	require.ErrorContains(t, runStarterBootstrapLocked(se, missingRootFile),
+		"must create 'test_keyspace.root'@'%'")
+	_, isNull, err := getTiDBVar(se, "starter_file_initial_missing_root")
+	require.NoError(t, err)
+	require.True(t, isNull)
+
 	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,
 		"bootstrap": [
-			"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_initial_bootstrap', '<keyspace>.boot', 'test')"
+			"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_initial_bootstrap', '<keyspace>.boot', 'test')",
+			"INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.root', '', 'mysql_native_password')"
 		],
 		"upgrades": [
 			{"version": 3, "sql": [
@@ -221,7 +245,9 @@ func TestStarterBootstrapFileInitialBootstrap(t *testing.T) {
 	require.NoError(t, runStarterBootstrapLocked(se, bootstrapFile))
 	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, se, starterBootstrapVersionVar))
 	require.Equal(t, "test_keyspace.boot", mustGetTiDBVarForStarterFile(t, se, "starter_file_initial_bootstrap"))
-	_, isNull, err := getTiDBVar(se, "starter_file_initial_upgrade")
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "test_keyspace.root"))
+	_, isNull, err = getTiDBVar(se, "starter_file_initial_upgrade")
 	require.NoError(t, err)
 	require.True(t, isNull)
 }
@@ -254,6 +280,8 @@ func TestStarterBootstrapFileUpgrade(t *testing.T) {
 		"version": 3,
 		"upgrades": [
 			{"version": 2, "sql": [
+				"SET SESSION sql_mode = 'ANSI_QUOTES'",
+				"CREATE TABLE test.\"starter_file_ansi_quotes\" (\"id\" INT)",
 				"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_upgrade_v2', '<keyspace>.v2', 'test')"
 			]},
 			{"version": 3, "sql": [
@@ -269,6 +297,8 @@ func TestStarterBootstrapFileUpgrade(t *testing.T) {
 	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, se, starterBootstrapVersionVar))
 	require.Equal(t, "test_keyspace.v2", mustGetTiDBVarForStarterFile(t, se, "starter_file_upgrade_v2"))
 	require.Equal(t, "test_keyspace.v3", mustGetTiDBVarForStarterFile(t, se, "starter_file_upgrade_v3"))
+	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'test' AND table_name = 'starter_file_ansi_quotes'"))
 }
 
 func TestStarterBootstrapFileUpgradePartialFailure(t *testing.T) {
@@ -337,6 +367,13 @@ func TestStarterBootstrapStoreVersionGate(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("classic mock store is sufficient for starter bootstrap reconciliation")
 	}
+	originConfig := config.GetGlobalConfig()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(originConfig)
+	})
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "test_keyspace"
+	})
 
 	store, dom := CreateStoreAndBootstrap(t)
 	t.Cleanup(func() {
@@ -348,7 +385,8 @@ func TestStarterBootstrapStoreVersionGate(t *testing.T) {
 	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,
 		"bootstrap": [
-			"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_store_version', 'initialized', 'test')"
+			"INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('starter_file_store_version', 'initialized', 'test')",
+			"INSERT INTO mysql.user (Host, User, authentication_string, plugin) VALUES ('%', '<keyspace>.root', '', 'mysql_native_password')"
 		]
 	}`))
 	require.NoError(t, err)
@@ -393,6 +431,7 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		name           string
 		config         map[string]string
 		pendingMarkers map[string]string
+		err            string
 	}{
 		{
 			name: "ordinary keyspace",
@@ -441,22 +480,145 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 			name: "branch and restore pending",
 			config: map[string]string{
 				starterBranchResetCompleteKey:  "False",
-				starterRestoreResetCompleteKey: "invalid",
+				starterRestoreResetCompleteKey: "false",
 			},
 			pendingMarkers: map[string]string{
 				starterBranchResetCompleteKey:  "False",
+				starterRestoreResetCompleteKey: "false",
+			},
+		},
+		{
+			name: "invalid marker",
+			config: map[string]string{
 				starterRestoreResetCompleteKey: "invalid",
 			},
+			err: "invalid starter privilege reset marker",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state, pending := pendingStarterPrivilegeReset(tt.config)
+			state, pending, err := pendingStarterPrivilegeReset(tt.config)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+				require.False(t, pending)
+				require.Empty(t, state.pendingMarkers)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, len(tt.pendingMarkers) > 0, pending)
 			require.Equal(t, tt.pendingMarkers, state.pendingMarkers)
 		})
 	}
+}
+
+func TestStarterPrivilegeResetWorkflow(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("classic mock store is sufficient for starter privilege reset orchestration")
+	}
+
+	originConfig := config.GetGlobalConfig()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(originConfig)
+	})
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "restored_keyspace"
+	})
+
+	keyspaceMeta := &keyspacepb.KeyspaceMeta{
+		Id:   42,
+		Name: "restored_keyspace",
+		Config: map[string]string{
+			starterBranchResetCompleteKey:  "False",
+			starterRestoreResetCompleteKey: "False",
+		},
+	}
+	underlyingStore, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
+	require.NoError(t, err)
+	pdHTTPClient := &starterResetPDHTTPClient{
+		keyspaceMeta:      keyspaceMeta,
+		remainingFailures: 1,
+	}
+	pdClient := &starterResetPDClient{
+		Client:       underlyingStore.(kv.StorageWithPD).GetPDClient(),
+		keyspaceMeta: keyspaceMeta,
+	}
+	codec := &starterResetCodec{
+		Codec:        underlyingStore.GetCodec(),
+		keyspaceMeta: keyspaceMeta,
+	}
+	store := &starterResetStorage{
+		Storage:      underlyingStore,
+		codec:        codec,
+		pdClient:     pdClient,
+		pdHTTPClient: pdHTTPClient,
+	}
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	_, _, err = loadStarterPrivilegeResetStateFromPD(&storageWithoutPD{Storage: store})
+	require.ErrorContains(t, err, "PD client is required")
+
+	dom, err := BootstrapSession(store)
+	require.NoError(t, err)
+	se := CreateSessionAndSetID(t, store)
+	seedStarterPrivilegeRows(t, se, "source_keyspace.user")
+	require.NoError(t, updateStarterBootstrapVersion(se, 2))
+	MustExec(t, se, "COMMIT")
+	require.NoError(t, finishStarterBootstrap(store, 2))
+	se.Close()
+	dom.Close()
+
+	bootstrapFile := validStarterPrivilegeBootstrapFile(t)
+	err = upgradeStarterBootstrapWithFile(store, bootstrapFile)
+	require.ErrorContains(t, err, "transient keyspace config update")
+	require.Equal(t, 1, pdHTTPClient.updateCalls)
+	completedVersion, err := getStoreStarterBootstrapVersion(store)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), completedVersion)
+	require.Equal(t, "False", keyspaceMeta.Config[starterBranchResetCompleteKey])
+	require.Equal(t, "False", keyspaceMeta.Config[starterRestoreResetCompleteKey])
+
+	dom, err = BootstrapSession(store)
+	require.NoError(t, err)
+	se = CreateSessionAndSetID(t, store)
+	requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
+	requireStarterRootUser(t, se)
+	se.Close()
+	dom.Close()
+
+	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
+	require.Equal(t, 2, pdHTTPClient.updateCalls)
+	require.Equal(t, "True", keyspaceMeta.Config[starterBranchResetCompleteKey])
+	require.Equal(t, "True", keyspaceMeta.Config[starterRestoreResetCompleteKey])
+	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
+	require.Equal(t, 2, pdHTTPClient.updateCalls)
+
+	codec.keyspaceMeta = &keyspacepb.KeyspaceMeta{
+		Id:   keyspaceMeta.Id,
+		Name: keyspaceMeta.Name,
+		Config: map[string]string{
+			starterRestoreResetCompleteKey: "False",
+		},
+	}
+	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
+	require.Equal(t, 3, pdClient.loadCalls)
+	require.Equal(t, 2, pdHTTPClient.updateCalls)
+	codec.keyspaceMeta = keyspaceMeta
+
+	dom, err = BootstrapSession(store)
+	require.NoError(t, err)
+	t.Cleanup(dom.Close)
+	se = CreateSessionAndSetID(t, store)
+	t.Cleanup(se.Close)
+	requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
+	requireStarterRootUser(t, se)
+
+	keyspaceMeta.Config[starterRestoreResetCompleteKey] = "invalid"
+	seedStarterPrivilegeRows(t, se, "invalid_marker.user")
+	err = upgradeStarterBootstrapWithFile(store, validStarterPrivilegeBootstrapFile(t))
+	require.ErrorContains(t, err, "invalid starter privilege reset marker")
+	requireStarterPrivilegeRows(t, se, "invalid_marker.user", 1)
 }
 
 func TestStarterPrivilegeReset(t *testing.T) {
@@ -464,6 +626,97 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		t.Skip("classic mock store is sufficient for starter privilege reset")
 	}
 
+	t.Run("validation does not mutate privileges", func(t *testing.T) {
+		_, se := newStarterPrivilegeResetSession(t)
+		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, &starterBootstrapFileSpec{Version: 3}),
+			"must contain bootstrap SQL")
+
+		nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
+			"version": 3,
+			"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
+		}`))
+		require.NoError(t, err)
+		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, nonTransactionalFile),
+			"must be INSERT, REPLACE, UPDATE, or DELETE")
+		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 1)
+	})
+
+	t.Run("missing root converges on retry", func(t *testing.T) {
+		_, se := newStarterPrivilegeResetSession(t)
+		missingRootFile, err := parseStarterBootstrapFile([]byte(`{
+			"version": 3,
+			"bootstrap": [
+				"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.not_root')"
+			]
+		}`))
+		require.NoError(t, err)
+		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, missingRootFile),
+			"must create 'restored_keyspace.root'@'%'")
+		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
+		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
+
+		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		requireStarterRootUser(t, se)
+	})
+
+	t.Run("execution failure converges on retry", func(t *testing.T) {
+		_, se := newStarterPrivilegeResetSession(t)
+		failingBootstrapFile, err := parseStarterBootstrapFile([]byte(`{
+			"version": 3,
+			"bootstrap": [
+				"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')",
+				"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')"
+			]
+		}`))
+		require.NoError(t, err)
+		require.Error(t, runStarterPrivilegeResetLocked(se, failingBootstrapFile))
+		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
+		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
+
+		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		requireStarterRootUser(t, se)
+	})
+
+	t.Run("bounded reset clears all grants", func(t *testing.T) {
+		store, se := newStarterPrivilegeResetSession(t)
+		seedManyStarterUsers(t, se, 1024)
+
+		originalLimit := kv.TxnTotalSizeLimit.Load()
+		kv.TxnTotalSizeLimit.Store(32 * 1024)
+		t.Cleanup(func() {
+			kv.TxnTotalSizeLimit.Store(originalLimit)
+		})
+		ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
+		_, err := se.ExecuteInternal(ctx, "DELETE FROM mysql.user")
+		require.ErrorContains(t, err, "txn too large")
+		_, rollbackErr := se.ExecuteInternal(ctx, "ROLLBACK")
+		require.NoError(t, rollbackErr)
+
+		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
+		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql.user WHERE User LIKE 'source_keyspace.user%'"))
+		requireStarterRootUser(t, se)
+		require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql.password_history WHERE User = ?", "source_keyspace.user"))
+
+		MustExec(t, se, "CREATE TABLE test.t (c INT)")
+		MustExec(t, se, "CREATE USER 'source_keyspace.user'@'%'")
+		userSe := CreateSessionAndSetID(t, store)
+		t.Cleanup(userSe.Close)
+		require.NoError(t, userSe.Auth(&auth.UserIdentity{Username: "source_keyspace.user", Hostname: "localhost"}, nil, nil, nil))
+		rs, err := exec(userSe, "SELECT c FROM test.t")
+		if rs != nil {
+			require.NoError(t, rs.Close())
+		}
+		require.ErrorContains(t, err, "SELECT command denied")
+	})
+}
+
+func newStarterPrivilegeResetSession(t *testing.T) (kv.Storage, sessionapi.Session) {
+	t.Helper()
 	originConfig := config.GetGlobalConfig()
 	t.Cleanup(func() {
 		config.StoreGlobalConfig(originConfig)
@@ -477,44 +730,17 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		dom.Close()
 		require.NoError(t, store.Close())
 	})
-
 	se := CreateSessionAndSetID(t, store)
-	t.Cleanup(func() {
-		se.Close()
-	})
+	t.Cleanup(se.Close)
 	seedStarterPrivilegeRows(t, se, "source_keyspace.user")
 	require.NoError(t, updateStarterBootstrapVersion(se, 3))
 	MustExec(t, se, "COMMIT")
 	require.NoError(t, finishStarterBootstrap(store, 3))
-	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, &starterBootstrapFileSpec{Version: 3}),
-		"must contain bootstrap SQL")
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
+	return store, se
+}
 
-	nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
-		"version": 3,
-		"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
-	}`))
-	require.NoError(t, err)
-	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, nonTransactionalFile),
-		"must be INSERT, REPLACE, UPDATE, or DELETE")
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
-
-	missingRootFile, err := parseStarterBootstrapFile([]byte(`{
-		"version": 3,
-		"bootstrap": [
-			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.not_root')"
-		]
-	}`))
-	require.NoError(t, err)
-	require.ErrorContains(t, runStarterPrivilegeResetLocked(se, missingRootFile),
-		"must create 'restored_keyspace.root'@'%'")
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "source_keyspace.user"))
-	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
-
+func validStarterPrivilegeBootstrapFile(t *testing.T) *starterBootstrapFileSpec {
+	t.Helper()
 	bootstrapFile, err := parseStarterBootstrapFile([]byte(`{
 		"version": 3,
 		"bootstrap": [
@@ -522,47 +748,149 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		]
 	}`))
 	require.NoError(t, err)
+	return bootstrapFile
+}
 
-	require.NoError(t, runStarterPrivilegeResetLocked(se, bootstrapFile))
-	for _, table := range []string{
-		"db",
-		"default_roles",
-		"global_grants",
-		"global_priv",
-		"user",
-	} {
-		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
-			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
+func requireStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string, expected int64) {
+	t.Helper()
+	for _, table := range starterPrivilegeResetTables {
+		userColumn := "User"
+		if table == "role_edges" {
+			userColumn = "TO_USER"
+		}
+		require.Equal(t, expected, mustCountStarterPrivilegeRows(t, se,
+			"SELECT COUNT(*) FROM mysql."+table+" WHERE "+userColumn+" = ?", user), table)
 	}
-	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.role_edges WHERE TO_USER = ?", "source_keyspace.user"), "role_edges")
-	for _, table := range []string{"columns_priv", "password_history", "tables_priv"} {
-		require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-			"SELECT COUNT(*) FROM mysql."+table+" WHERE User = ?", "source_keyspace.user"), table)
-	}
+}
+
+func requireStarterRootUser(t *testing.T, se sessionapi.Session) {
+	t.Helper()
 	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
 		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ? AND authentication_string = ''",
 		"restored_keyspace.root"))
 	require.Equal(t, "3", mustGetTiDBVarForStarterFile(t, se, starterBootstrapVersionVar))
+}
 
-	failingBootstrapFile, err := parseStarterBootstrapFile([]byte(`{
-		"version": 3,
-		"bootstrap": [
-			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')",
-			"INSERT INTO mysql.user (Host, User) VALUES ('%', '<keyspace>.failed')"
-		]
-	}`))
-	require.NoError(t, err)
-	require.Error(t, runStarterPrivilegeResetLocked(se, failingBootstrapFile))
-	require.Equal(t, int64(1), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.root"))
-	require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
-		"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
+func seedManyStarterUsers(t *testing.T, se sessionapi.Session, count int) {
+	t.Helper()
+	var sql strings.Builder
+	sql.WriteString("INSERT INTO mysql.user (Host, User) VALUES ")
+	for i := range count {
+		if i > 0 {
+			sql.WriteByte(',')
+		}
+		fmt.Fprintf(&sql, "('%%','source_keyspace.user%04d')", i)
+	}
+	MustExec(t, se, sql.String())
+}
+
+type storageWithoutPD struct {
+	kv.Storage
+}
+
+type starterResetStorage struct {
+	kv.Storage
+	codec        tikv.Codec
+	pdClient     pd.Client
+	pdHTTPClient pdhttp.Client
+}
+
+func (s *starterResetStorage) GetCodec() tikv.Codec {
+	return s.codec
+}
+
+func (s *starterResetStorage) GetPDClient() pd.Client {
+	return s.pdClient
+}
+
+func (s *starterResetStorage) GetPDHTTPClient() pdhttp.Client {
+	return s.pdHTTPClient
+}
+
+type starterResetCodec struct {
+	tikv.Codec
+	keyspaceMeta *keyspacepb.KeyspaceMeta
+}
+
+func (c *starterResetCodec) GetKeyspaceMeta() *keyspacepb.KeyspaceMeta {
+	return c.keyspaceMeta
+}
+
+type starterResetPDClient struct {
+	pd.Client
+	keyspaceMeta *keyspacepb.KeyspaceMeta
+	loadCalls    int
+}
+
+func (c *starterResetPDClient) LoadKeyspace(_ context.Context, name string) (*keyspacepb.KeyspaceMeta, error) {
+	c.loadCalls++
+	if name != c.keyspaceMeta.Name {
+		return nil, fmt.Errorf("unexpected keyspace %q", name)
+	}
+	return c.keyspaceMeta, nil
+}
+
+type starterResetPDHTTPClient struct {
+	pdhttp.Client
+	keyspaceMeta      *keyspacepb.KeyspaceMeta
+	remainingFailures int
+	updateCalls       int
+}
+
+func (c *starterResetPDHTTPClient) WithCallerID(string) pdhttp.Client {
+	return c
+}
+
+func (c *starterResetPDHTTPClient) WithRespHandler(func(*http.Response, any) error) pdhttp.Client {
+	return c
+}
+
+func (*starterResetPDHTTPClient) GetPlacementRuleGroupByID(context.Context, string) (*pdhttp.RuleGroup, error) {
+	return nil, errors.New("placement rules are unavailable in this test")
+}
+
+func (*starterResetPDHTTPClient) GetStores(context.Context) (*pdhttp.StoresInfo, error) {
+	return &pdhttp.StoresInfo{}, nil
+}
+
+func (c *starterResetPDHTTPClient) UpdateKeyspaceConfig(
+	_ context.Context,
+	keyspaceName string,
+	params *pdhttp.UpdateKeyspaceConfigParams,
+) (*keyspacepb.KeyspaceMeta, error) {
+	c.updateCalls++
+	if keyspaceName != c.keyspaceMeta.Name {
+		return nil, fmt.Errorf("unexpected keyspace %q", keyspaceName)
+	}
+	for key, expected := range params.Preconditions {
+		actual, ok := c.keyspaceMeta.Config[key]
+		if expected == nil {
+			if ok {
+				return nil, fmt.Errorf("keyspace config precondition failed for %s", key)
+			}
+			continue
+		}
+		if !ok || actual != *expected {
+			return nil, fmt.Errorf("keyspace config precondition failed for %s", key)
+		}
+	}
+	if c.remainingFailures > 0 {
+		c.remainingFailures--
+		return nil, errors.New("transient keyspace config update")
+	}
+	for key, value := range params.Config {
+		if value == nil {
+			delete(c.keyspaceMeta.Config, key)
+			continue
+		}
+		c.keyspaceMeta.Config[key] = *value
+	}
+	return c.keyspaceMeta, nil
 }
 
 func seedStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string) {
 	t.Helper()
-	MustExec(t, se, "INSERT INTO mysql.columns_priv (Host, DB, User, Table_name, Column_name) VALUES ('%', 'test', ?, 't', 'c')", user)
+	MustExec(t, se, "INSERT INTO mysql.columns_priv (Host, DB, User, Table_name, Column_name, Column_priv) VALUES ('%', 'test', ?, 't', 'c', 'Select')", user)
 	MustExec(t, se, "INSERT INTO mysql.db (Host, DB, User) VALUES ('%', 'test', ?)", user)
 	MustExec(t, se, "INSERT INTO mysql.default_roles (Host, User, DEFAULT_ROLE_HOST, DEFAULT_ROLE_USER) VALUES ('%', ?, '%', 'source_role')", user)
 	MustExec(t, se, "INSERT INTO mysql.global_grants (User, Host, Priv) VALUES (?, '%', 'BACKUP_ADMIN')", user)
@@ -570,7 +898,7 @@ func seedStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string) 
 	MustExec(t, se, "INSERT INTO mysql.password_history (Host, User, Password) VALUES ('%', ?, 'hash')", user)
 	MustExec(t, se, "INSERT INTO mysql.role_edges (FROM_HOST, FROM_USER, TO_HOST, TO_USER) VALUES ('%', 'source_role', '%', ?)", user)
 	MustExec(t, se, "INSERT INTO mysql.user (Host, User) VALUES ('%', ?)", user)
-	MustExec(t, se, "INSERT INTO mysql.tables_priv (Host, DB, User, Table_name) VALUES ('%', 'test', ?, 't')", user)
+	MustExec(t, se, "INSERT INTO mysql.tables_priv (Host, DB, User, Table_name, Table_priv) VALUES ('%', 'test', ?, 't', 'Select')", user)
 }
 
 func mustCountStarterPrivilegeRows(t *testing.T, se sessionapi.Session, sql string, args ...any) int64 {

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -439,58 +439,58 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		{
 			name: "restore pending",
 			config: map[string]string{
-				restoreBootstrapDoneKey: "False",
+				restoreResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				restoreBootstrapDoneKey: "False",
+				restoreResetDoneKey: "False",
 			},
 		},
 		{
 			name: "restore complete",
 			config: map[string]string{
-				restoreBootstrapDoneKey: "true",
+				restoreResetDoneKey: "true",
 			},
 		},
 		{
 			name: "branch pending",
 			config: map[string]string{
-				branchBootstrapDoneKey: "False",
+				branchResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				branchBootstrapDoneKey: "False",
+				branchResetDoneKey: "False",
 			},
 		},
 		{
 			name: "branch complete",
 			config: map[string]string{
-				branchBootstrapDoneKey: "true",
+				branchResetDoneKey: "true",
 			},
 		},
 		{
 			name: "branch complete and restore pending",
 			config: map[string]string{
-				branchBootstrapDoneKey:  "true",
-				restoreBootstrapDoneKey: "False",
+				branchResetDoneKey:  "true",
+				restoreResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				restoreBootstrapDoneKey: "False",
+				restoreResetDoneKey: "False",
 			},
 		},
 		{
 			name: "branch and restore pending",
 			config: map[string]string{
-				branchBootstrapDoneKey:  "False",
-				restoreBootstrapDoneKey: "false",
+				branchResetDoneKey:  "False",
+				restoreResetDoneKey: "false",
 			},
 			pendingMarkers: map[string]string{
-				branchBootstrapDoneKey:  "False",
-				restoreBootstrapDoneKey: "false",
+				branchResetDoneKey:  "False",
+				restoreResetDoneKey: "false",
 			},
 		},
 		{
 			name: "invalid marker",
 			config: map[string]string{
-				restoreBootstrapDoneKey: "invalid",
+				restoreResetDoneKey: "invalid",
 			},
 			err: "invalid starter privilege reset marker",
 		},
@@ -498,16 +498,16 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reset, pending, err := parsePrivilegeResetMarkers(tt.config)
+			state, pending, err := parsePrivilegeReset(tt.config)
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 				require.False(t, pending)
-				require.Empty(t, reset.markers)
+				require.Empty(t, state.pendingMarkers)
 				return
 			}
 			require.NoError(t, err)
 			require.Equal(t, len(tt.pendingMarkers) > 0, pending)
-			require.Equal(t, tt.pendingMarkers, reset.markers)
+			require.Equal(t, tt.pendingMarkers, state.pendingMarkers)
 		})
 	}
 }
@@ -529,8 +529,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   42,
 		Name: "restored_keyspace",
 		Config: map[string]string{
-			branchBootstrapDoneKey:  "False",
-			restoreBootstrapDoneKey: "False",
+			branchResetDoneKey:  "False",
+			restoreResetDoneKey: "False",
 		},
 	}
 	underlyingStore, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
@@ -576,8 +576,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	completedVersion, err := getStoreStarterBootstrapVersion(store)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), completedVersion)
-	require.Equal(t, "False", keyspaceMeta.Config[branchBootstrapDoneKey])
-	require.Equal(t, "False", keyspaceMeta.Config[restoreBootstrapDoneKey])
+	require.Equal(t, "False", keyspaceMeta.Config[branchResetDoneKey])
+	require.Equal(t, "False", keyspaceMeta.Config[restoreResetDoneKey])
 
 	dom, err = BootstrapSession(store)
 	require.NoError(t, err)
@@ -589,8 +589,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
-	require.Equal(t, "True", keyspaceMeta.Config[branchBootstrapDoneKey])
-	require.Equal(t, "True", keyspaceMeta.Config[restoreBootstrapDoneKey])
+	require.Equal(t, "True", keyspaceMeta.Config[branchResetDoneKey])
+	require.Equal(t, "True", keyspaceMeta.Config[restoreResetDoneKey])
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
 
@@ -598,7 +598,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   keyspaceMeta.Id,
 		Name: keyspaceMeta.Name,
 		Config: map[string]string{
-			restoreBootstrapDoneKey: "False",
+			restoreResetDoneKey: "False",
 		},
 	}
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
@@ -614,7 +614,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 	requireStarterRootUser(t, se)
 
-	keyspaceMeta.Config[restoreBootstrapDoneKey] = "invalid"
+	keyspaceMeta.Config[restoreResetDoneKey] = "invalid"
 	seedStarterPrivilegeRows(t, se, "invalid_marker.user")
 	err = upgradeStarterBootstrapWithFile(store, validStarterPrivilegeBootstrapFile(t))
 	require.ErrorContains(t, err, "invalid starter privilege reset marker")
@@ -628,7 +628,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 	t.Run("validation does not mutate privileges", func(t *testing.T) {
 		_, se := newStarterPrivilegeResetSession(t)
-		require.ErrorContains(t, resetStarterPrivilegesLocked(se, &starterBootstrapFileSpec{Version: 3}),
+		require.ErrorContains(t, resetPrivilegesLocked(se, &starterBootstrapFileSpec{Version: 3}),
 			"must contain bootstrap SQL")
 
 		nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
@@ -636,7 +636,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, resetStarterPrivilegesLocked(se, nonTransactionalFile),
+		require.ErrorContains(t, resetPrivilegesLocked(se, nonTransactionalFile),
 			"must be INSERT, REPLACE, UPDATE, or DELETE")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 1)
 	})
@@ -650,13 +650,13 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, resetStarterPrivilegesLocked(se, missingRootFile),
+		require.ErrorContains(t, resetPrivilegesLocked(se, missingRootFile),
 			"must create 'restored_keyspace.root'@'%'")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
 
-		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -670,12 +670,12 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.Error(t, resetStarterPrivilegesLocked(se, failingBootstrapFile))
+		require.Error(t, resetPrivilegesLocked(se, failingBootstrapFile))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
 
-		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -694,7 +694,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		_, rollbackErr := se.ExecuteInternal(ctx, "ROLLBACK")
 		require.NoError(t, rollbackErr)
 
-		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User LIKE 'source_keyspace.user%'"))
@@ -753,7 +753,7 @@ func validStarterPrivilegeBootstrapFile(t *testing.T) *starterBootstrapFileSpec 
 
 func requireStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string, expected int64) {
 	t.Helper()
-	for _, table := range privilegeTablesToClear {
+	for _, table := range privilegeResetTables {
 		userColumn := "User"
 		if table == "role_edges" {
 			userColumn = "TO_USER"

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -439,58 +439,58 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		{
 			name: "restore pending",
 			config: map[string]string{
-				starterRestoreResetCompleteKey: "False",
+				restoreResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				starterRestoreResetCompleteKey: "False",
+				restoreResetDoneKey: "False",
 			},
 		},
 		{
 			name: "restore complete",
 			config: map[string]string{
-				starterRestoreResetCompleteKey: "true",
+				restoreResetDoneKey: "true",
 			},
 		},
 		{
 			name: "branch pending",
 			config: map[string]string{
-				starterBranchResetCompleteKey: "False",
+				branchResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				starterBranchResetCompleteKey: "False",
+				branchResetDoneKey: "False",
 			},
 		},
 		{
 			name: "branch complete",
 			config: map[string]string{
-				starterBranchResetCompleteKey: "true",
+				branchResetDoneKey: "true",
 			},
 		},
 		{
 			name: "branch complete and restore pending",
 			config: map[string]string{
-				starterBranchResetCompleteKey:  "true",
-				starterRestoreResetCompleteKey: "False",
+				branchResetDoneKey:  "true",
+				restoreResetDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				starterRestoreResetCompleteKey: "False",
+				restoreResetDoneKey: "False",
 			},
 		},
 		{
 			name: "branch and restore pending",
 			config: map[string]string{
-				starterBranchResetCompleteKey:  "False",
-				starterRestoreResetCompleteKey: "false",
+				branchResetDoneKey:  "False",
+				restoreResetDoneKey: "false",
 			},
 			pendingMarkers: map[string]string{
-				starterBranchResetCompleteKey:  "False",
-				starterRestoreResetCompleteKey: "false",
+				branchResetDoneKey:  "False",
+				restoreResetDoneKey: "false",
 			},
 		},
 		{
 			name: "invalid marker",
 			config: map[string]string{
-				starterRestoreResetCompleteKey: "invalid",
+				restoreResetDoneKey: "invalid",
 			},
 			err: "invalid starter privilege reset marker",
 		},
@@ -498,7 +498,7 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state, pending, err := pendingStarterPrivilegeReset(tt.config)
+			state, pending, err := parsePrivilegeReset(tt.config)
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 				require.False(t, pending)
@@ -529,8 +529,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   42,
 		Name: "restored_keyspace",
 		Config: map[string]string{
-			starterBranchResetCompleteKey:  "False",
-			starterRestoreResetCompleteKey: "False",
+			branchResetDoneKey:  "False",
+			restoreResetDoneKey: "False",
 		},
 	}
 	underlyingStore, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
@@ -556,7 +556,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, store.Close())
 	})
-	_, _, err = loadStarterPrivilegeResetStateFromPD(&storageWithoutPD{Storage: store})
+	_, _, err = loadPrivilegeResetFromPD(&storageWithoutPD{Storage: store})
 	require.ErrorContains(t, err, "PD client is required")
 
 	dom, err := BootstrapSession(store)
@@ -576,8 +576,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	completedVersion, err := getStoreStarterBootstrapVersion(store)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), completedVersion)
-	require.Equal(t, "False", keyspaceMeta.Config[starterBranchResetCompleteKey])
-	require.Equal(t, "False", keyspaceMeta.Config[starterRestoreResetCompleteKey])
+	require.Equal(t, "False", keyspaceMeta.Config[branchResetDoneKey])
+	require.Equal(t, "False", keyspaceMeta.Config[restoreResetDoneKey])
 
 	dom, err = BootstrapSession(store)
 	require.NoError(t, err)
@@ -589,8 +589,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
-	require.Equal(t, "True", keyspaceMeta.Config[starterBranchResetCompleteKey])
-	require.Equal(t, "True", keyspaceMeta.Config[starterRestoreResetCompleteKey])
+	require.Equal(t, "True", keyspaceMeta.Config[branchResetDoneKey])
+	require.Equal(t, "True", keyspaceMeta.Config[restoreResetDoneKey])
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
 
@@ -598,7 +598,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   keyspaceMeta.Id,
 		Name: keyspaceMeta.Name,
 		Config: map[string]string{
-			starterRestoreResetCompleteKey: "False",
+			restoreResetDoneKey: "False",
 		},
 	}
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
@@ -614,7 +614,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 	requireStarterRootUser(t, se)
 
-	keyspaceMeta.Config[starterRestoreResetCompleteKey] = "invalid"
+	keyspaceMeta.Config[restoreResetDoneKey] = "invalid"
 	seedStarterPrivilegeRows(t, se, "invalid_marker.user")
 	err = upgradeStarterBootstrapWithFile(store, validStarterPrivilegeBootstrapFile(t))
 	require.ErrorContains(t, err, "invalid starter privilege reset marker")
@@ -628,7 +628,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 	t.Run("validation does not mutate privileges", func(t *testing.T) {
 		_, se := newStarterPrivilegeResetSession(t)
-		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, &starterBootstrapFileSpec{Version: 3}),
+		require.ErrorContains(t, resetPrivilegesLocked(se, &starterBootstrapFileSpec{Version: 3}),
 			"must contain bootstrap SQL")
 
 		nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
@@ -636,7 +636,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, nonTransactionalFile),
+		require.ErrorContains(t, resetPrivilegesLocked(se, nonTransactionalFile),
 			"must be INSERT, REPLACE, UPDATE, or DELETE")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 1)
 	})
@@ -650,13 +650,13 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, runStarterPrivilegeResetLocked(se, missingRootFile),
+		require.ErrorContains(t, resetPrivilegesLocked(se, missingRootFile),
 			"must create 'restored_keyspace.root'@'%'")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
 
-		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -670,12 +670,12 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.Error(t, runStarterPrivilegeResetLocked(se, failingBootstrapFile))
+		require.Error(t, resetPrivilegesLocked(se, failingBootstrapFile))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
 
-		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -694,7 +694,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		_, rollbackErr := se.ExecuteInternal(ctx, "ROLLBACK")
 		require.NoError(t, rollbackErr)
 
-		require.NoError(t, runStarterPrivilegeResetLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User LIKE 'source_keyspace.user%'"))
@@ -753,7 +753,7 @@ func validStarterPrivilegeBootstrapFile(t *testing.T) *starterBootstrapFileSpec 
 
 func requireStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string, expected int64) {
 	t.Helper()
-	for _, table := range starterPrivilegeResetTables {
+	for _, table := range privilegeResetTables {
 		userColumn := "User"
 		if table == "role_edges" {
 			userColumn = "TO_USER"

--- a/pkg/session/starter_bootstrap_file_test.go
+++ b/pkg/session/starter_bootstrap_file_test.go
@@ -439,58 +439,58 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 		{
 			name: "restore pending",
 			config: map[string]string{
-				restoreResetDoneKey: "False",
+				restoreBootstrapDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				restoreResetDoneKey: "False",
+				restoreBootstrapDoneKey: "False",
 			},
 		},
 		{
 			name: "restore complete",
 			config: map[string]string{
-				restoreResetDoneKey: "true",
+				restoreBootstrapDoneKey: "true",
 			},
 		},
 		{
 			name: "branch pending",
 			config: map[string]string{
-				branchResetDoneKey: "False",
+				branchBootstrapDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				branchResetDoneKey: "False",
+				branchBootstrapDoneKey: "False",
 			},
 		},
 		{
 			name: "branch complete",
 			config: map[string]string{
-				branchResetDoneKey: "true",
+				branchBootstrapDoneKey: "true",
 			},
 		},
 		{
 			name: "branch complete and restore pending",
 			config: map[string]string{
-				branchResetDoneKey:  "true",
-				restoreResetDoneKey: "False",
+				branchBootstrapDoneKey:  "true",
+				restoreBootstrapDoneKey: "False",
 			},
 			pendingMarkers: map[string]string{
-				restoreResetDoneKey: "False",
+				restoreBootstrapDoneKey: "False",
 			},
 		},
 		{
 			name: "branch and restore pending",
 			config: map[string]string{
-				branchResetDoneKey:  "False",
-				restoreResetDoneKey: "false",
+				branchBootstrapDoneKey:  "False",
+				restoreBootstrapDoneKey: "false",
 			},
 			pendingMarkers: map[string]string{
-				branchResetDoneKey:  "False",
-				restoreResetDoneKey: "false",
+				branchBootstrapDoneKey:  "False",
+				restoreBootstrapDoneKey: "false",
 			},
 		},
 		{
 			name: "invalid marker",
 			config: map[string]string{
-				restoreResetDoneKey: "invalid",
+				restoreBootstrapDoneKey: "invalid",
 			},
 			err: "invalid starter privilege reset marker",
 		},
@@ -498,16 +498,16 @@ func TestStarterPrivilegeResetMetadataState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state, pending, err := parsePrivilegeReset(tt.config)
+			reset, pending, err := parsePrivilegeResetMarkers(tt.config)
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 				require.False(t, pending)
-				require.Empty(t, state.pendingMarkers)
+				require.Empty(t, reset.markers)
 				return
 			}
 			require.NoError(t, err)
 			require.Equal(t, len(tt.pendingMarkers) > 0, pending)
-			require.Equal(t, tt.pendingMarkers, state.pendingMarkers)
+			require.Equal(t, tt.pendingMarkers, reset.markers)
 		})
 	}
 }
@@ -529,8 +529,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   42,
 		Name: "restored_keyspace",
 		Config: map[string]string{
-			branchResetDoneKey:  "False",
-			restoreResetDoneKey: "False",
+			branchBootstrapDoneKey:  "False",
+			restoreBootstrapDoneKey: "False",
 		},
 	}
 	underlyingStore, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
@@ -576,8 +576,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	completedVersion, err := getStoreStarterBootstrapVersion(store)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), completedVersion)
-	require.Equal(t, "False", keyspaceMeta.Config[branchResetDoneKey])
-	require.Equal(t, "False", keyspaceMeta.Config[restoreResetDoneKey])
+	require.Equal(t, "False", keyspaceMeta.Config[branchBootstrapDoneKey])
+	require.Equal(t, "False", keyspaceMeta.Config[restoreBootstrapDoneKey])
 
 	dom, err = BootstrapSession(store)
 	require.NoError(t, err)
@@ -589,8 +589,8 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
-	require.Equal(t, "True", keyspaceMeta.Config[branchResetDoneKey])
-	require.Equal(t, "True", keyspaceMeta.Config[restoreResetDoneKey])
+	require.Equal(t, "True", keyspaceMeta.Config[branchBootstrapDoneKey])
+	require.Equal(t, "True", keyspaceMeta.Config[restoreBootstrapDoneKey])
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
 	require.Equal(t, 2, pdHTTPClient.updateCalls)
 
@@ -598,7 +598,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 		Id:   keyspaceMeta.Id,
 		Name: keyspaceMeta.Name,
 		Config: map[string]string{
-			restoreResetDoneKey: "False",
+			restoreBootstrapDoneKey: "False",
 		},
 	}
 	require.NoError(t, upgradeStarterBootstrapWithFile(store, bootstrapFile))
@@ -614,7 +614,7 @@ func TestStarterPrivilegeResetWorkflow(t *testing.T) {
 	requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 	requireStarterRootUser(t, se)
 
-	keyspaceMeta.Config[restoreResetDoneKey] = "invalid"
+	keyspaceMeta.Config[restoreBootstrapDoneKey] = "invalid"
 	seedStarterPrivilegeRows(t, se, "invalid_marker.user")
 	err = upgradeStarterBootstrapWithFile(store, validStarterPrivilegeBootstrapFile(t))
 	require.ErrorContains(t, err, "invalid starter privilege reset marker")
@@ -628,7 +628,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 
 	t.Run("validation does not mutate privileges", func(t *testing.T) {
 		_, se := newStarterPrivilegeResetSession(t)
-		require.ErrorContains(t, resetPrivilegesLocked(se, &starterBootstrapFileSpec{Version: 3}),
+		require.ErrorContains(t, resetStarterPrivilegesLocked(se, &starterBootstrapFileSpec{Version: 3}),
 			"must contain bootstrap SQL")
 
 		nonTransactionalFile, err := parseStarterBootstrapFile([]byte(`{
@@ -636,7 +636,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			"bootstrap": ["CREATE TABLE mysql.starter_reset_ddl (id INT)"]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, resetPrivilegesLocked(se, nonTransactionalFile),
+		require.ErrorContains(t, resetStarterPrivilegesLocked(se, nonTransactionalFile),
 			"must be INSERT, REPLACE, UPDATE, or DELETE")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 1)
 	})
@@ -650,13 +650,13 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.ErrorContains(t, resetPrivilegesLocked(se, missingRootFile),
+		require.ErrorContains(t, resetStarterPrivilegesLocked(se, missingRootFile),
 			"must create 'restored_keyspace.root'@'%'")
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User = ?", "restored_keyspace.not_root"))
 
-		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -670,12 +670,12 @@ func TestStarterPrivilegeReset(t *testing.T) {
 			]
 		}`))
 		require.NoError(t, err)
-		require.Error(t, resetPrivilegesLocked(se, failingBootstrapFile))
+		require.Error(t, resetStarterPrivilegesLocked(se, failingBootstrapFile))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE Host = '%' AND User = ?", "restored_keyspace.failed"))
 
-		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterRootUser(t, se)
 	})
 
@@ -694,7 +694,7 @@ func TestStarterPrivilegeReset(t *testing.T) {
 		_, rollbackErr := se.ExecuteInternal(ctx, "ROLLBACK")
 		require.NoError(t, rollbackErr)
 
-		require.NoError(t, resetPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
+		require.NoError(t, resetStarterPrivilegesLocked(se, validStarterPrivilegeBootstrapFile(t)))
 		requireStarterPrivilegeRows(t, se, "source_keyspace.user", 0)
 		require.Equal(t, int64(0), mustCountStarterPrivilegeRows(t, se,
 			"SELECT COUNT(*) FROM mysql.user WHERE User LIKE 'source_keyspace.user%'"))
@@ -753,7 +753,7 @@ func validStarterPrivilegeBootstrapFile(t *testing.T) *starterBootstrapFileSpec 
 
 func requireStarterPrivilegeRows(t *testing.T, se sessionapi.Session, user string, expected int64) {
 	t.Helper()
-	for _, table := range privilegeResetTables {
+	for _, table := range privilegeTablesToClear {
 		userColumn := "User"
 		if table == "role_edges" {
 			userColumn = "TO_USER"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #67765

Problem Summary:

When a starter keyspace is created from a branch or restore, its copied TiKV state contains the source keyspace's privilege rows and applied starter bootstrap version. The existing version gate therefore treats the starter bootstrap file as complete and does not recreate accounts for the new keyspace.

### What changed and how does it work?

This PR adds a metadata-driven starter privilege reset to the existing starter bootstrap-file reconciliation path.

When branch or restore metadata reports that the privilege reset is pending, TiDB:

1. acquires the existing distributed bootstrap lock and refreshes the keyspace metadata;
2. rejects a bootstrap file older than the copied SQL or key-value bootstrap version;
3. parses the complete `bootstrap` array and allows only transactional `INSERT`, `REPLACE`, `UPDATE`, and `DELETE` statements;
4. clears copied privilege state from `mysql.columns_priv`, `mysql.db`, `mysql.default_roles`, `mysql.global_grants`, `mysql.global_priv`, `mysql.role_edges`, `mysql.tables_priv`, and `mysql.user` in bounded transactions;
5. replays the complete `bootstrap` array in one transaction, verifies the `<keyspace>.root`@`%` account, and updates the SQL starter bootstrap version;
6. updates the key-value starter bootstrap version; and
7. conditionally marks all observed pending metadata values complete.

Bootstrap statements are parsed and validated before privilege rows are changed. Each delete batch commits separately to stay below the transaction-size limit, while the metadata remains pending until the final bootstrap transaction and both version updates succeed. Interrupted runs therefore converge on retry. `mysql.password_history` is retained.

Initial starter bootstrap enforces the same root-account requirement. Missing bootstrap configuration, invalid bootstrap statements, and malformed reset markers fail before privilege rows are changed. A failed final bootstrap transaction leaves the metadata pending for retry.

When neither reset marker is pending and the bootstrap version is current, TiDB does not refresh metadata from PD, create a bootstrap session, or parse bootstrap SQL. The behavior is gated by starter deploy mode, which is available only in next-generation deployments.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Manual validation used a next-generation TiUP playground:

- Started a starter TiDB with a bootstrap file that creates the target-keyspace root account.
- Seeded inherited user and privilege state, changed the restore completion metadata from `True` to `False`, and restarted TiDB.
- Verified the inherited accounts were replaced, the target root account had the bootstrap-file authentication state, and metadata changed back to `True`.
- Inserted a sentinel account and restarted again; the sentinel remained, confirming completed metadata does not repeat the reset.

Automated coverage additionally verifies table and column grant removal, bounded deletion under a reduced transaction-size limit, malformed metadata rejection, both-marker completion, and convergence after a marker-update failure.

Additional validation:

- `go test ./pkg/session -run '^TestStarter(Bootstrap|PrivilegeReset)' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/session -run '^TestStarter(Bootstrap|PrivilegeReset)' -count=1`
- `make bazel_prepare`
- `bazel test //pkg/session:session_test --test_filter='TestStarter(Bootstrap|PrivilegeReset)' --test_output=errors`
- `NEXT_GEN=1 make server`
- `make lint`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic starter privilege reset support during starter bootstrap and upgrade/restore flows.
  - Resets now include stronger validation that the bootstrap/replay recreates the `<keyspace>.root`@`%` account before proceeding.
  - Privilege reset execution cleans up eligible `mysql.*` privilege rows while preserving required system state.

- **Documentation**
  - Updated starter bootstrap configuration guidance/examples to require supported DML-only statements and to reflect the account recreation behavior.

- **Tests**
  - Expanded coverage for privilege-reset metadata state and end-to-end reset scenarios (including invalid/incomplete bootstrap cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
