### PR TITLE
inference: add embedding provider adapters

### DIFF
--- a/pkg/inference/embedding/base/BUILD.bazel
+++ b/pkg/inference/embedding/base/BUILD.bazel
@@ -13,6 +13,6 @@ go_test(
     srcs = ["base_test.go"],
     embed = [":base"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/inference/embedding/base/BUILD.bazel
+++ b/pkg/inference/embedding/base/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["base.go"],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/base",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_docker_go_units//:go-units"],
 )
 
 go_test(
@@ -13,6 +14,6 @@ go_test(
     srcs = ["base_test.go"],
     embed = [":base"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/inference/embedding/base/BUILD.bazel
+++ b/pkg/inference/embedding/base/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["base.go"],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/base",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_docker_go_units//:go-units"],
+    deps = [
+        "//pkg/util/logutil",
+        "@com_github_docker_go_units//:go-units",
+        "@org_uber_go_zap//:zap",
+    ],
 )
 
 go_test(
@@ -15,5 +19,10 @@ go_test(
     embed = [":base"],
     flaky = True,
     shard_count = 6,
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_pingcap_log//:log",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
+    ],
 )

--- a/pkg/inference/embedding/base/BUILD.bazel
+++ b/pkg/inference/embedding/base/BUILD.bazel
@@ -13,6 +13,6 @@ go_test(
     srcs = ["base_test.go"],
     embed = [":base"],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
 )
 
 const (
@@ -100,6 +102,29 @@ type APIKeyProviderConfig struct {
 	// MaxResponseBodyBytes limits both successful and error response bodies.
 	// Non-positive values use DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
+}
+
+// JSONEmbeddingCall describes one conventional JSON embedding provider call.
+// Provider must be a stable, non-sensitive label because it is used in logs
+// and generic response errors. Provider-specific wire schemas stay in the
+// decoder functions supplied by the provider package.
+type JSONEmbeddingCall struct {
+	Provider             string
+	Client               *http.Client
+	Endpoint             string
+	Payload              any
+	Headers              http.Header
+	MaxResponseBodyBytes int64
+	Secrets              []string
+
+	// DecodeErrorMessage parses a non-200 response and returns an unsanitized
+	// provider message. ExecuteJSONEmbeddingCall owns sanitization and logging.
+	DecodeErrorMessage func(body []byte) (string, error)
+	// StatusErrors maps special HTTP statuses to provider-specific errors.
+	// Nil or missing entries use NewProviderResponseError.
+	StatusErrors map[int]error
+	// DecodeEmbeddings parses and validates a successful response.
+	DecodeEmbeddings func(body []byte, expectedCount int) ([][]float32, error)
 }
 
 // WithDefaults returns a copy with default values applied.
@@ -256,6 +281,54 @@ func PostJSON(
 	req.Header.Set("Content-Type", "application/json")
 
 	return DoRequest(ctx, client, provider, req, maxResponseBodyBytes)
+}
+
+// ExecuteJSONEmbeddingCall executes a conventional JSON provider call and
+// applies the common response lifecycle. Provider-specific error and success
+// schemas are delegated to the supplied decoder functions.
+func ExecuteJSONEmbeddingCall(
+	ctx context.Context,
+	expectedCount int,
+	call JSONEmbeddingCall,
+) ([][]float32, error) {
+	if call.DecodeErrorMessage == nil {
+		return nil, fmt.Errorf("%s error response decoder is not configured", call.Provider)
+	}
+	if call.DecodeEmbeddings == nil {
+		return nil, fmt.Errorf("%s success response decoder is not configured", call.Provider)
+	}
+
+	statusCode, body, err := PostJSON(
+		ctx,
+		call.Client,
+		call.Provider,
+		call.Endpoint,
+		call.Payload,
+		call.Headers,
+		call.MaxResponseBodyBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode == http.StatusOK {
+		return call.DecodeEmbeddings(body, expectedCount)
+	}
+
+	message, parseErr := call.DecodeErrorMessage(body)
+	message = SanitizeErrorText(message, call.Secrets...)
+	logFields := []zap.Field{zap.Int("status", statusCode)}
+	if message != "" {
+		logFields = append(logFields, zap.String("message", message))
+	}
+	if parseErr != nil {
+		logFields = append(logFields, zap.String("parse_error", SanitizeErrorText(parseErr.Error(), call.Secrets...)))
+	}
+	logutil.BgLogger().Error(call.Provider+" API request failed", logFields...)
+
+	if statusErr := call.StatusErrors[statusCode]; statusErr != nil {
+		return nil, statusErr
+	}
+	return nil, NewProviderResponseError(call.Provider, statusCode, message)
 }
 
 // NewProviderResponseError returns a consistent generic provider error. The

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -74,6 +75,64 @@ type Embedder interface {
 	// CreateEmbeddings generates embeddings for the given texts using the specified model and options.
 	// Different implementations requires different options types. Options can be nil if not needed.
 	CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error)
+}
+
+// IndexedBase64Embedding is an embedding response item whose position is
+// identified by Index and whose Embedding is base64-decoded by encoding/json.
+type IndexedBase64Embedding struct {
+	Object    string `json:"object"`
+	Index     int    `json:"index"`
+	Embedding []byte `json:"embedding"`
+}
+
+// APIKeyProviderConfig contains configuration shared by embedding providers
+// that authenticate with an API key and support custom missing-key and
+// unauthorized errors. Each provider defines the exact meaning of GetBaseURL.
+type APIKeyProviderConfig struct {
+	// GetAPIKey returns the current API key.
+	GetAPIKey func() string
+	// GetBaseURL returns the provider-specific configured base URL or endpoint.
+	GetBaseURL func() string
+	// ErrMissingAPIKey overrides the provider's default missing-key error.
+	ErrMissingAPIKey error
+	// ErrUnauthorized overrides the provider's default unauthorized error.
+	ErrUnauthorized error
+	// MaxResponseBodyBytes limits both successful and error response bodies.
+	// Non-positive values use DefaultMaxResponseBodyBytes.
+	MaxResponseBodyBytes int64
+}
+
+// WithDefaults returns a copy with default values applied.
+func (c APIKeyProviderConfig) WithDefaults() APIKeyProviderConfig {
+	if c.MaxResponseBodyBytes <= 0 {
+		c.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+	}
+	return c
+}
+
+// ResolveAPIKey returns the configured API key. If it is empty, the custom
+// missing-key error is preferred over fallbackErr.
+func (c APIKeyProviderConfig) ResolveAPIKey(fallbackErr error) (string, error) {
+	if c.GetAPIKey != nil {
+		if apiKey := c.GetAPIKey(); apiKey != "" {
+			return apiKey, nil
+		}
+	}
+	if c.ErrMissingAPIKey != nil {
+		return "", c.ErrMissingAPIKey
+	}
+	if fallbackErr != nil {
+		return "", fallbackErr
+	}
+	return "", fmt.Errorf("API key is not configured")
+}
+
+// ConfiguredBaseURL returns the configured provider URL or an empty string.
+func (c APIKeyProviderConfig) ConfiguredBaseURL() string {
+	if c.GetBaseURL == nil {
+		return ""
+	}
+	return c.GetBaseURL()
 }
 
 type redactedError struct {
@@ -167,6 +226,38 @@ func DoRequest(
 	return resp.StatusCode, body, nil
 }
 
+// PostJSON marshals payload, creates a JSON POST request, applies headers, and
+// executes it with a bounded response body.
+func PostJSON(
+	ctx context.Context,
+	client *http.Client,
+	provider string,
+	endpoint string,
+	payload any,
+	headers http.Header,
+	maxResponseBodyBytes int64,
+) (int, []byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("unexpected marshal request error: %w", err)
+	}
+
+	req, err := NewJSONRequest(ctx, provider, endpoint, body)
+	if err != nil {
+		return 0, nil, err
+	}
+	for name, values := range headers {
+		req.Header.Del(name)
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	// The payload is always JSON even if callers supplied a conflicting header.
+	req.Header.Set("Content-Type", "application/json")
+
+	return DoRequest(ctx, client, provider, req, maxResponseBodyBytes)
+}
+
 // NewProviderResponseError returns a consistent generic provider error. The
 // message must already be sanitized when it originated from a remote service.
 func NewProviderResponseError(provider string, statusCode int, message string) error {
@@ -187,6 +278,30 @@ func DecodeFloat32ArrayBytes(item []byte) ([]float32, error) {
 		bytes := item[i*4 : (i+1)*4]
 		bits := binary.LittleEndian.Uint32(bytes)
 		embeddings[i] = math.Float32frombits(bits)
+	}
+	return embeddings, nil
+}
+
+// DecodeIndexedBase64Embeddings validates and decodes indexed embedding
+// response items, restoring the order of the original input texts.
+func DecodeIndexedBase64Embeddings(items []IndexedBase64Embedding, expectedCount int) ([][]float32, error) {
+	if len(items) != expectedCount {
+		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(items), expectedCount)
+	}
+
+	embeddings := make([][]float32, expectedCount)
+	for _, item := range items {
+		if item.Index < 0 || item.Index >= expectedCount {
+			return nil, fmt.Errorf("response data index %d is out of range [0, %d)", item.Index, expectedCount)
+		}
+		if embeddings[item.Index] != nil {
+			return nil, fmt.Errorf("response data contains duplicate index %d", item.Index)
+		}
+		embedding, err := DecodeFloat32ArrayBytes(item.Embedding)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
+		}
+		embeddings[item.Index] = embedding
 	}
 	return embeddings, nil
 }

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -180,6 +181,16 @@ func NewRedactedError(message string, cause error) error {
 	return &redactedError{message: message, cause: cause}
 }
 
+// stripURLError removes the URL-bearing wrapper while preserving its
+// underlying transport error for errors.Is and errors.As.
+func stripURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return urlErr.Err
+	}
+	return err
+}
+
 // NewProviderRequestError redacts endpoint details from request and transport
 // errors. If the caller's context has completed, its cause is returned so
 // cancellation and deadline errors remain recognizable to callers.
@@ -187,7 +198,7 @@ func NewProviderRequestError(ctx context.Context, provider string, cause error) 
 	if contextCause := context.Cause(ctx); contextCause != nil {
 		return contextCause
 	}
-	return NewRedactedError(provider+" request failed", cause)
+	return NewRedactedError(provider+" request failed", stripURLError(cause))
 }
 
 // ParseHTTPURL parses and validates an absolute HTTP(S) URL. description must
@@ -195,7 +206,7 @@ func NewProviderRequestError(ctx context.Context, provider string, cause error) 
 func ParseHTTPURL(rawURL, description string) (*url.URL, error) {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
-		return nil, NewRedactedError("invalid "+description, err)
+		return nil, NewRedactedError("invalid "+description, stripURLError(err))
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return nil, fmt.Errorf("invalid %s: absolute HTTP(S) URL is required", description)
@@ -342,6 +353,9 @@ func NewProviderResponseError(provider string, statusCode int, message string) e
 
 // DecodeFloat32ArrayBytes decodes bytes of an float32 array in little endian into a float32 slice.
 func DecodeFloat32ArrayBytes(item []byte) ([]float32, error) {
+	if len(item) == 0 {
+		return nil, fmt.Errorf("embedding data is empty")
+	}
 	if len(item)%4 != 0 {
 		return nil, fmt.Errorf("invalid embedding data")
 	}

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"maps"
 	"math"
 	"regexp"
@@ -28,9 +29,34 @@ import (
 const (
 	// DefaultHTTPClientTimeout bounds embedding provider requests when the caller context is not cancelled.
 	DefaultHTTPClientTimeout = 30 * time.Second
+	// DefaultMaxResponseBodyBytes bounds memory used to read an embedding provider response.
+	DefaultMaxResponseBodyBytes int64 = 32 << 20
 
 	maxSanitizedErrorTextBytes = 4096
 )
+
+// ReadResponseBody reads an embedding provider response up to maxBytes and
+// reports an error if the response contains more data.
+func ReadResponseBody(reader io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes < 0 {
+		return nil, fmt.Errorf("maximum response body size must not be negative")
+	}
+
+	// Read one extra byte to distinguish a response at the limit from one over
+	// the limit. Avoid overflowing when callers intentionally use MaxInt64.
+	readLimit := maxBytes
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, readLimit))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds maximum size of %d bytes", maxBytes)
+	}
+	return body, nil
+}
 
 var (
 	sensitiveJSONFieldPattern = regexp.MustCompile(`(?i)("(?:authorization|api[_-]?key|token|access[_-]?token|credentials)"\s*:\s*")([^"]*)(")`)

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -71,6 +71,36 @@ type Embedder interface {
 	CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error)
 }
 
+type redactedError struct {
+	message string
+	cause   error
+}
+
+func (e *redactedError) Error() string {
+	return e.message
+}
+
+func (e *redactedError) Unwrap() error {
+	return e.cause
+}
+
+// NewRedactedError returns an error with a safe user-facing message while
+// preserving cause for errors.Is and errors.As. It is intended for errors
+// whose original text may contain configured endpoints or credentials.
+func NewRedactedError(message string, cause error) error {
+	return &redactedError{message: message, cause: cause}
+}
+
+// NewProviderRequestError redacts endpoint details from request and transport
+// errors. If the caller's context has completed, its cause is returned so
+// cancellation and deadline errors remain recognizable to callers.
+func NewProviderRequestError(ctx context.Context, provider string, cause error) error {
+	if contextCause := context.Cause(ctx); contextCause != nil {
+		return contextCause
+	}
+	return NewRedactedError(provider+" request failed", cause)
+}
+
 // DecodeFloat32ArrayBytes decodes bytes of an float32 array in little endian into a float32 slice.
 func DecodeFloat32ArrayBytes(item []byte) ([]float32, error) {
 	if len(item)%4 != 0 {

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -15,24 +15,29 @@
 package base
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"maps"
 	"math"
+	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/docker/go-units"
 )
 
 const (
 	// DefaultHTTPClientTimeout bounds embedding provider requests when the caller context is not cancelled.
 	DefaultHTTPClientTimeout = 30 * time.Second
 	// DefaultMaxResponseBodyBytes bounds memory used to read an embedding provider response.
-	DefaultMaxResponseBodyBytes int64 = 32 << 20
+	DefaultMaxResponseBodyBytes int64 = 32 * units.MiB
 
-	maxSanitizedErrorTextBytes = 4096
+	maxSanitizedErrorTextBytes = 4 * units.KiB
 )
 
 // ReadResponseBody reads an embedding provider response up to maxBytes and
@@ -99,6 +104,76 @@ func NewProviderRequestError(ctx context.Context, provider string, cause error) 
 		return contextCause
 	}
 	return NewRedactedError(provider+" request failed", cause)
+}
+
+// ParseHTTPURL parses and validates an absolute HTTP(S) URL. description must
+// be a fixed, non-sensitive name used to construct a safe error message.
+func ParseHTTPURL(rawURL, description string) (*url.URL, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, NewRedactedError("invalid "+description, err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, fmt.Errorf("invalid %s: absolute HTTP(S) URL is required", description)
+	}
+	return u, nil
+}
+
+// SetEscapedURLPath assigns an escaped URL path without exposing the original
+// path in an error. description must be a fixed, non-sensitive name.
+func SetEscapedURLPath(u *url.URL, escapedPath, description string) error {
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		return NewRedactedError("invalid "+description, err)
+	}
+	u.Path = path
+	u.RawPath = escapedPath
+	return nil
+}
+
+// NewJSONRequest creates an HTTP POST request with a JSON content type while
+// keeping endpoint details out of request-construction errors.
+func NewJSONRequest(ctx context.Context, provider, endpoint string, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, NewProviderRequestError(ctx, provider, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// DoRequest executes an embedding provider request, closes the response body,
+// and reads at most maxResponseBodyBytes bytes.
+func DoRequest(
+	ctx context.Context,
+	client *http.Client,
+	provider string,
+	req *http.Request,
+	maxResponseBodyBytes int64,
+) (int, []byte, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, NewProviderRequestError(ctx, provider, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ReadResponseBody(resp.Body, maxResponseBodyBytes)
+	if err != nil {
+		if contextCause := context.Cause(ctx); contextCause != nil {
+			return 0, nil, contextCause
+		}
+		return 0, nil, err
+	}
+	return resp.StatusCode, body, nil
+}
+
+// NewProviderResponseError returns a consistent generic provider error. The
+// message must already be sanitized when it originated from a remote service.
+func NewProviderResponseError(provider string, statusCode int, message string) error {
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return fmt.Errorf("%s: status code %d, message: %s", provider, statusCode, message)
 }
 
 // DecodeFloat32ArrayBytes decodes bytes of an float32 array in little endian into a float32 slice.

--- a/pkg/inference/embedding/base/base.go
+++ b/pkg/inference/embedding/base/base.go
@@ -153,6 +153,15 @@ func (c APIKeyProviderConfig) ResolveAPIKey(fallbackErr error) (string, error) {
 	return "", fmt.Errorf("API key is not configured")
 }
 
+// UnauthorizedError returns the configured unauthorized error, or a generic
+// provider-specific error for the given HTTP status.
+func (c APIKeyProviderConfig) UnauthorizedError(provider string, statusCode int) error {
+	if c.ErrUnauthorized != nil {
+		return c.ErrUnauthorized
+	}
+	return fmt.Errorf("%s returns status %s, check API key", provider, strings.ToLower(http.StatusText(statusCode)))
+}
+
 // ConfiguredBaseURL returns the configured provider URL or an empty string.
 func (c APIKeyProviderConfig) ConfiguredBaseURL() string {
 	if c.GetBaseURL == nil {
@@ -214,6 +223,20 @@ func ParseHTTPURL(rawURL, description string) (*url.URL, error) {
 	return u, nil
 }
 
+// EscapeURLPathSegment escapes one URL path segment. Complete dot segments
+// are encoded explicitly so intermediaries cannot remove or normalize them
+// according to RFC 3986 section 5.2.4.
+func EscapeURLPathSegment(segment string) string {
+	escaped := url.PathEscape(segment)
+	if escaped == "." {
+		return "%2E"
+	}
+	if escaped == ".." {
+		return "%2E%2E"
+	}
+	return escaped
+}
+
 // SetEscapedURLPath assigns an escaped URL path without exposing the original
 // path in an error. description must be a fixed, non-sensitive name.
 func SetEscapedURLPath(u *url.URL, escapedPath, description string) error {
@@ -254,9 +277,6 @@ func DoRequest(
 
 	body, err := ReadResponseBody(resp.Body, maxResponseBodyBytes)
 	if err != nil {
-		if contextCause := context.Cause(ctx); contextCause != nil {
-			return 0, nil, contextCause
-		}
 		return 0, nil, err
 	}
 	return resp.StatusCode, body, nil

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -17,6 +17,7 @@ package base
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -27,7 +28,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestDecodeBase64EmbeddingF32(t *testing.T) {
@@ -326,6 +330,95 @@ func TestHTTPHelpers(t *testing.T) {
 			64,
 		)
 		require.ErrorContains(t, err, "unexpected marshal request error")
+	})
+
+	t.Run("execute JSON embedding call", func(t *testing.T) {
+		core, observedLogs := observer.New(zap.ErrorLevel)
+		restore := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+		t.Cleanup(restore)
+
+		decodeErrorMessage := func(body []byte) (string, error) {
+			var response struct {
+				Message string `json:"message"`
+			}
+			if err := json.Unmarshal(body, &response); err != nil {
+				return "", err
+			}
+			return response.Message, nil
+		}
+		decodeEmbeddings := func(body []byte, expectedCount int) ([][]float32, error) {
+			require.JSONEq(t, `{"ok":true}`, string(body))
+			require.Equal(t, 2, expectedCount)
+			return [][]float32{{1}, {2}}, nil
+		}
+		execute := func(
+			statusCode int,
+			responseBody string,
+			configure func(*JSONEmbeddingCall),
+		) ([][]float32, error) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(statusCode)
+				_, _ = w.Write([]byte(responseBody))
+			}))
+			defer server.Close()
+
+			call := JSONEmbeddingCall{
+				Provider:             "test provider",
+				Client:               &http.Client{},
+				Endpoint:             server.URL,
+				Payload:              map[string]any{"input": []string{"hello"}},
+				MaxResponseBodyBytes: 64,
+				DecodeErrorMessage:   decodeErrorMessage,
+				DecodeEmbeddings:     decodeEmbeddings,
+			}
+			if configure != nil {
+				configure(&call)
+			}
+			return ExecuteJSONEmbeddingCall(context.Background(), 2, call)
+		}
+
+		embeddings, err := execute(http.StatusOK, `{"ok":true}`, nil)
+		require.NoError(t, err)
+		require.Equal(t, [][]float32{{1}, {2}}, embeddings)
+
+		_, err = execute(http.StatusBadRequest, `{"message":"invalid super-secret"}`, func(call *JSONEmbeddingCall) {
+			call.Secrets = []string{"super-secret"}
+		})
+		require.EqualError(t, err, "test provider: status code 400, message: invalid [REDACTED]")
+
+		customErr := errors.New("custom unauthorized error")
+		_, err = execute(http.StatusUnauthorized, `{"message":"unauthorized"}`, func(call *JSONEmbeddingCall) {
+			call.StatusErrors = map[int]error{http.StatusUnauthorized: customErr}
+		})
+		require.ErrorIs(t, err, customErr)
+
+		_, err = execute(http.StatusBadGateway, `{"message":`, nil)
+		require.EqualError(t, err, "test provider: status code 502, message: Bad Gateway")
+
+		decodeErr := errors.New("success decoder failed")
+		_, err = execute(http.StatusOK, `{"ok":true}`, func(call *JSONEmbeddingCall) {
+			call.DecodeEmbeddings = func([]byte, int) ([][]float32, error) {
+				return nil, decodeErr
+			}
+		})
+		require.ErrorIs(t, err, decodeErr)
+
+		entries := observedLogs.FilterMessage("test provider API request failed").All()
+		require.Len(t, entries, 3)
+		fields := entries[0].ContextMap()
+		require.Equal(t, int64(http.StatusBadRequest), fields["status"])
+		require.Equal(t, "invalid [REDACTED]", fields["message"])
+		fields = entries[2].ContextMap()
+		require.Equal(t, int64(http.StatusBadGateway), fields["status"])
+		require.NotEmpty(t, fields["parse_error"])
+
+		_, err = ExecuteJSONEmbeddingCall(context.Background(), 0, JSONEmbeddingCall{Provider: "test provider"})
+		require.EqualError(t, err, "test provider error response decoder is not configured")
+		_, err = ExecuteJSONEmbeddingCall(context.Background(), 0, JSONEmbeddingCall{
+			Provider:           "test provider",
+			DecodeErrorMessage: decodeErrorMessage,
+		})
+		require.EqualError(t, err, "test provider success response decoder is not configured")
 	})
 
 	t.Run("response error", func(t *testing.T) {

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -70,6 +71,39 @@ func TestDecodeBase64EmbeddingF32(t *testing.T) {
 	_, err = DecodeFloat32ArrayBytes([]byte{0x00, 0x01, 0x02, 0x03, 0x04})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid embedding data")
+
+	t.Run("indexed response", func(t *testing.T) {
+		items := []IndexedBase64Embedding{
+			{Index: 1, Embedding: []byte{0x00, 0x00, 0x00, 0x40}},
+			{Index: 0, Embedding: []byte{0x00, 0x00, 0x80, 0x3f}},
+		}
+		embeddings, err := DecodeIndexedBase64Embeddings(items, 2)
+		require.NoError(t, err)
+		require.Equal(t, [][]float32{{1}, {2}}, embeddings)
+
+		_, err = DecodeIndexedBase64Embeddings(items[:1], 2)
+		require.EqualError(t, err, "response data length 1 does not match input texts length 2")
+
+		for _, index := range []int{-1, 2} {
+			invalid := []IndexedBase64Embedding{
+				{Index: index, Embedding: []byte{0x00, 0x00, 0x80, 0x3f}},
+				{Index: 0, Embedding: []byte{0x00, 0x00, 0x00, 0x40}},
+			}
+			_, err = DecodeIndexedBase64Embeddings(invalid, 2)
+			require.EqualError(t, err, fmt.Sprintf("response data index %d is out of range [0, 2)", index))
+		}
+
+		duplicate := []IndexedBase64Embedding{
+			{Index: 0, Embedding: []byte{0x00, 0x00, 0x80, 0x3f}},
+			{Index: 0, Embedding: []byte{0x00, 0x00, 0x00, 0x40}},
+		}
+		_, err = DecodeIndexedBase64Embeddings(duplicate, 2)
+		require.EqualError(t, err, "response data contains duplicate index 0")
+
+		malformed := []IndexedBase64Embedding{{Index: 0, Embedding: []byte{0x00}}}
+		_, err = DecodeIndexedBase64Embeddings(malformed, 1)
+		require.EqualError(t, err, "failed to decode embedding for index 0: invalid embedding data")
+	})
 }
 
 func TestReadResponseBody(t *testing.T) {
@@ -159,6 +193,39 @@ func TestRedactedErrors(t *testing.T) {
 }
 
 func TestHTTPHelpers(t *testing.T) {
+	t.Run("API key provider config", func(t *testing.T) {
+		fallbackErr := errors.New("default missing API key error")
+		customErr := errors.New("custom missing API key error")
+		cfg := APIKeyProviderConfig{
+			GetAPIKey:        func() string { return "test-api-key" },
+			GetBaseURL:       func() string { return "https://example.com/embed" },
+			ErrMissingAPIKey: customErr,
+		}
+
+		normalized := cfg.WithDefaults()
+		require.Zero(t, cfg.MaxResponseBodyBytes)
+		require.Equal(t, DefaultMaxResponseBodyBytes, normalized.MaxResponseBodyBytes)
+		require.Equal(t, "https://example.com/embed", normalized.ConfiguredBaseURL())
+		apiKey, err := normalized.ResolveAPIKey(fallbackErr)
+		require.NoError(t, err)
+		require.Equal(t, "test-api-key", apiKey)
+
+		customLimit := APIKeyProviderConfig{MaxResponseBodyBytes: 64}.WithDefaults()
+		require.Equal(t, int64(64), customLimit.MaxResponseBodyBytes)
+		require.Empty(t, customLimit.ConfiguredBaseURL())
+
+		normalized.GetAPIKey = func() string { return "" }
+		_, err = normalized.ResolveAPIKey(fallbackErr)
+		require.ErrorIs(t, err, customErr)
+
+		normalized.ErrMissingAPIKey = nil
+		_, err = normalized.ResolveAPIKey(fallbackErr)
+		require.ErrorIs(t, err, fallbackErr)
+
+		_, err = APIKeyProviderConfig{}.ResolveAPIKey(nil)
+		require.EqualError(t, err, "API key is not configured")
+	})
+
 	t.Run("parse HTTP URL", func(t *testing.T) {
 		u, err := ParseHTTPURL("  https://example.com/root?tenant=x  ", "test provider URL")
 		require.NoError(t, err)
@@ -211,6 +278,54 @@ func TestHTTPHelpers(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, statusCode)
 		require.JSONEq(t, `{"ok":true}`, string(body))
+	})
+
+	t.Run("post JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("unexpected method %q", r.Method)
+			}
+			if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
+				t.Errorf("unexpected content type %q", contentType)
+			}
+			if authorization := r.Header.Get("Authorization"); authorization != "Bearer test-key" {
+				t.Errorf("unexpected authorization header %q", authorization)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("failed to read request body: %v", err)
+			}
+			if string(body) != `{"input":["hello"]}` {
+				t.Errorf("unexpected request body %q", body)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		statusCode, body, err := PostJSON(
+			context.Background(),
+			&http.Client{},
+			"test provider",
+			server.URL,
+			map[string]any{"input": []string{"hello"}},
+			http.Header{"Authorization": []string{"Bearer test-key"}},
+			64,
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode)
+		require.JSONEq(t, `{"ok":true}`, string(body))
+
+		_, _, err = PostJSON(
+			context.Background(),
+			&http.Client{},
+			"test provider",
+			server.URL,
+			map[string]any{"unsupported": make(chan struct{})},
+			nil,
+			64,
+		)
+		require.ErrorContains(t, err, "unexpected marshal request error")
 	})
 
 	t.Run("response error", func(t *testing.T) {

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -59,9 +59,8 @@ func TestDecodeBase64EmbeddingF32(t *testing.T) {
 
 	decodedBytes, err = base64.StdEncoding.DecodeString("")
 	require.NoError(t, err)
-	result, err = DecodeFloat32ArrayBytes(decodedBytes)
-	require.NoError(t, err)
-	require.Empty(t, result)
+	_, err = DecodeFloat32ArrayBytes(decodedBytes)
+	require.EqualError(t, err, "embedding data is empty")
 
 	decodedBytes, err = base64.StdEncoding.DecodeString("AAAY")
 	require.NoError(t, err)
@@ -107,6 +106,10 @@ func TestDecodeBase64EmbeddingF32(t *testing.T) {
 		malformed := []IndexedBase64Embedding{{Index: 0, Embedding: []byte{0x00}}}
 		_, err = DecodeIndexedBase64Embeddings(malformed, 1)
 		require.EqualError(t, err, "failed to decode embedding for index 0: invalid embedding data")
+
+		empty := []IndexedBase64Embedding{{Index: 0}}
+		_, err = DecodeIndexedBase64Embeddings(empty, 1)
+		require.EqualError(t, err, "failed to decode embedding for index 0: embedding data is empty")
 	})
 }
 
@@ -186,7 +189,9 @@ func TestRedactedErrors(t *testing.T) {
 	err = NewProviderRequestError(context.Background(), "test provider", cause)
 	require.EqualError(t, err, "test provider request failed")
 	require.NotContains(t, err.Error(), secretURL)
-	require.ErrorIs(t, err, cause)
+	require.ErrorIs(t, err, cause.Err)
+	var exposedURL *url.Error
+	require.False(t, errors.As(err, &exposedURL))
 
 	customCause := errors.New("caller stopped request")
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -239,6 +244,8 @@ func TestHTTPHelpers(t *testing.T) {
 		_, err = ParseHTTPURL("https://example.com/%zz?token="+secret, "test provider URL")
 		require.EqualError(t, err, "invalid test provider URL")
 		require.NotContains(t, err.Error(), secret)
+		var exposedURL *url.Error
+		require.False(t, errors.As(err, &exposedURL))
 
 		for _, rawURL := range []string{"/relative", "ftp://example.com/path"} {
 			_, err = ParseHTTPURL(rawURL, "test provider URL")

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"io"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -153,4 +156,67 @@ func TestRedactedErrors(t *testing.T) {
 	err = NewProviderRequestError(ctx, "test provider", cause)
 	require.ErrorIs(t, err, customCause)
 	require.Equal(t, customCause, err)
+}
+
+func TestHTTPHelpers(t *testing.T) {
+	t.Run("parse HTTP URL", func(t *testing.T) {
+		u, err := ParseHTTPURL("  https://example.com/root?tenant=x  ", "test provider URL")
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/root?tenant=x", u.String())
+
+		const secret = "super-secret"
+		_, err = ParseHTTPURL("https://example.com/%zz?token="+secret, "test provider URL")
+		require.EqualError(t, err, "invalid test provider URL")
+		require.NotContains(t, err.Error(), secret)
+
+		for _, rawURL := range []string{"/relative", "ftp://example.com/path"} {
+			_, err = ParseHTTPURL(rawURL, "test provider URL")
+			require.EqualError(t, err, "invalid test provider URL: absolute HTTP(S) URL is required")
+		}
+	})
+
+	t.Run("escaped path", func(t *testing.T) {
+		u, err := ParseHTTPURL("https://example.com?tenant=x", "test provider URL")
+		require.NoError(t, err)
+		require.NoError(t, SetEscapedURLPath(u, "/models/org%2Fmodel", "test provider URL path"))
+		require.Equal(t, "https://example.com/models/org%2Fmodel?tenant=x", u.String())
+
+		const secret = "super-secret"
+		err = SetEscapedURLPath(u, "/%zz/"+secret, "test provider URL path")
+		require.EqualError(t, err, "invalid test provider URL path")
+		require.NotContains(t, err.Error(), secret)
+	})
+
+	t.Run("JSON request", func(t *testing.T) {
+		req, err := NewJSONRequest(context.Background(), "test provider", "https://example.com/embed", []byte(`{"input":"test"}`))
+		require.NoError(t, err)
+		require.Equal(t, http.MethodPost, req.Method)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"input":"test"}`, string(body))
+	})
+
+	t.Run("execute request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		req, err := NewJSONRequest(context.Background(), "test provider", server.URL, nil)
+		require.NoError(t, err)
+		statusCode, body, err := DoRequest(context.Background(), &http.Client{}, "test provider", req, 64)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, statusCode)
+		require.JSONEq(t, `{"ok":true}`, string(body))
+	})
+
+	t.Run("response error", func(t *testing.T) {
+		err := NewProviderResponseError("test provider", http.StatusBadRequest, "invalid input")
+		require.EqualError(t, err, "test provider: status code 400, message: invalid input")
+		err = NewProviderResponseError("test provider", http.StatusServiceUnavailable, "")
+		require.EqualError(t, err, "test provider: status code 503, message: Service Unavailable")
+	})
 }

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -16,6 +16,7 @@ package base
 
 import (
 	"encoding/base64"
+	"math"
 	"strings"
 	"testing"
 
@@ -63,6 +64,22 @@ func TestDecodeBase64EmbeddingF32(t *testing.T) {
 	_, err = DecodeFloat32ArrayBytes([]byte{0x00, 0x01, 0x02, 0x03, 0x04})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid embedding data")
+}
+
+func TestReadResponseBody(t *testing.T) {
+	body, err := ReadResponseBody(strings.NewReader(strings.Repeat("x", 64)), 64)
+	require.NoError(t, err)
+	require.Len(t, body, 64)
+
+	_, err = ReadResponseBody(strings.NewReader(strings.Repeat("x", 65)), 64)
+	require.EqualError(t, err, "response body exceeds maximum size of 64 bytes")
+
+	body, err = ReadResponseBody(strings.NewReader("x"), math.MaxInt64)
+	require.NoError(t, err)
+	require.Equal(t, []byte("x"), body)
+
+	_, err = ReadResponseBody(strings.NewReader(""), -1)
+	require.EqualError(t, err, "maximum response body size must not be negative")
 }
 
 func TestJSONFieldsWithOptions(t *testing.T) {

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -15,8 +15,11 @@
 package base
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"math"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -128,4 +131,26 @@ func TestSanitizeErrorText(t *testing.T) {
 	require.NotContains(t, sanitized, longKey[:maxSanitizedErrorTextBytes/2])
 	require.Contains(t, sanitized, "[REDACTED]")
 	require.LessOrEqual(t, len(sanitized), maxSanitizedErrorTextBytes+len("...[truncated]"))
+}
+
+func TestRedactedErrors(t *testing.T) {
+	const secretURL = "http://internal.example/embed?token=super-secret"
+	cause := &url.Error{Op: "Post", URL: secretURL, Err: errors.New("connection failed")}
+
+	err := NewRedactedError("invalid provider endpoint", cause)
+	require.EqualError(t, err, "invalid provider endpoint")
+	require.NotContains(t, err.Error(), secretURL)
+	require.ErrorIs(t, err, cause)
+
+	err = NewProviderRequestError(context.Background(), "test provider", cause)
+	require.EqualError(t, err, "test provider request failed")
+	require.NotContains(t, err.Error(), secretURL)
+	require.ErrorIs(t, err, cause)
+
+	customCause := errors.New("caller stopped request")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(customCause)
+	err = NewProviderRequestError(ctx, "test provider", cause)
+	require.ErrorIs(t, err, customCause)
+	require.Equal(t, customCause, err)
 }

--- a/pkg/inference/embedding/base/base_test.go
+++ b/pkg/inference/embedding/base/base_test.go
@@ -205,10 +205,12 @@ func TestHTTPHelpers(t *testing.T) {
 	t.Run("API key provider config", func(t *testing.T) {
 		fallbackErr := errors.New("default missing API key error")
 		customErr := errors.New("custom missing API key error")
+		customUnauthorizedErr := errors.New("custom unauthorized error")
 		cfg := APIKeyProviderConfig{
 			GetAPIKey:        func() string { return "test-api-key" },
 			GetBaseURL:       func() string { return "https://example.com/embed" },
 			ErrMissingAPIKey: customErr,
+			ErrUnauthorized:  customUnauthorizedErr,
 		}
 
 		normalized := cfg.WithDefaults()
@@ -233,6 +235,11 @@ func TestHTTPHelpers(t *testing.T) {
 
 		_, err = APIKeyProviderConfig{}.ResolveAPIKey(nil)
 		require.EqualError(t, err, "API key is not configured")
+
+		require.ErrorIs(t, normalized.UnauthorizedError("test provider", http.StatusUnauthorized), customUnauthorizedErr)
+		normalized.ErrUnauthorized = nil
+		require.EqualError(t, normalized.UnauthorizedError("test provider", http.StatusUnauthorized), "test provider returns status unauthorized, check API key")
+		require.EqualError(t, normalized.UnauthorizedError("test provider", http.StatusForbidden), "test provider returns status forbidden, check API key")
 	})
 
 	t.Run("parse HTTP URL", func(t *testing.T) {
@@ -254,6 +261,10 @@ func TestHTTPHelpers(t *testing.T) {
 	})
 
 	t.Run("escaped path", func(t *testing.T) {
+		require.Equal(t, "model%2Fname", EscapeURLPathSegment("model/name"))
+		require.Equal(t, "%2E", EscapeURLPathSegment("."))
+		require.Equal(t, "%2E%2E", EscapeURLPathSegment(".."))
+
 		u, err := ParseHTTPURL("https://example.com?tenant=x", "test provider URL")
 		require.NoError(t, err)
 		require.NoError(t, SetEscapedURLPath(u, "/models/org%2Fmodel", "test provider URL path"))

--- a/pkg/inference/embedding/cohere/BUILD.bazel
+++ b/pkg/inference/embedding/cohere/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/cohere",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(
@@ -23,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 9,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/cohere/BUILD.bazel
+++ b/pkg/inference/embedding/cohere/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["cohere_test.go"],
     embed = [":cohere"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 13,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/cohere/BUILD.bazel
+++ b/pkg/inference/embedding/cohere/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cohere",
+    srcs = [
+        "cohere.go",
+        "protocol.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/cohere",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "cohere_test",
+    timeout = "short",
+    srcs = ["cohere_test.go"],
+    embed = [":cohere"],
+    flaky = True,
+    shard_count = 11,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/cohere/BUILD.bazel
+++ b/pkg/inference/embedding/cohere/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["cohere_test.go"],
     embed = [":cohere"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 9,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default endpoint URL for the Cohere embeddings API.
@@ -38,16 +36,13 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for CohereEmbedder.
-// GetBaseURL returns the complete Cohere embeddings endpoint. An empty value
-// uses DefaultAPIBaseURL.
-type EmbedderConfig base.APIKeyProviderConfig
-
 // NewCohereEmbedder creates a new CohereEmbedder instance with the provided configuration.
-func NewCohereEmbedder(cfg EmbedderConfig) *Embedder {
+// cfg.GetBaseURL returns the complete Cohere embeddings endpoint; an empty
+// value uses DefaultAPIBaseURL.
+func NewCohereEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -124,6 +119,36 @@ func decodeEmbeddings(raw json.RawMessage) ([][]float32, error) {
 	}
 }
 
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	return response.Message, nil
+}
+
+func decodeResponse(body []byte, expectedCount int) ([][]float32, error) {
+	var response Response
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	embeddings, err := decodeEmbeddings(response.Embeddings)
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) != expectedCount {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(embeddings), expectedCount)
+	}
+	return embeddings, nil
+}
+
+func (e *Embedder) unauthorizedError() error {
+	if e.cfg.ErrUnauthorized != nil {
+		return e.cfg.ErrUnauthorized
+	}
+	return fmt.Errorf("cohere returns status unauthorized, check API key")
+}
+
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // Cohere v3 and newer models require opts to include an "input_type" appropriate
 // for the current call, such as "search_document" or "search_query".
@@ -149,53 +174,21 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "Cohere", endpoint, base.JSONFieldsWithOptions(map[string]any{
-		"model": model,
-		"texts": texts,
-	}, opts), http.Header{
-		"Authorization": {"Bearer " + apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Message != "" {
-			message = base.SanitizeErrorText(errResp.Message, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("Cohere API request failed", logFields...)
-		if statusCode == http.StatusUnauthorized {
-			if e.cfg.ErrUnauthorized != nil {
-				return nil, e.cfg.ErrUnauthorized
-			}
-			return nil, fmt.Errorf("cohere returns status unauthorized, check API key")
-		}
-		return nil, base.NewProviderResponseError("Cohere", statusCode, message)
-	}
-
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-	embeddings, err := decodeEmbeddings(respObj.Embeddings)
-	if err != nil {
-		return nil, err
-	}
-	if len(embeddings) != len(texts) {
-		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(embeddings), len(texts))
-	}
-
-	return embeddings, nil
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "Cohere",
+		Client:   &e.client,
+		Endpoint: endpoint,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"model": model,
+			"texts": texts,
+		}, opts),
+		Headers:              http.Header{"Authorization": {"Bearer " + apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.unauthorizedError(),
+		},
+		DecodeEmbeddings: decodeResponse,
+	})
 }

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -83,6 +83,8 @@ func embeddingsEndpoint(configured string) (string, error) {
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
+// Cohere v3 and newer models require opts to include an "input_type" appropriate
+// for the current call, such as "search_document" or "search_query".
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
 	// ref: https://docs.cohere.com/v1/reference/embed

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -74,12 +74,70 @@ func embeddingsEndpoint(configured string) (string, error) {
 	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid Cohere API base URL: %w", err)
+		return "", base.NewRedactedError("invalid Cohere API base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid Cohere API base URL: absolute HTTP(S) URL is required")
 	}
 	return u.String(), nil
+}
+
+func validateEmbeddingTypes(opts map[string]any) error {
+	value, ok := opts["embedding_types"]
+	if !ok {
+		return nil
+	}
+
+	var embeddingTypes []string
+	switch types := value.(type) {
+	case []string:
+		embeddingTypes = types
+	case []any:
+		embeddingTypes = make([]string, len(types))
+		for i, item := range types {
+			var ok bool
+			embeddingTypes[i], ok = item.(string)
+			if !ok {
+				return fmt.Errorf(`Cohere embedding_types must be exactly ["float"]`)
+			}
+		}
+	default:
+		return fmt.Errorf(`Cohere embedding_types must be exactly ["float"]`)
+	}
+
+	if len(embeddingTypes) != 1 || embeddingTypes[0] != "float" {
+		return fmt.Errorf(`Cohere embedding_types must be exactly ["float"]`)
+	}
+	return nil
+}
+
+func decodeEmbeddings(raw json.RawMessage) ([][]float32, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("Cohere response does not contain embeddings")
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var embeddings [][]float32
+		if err := json.Unmarshal(trimmed, &embeddings); err != nil {
+			return nil, fmt.Errorf("unexpected unmarshal response embeddings error: %w", err)
+		}
+		return embeddings, nil
+	case '{':
+		var embeddingsByType struct {
+			Float [][]float32 `json:"float"`
+		}
+		if err := json.Unmarshal(trimmed, &embeddingsByType); err != nil {
+			return nil, fmt.Errorf("unexpected unmarshal typed response embeddings error: %w", err)
+		}
+		if embeddingsByType.Float == nil {
+			return nil, fmt.Errorf("Cohere response does not contain float embeddings")
+		}
+		return embeddingsByType.Float, nil
+	default:
+		return nil, fmt.Errorf("unexpected Cohere embeddings response format")
+	}
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -93,6 +151,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
+	}
+	if err := validateEmbeddingTypes(opts); err != nil {
+		return nil, err
 	}
 
 	var apiKey string
@@ -124,7 +185,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "Cohere", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -132,7 +193,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "Cohere", err)
 	}
 	defer resp.Body.Close()
 
@@ -174,9 +235,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err := json.Unmarshal(body, &respObj); err != nil {
 		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
 	}
-	if len(respObj.Embeddings) != len(texts) {
-		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
+	embeddings, err := decodeEmbeddings(respObj.Embeddings)
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) != len(texts) {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(embeddings), len(texts))
 	}
 
-	return respObj.Embeddings, nil
+	return embeddings, nil
 }

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -28,12 +27,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default endpoint URL for the Cohere embeddings API.
-	DefaultAPIBaseURL = "https://api.cohere.com/v1/embed"
-	// DefaultMaxResponseBodyBytes bounds memory used to read a Cohere response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default endpoint URL for the Cohere embeddings API.
+const DefaultAPIBaseURL = "https://api.cohere.com/v1/embed"
 
 // Embedder is for Cohere embeddings.
 type Embedder struct {
@@ -52,14 +47,14 @@ type EmbedderConfig struct {
 	ErrMissingAPIKey error // The error to return when API key is missing
 	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewCohereEmbedder creates a new CohereEmbedder instance with the provided configuration.
 func NewCohereEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -72,12 +67,9 @@ func embeddingsEndpoint(configured string) (string, error) {
 	if endpoint == "" {
 		endpoint = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(endpoint)
+	u, err := base.ParseHTTPURL(endpoint, "Cohere API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid Cohere API base URL", err)
-	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid Cohere API base URL: absolute HTTP(S) URL is required")
+		return "", err
 	}
 	return u.String(), nil
 }
@@ -112,6 +104,9 @@ func validateEmbeddingTypes(opts map[string]any) error {
 }
 
 func decodeEmbeddings(raw json.RawMessage) ([][]float32, error) {
+	// When embedding_types is omitted, Cohere returns embeddings as an array.
+	// When it is set, Cohere returns an object keyed by embedding type.
+	// See https://docs.cohere.com/v1/reference/embed.
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
 		return nil, fmt.Errorf("Cohere response does not contain embeddings")
@@ -183,26 +178,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "Cohere", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "Cohere", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "Cohere", endpoint, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "Cohere", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -211,7 +199,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		} else if errResp.Message != "" {
 			message = base.SanitizeErrorText(errResp.Message, apiKey)
 		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -219,16 +207,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("Cohere API request failed", logFields...)
-		if resp.StatusCode == http.StatusUnauthorized {
+		if statusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
 			return nil, fmt.Errorf("cohere returns status unauthorized, check API key")
 		}
-		if message != "" {
-			return nil, fmt.Errorf("cohere: %s", message)
-		}
-		return nil, fmt.Errorf("cohere: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("Cohere", statusCode, message)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -33,32 +33,21 @@ const DefaultAPIBaseURL = "https://api.cohere.com/v1/embed"
 // Embedder is for Cohere embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for CohereEmbedder.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns the complete Cohere embeddings endpoint. An empty
-	// value uses DefaultAPIBaseURL.
-	GetBaseURL       func() string
-	ErrMissingAPIKey error // The error to return when API key is missing
-	ErrUnauthorized  error // The error to return when API key is invalid
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
+// GetBaseURL returns the complete Cohere embeddings endpoint. An empty value
+// uses DefaultAPIBaseURL.
+type EmbedderConfig base.APIKeyProviderConfig
 
 // NewCohereEmbedder creates a new CohereEmbedder instance with the provided configuration.
 func NewCohereEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
 	}
 }
 
@@ -151,41 +140,21 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for cohere"))
+	if err != nil {
+		return nil, err
 	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for cohere")
-	}
-	var configuredBaseURL string
-	if e.cfg.GetBaseURL != nil {
-		configuredBaseURL = e.cfg.GetBaseURL()
-	}
-	endpoint, err := embeddingsEndpoint(configuredBaseURL)
+	endpoint, err := embeddingsEndpoint(e.cfg.ConfiguredBaseURL())
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "Cohere", endpoint, base.JSONFieldsWithOptions(map[string]any{
 		"model": model,
 		"texts": texts,
-	}, opts))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-
-	httpReq, err := base.NewJSONRequest(ctx, "Cohere", endpoint, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "Cohere", httpReq, e.cfg.MaxResponseBodyBytes)
+	}, opts), http.Header{
+		"Authorization": {"Bearer " + apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -1,0 +1,180 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultAPIBaseURL is the default endpoint URL for the Cohere embeddings API.
+	DefaultAPIBaseURL = "https://api.cohere.com/v1/embed"
+	// DefaultMaxResponseBodyBytes bounds memory used to read a Cohere response.
+	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
+)
+
+// Embedder is for Cohere embeddings.
+type Embedder struct {
+	client http.Client
+	cfg    EmbedderConfig
+}
+
+var _ base.Embedder = (*Embedder)(nil)
+
+// EmbedderConfig holds the configuration for CohereEmbedder.
+type EmbedderConfig struct {
+	GetAPIKey func() string
+	// GetBaseURL returns the complete Cohere embeddings endpoint. An empty
+	// value uses DefaultAPIBaseURL.
+	GetBaseURL       func() string
+	ErrMissingAPIKey error // The error to return when API key is missing
+	ErrUnauthorized  error // The error to return when API key is invalid
+	// MaxResponseBodyBytes limits both successful and error response bodies.
+	// Non-positive values use DefaultMaxResponseBodyBytes.
+	MaxResponseBodyBytes int64
+}
+
+// NewCohereEmbedder creates a new CohereEmbedder instance with the provided configuration.
+func NewCohereEmbedder(cfg EmbedderConfig) *Embedder {
+	if cfg.MaxResponseBodyBytes <= 0 {
+		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+	}
+	return &Embedder{
+		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
+		cfg:    cfg,
+	}
+}
+
+func embeddingsEndpoint(configured string) (string, error) {
+	endpoint := strings.TrimSpace(configured)
+	if endpoint == "" {
+		endpoint = DefaultAPIBaseURL
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid Cohere API base URL: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid Cohere API base URL: absolute HTTP(S) URL is required")
+	}
+	return u.String(), nil
+}
+
+// CreateEmbeddings creates embeddings for the given texts using the specified model.
+// CreateEmbeddings implements base.Embedder
+func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
+	// ref: https://docs.cohere.com/v1/reference/embed
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	if model == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	var apiKey string
+	if e.cfg.GetAPIKey != nil {
+		apiKey = e.cfg.GetAPIKey()
+	}
+	if apiKey == "" {
+		if e.cfg.ErrMissingAPIKey != nil {
+			return nil, e.cfg.ErrMissingAPIKey
+		}
+		return nil, fmt.Errorf("API key is not configured for cohere")
+	}
+	var configuredBaseURL string
+	if e.cfg.GetBaseURL != nil {
+		configuredBaseURL = e.cfg.GetBaseURL()
+	}
+	endpoint, err := embeddingsEndpoint(configuredBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+		"model": model,
+		"texts": texts,
+	}, opts))
+	if err != nil {
+		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ErrorResponse
+		message := ""
+		var parseErr error
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			parseErr = err
+		} else if errResp.Message != "" {
+			message = base.SanitizeErrorText(errResp.Message, apiKey)
+		}
+		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		if message != "" {
+			logFields = append(logFields, zap.String("message", message))
+		}
+		if parseErr != nil {
+			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
+		}
+		logutil.BgLogger().Error("Cohere API request failed", logFields...)
+		if resp.StatusCode == http.StatusUnauthorized {
+			if e.cfg.ErrUnauthorized != nil {
+				return nil, e.cfg.ErrUnauthorized
+			}
+			return nil, fmt.Errorf("cohere returns status unauthorized, check API key")
+		}
+		if message != "" {
+			return nil, fmt.Errorf("cohere: %s", message)
+		}
+		return nil, fmt.Errorf("cohere: status code %d", resp.StatusCode)
+	}
+
+	var respObj Response
+	if err := json.Unmarshal(body, &respObj); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	if len(respObj.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
+	}
+
+	return respObj.Embeddings, nil
+}

--- a/pkg/inference/embedding/cohere/cohere.go
+++ b/pkg/inference/embedding/cohere/cohere.go
@@ -142,13 +142,6 @@ func decodeResponse(body []byte, expectedCount int) ([][]float32, error) {
 	return embeddings, nil
 }
 
-func (e *Embedder) unauthorizedError() error {
-	if e.cfg.ErrUnauthorized != nil {
-		return e.cfg.ErrUnauthorized
-	}
-	return fmt.Errorf("cohere returns status unauthorized, check API key")
-}
-
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // Cohere v3 and newer models require opts to include an "input_type" appropriate
 // for the current call, such as "search_document" or "search_query".
@@ -187,7 +180,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
 		StatusErrors: map[int]error{
-			http.StatusUnauthorized: e.unauthorizedError(),
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("cohere", http.StatusUnauthorized),
 		},
 		DecodeEmbeddings: decodeResponse,
 	})

--- a/pkg/inference/embedding/cohere/cohere_test.go
+++ b/pkg/inference/embedding/cohere/cohere_test.go
@@ -26,6 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestCohereEmbedder_Success(t *testing.T) {
 	// Mock successful response from real Cohere API
 	mockResponse := `{
@@ -95,12 +101,13 @@ func TestCohereEmbedder_WithOptions(t *testing.T) {
 		assert.JSONEq(t, `{
 			"model": "embed-v4.0",
 			"texts": ["test"],
-			"input_type": "classification"
+			"input_type": "classification",
+			"embedding_types": ["float"]
 		}`, string(body))
 
 		mockResponse := `{
-			"response_type": "embeddings_floats",
-			"embeddings": [[0.1, 0.2, 0.3]],
+			"response_type": "embeddings_by_type",
+			"embeddings": {"float": [[0.1, 0.2, 0.3]]},
 			"id": "test-id",
 			"texts": ["test"]
 		}`
@@ -117,14 +124,44 @@ func TestCohereEmbedder_WithOptions(t *testing.T) {
 	})
 
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, map[string]any{
-		"input_type": "classification",
-		"model":      "must-not-override",
-		"texts":      []string{"must-not-override"},
+		"input_type":      "classification",
+		"embedding_types": []string{"float"},
+		"model":           "must-not-override",
+		"texts":           []string{"must-not-override"},
 	})
 
 	require.NoError(t, err)
 	require.Len(t, embeddings, 1)
 	require.Equal(t, embeddings[0], []float32{0.1, 0.2, 0.3})
+}
+
+func TestCohereEmbedderEmbeddingTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "non-float", value: []string{"int8"}},
+		{name: "multiple", value: []string{"float", "int8"}},
+		{name: "not an array", value: "float"},
+		{name: "non-string element", value: []any{"float", 8}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			embedder := NewCohereEmbedder(EmbedderConfig{
+				GetAPIKey:  func() string { panic("request validation should happen before reading the API key") },
+				GetBaseURL: func() string { panic("invalid options must not issue a request") },
+			})
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, map[string]any{
+				"embedding_types": tt.value,
+			})
+			require.Nil(t, embeddings)
+			require.EqualError(t, err, `Cohere embedding_types must be exactly ["float"]`)
+		})
+	}
+
+	_, err := decodeEmbeddings([]byte(`{"int8":[[1,2,3]]}`))
+	require.EqualError(t, err, "Cohere response does not contain float embeddings")
 }
 
 func TestCohereEmbedder_NoAPIKey(t *testing.T) {
@@ -282,4 +319,20 @@ func TestCohereEmbedderMismatchedResponseLength(t *testing.T) {
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"a", "b"}, nil)
 	require.Nil(t, embeddings)
 	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
+}
+
+func TestCohereEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/v1/embed?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
+	require.EqualError(t, err, "Cohere request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/cohere/cohere_test.go
+++ b/pkg/inference/embedding/cohere/cohere_test.go
@@ -1,0 +1,282 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCohereEmbedder_Success(t *testing.T) {
+	// Mock successful response from real Cohere API
+	mockResponse := `{
+		"response_type": "embeddings_floats",
+		"embeddings": [
+			[0.016296387, -0.008354187, 0.12345678, -0.98765432, 0.5],
+			[0.04663086, -0.023239136, 0.87654321, -0.11111111, 0.3],
+			[0.11111111, 0.22222222, 0.33333333, 0.44444444, 0.55555555]
+		],
+		"id": "1c62213a-1f15-46f1-ac62-36f6bbaf3972",
+		"texts": ["hello world", "test text", "sample input"],
+		"meta": {
+			"api_version": {
+				"version": "1"
+			},
+			"billed_units": {
+				"input_tokens": 6
+			}
+		}
+	}`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "embed-v4.0",
+			"texts": ["hello world", "test text", "sample input"]
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world", "test text", "sample input"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 3)
+	require.Equal(t, embeddings[0], []float32{0.016296387, -0.008354187, 0.12345678, -0.98765432, 0.5})
+	require.Equal(t, embeddings[1], []float32{0.04663086, -0.023239136, 0.87654321, -0.11111111, 0.3})
+	require.Equal(t, embeddings[2], []float32{0.11111111, 0.22222222, 0.33333333, 0.44444444, 0.55555555})
+}
+
+func TestCohereEmbedder_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "embed-v4.0",
+			"texts": ["test"],
+			"input_type": "classification"
+		}`, string(body))
+
+		mockResponse := `{
+			"response_type": "embeddings_floats",
+			"embeddings": [[0.1, 0.2, 0.3]],
+			"id": "test-id",
+			"texts": ["test"]
+		}`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, map[string]any{
+		"input_type": "classification",
+		"model":      "must-not-override",
+		"texts":      []string{"must-not-override"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	require.Equal(t, embeddings[0], []float32{0.1, 0.2, 0.3})
+}
+
+func TestCohereEmbedder_NoAPIKey(t *testing.T) {
+	// Mock no API key response from real Cohere API
+	mockResponse := `{"id":"b6a8a658-261e-4fc2-b44d-0ee3fefa145e","message":"no api key supplied"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "API key is not configured for cohere")
+}
+
+func TestCohereEmbedder_InvalidAPIKey(t *testing.T) {
+	// Mock invalid API key response from real Cohere API
+	mockResponse := `{"id":"276562f4-bb27-49f9-a044-9145b05f0fd0","message":"invalid api token"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "invalid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "check API key")
+}
+
+func TestCohereEmbedder_InvalidModel(t *testing.T) {
+	// Mock model not found response from real Cohere API
+	mockResponse := `{"id":"da62a855-b6e9-4c4e-b232-9ba335a9549a","message":"model 'embed-v4.0x' not found, make sure the correct model ID was used and that you have access to the model."}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0x", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cohere: model 'embed-v4.0x' not found")
+}
+
+func TestCohereEmbedder_EmptyTexts(t *testing.T) {
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, embeddings, 0)
+}
+
+func TestCohereEmbedder_NoModel(t *testing.T) {
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "model name is required")
+}
+
+func TestCohereEmbedderEndpoint(t *testing.T) {
+	endpoint, err := embeddingsEndpoint("  https://example.com/v1/embed?api-version=x  ")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/v1/embed?api-version=x", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/embed"} {
+		_, err := embeddingsEndpoint(baseURL)
+		require.ErrorContains(t, err, "invalid Cohere API base URL")
+	}
+}
+
+func TestCohereEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewCohereEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
+			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
+		})
+	}
+}
+
+func TestCohereEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"invalid api key: provider-secret"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
+	require.EqualError(t, err, "cohere: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestCohereEmbedderMismatchedResponseLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[[1.0]]}`))
+	}))
+	defer server.Close()
+
+	embedder := NewCohereEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"a", "b"}, nil)
+	require.Nil(t, embeddings)
+	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
+}

--- a/pkg/inference/embedding/cohere/cohere_test.go
+++ b/pkg/inference/embedding/cohere/cohere_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,7 +71,7 @@ func TestCohereEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -112,7 +113,7 @@ func TestCohereEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -142,7 +143,7 @@ func TestCohereEmbedderEmbeddingTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			embedder := NewCohereEmbedder(EmbedderConfig{
+			embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:  func() string { panic("request validation should happen before reading the API key") },
 				GetBaseURL: func() string { panic("invalid options must not issue a request") },
 			})
@@ -159,7 +160,7 @@ func TestCohereEmbedderEmbeddingTypes(t *testing.T) {
 }
 
 func TestCohereEmbedder_NoAPIKey(t *testing.T) {
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey: func() string { return "" },
 	})
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"hello world"}, nil)
@@ -172,7 +173,7 @@ func TestCohereEmbedder_NoAPIKey(t *testing.T) {
 func TestCohereEmbedder_InvalidAPIKey(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"message":"invalid api token"}`)
 
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -187,7 +188,7 @@ func TestCohereEmbedder_InvalidModel(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusNotFound,
 		`{"message":"model 'embed-v4.0x' not found, make sure the correct model ID was used and that you have access to the model."}`)
 
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -212,7 +213,7 @@ func TestCohereEmbedderEndpoint(t *testing.T) {
 func TestCohereEmbedderMismatchedResponseLength(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusOK, `{"embeddings":[[1.0]]}`)
 
-	embedder := NewCohereEmbedder(EmbedderConfig{
+	embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -225,7 +226,7 @@ func TestCohereEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "embed-v4.0",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewCohereEmbedder(EmbedderConfig{
+			embedder := NewCohereEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/cohere/cohere_test.go
+++ b/pkg/inference/embedding/cohere/cohere_test.go
@@ -59,7 +59,8 @@ func TestCohereEmbedder_Success(t *testing.T) {
 		assert.NoError(t, err)
 		assert.JSONEq(t, `{
 			"model": "embed-v4.0",
-			"texts": ["hello world", "test text", "sample input"]
+			"texts": ["hello world", "test text", "sample input"],
+			"input_type": "search_document"
 		}`, string(body))
 
 		w.Header().Set("Content-Type", "application/json")
@@ -75,7 +76,9 @@ func TestCohereEmbedder_Success(t *testing.T) {
 	})
 
 	texts := []string{"hello world", "test text", "sample input"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, map[string]any{
+		"input_type": "search_document",
+	})
 
 	require.NoError(t, err)
 	require.Len(t, embeddings, 3)

--- a/pkg/inference/embedding/cohere/cohere_test.go
+++ b/pkg/inference/embedding/cohere/cohere_test.go
@@ -19,18 +19,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 func TestCohereEmbedder_Success(t *testing.T) {
 	// Mock successful response from real Cohere API
@@ -165,23 +159,10 @@ func TestCohereEmbedderEmbeddingTypes(t *testing.T) {
 }
 
 func TestCohereEmbedder_NoAPIKey(t *testing.T) {
-	// Mock no API key response from real Cohere API
-	mockResponse := `{"id":"b6a8a658-261e-4fc2-b44d-0ee3fefa145e","message":"no api key supplied"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
 	embedder := NewCohereEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "" },
-		GetBaseURL: func() string { return server.URL },
+		GetAPIKey: func() string { return "" },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -189,23 +170,13 @@ func TestCohereEmbedder_NoAPIKey(t *testing.T) {
 }
 
 func TestCohereEmbedder_InvalidAPIKey(t *testing.T) {
-	// Mock invalid API key response from real Cohere API
-	mockResponse := `{"id":"276562f4-bb27-49f9-a044-9145b05f0fd0","message":"invalid api token"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"message":"invalid api token"}`)
 
 	embedder := NewCohereEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -213,49 +184,18 @@ func TestCohereEmbedder_InvalidAPIKey(t *testing.T) {
 }
 
 func TestCohereEmbedder_InvalidModel(t *testing.T) {
-	// Mock model not found response from real Cohere API
-	mockResponse := `{"id":"da62a855-b6e9-4c4e-b232-9ba335a9549a","message":"model 'embed-v4.0x' not found, make sure the correct model ID was used and that you have access to the model."}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusNotFound,
+		`{"message":"model 'embed-v4.0x' not found, make sure the correct model ID was used and that you have access to the model."}`)
 
 	embedder := NewCohereEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0x", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0x", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "cohere: model 'embed-v4.0x' not found")
-}
-
-func TestCohereEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewCohereEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestCohereEmbedder_NoModel(t *testing.T) {
-	embedder := NewCohereEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "model name is required")
+	require.ErrorContains(t, err, "Cohere: status code 404, message: model 'embed-v4.0x' not found")
 }
 
 func TestCohereEmbedderEndpoint(t *testing.T) {
@@ -269,70 +209,34 @@ func TestCohereEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestCohereEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
-			embedder := NewCohereEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
-			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
-func TestCohereEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"message":"invalid api key: provider-secret"}`))
-	}))
-	defer server.Close()
-
-	embedder := NewCohereEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
-	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
-	require.EqualError(t, err, "cohere: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
-}
-
 func TestCohereEmbedderMismatchedResponseLength(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"embeddings":[[1.0]]}`))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusOK, `{"embeddings":[[1.0]]}`)
 
 	embedder := NewCohereEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"a", "b"}, nil)
 	require.Nil(t, embeddings)
 	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
 }
 
-func TestCohereEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	embedder := NewCohereEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/v1/embed?token=" + secret },
+func TestCohereEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "embed-v4.0",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
+			embedder := NewCohereEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
+			})
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "Cohere request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
+		RedactionResponse:         `{"message":"invalid api key: provider-secret"}`,
+		RedactionError:            "Cohere: status code 400, message: invalid api key: [REDACTED]",
 	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, assert.AnError
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "embed-v4.0", []string{"test"}, nil)
-	require.EqualError(t, err, "Cohere request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/cohere/protocol.go
+++ b/pkg/inference/embedding/cohere/protocol.go
@@ -17,6 +17,7 @@ package cohere
 import "encoding/json"
 
 // Response is the model for Cohere embeddings API response.
+// See https://docs.cohere.com/v1/reference/embed.
 type Response struct {
 	Embeddings json.RawMessage `json:"embeddings"`
 }

--- a/pkg/inference/embedding/cohere/protocol.go
+++ b/pkg/inference/embedding/cohere/protocol.go
@@ -1,0 +1,31 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cohere
+
+// Request is the model for Cohere embeddings API request.
+type Request struct {
+	Model string   `json:"model"`
+	Texts []string `json:"texts"`
+}
+
+// Response is the model for Cohere embeddings API response.
+type Response struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+// ErrorResponse is the model for Cohere embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Message string `json:"message"`
+}

--- a/pkg/inference/embedding/cohere/protocol.go
+++ b/pkg/inference/embedding/cohere/protocol.go
@@ -14,9 +14,11 @@
 
 package cohere
 
+import "encoding/json"
+
 // Response is the model for Cohere embeddings API response.
 type Response struct {
-	Embeddings [][]float32 `json:"embeddings"`
+	Embeddings json.RawMessage `json:"embeddings"`
 }
 
 // ErrorResponse is the model for Cohere embeddings API response when an error occurs.

--- a/pkg/inference/embedding/cohere/protocol.go
+++ b/pkg/inference/embedding/cohere/protocol.go
@@ -14,12 +14,6 @@
 
 package cohere
 
-// Request is the model for Cohere embeddings API request.
-type Request struct {
-	Model string   `json:"model"`
-	Texts []string `json:"texts"`
-}
-
 // Response is the model for Cohere embeddings API response.
 type Response struct {
 	Embeddings [][]float32 `json:"embeddings"`

--- a/pkg/inference/embedding/gemini/BUILD.bazel
+++ b/pkg/inference/embedding/gemini/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["gemini_test.go"],
     embed = [":gemini"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 9,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/gemini/BUILD.bazel
+++ b/pkg/inference/embedding/gemini/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["gemini_test.go"],
     embed = [":gemini"],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/gemini/BUILD.bazel
+++ b/pkg/inference/embedding/gemini/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gemini",
+    srcs = [
+        "gemini.go",
+        "protocol.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/gemini",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "gemini_test",
+    timeout = "short",
+    srcs = ["gemini_test.go"],
+    embed = [":gemini"],
+    flaky = True,
+    shard_count = 12,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/gemini/BUILD.bazel
+++ b/pkg/inference/embedding/gemini/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/gemini",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(

--- a/pkg/inference/embedding/gemini/BUILD.bazel
+++ b/pkg/inference/embedding/gemini/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 9,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -74,7 +74,7 @@ func batchEmbeddingsEndpoint(configured, model string) (string, error) {
 	}
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid Gemini API base URL: %w", err)
+		return "", base.NewRedactedError("invalid Gemini API base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid Gemini API base URL: absolute HTTP(S) URL is required")
@@ -82,7 +82,7 @@ func batchEmbeddingsEndpoint(configured, model string) (string, error) {
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/" + url.PathEscape(model) + ":batchEmbedContents"
 	path, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", fmt.Errorf("invalid Gemini API base URL path: %w", err)
+		return "", base.NewRedactedError("invalid Gemini API base URL path", err)
 	}
 	u.Path = path
 	u.RawPath = escapedPath
@@ -137,7 +137,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "Gemini", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -145,7 +145,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "Gemini", err)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -1,0 +1,195 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultAPIBaseURL is the default base URL for the Gemini embeddings API.
+	DefaultAPIBaseURL = "https://generativelanguage.googleapis.com/v1beta/models"
+	// DefaultMaxResponseBodyBytes bounds memory used to read a Gemini response.
+	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
+)
+
+// Embedder is for Gemini embeddings.
+type Embedder struct {
+	client http.Client
+	cfg    EmbedderConfig
+}
+
+var _ base.Embedder = (*Embedder)(nil)
+
+// EmbedderConfig holds the configuration for GeminiEmbedder.
+type EmbedderConfig struct {
+	GetAPIKey func() string
+	// GetBaseURL returns the API base ending before the model name. The
+	// embedder appends /<model>:batchEmbedContents. An empty value uses
+	// DefaultAPIBaseURL.
+	GetBaseURL       func() string
+	ErrMissingAPIKey error // The error to return when API key is missing
+	// MaxResponseBodyBytes limits both successful and error response bodies.
+	// Non-positive values use DefaultMaxResponseBodyBytes.
+	MaxResponseBodyBytes int64
+}
+
+// NewGeminiEmbedder creates a new GeminiEmbedder instance with the provided configuration.
+func NewGeminiEmbedder(cfg EmbedderConfig) *Embedder {
+	if cfg.MaxResponseBodyBytes <= 0 {
+		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+	}
+	return &Embedder{
+		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
+		cfg:    cfg,
+	}
+}
+
+func batchEmbeddingsEndpoint(configured, model string) (string, error) {
+	baseURL := strings.TrimSpace(configured)
+	if baseURL == "" {
+		baseURL = DefaultAPIBaseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid Gemini API base URL: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid Gemini API base URL: absolute HTTP(S) URL is required")
+	}
+	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/" + url.PathEscape(model) + ":batchEmbedContents"
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid Gemini API base URL path: %w", err)
+	}
+	u.Path = path
+	u.RawPath = escapedPath
+	return u.String(), nil
+}
+
+// CreateEmbeddings creates embeddings for the given texts using the specified model.
+// CreateEmbeddings implements base.Embedder
+func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
+	// ref: https://ai.google.dev/api/rest/v1beta/models/batchEmbedContents
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	if model == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	requests := make([]map[string]any, len(texts))
+	for i, text := range texts {
+		requests[i] = base.JSONFieldsWithOptions(map[string]any{
+			"model": fmt.Sprintf("models/%s", model),
+			"content": map[string]any{
+				"parts": []map[string]string{{"text": text}},
+			},
+		}, opts)
+	}
+
+	var apiKey string
+	if e.cfg.GetAPIKey != nil {
+		apiKey = e.cfg.GetAPIKey()
+	}
+	if apiKey == "" {
+		if e.cfg.ErrMissingAPIKey != nil {
+			return nil, e.cfg.ErrMissingAPIKey
+		}
+		return nil, fmt.Errorf("API key is not configured for Gemini")
+	}
+
+	var configuredBaseURL string
+	if e.cfg.GetBaseURL != nil {
+		configuredBaseURL = e.cfg.GetBaseURL()
+	}
+	fullURL, err := batchEmbeddingsEndpoint(configuredBaseURL, model)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(map[string]any{"requests": requests})
+	if err != nil {
+		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", apiKey)
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp ErrorResponse
+		message := ""
+		var parseErr error
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			parseErr = err
+		} else if errResp.Error.Message != "" {
+			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
+		}
+		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		if message != "" {
+			logFields = append(logFields, zap.String("message", message))
+		}
+		if parseErr != nil {
+			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
+		}
+		logutil.BgLogger().Error("Gemini API request failed", logFields...)
+		if message != "" {
+			return nil, fmt.Errorf("Gemini: %s", message)
+		}
+		return nil, fmt.Errorf("Gemini: status code %d", resp.StatusCode)
+	}
+
+	var respObj BatchResponse
+	if err := json.Unmarshal(body, &respObj); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+
+	if len(respObj.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
+	}
+
+	embeddings := make([][]float32, len(respObj.Embeddings))
+	for i, embedding := range respObj.Embeddings {
+		embeddings[i] = embedding.Values
+	}
+
+	return embeddings, nil
+}

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default base URL for the Gemini embeddings API.
@@ -39,6 +37,9 @@ type Embedder struct {
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for GeminiEmbedder.
+// It remains provider-specific because Gemini handles non-200 responses
+// through its regular error schema and does not expose the configurable
+// unauthorized-error mapping provided by base.APIKeyProviderConfig.
 type EmbedderConfig struct {
 	GetAPIKey func() string
 	// GetBaseURL returns the API base ending before the model name. The
@@ -78,6 +79,29 @@ func batchEmbeddingsEndpoint(configured, model string) (string, error) {
 		return "", err
 	}
 	return u.String(), nil
+}
+
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	return response.Error.Message, nil
+}
+
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var response BatchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	if len(response.Embeddings) != expectedCount {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(response.Embeddings), expectedCount)
+	}
+	embeddings := make([][]float32, len(response.Embeddings))
+	for i, embedding := range response.Embeddings {
+		embeddings[i] = embedding.Values
+	}
+	return embeddings, nil
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -121,48 +145,17 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "Gemini", fullURL, map[string]any{
-		"requests": requests,
-	}, http.Header{
-		"x-goog-api-key": {apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Error.Message != "" {
-			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("Gemini API request failed", logFields...)
-		return nil, base.NewProviderResponseError("Gemini", statusCode, message)
-	}
-
-	var respObj BatchResponse
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-
-	if len(respObj.Embeddings) != len(texts) {
-		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
-	}
-
-	embeddings := make([][]float32, len(respObj.Embeddings))
-	for i, embedding := range respObj.Embeddings {
-		embeddings[i] = embedding.Values
-	}
-
-	return embeddings, nil
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "Gemini",
+		Client:   &e.client,
+		Endpoint: fullURL,
+		Payload: map[string]any{
+			"requests": requests,
+		},
+		Headers:              http.Header{"x-goog-api-key": {apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		DecodeEmbeddings:     decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -15,7 +15,6 @@
 package gemini
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,12 +27,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default base URL for the Gemini embeddings API.
-	DefaultAPIBaseURL = "https://generativelanguage.googleapis.com/v1beta/models"
-	// DefaultMaxResponseBodyBytes bounds memory used to read a Gemini response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default base URL for the Gemini embeddings API.
+const DefaultAPIBaseURL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 // Embedder is for Gemini embeddings.
 type Embedder struct {
@@ -52,14 +47,14 @@ type EmbedderConfig struct {
 	GetBaseURL       func() string
 	ErrMissingAPIKey error // The error to return when API key is missing
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewGeminiEmbedder creates a new GeminiEmbedder instance with the provided configuration.
 func NewGeminiEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -72,20 +67,16 @@ func batchEmbeddingsEndpoint(configured, model string) (string, error) {
 	if baseURL == "" {
 		baseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(baseURL)
+	u, err := base.ParseHTTPURL(baseURL, "Gemini API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid Gemini API base URL", err)
+		return "", err
 	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid Gemini API base URL: absolute HTTP(S) URL is required")
-	}
+	// Gemini batch embeddings append /<model>:batchEmbedContents to the models
+	// base. See https://ai.google.dev/api/rest/v1beta/models/batchEmbedContents.
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/" + url.PathEscape(model) + ":batchEmbedContents"
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", base.NewRedactedError("invalid Gemini API base URL path", err)
+	if err := base.SetEscapedURLPath(u, escapedPath, "Gemini API base URL path"); err != nil {
+		return "", err
 	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
@@ -135,26 +126,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "Gemini", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-goog-api-key", apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "Gemini", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "Gemini", fullURL, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("x-goog-api-key", apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "Gemini", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -163,7 +147,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		} else if errResp.Error.Message != "" {
 			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
 		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -171,10 +155,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("Gemini API request failed", logFields...)
-		if message != "" {
-			return nil, fmt.Errorf("Gemini: %s", message)
-		}
-		return nil, fmt.Errorf("Gemini: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("Gemini", statusCode, message)
 	}
 
 	var respObj BatchResponse

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -121,19 +121,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(map[string]any{"requests": requests})
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-
-	httpReq, err := base.NewJSONRequest(ctx, "Gemini", fullURL, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("x-goog-api-key", apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "Gemini", httpReq, e.cfg.MaxResponseBodyBytes)
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "Gemini", fullURL, map[string]any{
+		"requests": requests,
+	}, http.Header{
+		"x-goog-api-key": {apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inference/embedding/gemini/gemini.go
+++ b/pkg/inference/embedding/gemini/gemini.go
@@ -31,35 +31,19 @@ const DefaultAPIBaseURL = "https://generativelanguage.googleapis.com/v1beta/mode
 // Embedder is for Gemini embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for GeminiEmbedder.
-// It remains provider-specific because Gemini handles non-200 responses
-// through its regular error schema and does not expose the configurable
-// unauthorized-error mapping provided by base.APIKeyProviderConfig.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns the API base ending before the model name. The
-	// embedder appends /<model>:batchEmbedContents. An empty value uses
-	// DefaultAPIBaseURL.
-	GetBaseURL       func() string
-	ErrMissingAPIKey error // The error to return when API key is missing
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
-
 // NewGeminiEmbedder creates a new GeminiEmbedder instance with the provided configuration.
-func NewGeminiEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
+// cfg.GetBaseURL returns the API base ending before the model name. The
+// embedder appends /<model>:batchEmbedContents; an empty value uses
+// DefaultAPIBaseURL.
+func NewGeminiEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -125,22 +109,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		}, opts)
 	}
 
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for Gemini"))
+	if err != nil {
+		return nil, err
 	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for Gemini")
-	}
-
-	var configuredBaseURL string
-	if e.cfg.GetBaseURL != nil {
-		configuredBaseURL = e.cfg.GetBaseURL()
-	}
-	fullURL, err := batchEmbeddingsEndpoint(configuredBaseURL, model)
+	fullURL, err := batchEmbeddingsEndpoint(e.cfg.ConfiguredBaseURL(), model)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +129,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
-		DecodeEmbeddings:     decodeEmbeddings,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("Gemini", http.StatusUnauthorized),
+		},
+		DecodeEmbeddings: decodeEmbeddings,
 	})
 }

--- a/pkg/inference/embedding/gemini/gemini_test.go
+++ b/pkg/inference/embedding/gemini/gemini_test.go
@@ -20,18 +20,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 func TestGeminiEmbedder_Success(t *testing.T) {
 	// Mock successful response from Gemini API
@@ -236,20 +230,13 @@ func TestGeminiEmbedder_InvalidAPIKey(t *testing.T) {
 		}
 	}`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusBadRequest, mockResponse)
 
 	embedder := NewGeminiEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -265,46 +252,17 @@ func TestGeminiEmbedder_InvalidModel(t *testing.T) {
 		}
 	}`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, mockResponse)
 
 	embedder := NewGeminiEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "gemini-embedding-exp-03-09", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "gemini-embedding-exp-03-09", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "not found for API version v1beta")
-}
-
-func TestGeminiEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewGeminiEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestGeminiEmbedder_NoModel(t *testing.T) {
-	embedder := NewGeminiEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "model name is required")
 }
 
 func TestGeminiEmbedder_MissingAPIKey(t *testing.T) {
@@ -333,70 +291,34 @@ func TestGeminiEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestGeminiEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
-			embedder := NewGeminiEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
-			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
-func TestGeminiEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key: provider-secret"}}`))
-	}))
-	defer server.Close()
-
-	embedder := NewGeminiEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
-	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
-	require.EqualError(t, err, "Gemini: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
-}
-
 func TestGeminiEmbedderMismatchedResponseLength(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"embeddings":[{"values":[1.0]}]}`))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusOK, `{"embeddings":[{"values":[1.0]}]}`)
 
 	embedder := NewGeminiEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"a", "b"}, nil)
 	require.Nil(t, embeddings)
 	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
 }
 
-func TestGeminiEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	embedder := NewGeminiEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/v1beta/models?token=" + secret },
+func TestGeminiEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "text-embedding-004",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
+			embedder := NewGeminiEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
+			})
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "Gemini request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
+		RedactionResponse:         `{"error":{"message":"invalid api key: provider-secret"}}`,
+		RedactionError:            "Gemini: status code 400, message: invalid api key: [REDACTED]",
 	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, assert.AnError
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
-	require.EqualError(t, err, "Gemini request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/gemini/gemini_test.go
+++ b/pkg/inference/embedding/gemini/gemini_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestGeminiEmbedder_Success(t *testing.T) {
 	// Mock successful response from Gemini API
 	mockResponse := `{
@@ -377,4 +383,20 @@ func TestGeminiEmbedderMismatchedResponseLength(t *testing.T) {
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"a", "b"}, nil)
 	require.Nil(t, embeddings)
 	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
+}
+
+func TestGeminiEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/v1beta/models?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
+	require.EqualError(t, err, "Gemini request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/gemini/gemini_test.go
+++ b/pkg/inference/embedding/gemini/gemini_test.go
@@ -1,0 +1,380 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gemini
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeminiEmbedder_Success(t *testing.T) {
+	// Mock successful response from Gemini API
+	mockResponse := `{
+		"embeddings": [
+			{
+				"values": [
+					-0.010632273,
+					0.019375853,
+					0.020965198,
+					0.0007706437,
+					-0.061464068
+				]
+			},
+			{
+				"values": [
+					0.018468002,
+					0.0054281265,
+					-0.017658807,
+					0.013859263,
+					0.05341865
+				]
+			},
+			{
+				"values": [
+					0.058089074,
+					0.020941732,
+					-0.10872878,
+					-0.04039259,
+					0.12345678
+				]
+			}
+		]
+	}`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "test-api-key", r.Header.Get("x-goog-api-key"))
+
+		// Verify URL path
+		assert.Equal(t, "/text-embedding-004:batchEmbedContents", r.URL.Path)
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"requests": [
+				{
+					"model": "models/text-embedding-004",
+					"content": {
+						"parts": [{"text": "hello world"}]
+					}
+				},
+				{
+					"model": "models/text-embedding-004",
+					"content": {
+						"parts": [{"text": "test text"}]
+					}
+				},
+				{
+					"model": "models/text-embedding-004",
+					"content": {
+						"parts": [{"text": "sample input"}]
+					}
+				}
+			]
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world", "test text", "sample input"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 3)
+	require.Equal(t, embeddings[0], []float32{
+		-0.010632273, 0.019375853, 0.020965198, 0.0007706437, -0.061464068,
+	})
+	require.Equal(t, embeddings[1], []float32{
+		0.018468002, 0.0054281265, -0.017658807, 0.013859263, 0.05341865,
+	})
+	require.Equal(t, embeddings[2], []float32{
+		0.058089074, 0.020941732, -0.10872878, -0.04039259, 0.12345678,
+	})
+}
+
+func TestGeminiEmbedder_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body includes options
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"requests": [
+				{
+					"model": "models/text-embedding-004",
+					"content": {
+						"parts": [{"text": "test"}]
+					},
+					"outputDimensionality": 10
+				}
+			]
+		}`, string(body))
+
+		mockResponse := `{
+			"embeddings": [
+				{
+					"values": [
+						-0.010632273,
+						0.019375853,
+						0.020965198,
+						0.0007706437,
+						-0.061464068,
+						0.123456,
+						0.789012,
+						0.345678,
+						0.901234,
+						0.567890
+					]
+				}
+			]
+		}`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, map[string]any{
+		"outputDimensionality": 10,
+		"model":                "must-not-override",
+		"content":              "must-not-override",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	require.Len(t, embeddings[0], 10)
+	require.Equal(t, embeddings[0], []float32{
+		-0.010632273, 0.019375853, 0.020965198, 0.0007706437, -0.061464068,
+		0.123456, 0.789012, 0.345678, 0.901234, 0.567890,
+	})
+}
+
+func TestGeminiEmbedder_EscapeModelInURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/text%20embedding%2F004%3Fx=1:batchEmbedContents", r.URL.EscapedPath())
+		assert.Empty(t, r.URL.RawQuery)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"requests": [
+				{
+					"model": "models/text embedding/004?x=1",
+					"content": {
+						"parts": [{"text": "test"}]
+					}
+				}
+			]
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embeddings":[{"values":[1.0]}]}`))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL + "/" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text embedding/004?x=1", []string{"test"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{1.0}}, embeddings)
+}
+
+func TestGeminiEmbedder_InvalidAPIKey(t *testing.T) {
+	mockResponse := `{
+		"error": {
+			"code": 400,
+			"message": "API key not valid. Please pass a valid API key.",
+			"status": "INVALID_ARGUMENT"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "invalid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "API key not valid")
+}
+
+func TestGeminiEmbedder_InvalidModel(t *testing.T) {
+	mockResponse := `{
+		"error": {
+			"code": 404,
+			"message": "models/gemini-embedding-exp-03-09 is not found for API version v1beta, or is not supported for embedContent. Call ListModels to see the list of available models and their supported methods.",
+			"status": "NOT_FOUND"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "gemini-embedding-exp-03-09", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not found for API version v1beta")
+}
+
+func TestGeminiEmbedder_EmptyTexts(t *testing.T) {
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, embeddings, 0)
+}
+
+func TestGeminiEmbedder_NoModel(t *testing.T) {
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "model name is required")
+}
+
+func TestGeminiEmbedder_MissingAPIKey(t *testing.T) {
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:        func() string { return "" },
+		GetBaseURL:       func() string { return "http://mock-url" },
+		ErrMissingAPIKey: fmt.Errorf("custom missing API key error"),
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "custom missing API key error")
+}
+
+func TestGeminiEmbedderEndpoint(t *testing.T) {
+	endpoint, err := batchEmbeddingsEndpoint(
+		" https://example.com/v1beta/models/?api-version=x ",
+		"text embedding/004?revision=1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/v1beta/models/text%20embedding%2F004%3Frevision=1:batchEmbedContents?api-version=x", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/models"} {
+		_, err := batchEmbeddingsEndpoint(baseURL, "text-embedding-004")
+		require.ErrorContains(t, err, "invalid Gemini API base URL")
+	}
+}
+
+func TestGeminiEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewGeminiEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
+			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
+		})
+	}
+}
+
+func TestGeminiEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key: provider-secret"}}`))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"test"}, nil)
+	require.EqualError(t, err, "Gemini: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestGeminiEmbedderMismatchedResponseLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"embeddings":[{"values":[1.0]}]}`))
+	}))
+	defer server.Close()
+
+	embedder := NewGeminiEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"a", "b"}, nil)
+	require.Nil(t, embeddings)
+	require.ErrorContains(t, err, "response embeddings length 1 does not match input texts length 2")
+}

--- a/pkg/inference/embedding/gemini/gemini_test.go
+++ b/pkg/inference/embedding/gemini/gemini_test.go
@@ -16,12 +16,14 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,7 +106,7 @@ func TestGeminiEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -167,7 +169,7 @@ func TestGeminiEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -211,7 +213,7 @@ func TestGeminiEmbedder_EscapeModelInURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL + "/" },
 	})
@@ -232,7 +234,7 @@ func TestGeminiEmbedder_InvalidAPIKey(t *testing.T) {
 
 	serverURL := testutil.NewJSONServer(t, http.StatusBadRequest, mockResponse)
 
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -241,6 +243,17 @@ func TestGeminiEmbedder_InvalidAPIKey(t *testing.T) {
 	require.Nil(t, embeddings)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "API key not valid")
+
+	customErr := errors.New("custom unauthorized error")
+	serverURL = testutil.NewJSONServer(t, http.StatusUnauthorized, mockResponse)
+	embedder = NewGeminiEmbedder(base.APIKeyProviderConfig{
+		GetAPIKey:       func() string { return "invalid-api-key" },
+		GetBaseURL:      func() string { return serverURL },
+		ErrUnauthorized: customErr,
+	})
+	embeddings, err = embedder.CreateEmbeddings(context.Background(), "text-embedding-004", []string{"hello world"}, nil)
+	require.Nil(t, embeddings)
+	require.ErrorIs(t, err, customErr)
 }
 
 func TestGeminiEmbedder_InvalidModel(t *testing.T) {
@@ -254,7 +267,7 @@ func TestGeminiEmbedder_InvalidModel(t *testing.T) {
 
 	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, mockResponse)
 
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -266,7 +279,7 @@ func TestGeminiEmbedder_InvalidModel(t *testing.T) {
 }
 
 func TestGeminiEmbedder_MissingAPIKey(t *testing.T) {
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:        func() string { return "" },
 		GetBaseURL:       func() string { return "http://mock-url" },
 		ErrMissingAPIKey: fmt.Errorf("custom missing API key error"),
@@ -294,7 +307,7 @@ func TestGeminiEmbedderEndpoint(t *testing.T) {
 func TestGeminiEmbedderMismatchedResponseLength(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusOK, `{"embeddings":[{"values":[1.0]}]}`)
 
-	embedder := NewGeminiEmbedder(EmbedderConfig{
+	embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -307,7 +320,7 @@ func TestGeminiEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "text-embedding-004",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewGeminiEmbedder(EmbedderConfig{
+			embedder := NewGeminiEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/gemini/protocol.go
+++ b/pkg/inference/embedding/gemini/protocol.go
@@ -15,6 +15,7 @@
 package gemini
 
 // BatchResponse is the model for Gemini batch embeddings API response.
+// See https://ai.google.dev/api/rest/v1beta/models/batchEmbedContents.
 type BatchResponse struct {
 	Embeddings []struct {
 		Values []float32 `json:"values"`

--- a/pkg/inference/embedding/gemini/protocol.go
+++ b/pkg/inference/embedding/gemini/protocol.go
@@ -14,21 +14,6 @@
 
 package gemini
 
-// BatchRequest is the model for Gemini batch embeddings API request.
-type BatchRequest struct {
-	Requests []Request `json:"requests"`
-}
-
-// Request is the model for a single Gemini embeddings API request.
-type Request struct {
-	Model   string `json:"model"`
-	Content struct {
-		Parts []struct {
-			Text string `json:"text"`
-		} `json:"parts"`
-	} `json:"content"`
-}
-
 // BatchResponse is the model for Gemini batch embeddings API response.
 type BatchResponse struct {
 	Embeddings []struct {

--- a/pkg/inference/embedding/gemini/protocol.go
+++ b/pkg/inference/embedding/gemini/protocol.go
@@ -1,0 +1,46 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gemini
+
+// BatchRequest is the model for Gemini batch embeddings API request.
+type BatchRequest struct {
+	Requests []Request `json:"requests"`
+}
+
+// Request is the model for a single Gemini embeddings API request.
+type Request struct {
+	Model   string `json:"model"`
+	Content struct {
+		Parts []struct {
+			Text string `json:"text"`
+		} `json:"parts"`
+	} `json:"content"`
+}
+
+// BatchResponse is the model for Gemini batch embeddings API response.
+type BatchResponse struct {
+	Embeddings []struct {
+		Values []float32 `json:"values"`
+	} `json:"embeddings"`
+}
+
+// ErrorResponse is the model for Gemini embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}

--- a/pkg/inference/embedding/huggingface/BUILD.bazel
+++ b/pkg/inference/embedding/huggingface/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "huggingface",
+    srcs = [
+        "huggingface.go",
+        "protocol.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/huggingface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "huggingface_test",
+    timeout = "short",
+    srcs = ["huggingface_test.go"],
+    embed = [":huggingface"],
+    flaky = True,
+    shard_count = 14,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/huggingface/BUILD.bazel
+++ b/pkg/inference/embedding/huggingface/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["huggingface_test.go"],
     embed = [":huggingface"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 11,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/huggingface/BUILD.bazel
+++ b/pkg/inference/embedding/huggingface/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["huggingface_test.go"],
     embed = [":huggingface"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/huggingface/BUILD.bazel
+++ b/pkg/inference/embedding/huggingface/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/huggingface",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(
@@ -23,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 11,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -15,7 +15,6 @@
 package huggingface
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,12 +27,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default base URL for HuggingFace inference API.
-	DefaultAPIBaseURL = "https://router.huggingface.co/hf-inference"
-	// DefaultMaxResponseBodyBytes bounds memory used to read a HuggingFace response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default base URL for HuggingFace inference API.
+const DefaultAPIBaseURL = "https://router.huggingface.co/hf-inference"
 
 // Embedder is for HuggingFace embeddings.
 type Embedder struct {
@@ -53,14 +48,14 @@ type EmbedderConfig struct {
 	ErrMissingAPIKey error // The error to return when API key is missing
 	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewHuggingFaceEmbedder creates a new HuggingFaceEmbedder instance with the provided configuration.
 func NewHuggingFaceEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -73,29 +68,26 @@ func featureExtractionEndpoint(configured, model string) (string, error) {
 	if baseURL == "" {
 		baseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(baseURL)
+	u, err := base.ParseHTTPURL(baseURL, "HuggingFace API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid HuggingFace API base URL", err)
-	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid HuggingFace API base URL: absolute HTTP(S) URL is required")
+		return "", err
 	}
 	modelParts := strings.Split(model, "/")
 	for i := range modelParts {
 		modelParts[i] = escapePathSegment(modelParts[i])
 	}
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/models/" + strings.Join(modelParts, "/") + "/pipeline/feature-extraction"
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", base.NewRedactedError("invalid HuggingFace API base URL path", err)
+	if err := base.SetEscapedURLPath(u, escapedPath, "HuggingFace API base URL path"); err != nil {
+		return "", err
 	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
 func escapePathSegment(segment string) string {
 	escaped := url.PathEscape(segment)
+	// url.PathEscape intentionally leaves the complete dot segments "." and
+	// ".." unchanged. Escape them explicitly so intermediaries cannot remove
+	// or normalize model path segments according to RFC 3986 section 5.2.4.
 	if escaped == "." {
 		return "%2E"
 	}
@@ -143,26 +135,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "HuggingFace", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "HuggingFace", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "HuggingFace", endpoint, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "HuggingFace", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -171,7 +156,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		} else if errResp.Error != "" {
 			message = base.SanitizeErrorText(errResp.Error, apiKey)
 		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -180,22 +165,18 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		}
 		logutil.BgLogger().Error("HuggingFace API request failed", logFields...)
 
-		if resp.StatusCode == http.StatusUnauthorized {
+		if statusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
 			return nil, fmt.Errorf("HuggingFace returns status unauthorized, check API key")
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if statusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("HuggingFace model '%s' does not exist or is not available", model)
 		}
 
-		if message != "" {
-			return nil, fmt.Errorf("HuggingFace: %s", message)
-		}
-
-		return nil, fmt.Errorf("HuggingFace: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("HuggingFace", statusCode, message)
 	}
 
 	var embeddings Response

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -33,33 +33,22 @@ const DefaultAPIBaseURL = "https://router.huggingface.co/hf-inference"
 // Embedder is for HuggingFace embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for HuggingFaceEmbedder.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns the inference API base. The embedder appends
-	// /models/<model>/pipeline/feature-extraction. An empty value uses
-	// DefaultAPIBaseURL.
-	GetBaseURL       func() string
-	ErrMissingAPIKey error // The error to return when API key is missing
-	ErrUnauthorized  error // The error to return when API key is invalid
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
+// GetBaseURL returns the inference API base. The embedder appends
+// /models/<model>/pipeline/feature-extraction. An empty value uses
+// DefaultAPIBaseURL.
+type EmbedderConfig base.APIKeyProviderConfig
 
 // NewHuggingFaceEmbedder creates a new HuggingFaceEmbedder instance with the provided configuration.
 func NewHuggingFaceEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
 	}
 }
 
@@ -108,41 +97,21 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("model name is required")
 	}
 
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
-	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for HuggingFace")
-	}
-
-	var configuredBaseURL string
-	if e.cfg.GetBaseURL != nil {
-		configuredBaseURL = e.cfg.GetBaseURL()
-	}
-	endpoint, err := featureExtractionEndpoint(configuredBaseURL, model)
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for HuggingFace"))
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+	endpoint, err := featureExtractionEndpoint(e.cfg.ConfiguredBaseURL(), model)
+	if err != nil {
+		return nil, err
+	}
+
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "HuggingFace", endpoint, base.JSONFieldsWithOptions(map[string]any{
 		"inputs": texts,
-	}, opts))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-
-	httpReq, err := base.NewJSONRequest(ctx, "HuggingFace", endpoint, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "HuggingFace", httpReq, e.cfg.MaxResponseBodyBytes)
+	}, opts), http.Header{
+		"Authorization": {"Bearer " + apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package openai
+package huggingface
 
 import (
 	"bytes"
@@ -29,13 +29,13 @@ import (
 )
 
 const (
-	// DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
-	DefaultAPIBaseURL = "https://api.openai.com/v1"
-	// DefaultMaxResponseBodyBytes bounds memory used to read an OpenAI-compatible response.
+	// DefaultAPIBaseURL is the default base URL for HuggingFace inference API.
+	DefaultAPIBaseURL = "https://router.huggingface.co/hf-inference"
+	// DefaultMaxResponseBodyBytes bounds memory used to read a HuggingFace response.
 	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
 )
 
-// Embedder is for OpenAI embeddings.
+// Embedder is for HuggingFace embeddings.
 type Embedder struct {
 	client http.Client
 	cfg    EmbedderConfig
@@ -43,25 +43,22 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for OpenAIEmbedder.
+// EmbedderConfig holds the configuration for HuggingFaceEmbedder.
 type EmbedderConfig struct {
 	GetAPIKey func() string
-	// GetBaseURL returns an OpenAI-compatible API base URL. A trailing
-	// /embeddings path is optional and is normalized by the embedder.
-	GetBaseURL func() string
-	// ErrMissingAPIKey optionally overrides the default missing-key error so
-	// callers can include deployment-specific configuration guidance.
-	ErrMissingAPIKey error
-	// ErrUnauthorized optionally overrides the default unauthorized error so
-	// callers can include deployment-specific configuration guidance.
-	ErrUnauthorized error
+	// GetBaseURL returns the inference API base. The embedder appends
+	// /models/<model>/pipeline/feature-extraction. An empty value uses
+	// DefaultAPIBaseURL.
+	GetBaseURL       func() string
+	ErrMissingAPIKey error // The error to return when API key is missing
+	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
 	// Non-positive values use DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
-// NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
-func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
+// NewHuggingFaceEmbedder creates a new HuggingFaceEmbedder instance with the provided configuration.
+func NewHuggingFaceEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
 		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
 	}
@@ -71,42 +68,54 @@ func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 	}
 }
 
-// embeddingsEndpoint resolves an OpenAI-compatible base URL to the embeddings endpoint.
-// The OpenAI API defines the endpoint as POST /v1/embeddings:
-// https://platform.openai.com/docs/api-reference/embeddings/create
-// For compatibility with existing callers, baseURL may already end in /embeddings.
-func embeddingsEndpoint(baseURL string) (string, error) {
+func featureExtractionEndpoint(configured, model string) (string, error) {
+	baseURL := strings.TrimSpace(configured)
+	if baseURL == "" {
+		baseURL = DefaultAPIBaseURL
+	}
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL: %w", err)
+		return "", fmt.Errorf("invalid HuggingFace API base URL: %w", err)
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("invalid OpenAI API base URL: absolute URL is required")
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid HuggingFace API base URL: absolute HTTP(S) URL is required")
 	}
-
-	escapedPath := strings.TrimRight(u.EscapedPath(), "/")
-	if !strings.HasSuffix(escapedPath, "/embeddings") {
-		escapedPath += "/embeddings"
+	modelParts := strings.Split(model, "/")
+	for i := range modelParts {
+		modelParts[i] = escapePathSegment(modelParts[i])
 	}
+	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/models/" + strings.Join(modelParts, "/") + "/pipeline/feature-extraction"
 	path, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL path: %w", err)
+		return "", fmt.Errorf("invalid HuggingFace API base URL path: %w", err)
 	}
 	u.Path = path
 	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
+func escapePathSegment(segment string) string {
+	escaped := url.PathEscape(segment)
+	if escaped == "." {
+		return "%2E"
+	}
+	if escaped == ".." {
+		return "%2E%2E"
+	}
+	return escaped
+}
+
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
-	// ref: https://platform.openai.com/docs/api-reference/embeddings/create
+	// ref: https://huggingface.co/docs/inference-providers/en/tasks/feature-extraction
 	if len(texts) == 0 {
 		return [][]float32{}, nil
 	}
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
+
 	var apiKey string
 	if e.cfg.GetAPIKey != nil {
 		apiKey = e.cfg.GetAPIKey()
@@ -115,27 +124,25 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if e.cfg.ErrMissingAPIKey != nil {
 			return nil, e.cfg.ErrMissingAPIKey
 		}
-		return nil, fmt.Errorf("API key is not configured for OpenAI")
+		return nil, fmt.Errorf("API key is not configured for HuggingFace")
 	}
-	baseURL := DefaultAPIBaseURL
+
+	var configuredBaseURL string
 	if e.cfg.GetBaseURL != nil {
-		if configured := strings.TrimSpace(e.cfg.GetBaseURL()); configured != "" {
-			baseURL = configured
-		}
+		configuredBaseURL = e.cfg.GetBaseURL()
 	}
-	endpoint, err := embeddingsEndpoint(baseURL)
+	endpoint, err := featureExtractionEndpoint(configuredBaseURL, model)
 	if err != nil {
 		return nil, err
 	}
 
 	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
-		"model":           model,
-		"input":           texts,
-		"encoding_format": "base64",
+		"inputs": texts,
 	}, opts))
 	if err != nil {
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
+
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
@@ -161,10 +168,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		var parseErr error
 		if err := json.Unmarshal(body, &errResp); err != nil {
 			parseErr = err
-		} else if errResp.Error.Message != "" {
-			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
+		} else if errResp.Error != "" {
+			message = base.SanitizeErrorText(errResp.Error, apiKey)
 		}
-
 		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
@@ -172,43 +178,34 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if parseErr != nil {
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
-		logutil.BgLogger().Error("OpenAI API request failed",
-			logFields...,
-		)
+		logutil.BgLogger().Error("HuggingFace API request failed", logFields...)
+
 		if resp.StatusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
-			return nil, fmt.Errorf("OpenAI returns status unauthorized, check API key")
+			return nil, fmt.Errorf("HuggingFace returns status unauthorized, check API key")
 		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("HuggingFace model '%s' does not exist or is not available", model)
 		}
-		return nil, fmt.Errorf("OpenAI: status code %d, message: %s", resp.StatusCode, message)
+
+		if message != "" {
+			return nil, fmt.Errorf("HuggingFace: %s", message)
+		}
+
+		return nil, fmt.Errorf("HuggingFace: status code %d", resp.StatusCode)
 	}
 
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
+	var embeddings Response
+	if err := json.Unmarshal(body, &embeddings); err != nil {
 		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
 	}
-	if len(respObj.Data) != len(texts) {
-		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(respObj.Data), len(texts))
+
+	if len(embeddings) != len(texts) {
+		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(embeddings), len(texts))
 	}
-	embeddings := make([][]float32, len(respObj.Data))
-	for _, item := range respObj.Data {
-		if item.Index < 0 || item.Index >= len(texts) {
-			return nil, fmt.Errorf("response data index %d is out of range [0, %d)", item.Index, len(texts))
-		}
-		if embeddings[item.Index] != nil {
-			return nil, fmt.Errorf("response data contains duplicate index %d", item.Index)
-		}
-		// item.Embedding is []byte. During JSON unmarshal,
-		// it is already base64 decoded by Golang from base64.
-		e, err := base.DecodeFloat32ArrayBytes(item.Embedding)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
-		}
-		embeddings[item.Index] = e
-	}
+
 	return embeddings, nil
 }

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default base URL for HuggingFace inference API.
@@ -38,17 +36,14 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for HuggingFaceEmbedder.
-// GetBaseURL returns the inference API base. The embedder appends
+// NewHuggingFaceEmbedder creates a new HuggingFaceEmbedder instance with the provided configuration.
+// cfg.GetBaseURL returns the inference API base; the embedder appends
 // /models/<model>/pipeline/feature-extraction. An empty value uses
 // DefaultAPIBaseURL.
-type EmbedderConfig base.APIKeyProviderConfig
-
-// NewHuggingFaceEmbedder creates a new HuggingFaceEmbedder instance with the provided configuration.
-func NewHuggingFaceEmbedder(cfg EmbedderConfig) *Embedder {
+func NewHuggingFaceEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -86,6 +81,32 @@ func escapePathSegment(segment string) string {
 	return escaped
 }
 
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	return response.Error, nil
+}
+
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var embeddings Response
+	if err := json.Unmarshal(body, &embeddings); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	if len(embeddings) != expectedCount {
+		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(embeddings), expectedCount)
+	}
+	return embeddings, nil
+}
+
+func (e *Embedder) unauthorizedError() error {
+	if e.cfg.ErrUnauthorized != nil {
+		return e.cfg.ErrUnauthorized
+	}
+	return fmt.Errorf("HuggingFace returns status unauthorized, check API key")
+}
+
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -107,55 +128,21 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "HuggingFace", endpoint, base.JSONFieldsWithOptions(map[string]any{
-		"inputs": texts,
-	}, opts), http.Header{
-		"Authorization": {"Bearer " + apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Error != "" {
-			message = base.SanitizeErrorText(errResp.Error, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("HuggingFace API request failed", logFields...)
-
-		if statusCode == http.StatusUnauthorized {
-			if e.cfg.ErrUnauthorized != nil {
-				return nil, e.cfg.ErrUnauthorized
-			}
-			return nil, fmt.Errorf("HuggingFace returns status unauthorized, check API key")
-		}
-
-		if statusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("HuggingFace model '%s' does not exist or is not available", model)
-		}
-
-		return nil, base.NewProviderResponseError("HuggingFace", statusCode, message)
-	}
-
-	var embeddings Response
-	if err := json.Unmarshal(body, &embeddings); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-
-	if len(embeddings) != len(texts) {
-		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(embeddings), len(texts))
-	}
-
-	return embeddings, nil
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "HuggingFace",
+		Client:   &e.client,
+		Endpoint: endpoint,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"inputs": texts,
+		}, opts),
+		Headers:              http.Header{"Authorization": {"Bearer " + apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.unauthorizedError(),
+			http.StatusNotFound:     fmt.Errorf("HuggingFace model '%s' does not exist or is not available", model),
+		},
+		DecodeEmbeddings: decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -75,7 +75,7 @@ func featureExtractionEndpoint(configured, model string) (string, error) {
 	}
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid HuggingFace API base URL: %w", err)
+		return "", base.NewRedactedError("invalid HuggingFace API base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid HuggingFace API base URL: absolute HTTP(S) URL is required")
@@ -87,7 +87,7 @@ func featureExtractionEndpoint(configured, model string) (string, error) {
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/models/" + strings.Join(modelParts, "/") + "/pipeline/feature-extraction"
 	path, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", fmt.Errorf("invalid HuggingFace API base URL path: %w", err)
+		return "", base.NewRedactedError("invalid HuggingFace API base URL path", err)
 	}
 	u.Path = path
 	u.RawPath = escapedPath
@@ -145,7 +145,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "HuggingFace", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -153,7 +153,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "HuggingFace", err)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/inference/embedding/huggingface/huggingface.go
+++ b/pkg/inference/embedding/huggingface/huggingface.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -58,27 +57,13 @@ func featureExtractionEndpoint(configured, model string) (string, error) {
 	}
 	modelParts := strings.Split(model, "/")
 	for i := range modelParts {
-		modelParts[i] = escapePathSegment(modelParts[i])
+		modelParts[i] = base.EscapeURLPathSegment(modelParts[i])
 	}
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/models/" + strings.Join(modelParts, "/") + "/pipeline/feature-extraction"
 	if err := base.SetEscapedURLPath(u, escapedPath, "HuggingFace API base URL path"); err != nil {
 		return "", err
 	}
 	return u.String(), nil
-}
-
-func escapePathSegment(segment string) string {
-	escaped := url.PathEscape(segment)
-	// url.PathEscape intentionally leaves the complete dot segments "." and
-	// ".." unchanged. Escape them explicitly so intermediaries cannot remove
-	// or normalize model path segments according to RFC 3986 section 5.2.4.
-	if escaped == "." {
-		return "%2E"
-	}
-	if escaped == ".." {
-		return "%2E%2E"
-	}
-	return escaped
 }
 
 func decodeErrorMessage(body []byte) (string, error) {
@@ -98,13 +83,6 @@ func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
 		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(embeddings), expectedCount)
 	}
 	return embeddings, nil
-}
-
-func (e *Embedder) unauthorizedError() error {
-	if e.cfg.ErrUnauthorized != nil {
-		return e.cfg.ErrUnauthorized
-	}
-	return fmt.Errorf("HuggingFace returns status unauthorized, check API key")
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -140,7 +118,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
 		StatusErrors: map[int]error{
-			http.StatusUnauthorized: e.unauthorizedError(),
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("HuggingFace", http.StatusUnauthorized),
 			http.StatusNotFound:     fmt.Errorf("HuggingFace model '%s' does not exist or is not available", model),
 		},
 		DecodeEmbeddings: decodeEmbeddings,

--- a/pkg/inference/embedding/huggingface/huggingface_test.go
+++ b/pkg/inference/embedding/huggingface/huggingface_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestHuggingFaceEmbedder_Success(t *testing.T) {
 	// Mock successful response from real HuggingFace API
 	mockResponse := `[
@@ -310,4 +316,20 @@ func TestHuggingFaceEmbedderErrorRedaction(t *testing.T) {
 	_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
 	require.EqualError(t, err, "HuggingFace: invalid api key: [REDACTED]")
 	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestHuggingFaceEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/inference?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
+	require.EqualError(t, err, "HuggingFace request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/huggingface/huggingface_test.go
+++ b/pkg/inference/embedding/huggingface/huggingface_test.go
@@ -23,15 +23,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 func TestHuggingFaceEmbedder_Success(t *testing.T) {
 	// Mock successful response from real HuggingFace API
@@ -83,23 +78,13 @@ func TestHuggingFaceEmbedder_Success(t *testing.T) {
 }
 
 func TestHuggingFaceEmbedder_UnauthorizedAPIKey(t *testing.T) {
-	// Mock unauthorized response from real HuggingFace API
-	mockResponse := `{"error":"Invalid credentials in Authorization header"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"error":"Invalid credentials in Authorization header"}`)
 
 	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -107,20 +92,13 @@ func TestHuggingFaceEmbedder_UnauthorizedAPIKey(t *testing.T) {
 }
 
 func TestHuggingFaceEmbedder_InvalidModel(t *testing.T) {
-	// Mock model not found response from real HuggingFace API (404 with no body)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		// No body for 404 responses from HuggingFace
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, "")
 
 	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "abc/def", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "abc/def", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -128,50 +106,17 @@ func TestHuggingFaceEmbedder_InvalidModel(t *testing.T) {
 }
 
 func TestHuggingFaceEmbedder_ErrorWithMessage(t *testing.T) {
-	// Mock error response with message
-	mockResponse := `{"error":"Model is currently loading"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusServiceUnavailable, `{"error":"Model is currently loading"}`)
 
 	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "some/model", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "some/model", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "HuggingFace: Model is currently loading")
-}
-
-func TestHuggingFaceEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestHuggingFaceEmbedder_NoModel(t *testing.T) {
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "model name is required")
+	require.EqualError(t, err, "HuggingFace: status code 503, message: Model is currently loading")
 }
 
 func TestHuggingFaceEmbedder_NoAPIKey(t *testing.T) {
@@ -199,14 +144,11 @@ func TestHuggingFaceEmbedder_CustomErrorHandling(t *testing.T) {
 
 func TestHuggingFaceEmbedder_CustomUnauthorizedError(t *testing.T) {
 	customErr := fmt.Errorf("custom unauthorized error")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, "")
 
 	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
 		GetAPIKey:       func() string { return "invalid-key" },
-		GetBaseURL:      func() string { return server.URL },
+		GetBaseURL:      func() string { return serverURL },
 		ErrUnauthorized: customErr,
 	})
 
@@ -216,21 +158,14 @@ func TestHuggingFaceEmbedder_CustomUnauthorizedError(t *testing.T) {
 }
 
 func TestHuggingFaceEmbedder_MismatchedResponseLength(t *testing.T) {
-	// Mock response with different length than input
 	mockResponse := `[
 		[0.1, 0.2, 0.3]
 	]`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusOK, mockResponse)
 
 	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
 
 	texts := []string{"hello", "world"} // 2 texts but response has only 1 embedding
@@ -281,55 +216,22 @@ func TestHuggingFaceEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestHuggingFaceEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
+func TestHuggingFaceEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "org/model",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
 			embedder := NewHuggingFaceEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
 			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
-func TestHuggingFaceEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
-	}))
-	defer server.Close()
-
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "HuggingFace request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
+		RedactionResponse:         `{"error":"invalid api key: provider-secret"}`,
+		RedactionError:            "HuggingFace: status code 400, message: invalid api key: [REDACTED]",
 	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
-	require.EqualError(t, err, "HuggingFace: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
-}
-
-func TestHuggingFaceEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/inference?token=" + secret },
-	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, assert.AnError
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
-	require.EqualError(t, err, "HuggingFace request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/huggingface/huggingface_test.go
+++ b/pkg/inference/embedding/huggingface/huggingface_test.go
@@ -1,0 +1,313 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package huggingface
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHuggingFaceEmbedder_Success(t *testing.T) {
+	// Mock successful response from real HuggingFace API
+	mockResponse := `[
+		[0.022240305319428444, -0.004567116964608431, 0.15847662091255188, -0.08124932646751404],
+		[-0.013980913907289505, -0.058682069182395935, 0.23456789012345678, 0.98765432109876543]
+	]`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		// Verify URL path contains the model
+		assert.True(t, strings.Contains(r.URL.Path, "/models/intfloat/multilingual-e5-large/pipeline/feature-extraction"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"inputs": ["hello world", "goodbye world"]
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world", "goodbye world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 2)
+	require.Equal(t, embeddings[0], []float32{
+		0.022240305319428444, -0.004567116964608431, 0.15847662091255188, -0.08124932646751404,
+	})
+	require.Equal(t, embeddings[1], []float32{
+		-0.013980913907289505, -0.058682069182395935, 0.23456789012345678, 0.98765432109876543,
+	})
+}
+
+func TestHuggingFaceEmbedder_UnauthorizedAPIKey(t *testing.T) {
+	// Mock unauthorized response from real HuggingFace API
+	mockResponse := `{"error":"Invalid credentials in Authorization header"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "invalid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "check API key")
+}
+
+func TestHuggingFaceEmbedder_InvalidModel(t *testing.T) {
+	// Mock model not found response from real HuggingFace API (404 with no body)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		// No body for 404 responses from HuggingFace
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "abc/def", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "model 'abc/def' does not exist")
+}
+
+func TestHuggingFaceEmbedder_ErrorWithMessage(t *testing.T) {
+	// Mock error response with message
+	mockResponse := `{"error":"Model is currently loading"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "some/model", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "HuggingFace: Model is currently loading")
+}
+
+func TestHuggingFaceEmbedder_EmptyTexts(t *testing.T) {
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", []string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, embeddings, 0)
+}
+
+func TestHuggingFaceEmbedder_NoModel(t *testing.T) {
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "model name is required")
+}
+
+func TestHuggingFaceEmbedder_NoAPIKey(t *testing.T) {
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey: func() string { return "" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "API key is not configured for HuggingFace")
+}
+
+func TestHuggingFaceEmbedder_CustomErrorHandling(t *testing.T) {
+	customErr := fmt.Errorf("custom missing API key error")
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:        func() string { return "" },
+		ErrMissingAPIKey: customErr,
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Equal(t, customErr, err)
+}
+
+func TestHuggingFaceEmbedder_CustomUnauthorizedError(t *testing.T) {
+	customErr := fmt.Errorf("custom unauthorized error")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:       func() string { return "invalid-key" },
+		GetBaseURL:      func() string { return server.URL },
+		ErrUnauthorized: customErr,
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Equal(t, customErr, err)
+}
+
+func TestHuggingFaceEmbedder_MismatchedResponseLength(t *testing.T) {
+	// Mock response with different length than input
+	mockResponse := `[
+		[0.1, 0.2, 0.3]
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello", "world"} // 2 texts but response has only 1 embedding
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "response data length 1 does not match input texts length 2")
+}
+
+func TestHuggingFaceEmbedder_WithOptions(t *testing.T) {
+	requestCh := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		requestCh <- body
+		_, _ = w.Write([]byte(`[[1.0]]`))
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "intfloat/multilingual-e5-large", []string{"test"}, map[string]any{
+		"normalize": true,
+		"inputs":    []string{"must-not-override"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]float32{{1.0}}, embeddings)
+	require.JSONEq(t, `{"inputs":["test"],"normalize":true}`, string(<-requestCh))
+}
+
+func TestHuggingFaceEmbedderEndpoint(t *testing.T) {
+	endpoint, err := featureExtractionEndpoint(
+		" https://example.com/base/?tenant=x ",
+		"org/model?revision=1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/base/models/org/model%3Frevision=1/pipeline/feature-extraction?tenant=x", endpoint)
+	endpoint, err = featureExtractionEndpoint("https://example.com", "org/../model")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/models/org/%2E%2E/model/pipeline/feature-extraction", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/inference"} {
+		_, err := featureExtractionEndpoint(baseURL, "org/model")
+		require.ErrorContains(t, err, "invalid HuggingFace API base URL")
+	}
+}
+
+func TestHuggingFaceEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
+			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
+		})
+	}
+}
+
+func TestHuggingFaceEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "org/model", []string{"test"}, nil)
+	require.EqualError(t, err, "HuggingFace: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}

--- a/pkg/inference/embedding/huggingface/huggingface_test.go
+++ b/pkg/inference/embedding/huggingface/huggingface_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestHuggingFaceEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -80,7 +81,7 @@ func TestHuggingFaceEmbedder_Success(t *testing.T) {
 func TestHuggingFaceEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"error":"Invalid credentials in Authorization header"}`)
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -94,7 +95,7 @@ func TestHuggingFaceEmbedder_UnauthorizedAPIKey(t *testing.T) {
 func TestHuggingFaceEmbedder_InvalidModel(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, "")
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -108,7 +109,7 @@ func TestHuggingFaceEmbedder_InvalidModel(t *testing.T) {
 func TestHuggingFaceEmbedder_ErrorWithMessage(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusServiceUnavailable, `{"error":"Model is currently loading"}`)
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -120,7 +121,7 @@ func TestHuggingFaceEmbedder_ErrorWithMessage(t *testing.T) {
 }
 
 func TestHuggingFaceEmbedder_NoAPIKey(t *testing.T) {
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey: func() string { return "" },
 	})
 
@@ -132,7 +133,7 @@ func TestHuggingFaceEmbedder_NoAPIKey(t *testing.T) {
 
 func TestHuggingFaceEmbedder_CustomErrorHandling(t *testing.T) {
 	customErr := fmt.Errorf("custom missing API key error")
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:        func() string { return "" },
 		ErrMissingAPIKey: customErr,
 	})
@@ -146,7 +147,7 @@ func TestHuggingFaceEmbedder_CustomUnauthorizedError(t *testing.T) {
 	customErr := fmt.Errorf("custom unauthorized error")
 	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, "")
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:       func() string { return "invalid-key" },
 		GetBaseURL:      func() string { return serverURL },
 		ErrUnauthorized: customErr,
@@ -163,7 +164,7 @@ func TestHuggingFaceEmbedder_MismatchedResponseLength(t *testing.T) {
 	]`
 	serverURL := testutil.NewJSONServer(t, http.StatusOK, mockResponse)
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -186,7 +187,7 @@ func TestHuggingFaceEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+	embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -220,7 +221,7 @@ func TestHuggingFaceEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "org/model",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewHuggingFaceEmbedder(EmbedderConfig{
+			embedder := NewHuggingFaceEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/huggingface/protocol.go
+++ b/pkg/inference/embedding/huggingface/protocol.go
@@ -21,6 +21,7 @@ type Request struct {
 
 // Response is the model for HuggingFace embeddings API response.
 // HuggingFace returns a 2D array of float32 values directly.
+// See https://huggingface.co/docs/inference-providers/en/tasks/feature-extraction.
 type Response [][]float32
 
 // ErrorResponse is the model for HuggingFace embeddings API response when an error occurs.

--- a/pkg/inference/embedding/huggingface/protocol.go
+++ b/pkg/inference/embedding/huggingface/protocol.go
@@ -1,0 +1,29 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package huggingface
+
+// Request is the model for HuggingFace embeddings API request.
+type Request struct {
+	Inputs []string `json:"inputs"`
+}
+
+// Response is the model for HuggingFace embeddings API response.
+// HuggingFace returns a 2D array of float32 values directly.
+type Response [][]float32
+
+// ErrorResponse is the model for HuggingFace embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/pkg/inference/embedding/internal/testutil/BUILD.bazel
+++ b/pkg/inference/embedding/internal/testutil/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testutil",
+    srcs = ["testutil.go"],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil",
+    visibility = ["//pkg/inference/embedding:__subpackages__"],
+    deps = ["//pkg/inference/embedding/base"],
+)

--- a/pkg/inference/embedding/internal/testutil/testutil.go
+++ b/pkg/inference/embedding/internal/testutil/testutil.go
@@ -1,0 +1,197 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides shared contract tests and fixtures for embedding
+// provider adapters.
+package testutil
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
+)
+
+const (
+	testAPIKey         = "test-api-key"
+	testSecret         = "super-secret"
+	testProviderSecret = "provider-secret"
+)
+
+// RoundTripFunc adapts a function to http.RoundTripper.
+type RoundTripFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip implements http.RoundTripper.
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// EmbedderConfig contains the protocol-independent test knobs used by an
+// embedding provider factory.
+type EmbedderConfig struct {
+	APIKey               string
+	BaseURL              string
+	MaxResponseBodyBytes int64
+	Transport            http.RoundTripper
+}
+
+// EmbedderContract describes behavior shared by every provider adapter.
+type EmbedderContract[T base.Embedder] struct {
+	Model                     string
+	New                       func(EmbedderConfig) T
+	RequestError              string
+	ResponseBodyLimitError    string
+	TransportCauseIsPreserved bool
+	RedactionResponse         string
+	RedactionError            string
+}
+
+// RunEmbedderContract verifies behavior that is independent of provider wire
+// formats. Provider-specific request, response, and status mappings remain in
+// each provider package's own tests.
+func RunEmbedderContract[T base.Embedder](t *testing.T, contract EmbedderContract[T]) {
+	t.Helper()
+
+	t.Run("empty texts", func(t *testing.T) {
+		embedder := contract.New(EmbedderConfig{APIKey: testAPIKey, BaseURL: "http://unused.example"})
+		embeddings, err := embedder.CreateEmbeddings(context.Background(), contract.Model, nil, nil)
+		if err != nil {
+			t.Fatalf("empty texts returned an error: %v", err)
+		}
+		if len(embeddings) != 0 {
+			t.Fatalf("empty texts returned %d embeddings, expected none", len(embeddings))
+		}
+	})
+
+	t.Run("empty model", func(t *testing.T) {
+		embedder := contract.New(EmbedderConfig{APIKey: testAPIKey, BaseURL: "http://unused.example"})
+		embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+		if embeddings != nil {
+			t.Fatalf("empty model returned embeddings: %v", embeddings)
+		}
+		if err == nil || !strings.Contains(err.Error(), "model name is required") {
+			t.Fatalf("empty model returned error %v, expected model name validation", err)
+		}
+	})
+
+	t.Run("response body limit", func(t *testing.T) {
+		for _, statusCode := range []int{http.StatusOK, http.StatusBadRequest} {
+			t.Run(http.StatusText(statusCode), func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(statusCode)
+					_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+				}))
+				t.Cleanup(server.Close)
+
+				embedder := contract.New(EmbedderConfig{
+					APIKey:               testAPIKey,
+					BaseURL:              server.URL,
+					MaxResponseBodyBytes: 64,
+				})
+				_, err := embedder.CreateEmbeddings(context.Background(), contract.Model, []string{"test"}, nil)
+				if err == nil || !strings.Contains(err.Error(), contract.ResponseBodyLimitError) {
+					t.Fatalf("oversized response returned error %v, expected %q", err, contract.ResponseBodyLimitError)
+				}
+			})
+		}
+	})
+
+	t.Run("transport error redaction", func(t *testing.T) {
+		transportErr := errors.New("transport failed")
+		embedder := contract.New(EmbedderConfig{
+			APIKey:  testAPIKey,
+			BaseURL: "https://internal.example/root?token=" + testSecret,
+			Transport: RoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, transportErr
+			}),
+		})
+
+		_, err := embedder.CreateEmbeddings(context.Background(), contract.Model, []string{"test"}, nil)
+		if err == nil || err.Error() != contract.RequestError {
+			t.Fatalf("transport failure returned error %v, expected %q", err, contract.RequestError)
+		}
+		if strings.Contains(err.Error(), testSecret) {
+			t.Fatalf("transport failure exposed secret in %q", err.Error())
+		}
+		if contract.TransportCauseIsPreserved && !errors.Is(err, transportErr) {
+			t.Fatalf("transport failure did not preserve its cause: %v", err)
+		}
+	})
+
+	if contract.RedactionResponse != "" {
+		t.Run("error redaction", func(t *testing.T) {
+			serverURL := NewJSONServer(t, http.StatusBadRequest, contract.RedactionResponse)
+			embedder := contract.New(EmbedderConfig{
+				APIKey:  testProviderSecret,
+				BaseURL: serverURL,
+			})
+
+			_, err := embedder.CreateEmbeddings(context.Background(), contract.Model, []string{"test"}, nil)
+			if err == nil || err.Error() != contract.RedactionError {
+				t.Fatalf("provider error returned %v, expected %q", err, contract.RedactionError)
+			}
+			if strings.Contains(err.Error(), testProviderSecret) {
+				t.Fatalf("provider error exposed secret in %q", err.Error())
+			}
+		})
+	}
+
+	t.Run("context cause", func(t *testing.T) {
+		cause := errors.New("request canceled by caller")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(cause)
+
+		embedder := contract.New(EmbedderConfig{
+			APIKey:  testAPIKey,
+			BaseURL: "http://127.0.0.1",
+			Transport: RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, req.Context().Err()
+			}),
+		})
+		_, err := embedder.CreateEmbeddings(ctx, contract.Model, []string{"test"}, nil)
+		if !errors.Is(err, cause) {
+			t.Fatalf("context cancellation returned %v, expected cause %v", err, cause)
+		}
+	})
+}
+
+// NewJSONServer starts a test server that returns a fixed JSON response and
+// registers its cleanup with t.
+func NewJSONServer(t *testing.T, statusCode int, body string) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+// EncodeFloat32Base64 returns the base64 representation used by providers
+// whose embedding response is a little-endian float32 byte array.
+func EncodeFloat32Base64(values ...float32) string {
+	data := make([]byte, len(values)*4)
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(data[i*4:], math.Float32bits(value))
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}

--- a/pkg/inference/embedding/jina/BUILD.bazel
+++ b/pkg/inference/embedding/jina/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "jina",
+    srcs = [
+        "jina.go",
+        "protocol.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/jina",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "jina_test",
+    timeout = "short",
+    srcs = ["jina_test.go"],
+    embed = [":jina"],
+    flaky = True,
+    shard_count = 10,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/jina/BUILD.bazel
+++ b/pkg/inference/embedding/jina/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/jina",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(
@@ -23,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/jina/BUILD.bazel
+++ b/pkg/inference/embedding/jina/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["jina_test.go"],
     embed = [":jina"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 7,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/jina/BUILD.bazel
+++ b/pkg/inference/embedding/jina/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["jina_test.go"],
     embed = [":jina"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -184,11 +184,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		}
 		// item.Embedding is []byte. During JSON unmarshal,
 		// it is already base64 decoded by Golang from base64.
-		e, err := base.DecodeFloat32ArrayBytes(item.Embedding)
+		embedding, err := base.DecodeFloat32ArrayBytes(item.Embedding)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
 		}
-		embeddings[item.Index] = e
+		embeddings[item.Index] = embedding
 	}
 	return embeddings, nil
 }

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -15,12 +15,10 @@
 package jina
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -28,12 +26,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default endpoint URL for the Jina AI embeddings API.
-	DefaultAPIBaseURL = "https://api.jina.ai/v1/embeddings"
-	// DefaultMaxResponseBodyBytes bounds memory used to read a Jina AI response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default endpoint URL for the Jina AI embeddings API.
+const DefaultAPIBaseURL = "https://api.jina.ai/v1/embeddings"
 
 // Embedder is for JinaAI embeddings.
 type Embedder struct {
@@ -52,14 +46,14 @@ type EmbedderConfig struct {
 	ErrMissingAPIKey error // The error to return when API key is missing
 	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewJinaEmbedder creates a new JinaEmbedder instance with the provided configuration.
 func NewJinaEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -72,12 +66,9 @@ func embeddingsEndpoint(configured string) (string, error) {
 	if endpoint == "" {
 		endpoint = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(endpoint)
+	u, err := base.ParseHTTPURL(endpoint, "Jina AI API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid Jina AI API base URL", err)
-	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid Jina AI API base URL: absolute HTTP(S) URL is required")
+		return "", err
 	}
 	return u.String(), nil
 }
@@ -119,26 +110,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err != nil {
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "JinaAI", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "JinaAI", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "JinaAI", endpoint, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "JinaAI", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -147,7 +131,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		} else if errResp.Detail != "" {
 			message = base.SanitizeErrorText(errResp.Detail, apiKey)
 		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -155,16 +139,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("JinaAI API request failed", logFields...)
-		if resp.StatusCode == http.StatusUnauthorized {
+		if statusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
 			return nil, fmt.Errorf("JinaAI returns status unauthorized, check API key")
 		}
-		if message != "" {
-			return nil, fmt.Errorf("JinaAI: %s", message)
-		}
-		return nil, fmt.Errorf("JinaAI: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("JinaAI", statusCode, message)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -73,6 +73,13 @@ func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
 	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
 }
 
+func validateOptions(opts map[string]any) error {
+	if enabled, ok := opts["return_multivector"].(bool); ok && enabled {
+		return fmt.Errorf("JinaAI option return_multivector=true is not supported")
+	}
+	return nil
+}
+
 func (e *Embedder) unauthorizedError() error {
 	if e.cfg.ErrUnauthorized != nil {
 		return e.cfg.ErrUnauthorized
@@ -89,6 +96,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
+	}
+	if err := validateOptions(opts); err != nil {
+		return nil, err
 	}
 	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for JinaAI"))
 	if err != nil {

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package openai
+package jina
 
 import (
 	"bytes"
@@ -29,13 +29,13 @@ import (
 )
 
 const (
-	// DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
-	DefaultAPIBaseURL = "https://api.openai.com/v1"
-	// DefaultMaxResponseBodyBytes bounds memory used to read an OpenAI-compatible response.
+	// DefaultAPIBaseURL is the default endpoint URL for the Jina AI embeddings API.
+	DefaultAPIBaseURL = "https://api.jina.ai/v1/embeddings"
+	// DefaultMaxResponseBodyBytes bounds memory used to read a Jina AI response.
 	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
 )
 
-// Embedder is for OpenAI embeddings.
+// Embedder is for JinaAI embeddings.
 type Embedder struct {
 	client http.Client
 	cfg    EmbedderConfig
@@ -43,25 +43,21 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for OpenAIEmbedder.
+// EmbedderConfig holds the configuration for JinaEmbedder.
 type EmbedderConfig struct {
 	GetAPIKey func() string
-	// GetBaseURL returns an OpenAI-compatible API base URL. A trailing
-	// /embeddings path is optional and is normalized by the embedder.
-	GetBaseURL func() string
-	// ErrMissingAPIKey optionally overrides the default missing-key error so
-	// callers can include deployment-specific configuration guidance.
-	ErrMissingAPIKey error
-	// ErrUnauthorized optionally overrides the default unauthorized error so
-	// callers can include deployment-specific configuration guidance.
-	ErrUnauthorized error
+	// GetBaseURL returns the complete Jina AI embeddings endpoint. An empty
+	// value uses DefaultAPIBaseURL.
+	GetBaseURL       func() string
+	ErrMissingAPIKey error // The error to return when API key is missing
+	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
 	// Non-positive values use DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
-// NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
-func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
+// NewJinaEmbedder creates a new JinaEmbedder instance with the provided configuration.
+func NewJinaEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
 		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
 	}
@@ -71,36 +67,25 @@ func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 	}
 }
 
-// embeddingsEndpoint resolves an OpenAI-compatible base URL to the embeddings endpoint.
-// The OpenAI API defines the endpoint as POST /v1/embeddings:
-// https://platform.openai.com/docs/api-reference/embeddings/create
-// For compatibility with existing callers, baseURL may already end in /embeddings.
-func embeddingsEndpoint(baseURL string) (string, error) {
-	u, err := url.Parse(baseURL)
+func embeddingsEndpoint(configured string) (string, error) {
+	endpoint := strings.TrimSpace(configured)
+	if endpoint == "" {
+		endpoint = DefaultAPIBaseURL
+	}
+	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL: %w", err)
+		return "", fmt.Errorf("invalid Jina AI API base URL: %w", err)
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("invalid OpenAI API base URL: absolute URL is required")
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid Jina AI API base URL: absolute HTTP(S) URL is required")
 	}
-
-	escapedPath := strings.TrimRight(u.EscapedPath(), "/")
-	if !strings.HasSuffix(escapedPath, "/embeddings") {
-		escapedPath += "/embeddings"
-	}
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL path: %w", err)
-	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
-	// ref: https://platform.openai.com/docs/api-reference/embeddings/create
+	// ref: https://jina.ai/embeddings/
 	if len(texts) == 0 {
 		return [][]float32{}, nil
 	}
@@ -115,23 +100,21 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if e.cfg.ErrMissingAPIKey != nil {
 			return nil, e.cfg.ErrMissingAPIKey
 		}
-		return nil, fmt.Errorf("API key is not configured for OpenAI")
+		return nil, fmt.Errorf("API key is not configured for JinaAI")
 	}
-	baseURL := DefaultAPIBaseURL
+	var configuredBaseURL string
 	if e.cfg.GetBaseURL != nil {
-		if configured := strings.TrimSpace(e.cfg.GetBaseURL()); configured != "" {
-			baseURL = configured
-		}
+		configuredBaseURL = e.cfg.GetBaseURL()
 	}
-	endpoint, err := embeddingsEndpoint(baseURL)
+	endpoint, err := embeddingsEndpoint(configuredBaseURL)
 	if err != nil {
 		return nil, err
 	}
 
 	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
-		"model":           model,
-		"input":           texts,
-		"encoding_format": "base64",
+		"model":          model,
+		"input":          texts,
+		"embedding_type": "base64",
 	}, opts))
 	if err != nil {
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
@@ -161,10 +144,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		var parseErr error
 		if err := json.Unmarshal(body, &errResp); err != nil {
 			parseErr = err
-		} else if errResp.Error.Message != "" {
-			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
+		} else if errResp.Detail != "" {
+			message = base.SanitizeErrorText(errResp.Detail, apiKey)
 		}
-
 		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
@@ -172,19 +154,17 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if parseErr != nil {
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
-		logutil.BgLogger().Error("OpenAI API request failed",
-			logFields...,
-		)
+		logutil.BgLogger().Error("JinaAI API request failed", logFields...)
 		if resp.StatusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
-			return nil, fmt.Errorf("OpenAI returns status unauthorized, check API key")
+			return nil, fmt.Errorf("JinaAI returns status unauthorized, check API key")
 		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
+		if message != "" {
+			return nil, fmt.Errorf("JinaAI: %s", message)
 		}
-		return nil, fmt.Errorf("OpenAI: status code %d, message: %s", resp.StatusCode, message)
+		return nil, fmt.Errorf("JinaAI: status code %d", resp.StatusCode)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -74,7 +74,7 @@ func embeddingsEndpoint(configured string) (string, error) {
 	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid Jina AI API base URL: %w", err)
+		return "", base.NewRedactedError("invalid Jina AI API base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid Jina AI API base URL: absolute HTTP(S) URL is required")
@@ -121,7 +121,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "JinaAI", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -129,7 +129,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "JinaAI", err)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -32,32 +32,21 @@ const DefaultAPIBaseURL = "https://api.jina.ai/v1/embeddings"
 // Embedder is for JinaAI embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for JinaEmbedder.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns the complete Jina AI embeddings endpoint. An empty
-	// value uses DefaultAPIBaseURL.
-	GetBaseURL       func() string
-	ErrMissingAPIKey error // The error to return when API key is missing
-	ErrUnauthorized  error // The error to return when API key is invalid
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
+// GetBaseURL returns the complete Jina AI embeddings endpoint. An empty value
+// uses DefaultAPIBaseURL.
+type EmbedderConfig base.APIKeyProviderConfig
 
 // NewJinaEmbedder creates a new JinaEmbedder instance with the provided configuration.
 func NewJinaEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
 	}
 }
 
@@ -83,41 +72,22 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for JinaAI"))
+	if err != nil {
+		return nil, err
 	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for JinaAI")
-	}
-	var configuredBaseURL string
-	if e.cfg.GetBaseURL != nil {
-		configuredBaseURL = e.cfg.GetBaseURL()
-	}
-	endpoint, err := embeddingsEndpoint(configuredBaseURL)
+	endpoint, err := embeddingsEndpoint(e.cfg.ConfiguredBaseURL())
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "JinaAI", endpoint, base.JSONFieldsWithOptions(map[string]any{
 		"model":          model,
 		"input":          texts,
 		"embedding_type": "base64",
-	}, opts))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-	httpReq, err := base.NewJSONRequest(ctx, "JinaAI", endpoint, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "JinaAI", httpReq, e.cfg.MaxResponseBodyBytes)
+	}, opts), http.Header{
+		"Authorization": {"Bearer " + apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -152,24 +122,5 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err := json.Unmarshal(body, &respObj); err != nil {
 		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
 	}
-	if len(respObj.Data) != len(texts) {
-		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(respObj.Data), len(texts))
-	}
-	embeddings := make([][]float32, len(respObj.Data))
-	for _, item := range respObj.Data {
-		if item.Index < 0 || item.Index >= len(texts) {
-			return nil, fmt.Errorf("response data index %d is out of range [0, %d)", item.Index, len(texts))
-		}
-		if embeddings[item.Index] != nil {
-			return nil, fmt.Errorf("response data contains duplicate index %d", item.Index)
-		}
-		// item.Embedding is []byte. During JSON unmarshal,
-		// it is already base64 decoded by Golang from base64.
-		embedding, err := base.DecodeFloat32ArrayBytes(item.Embedding)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
-		}
-		embeddings[item.Index] = embedding
-	}
-	return embeddings, nil
+	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
 }

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default endpoint URL for the Jina AI embeddings API.
@@ -37,16 +35,13 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for JinaEmbedder.
-// GetBaseURL returns the complete Jina AI embeddings endpoint. An empty value
-// uses DefaultAPIBaseURL.
-type EmbedderConfig base.APIKeyProviderConfig
-
 // NewJinaEmbedder creates a new JinaEmbedder instance with the provided configuration.
-func NewJinaEmbedder(cfg EmbedderConfig) *Embedder {
+// cfg.GetBaseURL returns the complete Jina AI embeddings endpoint; an empty
+// value uses DefaultAPIBaseURL.
+func NewJinaEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -60,6 +55,29 @@ func embeddingsEndpoint(configured string) (string, error) {
 		return "", err
 	}
 	return u.String(), nil
+}
+
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	return response.Detail, nil
+}
+
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var response Response
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
+}
+
+func (e *Embedder) unauthorizedError() error {
+	if e.cfg.ErrUnauthorized != nil {
+		return e.cfg.ErrUnauthorized
+	}
+	return fmt.Errorf("JinaAI returns status unauthorized, check API key")
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -81,46 +99,22 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "JinaAI", endpoint, base.JSONFieldsWithOptions(map[string]any{
-		"model":          model,
-		"input":          texts,
-		"embedding_type": "base64",
-	}, opts), http.Header{
-		"Authorization": {"Bearer " + apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Detail != "" {
-			message = base.SanitizeErrorText(errResp.Detail, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("JinaAI API request failed", logFields...)
-		if statusCode == http.StatusUnauthorized {
-			if e.cfg.ErrUnauthorized != nil {
-				return nil, e.cfg.ErrUnauthorized
-			}
-			return nil, fmt.Errorf("JinaAI returns status unauthorized, check API key")
-		}
-		return nil, base.NewProviderResponseError("JinaAI", statusCode, message)
-	}
-
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "JinaAI",
+		Client:   &e.client,
+		Endpoint: endpoint,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"model":          model,
+			"input":          texts,
+			"embedding_type": "base64",
+		}, opts),
+		Headers:              http.Header{"Authorization": {"Bearer " + apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.unauthorizedError(),
+		},
+		DecodeEmbeddings: decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/jina/jina.go
+++ b/pkg/inference/embedding/jina/jina.go
@@ -80,13 +80,6 @@ func validateOptions(opts map[string]any) error {
 	return nil
 }
 
-func (e *Embedder) unauthorizedError() error {
-	if e.cfg.ErrUnauthorized != nil {
-		return e.cfg.ErrUnauthorized
-	}
-	return fmt.Errorf("JinaAI returns status unauthorized, check API key")
-}
-
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -123,7 +116,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
 		StatusErrors: map[int]error{
-			http.StatusUnauthorized: e.unauthorizedError(),
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("JinaAI", http.StatusUnauthorized),
 		},
 		DecodeEmbeddings: decodeEmbeddings,
 	})

--- a/pkg/inference/embedding/jina/jina_test.go
+++ b/pkg/inference/embedding/jina/jina_test.go
@@ -19,54 +19,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
 func TestJinaEmbedder_Success(t *testing.T) {
-	// Mock successful response from real Jina API
 	mockResponse := `{
-		"model": "jina-embeddings-v3",
-		"object": "list",
-		"usage": {
-			"total_tokens": 410,
-			"prompt_tokens": 410
-		},
 		"data": [
-			{
-				"object": "embedding",
-				"index": 0,
-				"embedding": "39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="
-			},
-			{
-				"object": "embedding",
-				"index": 1,
-				"embedding": "bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="
-			},
-			{
-				"object": "embedding",
-				"index": 2,
-				"embedding": "BW9wvjO4Dz/Ot/E9k1XCvnOLSj1Tady+s3qZPth9yT37tUa+wSDEPg=="
-			},
-			{
-				"object": "embedding",
-				"index": 3,
-				"embedding": "ejyDPk6/QD7fGMA9DdaAvnlv7j6C7R2/z6yXvUxqlT65eyq9tnW9Pg=="
-			},
-			{
-				"object": "embedding",
-				"index": 4,
-				"embedding": "2ptJP3bYAj6CbKe9Ff71vY6eOj5imZ6+3GfEvqggUT6Urx8+2JwZuw=="
-			}
+			{"index": 0, "embedding": "` + testutil.EncodeFloat32Base64(1, 2) + `"},
+			{"index": 1, "embedding": "` + testutil.EncodeFloat32Base64(3, 4) + `"}
 		]
 	}`
 
@@ -82,7 +46,7 @@ func TestJinaEmbedder_Success(t *testing.T) {
 		assert.NoError(t, err)
 		assert.JSONEq(t, `{
 			"model": "jina-embeddings-v3",
-			"input": ["hello world", "test text", "sample input", "more text", "last item"],
+			"input": ["hello world", "test text"],
 			"embedding_type": "base64"
 		}`, string(body))
 
@@ -98,26 +62,11 @@ func TestJinaEmbedder_Success(t *testing.T) {
 		GetBaseURL: func() string { return server.URL },
 	})
 
-	texts := []string{"hello world", "test text", "sample input", "more text", "last item"}
+	texts := []string{"hello world", "test text"}
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", texts, nil)
 
 	require.NoError(t, err)
-	require.Len(t, embeddings, 5)
-	require.Equal(t, embeddings[0], []float32{
-		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
-	})
-	require.Equal(t, embeddings[1], []float32{
-		-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
-	})
-	require.Equal(t, embeddings[2], []float32{
-		-0.2347985, 0.5614044, 0.11802636, -0.37955913, 0.049449395, -0.43049106, 0.29976425, 0.09838456, -0.19405358, 0.3830624,
-	})
-	require.Equal(t, embeddings[3], []float32{
-		0.25632077, 0.18822977, 0.09379744, -0.25163308, 0.46569422, -0.61690533, -0.074060075, 0.2918266, -0.041621897, 0.3700387,
-	})
-	require.Equal(t, embeddings[4], []float32{
-		0.78753436, 0.12777886, -0.08174993, -0.12011353, 0.18224546, -0.30976397, -0.38360488, 0.20422614, 0.15594321, -0.0023439433,
-	})
+	require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 }
 
 func TestJinaEmbedder_WithOptions(t *testing.T) {
@@ -168,6 +117,8 @@ func TestJinaEmbedder_WithOptions(t *testing.T) {
 }
 
 func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
+	firstEmbedding := testutil.EncodeFloat32Base64(1, 2)
+	secondEmbedding := testutil.EncodeFloat32Base64(3, 4)
 	tests := []struct {
 		name         string
 		responseData string
@@ -176,30 +127,30 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 		{
 			name: "out of order",
 			responseData: `[
-				{"object":"embedding","index":1,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="},
-				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"}
 			]`,
 		},
 		{
 			name: "mismatched length",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"}
 			]`,
 			errContains: "response data length 1 does not match input texts length 2",
 		},
 		{
 			name: "duplicate index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="},
-				{"object":"embedding","index":0,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "duplicate index 0",
 		},
 		{
 			name: "out of range index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="},
-				{"object":"embedding","index":2,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":2,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "out of range",
 		},
@@ -207,7 +158,7 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 			name: "invalid decoded embedding length",
 			responseData: `[
 				{"object":"embedding","index":0,"embedding":"AAEC"},
-				{"object":"embedding","index":1,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "invalid embedding data",
 		},
@@ -215,16 +166,12 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"object":"list","model":"jina-embeddings-v3","data":` + tt.responseData + `}`))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, http.StatusOK,
+				`{"object":"list","model":"jina-embeddings-v3","data":`+tt.responseData+`}`)
 
 			embedder := NewJinaEmbedder(EmbedderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
-				GetBaseURL: func() string { return server.URL },
+				GetBaseURL: func() string { return serverURL },
 			})
 
 			embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"a", "b"}, nil)
@@ -234,35 +181,19 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Len(t, embeddings, 2)
-			require.Equal(t, []float32{
-				0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
-			}, embeddings[0])
-			require.Equal(t, []float32{
-				-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
-			}, embeddings[1])
+			require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 		})
 	}
 }
 
 func TestJinaEmbedder_UnauthorizedAPIKey(t *testing.T) {
-	// Mock unauthorized response from real Jina API
-	mockResponse := `{"detail":"Unauthorized"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"detail":"Unauthorized"}`)
 
 	embedder := NewJinaEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -270,48 +201,17 @@ func TestJinaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 }
 
 func TestJinaEmbedder_InvalidModel(t *testing.T) {
-	// Mock model not found response from real Jina API
-	mockResponse := `{"detail":"Model jina-embeddings-v2-small-enx not found"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, `{"detail":"Model jina-embeddings-v2-small-enx not found"}`)
 
 	embedder := NewJinaEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v2-small-enx", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v2-small-enx", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "JinaAI: Model jina-embeddings-v2-small-enx not found")
-}
-
-func TestJinaEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewJinaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestJinaEmbedder_NoModel(t *testing.T) {
-	embedder := NewJinaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
+	require.EqualError(t, err, "JinaAI: status code 404, message: Model jina-embeddings-v2-small-enx not found")
 }
 
 func TestJinaEmbedderEndpoint(t *testing.T) {
@@ -325,55 +225,22 @@ func TestJinaEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestJinaEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
+func TestJinaEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "jina-embeddings-v3",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
 			embedder := NewJinaEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
 			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
-func TestJinaEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"detail":"invalid api key: provider-secret"}`))
-	}))
-	defer server.Close()
-
-	embedder := NewJinaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "JinaAI request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
+		RedactionResponse:         `{"detail":"invalid api key: provider-secret"}`,
+		RedactionError:            "JinaAI: status code 400, message: invalid api key: [REDACTED]",
 	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
-	require.EqualError(t, err, "JinaAI: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
-}
-
-func TestJinaEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	embedder := NewJinaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/v1/embeddings?token=" + secret },
-	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, assert.AnError
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
-	require.EqualError(t, err, "JinaAI request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/jina/jina_test.go
+++ b/pkg/inference/embedding/jina/jina_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestJinaEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewJinaEmbedder(EmbedderConfig{
+	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -97,7 +98,7 @@ func TestJinaEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewJinaEmbedder(EmbedderConfig{
+	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -169,7 +170,7 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 			serverURL := testutil.NewJSONServer(t, http.StatusOK,
 				`{"object":"list","model":"jina-embeddings-v3","data":`+tt.responseData+`}`)
 
-			embedder := NewJinaEmbedder(EmbedderConfig{
+			embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
 				GetBaseURL: func() string { return serverURL },
 			})
@@ -189,7 +190,7 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 func TestJinaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusUnauthorized, `{"detail":"Unauthorized"}`)
 
-	embedder := NewJinaEmbedder(EmbedderConfig{
+	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -203,7 +204,7 @@ func TestJinaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 func TestJinaEmbedder_InvalidModel(t *testing.T) {
 	serverURL := testutil.NewJSONServer(t, http.StatusNotFound, `{"detail":"Model jina-embeddings-v2-small-enx not found"}`)
 
-	embedder := NewJinaEmbedder(EmbedderConfig{
+	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -229,7 +230,7 @@ func TestJinaEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "jina-embeddings-v3",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewJinaEmbedder(EmbedderConfig{
+			embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/jina/jina_test.go
+++ b/pkg/inference/embedding/jina/jina_test.go
@@ -1,0 +1,357 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jina
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJinaEmbedder_Success(t *testing.T) {
+	// Mock successful response from real Jina API
+	mockResponse := `{
+		"model": "jina-embeddings-v3",
+		"object": "list",
+		"usage": {
+			"total_tokens": 410,
+			"prompt_tokens": 410
+		},
+		"data": [
+			{
+				"object": "embedding",
+				"index": 0,
+				"embedding": "39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="
+			},
+			{
+				"object": "embedding",
+				"index": 1,
+				"embedding": "bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="
+			},
+			{
+				"object": "embedding",
+				"index": 2,
+				"embedding": "BW9wvjO4Dz/Ot/E9k1XCvnOLSj1Tady+s3qZPth9yT37tUa+wSDEPg=="
+			},
+			{
+				"object": "embedding",
+				"index": 3,
+				"embedding": "ejyDPk6/QD7fGMA9DdaAvnlv7j6C7R2/z6yXvUxqlT65eyq9tnW9Pg=="
+			},
+			{
+				"object": "embedding",
+				"index": 4,
+				"embedding": "2ptJP3bYAj6CbKe9Ff71vY6eOj5imZ6+3GfEvqggUT6Urx8+2JwZuw=="
+			}
+		]
+	}`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "jina-embeddings-v3",
+			"input": ["hello world", "test text", "sample input", "more text", "last item"],
+			"embedding_type": "base64"
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world", "test text", "sample input", "more text", "last item"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 5)
+	require.Equal(t, embeddings[0], []float32{
+		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
+	})
+	require.Equal(t, embeddings[1], []float32{
+		-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
+	})
+	require.Equal(t, embeddings[2], []float32{
+		-0.2347985, 0.5614044, 0.11802636, -0.37955913, 0.049449395, -0.43049106, 0.29976425, 0.09838456, -0.19405358, 0.3830624,
+	})
+	require.Equal(t, embeddings[3], []float32{
+		0.25632077, 0.18822977, 0.09379744, -0.25163308, 0.46569422, -0.61690533, -0.074060075, 0.2918266, -0.041621897, 0.3700387,
+	})
+	require.Equal(t, embeddings[4], []float32{
+		0.78753436, 0.12777886, -0.08174993, -0.12011353, 0.18224546, -0.30976397, -0.38360488, 0.20422614, 0.15594321, -0.0023439433,
+	})
+}
+
+func TestJinaEmbedder_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "jina-embeddings-v3",
+			"input": ["test"],
+			"embedding_type": "base64",
+			"task": "retrieval.passage"
+		}`, string(body))
+
+		mockResponse := `{
+			"model": "jina-embeddings-v3",
+			"object": "list",
+			"data": [{
+				"object": "embedding",
+				"index": 0,
+				"embedding": "39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="
+			}]
+		}`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, map[string]any{
+		"task":           "retrieval.passage",
+		"model":          "must-not-override",
+		"input":          []string{"must-not-override"},
+		"embedding_type": "float",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	require.Equal(t, embeddings[0], []float32{
+		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
+	})
+}
+
+func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseData string
+		errContains  string
+	}{
+		{
+			name: "out of order",
+			responseData: `[
+				{"object":"embedding","index":1,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="},
+				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="}
+			]`,
+		},
+		{
+			name: "mismatched length",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="}
+			]`,
+			errContains: "response data length 1 does not match input texts length 2",
+		},
+		{
+			name: "duplicate index",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="},
+				{"object":"embedding","index":0,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+			]`,
+			errContains: "duplicate index 0",
+		},
+		{
+			name: "out of range index",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="},
+				{"object":"embedding","index":2,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+			]`,
+			errContains: "out of range",
+		},
+		{
+			name: "invalid decoded embedding length",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"AAEC"},
+				{"object":"embedding","index":1,"embedding":"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="}
+			]`,
+			errContains: "invalid embedding data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"object":"list","model":"jina-embeddings-v3","data":` + tt.responseData + `}`))
+			}))
+			defer server.Close()
+
+			embedder := NewJinaEmbedder(EmbedderConfig{
+				GetAPIKey:  func() string { return "test-api-key" },
+				GetBaseURL: func() string { return server.URL },
+			})
+
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"a", "b"}, nil)
+			if tt.errContains != "" {
+				require.Nil(t, embeddings)
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, embeddings, 2)
+			require.Equal(t, []float32{
+				0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
+			}, embeddings[0])
+			require.Equal(t, []float32{
+				-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
+			}, embeddings[1])
+		})
+	}
+}
+
+func TestJinaEmbedder_UnauthorizedAPIKey(t *testing.T) {
+	// Mock unauthorized response from real Jina API
+	mockResponse := `{"detail":"Unauthorized"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "invalid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "check API key")
+}
+
+func TestJinaEmbedder_InvalidModel(t *testing.T) {
+	// Mock model not found response from real Jina API
+	mockResponse := `{"detail":"Model jina-embeddings-v2-small-enx not found"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v2-small-enx", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "JinaAI: Model jina-embeddings-v2-small-enx not found")
+}
+
+func TestJinaEmbedder_EmptyTexts(t *testing.T) {
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, embeddings, 0)
+}
+
+func TestJinaEmbedder_NoModel(t *testing.T) {
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+}
+
+func TestJinaEmbedderEndpoint(t *testing.T) {
+	endpoint, err := embeddingsEndpoint("  https://example.com/v1/embeddings?api-version=x  ")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/v1/embeddings?api-version=x", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/embeddings"} {
+		_, err := embeddingsEndpoint(baseURL)
+		require.ErrorContains(t, err, "invalid Jina AI API base URL")
+	}
+}
+
+func TestJinaEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewJinaEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
+			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
+		})
+	}
+}
+
+func TestJinaEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail":"invalid api key: provider-secret"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
+	require.EqualError(t, err, "JinaAI: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}

--- a/pkg/inference/embedding/jina/jina_test.go
+++ b/pkg/inference/embedding/jina/jina_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -71,7 +72,20 @@ func TestJinaEmbedder_Success(t *testing.T) {
 }
 
 func TestJinaEmbedder_WithOptions(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	const mockResponse = `{
+		"model": "jina-embeddings-v3",
+		"object": "list",
+		"data": [{
+			"object": "embedding",
+			"index": 0,
+			"embedding": "39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="
+		}]
+	}`
+	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://unused.example" },
+	})
+	embedder.client.Transport = testutil.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// Verify request body
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
@@ -82,25 +96,12 @@ func TestJinaEmbedder_WithOptions(t *testing.T) {
 			"task": "retrieval.passage"
 		}`, string(body))
 
-		mockResponse := `{
-			"model": "jina-embeddings-v3",
-			"object": "list",
-			"data": [{
-				"object": "embedding",
-				"index": 0,
-				"embedding": "39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg=="
-			}]
-		}`
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(mockResponse)),
+			Request:    r,
+		}, nil
 	})
 
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, map[string]any{
@@ -115,6 +116,26 @@ func TestJinaEmbedder_WithOptions(t *testing.T) {
 	require.Equal(t, embeddings[0], []float32{
 		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
 	})
+
+	t.Run("reject multi-vector response option", func(t *testing.T) {
+		embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
+			GetAPIKey:  func() string { return "test-api-key" },
+			GetBaseURL: func() string { return "http://unused.example" },
+		})
+		embedder.client.Transport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+			require.FailNow(t, "unsupported option reached the provider")
+			return nil, nil
+		})
+
+		embeddings, err := embedder.CreateEmbeddings(
+			context.Background(),
+			"jina-colbert-v2",
+			[]string{"test"},
+			map[string]any{"return_multivector": true},
+		)
+		require.Nil(t, embeddings)
+		require.EqualError(t, err, "JinaAI option return_multivector=true is not supported")
+	})
 }
 
 func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
@@ -123,6 +144,7 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 	tests := []struct {
 		name         string
 		responseData string
+		texts        []string
 		errContains  string
 	}{
 		{
@@ -163,19 +185,50 @@ func TestJinaEmbedder_ResponseIndexValidation(t *testing.T) {
 			]`,
 			errContains: "invalid embedding data",
 		},
+		{
+			name: "multi-vector response",
+			responseData: `[
+				{"object":"embedding","index":0,"embeddings":["AACAPw=="]}
+			]`,
+			texts:       []string{"a"},
+			errContains: "embedding data is empty",
+		},
+		{
+			name: "missing dense embedding",
+			responseData: `[
+				{"object":"embedding","index":0}
+			]`,
+			texts:       []string{"a"},
+			errContains: "embedding data is empty",
+		},
+		{
+			name: "null dense embedding",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":null}
+			]`,
+			texts:       []string{"a"},
+			errContains: "embedding data is empty",
+		},
+		{
+			name: "empty dense embedding",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":""}
+			]`,
+			texts:       []string{"a"},
+			errContains: "embedding data is empty",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			serverURL := testutil.NewJSONServer(t, http.StatusOK,
-				`{"object":"list","model":"jina-embeddings-v3","data":`+tt.responseData+`}`)
-
-			embedder := NewJinaEmbedder(base.APIKeyProviderConfig{
-				GetAPIKey:  func() string { return "test-api-key" },
-				GetBaseURL: func() string { return serverURL },
-			})
-
-			embeddings, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"a", "b"}, nil)
+			texts := tt.texts
+			if texts == nil {
+				texts = []string{"a", "b"}
+			}
+			embeddings, err := decodeEmbeddings(
+				[]byte(`{"object":"list","model":"jina-embeddings-v3","data":`+tt.responseData+`}`),
+				len(texts),
+			)
 			if tt.errContains != "" {
 				require.Nil(t, embeddings)
 				require.ErrorContains(t, err, tt.errContains)

--- a/pkg/inference/embedding/jina/jina_test.go
+++ b/pkg/inference/embedding/jina/jina_test.go
@@ -26,6 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestJinaEmbedder_Success(t *testing.T) {
 	// Mock successful response from real Jina API
 	mockResponse := `{
@@ -354,4 +360,20 @@ func TestJinaEmbedderErrorRedaction(t *testing.T) {
 	_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
 	require.EqualError(t, err, "JinaAI: invalid api key: [REDACTED]")
 	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestJinaEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	embedder := NewJinaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/v1/embeddings?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "jina-embeddings-v3", []string{"test"}, nil)
+	require.EqualError(t, err, "JinaAI request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/jina/protocol.go
+++ b/pkg/inference/embedding/jina/protocol.go
@@ -14,6 +14,8 @@
 
 package jina
 
+import "github.com/pingcap/tidb/pkg/inference/embedding/base"
+
 // Request is the model for JinaAI embeddings API request.
 type Request struct {
 	Input         []string `json:"input"`
@@ -24,12 +26,8 @@ type Request struct {
 // Response is the model for JinaAI embeddings API response.
 // See https://jina.ai/embeddings/.
 type Response struct {
-	Model string `json:"model"`
-	Data  []struct {
-		Object    string `json:"object"`
-		Index     int    `json:"index"`
-		Embedding []byte `json:"embedding"` // We always use base64 embedding_type
-	} `json:"data"`
+	Model string                        `json:"model"`
+	Data  []base.IndexedBase64Embedding `json:"data"`
 }
 
 // ErrorResponse is the model for JinaAI embeddings API response when an error occurs.

--- a/pkg/inference/embedding/jina/protocol.go
+++ b/pkg/inference/embedding/jina/protocol.go
@@ -22,6 +22,7 @@ type Request struct {
 }
 
 // Response is the model for JinaAI embeddings API response.
+// See https://jina.ai/embeddings/.
 type Response struct {
 	Model string `json:"model"`
 	Data  []struct {

--- a/pkg/inference/embedding/jina/protocol.go
+++ b/pkg/inference/embedding/jina/protocol.go
@@ -1,0 +1,37 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jina
+
+// Request is the model for JinaAI embeddings API request.
+type Request struct {
+	Input         []string `json:"input"`
+	Model         string   `json:"model"`
+	EmbeddingType string   `json:"embedding_type"`
+}
+
+// Response is the model for JinaAI embeddings API response.
+type Response struct {
+	Model string `json:"model"`
+	Data  []struct {
+		Object    string `json:"object"`
+		Index     int    `json:"index"`
+		Embedding []byte `json:"embedding"` // We always use base64 embedding_type
+	} `json:"data"`
+}
+
+// ErrorResponse is the model for JinaAI embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Detail string `json:"detail"`
+}

--- a/pkg/inference/embedding/nvidia/BUILD.bazel
+++ b/pkg/inference/embedding/nvidia/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/nvidia",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(
@@ -23,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 11,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/nvidia/BUILD.bazel
+++ b/pkg/inference/embedding/nvidia/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["nvidia_test.go"],
     embed = [":nvidia"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 15,
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/nvidia/BUILD.bazel
+++ b/pkg/inference/embedding/nvidia/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "nvidia",
+    srcs = [
+        "nvidia.go",
+        "protocol.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/nvidia",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "nvidia_test",
+    timeout = "short",
+    srcs = ["nvidia_test.go"],
+    embed = [":nvidia"],
+    flaky = True,
+    shard_count = 13,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/nvidia/BUILD.bazel
+++ b/pkg/inference/embedding/nvidia/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["nvidia_test.go"],
     embed = [":nvidia"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 11,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -191,11 +191,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		}
 		// item.Embedding is []byte. During JSON unmarshal,
 		// it is already base64 decoded by Golang from base64.
-		e, err := base.DecodeFloat32ArrayBytes(item.Embedding)
+		embedding, err := base.DecodeFloat32ArrayBytes(item.Embedding)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
 		}
-		embeddings[item.Index] = e
+		embeddings[item.Index] = embedding
 	}
 	return embeddings, nil
 }

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default endpoint URL for the NVIDIA NIM embeddings API.
@@ -37,16 +35,13 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for NvidiaEmbedder.
-// GetBaseURL returns the complete NVIDIA NIM embeddings endpoint. An empty
-// value uses DefaultAPIBaseURL.
-type EmbedderConfig base.APIKeyProviderConfig
-
 // NewNvidiaEmbedder creates a new NvidiaEmbedder instance with the provided configuration.
-func NewNvidiaEmbedder(cfg EmbedderConfig) *Embedder {
+// cfg.GetBaseURL returns the complete NVIDIA NIM embeddings endpoint; an empty
+// value uses DefaultAPIBaseURL.
+func NewNvidiaEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -74,6 +69,37 @@ func validateEmbeddingType(opts map[string]any) error {
 	return nil
 }
 
+func decodeErrorMessage(body []byte) (string, error) {
+	// NVIDIA endpoints use different error schemas across hosted and
+	// self-hosted versions, so accept all known message fields.
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	if response.Detail != "" {
+		return response.Detail, nil
+	}
+	if response.Message != "" {
+		return response.Message, nil
+	}
+	return response.Error, nil
+}
+
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var response Response
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
+}
+
+func (e *Embedder) unauthorizedError(statusCode int) error {
+	if e.cfg.ErrUnauthorized != nil {
+		return e.cfg.ErrUnauthorized
+	}
+	return fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(statusCode)))
+}
+
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -96,55 +122,24 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "NVIDIA NIM", endpoint, base.JSONFieldsWithOptions(map[string]any{
-		"model":           model,
-		"input":           texts,
-		"encoding_format": "base64",
-	}, opts), http.Header{
-		"Authorization": {"Bearer " + apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		// NVIDIA endpoints use different error schemas across hosted and
-		// self-hosted versions, so accept all known message fields.
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Detail != "" {
-			message = base.SanitizeErrorText(errResp.Detail, apiKey)
-		} else if errResp.Message != "" {
-			message = base.SanitizeErrorText(errResp.Message, apiKey)
-		} else if errResp.Error != "" {
-			message = base.SanitizeErrorText(errResp.Error, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("NVIDIA NIM API request failed", logFields...)
-		if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
-			if e.cfg.ErrUnauthorized != nil {
-				return nil, e.cfg.ErrUnauthorized
-			}
-			return nil, fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(statusCode)))
-		}
-		if statusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model)
-		}
-		return nil, base.NewProviderResponseError("NVIDIA NIM", statusCode, message)
-	}
-
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "NVIDIA NIM",
+		Client:   &e.client,
+		Endpoint: endpoint,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"model":           model,
+			"input":           texts,
+			"encoding_format": "base64",
+		}, opts),
+		Headers:              http.Header{"Authorization": {"Bearer " + apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.unauthorizedError(http.StatusUnauthorized),
+			http.StatusForbidden:    e.unauthorizedError(http.StatusForbidden),
+			http.StatusNotFound:     fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model),
+		},
+		DecodeEmbeddings: decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -32,32 +32,21 @@ const DefaultAPIBaseURL = "https://integrate.api.nvidia.com/v1/embeddings"
 // Embedder is for NVIDIA NIM embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for NvidiaEmbedder.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns the complete NVIDIA NIM embeddings endpoint. An
-	// empty value uses DefaultAPIBaseURL.
-	GetBaseURL       func() string
-	ErrMissingAPIKey error // The error to return when API key is missing
-	ErrUnauthorized  error // The error to return when API key is invalid
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
+// GetBaseURL returns the complete NVIDIA NIM embeddings endpoint. An empty
+// value uses DefaultAPIBaseURL.
+type EmbedderConfig base.APIKeyProviderConfig
 
 // NewNvidiaEmbedder creates a new NvidiaEmbedder instance with the provided configuration.
 func NewNvidiaEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
 	}
 }
 
@@ -98,41 +87,22 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err := validateEmbeddingType(opts); err != nil {
 		return nil, err
 	}
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for NVIDIA NIM"))
+	if err != nil {
+		return nil, err
 	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for NVIDIA NIM")
-	}
-	var configuredBaseURL string
-	if e.cfg.GetBaseURL != nil {
-		configuredBaseURL = e.cfg.GetBaseURL()
-	}
-	endpoint, err := embeddingsEndpoint(configuredBaseURL)
+	endpoint, err := embeddingsEndpoint(e.cfg.ConfiguredBaseURL())
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "NVIDIA NIM", endpoint, base.JSONFieldsWithOptions(map[string]any{
 		"model":           model,
 		"input":           texts,
 		"encoding_format": "base64",
-	}, opts))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-	httpReq, err := base.NewJSONRequest(ctx, "NVIDIA NIM", endpoint, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "NVIDIA NIM", httpReq, e.cfg.MaxResponseBodyBytes)
+	}, opts), http.Header{
+		"Authorization": {"Bearer " + apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -176,24 +146,5 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err := json.Unmarshal(body, &respObj); err != nil {
 		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
 	}
-	if len(respObj.Data) != len(texts) {
-		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(respObj.Data), len(texts))
-	}
-	embeddings := make([][]float32, len(respObj.Data))
-	for _, item := range respObj.Data {
-		if item.Index < 0 || item.Index >= len(texts) {
-			return nil, fmt.Errorf("response data index %d is out of range [0, %d)", item.Index, len(texts))
-		}
-		if embeddings[item.Index] != nil {
-			return nil, fmt.Errorf("response data contains duplicate index %d", item.Index)
-		}
-		// item.Embedding is []byte. During JSON unmarshal,
-		// it is already base64 decoded by Golang from base64.
-		embedding, err := base.DecodeFloat32ArrayBytes(item.Embedding)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
-		}
-		embeddings[item.Index] = embedding
-	}
-	return embeddings, nil
+	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
 }

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package openai
+package nvidia
 
 import (
 	"bytes"
@@ -29,13 +29,13 @@ import (
 )
 
 const (
-	// DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
-	DefaultAPIBaseURL = "https://api.openai.com/v1"
-	// DefaultMaxResponseBodyBytes bounds memory used to read an OpenAI-compatible response.
+	// DefaultAPIBaseURL is the default endpoint URL for the NVIDIA NIM embeddings API.
+	DefaultAPIBaseURL = "https://integrate.api.nvidia.com/v1/embeddings"
+	// DefaultMaxResponseBodyBytes bounds memory used to read an NVIDIA NIM response.
 	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
 )
 
-// Embedder is for OpenAI embeddings.
+// Embedder is for NVIDIA NIM embeddings.
 type Embedder struct {
 	client http.Client
 	cfg    EmbedderConfig
@@ -43,25 +43,21 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for OpenAIEmbedder.
+// EmbedderConfig holds the configuration for NvidiaEmbedder.
 type EmbedderConfig struct {
 	GetAPIKey func() string
-	// GetBaseURL returns an OpenAI-compatible API base URL. A trailing
-	// /embeddings path is optional and is normalized by the embedder.
-	GetBaseURL func() string
-	// ErrMissingAPIKey optionally overrides the default missing-key error so
-	// callers can include deployment-specific configuration guidance.
-	ErrMissingAPIKey error
-	// ErrUnauthorized optionally overrides the default unauthorized error so
-	// callers can include deployment-specific configuration guidance.
-	ErrUnauthorized error
+	// GetBaseURL returns the complete NVIDIA NIM embeddings endpoint. An
+	// empty value uses DefaultAPIBaseURL.
+	GetBaseURL       func() string
+	ErrMissingAPIKey error // The error to return when API key is missing
+	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
 	// Non-positive values use DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
-// NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
-func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
+// NewNvidiaEmbedder creates a new NvidiaEmbedder instance with the provided configuration.
+func NewNvidiaEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
 		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
 	}
@@ -71,36 +67,25 @@ func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 	}
 }
 
-// embeddingsEndpoint resolves an OpenAI-compatible base URL to the embeddings endpoint.
-// The OpenAI API defines the endpoint as POST /v1/embeddings:
-// https://platform.openai.com/docs/api-reference/embeddings/create
-// For compatibility with existing callers, baseURL may already end in /embeddings.
-func embeddingsEndpoint(baseURL string) (string, error) {
-	u, err := url.Parse(baseURL)
+func embeddingsEndpoint(configured string) (string, error) {
+	endpoint := strings.TrimSpace(configured)
+	if endpoint == "" {
+		endpoint = DefaultAPIBaseURL
+	}
+	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL: %w", err)
+		return "", fmt.Errorf("invalid NVIDIA NIM API base URL: %w", err)
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("invalid OpenAI API base URL: absolute URL is required")
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid NVIDIA NIM API base URL: absolute HTTP(S) URL is required")
 	}
-
-	escapedPath := strings.TrimRight(u.EscapedPath(), "/")
-	if !strings.HasSuffix(escapedPath, "/embeddings") {
-		escapedPath += "/embeddings"
-	}
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL path: %w", err)
-	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
-	// ref: https://platform.openai.com/docs/api-reference/embeddings/create
+	// ref: https://docs.api.nvidia.com/nim/reference/baai-bge-m3-invoke
 	if len(texts) == 0 {
 		return [][]float32{}, nil
 	}
@@ -115,15 +100,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if e.cfg.ErrMissingAPIKey != nil {
 			return nil, e.cfg.ErrMissingAPIKey
 		}
-		return nil, fmt.Errorf("API key is not configured for OpenAI")
+		return nil, fmt.Errorf("API key is not configured for NVIDIA NIM")
 	}
-	baseURL := DefaultAPIBaseURL
+	var configuredBaseURL string
 	if e.cfg.GetBaseURL != nil {
-		if configured := strings.TrimSpace(e.cfg.GetBaseURL()); configured != "" {
-			baseURL = configured
-		}
+		configuredBaseURL = e.cfg.GetBaseURL()
 	}
-	endpoint, err := embeddingsEndpoint(baseURL)
+	endpoint, err := embeddingsEndpoint(configuredBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -156,15 +139,18 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// NVIDIA endpoints may return the error message in either the documented
+		// detail field or a separate error field, so accept both variants.
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
 		if err := json.Unmarshal(body, &errResp); err != nil {
 			parseErr = err
-		} else if errResp.Error.Message != "" {
-			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
+		} else if errResp.Detail != "" {
+			message = base.SanitizeErrorText(errResp.Detail, apiKey)
+		} else if errResp.Error != "" {
+			message = base.SanitizeErrorText(errResp.Error, apiKey)
 		}
-
 		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
@@ -172,19 +158,20 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		if parseErr != nil {
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
-		logutil.BgLogger().Error("OpenAI API request failed",
-			logFields...,
-		)
-		if resp.StatusCode == http.StatusUnauthorized {
+		logutil.BgLogger().Error("NVIDIA NIM API request failed", logFields...)
+		if resp.StatusCode == http.StatusForbidden {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
-			return nil, fmt.Errorf("OpenAI returns status unauthorized, check API key")
+			return nil, fmt.Errorf("NVIDIA NIM returns status forbidden, check API key")
 		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model)
 		}
-		return nil, fmt.Errorf("OpenAI: status code %d, message: %s", resp.StatusCode, message)
+		if message != "" {
+			return nil, fmt.Errorf("NVIDIA NIM: %s", message)
+		}
+		return nil, fmt.Errorf("NVIDIA NIM: status code %d", resp.StatusCode)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -15,12 +15,10 @@
 package nvidia
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -28,12 +26,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default endpoint URL for the NVIDIA NIM embeddings API.
-	DefaultAPIBaseURL = "https://integrate.api.nvidia.com/v1/embeddings"
-	// DefaultMaxResponseBodyBytes bounds memory used to read an NVIDIA NIM response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default endpoint URL for the NVIDIA NIM embeddings API.
+const DefaultAPIBaseURL = "https://integrate.api.nvidia.com/v1/embeddings"
 
 // Embedder is for NVIDIA NIM embeddings.
 type Embedder struct {
@@ -52,14 +46,14 @@ type EmbedderConfig struct {
 	ErrMissingAPIKey error // The error to return when API key is missing
 	ErrUnauthorized  error // The error to return when API key is invalid
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewNvidiaEmbedder creates a new NvidiaEmbedder instance with the provided configuration.
 func NewNvidiaEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -72,12 +66,9 @@ func embeddingsEndpoint(configured string) (string, error) {
 	if endpoint == "" {
 		endpoint = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(endpoint)
+	u, err := base.ParseHTTPURL(endpoint, "NVIDIA NIM API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid NVIDIA NIM API base URL", err)
-	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid NVIDIA NIM API base URL: absolute HTTP(S) URL is required")
+		return "", err
 	}
 	return u.String(), nil
 }
@@ -134,26 +125,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err != nil {
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "NVIDIA NIM", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "NVIDIA NIM", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "NVIDIA NIM", endpoint, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "NVIDIA NIM", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		// NVIDIA endpoints use different error schemas across hosted and
 		// self-hosted versions, so accept all known message fields.
 		var errResp ErrorResponse
@@ -168,7 +152,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		} else if errResp.Error != "" {
 			message = base.SanitizeErrorText(errResp.Error, apiKey)
 		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -176,19 +160,16 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("NVIDIA NIM API request failed", logFields...)
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
-			return nil, fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(resp.StatusCode)))
+			return nil, fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(statusCode)))
 		}
-		if resp.StatusCode == http.StatusNotFound {
+		if statusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model)
 		}
-		if message != "" {
-			return nil, fmt.Errorf("NVIDIA NIM: %s", message)
-		}
-		return nil, fmt.Errorf("NVIDIA NIM: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("NVIDIA NIM", statusCode, message)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -74,12 +74,24 @@ func embeddingsEndpoint(configured string) (string, error) {
 	}
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid NVIDIA NIM API base URL: %w", err)
+		return "", base.NewRedactedError("invalid NVIDIA NIM API base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid NVIDIA NIM API base URL: absolute HTTP(S) URL is required")
 	}
 	return u.String(), nil
+}
+
+func validateEmbeddingType(opts map[string]any) error {
+	value, ok := opts["embedding_type"]
+	if !ok {
+		return nil
+	}
+	embeddingType, ok := value.(string)
+	if !ok || embeddingType != "float" {
+		return fmt.Errorf(`NVIDIA NIM embedding_type must be "float"`)
+	}
+	return nil
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -91,6 +103,9 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
+	}
+	if err := validateEmbeddingType(opts); err != nil {
+		return nil, err
 	}
 	var apiKey string
 	if e.cfg.GetAPIKey != nil {
@@ -121,7 +136,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "NVIDIA NIM", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -129,7 +144,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "NVIDIA NIM", err)
 	}
 	defer resp.Body.Close()
 
@@ -139,8 +154,8 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		// NVIDIA endpoints may return the error message in either the documented
-		// detail field or a separate error field, so accept both variants.
+		// NVIDIA endpoints use different error schemas across hosted and
+		// self-hosted versions, so accept all known message fields.
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -148,6 +163,8 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			parseErr = err
 		} else if errResp.Detail != "" {
 			message = base.SanitizeErrorText(errResp.Detail, apiKey)
+		} else if errResp.Message != "" {
+			message = base.SanitizeErrorText(errResp.Message, apiKey)
 		} else if errResp.Error != "" {
 			message = base.SanitizeErrorText(errResp.Error, apiKey)
 		}
@@ -159,11 +176,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("NVIDIA NIM API request failed", logFields...)
-		if resp.StatusCode == http.StatusForbidden {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
-			return nil, fmt.Errorf("NVIDIA NIM returns status forbidden, check API key")
+			return nil, fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(resp.StatusCode)))
 		}
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model)

--- a/pkg/inference/embedding/nvidia/nvidia.go
+++ b/pkg/inference/embedding/nvidia/nvidia.go
@@ -93,13 +93,6 @@ func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
 	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
 }
 
-func (e *Embedder) unauthorizedError(statusCode int) error {
-	if e.cfg.ErrUnauthorized != nil {
-		return e.cfg.ErrUnauthorized
-	}
-	return fmt.Errorf("NVIDIA NIM returns status %s, check API key", strings.ToLower(http.StatusText(statusCode)))
-}
-
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -136,8 +129,8 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
 		StatusErrors: map[int]error{
-			http.StatusUnauthorized: e.unauthorizedError(http.StatusUnauthorized),
-			http.StatusForbidden:    e.unauthorizedError(http.StatusForbidden),
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("NVIDIA NIM", http.StatusUnauthorized),
+			http.StatusForbidden:    e.cfg.UnauthorizedError("NVIDIA NIM", http.StatusForbidden),
 			http.StatusNotFound:     fmt.Errorf("NVIDIA NIM model '%s' does not exist or is not available", model),
 		},
 		DecodeEmbeddings: decodeEmbeddings,

--- a/pkg/inference/embedding/nvidia/nvidia_test.go
+++ b/pkg/inference/embedding/nvidia/nvidia_test.go
@@ -23,54 +23,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
 func TestNvidiaEmbedder_Success(t *testing.T) {
-	// Mock successful response from Nvidia NIM API
-	mockResponse := `
-    {
-      "object": "list",
-      "data": [
-        {
-          "object": "embedding",
-          "index": 0,
-          "embedding": "oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="
-        },
-        {
-          "object": "embedding",
-          "index": 1,
-          "embedding": "LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="
-        },
-        {
-          "object": "embedding",
-          "index": 2,
-          "embedding": "fSC3PuGE5b3tlAc/C0BCPYgoMTvDC+k+MTB5PkS+7j5W9pm+4DxNvQ=="
-        },
-        {
-          "object": "embedding",
-          "index": 3,
-          "embedding": "9Lo8vsEPLD4Dqho/+EVqPtFTV75Zg6q9NR3HPfjuGL6j26C+SwQVvw=="
-        },
-        {
-          "object": "embedding",
-          "index": 4,
-          "embedding": "57uJvmuWor7Zn0o+adtgPt1OlD5osRC/TzTUvgBgGD6aNfI9qEi3vg=="
-        }
-      ],
-      "model": "baai/bge-m3",
-      "usage": {
-        "prompt_tokens": 18,
-        "total_tokens": 18
-      }
-    }`
+	mockResponse := `{
+		"data": [
+			{"index": 0, "embedding": "` + testutil.EncodeFloat32Base64(1, 2) + `"},
+			{"index": 1, "embedding": "` + testutil.EncodeFloat32Base64(3, 4) + `"}
+		]
+	}`
 
 	// Create mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -84,7 +48,7 @@ func TestNvidiaEmbedder_Success(t *testing.T) {
 		assert.NoError(t, err)
 		assert.JSONEq(t, `{
 			"model": "baai/bge-m3",
-			"input": ["hello world", "test text", "sample input", "more text", "last item"],
+			"input": ["hello world", "test text"],
 			"encoding_format": "base64"
 		}`, string(body))
 
@@ -100,26 +64,11 @@ func TestNvidiaEmbedder_Success(t *testing.T) {
 		GetBaseURL: func() string { return server.URL },
 	})
 
-	texts := []string{"hello world", "test text", "sample input", "more text", "last item"}
+	texts := []string{"hello world", "test text"}
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", texts, nil)
 
 	require.NoError(t, err)
-	require.Len(t, embeddings, 5)
-	require.Equal(t, embeddings[0], []float32{
-		0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
-	})
-	require.Equal(t, embeddings[1], []float32{
-		0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
-	})
-	require.Equal(t, embeddings[2], []float32{
-		0.35766974, -0.11206985, 0.5296162, 0.047424357, 0.0027032215, 0.45516786, 0.2433479, 0.46629536, -0.30070752, -0.050106883,
-	})
-	require.Equal(t, embeddings[3], []float32{
-		-0.18430692, 0.16802885, 0.6041567, 0.22878253, -0.21028067, -0.08325834, 0.09722368, -0.1493491, -0.3141757, -0.58209676,
-	})
-	require.Equal(t, embeddings[4], []float32{
-		-0.2690117, -0.31755385, 0.1978754, 0.21958698, 0.28966418, -0.565207, -0.41446158, 0.14880371, 0.1182663, -0.3579762,
-	})
+	require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 }
 
 func TestNvidiaEmbedder_WithOptions(t *testing.T) {
@@ -193,6 +142,8 @@ func TestNvidiaEmbedderEmbeddingType(t *testing.T) {
 }
 
 func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
+	firstEmbedding := testutil.EncodeFloat32Base64(1, 2)
+	secondEmbedding := testutil.EncodeFloat32Base64(3, 4)
 	tests := []struct {
 		name         string
 		responseData string
@@ -201,30 +152,30 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 		{
 			name: "out of order",
 			responseData: `[
-				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="},
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"}
 			]`,
 		},
 		{
 			name: "mismatched length",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"}
 			]`,
 			errContains: "response data length 1 does not match input texts length 2",
 		},
 		{
 			name: "duplicate index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
-				{"object":"embedding","index":0,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "duplicate index 0",
 		},
 		{
 			name: "out of range index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
-				{"object":"embedding","index":2,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":2,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "out of range",
 		},
@@ -232,7 +183,7 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 			name: "invalid decoded embedding length",
 			responseData: `[
 				{"object":"embedding","index":0,"embedding":"AAEC"},
-				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "invalid embedding data",
 		},
@@ -240,16 +191,12 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"object":"list","model":"baai/bge-m3","data":` + tt.responseData + `}`))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, http.StatusOK,
+				`{"object":"list","model":"baai/bge-m3","data":`+tt.responseData+`}`)
 
 			embedder := NewNvidiaEmbedder(EmbedderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
-				GetBaseURL: func() string { return server.URL },
+				GetBaseURL: func() string { return serverURL },
 			})
 
 			embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"a", "b"}, nil)
@@ -259,13 +206,7 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Len(t, embeddings, 2)
-			require.Equal(t, []float32{
-				0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
-			}, embeddings[0])
-			require.Equal(t, []float32{
-				0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
-			}, embeddings[1])
+			require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 		})
 	}
 }
@@ -273,16 +214,11 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 func TestNvidiaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/problem+json")
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(`{"detail":"Authorization failed"}`))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, status, `{"detail":"Authorization failed"}`)
 
 			embedder := NewNvidiaEmbedder(EmbedderConfig{
 				GetAPIKey:  func() string { return "invalid-api-key" },
-				GetBaseURL: func() string { return server.URL },
+				GetBaseURL: func() string { return serverURL },
 			})
 
 			embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"hello world"}, nil)
@@ -293,20 +229,18 @@ func TestNvidiaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 }
 
 func TestNvidiaEmbedder_InvalidModel(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("404 page not found"))
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	embedder := NewNvidiaEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3xxxx", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3xxxx", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
@@ -320,45 +254,17 @@ func TestNvidiaEmbedder_BadRequest(t *testing.T) {
 	    "type": "validation_error"
 	}`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+	serverURL := testutil.NewJSONServer(t, http.StatusBadRequest, mockResponse)
 
 	embedder := NewNvidiaEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
-		GetBaseURL: func() string { return server.URL },
+		GetBaseURL: func() string { return serverURL },
 	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "nvidia/embed-qa-4", texts, nil)
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "nvidia/embed-qa-4", []string{"hello world"}, nil)
 
 	require.Nil(t, embeddings)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "input_type")
-}
-
-func TestNvidiaEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestNvidiaEmbedder_NoModel(t *testing.T) {
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
 }
 
 func TestNvidiaEmbedder_MissingAPIKey(t *testing.T) {
@@ -377,15 +283,11 @@ func TestNvidiaEmbedder_CustomUnauthorizedError(t *testing.T) {
 	customErr := fmt.Errorf("custom unauthorized error")
 	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(`{"detail": "Authorization failed"}`))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, status, `{"detail": "Authorization failed"}`)
 
 			embedder := NewNvidiaEmbedder(EmbedderConfig{
 				GetAPIKey:       func() string { return "invalid-key" },
-				GetBaseURL:      func() string { return server.URL },
+				GetBaseURL:      func() string { return serverURL },
 				ErrUnauthorized: customErr,
 			})
 
@@ -407,55 +309,22 @@ func TestNvidiaEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestNvidiaEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
+func TestNvidiaEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "baai/bge-m3",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
 			embedder := NewNvidiaEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
 			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
-func TestNvidiaEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
-	}))
-	defer server.Close()
-
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "NVIDIA NIM request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
+		RedactionResponse:         `{"error":"invalid api key: provider-secret"}`,
+		RedactionError:            "NVIDIA NIM: status code 400, message: invalid api key: [REDACTED]",
 	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
-	require.EqualError(t, err, "NVIDIA NIM: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
-}
-
-func TestNvidiaEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/v1/embeddings?token=" + secret },
-	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, assert.AnError
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
-	require.EqualError(t, err, "NVIDIA NIM request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/nvidia/nvidia_test.go
+++ b/pkg/inference/embedding/nvidia/nvidia_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestNvidiaEmbedder_Success(t *testing.T) {
 	// Mock successful response from Nvidia NIM API
 	mockResponse := `
@@ -125,6 +131,7 @@ func TestNvidiaEmbedder_WithOptions(t *testing.T) {
 			"model": "baai/bge-m3",
 			"input": ["test"],
 			"encoding_format": "base64",
+			"embedding_type": "float",
 			"input_type": "query"
 		}`, string(body))
 
@@ -158,6 +165,7 @@ func TestNvidiaEmbedder_WithOptions(t *testing.T) {
 
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, map[string]any{
 		"input_type":      "query",
+		"embedding_type":  "float",
 		"model":           "must-not-override",
 		"input":           []string{"must-not-override"},
 		"encoding_format": "float",
@@ -168,6 +176,20 @@ func TestNvidiaEmbedder_WithOptions(t *testing.T) {
 	require.Equal(t, embeddings[0], []float32{
 		0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
 	})
+}
+
+func TestNvidiaEmbedderEmbeddingType(t *testing.T) {
+	for _, value := range []any{"int8", "uint8", "binary", 1} {
+		embedder := NewNvidiaEmbedder(EmbedderConfig{
+			GetAPIKey:  func() string { panic("request validation should happen before reading the API key") },
+			GetBaseURL: func() string { panic("invalid options must not issue a request") },
+		})
+		embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, map[string]any{
+			"embedding_type": value,
+		})
+		require.Nil(t, embeddings)
+		require.EqualError(t, err, `NVIDIA NIM embedding_type must be "float"`)
+	}
 }
 
 func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
@@ -249,30 +271,25 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 }
 
 func TestNvidiaEmbedder_UnauthorizedAPIKey(t *testing.T) {
-	mockResponse := `{
-    "status": 403,
-    "title": "Forbidden",
-    "detail": "Authorization failed"
-}`
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"detail":"Authorization failed"}`))
+			}))
+			defer server.Close()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/problem+json")
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
+			embedder := NewNvidiaEmbedder(EmbedderConfig{
+				GetAPIKey:  func() string { return "invalid-api-key" },
+				GetBaseURL: func() string { return server.URL },
+			})
 
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "invalid-api-key" },
-		GetBaseURL: func() string { return server.URL },
-	})
-
-	texts := []string{"hello world"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", texts, nil)
-
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "check API key")
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"hello world"}, nil)
+			require.Nil(t, embeddings)
+			require.EqualError(t, err, "NVIDIA NIM returns status "+strings.ToLower(http.StatusText(status))+", check API key")
+		})
+	}
 }
 
 func TestNvidiaEmbedder_InvalidModel(t *testing.T) {
@@ -298,8 +315,10 @@ func TestNvidiaEmbedder_InvalidModel(t *testing.T) {
 
 func TestNvidiaEmbedder_BadRequest(t *testing.T) {
 	mockResponse := `{
-    "error": "The model expects an input_type from one of 'passage' or 'query' but none was provided."
-}`
+	    "object": "error",
+	    "message": "The model expects an input_type from one of 'passage' or 'query' but none was provided.",
+	    "type": "validation_error"
+	}`
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -356,21 +375,25 @@ func TestNvidiaEmbedder_MissingAPIKey(t *testing.T) {
 
 func TestNvidiaEmbedder_CustomUnauthorizedError(t *testing.T) {
 	customErr := fmt.Errorf("custom unauthorized error")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail": "Authorization failed"}`))
-	}))
-	defer server.Close()
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"detail": "Authorization failed"}`))
+			}))
+			defer server.Close()
 
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
-		GetAPIKey:       func() string { return "invalid-key" },
-		GetBaseURL:      func() string { return server.URL },
-		ErrUnauthorized: customErr,
-	})
+			embedder := NewNvidiaEmbedder(EmbedderConfig{
+				GetAPIKey:       func() string { return "invalid-key" },
+				GetBaseURL:      func() string { return server.URL },
+				ErrUnauthorized: customErr,
+			})
 
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Equal(t, customErr, err)
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+			require.Nil(t, embeddings)
+			require.Equal(t, customErr, err)
+		})
+	}
 }
 
 func TestNvidiaEmbedderEndpoint(t *testing.T) {
@@ -419,4 +442,20 @@ func TestNvidiaEmbedderErrorRedaction(t *testing.T) {
 	_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
 	require.EqualError(t, err, "NVIDIA NIM: invalid api key: [REDACTED]")
 	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestNvidiaEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/v1/embeddings?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+	require.EqualError(t, err, "NVIDIA NIM request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/inference/embedding/nvidia/nvidia_test.go
+++ b/pkg/inference/embedding/nvidia/nvidia_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestNvidiaEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
+	embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -107,7 +108,7 @@ func TestNvidiaEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
+	embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -129,7 +130,7 @@ func TestNvidiaEmbedder_WithOptions(t *testing.T) {
 
 func TestNvidiaEmbedderEmbeddingType(t *testing.T) {
 	for _, value := range []any{"int8", "uint8", "binary", 1} {
-		embedder := NewNvidiaEmbedder(EmbedderConfig{
+		embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 			GetAPIKey:  func() string { panic("request validation should happen before reading the API key") },
 			GetBaseURL: func() string { panic("invalid options must not issue a request") },
 		})
@@ -194,7 +195,7 @@ func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
 			serverURL := testutil.NewJSONServer(t, http.StatusOK,
 				`{"object":"list","model":"baai/bge-m3","data":`+tt.responseData+`}`)
 
-			embedder := NewNvidiaEmbedder(EmbedderConfig{
+			embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
 				GetBaseURL: func() string { return serverURL },
 			})
@@ -216,7 +217,7 @@ func TestNvidiaEmbedder_UnauthorizedAPIKey(t *testing.T) {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			serverURL := testutil.NewJSONServer(t, status, `{"detail":"Authorization failed"}`)
 
-			embedder := NewNvidiaEmbedder(EmbedderConfig{
+			embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:  func() string { return "invalid-api-key" },
 				GetBaseURL: func() string { return serverURL },
 			})
@@ -236,7 +237,7 @@ func TestNvidiaEmbedder_InvalidModel(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
+	embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -256,7 +257,7 @@ func TestNvidiaEmbedder_BadRequest(t *testing.T) {
 
 	serverURL := testutil.NewJSONServer(t, http.StatusBadRequest, mockResponse)
 
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
+	embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return serverURL },
 	})
@@ -269,7 +270,7 @@ func TestNvidiaEmbedder_BadRequest(t *testing.T) {
 
 func TestNvidiaEmbedder_MissingAPIKey(t *testing.T) {
 	customErr := fmt.Errorf("custom missing API key error")
-	embedder := NewNvidiaEmbedder(EmbedderConfig{
+	embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:        func() string { return "" },
 		GetBaseURL:       func() string { return "http://mock-url" },
 		ErrMissingAPIKey: customErr,
@@ -285,7 +286,7 @@ func TestNvidiaEmbedder_CustomUnauthorizedError(t *testing.T) {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			serverURL := testutil.NewJSONServer(t, status, `{"detail": "Authorization failed"}`)
 
-			embedder := NewNvidiaEmbedder(EmbedderConfig{
+			embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:       func() string { return "invalid-key" },
 				GetBaseURL:      func() string { return serverURL },
 				ErrUnauthorized: customErr,
@@ -313,7 +314,7 @@ func TestNvidiaEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "baai/bge-m3",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewNvidiaEmbedder(EmbedderConfig{
+			embedder := NewNvidiaEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/nvidia/nvidia_test.go
+++ b/pkg/inference/embedding/nvidia/nvidia_test.go
@@ -1,0 +1,422 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNvidiaEmbedder_Success(t *testing.T) {
+	// Mock successful response from Nvidia NIM API
+	mockResponse := `
+    {
+      "object": "list",
+      "data": [
+        {
+          "object": "embedding",
+          "index": 0,
+          "embedding": "oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="
+        },
+        {
+          "object": "embedding",
+          "index": 1,
+          "embedding": "LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="
+        },
+        {
+          "object": "embedding",
+          "index": 2,
+          "embedding": "fSC3PuGE5b3tlAc/C0BCPYgoMTvDC+k+MTB5PkS+7j5W9pm+4DxNvQ=="
+        },
+        {
+          "object": "embedding",
+          "index": 3,
+          "embedding": "9Lo8vsEPLD4Dqho/+EVqPtFTV75Zg6q9NR3HPfjuGL6j26C+SwQVvw=="
+        },
+        {
+          "object": "embedding",
+          "index": 4,
+          "embedding": "57uJvmuWor7Zn0o+adtgPt1OlD5osRC/TzTUvgBgGD6aNfI9qEi3vg=="
+        }
+      ],
+      "model": "baai/bge-m3",
+      "usage": {
+        "prompt_tokens": 18,
+        "total_tokens": 18
+      }
+    }`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "baai/bge-m3",
+			"input": ["hello world", "test text", "sample input", "more text", "last item"],
+			"encoding_format": "base64"
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world", "test text", "sample input", "more text", "last item"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 5)
+	require.Equal(t, embeddings[0], []float32{
+		0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
+	})
+	require.Equal(t, embeddings[1], []float32{
+		0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
+	})
+	require.Equal(t, embeddings[2], []float32{
+		0.35766974, -0.11206985, 0.5296162, 0.047424357, 0.0027032215, 0.45516786, 0.2433479, 0.46629536, -0.30070752, -0.050106883,
+	})
+	require.Equal(t, embeddings[3], []float32{
+		-0.18430692, 0.16802885, 0.6041567, 0.22878253, -0.21028067, -0.08325834, 0.09722368, -0.1493491, -0.3141757, -0.58209676,
+	})
+	require.Equal(t, embeddings[4], []float32{
+		-0.2690117, -0.31755385, 0.1978754, 0.21958698, 0.28966418, -0.565207, -0.41446158, 0.14880371, 0.1182663, -0.3579762,
+	})
+}
+
+func TestNvidiaEmbedder_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "baai/bge-m3",
+			"input": ["test"],
+			"encoding_format": "base64",
+			"input_type": "query"
+		}`, string(body))
+
+		mockResponse := `
+    {
+      "object": "list",
+      "data": [
+        {
+          "object": "embedding",
+          "index": 0,
+          "embedding": "oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="
+        }
+      ],
+      "model": "baai/bge-m3",
+      "usage": {
+        "prompt_tokens": 7,
+        "total_tokens": 7
+      }
+    }`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, map[string]any{
+		"input_type":      "query",
+		"model":           "must-not-override",
+		"input":           []string{"must-not-override"},
+		"encoding_format": "float",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	require.Equal(t, embeddings[0], []float32{
+		0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
+	})
+}
+
+func TestNvidiaEmbedder_ResponseIndexValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseData string
+		errContains  string
+	}{
+		{
+			name: "out of order",
+			responseData: `[
+				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="},
+				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="}
+			]`,
+		},
+		{
+			name: "mismatched length",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="}
+			]`,
+			errContains: "response data length 1 does not match input texts length 2",
+		},
+		{
+			name: "duplicate index",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
+				{"object":"embedding","index":0,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+			]`,
+			errContains: "duplicate index 0",
+		},
+		{
+			name: "out of range index",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
+				{"object":"embedding","index":2,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+			]`,
+			errContains: "out of range",
+		},
+		{
+			name: "invalid decoded embedding length",
+			responseData: `[
+				{"object":"embedding","index":0,"embedding":"AAEC"},
+				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+			]`,
+			errContains: "invalid embedding data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"object":"list","model":"baai/bge-m3","data":` + tt.responseData + `}`))
+			}))
+			defer server.Close()
+
+			embedder := NewNvidiaEmbedder(EmbedderConfig{
+				GetAPIKey:  func() string { return "test-api-key" },
+				GetBaseURL: func() string { return server.URL },
+			})
+
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"a", "b"}, nil)
+			if tt.errContains != "" {
+				require.Nil(t, embeddings)
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, embeddings, 2)
+			require.Equal(t, []float32{
+				0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
+			}, embeddings[0])
+			require.Equal(t, []float32{
+				0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
+			}, embeddings[1])
+		})
+	}
+}
+
+func TestNvidiaEmbedder_UnauthorizedAPIKey(t *testing.T) {
+	mockResponse := `{
+    "status": 403,
+    "title": "Forbidden",
+    "detail": "Authorization failed"
+}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "invalid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "check API key")
+}
+
+func TestNvidiaEmbedder_InvalidModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("404 page not found"))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3xxxx", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "model 'baai/bge-m3xxxx' does not exist")
+}
+
+func TestNvidiaEmbedder_BadRequest(t *testing.T) {
+	mockResponse := `{
+    "error": "The model expects an input_type from one of 'passage' or 'query' but none was provided."
+}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "valid-api-key" },
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"hello world"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "nvidia/embed-qa-4", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "input_type")
+}
+
+func TestNvidiaEmbedder_EmptyTexts(t *testing.T) {
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, embeddings, 0)
+}
+
+func TestNvidiaEmbedder_NoModel(t *testing.T) {
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://mock-url" },
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+}
+
+func TestNvidiaEmbedder_MissingAPIKey(t *testing.T) {
+	customErr := fmt.Errorf("custom missing API key error")
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:        func() string { return "" },
+		GetBaseURL:       func() string { return "http://mock-url" },
+		ErrMissingAPIKey: customErr,
+	})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Equal(t, customErr, err)
+}
+
+func TestNvidiaEmbedder_CustomUnauthorizedError(t *testing.T) {
+	customErr := fmt.Errorf("custom unauthorized error")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": "Authorization failed"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:       func() string { return "invalid-key" },
+		GetBaseURL:      func() string { return server.URL },
+		ErrUnauthorized: customErr,
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.Equal(t, customErr, err)
+}
+
+func TestNvidiaEmbedderEndpoint(t *testing.T) {
+	endpoint, err := embeddingsEndpoint("  https://example.com/v1/embeddings?api-version=x  ")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/v1/embeddings?api-version=x", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/embeddings"} {
+		_, err := embeddingsEndpoint(baseURL)
+		require.ErrorContains(t, err, "invalid NVIDIA NIM API base URL")
+	}
+}
+
+func TestNvidiaEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewNvidiaEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
+		})
+	}
+}
+
+func TestNvidiaEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewNvidiaEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "baai/bge-m3", []string{"test"}, nil)
+	require.EqualError(t, err, "NVIDIA NIM: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}

--- a/pkg/inference/embedding/nvidia/protocol.go
+++ b/pkg/inference/embedding/nvidia/protocol.go
@@ -14,6 +14,8 @@
 
 package nvidia
 
+import "github.com/pingcap/tidb/pkg/inference/embedding/base"
+
 // Request is the model for Nvidia NIM embeddings API request.
 type Request struct {
 	Input          []string `json:"input"`
@@ -23,14 +25,10 @@ type Request struct {
 
 // Response is the model for Nvidia NIM embeddings API response.
 type Response struct {
-	Object string `json:"object"`
-	Model  string `json:"model"`
-	Data   []struct {
-		Object    string `json:"object"`
-		Index     int    `json:"index"`
-		Embedding []byte `json:"embedding"` // We always use base64 encoding_format
-	} `json:"data"`
-	Usage struct {
+	Object string                        `json:"object"`
+	Model  string                        `json:"model"`
+	Data   []base.IndexedBase64Embedding `json:"data"`
+	Usage  struct {
 		PromptTokens int `json:"prompt_tokens"`
 		TotalTokens  int `json:"total_tokens"`
 	} `json:"usage"`

--- a/pkg/inference/embedding/nvidia/protocol.go
+++ b/pkg/inference/embedding/nvidia/protocol.go
@@ -38,8 +38,11 @@ type Response struct {
 
 // ErrorResponse is the model for Nvidia NIM embeddings API response when an error occurs.
 type ErrorResponse struct {
-	Status int    `json:"status"`
-	Title  string `json:"title"`
-	Detail string `json:"detail"`
-	Error  string `json:"error"`
+	Object  string `json:"object"`
+	Status  int    `json:"status"`
+	Title   string `json:"title"`
+	Detail  string `json:"detail"`
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Error   string `json:"error"`
 }

--- a/pkg/inference/embedding/nvidia/protocol.go
+++ b/pkg/inference/embedding/nvidia/protocol.go
@@ -1,0 +1,45 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvidia
+
+// Request is the model for Nvidia NIM embeddings API request.
+type Request struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	EncodingFormat string   `json:"encoding_format"`
+}
+
+// Response is the model for Nvidia NIM embeddings API response.
+type Response struct {
+	Object string `json:"object"`
+	Model  string `json:"model"`
+	Data   []struct {
+		Object    string `json:"object"`
+		Index     int    `json:"index"`
+		Embedding []byte `json:"embedding"` // We always use base64 encoding_format
+	} `json:"data"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// ErrorResponse is the model for Nvidia NIM embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Status int    `json:"status"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+	Error  string `json:"error"`
+}

--- a/pkg/inference/embedding/openai/BUILD.bazel
+++ b/pkg/inference/embedding/openai/BUILD.bazel
@@ -21,7 +21,7 @@ go_test(
     srcs = ["openai_test.go"],
     embed = [":openai"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/openai/BUILD.bazel
+++ b/pkg/inference/embedding/openai/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/openai",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(
@@ -23,6 +19,7 @@ go_test(
     flaky = True,
     shard_count = 8,
     deps = [
+        "//pkg/inference/embedding/base",
         "//pkg/inference/embedding/internal/testutil",
         "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",

--- a/pkg/inference/embedding/openai/BUILD.bazel
+++ b/pkg/inference/embedding/openai/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["openai_test.go"],
     embed = [":openai"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 8,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_zap//:zap",

--- a/pkg/inference/embedding/openai/openai.go
+++ b/pkg/inference/embedding/openai/openai.go
@@ -78,7 +78,7 @@ func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 func embeddingsEndpoint(baseURL string) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL: %w", err)
+		return "", base.NewRedactedError("invalid OpenAI API base URL", err)
 	}
 	if u.Scheme == "" || u.Host == "" {
 		return "", fmt.Errorf("invalid OpenAI API base URL: absolute URL is required")
@@ -90,7 +90,7 @@ func embeddingsEndpoint(baseURL string) (string, error) {
 	}
 	path, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", fmt.Errorf("invalid OpenAI API base URL path: %w", err)
+		return "", base.NewRedactedError("invalid OpenAI API base URL path", err)
 	}
 	u.Path = path
 	u.RawPath = escapedPath
@@ -138,7 +138,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, base.NewProviderRequestError(ctx, "OpenAI", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -146,7 +146,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, base.NewProviderRequestError(ctx, "OpenAI", err)
 	}
 	defer resp.Body.Close()
 

--- a/pkg/inference/embedding/openai/openai.go
+++ b/pkg/inference/embedding/openai/openai.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
@@ -37,16 +35,13 @@ type Embedder struct {
 
 var _ base.Embedder = (*Embedder)(nil)
 
-// EmbedderConfig holds the configuration for OpenAIEmbedder.
-// GetBaseURL returns an OpenAI-compatible API base URL. A trailing /embeddings
-// path is optional and is normalized by the embedder.
-type EmbedderConfig base.APIKeyProviderConfig
-
 // NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
-func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
+// cfg.GetBaseURL may return an OpenAI-compatible API base URL with or without
+// the trailing /embeddings path.
+func NewOpenAIEmbedder(cfg base.APIKeyProviderConfig) *Embedder {
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
+		cfg:    cfg.WithDefaults(),
 	}
 }
 
@@ -68,6 +63,29 @@ func embeddingsEndpoint(baseURL string) (string, error) {
 		return "", err
 	}
 	return u.String(), nil
+}
+
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
+	return response.Error.Message, nil
+}
+
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var response Response
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
+}
+
+func (e *Embedder) unauthorizedError() error {
+	if e.cfg.ErrUnauthorized != nil {
+		return e.cfg.ErrUnauthorized
+	}
+	return fmt.Errorf("OpenAI returns status unauthorized, check API key")
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -93,49 +111,22 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, err
 	}
 
-	statusCode, body, err := base.PostJSON(ctx, &e.client, "OpenAI", endpoint, base.JSONFieldsWithOptions(map[string]any{
-		"model":           model,
-		"input":           texts,
-		"encoding_format": "base64",
-	}, opts), http.Header{
-		"Authorization": {"Bearer " + apiKey},
-	}, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if statusCode != http.StatusOK {
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Error.Message != "" {
-			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
-		}
-
-		logFields := []zap.Field{zap.Int("status", statusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("OpenAI API request failed",
-			logFields...,
-		)
-		if statusCode == http.StatusUnauthorized {
-			if e.cfg.ErrUnauthorized != nil {
-				return nil, e.cfg.ErrUnauthorized
-			}
-			return nil, fmt.Errorf("OpenAI returns status unauthorized, check API key")
-		}
-		return nil, base.NewProviderResponseError("OpenAI", statusCode, message)
-	}
-
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "OpenAI",
+		Client:   &e.client,
+		Endpoint: endpoint,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"model":           model,
+			"input":           texts,
+			"encoding_format": "base64",
+		}, opts),
+		Headers:              http.Header{"Authorization": {"Bearer " + apiKey}},
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		StatusErrors: map[int]error{
+			http.StatusUnauthorized: e.unauthorizedError(),
+		},
+		DecodeEmbeddings: decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/openai/openai.go
+++ b/pkg/inference/embedding/openai/openai.go
@@ -32,36 +32,21 @@ const DefaultAPIBaseURL = "https://api.openai.com/v1"
 // Embedder is for OpenAI embeddings.
 type Embedder struct {
 	client http.Client
-	cfg    EmbedderConfig
+	cfg    base.APIKeyProviderConfig
 }
 
 var _ base.Embedder = (*Embedder)(nil)
 
 // EmbedderConfig holds the configuration for OpenAIEmbedder.
-type EmbedderConfig struct {
-	GetAPIKey func() string
-	// GetBaseURL returns an OpenAI-compatible API base URL. A trailing
-	// /embeddings path is optional and is normalized by the embedder.
-	GetBaseURL func() string
-	// ErrMissingAPIKey optionally overrides the default missing-key error so
-	// callers can include deployment-specific configuration guidance.
-	ErrMissingAPIKey error
-	// ErrUnauthorized optionally overrides the default unauthorized error so
-	// callers can include deployment-specific configuration guidance.
-	ErrUnauthorized error
-	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use base.DefaultMaxResponseBodyBytes.
-	MaxResponseBodyBytes int64
-}
+// GetBaseURL returns an OpenAI-compatible API base URL. A trailing /embeddings
+// path is optional and is normalized by the embedder.
+type EmbedderConfig base.APIKeyProviderConfig
 
 // NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
 func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
-	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
-	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
-		cfg:    cfg,
+		cfg:    base.APIKeyProviderConfig(cfg).WithDefaults(),
 	}
 }
 
@@ -95,43 +80,26 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if model == "" {
 		return nil, fmt.Errorf("model name is required")
 	}
-	var apiKey string
-	if e.cfg.GetAPIKey != nil {
-		apiKey = e.cfg.GetAPIKey()
-	}
-	if apiKey == "" {
-		if e.cfg.ErrMissingAPIKey != nil {
-			return nil, e.cfg.ErrMissingAPIKey
-		}
-		return nil, fmt.Errorf("API key is not configured for OpenAI")
+	apiKey, err := e.cfg.ResolveAPIKey(fmt.Errorf("API key is not configured for OpenAI"))
+	if err != nil {
+		return nil, err
 	}
 	baseURL := DefaultAPIBaseURL
-	if e.cfg.GetBaseURL != nil {
-		if configured := strings.TrimSpace(e.cfg.GetBaseURL()); configured != "" {
-			baseURL = configured
-		}
+	if configured := strings.TrimSpace(e.cfg.ConfiguredBaseURL()); configured != "" {
+		baseURL = configured
 	}
 	endpoint, err := embeddingsEndpoint(baseURL)
 	if err != nil {
 		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+	statusCode, body, err := base.PostJSON(ctx, &e.client, "OpenAI", endpoint, base.JSONFieldsWithOptions(map[string]any{
 		"model":           model,
 		"input":           texts,
 		"encoding_format": "base64",
-	}, opts))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
-	}
-	httpReq, err := base.NewJSONRequest(ctx, "OpenAI", endpoint, jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	statusCode, body, err := base.DoRequest(ctx, &e.client, "OpenAI", httpReq, e.cfg.MaxResponseBodyBytes)
+	}, opts), http.Header{
+		"Authorization": {"Bearer " + apiKey},
+	}, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -169,24 +137,5 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err := json.Unmarshal(body, &respObj); err != nil {
 		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
 	}
-	if len(respObj.Data) != len(texts) {
-		return nil, fmt.Errorf("response data length %d does not match input texts length %d", len(respObj.Data), len(texts))
-	}
-	embeddings := make([][]float32, len(respObj.Data))
-	for _, item := range respObj.Data {
-		if item.Index < 0 || item.Index >= len(texts) {
-			return nil, fmt.Errorf("response data index %d is out of range [0, %d)", item.Index, len(texts))
-		}
-		if embeddings[item.Index] != nil {
-			return nil, fmt.Errorf("response data contains duplicate index %d", item.Index)
-		}
-		// item.Embedding is []byte. During JSON unmarshal,
-		// it is already base64 decoded by Golang from base64.
-		e, err := base.DecodeFloat32ArrayBytes(item.Embedding)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", item.Index, err)
-		}
-		embeddings[item.Index] = e
-	}
-	return embeddings, nil
+	return base.DecodeIndexedBase64Embeddings(respObj.Data, len(texts))
 }

--- a/pkg/inference/embedding/openai/openai.go
+++ b/pkg/inference/embedding/openai/openai.go
@@ -15,12 +15,10 @@
 package openai
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
@@ -28,12 +26,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
-	DefaultAPIBaseURL = "https://api.openai.com/v1"
-	// DefaultMaxResponseBodyBytes bounds memory used to read an OpenAI-compatible response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
-)
+// DefaultAPIBaseURL is the default base URL (without the /embeddings suffix) for OpenAI embeddings API.
+const DefaultAPIBaseURL = "https://api.openai.com/v1"
 
 // Embedder is for OpenAI embeddings.
 type Embedder struct {
@@ -56,14 +50,14 @@ type EmbedderConfig struct {
 	// callers can include deployment-specific configuration guidance.
 	ErrUnauthorized error
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewOpenAIEmbedder creates a new OpenAIEmbedder instance with the provided configuration.
 func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -76,24 +70,18 @@ func NewOpenAIEmbedder(cfg EmbedderConfig) *Embedder {
 // https://platform.openai.com/docs/api-reference/embeddings/create
 // For compatibility with existing callers, baseURL may already end in /embeddings.
 func embeddingsEndpoint(baseURL string) (string, error) {
-	u, err := url.Parse(baseURL)
+	u, err := base.ParseHTTPURL(baseURL, "OpenAI API base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid OpenAI API base URL", err)
-	}
-	if u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("invalid OpenAI API base URL: absolute URL is required")
+		return "", err
 	}
 
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/")
 	if !strings.HasSuffix(escapedPath, "/embeddings") {
 		escapedPath += "/embeddings"
 	}
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", base.NewRedactedError("invalid OpenAI API base URL path", err)
+	if err := base.SetEscapedURLPath(u, escapedPath, "OpenAI API base URL path"); err != nil {
+		return "", err
 	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
@@ -136,26 +124,19 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	if err != nil {
 		return nil, fmt.Errorf("unexpected marshal request error: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "OpenAI", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		return nil, base.NewProviderRequestError(ctx, "OpenAI", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	httpReq, err := base.NewJSONRequest(ctx, "OpenAI", endpoint, jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	statusCode, body, err := base.DoRequest(ctx, &e.client, "OpenAI", httpReq, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
 		var errResp ErrorResponse
 		message := ""
 		var parseErr error
@@ -165,7 +146,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			message = base.SanitizeErrorText(errResp.Error.Message, apiKey)
 		}
 
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		logFields := []zap.Field{zap.Int("status", statusCode)}
 		if message != "" {
 			logFields = append(logFields, zap.String("message", message))
 		}
@@ -175,16 +156,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		logutil.BgLogger().Error("OpenAI API request failed",
 			logFields...,
 		)
-		if resp.StatusCode == http.StatusUnauthorized {
+		if statusCode == http.StatusUnauthorized {
 			if e.cfg.ErrUnauthorized != nil {
 				return nil, e.cfg.ErrUnauthorized
 			}
 			return nil, fmt.Errorf("OpenAI returns status unauthorized, check API key")
 		}
-		if message == "" {
-			message = http.StatusText(resp.StatusCode)
-		}
-		return nil, fmt.Errorf("OpenAI: status code %d, message: %s", resp.StatusCode, message)
+		return nil, base.NewProviderResponseError("OpenAI", statusCode, message)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/openai/openai.go
+++ b/pkg/inference/embedding/openai/openai.go
@@ -81,13 +81,6 @@ func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
 	return base.DecodeIndexedBase64Embeddings(response.Data, expectedCount)
 }
 
-func (e *Embedder) unauthorizedError() error {
-	if e.cfg.ErrUnauthorized != nil {
-		return e.cfg.ErrUnauthorized
-	}
-	return fmt.Errorf("OpenAI returns status unauthorized, check API key")
-}
-
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -125,7 +118,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		Secrets:              []string{apiKey},
 		DecodeErrorMessage:   decodeErrorMessage,
 		StatusErrors: map[int]error{
-			http.StatusUnauthorized: e.unauthorizedError(),
+			http.StatusUnauthorized: e.cfg.UnauthorizedError("OpenAI", http.StatusUnauthorized),
 		},
 		DecodeEmbeddings: decodeEmbeddings,
 	})

--- a/pkg/inference/embedding/openai/openai_test.go
+++ b/pkg/inference/embedding/openai/openai_test.go
@@ -16,26 +16,19 @@ package openai
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 type capturedHTTPRequest struct {
 	path          string
@@ -70,43 +63,12 @@ func receiveRequestPath(t *testing.T, requestPathCh <-chan string) string {
 }
 
 func TestOpenAIEmbedder_Success(t *testing.T) {
-	// Mock successful response from real OpenAI API
-	mockResponse := `
-    {
-      "object": "list",
-      "data": [
-        {
-          "object": "embedding",
-          "index": 0,
-          "embedding": "oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="
-        },
-        {
-          "object": "embedding",
-          "index": 1,
-          "embedding": "LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="
-        },
-        {
-          "object": "embedding",
-          "index": 2,
-          "embedding": "fSC3PuGE5b3tlAc/C0BCPYgoMTvDC+k+MTB5PkS+7j5W9pm+4DxNvQ=="
-        },
-        {
-          "object": "embedding",
-          "index": 3,
-          "embedding": "9Lo8vsEPLD4Dqho/+EVqPtFTV75Zg6q9NR3HPfjuGL6j26C+SwQVvw=="
-        },
-        {
-          "object": "embedding",
-          "index": 4,
-          "embedding": "57uJvmuWor7Zn0o+adtgPt1OlD5osRC/TzTUvgBgGD6aNfI9qEi3vg=="
-        }
-      ],
-      "model": "text-embedding-3-small",
-      "usage": {
-        "prompt_tokens": 7,
-        "total_tokens": 7
-      }
-    }`
+	mockResponse := `{
+		"data": [
+			{"index": 0, "embedding": "` + testutil.EncodeFloat32Base64(1, 2) + `"},
+			{"index": 1, "embedding": "` + testutil.EncodeFloat32Base64(3, 4) + `"}
+		]
+	}`
 
 	requestCh := make(chan capturedHTTPRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +85,7 @@ func TestOpenAIEmbedder_Success(t *testing.T) {
 		GetBaseURL: func() string { return server.URL },
 	})
 
-	texts := []string{"hello world", "test text", "sample input", "more text", "last item"}
+	texts := []string{"hello world", "test text"}
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", texts, nil)
 
 	require.NoError(t, err)
@@ -135,25 +97,10 @@ func TestOpenAIEmbedder_Success(t *testing.T) {
 	require.Equal(t, "Bearer test-api-key", request.authorization)
 	require.JSONEq(t, `{
 		"model": "text-embedding-3-small",
-		"input": ["hello world", "test text", "sample input", "more text", "last item"],
+		"input": ["hello world", "test text"],
 		"encoding_format": "base64"
 	}`, string(request.body))
-	require.Len(t, embeddings, 5)
-	require.Equal(t, embeddings[0], []float32{
-		0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
-	})
-	require.Equal(t, embeddings[1], []float32{
-		0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
-	})
-	require.Equal(t, embeddings[2], []float32{
-		0.35766974, -0.11206985, 0.5296162, 0.047424357, 0.0027032215, 0.45516786, 0.2433479, 0.46629536, -0.30070752, -0.050106883,
-	})
-	require.Equal(t, embeddings[3], []float32{
-		-0.18430692, 0.16802885, 0.6041567, 0.22878253, -0.21028067, -0.08325834, 0.09722368, -0.1493491, -0.3141757, -0.58209676,
-	})
-	require.Equal(t, embeddings[4], []float32{
-		-0.2690117, -0.31755385, 0.1978754, 0.21958698, 0.28966418, -0.565207, -0.41446158, 0.14880371, 0.1182663, -0.3579762,
-	})
+	require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 }
 
 func TestOpenAIEmbedder_WithOptions(t *testing.T) {
@@ -278,28 +225,9 @@ func TestOpenAIEmbedderHTTPClientTimeout(t *testing.T) {
 	require.True(t, netErr.Timeout())
 }
 
-func TestOpenAIEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
-			embedder := NewOpenAIEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
-			})
-
-			_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", []string{"test"}, nil)
-			require.ErrorContains(t, err, "response body exceeds maximum size of 64 bytes")
-		})
-	}
-}
-
 func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
+	firstEmbedding := testutil.EncodeFloat32Base64(1, 2)
+	secondEmbedding := testutil.EncodeFloat32Base64(3, 4)
 	tests := []struct {
 		name         string
 		responseData string
@@ -308,23 +236,23 @@ func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
 		{
 			name: "out of order",
 			responseData: `[
-				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="},
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"}
 			]`,
 		},
 		{
 			name: "duplicate index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
-				{"object":"embedding","index":0,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":0,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "duplicate index 0",
 		},
 		{
 			name: "out of range index",
 			responseData: `[
-				{"object":"embedding","index":0,"embedding":"oTwEP2H/Kz4Jwho/Gf2RPvl5lb3N1IU+z+t6Pb9Sej5h/6u+UXO5vQ=="},
-				{"object":"embedding","index":2,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":0,"embedding":"` + firstEmbedding + `"},
+				{"object":"embedding","index":2,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "out of range",
 		},
@@ -332,7 +260,7 @@ func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
 			name: "invalid decoded embedding length",
 			responseData: `[
 				{"object":"embedding","index":0,"embedding":"AAEC"},
-				{"object":"embedding","index":1,"embedding":"LhF9PkGwzzwFGLA+qFe+PlU42j5Fo4K+ExUAvwi7eD5pNLU9ucivPg=="}
+				{"object":"embedding","index":1,"embedding":"` + secondEmbedding + `"}
 			]`,
 			errContains: "invalid embedding data",
 		},
@@ -340,16 +268,12 @@ func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"object":"list","model":"text-embedding-3-small","data":` + tt.responseData + `}`))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, http.StatusOK,
+				`{"object":"list","model":"text-embedding-3-small","data":`+tt.responseData+`}`)
 
 			embedder := NewOpenAIEmbedder(EmbedderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
-				GetBaseURL: func() string { return server.URL },
+				GetBaseURL: func() string { return serverURL },
 			})
 
 			embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", []string{"a", "b"}, nil)
@@ -359,13 +283,7 @@ func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Len(t, embeddings, 2)
-			require.Equal(t, []float32{
-				0.5165501, 0.16796638, 0.60452324, 0.2851341, -0.07298655, 0.26138917, 0.06126004, 0.24445628, -0.33593276, -0.09055198,
-			}, embeddings[0])
-			require.Equal(t, []float32{
-				0.24713585, 0.0253526, 0.34393325, 0.3717625, 0.42621103, -0.2551519, -0.50032157, 0.24290097, 0.08847887, 0.34332827,
-			}, embeddings[1])
+			require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 		})
 	}
 }
@@ -407,16 +325,12 @@ func TestOpenAIEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	t.Cleanup(restore)
 
 	providerKey := `dash"secret`
-	badRequestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key: dash\"secret"}}`))
-	}))
-	defer badRequestServer.Close()
+	badRequestServerURL := testutil.NewJSONServer(t, http.StatusBadRequest,
+		`{"error":{"message":"invalid api key: dash\"secret"}}`)
 
 	embedder = NewOpenAIEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return providerKey },
-		GetBaseURL: func() string { return badRequestServer.URL },
+		GetBaseURL: func() string { return badRequestServerURL },
 	})
 	_, err = embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", texts, nil)
 	require.EqualError(t, err, "OpenAI: status code 400, message: invalid api key: [REDACTED]")
@@ -429,16 +343,11 @@ func TestOpenAIEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	require.Equal(t, "invalid api key: [REDACTED]", fields["message"])
 	require.NotContains(t, fields, "body")
 
-	malformedResponseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write([]byte(`{"error":`))
-	}))
-	defer malformedResponseServer.Close()
+	malformedResponseServerURL := testutil.NewJSONServer(t, http.StatusBadGateway, `{"error":`)
 
 	embedder = NewOpenAIEmbedder(EmbedderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return malformedResponseServer.URL },
+		GetBaseURL: func() string { return malformedResponseServerURL },
 	})
 	_, err = embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", texts, nil)
 	require.EqualError(t, err, "OpenAI: status code 502, message: Bad Gateway")
@@ -486,40 +395,20 @@ func TestOpenAIEmbedder_InvalidModel(t *testing.T) {
 	require.ErrorContains(t, err, "model 'text-embedding-3x' does not exist")
 }
 
-func TestOpenAIEmbedder_EmptyTexts(t *testing.T) {
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
+func TestOpenAIEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "text-embedding-3-small",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
+			embedder := NewOpenAIEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
+			})
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "OpenAI request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
 	})
-
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", []string{}, nil)
-	require.NoError(t, err)
-	require.Len(t, embeddings, 0)
-}
-
-func TestOpenAIEmbedder_NoModel(t *testing.T) {
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "http://mock-url" },
-	})
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-}
-
-func TestOpenAIEmbedderTransportErrorRedaction(t *testing.T) {
-	const secret = "super-secret"
-	transportErr := errors.New("transport failed")
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return "test-api-key" },
-		GetBaseURL: func() string { return "https://internal.example/v1?token=" + secret },
-	})
-	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return nil, transportErr
-	})
-
-	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", []string{"test"}, nil)
-	require.EqualError(t, err, "OpenAI request failed")
-	require.NotContains(t, err.Error(), secret)
-	require.ErrorIs(t, err, transportErr)
 }

--- a/pkg/inference/embedding/openai/openai_test.go
+++ b/pkg/inference/embedding/openai/openai_test.go
@@ -16,6 +16,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -29,6 +30,12 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 type capturedHTTPRequest struct {
 	path          string
@@ -498,4 +505,21 @@ func TestOpenAIEmbedder_NoModel(t *testing.T) {
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "", []string{"test"}, nil)
 	require.Nil(t, embeddings)
 	require.Error(t, err)
+}
+
+func TestOpenAIEmbedderTransportErrorRedaction(t *testing.T) {
+	const secret = "super-secret"
+	transportErr := errors.New("transport failed")
+	embedder := NewOpenAIEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "https://internal.example/v1?token=" + secret },
+	})
+	embedder.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, transportErr
+	})
+
+	_, err := embedder.CreateEmbeddings(context.Background(), "text-embedding-3-small", []string{"test"}, nil)
+	require.EqualError(t, err, "OpenAI request failed")
+	require.NotContains(t, err.Error(), secret)
+	require.ErrorIs(t, err, transportErr)
 }

--- a/pkg/inference/embedding/openai/openai_test.go
+++ b/pkg/inference/embedding/openai/openai_test.go
@@ -272,10 +272,6 @@ func TestOpenAIEmbedderHTTPClientTimeout(t *testing.T) {
 }
 
 func TestOpenAIEmbedderResponseBodyLimit(t *testing.T) {
-	body, err := readResponseBody(strings.NewReader(strings.Repeat("x", 64)), 64)
-	require.NoError(t, err)
-	require.Len(t, body, 64)
-
 	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/inference/embedding/openai/openai_test.go
+++ b/pkg/inference/embedding/openai/openai_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -80,7 +81,7 @@ func TestOpenAIEmbedder_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create embedder with mock server URL
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -130,7 +131,7 @@ func TestOpenAIEmbedder_WithOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -185,7 +186,7 @@ func TestOpenAIEmbedderBaseURL(t *testing.T) {
 		{suffix: "/v1/embeddings/?api-version=x#section", path: "/v1/embeddings", rawQuery: "api-version=x"},
 	}
 	for _, tt := range testCases {
-		embedder := NewOpenAIEmbedder(EmbedderConfig{
+		embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 			GetAPIKey:  func() string { return "test-api-key" },
 			GetBaseURL: func() string { return server.URL + tt.suffix },
 		})
@@ -197,7 +198,7 @@ func TestOpenAIEmbedderBaseURL(t *testing.T) {
 		require.Equal(t, [][]float32{{1}}, embeddings)
 	}
 
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return "://invalid" },
 	})
@@ -212,7 +213,7 @@ func TestOpenAIEmbedderHTTPClientTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -271,7 +272,7 @@ func TestOpenAIEmbedder_ResponseIndexValidation(t *testing.T) {
 			serverURL := testutil.NewJSONServer(t, http.StatusOK,
 				`{"object":"list","model":"text-embedding-3-small","data":`+tt.responseData+`}`)
 
-			embedder := NewOpenAIEmbedder(EmbedderConfig{
+			embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:  func() string { return "test-api-key" },
 				GetBaseURL: func() string { return serverURL },
 			})
@@ -307,7 +308,7 @@ func TestOpenAIEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "invalid-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -328,7 +329,7 @@ func TestOpenAIEmbedder_UnauthorizedAPIKey(t *testing.T) {
 	badRequestServerURL := testutil.NewJSONServer(t, http.StatusBadRequest,
 		`{"error":{"message":"invalid api key: dash\"secret"}}`)
 
-	embedder = NewOpenAIEmbedder(EmbedderConfig{
+	embedder = NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return providerKey },
 		GetBaseURL: func() string { return badRequestServerURL },
 	})
@@ -345,7 +346,7 @@ func TestOpenAIEmbedder_UnauthorizedAPIKey(t *testing.T) {
 
 	malformedResponseServerURL := testutil.NewJSONServer(t, http.StatusBadGateway, `{"error":`)
 
-	embedder = NewOpenAIEmbedder(EmbedderConfig{
+	embedder = NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "test-api-key" },
 		GetBaseURL: func() string { return malformedResponseServerURL },
 	})
@@ -381,7 +382,7 @@ func TestOpenAIEmbedder_InvalidModel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	embedder := NewOpenAIEmbedder(EmbedderConfig{
+	embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 		GetAPIKey:  func() string { return "valid-api-key" },
 		GetBaseURL: func() string { return server.URL },
 	})
@@ -399,7 +400,7 @@ func TestOpenAIEmbedderContract(t *testing.T) {
 	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
 		Model: "text-embedding-3-small",
 		New: func(cfg testutil.EmbedderConfig) *Embedder {
-			embedder := NewOpenAIEmbedder(EmbedderConfig{
+			embedder := NewOpenAIEmbedder(base.APIKeyProviderConfig{
 				GetAPIKey:            func() string { return cfg.APIKey },
 				GetBaseURL:           func() string { return cfg.BaseURL },
 				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,

--- a/pkg/inference/embedding/openai/protocol.go
+++ b/pkg/inference/embedding/openai/protocol.go
@@ -14,6 +14,8 @@
 
 package openai
 
+import "github.com/pingcap/tidb/pkg/inference/embedding/base"
+
 // OpenAI embeddings protocol reference:
 // https://platform.openai.com/docs/api-reference/embeddings/create
 
@@ -26,12 +28,8 @@ type Request struct {
 
 // Response is the model for OpenAI embeddings API response.
 type Response struct {
-	Model string `json:"model"`
-	Data  []struct {
-		Object    string `json:"object"`
-		Index     int    `json:"index"`
-		Embedding []byte `json:"embedding"` // We always use base64 encoding_format
-	} `json:"data"`
+	Model string                        `json:"model"`
+	Data  []base.IndexedBase64Embedding `json:"data"`
 }
 
 // ErrorResponse is the model for OpenAI embeddings API response when an error occurs.

--- a/pkg/inference/embedding/tidbcloud/BUILD.bazel
+++ b/pkg/inference/embedding/tidbcloud/BUILD.bazel
@@ -21,8 +21,9 @@ go_test(
     srcs = ["tidbcloud_free_test.go"],
     embed = [":tidbcloud"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 8,
     deps = [
+        "//pkg/inference/embedding/internal/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/inference/embedding/tidbcloud/BUILD.bazel
+++ b/pkg/inference/embedding/tidbcloud/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tidbcloud",
+    srcs = [
+        "protocol.go",
+        "tidbcloud_free.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/inference/embedding/tidbcloud",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/inference/embedding/base",
+        "//pkg/util/logutil",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "tidbcloud_test",
+    timeout = "short",
+    srcs = ["tidbcloud_free_test.go"],
+    embed = [":tidbcloud"],
+    flaky = True,
+    shard_count = 13,
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/inference/embedding/tidbcloud/BUILD.bazel
+++ b/pkg/inference/embedding/tidbcloud/BUILD.bazel
@@ -8,11 +8,7 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/inference/embedding/tidbcloud",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/inference/embedding/base",
-        "//pkg/util/logutil",
-        "@org_uber_go_zap//:zap",
-    ],
+    deps = ["//pkg/inference/embedding/base"],
 )
 
 go_test(

--- a/pkg/inference/embedding/tidbcloud/protocol.go
+++ b/pkg/inference/embedding/tidbcloud/protocol.go
@@ -1,0 +1,31 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbcloud
+
+// Request is the model for TiDB Cloud Free embeddings API request.
+type Request struct {
+	Model string   `json:"model"`
+	Texts []string `json:"texts"`
+}
+
+// Response is the model for TiDB Cloud Free embeddings API response.
+type Response struct {
+	Embeddings [][]byte `json:"embeddings"` // Base64 encoded embeddings, will be decoded by Golang
+}
+
+// ErrorResponse is the model for TiDB Cloud Free embeddings API response when an error occurs.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/pkg/inference/embedding/tidbcloud/protocol.go
+++ b/pkg/inference/embedding/tidbcloud/protocol.go
@@ -14,12 +14,6 @@
 
 package tidbcloud
 
-// Request is the model for TiDB Cloud Free embeddings API request.
-type Request struct {
-	Model string   `json:"model"`
-	Texts []string `json:"texts"`
-}
-
 // Response is the model for TiDB Cloud Free embeddings API response.
 type Response struct {
 	Embeddings [][]byte `json:"embeddings"` // Base64 encoded embeddings, will be decoded by Golang

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -69,7 +69,7 @@ func NewTiDBCloudFreeEmbedder(cfg EmbedderConfig) *Embedder {
 func embeddingsEndpoint(configured, billingID string) (string, error) {
 	u, err := url.Parse(strings.TrimSpace(configured))
 	if err != nil {
-		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL: %w", err)
+		return "", base.NewRedactedError("invalid TiDB Cloud Inference base URL", err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL: absolute HTTP(S) URL is required")
@@ -77,7 +77,7 @@ func embeddingsEndpoint(configured, billingID string) (string, error) {
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/api/v1/inference/embeddings/" + escapePathSegment(billingID)
 	path, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL path: %w", err)
+		return "", base.NewRedactedError("invalid TiDB Cloud Inference base URL path", err)
 	}
 	u.Path = path
 	u.RawPath = escapedPath
@@ -148,7 +148,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		logRequestError(apiKey, err)
+		logRequestError(apiKey, base.NewProviderRequestError(ctx, "TiDB Cloud Inference", err))
 		// Do not return error directly to users to avoid exposing URLs
 		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
 	}
@@ -158,7 +158,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		logRequestError(apiKey, err)
+		logRequestError(apiKey, base.NewProviderRequestError(ctx, "TiDB Cloud Inference", err))
 		if ctx.Err() != nil {
 			return nil, context.Cause(ctx)
 		}

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -1,0 +1,223 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pingcap/tidb/pkg/inference/embedding/base"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultMaxResponseBodyBytes bounds memory used to read a TiDB Cloud Inference response.
+	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
+)
+
+// Embedder is for TiDB Cloud Free embeddings.
+type Embedder struct {
+	client http.Client
+	cfg    EmbedderConfig
+}
+
+var _ base.Embedder = (*Embedder)(nil)
+
+// EmbedderConfig holds the configuration for TiDBCloudFreeEmbedder.
+type EmbedderConfig struct {
+	// GetBillingID returns the billing identifier appended to the request
+	// path. An empty value uses the service's default billing identifier.
+	GetBillingID func() string
+	GetAPIKey    func() string
+	// GetBaseURL returns the TiDB Cloud Inference service base. The embedder
+	// appends /api/v1/inference/embeddings/<billing-id>.
+	GetBaseURL func() string
+	// MaxResponseBodyBytes limits both successful and error response bodies.
+	// Non-positive values use DefaultMaxResponseBodyBytes.
+	MaxResponseBodyBytes int64
+}
+
+// NewTiDBCloudFreeEmbedder creates a new TiDBCloudFreeEmbedder instance with the provided configuration.
+func NewTiDBCloudFreeEmbedder(cfg EmbedderConfig) *Embedder {
+	if cfg.MaxResponseBodyBytes <= 0 {
+		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+	}
+	return &Embedder{
+		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
+		cfg:    cfg,
+	}
+}
+
+func embeddingsEndpoint(configured, billingID string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(configured))
+	if err != nil {
+		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL: absolute HTTP(S) URL is required")
+	}
+	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/api/v1/inference/embeddings/" + escapePathSegment(billingID)
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL path: %w", err)
+	}
+	u.Path = path
+	u.RawPath = escapedPath
+	return u.String(), nil
+}
+
+func escapePathSegment(segment string) string {
+	escaped := url.PathEscape(segment)
+	if escaped == "." {
+		return "%2E"
+	}
+	if escaped == ".." {
+		return "%2E%2E"
+	}
+	return escaped
+}
+
+// CreateEmbeddings creates embeddings for the given texts using the specified model.
+// CreateEmbeddings implements base.Embedder
+func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	if model == "" {
+		return nil, fmt.Errorf("model name is required")
+	}
+
+	var apiKey string
+	if e.cfg.GetAPIKey != nil {
+		apiKey = e.cfg.GetAPIKey()
+	}
+	var baseURL string
+	if e.cfg.GetBaseURL != nil {
+		baseURL = e.cfg.GetBaseURL()
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("base URL is not configured for TiDB Cloud Inference")
+	}
+
+	var billingID string
+	if e.cfg.GetBillingID != nil {
+		billingID = e.cfg.GetBillingID()
+	}
+	if billingID == "" {
+		billingID = "default_billing_id"
+	}
+
+	fullURL, err := embeddingsEndpoint(baseURL, billingID)
+	if err != nil {
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		// Do not return error directly to users to avoid exposing URLs.
+		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
+	}
+
+	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
+		"model": model,
+		"texts": texts,
+	}, opts))
+	if err != nil {
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		return nil, fmt.Errorf("unexpected marshal request error")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		// Do not return error directly to users to avoid exposing URLs
+		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		// Do not return error directly to users to avoid exposing URLs
+		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
+	}
+	defer resp.Body.Close()
+
+	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
+	if err != nil {
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		// Do not return error directly to users to avoid exposing URLs
+		return nil, fmt.Errorf("failed to read from TiDB Cloud Inference Service")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Try to unmarshal an error response if available
+		var errResp ErrorResponse
+		message := ""
+		var parseErr error
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			parseErr = err
+		} else if errResp.Error != "" {
+			message = base.SanitizeErrorText(errResp.Error, apiKey)
+		}
+		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
+		if message != "" {
+			logFields = append(logFields, zap.String("message", message))
+		}
+		if parseErr != nil {
+			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
+		}
+		logutil.BgLogger().Error("TiDB Cloud Inference API request failed", logFields...)
+		if message != "" {
+			return nil, fmt.Errorf("TiDB Cloud Inference: %s", message)
+		}
+		return nil, fmt.Errorf("TiDB Cloud Inference: status code %d", resp.StatusCode)
+	}
+
+	var respObj Response
+	if err := json.Unmarshal(body, &respObj); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	if len(respObj.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
+	}
+
+	embeddings := make([][]float32, len(respObj.Embeddings))
+	for idx, item := range respObj.Embeddings {
+		// item.Embedding is []byte. During JSON unmarshal,
+		// it is already base64 decoded by Golang from base64.
+		e, err := base.DecodeFloat32ArrayBytes(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", idx, err)
+		}
+		embeddings[idx] = e
+	}
+	return embeddings, nil
+}

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -95,6 +95,11 @@ func escapePathSegment(segment string) string {
 	return escaped
 }
 
+func logRequestError(apiKey string, err error) {
+	logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
+		zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+}
+
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
 // CreateEmbeddings implements base.Embedder
 func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []string, opts map[string]any) ([][]float32, error) {
@@ -127,8 +132,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	fullURL, err := embeddingsEndpoint(baseURL, billingID)
 	if err != nil {
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		logRequestError(apiKey, err)
 		// Do not return error directly to users to avoid exposing URLs.
 		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
 	}
@@ -138,15 +142,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		"texts": texts,
 	}, opts))
 	if err != nil {
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		logRequestError(apiKey, err)
 		return nil, fmt.Errorf("unexpected marshal request error")
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		logRequestError(apiKey, err)
 		// Do not return error directly to users to avoid exposing URLs
 		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
 	}
@@ -156,8 +158,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		logRequestError(apiKey, err)
 		if ctx.Err() != nil {
 			return nil, context.Cause(ctx)
 		}
@@ -168,8 +169,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
 	if err != nil {
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-			zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+		logRequestError(apiKey, err)
 		if ctx.Err() != nil {
 			return nil, context.Cause(ctx)
 		}
@@ -213,11 +213,11 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 	for idx, item := range respObj.Embeddings {
 		// item.Embedding is []byte. During JSON unmarshal,
 		// it is already base64 decoded by Golang from base64.
-		e, err := base.DecodeFloat32ArrayBytes(item)
+		embedding, err := base.DecodeFloat32ArrayBytes(item)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", idx, err)
 		}
-		embeddings[idx] = e
+		embeddings[idx] = embedding
 	}
 	return embeddings, nil
 }

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -15,7 +15,6 @@
 package tidbcloud
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -26,11 +25,6 @@ import (
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
-)
-
-const (
-	// DefaultMaxResponseBodyBytes bounds memory used to read a TiDB Cloud Inference response.
-	DefaultMaxResponseBodyBytes int64 = base.DefaultMaxResponseBodyBytes
 )
 
 // Embedder is for TiDB Cloud Free embeddings.
@@ -51,14 +45,14 @@ type EmbedderConfig struct {
 	// appends /api/v1/inference/embeddings/<billing-id>.
 	GetBaseURL func() string
 	// MaxResponseBodyBytes limits both successful and error response bodies.
-	// Non-positive values use DefaultMaxResponseBodyBytes.
+	// Non-positive values use base.DefaultMaxResponseBodyBytes.
 	MaxResponseBodyBytes int64
 }
 
 // NewTiDBCloudFreeEmbedder creates a new TiDBCloudFreeEmbedder instance with the provided configuration.
 func NewTiDBCloudFreeEmbedder(cfg EmbedderConfig) *Embedder {
 	if cfg.MaxResponseBodyBytes <= 0 {
-		cfg.MaxResponseBodyBytes = DefaultMaxResponseBodyBytes
+		cfg.MaxResponseBodyBytes = base.DefaultMaxResponseBodyBytes
 	}
 	return &Embedder{
 		client: http.Client{Timeout: base.DefaultHTTPClientTimeout},
@@ -67,20 +61,14 @@ func NewTiDBCloudFreeEmbedder(cfg EmbedderConfig) *Embedder {
 }
 
 func embeddingsEndpoint(configured, billingID string) (string, error) {
-	u, err := url.Parse(strings.TrimSpace(configured))
+	u, err := base.ParseHTTPURL(configured, "TiDB Cloud Inference base URL")
 	if err != nil {
-		return "", base.NewRedactedError("invalid TiDB Cloud Inference base URL", err)
-	}
-	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return "", fmt.Errorf("invalid TiDB Cloud Inference base URL: absolute HTTP(S) URL is required")
+		return "", err
 	}
 	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/api/v1/inference/embeddings/" + escapePathSegment(billingID)
-	path, err := url.PathUnescape(escapedPath)
-	if err != nil {
-		return "", base.NewRedactedError("invalid TiDB Cloud Inference base URL path", err)
+	if err := base.SetEscapedURLPath(u, escapedPath, "TiDB Cloud Inference base URL path"); err != nil {
+		return "", err
 	}
-	u.Path = path
-	u.RawPath = escapedPath
 	return u.String(), nil
 }
 
@@ -146,14 +134,13 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("unexpected marshal request error")
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewBuffer(jsonData))
+	httpReq, err := base.NewJSONRequest(ctx, "TiDB Cloud Inference", fullURL, jsonData)
 	if err != nil {
-		logRequestError(apiKey, base.NewProviderRequestError(ctx, "TiDB Cloud Inference", err))
+		logRequestError(apiKey, err)
 		// Do not return error directly to users to avoid exposing URLs
 		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 
 	resp, err := e.client.Do(httpReq)
@@ -195,10 +182,7 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
 		}
 		logutil.BgLogger().Error("TiDB Cloud Inference API request failed", logFields...)
-		if message != "" {
-			return nil, fmt.Errorf("TiDB Cloud Inference: %s", message)
-		}
-		return nil, fmt.Errorf("TiDB Cloud Inference: status code %d", resp.StatusCode)
+		return nil, base.NewProviderResponseError("TiDB Cloud Inference", resp.StatusCode, message)
 	}
 
 	var respObj Response

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -40,7 +40,9 @@ type EmbedderConfig struct {
 	// GetBillingID returns the billing identifier appended to the request
 	// path. An empty value uses the service's default billing identifier.
 	GetBillingID func() string
-	GetAPIKey    func() string
+	// GetAPIKey returns an optional API key. An empty key sends the request
+	// without an Authorization header.
+	GetAPIKey func() string
 	// GetBaseURL returns the TiDB Cloud Inference service base. The embedder
 	// appends /api/v1/inference/embeddings/<billing-id>.
 	GetBaseURL func() string
@@ -141,7 +143,10 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	// TiDB Cloud Free may allow anonymous requests when no API key is configured.
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free.go
@@ -19,12 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/inference/embedding/base"
-	"github.com/pingcap/tidb/pkg/util/logutil"
-	"go.uber.org/zap"
 )
 
 // Embedder is for TiDB Cloud Free embeddings.
@@ -67,27 +64,39 @@ func embeddingsEndpoint(configured, billingID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/api/v1/inference/embeddings/" + escapePathSegment(billingID)
+	escapedPath := strings.TrimRight(u.EscapedPath(), "/") + "/api/v1/inference/embeddings/" + base.EscapeURLPathSegment(billingID)
 	if err := base.SetEscapedURLPath(u, escapedPath, "TiDB Cloud Inference base URL path"); err != nil {
 		return "", err
 	}
 	return u.String(), nil
 }
 
-func escapePathSegment(segment string) string {
-	escaped := url.PathEscape(segment)
-	if escaped == "." {
-		return "%2E"
+func decodeErrorMessage(body []byte) (string, error) {
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
 	}
-	if escaped == ".." {
-		return "%2E%2E"
-	}
-	return escaped
+	return response.Error, nil
 }
 
-func logRequestError(apiKey string, err error) {
-	logutil.BgLogger().Error("TiDB Cloud Inference API request failed",
-		zap.String("error", base.SanitizeErrorText(err.Error(), apiKey)))
+func decodeEmbeddings(body []byte, expectedCount int) ([][]float32, error) {
+	var response Response
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
+	}
+	if len(response.Embeddings) != expectedCount {
+		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(response.Embeddings), expectedCount)
+	}
+
+	embeddings := make([][]float32, len(response.Embeddings))
+	for idx, item := range response.Embeddings {
+		embedding, err := base.DecodeFloat32ArrayBytes(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", idx, err)
+		}
+		embeddings[idx] = embedding
+	}
+	return embeddings, nil
 }
 
 // CreateEmbeddings creates embeddings for the given texts using the specified model.
@@ -122,91 +131,27 @@ func (e *Embedder) CreateEmbeddings(ctx context.Context, model string, texts []s
 
 	fullURL, err := embeddingsEndpoint(baseURL, billingID)
 	if err != nil {
-		logRequestError(apiKey, err)
-		// Do not return error directly to users to avoid exposing URLs.
-		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
+		return nil, err
 	}
 
-	jsonData, err := json.Marshal(base.JSONFieldsWithOptions(map[string]any{
-		"model": model,
-		"texts": texts,
-	}, opts))
-	if err != nil {
-		logRequestError(apiKey, err)
-		return nil, fmt.Errorf("unexpected marshal request error")
-	}
-
-	httpReq, err := base.NewJSONRequest(ctx, "TiDB Cloud Inference", fullURL, jsonData)
-	if err != nil {
-		logRequestError(apiKey, err)
-		// Do not return error directly to users to avoid exposing URLs
-		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
-	}
-
+	headers := make(http.Header)
 	// TiDB Cloud Free may allow anonymous requests when no API key is configured.
 	if apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+		headers.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := e.client.Do(httpReq)
-	if err != nil {
-		logRequestError(apiKey, base.NewProviderRequestError(ctx, "TiDB Cloud Inference", err))
-		if ctx.Err() != nil {
-			return nil, context.Cause(ctx)
-		}
-		// Do not return error directly to users to avoid exposing URLs
-		return nil, fmt.Errorf("failed to request TiDB Cloud Inference Service")
-	}
-	defer resp.Body.Close()
-
-	body, err := base.ReadResponseBody(resp.Body, e.cfg.MaxResponseBodyBytes)
-	if err != nil {
-		logRequestError(apiKey, err)
-		if ctx.Err() != nil {
-			return nil, context.Cause(ctx)
-		}
-		// Do not return error directly to users to avoid exposing URLs
-		return nil, fmt.Errorf("failed to read from TiDB Cloud Inference Service")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		// Try to unmarshal an error response if available
-		var errResp ErrorResponse
-		message := ""
-		var parseErr error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			parseErr = err
-		} else if errResp.Error != "" {
-			message = base.SanitizeErrorText(errResp.Error, apiKey)
-		}
-		logFields := []zap.Field{zap.Int("status", resp.StatusCode)}
-		if message != "" {
-			logFields = append(logFields, zap.String("message", message))
-		}
-		if parseErr != nil {
-			logFields = append(logFields, zap.String("parse_error", base.SanitizeErrorText(parseErr.Error(), apiKey)))
-		}
-		logutil.BgLogger().Error("TiDB Cloud Inference API request failed", logFields...)
-		return nil, base.NewProviderResponseError("TiDB Cloud Inference", resp.StatusCode, message)
-	}
-
-	var respObj Response
-	if err := json.Unmarshal(body, &respObj); err != nil {
-		return nil, fmt.Errorf("unexpected unmarshal response error: %w", err)
-	}
-	if len(respObj.Embeddings) != len(texts) {
-		return nil, fmt.Errorf("response embeddings length %d does not match input texts length %d", len(respObj.Embeddings), len(texts))
-	}
-
-	embeddings := make([][]float32, len(respObj.Embeddings))
-	for idx, item := range respObj.Embeddings {
-		// item.Embedding is []byte. During JSON unmarshal,
-		// it is already base64 decoded by Golang from base64.
-		embedding, err := base.DecodeFloat32ArrayBytes(item)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode embedding for index %d: %w", idx, err)
-		}
-		embeddings[idx] = embedding
-	}
-	return embeddings, nil
+	return base.ExecuteJSONEmbeddingCall(ctx, len(texts), base.JSONEmbeddingCall{
+		Provider: "TiDB Cloud Inference",
+		Client:   &e.client,
+		Endpoint: fullURL,
+		Payload: base.JSONFieldsWithOptions(map[string]any{
+			"model": model,
+			"texts": texts,
+		}, opts),
+		Headers:              headers,
+		MaxResponseBodyBytes: e.cfg.MaxResponseBodyBytes,
+		Secrets:              []string{apiKey},
+		DecodeErrorMessage:   decodeErrorMessage,
+		DecodeEmbeddings:     decodeEmbeddings,
+	})
 }

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,11 +47,14 @@ func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 		]
 	}`
 
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return "http://unused.example" },
+	})
+	embedder.client.Transport = testutil.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// Verify request method and headers
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Empty(t, r.Header.Values("Authorization"))
 		assert.Equal(t, "/api/v1/inference/embeddings/default_billing_id", r.URL.Path)
 
 		// Verify request body
@@ -62,15 +65,12 @@ func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 			"texts": ["abc", "def"]
 		}`, string(body))
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	// Create embedder with mock server URL
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetBaseURL: func() string { return server.URL },
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(mockResponse)),
+			Request:    r,
+		}, nil
 	})
 
 	texts := []string{"abc", "def"}
@@ -81,7 +81,15 @@ func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 }
 
 func TestTiDBCloudFreeEmbedder_WithOptions(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	const mockResponse = `{
+		"embeddings": ["AAAAAAAAAAA="]
+	}`
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return "test-api-key" },
+		GetBaseURL: func() string { return "http://unused.example" },
+	})
+	embedder.client.Transport = testutil.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
 		// Verify request body includes additional options
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
@@ -91,18 +99,12 @@ func TestTiDBCloudFreeEmbedder_WithOptions(t *testing.T) {
 			"input_type": "search_document"
 		}`, string(body))
 
-		mockResponse := `{
-			"embeddings": ["AAAAAAAAAAA="]
-		}`
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetBaseURL: func() string { return server.URL },
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(mockResponse)),
+			Request:    r,
+		}, nil
 	})
 
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "cohere/embed-english-v3", []string{"test"}, map[string]any{

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
@@ -1,0 +1,385 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tidbcloud
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type contextBlockingReader struct {
+	ctx         context.Context
+	readStarted chan<- struct{}
+}
+
+func (r *contextBlockingReader) Read([]byte) (int, error) {
+	close(r.readStarted)
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func TestCreateEmbeddings_EmptyTexts(t *testing.T) {
+	cfg := EmbedderConfig{}
+	embedder := NewTiDBCloudFreeEmbedder(cfg)
+
+	ctx := context.Background()
+	embeddings, err := embedder.CreateEmbeddings(ctx, "test-model", []string{}, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, embeddings)
+}
+
+func TestCreateEmbeddings_EmptyModel(t *testing.T) {
+	cfg := EmbedderConfig{}
+	embedder := NewTiDBCloudFreeEmbedder(cfg)
+
+	ctx := context.Background()
+	_, err := embedder.CreateEmbeddings(ctx, "", []string{"test"}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "model name is required")
+}
+
+func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
+	mockResponse := `{
+		"embeddings": [
+			"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg==",
+			"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="
+		]
+	}`
+
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and headers
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "/api/v1/inference/embeddings/default_billing_id", r.URL.Path)
+
+		// Verify request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "amazon/titan-embed-text-v2",
+			"texts": ["abc", "def"]
+		}`, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	// Create embedder with mock server URL
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"abc", "def"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "amazon/titan-embed-text-v2", texts, nil)
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 2)
+	require.Equal(t, embeddings[0], []float32{
+		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
+	})
+	require.Equal(t, embeddings[1], []float32{
+		-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
+	})
+}
+
+func TestTiDBCloudFreeEmbedder_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body includes additional options
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"model": "cohere/embed-english-v3",
+			"texts": ["test"],
+			"input_type": "search_document"
+		}`, string(body))
+
+		mockResponse := `{
+			"embeddings": ["AAAAAAAAAAA="]
+		}`
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "cohere/embed-english-v3", []string{"test"}, map[string]any{
+		"input_type": "search_document",
+		"model":      "must-not-override",
+		"texts":      []string{"must-not-override"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	require.NotEmpty(t, embeddings[0])
+}
+
+func TestTiDBCloudFreeEmbedder_UnknownModel(t *testing.T) {
+	// Mock error response for unknown model
+	mockResponse := `{"error":"Unknown model 'abc'"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"abc", "def"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "abc", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Unknown model 'abc'")
+}
+
+func TestTiDBCloudFreeEmbedder_MalformedRequest(t *testing.T) {
+	// Mock error response for malformed request (missing required parameters)
+	mockResponse := `{"error":"Malformed input request: #: required key [input_type] not found#: required key [images] not found#/texts: false schema always fails, please reformat your input and try again."}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"abc", "def"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "cohere/embed-english-v3", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "required key [input_type] not found")
+}
+
+func TestTiDBCloudFreeEmbedder_QuotaExceeded(t *testing.T) {
+	// Mock error response for quota exceeded
+	mockResponse := `{"error":"Exceeded quota limit. Current usage: $0.0000, Limit: $0.0000"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetBaseURL: func() string { return server.URL },
+	})
+
+	texts := []string{"abc", "def"}
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "amazon/titan-embed-text-v2", texts, nil)
+
+	require.Nil(t, embeddings)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Exceeded quota limit")
+}
+
+func TestTiDBCloudFreeEmbedderEndpoint(t *testing.T) {
+	endpoint, err := embeddingsEndpoint(
+		" https://example.com/root/?tenant=x ",
+		"billing/id?revision=1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/root/api/v1/inference/embeddings/billing%2Fid%3Frevision=1?tenant=x", endpoint)
+	endpoint, err = embeddingsEndpoint("https://example.com", "..")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/api/v1/inference/embeddings/%2E%2E", endpoint)
+
+	for _, baseURL := range []string{"://invalid", "/relative", "ftp://example.com/inference"} {
+		_, err := embeddingsEndpoint(baseURL, "billing-id")
+		require.ErrorContains(t, err, "invalid TiDB Cloud Inference base URL")
+	}
+}
+
+func TestTiDBCloudFreeEmbedderResponseBodyLimit(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
+			}))
+			defer server.Close()
+
+			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return "test-api-key" },
+				GetBaseURL:           func() string { return server.URL },
+				MaxResponseBodyBytes: 64,
+			})
+			_, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+			require.EqualError(t, err, "failed to read from TiDB Cloud Inference Service")
+		})
+	}
+}
+
+func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
+	t.Run("request", func(t *testing.T) {
+		cause := errors.New("request canceled by caller")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(cause)
+
+		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+			GetBaseURL: func() string { return "http://127.0.0.1" },
+		})
+		_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
+		require.ErrorIs(t, err, cause)
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+			GetBaseURL: func() string { return "http://127.0.0.1" },
+		})
+		_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("response body", func(t *testing.T) {
+		cause := errors.New("response read canceled by caller")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		readStarted := make(chan struct{})
+		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+			GetBaseURL: func() string { return "http://127.0.0.1" },
+		})
+		embedder.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(&contextBlockingReader{
+					ctx:         req.Context(),
+					readStarted: readStarted,
+				}),
+				Request: req,
+			}, nil
+		})
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
+			errCh <- err
+		}()
+
+		select {
+		case <-readStarted:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "provider did not start reading the response body")
+		}
+		cancel(cause)
+
+		select {
+		case err := <-errCh:
+			require.ErrorIs(t, err, cause)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "provider did not return after context cancellation")
+		}
+	})
+}
+
+func TestTiDBCloudFreeEmbedderErrorRedaction(t *testing.T) {
+	const apiKey = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
+	}))
+	defer server.Close()
+
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+		GetAPIKey:  func() string { return apiKey },
+		GetBaseURL: func() string { return server.URL },
+	})
+	_, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+	require.EqualError(t, err, "TiDB Cloud Inference: invalid api key: [REDACTED]")
+	require.NotContains(t, err.Error(), apiKey)
+}
+
+func TestTiDBCloudFreeEmbedderResponseValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    string
+		texts       []string
+		errContains string
+	}{
+		{
+			name:        "mismatched length",
+			response:    `{"embeddings":["AACAPw=="]}`,
+			texts:       []string{"a", "b"},
+			errContains: "response embeddings length 1 does not match input texts length 2",
+		},
+		{
+			name:        "invalid decoded embedding length",
+			response:    `{"embeddings":["AAEC"]}`,
+			texts:       []string{"a"},
+			errContains: "invalid embedding data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+				GetBaseURL: func() string { return server.URL },
+			})
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", tt.texts, nil)
+			require.Nil(t, embeddings)
+			require.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestTiDBCloudFreeEmbedderMissingBaseURL(t *testing.T) {
+	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{})
+	embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
+	require.Nil(t, embeddings)
+	require.ErrorContains(t, err, "base URL is not configured for TiDB Cloud Inference")
+}

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
@@ -20,19 +20,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/inference/embedding/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
 
 type contextBlockingReader struct {
 	ctx         context.Context
@@ -45,33 +39,11 @@ func (r *contextBlockingReader) Read([]byte) (int, error) {
 	return 0, r.ctx.Err()
 }
 
-func TestCreateEmbeddings_EmptyTexts(t *testing.T) {
-	cfg := EmbedderConfig{}
-	embedder := NewTiDBCloudFreeEmbedder(cfg)
-
-	ctx := context.Background()
-	embeddings, err := embedder.CreateEmbeddings(ctx, "test-model", []string{}, nil)
-
-	require.NoError(t, err)
-	assert.Empty(t, embeddings)
-}
-
-func TestCreateEmbeddings_EmptyModel(t *testing.T) {
-	cfg := EmbedderConfig{}
-	embedder := NewTiDBCloudFreeEmbedder(cfg)
-
-	ctx := context.Background()
-	_, err := embedder.CreateEmbeddings(ctx, "", []string{"test"}, nil)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "model name is required")
-}
-
 func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 	mockResponse := `{
 		"embeddings": [
-			"39MmPZun+j7S4Gw+ZEDbvkeeKj5cVwa/96yDPjPxED6S+VW+3JGYPg==",
-			"bTC0vQlWEz+9nwo+JkCYvp5FSj7cU9q+l3O6PgBCTD7oCUe+LLyzPg=="
+			"` + testutil.EncodeFloat32Base64(1, 2) + `",
+			"` + testutil.EncodeFloat32Base64(3, 4) + `"
 		]
 	}`
 
@@ -105,13 +77,7 @@ func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 	embeddings, err := embedder.CreateEmbeddings(context.Background(), "amazon/titan-embed-text-v2", texts, nil)
 
 	require.NoError(t, err)
-	require.Len(t, embeddings, 2)
-	require.Equal(t, embeddings[0], []float32{
-		0.0407294, 0.48955998, 0.23132637, -0.42822564, 0.1666194, -0.5247705, 0.257179, 0.1415451, -0.20895985, 0.29798782,
-	})
-	require.Equal(t, embeddings[1], []float32{
-		-0.08798299, 0.57553154, 0.13537498, -0.2973644, 0.1975312, -0.42642105, 0.36416313, 0.19947052, -0.19437373, 0.351045,
-	})
+	require.Equal(t, [][]float32{{1, 2}, {3, 4}}, embeddings)
 }
 
 func TestTiDBCloudFreeEmbedder_WithOptions(t *testing.T) {
@@ -150,73 +116,48 @@ func TestTiDBCloudFreeEmbedder_WithOptions(t *testing.T) {
 	require.NotEmpty(t, embeddings[0])
 }
 
-func TestTiDBCloudFreeEmbedder_UnknownModel(t *testing.T) {
-	// Mock error response for unknown model
-	mockResponse := `{"error":"Unknown model 'abc'"}`
+func TestTiDBCloudFreeEmbedderErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		response    string
+		model       string
+		errContains string
+	}{
+		{
+			name:        "unknown model",
+			statusCode:  http.StatusBadRequest,
+			response:    `{"error":"Unknown model 'abc'"}`,
+			model:       "abc",
+			errContains: "Unknown model 'abc'",
+		},
+		{
+			name:        "malformed request",
+			statusCode:  http.StatusBadRequest,
+			response:    `{"error":"Malformed input request: #: required key [input_type] not found#: required key [images] not found#/texts: false schema always fails, please reformat your input and try again."}`,
+			model:       "cohere/embed-english-v3",
+			errContains: "required key [input_type] not found",
+		},
+		{
+			name:        "quota exceeded",
+			statusCode:  http.StatusForbidden,
+			response:    `{"error":"Exceeded quota limit. Current usage: $0.0000, Limit: $0.0000"}`,
+			model:       "amazon/titan-embed-text-v2",
+			errContains: "Exceeded quota limit",
+		},
+	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetBaseURL: func() string { return server.URL },
-	})
-
-	texts := []string{"abc", "def"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "abc", texts, nil)
-
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "Unknown model 'abc'")
-}
-
-func TestTiDBCloudFreeEmbedder_MalformedRequest(t *testing.T) {
-	// Mock error response for malformed request (missing required parameters)
-	mockResponse := `{"error":"Malformed input request: #: required key [input_type] not found#: required key [images] not found#/texts: false schema always fails, please reformat your input and try again."}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetBaseURL: func() string { return server.URL },
-	})
-
-	texts := []string{"abc", "def"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "cohere/embed-english-v3", texts, nil)
-
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "required key [input_type] not found")
-}
-
-func TestTiDBCloudFreeEmbedder_QuotaExceeded(t *testing.T) {
-	// Mock error response for quota exceeded
-	mockResponse := `{"error":"Exceeded quota limit. Current usage: $0.0000, Limit: $0.0000"}`
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(mockResponse))
-	}))
-	defer server.Close()
-
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetBaseURL: func() string { return server.URL },
-	})
-
-	texts := []string{"abc", "def"}
-	embeddings, err := embedder.CreateEmbeddings(context.Background(), "amazon/titan-embed-text-v2", texts, nil)
-
-	require.Nil(t, embeddings)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "Exceeded quota limit")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverURL := testutil.NewJSONServer(t, tt.statusCode, tt.response)
+			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+				GetBaseURL: func() string { return serverURL },
+			})
+			embeddings, err := embedder.CreateEmbeddings(context.Background(), tt.model, []string{"abc", "def"}, nil)
+			require.Nil(t, embeddings)
+			require.ErrorContains(t, err, tt.errContains)
+		})
+	}
 }
 
 func TestTiDBCloudFreeEmbedderEndpoint(t *testing.T) {
@@ -236,39 +177,7 @@ func TestTiDBCloudFreeEmbedderEndpoint(t *testing.T) {
 	}
 }
 
-func TestTiDBCloudFreeEmbedderResponseBodyLimit(t *testing.T) {
-	for _, status := range []int{http.StatusOK, http.StatusBadRequest} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(status)
-				_, _ = w.Write([]byte(strings.Repeat("x", 65)))
-			}))
-			defer server.Close()
-
-			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-				GetAPIKey:            func() string { return "test-api-key" },
-				GetBaseURL:           func() string { return server.URL },
-				MaxResponseBodyBytes: 64,
-			})
-			_, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
-			require.EqualError(t, err, "failed to read from TiDB Cloud Inference Service")
-		})
-	}
-}
-
 func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
-	t.Run("request", func(t *testing.T) {
-		cause := errors.New("request canceled by caller")
-		ctx, cancel := context.WithCancelCause(context.Background())
-		cancel(cause)
-
-		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-			GetBaseURL: func() string { return "http://127.0.0.1" },
-		})
-		_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
-		require.ErrorIs(t, err, cause)
-	})
-
 	t.Run("deadline", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
@@ -288,7 +197,7 @@ func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
 		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
 			GetBaseURL: func() string { return "http://127.0.0.1" },
 		})
-		embedder.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		embedder.client.Transport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				Status:     "200 OK",
 				StatusCode: http.StatusOK,
@@ -322,21 +231,24 @@ func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
 	})
 }
 
-func TestTiDBCloudFreeEmbedderErrorRedaction(t *testing.T) {
-	const apiKey = "provider-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"invalid api key: provider-secret"}`))
-	}))
-	defer server.Close()
-
-	embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-		GetAPIKey:  func() string { return apiKey },
-		GetBaseURL: func() string { return server.URL },
+func TestTiDBCloudFreeEmbedderContract(t *testing.T) {
+	testutil.RunEmbedderContract(t, testutil.EmbedderContract[*Embedder]{
+		Model: "test-model",
+		New: func(cfg testutil.EmbedderConfig) *Embedder {
+			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
+				GetAPIKey:            func() string { return cfg.APIKey },
+				GetBaseURL:           func() string { return cfg.BaseURL },
+				MaxResponseBodyBytes: cfg.MaxResponseBodyBytes,
+			})
+			embedder.client.Transport = cfg.Transport
+			return embedder
+		},
+		RequestError:              "failed to request TiDB Cloud Inference Service",
+		ResponseBodyLimitError:    "failed to read from TiDB Cloud Inference Service",
+		TransportCauseIsPreserved: false,
+		RedactionResponse:         `{"error":"invalid api key: provider-secret"}`,
+		RedactionError:            "TiDB Cloud Inference: status code 400, message: invalid api key: [REDACTED]",
 	})
-	_, err := embedder.CreateEmbeddings(context.Background(), "test-model", []string{"test"}, nil)
-	require.EqualError(t, err, "TiDB Cloud Inference: invalid api key: [REDACTED]")
-	require.NotContains(t, err.Error(), apiKey)
 }
 
 func TestTiDBCloudFreeEmbedderResponseValidation(t *testing.T) {
@@ -362,13 +274,10 @@ func TestTiDBCloudFreeEmbedderResponseValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write([]byte(tt.response))
-			}))
-			defer server.Close()
+			serverURL := testutil.NewJSONServer(t, http.StatusOK, tt.response)
 
 			embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-				GetBaseURL: func() string { return server.URL },
+				GetBaseURL: func() string { return serverURL },
 			})
 			embeddings, err := embedder.CreateEmbeddings(context.Background(), "test-model", tt.texts, nil)
 			require.Nil(t, embeddings)

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
@@ -178,7 +178,6 @@ func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
 		_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
-
 }
 
 func TestTiDBCloudFreeEmbedderContract(t *testing.T) {

--- a/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
+++ b/pkg/inference/embedding/tidbcloud/tidbcloud_free_test.go
@@ -16,7 +16,6 @@ package tidbcloud
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -27,17 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type contextBlockingReader struct {
-	ctx         context.Context
-	readStarted chan<- struct{}
-}
-
-func (r *contextBlockingReader) Read([]byte) (int, error) {
-	close(r.readStarted)
-	<-r.ctx.Done()
-	return 0, r.ctx.Err()
-}
 
 func TestTiDBCloudFreeEmbedder_Success(t *testing.T) {
 	mockResponse := `{
@@ -191,46 +179,6 @@ func TestTiDBCloudFreeEmbedderPreservesContextCause(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
-	t.Run("response body", func(t *testing.T) {
-		cause := errors.New("response read canceled by caller")
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(nil)
-		readStarted := make(chan struct{})
-		embedder := NewTiDBCloudFreeEmbedder(EmbedderConfig{
-			GetBaseURL: func() string { return "http://127.0.0.1" },
-		})
-		embedder.client.Transport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				Status:     "200 OK",
-				StatusCode: http.StatusOK,
-				Header:     make(http.Header),
-				Body: io.NopCloser(&contextBlockingReader{
-					ctx:         req.Context(),
-					readStarted: readStarted,
-				}),
-				Request: req,
-			}, nil
-		})
-		errCh := make(chan error, 1)
-		go func() {
-			_, err := embedder.CreateEmbeddings(ctx, "test-model", []string{"test"}, nil)
-			errCh <- err
-		}()
-
-		select {
-		case <-readStarted:
-		case <-time.After(5 * time.Second):
-			require.FailNow(t, "provider did not start reading the response body")
-		}
-		cancel(cause)
-
-		select {
-		case err := <-errCh:
-			require.ErrorIs(t, err, cause)
-		case <-time.After(5 * time.Second):
-			require.FailNow(t, "provider did not return after context cancellation")
-		}
-	})
 }
 
 func TestTiDBCloudFreeEmbedderContract(t *testing.T) {
@@ -245,9 +193,9 @@ func TestTiDBCloudFreeEmbedderContract(t *testing.T) {
 			embedder.client.Transport = cfg.Transport
 			return embedder
 		},
-		RequestError:              "failed to request TiDB Cloud Inference Service",
-		ResponseBodyLimitError:    "failed to read from TiDB Cloud Inference Service",
-		TransportCauseIsPreserved: false,
+		RequestError:              "TiDB Cloud Inference request failed",
+		ResponseBodyLimitError:    "response body exceeds maximum size of 64 bytes",
+		TransportCauseIsPreserved: true,
 		RedactionResponse:         `{"error":"invalid api key: provider-secret"}`,
 		RedactionError:            "TiDB Cloud Inference: status code 400, message: invalid api key: [REDACTED]",
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67765 

### Problem Summary

The embedding foundation introduced in #69903 defines the common embedding interface and batching behavior, but TiDB still lacks adapters for the additional embedding services needed by the upcoming `EMBED_TEXT` integration. These services use different endpoints, authentication schemes, request/response formats, and error contracts, so provider-specific implementations are required.

### What changed and how does it work?

This PR adds `base.Embedder` implementations for Cohere, Google Gemini, Hugging Face, Jina AI, NVIDIA NIM, and TiDB Cloud Inference Free.

Each adapter converts the common embedding request into its provider-specific HTTP protocol and handles endpoint construction, authentication, request options, response decoding, and provider errors. The implementations validate response structure, bound response-body memory usage, preserve cancellation and timeout behavior, and sanitize credentials and sensitive error details.

Unit tests cover successful requests, provider-specific options, validation and authentication failures, malformed or oversized responses, and cancellation behavior.

This PR only adds the provider adapters; registration, configuration wiring, and SQL-facing `EMBED_TEXT` integration are intentionally left to subsequent PRs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
* **New Features**
  * Added embedding support for Cohere, Google Gemini, Hugging Face, Jina AI, NVIDIA, and TiDB Cloud Free.
* **Bug Fixes**
  * Enforced configurable maximum response-body sizes across providers.
  * Improved error handling by preserving original cancellation causes and redacting sensitive API details (including OpenAI).
* **Tests**
  * Expanded contract and end-to-end tests covering request/response correctness, option validation, response shape/index checks, and response-size limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->