### PR TITLE
planner: fix partial index wrongly kept due to shared Range pointer mutation

### DIFF
--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -681,7 +681,11 @@ func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive 
 		return bytes.Compare(i.encodedStart, j.encodedStart)
 	})
 	ranges = ranges[:0]
-	lastRange := objects[0]
+	lastRange := &sortRange{
+		originalValue: objects[0].originalValue.Clone(),
+		encodedStart:  objects[0].encodedStart,
+		encodedEnd:    objects[0].encodedEnd,
+	}
 	for i := 1; i < len(objects); i++ {
 		if (mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0) ||
 			(!mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) > 0) {
@@ -692,7 +696,9 @@ func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive 
 			}
 		} else {
 			ranges = append(ranges, lastRange.originalValue)
-			lastRange = objects[i]
+			lastRange.encodedStart = objects[i].encodedStart
+			lastRange.encodedEnd = objects[i].encodedEnd
+			lastRange.originalValue = objects[i].originalValue.Clone()
 		}
 	}
 	ranges = append(ranges, lastRange.originalValue)

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -688,11 +688,11 @@ func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive 
 	for i := 1; i < len(objects); i++ {
 		if (mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0) ||
 			(!mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) > 0) {
-			if !detached {
-				lastRange.originalValue = lastRange.originalValue.Clone()
-				detached = true
-			}
 			if bytes.Compare(lastRange.encodedEnd, objects[i].encodedEnd) < 0 {
+				if !detached {
+					lastRange.originalValue = lastRange.originalValue.Clone()
+					detached = true
+				}
 				lastRange.encodedEnd = objects[i].encodedEnd
 				lastRange.originalValue.HighVal = objects[i].originalValue.HighVal
 				lastRange.originalValue.HighExclude = objects[i].originalValue.HighExclude

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -653,6 +653,8 @@ type sortRange struct {
 // For two intervals [a, b], [c, d], we have guaranteed that a <= c. If b >= c. Then two intervals are overlapped.
 // And this two can be merged as [a, max(b, d)].
 // Otherwise they aren't overlapped.
+//
+// The function does not modify the caller's ranges (see issue #69779).
 func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive bool) (Ranges, error) {
 	if len(ranges) == 0 {
 		return nil, nil
@@ -681,14 +683,15 @@ func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive 
 		return bytes.Compare(i.encodedStart, j.encodedStart)
 	})
 	ranges = ranges[:0]
-	lastRange := &sortRange{
-		originalValue: objects[0].originalValue.Clone(),
-		encodedStart:  objects[0].encodedStart,
-		encodedEnd:    objects[0].encodedEnd,
-	}
+	lastRange := objects[0]
+	detached := false
 	for i := 1; i < len(objects); i++ {
 		if (mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0) ||
 			(!mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) > 0) {
+			if !detached {
+				lastRange.originalValue = lastRange.originalValue.Clone()
+				detached = true
+			}
 			if bytes.Compare(lastRange.encodedEnd, objects[i].encodedEnd) < 0 {
 				lastRange.encodedEnd = objects[i].encodedEnd
 				lastRange.originalValue.HighVal = objects[i].originalValue.HighVal
@@ -696,9 +699,8 @@ func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive 
 			}
 		} else {
 			ranges = append(ranges, lastRange.originalValue)
-			lastRange.encodedStart = objects[i].encodedStart
-			lastRange.encodedEnd = objects[i].encodedEnd
-			lastRange.originalValue = objects[i].originalValue.Clone()
+			lastRange = objects[i]
+			detached = false
 		}
 	}
 	ranges = append(ranges, lastRange.originalValue)

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -654,7 +654,8 @@ type sortRange struct {
 // And this two can be merged as [a, max(b, d)].
 // Otherwise they aren't overlapped.
 //
-// The function does not modify the caller's ranges (see issue #69779).
+// The function may reuse the caller's backing slice, but never mutates
+// the caller's Range objects in-place (see issue #69779).
 func UnionRanges(sctx *rangerctx.RangerContext, ranges Ranges, mergeConsecutive bool) (Ranges, error) {
 	if len(ranges) == 0 {
 		return nil, nil

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2640,8 +2640,10 @@ func TestUnionRangesPreservesCallerRanges(t *testing.T) {
 	sctx := tk.Session()
 	rctx := sctx.GetRangerCtx()
 
-	// Build 3 ranges where r1 and r2 overlap so they trigger the merge path.
+	// First group: r1 and r2 overlap, r3 is disjoint.
 	// r1 = [1, 3], r2 = [2, 4], r3 = [5, 7].
+	// Second group: r4 and r5 overlap, covers the "start new merge" branch.
+	// r4 = [10, 13], r5 = [12, 15].
 	binaryCollator := collate.GetBinaryCollator()
 	r1 := &ranger.Range{
 		LowVal:      []types.Datum{types.NewIntDatum(1)},
@@ -2664,17 +2666,34 @@ func TestUnionRangesPreservesCallerRanges(t *testing.T) {
 		HighExclude: false,
 		Collators:   []collate.Collator{binaryCollator},
 	}
-	input := ranger.Ranges{r1, r2, r3}
+	r4 := &ranger.Range{
+		LowVal:      []types.Datum{types.NewIntDatum(10)},
+		HighVal:     []types.Datum{types.NewIntDatum(13)},
+		LowExclude:  false,
+		HighExclude: false,
+		Collators:   []collate.Collator{binaryCollator},
+	}
+	r5 := &ranger.Range{
+		LowVal:      []types.Datum{types.NewIntDatum(12)},
+		HighVal:     []types.Datum{types.NewIntDatum(15)},
+		LowExclude:  false,
+		HighExclude: false,
+		Collators:   []collate.Collator{binaryCollator},
+	}
+	input := ranger.Ranges{r1, r2, r3, r4, r5}
 
 	// r1 and r2 overlap -> merged to [1, 4]. r3 is disjoint -> kept as [5, 7].
-	// Expected result: [[1, 4], [5, 7]].
+	// r4 and r5 overlap -> merged to [10, 15].
+	// Expected result: [[1, 4], [5, 7], [10, 15]].
 	result, err := ranger.UnionRanges(rctx, input, false /* mergeConsecutive */)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(result))
+	require.Equal(t, 3, len(result))
 	require.Equal(t, int64(1), result[0].LowVal[0].GetInt64())
 	require.Equal(t, int64(4), result[0].HighVal[0].GetInt64())
 	require.Equal(t, int64(5), result[1].LowVal[0].GetInt64())
 	require.Equal(t, int64(7), result[1].HighVal[0].GetInt64())
+	require.Equal(t, int64(10), result[2].LowVal[0].GetInt64())
+	require.Equal(t, int64(15), result[2].HighVal[0].GetInt64())
 
 	// The original range objects must not be modified.
 	require.Equal(t, int64(1), r1.LowVal[0].GetInt64())
@@ -2686,16 +2705,26 @@ func TestUnionRangesPreservesCallerRanges(t *testing.T) {
 	require.Equal(t, int64(5), r3.LowVal[0].GetInt64())
 	require.Equal(t, int64(7), r3.HighVal[0].GetInt64())
 	require.False(t, r3.HighExclude)
+	require.Equal(t, int64(10), r4.LowVal[0].GetInt64())
+	require.Equal(t, int64(13), r4.HighVal[0].GetInt64())
+	require.False(t, r4.HighExclude)
+	require.Equal(t, int64(12), r5.LowVal[0].GetInt64())
+	require.Equal(t, int64(15), r5.HighVal[0].GetInt64())
+	require.False(t, r5.HighExclude)
 
 	// [1, 4] and [5, 7] are consecutive after encoding (PrefixNext makes
 	// the encoded end of [1, 4] touch the encoded start of [5, 7]),
-	// so all three ranges merge into one: [1, 7].
-	input = ranger.Ranges{r1, r2, r3}
+	// so the first three ranges merge into [1, 7].
+	// r4 and r5 overlap -> merged to [10, 15], disjoint from [1, 7].
+	// Expected result: [[1, 7], [10, 15]].
+	input = ranger.Ranges{r1, r2, r3, r4, r5}
 	result2, err := ranger.UnionRanges(rctx, input, true /* mergeConsecutive */)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(result2))
+	require.Equal(t, 2, len(result2))
 	require.Equal(t, int64(1), result2[0].LowVal[0].GetInt64())
 	require.Equal(t, int64(7), result2[0].HighVal[0].GetInt64())
+	require.Equal(t, int64(10), result2[1].LowVal[0].GetInt64())
+	require.Equal(t, int64(15), result2[1].HighVal[0].GetInt64())
 
 	// The original range objects still must not be modified.
 	require.Equal(t, int64(1), r1.LowVal[0].GetInt64())
@@ -2707,6 +2736,12 @@ func TestUnionRangesPreservesCallerRanges(t *testing.T) {
 	require.Equal(t, int64(5), r3.LowVal[0].GetInt64())
 	require.Equal(t, int64(7), r3.HighVal[0].GetInt64())
 	require.False(t, r3.HighExclude)
+	require.Equal(t, int64(10), r4.LowVal[0].GetInt64())
+	require.Equal(t, int64(13), r4.HighVal[0].GetInt64())
+	require.False(t, r4.HighExclude)
+	require.Equal(t, int64(12), r5.LowVal[0].GetInt64())
+	require.Equal(t, int64(15), r5.HighVal[0].GetInt64())
+	require.False(t, r5.HighExclude)
 }
 
 func TestBinCollationRangeForIndex(t *testing.T) {

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2633,6 +2633,82 @@ func TestMinAccessCondsForDNFCond(t *testing.T) {
 	}
 }
 
+func TestUnionRangesPreservesCallerRanges(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	sctx := tk.Session()
+	rctx := sctx.GetRangerCtx()
+
+	// Build 3 ranges where r1 and r2 overlap so they trigger the merge path.
+	// r1 = [1, 3], r2 = [2, 4], r3 = [5, 7].
+	binaryCollator := collate.GetBinaryCollator()
+	r1 := &ranger.Range{
+		LowVal:      []types.Datum{types.NewIntDatum(1)},
+		HighVal:     []types.Datum{types.NewIntDatum(3)},
+		LowExclude:  false,
+		HighExclude: false,
+		Collators:   []collate.Collator{binaryCollator},
+	}
+	r2 := &ranger.Range{
+		LowVal:      []types.Datum{types.NewIntDatum(2)},
+		HighVal:     []types.Datum{types.NewIntDatum(4)},
+		LowExclude:  false,
+		HighExclude: false,
+		Collators:   []collate.Collator{binaryCollator},
+	}
+	r3 := &ranger.Range{
+		LowVal:      []types.Datum{types.NewIntDatum(5)},
+		HighVal:     []types.Datum{types.NewIntDatum(7)},
+		LowExclude:  false,
+		HighExclude: false,
+		Collators:   []collate.Collator{binaryCollator},
+	}
+	input := ranger.Ranges{r1, r2, r3}
+
+	// r1 and r2 overlap -> merged to [1, 4]. r3 is disjoint -> kept as [5, 7].
+	// Expected result: [[1, 4], [5, 7]].
+	result, err := ranger.UnionRanges(rctx, input, false /* mergeConsecutive */)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(result))
+	require.Equal(t, int64(1), result[0].LowVal[0].GetInt64())
+	require.Equal(t, int64(4), result[0].HighVal[0].GetInt64())
+	require.Equal(t, int64(5), result[1].LowVal[0].GetInt64())
+	require.Equal(t, int64(7), result[1].HighVal[0].GetInt64())
+
+	// The original range objects must not be modified.
+	require.Equal(t, int64(1), r1.LowVal[0].GetInt64())
+	require.Equal(t, int64(3), r1.HighVal[0].GetInt64())
+	require.False(t, r1.HighExclude)
+	require.Equal(t, int64(2), r2.LowVal[0].GetInt64())
+	require.Equal(t, int64(4), r2.HighVal[0].GetInt64())
+	require.False(t, r2.HighExclude)
+	require.Equal(t, int64(5), r3.LowVal[0].GetInt64())
+	require.Equal(t, int64(7), r3.HighVal[0].GetInt64())
+	require.False(t, r3.HighExclude)
+
+	// [1, 4] and [5, 7] are consecutive after encoding (PrefixNext makes
+	// the encoded end of [1, 4] touch the encoded start of [5, 7]),
+	// so all three ranges merge into one: [1, 7].
+	input = ranger.Ranges{r1, r2, r3}
+	result2, err := ranger.UnionRanges(rctx, input, true /* mergeConsecutive */)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result2))
+	require.Equal(t, int64(1), result2[0].LowVal[0].GetInt64())
+	require.Equal(t, int64(7), result2[0].HighVal[0].GetInt64())
+
+	// The original range objects still must not be modified.
+	require.Equal(t, int64(1), r1.LowVal[0].GetInt64())
+	require.Equal(t, int64(3), r1.HighVal[0].GetInt64())
+	require.False(t, r1.HighExclude)
+	require.Equal(t, int64(2), r2.LowVal[0].GetInt64())
+	require.Equal(t, int64(4), r2.HighVal[0].GetInt64())
+	require.False(t, r2.HighExclude)
+	require.Equal(t, int64(5), r3.LowVal[0].GetInt64())
+	require.Equal(t, int64(7), r3.HighVal[0].GetInt64())
+	require.False(t, r3.HighExclude)
+}
+
 func TestBinCollationRangeForIndex(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
@@ -107,4 +107,22 @@ IndexMerge	5555.56	root		type: union
 ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:tt, index:idx1(a)	range:(10,+inf], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:tt, index:idx2(b)	range:(10,+inf], keep order:false, stats:pseudo
 └─TableRowIDScan(Probe)	5555.56	cop[tikv]	table:tt	keep order:false, stats:pseudo
+drop table if exists t3;
+create table t3(id int primary key, a int not null, b int not null, index pi(b) where a < 3);
+insert into t3 values (1, 0, 1), (2, 1, 2), (3, 2, 3), (4, 3, 4), (5, 10, 5);
+select id, a, b from t3 where a >= 0 order by b limit 5;
+id	a	b
+1	0	1
+2	1	2
+3	2	3
+4	3	4
+5	10	5
+select id, a, b from t3 ignore index(pi) where a >= 0 order by b limit 5;
+id	a	b
+1	0	1
+2	1	2
+3	2	3
+4	3	4
+5	10	5
+drop table t3;
 drop table t, tt;

--- a/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/partialindex.result
@@ -110,6 +110,11 @@ IndexMerge	5555.56	root		type: union
 drop table if exists t3;
 create table t3(id int primary key, a int not null, b int not null, index pi(b) where a < 3);
 insert into t3 values (1, 0, 1), (2, 1, 2), (3, 2, 3), (4, 3, 4), (5, 10, 5);
+explain format='brief' select * from t3 where a >= 0;
+id	estRows	task	access object	operator info
+TableReader	3333.33	root		data:Selection
+└─Selection	3333.33	cop[tikv]		ge(planner__core__casetest__index__partialindex.t3.a, 0)
+  └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 select id, a, b from t3 where a >= 0 order by b limit 5;
 id	a	b
 1	0	1

--- a/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
@@ -36,4 +36,13 @@ explain format='brief' select /*+ inl_join(t2) */ * from tt t1, tt t2 where t1.b
 explain format='brief' select /*+ use_index_merge(t, idx1, idx2) */ * from t where (a > 10) or (b > 10);
 explain format='brief' select /*+ use_index_merge(tt, idx1, idx2) */ * from tt where (a > 10) or (b > 10);
 
+# TestPartialIndexImplicationCheck
+# a >= 0 does NOT imply a < 3, partial index pi should NOT be used.
+drop table if exists t3;
+create table t3(id int primary key, a int not null, b int not null, index pi(b) where a < 3);
+insert into t3 values (1, 0, 1), (2, 1, 2), (3, 2, 3), (4, 3, 4), (5, 10, 5);
+select id, a, b from t3 where a >= 0 order by b limit 5;
+select id, a, b from t3 ignore index(pi) where a >= 0 order by b limit 5;
+drop table t3;
+
 drop table t, tt;

--- a/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
+++ b/tests/integrationtest/t/planner/core/casetest/index/partialindex.test
@@ -41,6 +41,7 @@ explain format='brief' select /*+ use_index_merge(tt, idx1, idx2) */ * from tt w
 drop table if exists t3;
 create table t3(id int primary key, a int not null, b int not null, index pi(b) where a < 3);
 insert into t3 values (1, 0, 1), (2, 1, 2), (3, 2, 3), (4, 3, 4), (5, 10, 5);
+explain format='brief' select * from t3 where a >= 0;
 select id, a, b from t3 where a >= 0 order by b limit 5;
 select id, a, b from t3 ignore index(pi) where a >= 0 order by b limit 5;
 drop table t3;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69779

Problem Summary:

### What changed and how does it work?
When query condition is a >= 0 and partial index condition is a < 3, CheckPartialIndexes wrongly keeps/retains the index (instead of pruning it), leading to incorrect query results. The root cause is UnionRanges mutating shared Range pointers, corrupting the caller's input and causing the implication check to fail. See issue #69779 for details.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated range merging to preserve caller-provided ranges and their boundary metadata.
  * Improved partial-index selection so indexes are not used when query conditions don’t satisfy the index predicate.
* **Tests**
  * Added regression coverage for preserving original range inputs.
  * Added integration coverage for partial-index implication and consistent results when the index is ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->