### PR TITLE
sessionctx: add sysvar for plan replayer GC retention

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1867,7 +1867,7 @@ func (do *Domain) DumpFileGcCheckerLoop() {
 			case <-do.exit:
 				return
 			case <-gcTicker.C:
-				do.dumpFileGcChecker.GCDumpFiles(do.ctx, vardef.GetPlanReplayerGCDuration(), time.Hour*24*7)
+				do.dumpFileGcChecker.GCDumpFiles(do.ctx, vardef.GetPlanReplayerFileRetentionTime(), time.Hour*24*7)
 			}
 		}
 	}, "dumpFileGcChecker")

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1867,7 +1867,7 @@ func (do *Domain) DumpFileGcCheckerLoop() {
 			case <-do.exit:
 				return
 			case <-gcTicker.C:
-				do.dumpFileGcChecker.GCDumpFiles(do.ctx, time.Hour, time.Hour*24*7)
+				do.dumpFileGcChecker.GCDumpFiles(do.ctx, vardef.GetPlanReplayerGCDuration(), time.Hour*24*7)
 			}
 		}
 	}, "dumpFileGcChecker")

--- a/pkg/sessionctx/vardef/runtime.go
+++ b/pkg/sessionctx/vardef/runtime.go
@@ -31,8 +31,8 @@ var (
 	statsLease = int64(3 * time.Second)
 	// planReplayerGCLease is the time for plan replayer gc.
 	planReplayerGCLease = int64(10 * time.Minute)
-	// planReplayerGCDuration is the retention time for non-capture plan replayer files.
-	planReplayerGCDuration = int64(DefTiDBPlanReplayerGCDuration)
+	// planReplayerFileRetentionTime is the retention time for non-capture plan replayer files.
+	planReplayerFileRetentionTime = int64(DefTiDBPlanReplayerFileRetentionTime)
 )
 
 // SetSchemaLease changes the default schema lease time for DDL.
@@ -67,14 +67,14 @@ func GetPlanReplayerGCLease() time.Duration {
 	return time.Duration(atomic.LoadInt64(&planReplayerGCLease))
 }
 
-// SetPlanReplayerGCDuration changes the retention time for non-capture plan replayer files.
-func SetPlanReplayerGCDuration(duration time.Duration) {
-	atomic.StoreInt64(&planReplayerGCDuration, int64(duration))
+// SetPlanReplayerFileRetentionTime changes the retention time for non-capture plan replayer files.
+func SetPlanReplayerFileRetentionTime(duration time.Duration) {
+	atomic.StoreInt64(&planReplayerFileRetentionTime, int64(duration))
 }
 
-// GetPlanReplayerGCDuration returns the retention time for non-capture plan replayer files.
-func GetPlanReplayerGCDuration() time.Duration {
-	return time.Duration(atomic.LoadInt64(&planReplayerGCDuration))
+// GetPlanReplayerFileRetentionTime returns the retention time for non-capture plan replayer files.
+func GetPlanReplayerFileRetentionTime() time.Duration {
+	return time.Duration(atomic.LoadInt64(&planReplayerFileRetentionTime))
 }
 
 // IsReadOnlyVarInNextGen checks if the variable is read-only in the nextgen.

--- a/pkg/sessionctx/vardef/runtime.go
+++ b/pkg/sessionctx/vardef/runtime.go
@@ -31,6 +31,8 @@ var (
 	statsLease = int64(3 * time.Second)
 	// planReplayerGCLease is the time for plan replayer gc.
 	planReplayerGCLease = int64(10 * time.Minute)
+	// planReplayerGCDuration is the retention time for non-capture plan replayer files.
+	planReplayerGCDuration = int64(DefTiDBPlanReplayerGCDuration)
 )
 
 // SetSchemaLease changes the default schema lease time for DDL.
@@ -63,6 +65,16 @@ func SetPlanReplayerGCLease(lease time.Duration) {
 // GetPlanReplayerGCLease returns the plan replayer gc lease time.
 func GetPlanReplayerGCLease() time.Duration {
 	return time.Duration(atomic.LoadInt64(&planReplayerGCLease))
+}
+
+// SetPlanReplayerGCDuration changes the retention time for non-capture plan replayer files.
+func SetPlanReplayerGCDuration(duration time.Duration) {
+	atomic.StoreInt64(&planReplayerGCDuration, int64(duration))
+}
+
+// GetPlanReplayerGCDuration returns the retention time for non-capture plan replayer files.
+func GetPlanReplayerGCDuration() time.Duration {
+	return time.Duration(atomic.LoadInt64(&planReplayerGCDuration))
 }
 
 // IsReadOnlyVarInNextGen checks if the variable is read-only in the nextgen.

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1048,8 +1048,8 @@ const (
 	// TiDBEnablePlanReplayerContinuousCapture indicates whether to enable continuous capture
 	TiDBEnablePlanReplayerContinuousCapture = "tidb_enable_plan_replayer_continuous_capture"
 
-	// TiDBPlanReplayerGCDuration indicates how long to retain non-capture plan replayer files.
-	TiDBPlanReplayerGCDuration = "tidb_plan_replayer_gc_duration"
+	// TiDBPlanReplayerFileRetentionTime indicates how long to retain non-capture plan replayer files.
+	TiDBPlanReplayerFileRetentionTime = "tidb_plan_replayer_file_retention_time"
 	// TiDBEnableReusechunk indicates whether to enable chunk alloc
 	TiDBEnableReusechunk = "tidb_enable_reuse_chunk"
 
@@ -1766,7 +1766,7 @@ const (
 	DefTiDBEnableReusechunk                           = true
 	DefTiDBUseAlloc                                   = false
 	DefTiDBEnablePlanReplayerCapture                  = true
-	DefTiDBPlanReplayerGCDuration                     = 7 * 24 * time.Hour
+	DefTiDBPlanReplayerFileRetentionTime              = 7 * 24 * time.Hour
 	DefTiDBIndexMergeIntersectionConcurrency          = ConcurrencyUnset
 	DefTiDBTTLJobEnable                               = true
 	DefTiDBTTLScanBatchSize                           = 500

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1047,6 +1047,9 @@ const (
 
 	// TiDBEnablePlanReplayerContinuousCapture indicates whether to enable continuous capture
 	TiDBEnablePlanReplayerContinuousCapture = "tidb_enable_plan_replayer_continuous_capture"
+
+	// TiDBPlanReplayerGCDuration indicates how long to retain non-capture plan replayer files.
+	TiDBPlanReplayerGCDuration = "tidb_plan_replayer_gc_duration"
 	// TiDBEnableReusechunk indicates whether to enable chunk alloc
 	TiDBEnableReusechunk = "tidb_enable_reuse_chunk"
 
@@ -1763,6 +1766,7 @@ const (
 	DefTiDBEnableReusechunk                           = true
 	DefTiDBUseAlloc                                   = false
 	DefTiDBEnablePlanReplayerCapture                  = true
+	DefTiDBPlanReplayerGCDuration                     = 7 * 24 * time.Hour
 	DefTiDBIndexMergeIntersectionConcurrency          = ConcurrencyUnset
 	DefTiDBTTLJobEnable                               = true
 	DefTiDBTTLScanBatchSize                           = 500

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1835,6 +1835,17 @@ var defaultSysVars = []*SysVar{
 			vardef.HistoricalStatsDuration.Store(d)
 			return nil
 		}},
+	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBPlanReplayerGCDuration, Value: vardef.DefTiDBPlanReplayerGCDuration.String(), Type: vardef.TypeDuration, MaxValue: uint64(time.Hour * 24 * 365),
+		GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
+			return vardef.GetPlanReplayerGCDuration().String(), nil
+		}, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return err
+			}
+			vardef.SetPlanReplayerGCDuration(d)
+			return nil
+		}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBLowResolutionTSOUpdateInterval, Value: strconv.Itoa(vardef.DefTiDBLowResolutionTSOUpdateInterval), Type: vardef.TypeInt, MinValue: 10, MaxValue: 60000,
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 			vardef.LowResolutionTSOUpdateInterval.Store(uint32(TidbOptInt64(val, vardef.DefTiDBLowResolutionTSOUpdateInterval)))

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1835,15 +1835,15 @@ var defaultSysVars = []*SysVar{
 			vardef.HistoricalStatsDuration.Store(d)
 			return nil
 		}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBPlanReplayerGCDuration, Value: vardef.DefTiDBPlanReplayerGCDuration.String(), Type: vardef.TypeDuration, MaxValue: uint64(time.Hour * 24 * 365),
+	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBPlanReplayerFileRetentionTime, Value: vardef.DefTiDBPlanReplayerFileRetentionTime.String(), Type: vardef.TypeDuration, MaxValue: uint64(time.Hour * 24 * 365),
 		GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
-			return vardef.GetPlanReplayerGCDuration().String(), nil
+			return vardef.GetPlanReplayerFileRetentionTime().String(), nil
 		}, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
 			d, err := time.ParseDuration(s)
 			if err != nil {
 				return err
 			}
-			vardef.SetPlanReplayerGCDuration(d)
+			vardef.SetPlanReplayerFileRetentionTime(d)
 			return nil
 		}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBLowResolutionTSOUpdateInterval, Value: strconv.Itoa(vardef.DefTiDBLowResolutionTSOUpdateInterval), Type: vardef.TypeInt, MinValue: 10, MaxValue: 60000,

--- a/pkg/sessionctx/variable/tests/variable_test.go
+++ b/pkg/sessionctx/variable/tests/variable_test.go
@@ -635,6 +635,7 @@ func TestSetSysVar(t *testing.T) {
 	originalDeployMode := deploymode.Get()
 	originalRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
 	originalEnableConnectionEventLog := vardef.EnableConnectionEventLog.Load()
+	originalPlanReplayerGCDuration := vardef.GetPlanReplayerGCDuration()
 	t.Cleanup(func() {
 		config.StoreGlobalConfig(&originalCfg)
 		if kerneltype.IsNextGen() {
@@ -642,6 +643,7 @@ func TestSetSysVar(t *testing.T) {
 		}
 		tidbtls.RequireSecureTransport.Store(originalRequireSecureTransport)
 		vardef.EnableConnectionEventLog.Store(originalEnableConnectionEventLog)
+		vardef.SetPlanReplayerGCDuration(originalPlanReplayerGCDuration)
 	})
 
 	mock := variable.NewMockGlobalAccessor4Tests()
@@ -677,6 +679,16 @@ func TestSetSysVar(t *testing.T) {
 
 	require.NoError(t, variable.GetSysVar(vardef.TiDBEnableConnectionEventLog).SetGlobalFromHook(context.Background(), mock.SessionVars, vardef.Off, false))
 	require.False(t, vardef.EnableConnectionEventLog.Load())
+
+	planReplayerGCDurationVar := variable.GetSysVar(vardef.TiDBPlanReplayerGCDuration)
+	require.NotNil(t, planReplayerGCDurationVar)
+	require.Equal(t, (7 * 24 * time.Hour).String(), planReplayerGCDurationVar.Value)
+	require.NoError(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerGCDuration, "2h"))
+	require.Equal(t, 2*time.Hour, vardef.GetPlanReplayerGCDuration())
+	val, err = mock.GetGlobalSysVar(vardef.TiDBPlanReplayerGCDuration)
+	require.NoError(t, err)
+	require.Equal(t, (2 * time.Hour).String(), val)
+	require.Error(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerGCDuration, "2hours"))
 }
 
 func TestSkipSysvarCache(t *testing.T) {

--- a/pkg/sessionctx/variable/tests/variable_test.go
+++ b/pkg/sessionctx/variable/tests/variable_test.go
@@ -635,7 +635,7 @@ func TestSetSysVar(t *testing.T) {
 	originalDeployMode := deploymode.Get()
 	originalRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
 	originalEnableConnectionEventLog := vardef.EnableConnectionEventLog.Load()
-	originalPlanReplayerGCDuration := vardef.GetPlanReplayerGCDuration()
+	originalPlanReplayerFileRetentionTime := vardef.GetPlanReplayerFileRetentionTime()
 	t.Cleanup(func() {
 		config.StoreGlobalConfig(&originalCfg)
 		if kerneltype.IsNextGen() {
@@ -643,7 +643,7 @@ func TestSetSysVar(t *testing.T) {
 		}
 		tidbtls.RequireSecureTransport.Store(originalRequireSecureTransport)
 		vardef.EnableConnectionEventLog.Store(originalEnableConnectionEventLog)
-		vardef.SetPlanReplayerGCDuration(originalPlanReplayerGCDuration)
+		vardef.SetPlanReplayerFileRetentionTime(originalPlanReplayerFileRetentionTime)
 	})
 
 	mock := variable.NewMockGlobalAccessor4Tests()
@@ -680,15 +680,15 @@ func TestSetSysVar(t *testing.T) {
 	require.NoError(t, variable.GetSysVar(vardef.TiDBEnableConnectionEventLog).SetGlobalFromHook(context.Background(), mock.SessionVars, vardef.Off, false))
 	require.False(t, vardef.EnableConnectionEventLog.Load())
 
-	planReplayerGCDurationVar := variable.GetSysVar(vardef.TiDBPlanReplayerGCDuration)
-	require.NotNil(t, planReplayerGCDurationVar)
-	require.Equal(t, (7 * 24 * time.Hour).String(), planReplayerGCDurationVar.Value)
-	require.NoError(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerGCDuration, "2h"))
-	require.Equal(t, 2*time.Hour, vardef.GetPlanReplayerGCDuration())
-	val, err = mock.GetGlobalSysVar(vardef.TiDBPlanReplayerGCDuration)
+	planReplayerFileRetentionTimeVar := variable.GetSysVar(vardef.TiDBPlanReplayerFileRetentionTime)
+	require.NotNil(t, planReplayerFileRetentionTimeVar)
+	require.Equal(t, (7 * 24 * time.Hour).String(), planReplayerFileRetentionTimeVar.Value)
+	require.NoError(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerFileRetentionTime, "2h"))
+	require.Equal(t, 2*time.Hour, vardef.GetPlanReplayerFileRetentionTime())
+	val, err = mock.GetGlobalSysVar(vardef.TiDBPlanReplayerFileRetentionTime)
 	require.NoError(t, err)
 	require.Equal(t, (2 * time.Hour).String(), val)
-	require.Error(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerGCDuration, "2hours"))
+	require.Error(t, mock.SetGlobalSysVar(context.Background(), vardef.TiDBPlanReplayerFileRetentionTime, "2hours"))
 }
 
 func TestSkipSysvarCache(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69100

Problem Summary: sessionctx: add sysvar for plan replayer GC retention

### What changed and how does it work?

Add a new global SQL variable, tidb_plan_replayer_gc_duration, to configure the retention duration for non-capture plan replayer files.
The default is 7d (168h0m0s). The dump file GC loop now reads this runtime value instead of using a hard-coded duration, while capture replayer retention remains unchanged.
Also adds unit coverage for the new sysvar default, global setter behavior, and invalid duration handling.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `tidb_plan_replayer_file_retention_time` system variable.
  * Plan replayer file retention is now configurable, with a default of 7 days.
  * Retention settings accept duration values such as `2h` and are applied to cleanup behavior.

* **Bug Fixes**
  * Plan replayer file cleanup now respects the configured retention period instead of a fixed duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->