### PR TITLE
br: preserve stream listener cancellation error

### DIFF
--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -222,7 +222,12 @@ func (t AdvancerExt) startListen(ctx context.Context, rev int64, ch chan<- TaskE
 					ok = false
 				})
 				if !ok {
-					ch <- errorEvent(io.EOF)
+					if err := ctx.Err(); err != nil {
+						collectRemaining()
+						ch <- errorEvent(err)
+					} else {
+						ch <- errorEvent(io.EOF)
+					}
 					return
 				}
 				if !handleResponse(resp) {
@@ -234,7 +239,12 @@ func (t AdvancerExt) startListen(ctx context.Context, rev int64, ch chan<- TaskE
 					ok = false
 				})
 				if !ok {
-					ch <- errorEvent(io.EOF)
+					if err := ctx.Err(); err != nil {
+						collectRemaining()
+						ch <- errorEvent(err)
+					} else {
+						ch <- errorEvent(io.EOF)
+					}
 					return
 				}
 				if !handleResponse(resp) {

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -182,6 +182,17 @@ func TestChecking(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func receiveTaskEvent(t *testing.T, ch <-chan streamhelper.TaskEvent) (streamhelper.TaskEvent, bool) {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		return event, ok
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for stream task event")
+	}
+	return streamhelper.TaskEvent{}, false
+}
+
 func testBasic(t *testing.T, metaCli streamhelper.MetaDataClient, etcd *embed.Etcd) {
 	ctx := context.Background()
 	taskName := "two_tables"
@@ -291,6 +302,7 @@ func testGetGlobalCheckPointTS(t *testing.T, metaCli streamhelper.MetaDataClient
 
 func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	taskName := "simple"
 	taskInfo := simpleTask(taskName, 4)
 
@@ -304,26 +316,30 @@ func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	require.NoError(t, metaCli.PutTask(ctx, taskInfo2))
 	require.NoError(t, metaCli.DeleteTask(ctx, taskName2))
 
-	first := <-ch
+	first, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, first.Type, streamhelper.EventAdd)
 	require.Equal(t, first.Name, taskName)
 	require.ElementsMatch(t, first.Ranges, simpleRanges(4))
-	second := <-ch
+	second, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, second.Type, streamhelper.EventDel)
 	require.Equal(t, second.Name, taskName)
-	third := <-ch
+	third, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, third.Type, streamhelper.EventAdd)
 	require.Equal(t, third.Name, taskName2)
 	require.ElementsMatch(t, first.Ranges, simpleRanges(4))
-	forth := <-ch
+	forth, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, forth.Type, streamhelper.EventDel)
 	require.Equal(t, forth.Name, taskName2)
 	cancel()
-	fifth, ok := <-ch
+	fifth, ok := receiveTaskEvent(t, ch)
 	require.True(t, ok)
 	require.Equal(t, fifth.Type, streamhelper.EventErr)
 	require.ErrorIs(t, fifth.Err, context.Canceled)
-	item, ok := <-ch
+	item, ok := receiveTaskEvent(t, ch)
 	require.False(t, ok, "%v", item)
 }
 

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -182,17 +182,6 @@ func TestChecking(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func receiveTaskEvent(t *testing.T, ch <-chan streamhelper.TaskEvent) (streamhelper.TaskEvent, bool) {
-	t.Helper()
-	select {
-	case event, ok := <-ch:
-		return event, ok
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for stream task event")
-	}
-	return streamhelper.TaskEvent{}, false
-}
-
 func testBasic(t *testing.T, metaCli streamhelper.MetaDataClient, etcd *embed.Etcd) {
 	ctx := context.Background()
 	taskName := "two_tables"
@@ -302,7 +291,6 @@ func testGetGlobalCheckPointTS(t *testing.T, metaCli streamhelper.MetaDataClient
 
 func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	taskName := "simple"
 	taskInfo := simpleTask(taskName, 4)
 
@@ -314,32 +302,28 @@ func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	taskName2 := "simple2"
 	taskInfo2 := simpleTask(taskName2, 4)
 	require.NoError(t, metaCli.PutTask(ctx, taskInfo2))
-	require.NoError(t, metaCli.DeleteTask(ctx, taskName2))
 
-	first, ok := receiveTaskEvent(t, ch)
-	require.True(t, ok)
+	first := <-ch
 	require.Equal(t, first.Type, streamhelper.EventAdd)
 	require.Equal(t, first.Name, taskName)
 	require.ElementsMatch(t, first.Ranges, simpleRanges(4))
-	second, ok := receiveTaskEvent(t, ch)
-	require.True(t, ok)
+	second := <-ch
 	require.Equal(t, second.Type, streamhelper.EventDel)
 	require.Equal(t, second.Name, taskName)
-	third, ok := receiveTaskEvent(t, ch)
-	require.True(t, ok)
+	third := <-ch
 	require.Equal(t, third.Type, streamhelper.EventAdd)
 	require.Equal(t, third.Name, taskName2)
 	require.ElementsMatch(t, third.Ranges, simpleRanges(4))
-	forth, ok := receiveTaskEvent(t, ch)
-	require.True(t, ok)
+	require.NoError(t, metaCli.DeleteTask(ctx, taskName2))
+	forth := <-ch
 	require.Equal(t, forth.Type, streamhelper.EventDel)
 	require.Equal(t, forth.Name, taskName2)
 	cancel()
-	fifth, ok := receiveTaskEvent(t, ch)
+	fifth, ok := <-ch
 	require.True(t, ok)
 	require.Equal(t, fifth.Type, streamhelper.EventErr)
 	require.ErrorIs(t, fifth.Err, context.Canceled)
-	item, ok := receiveTaskEvent(t, ch)
+	item, ok := <-ch
 	require.False(t, ok, "%v", item)
 }
 

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -329,7 +329,7 @@ func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	require.True(t, ok)
 	require.Equal(t, third.Type, streamhelper.EventAdd)
 	require.Equal(t, third.Name, taskName2)
-	require.ElementsMatch(t, first.Ranges, simpleRanges(4))
+	require.ElementsMatch(t, third.Ranges, simpleRanges(4))
 	forth, ok := receiveTaskEvent(t, ch)
 	require.True(t, ok)
 	require.Equal(t, forth.Type, streamhelper.EventDel)

--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -289,8 +289,21 @@ func testGetGlobalCheckPointTS(t *testing.T, metaCli streamhelper.MetaDataClient
 	require.Equal(t, globalTS, uint64(1003))
 }
 
+// receiveTaskEvent waits up to 10 seconds for the next stream task event.
+func receiveTaskEvent(t *testing.T, ch <-chan streamhelper.TaskEvent) (streamhelper.TaskEvent, bool) {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		return event, ok
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for stream task event")
+	}
+	return streamhelper.TaskEvent{}, false
+}
+
 func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	taskName := "simple"
 	taskInfo := simpleTask(taskName, 4)
 
@@ -303,27 +316,31 @@ func testStreamListening(t *testing.T, metaCli streamhelper.AdvancerExt) {
 	taskInfo2 := simpleTask(taskName2, 4)
 	require.NoError(t, metaCli.PutTask(ctx, taskInfo2))
 
-	first := <-ch
+	first, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, first.Type, streamhelper.EventAdd)
 	require.Equal(t, first.Name, taskName)
 	require.ElementsMatch(t, first.Ranges, simpleRanges(4))
-	second := <-ch
+	second, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, second.Type, streamhelper.EventDel)
 	require.Equal(t, second.Name, taskName)
-	third := <-ch
+	third, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, third.Type, streamhelper.EventAdd)
 	require.Equal(t, third.Name, taskName2)
 	require.ElementsMatch(t, third.Ranges, simpleRanges(4))
 	require.NoError(t, metaCli.DeleteTask(ctx, taskName2))
-	forth := <-ch
+	forth, ok := receiveTaskEvent(t, ch)
+	require.True(t, ok)
 	require.Equal(t, forth.Type, streamhelper.EventDel)
 	require.Equal(t, forth.Name, taskName2)
 	cancel()
-	fifth, ok := <-ch
+	fifth, ok := receiveTaskEvent(t, ch)
 	require.True(t, ok)
 	require.Equal(t, fifth.Type, streamhelper.EventErr)
 	require.ErrorIs(t, fifth.Err, context.Canceled)
-	item, ok := <-ch
+	item, ok := receiveTaskEvent(t, ch)
 	require.False(t, ok, "%v", item)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69984

Problem Summary:
Flaky test `TestIntegration/TestStreamListening` in `br/pkg/streamhelper` intermittently receives `io.EOF` after canceling its listener context, instead of the expected `context.Canceled`.

### What changed and how does it work?
#### Root Cause

`AdvancerExt.startListen` selects between two etcd watch channels and `ctx.Done()`. Canceling the shared context closes the watch channels as well as signaling `ctx.Done()`. If `select` chooses a closed watch channel first, the listener previously emitted `io.EOF` unconditionally, racing the intended cancellation result.

The test also deleted the second task before consuming and validating its Add event. Because event conversion loads task ranges from metadata, the Add event could observe the task after deletion and contain empty ranges.

#### Fix

When a watch channel closes, preserve cancellation semantics by collecting remaining events and emitting `ctx.Err()` if the context is already canceled. Continue emitting `io.EOF` when a watch channel closes while the context is active.

Consume and validate the second task's Add event before deleting that task. Keep the corrected `third.Ranges` assertion. Use `receiveTaskEvent` to bound every event read to 10 seconds, and register `cancel` with `t.Cleanup` so early assertion failures release the listener and etcd watches.

#### Verification

- Original Bazel failure: `//br/pkg/streamhelper:streamhelper_test`, shard 37, attempt 1; `TestIntegration/TestStreamListening` expected `context canceled` but received `EOF`.
- Native pre-fix run: 100 repetitions did not reproduce the low-probability race.
- Timing-only precise reproduction: pausing immediately before the listener `select`, canceling the context, waiting for watch closure, and resuming reproduced the original signature 1/1 before the fix; the same reproduction passed 5/5 after the fix. The diagnostic hook was removed from the final diff.
- Final failpoint-aware race run: `TestStreamListening` and `TestStreamClose` each passed 20 repetitions.
- The Bazel target passed across 48 shards. The local test filter reported zero parsed test cases, so this result is treated as a Bazel build/target check rather than proof that the required case executed.
- `make lint` and `git diff --check` passed.
- `make bazel_prepare` is not required because no Go files/imports/top-level tests, Bazel files, or module files were added or changed.

Commands:
- `./tools/check/failpoint-go-test.sh br/pkg/streamhelper -run '^TestIntegration/(TestStreamListening|TestStreamClose)$' -count=20 -race`
- `bazel test //br/pkg/streamhelper:streamhelper_test --test_filter='TestIntegration/TestStreamListening' --test_output=errors`
- `make lint`
- `git diff --check`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stream listeners now accurately report context cancellation when task or pause event channels close.
  * Remaining events are collected before cancellation errors are emitted, helping preserve event delivery during shutdown.

* **Tests**
  * Stream listening tests now use bounded waits and validate event ordering, range handling, and successful event receipt.
  * Test contexts are canceled during cleanup to ensure reliable shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
