### PR TITLE
test: stabilize flaky TestIntegration

### DIFF
--- a/br/pkg/streamhelper/integration_test.go
+++ b/br/pkg/streamhelper/integration_test.go
@@ -48,25 +48,33 @@ func getRandomLocalAddr() url.URL {
 }
 
 func runEtcd(t *testing.T) (*embed.Etcd, *clientv3.Client) {
-	cfg := embed.NewConfig()
-	cfg.Dir = t.TempDir()
-	clientURL := getRandomLocalAddr()
-	cfg.ListenClientUrls = []url.URL{clientURL}
-	cfg.ListenPeerUrls = []url.URL{getRandomLocalAddr()}
-	cfg.LogLevel = "fatal"
-	etcd, err := embed.StartEtcd(cfg)
-	if err != nil {
-		log.Panic("failed to start etcd server", logutil.ShortError(err))
+	const maxEtcdStartAttempts = 10
+	for attempt := range maxEtcdStartAttempts {
+		cfg := embed.NewConfig()
+		cfg.Dir = t.TempDir()
+		clientURL := getRandomLocalAddr()
+		cfg.ListenClientUrls = []url.URL{clientURL}
+		cfg.ListenPeerUrls = []url.URL{getRandomLocalAddr()}
+		cfg.LogLevel = "fatal"
+		etcd, err := embed.StartEtcd(cfg)
+		if err != nil {
+			if attempt == maxEtcdStartAttempts-1 {
+				log.Panic("failed to start etcd server", logutil.ShortError(err))
+			}
+			continue
+		}
+		<-etcd.Server.ReadyNotify()
+		cliCfg := clientv3.Config{
+			Endpoints: []string{clientURL.String()},
+		}
+		cli, err := clientv3.New(cliCfg)
+		if err != nil {
+			etcd.Close()
+			log.Panic("failed to connect to etcd server", logutil.ShortError(err))
+		}
+		return etcd, cli
 	}
-	<-etcd.Server.ReadyNotify()
-	cliCfg := clientv3.Config{
-		Endpoints: []string{clientURL.String()},
-	}
-	cli, err := clientv3.New(cliCfg)
-	if err != nil {
-		log.Panic("failed to connect to etcd server", logutil.ShortError(err))
-	}
-	return etcd, cli
+	panic("unreachable")
 }
 
 func simpleRanges(tableCount int) streamhelper.Ranges {
@@ -138,7 +146,10 @@ func rangeIsEmpty(t *testing.T, prefix []byte, etcd *embed.Etcd) {
 
 func TestIntegration(t *testing.T) {
 	etcd, cli := runEtcd(t)
-	defer etcd.Server.Stop()
+	t.Cleanup(func() {
+		require.NoError(t, cli.Close())
+		etcd.Close()
+	})
 	metaCli := streamhelper.MetaDataClient{Client: cli}
 	t.Run("TestBasic", func(t *testing.T) { testBasic(t, metaCli, etcd) })
 	t.Run("testGetStorageCheckpoint", func(t *testing.T) { testGetStorageCheckpoint(t, metaCli) })


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69983

Problem Summary:
Flaky test `TestIntegration` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Embedded etcd setup raced on released random ports and cleanup did not fully close the client/server wrapper.

#### Fix

Retrying only failed etcd startup and fully closing test-owned resources removes setup noise without changing the streamhelper behavior being asserted.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestIntegration`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_failpoint_case passed.
package_failpoint passed.
build passed.

Gate checklist:
- target_failpoint_case: PASS
- target_raw_runtime: SKIPPED
- package_failpoint: PASS
- build: PASS

Commands:
- `./tools/check/failpoint-go-test.sh br/pkg/streamhelper -json -run '^TestIntegration$' -count=1`
- `./tools/check/failpoint-go-test.sh br/pkg/streamhelper -json -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test startup reliability with bounded retries and readiness checks for the embedded etcd service.
  * Added explicit cleanup for the embedded service and client connections, helping ensure consistent test isolation and shutdown behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->