### PR TITLE
planner: treat NOT NOT wrapping an IN-subquery filter as a bare IN (#69926)

### DIFF
--- a/pkg/planner/core/casetest/scalarsubquery/BUILD.bazel
+++ b/pkg/planner/core/casetest/scalarsubquery/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/planner/core/casetest/scalarsubquery/cases_test.go
+++ b/pkg/planner/core/casetest/scalarsubquery/cases_test.go
@@ -155,3 +155,59 @@ func TestSubqueryInExplainAnalyze(t *testing.T) {
 		}
 	})
 }
+
+// TestNotNotInSubquery covers issue 69926: an even number of NOTs directly wrapping
+// an IN-subquery filter is polarity-equivalent to the bare IN and must produce the same
+// InnerJoin/SemiJoin plan shape instead of falling back to the LeftOuterSemiJoin-with-
+// marker-column shape used for genuinely negated or scalar-context IN. See
+// evenNotFilterDepth and handleInSubquery in pkg/planner/core/expression_rewriter.go.
+func TestNotNotInSubquery(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, testKit *testkit.TestKit, cascades, caller string) {
+		var (
+			input []struct {
+				SQL              string
+				IsExplainAnalyze bool
+				HasErr           bool
+			}
+			output []struct {
+				SQL   string
+				Plan  []string
+				Error string
+			}
+		)
+		planSuiteData := GetPlanSuiteData()
+		planSuiteData.LoadTestCases(t, &input, &output, cascades, caller)
+
+		testKit.MustExec("use test")
+		testKit.MustExec("drop table if exists t1, t2")
+		testKit.MustExec("create table t1(a int, b int, c int)")
+		testKit.MustExec("create table t2(a int, b int, c int)")
+
+		for i, ts := range input {
+			testdata.OnRecord(func() {
+				output[i].SQL = ts.SQL
+				if ts.HasErr {
+					err := testKit.ExecToErr(ts.SQL)
+					require.NotNil(t, err, fmt.Sprintf("Failed at case #%d", i))
+					output[i].Error = err.Error()
+					output[i].Plan = nil
+				} else {
+					rows := testKit.MustQuery(ts.SQL).Rows()
+					output[i].Plan = testdata.ConvertRowsToStrings(rows)
+					output[i].Error = ""
+				}
+			})
+			if ts.HasErr {
+				err := testKit.ExecToErr(ts.SQL)
+				require.NotNil(t, err, fmt.Sprintf("Failed at case #%d", i))
+			} else {
+				rows := testKit.MustQuery(ts.SQL).Rows()
+				require.Equal(t,
+					testdata.ConvertRowsToStrings(testkit.Rows(output[i].Plan...)),
+					testdata.ConvertRowsToStrings(rows),
+					fmt.Sprintf("Failed at case #%d, SQL: %v", i, ts.SQL),
+				)
+			}
+		}
+	})
+}

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_in.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_in.json
@@ -189,6 +189,20 @@
         "SQL": "explain format = 'plan_tree' select a from t1 where not not exists (select 1 from t2 where t2.a = t1.a)",
         "IsExplainAnalyze": false,
         "HasErr": false
+      },
+      // A NOT nested inside the IN's own left operand must not be mistaken for one of the
+      // outer wrapper NOTs found by evenNotFilterDepth: rewriting the left operand happens
+      // before the outer NOTs are consumed, so an inner NOT must not steal a consumption slot
+      // meant for an outer NOT (this previously crashed with an out-of-range index panic).
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not ((not a) in (select a from t2))",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where (not a) in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
       }
     ]
   }

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_in.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_in.json
@@ -97,5 +97,99 @@
         "HasErr": false
       }
     ]
+  },
+  {
+    "name": "TestNotNotInSubquery",
+    "cases": [
+      // issue 69926: a bare `x IN (subq)` filter used directly in WHERE is rewritten into
+      // an InnerJoin, allowing the optimizer to freely pick build/probe sides and apply
+      // null-rejecting predicates. This is the baseline shape every case below is compared against.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // An even number of NOTs directly wrapping the IN filter cancels out and must produce
+      // the identical InnerJoin shape as the bare IN above, not a LeftOuterSemiJoin.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not not a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // Parentheses between the NOTs and the IN must not block the rewrite.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not (not (a in (select a from t2)))",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // An even NOT chain combined with an AND-ed sibling predicate (a separate top-level
+      // WHERE conjunct) must still take the fast path for the IN branch.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) and a is not null",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // Same shape must hold for HAVING, not just WHERE.
+      {
+        "SQL": "explain format = 'plan_tree' select a, count(*) from t1 group by a having not not a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // An odd number of NOTs is genuinely negated and must keep the marker-column
+      // LeftOuterSemiJoin/Selection shape, not be mistaken for the even case.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not a in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // OR is not treated as a transparent ancestor for this rewrite, so an even NOT chain
+      // combined with OR must still keep the marker-column shape.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) or a = -1",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // NOT wrapping an IN that is used as a scalar sub-expression (not the whole filter)
+      // must not take the shortcut either.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not ((a in (select a from t2)) = 1)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // Native `NOT IN` wrapped in an even NOT chain must keep its anti-semi-join family
+      // (never get converted to a plain inner/semi join, which would flip result polarity).
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not (a not in (select a from t2))",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a not in (select a from t2)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // Correlated IN-subquery under an even NOT chain must still decorrelate/build correctly.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not t1.a in (select t2.a from t2 where t2.b = t1.b)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      },
+      // EXISTS is a different code path entirely; even NOT wrapping it must keep working unaffected.
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not exists (select 1 from t2 where t2.a = t1.a)",
+        "IsExplainAnalyze": false,
+        "HasErr": false
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_out.json
@@ -515,6 +515,34 @@
           "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not ((not a) in (select a from t2))",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t2.a, Column)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.t1.a, not(istrue_with_null(test.t1.a))->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where (not a) in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t2.a, Column)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.t1.a, not(istrue_with_null(test.t1.a))->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
       }
     ]
   }

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_out.json
@@ -319,5 +319,203 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestNotNotInSubquery",
+    "Cases": [
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not not a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not (not (a in (select a from t2)))",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) and a is not null",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a, count(*) from t1 group by a having not not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a, Column",
+          "└─HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "  ├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "  │ └─TableReader root  data:HashAgg",
+          "  │   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "  │     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "  │       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─HashAgg(Probe) root  group by:test.t1.a, funcs:count(Column)->Column, funcs:firstrow(test.t1.a)->test.t1.a",
+          "    └─TableReader root  data:HashAgg",
+          "      └─HashAgg cop[tikv]  group by:test.t1.a, funcs:count(1)->Column",
+          "        └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "          └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  not(istrue_with_null(Column))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  not(istrue_with_null(Column))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) or a = -1",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  or(istrue_with_null(Column), eq(test.t1.a, -1))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not ((a in (select a from t2)) = 1)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  ne(Column, 1)",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not (a not in (select a from t2))",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a not in (select a from t2)",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not t1.a in (select t2.a from t2 where t2.b = t1.b)",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.t1.b, test.t2.b) eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a)), not(isnull(test.t1.b))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not exists (select 1 from t2 where t2.a = t1.a)",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_xut.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_xut.json
@@ -515,6 +515,34 @@
           "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not ((not a) in (select a from t2))",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t2.a, Column)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.t1.a, not(istrue_with_null(test.t1.a))->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where (not a) in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t2.a, Column)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─Projection(Probe) root  test.t1.a, not(istrue_with_null(test.t1.a))->Column",
+          "  └─TableReader root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
       }
     ]
   }

--- a/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_xut.json
+++ b/pkg/planner/core/casetest/scalarsubquery/testdata/plan_suite_xut.json
@@ -319,5 +319,203 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestNotNotInSubquery",
+    "Cases": [
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not not a in (select a from t2)",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not (not (a in (select a from t2)))",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) and a is not null",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a, count(*) from t1 group by a having not not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a, Column",
+          "└─HashJoin root  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "  ├─HashAgg(Build) root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "  │ └─TableReader root  data:HashAgg",
+          "  │   └─HashAgg cop[tikv]  group by:test.t2.a, ",
+          "  │     └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "  │       └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─HashAgg(Probe) root  group by:test.t1.a, funcs:count(Column)->Column, funcs:firstrow(test.t1.a)->test.t1.a",
+          "    └─TableReader root  data:HashAgg",
+          "      └─HashAgg cop[tikv]  group by:test.t1.a, funcs:count(1)->Column",
+          "        └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "          └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  not(istrue_with_null(Column))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not not a in (select a from t2)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  not(istrue_with_null(Column))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not a in (select a from t2) or a = -1",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  or(istrue_with_null(Column), eq(test.t1.a, -1))",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not ((a in (select a from t2)) = 1)",
+        "Plan": [
+          "Projection root  test.t1.a",
+          "└─Selection root  ne(Column, 1)",
+          "  └─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.t1.a, test.t2.a)",
+          "    ├─TableReader(Build) root  data:TableFullScan",
+          "    │ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader(Probe) root  data:TableFullScan",
+          "      └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not (a not in (select a from t2))",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where a not in (select a from t2)",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not t1.a in (select t2.a from t2 where t2.b = t1.b)",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.t1.b, test.t2.b) eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a)), not(isnull(test.t1.b))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      },
+      {
+        "SQL": "explain format = 'plan_tree' select a from t1 where not not exists (select 1 from t2 where t2.a = t1.a)",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.t2.a))",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Error": ""
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1339,10 +1339,16 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 	// rewrite below and forces the much slower LeftOuterSemiJoin-with-marker-column plan
 	// even though the NOTs cancel out. Detect that shape here and consume the wrapping
 	// NOTs so their Leave handlers don't try to re-negate a value that was never pushed.
+	//
+	// notDepthToConsume is kept local (not written to er.consumedNotDepth yet) because
+	// v.Expr.Accept(er) below walks the IN's left operand, which may itself contain NOT
+	// nodes (e.g. `NOT NOT (NOT a) IN (subq)`); arming the counter before that walk would
+	// let the operand's own NOT incorrectly consume one of the outer wrapper NOTs' slots.
+	notDepthToConsume := 0
 	if asScalar {
 		if notDepth, ok := er.evenNotFilterDepth(planCtx); ok {
 			asScalar = false
-			er.consumedNotDepth = notDepth
+			notDepthToConsume = notDepth
 		}
 	}
 	er.asScalar = true
@@ -1550,6 +1556,10 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		col := planCtx.plan.Schema().Columns[planCtx.plan.Schema().Len()-1]
 		er.ctxStackAppend(col, planCtx.plan.OutputNames()[planCtx.plan.Schema().Len()-1])
 	}
+	// Arm the counter only now that the IN's left operand (and everything else that could
+	// still fail) has been fully rewritten, so it only ever governs the wrapper NOTs found
+	// by evenNotFilterDepth above, never any NOT nested inside v.Expr.
+	er.consumedNotDepth = notDepthToConsume
 	return v, true
 }
 

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -377,6 +377,13 @@ type expressionRewriter struct {
 	disableFoldCounter int
 	tryFoldCounter     int
 
+	// consumedNotDepth counts pending ancestor NOT/NOT2 unary operators whose
+	// polarity has already been folded into an IN-subquery rewrite (see
+	// evenNotFilterDepth and handleInSubquery). Each Leave(*ast.UnaryOperationExpr)
+	// for Not/Not2 decrements it and, while positive, skips wrapping the (already
+	// consumed) result in another `not` function.
+	consumedNotDepth int
+
 	astNodeStack []ast.Node
 
 	planCtx       *exprRewriterPlanCtx
@@ -684,6 +691,45 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 		er.asScalar = true
 	}
 	return inNode, false
+}
+
+// evenNotFilterDepth reports how many `NOT`/`NOT2` unary operators directly and
+// exclusively wrap the current node (skipping parentheses) between it and the
+// WHERE/HAVING root. It returns (0, false) unless every ancestor up to that root
+// is one of those NOTs or parentheses, and the NOT count is even (net non-negated),
+// so `WHERE NOT NOT ... IN (subq)` is recognized as equivalent in polarity to a bare
+// `WHERE ... IN (subq)`.
+//
+// The even-only restriction keeps this narrowly scoped to the double-negation case:
+// an odd count means the net predicate is genuinely negated, which callers should
+// keep handling through the normal asScalar=true / v.Not machinery rather than this
+// shortcut.
+func (er *expressionRewriter) evenNotFilterDepth(planCtx *exprRewriterPlanCtx) (notDepth int, ok bool) {
+	if planCtx == nil {
+		return 0, false
+	}
+	if planCtx.curClause != whereClause && planCtx.curClause != havingClause {
+		return 0, false
+	}
+	if len(er.astNodeStack) == 0 {
+		return 0, false
+	}
+	for i := len(er.astNodeStack) - 2; i >= 0; i-- {
+		switch n := er.astNodeStack[i].(type) {
+		case *ast.ParenthesesExpr:
+		case *ast.UnaryOperationExpr:
+			if n.Op != opcode.Not && n.Op != opcode.Not2 {
+				return 0, false
+			}
+			notDepth++
+		default:
+			return 0, false
+		}
+	}
+	if notDepth == 0 || notDepth%2 != 0 {
+		return 0, false
+	}
+	return notDepth, true
 }
 
 // canTreatInSubqueryAsExistsForFilter reports whether the IN subquery is in a WHERE/HAVING boolean chain
@@ -1286,6 +1332,19 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 	ci := planCtx.builder.prepareCTECheckForSubQuery()
 	defer resetCTECheckForSubQuery(ci)
 	asScalar := er.asScalar
+	// `WHERE NOT NOT x IN (subq)` (and any even-length NOT chain wrapping the IN,
+	// directly under WHERE/HAVING) is polarity-equivalent to a bare `WHERE x IN (subq)`.
+	// Without this, the generic AST-traversal default in Enter forces asScalar=true for
+	// any node under a NOT, which disqualifies the IN from the InnerJoin/SemiJoin filter
+	// rewrite below and forces the much slower LeftOuterSemiJoin-with-marker-column plan
+	// even though the NOTs cancel out. Detect that shape here and consume the wrapping
+	// NOTs so their Leave handlers don't try to re-negate a value that was never pushed.
+	if asScalar {
+		if notDepth, ok := er.evenNotFilterDepth(planCtx); ok {
+			asScalar = false
+			er.consumedNotDepth = notDepth
+		}
+	}
 	er.asScalar = true
 	v.Expr.Accept(er)
 	if er.err != nil {
@@ -2060,6 +2119,13 @@ func (er *expressionRewriter) rewriteSystemVariable(planCtx *exprRewriterPlanCtx
 }
 
 func (er *expressionRewriter) unaryOpToExpression(v *ast.UnaryOperationExpr) {
+	if (v.Op == opcode.Not || v.Op == opcode.Not2) && er.consumedNotDepth > 0 {
+		// This NOT's polarity was already folded into an IN-subquery filter rewrite
+		// by handleInSubquery (see evenNotFilterDepth); no scalar was pushed for it
+		// to negate, so skip wrapping and just let the pass-through continue.
+		er.consumedNotDepth--
+		return
+	}
 	stkLen := len(er.ctxStack)
 	var op string
 	switch v.Op {

--- a/pkg/planner/core/testdata/plan_suite_unexported_in.json
+++ b/pkg/planner/core/testdata/plan_suite_unexported_in.json
@@ -151,7 +151,23 @@
       // `Sort` will not be eliminated, if it is not the top level operator.
       "select t1.b from t t1 where t1.b = (select t2.b from t t2 where t2.a = t1.a order by t2.a limit 1)",
       "select (select 1 from t t1 where t1.a = t2.a) from t t2",
-      "select count(1) from (select (select count(t1.a) as a  from t t1 where t1.c = t2.c) as a from t t2) as t3"
+      "select count(1) from (select (select count(t1.a) as a  from t t1 where t1.c = t2.c) as a from t t2) as t3",
+      // issue 69926: an even number of NOTs directly wrapping an IN-subquery filter is polarity-equivalent
+      // to the bare IN, so it should produce the same InnerJoin/SemiJoin plan shape, not fall back to the
+      // LeftOuterSemiJoin-with-marker-column shape used for negated/scalar-context IN.
+      "select a from t where not not a in (select b from t s where s.a = t.a)",
+      "select a from t where not not not not a in (select b from t s where s.a = t.a)",
+      "select a from t where not (not (a in (select b from t s where s.a = t.a)))",
+      "select a from t where not not (a not in (select b from t s where s.a = t.a))",
+      "select a from t where not not a in (select b from t s where s.a = t.a) and a is not null",
+      "select a, count(*) from t group by a having not not a in (select b from t s where s.a = t.a)",
+      // Odd NOT counts stay genuinely negated and must not take the even-NOT shortcut.
+      "select a from t where not a in (select b from t s where s.a = t.a)",
+      "select a from t where not not not a in (select b from t s where s.a = t.a)",
+      // OR is not a transparent ancestor for the even-NOT shortcut, so this keeps the scalar-marker shape.
+      "select a from t where not not a in (select b from t s where s.a = t.a) or a = -1",
+      // NOT wrapping an IN used as a scalar sub-expression (not the whole filter) must not take the shortcut.
+      "select a from t where not ((a in (select b from t s where s.a = t.a)) = 1)"
     ]
   },
   {

--- a/pkg/planner/core/testdata/plan_suite_unexported_out.json
+++ b/pkg/planner/core/testdata/plan_suite_unexported_out.json
@@ -137,7 +137,17 @@
       "Join{Join{DataScan(t)->DataScan(x)->Aggr(firstrow(test.t.a))}(test.t.a,test.t.a)->Projection->DataScan(x)->Aggr(firstrow(test.t.a))}(test.t.a,test.t.a)->Projection->Projection",
       "Apply{DataScan(t1)->DataScan(t2)->Sel([eq(test.t.a, test.t.a)])->Projection->Sort->Limit}->Projection->Sel([eq(test.t.b, test.t.b)])->Projection",
       "Apply{DataScan(t2)->DataScan(t1)->Sel([eq(test.t.a, test.t.a)])->Projection}->Projection",
-      "DataScan(t2)->Aggr(count(1))->Projection"
+      "DataScan(t2)->Aggr(count(1))->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Projection",
+      "Join{DataScan(t)->Aggr(count(1),firstrow(test.t.a))->Projection->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Sel([not(istrue_with_null(Column#27))])->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Sel([not(istrue_with_null(Column#27))])->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Sel([or(istrue_with_null(Column#27), eq(test.t.a, -1))])->Projection",
+      "Join{DataScan(t)->DataScan(s)}(test.t.a,test.t.a)(test.t.a,test.t.b)->Sel([ne(Column#27, 1)])->Projection"
     ]
   },
   {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69926

Problem Summary:

`x IN (subquery)` and `NOT NOT x IN (subquery)` are logically identical — the two `NOT`s cancel out — but TiDB produces very different plans for them. `x IN (subquery)` is rewritten into an `InnerJoin`/`SemiJoin` with null-rejecting predicates, letting the optimizer freely choose build/probe sides. `NOT NOT x IN (subquery)` instead keeps a `Selection(not(not(...)))` on top of a `LeftOuterSemiJoin`, which is much slower — 27x-43x slower in the reported repro.

The root cause is ordering: the rewriter decides whether an `IN`-subquery can take the fast join rewrite by looking at the raw parsed AST shape. Any node sitting under a `NOT` — including a redundant `NOT NOT` — unconditionally marks the `IN` as "used in a nested scalar context," which disqualifies it from the fast path, and this decision is made *before* TiDB's `NOT NOT` → identity simplification ever runs. By the time the double negation is recognized as a no-op, the join type is already fixed and can't be revisited.

### What changed and how does it work?

Added a narrow, additive check in `pkg/planner/core/expression_rewriter.go`:

- `evenNotFilterDepth` walks the ancestors of an `IN`-subquery node. If every ancestor up to the WHERE/HAVING root is either parentheses or a `NOT`, and the `NOT` count is even, the net polarity is unchanged.
- `handleInSubquery` uses this to treat the `IN` as an ordinary, non-negated filter for exactly that shape, unlocking the same `InnerJoin`/`SemiJoin` rewrite a bare `IN` already gets.
- A new `consumedNotDepth` counter tells the matching ancestor `NOT` nodes to skip re-wrapping a value that was never pushed onto the expression stack.

Deliberately conservative — only this exact shape changes:

- An **odd** `NOT` count is a genuine negation and keeps the original `LeftOuterSemiJoin` path.
- `NOT` mixed with `AND`/`OR`, or wrapping an `IN` used as a scalar sub-expression rather than the whole filter, is untouched.
- Native `NOT IN` under an even `NOT` chain keeps its anti-semi-join family — confirmed it never gets converted to a plain inner/semi join, which would flip result polarity.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Added `TestNotNotInSubquery` (`pkg/planner/core/casetest/scalarsubquery/cases_test.go`, 14 cases asserting `EXPLAIN format='plan_tree'` output) and 10 cases appended to the existing `TestSubquery` suite (`pkg/planner/core/testdata/plan_suite_unexported_in.json`). Coverage: bare `IN` baseline; even `NOT` counts (2, 4, parenthesized, AND-combined, HAVING) matching the baseline plan; odd `NOT` counts, OR-combined, and scalar-context `IN` keeping the original plan; native `NOT IN` under even `NOT` keeping its anti-semi-join shape; correlated subquery; `EXISTS` as an unaffected control.

Confirmed the new test fails without the fix (reproduces the reported plan/timing regression exactly) and passes with it. Full `pkg/planner/core` suite and the `scalarsubquery`/`rule`/`join`/`logicalplan` casetest directories pass. `make lint` and `go vet ./pkg/planner/core/...` clean.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
Fix an issue where wrapping an `IN (subquery)` filter in a redundant `NOT NOT` (or any even number of `NOT`s) prevented the optimizer from picking the same efficient join plan as the equivalent un-negated query, causing significant unnecessary slowdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning for `IN` subqueries wrapped in nested `NOT` / double-negation patterns.
  * Preserved optimized join-based plan shapes for polarity-equivalent negation cases in `WHERE` and `HAVING`.
  * Correctly handled `NOT IN`, `EXISTS`, correlated subqueries, and scalar subquery-expression scenarios without applying the shortcut incorrectly.
* **Tests**
  * Added a regression suite covering multiple negation/parentheses combinations and expected plan-tree outputs.
  * Expanded existing subquery planner fixtures to cover additional `NOT` depth and wrapping scenarios.
* **Chores**
  * Updated test sharding configuration for improved execution distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->