### PR TITLE
expression: keep month and day when a year/month interval underflows to year 0

### DIFF
--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -3204,7 +3204,17 @@ func (du *baseDateArithmetical) addDate(ctx EvalContext, date types.Time, year, 
 	// fix https://github.com/pingcap/tidb/issues/11329
 	if goTime.Year() == 0 {
 		hour, minute, second := goTime.Clock()
-		date.SetCoreTime(types.FromDate(0, 0, 0, hour, minute, second, goTime.Nanosecond()/1000))
+		// Year/month intervals (day == 0 && nano == 0) do calendar arithmetic, so when
+		// they drive the year down to 0 MySQL keeps the month and day, e.g.
+		// DATE_SUB('1000-01-01', INTERVAL 1000 YEAR) -> 0000-01-01 (issue #59789).
+		// Day/time intervals instead underflow past the minimum datetime and yield a
+		// zero date with the wrapped time, e.g.
+		// DATE_ADD('0001-01-01 00:00:00', INTERVAL -2 HOUR) -> 0000-00-00 22:00:00 (issue #11329).
+		if day == 0 && nano == 0 {
+			date.SetCoreTime(types.FromDate(0, int(goTime.Month()), goTime.Day(), hour, minute, second, goTime.Nanosecond()/1000))
+		} else {
+			date.SetCoreTime(types.FromDate(0, 0, 0, hour, minute, second, goTime.Nanosecond()/1000))
+		}
 		return date, false, nil
 	}
 

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -3204,13 +3204,15 @@ func (du *baseDateArithmetical) addDate(ctx EvalContext, date types.Time, year, 
 	// fix https://github.com/pingcap/tidb/issues/11329
 	if goTime.Year() == 0 {
 		hour, minute, second := goTime.Clock()
-		// Year/month intervals (day == 0 && nano == 0) do calendar arithmetic, so when
-		// they drive the year down to 0 MySQL keeps the month and day, e.g.
+		// Year/month intervals do calendar arithmetic, so when they drive the year down
+		// to 0 MySQL keeps the month and day, e.g.
 		// DATE_SUB('1000-01-01', INTERVAL 1000 YEAR) -> 0000-01-01 (issue #59789).
 		// Day/time intervals instead underflow past the minimum datetime and yield a
 		// zero date with the wrapped time, e.g.
 		// DATE_ADD('0001-01-01 00:00:00', INTERVAL -2 HOUR) -> 0000-00-00 22:00:00 (issue #11329).
-		if day == 0 && nano == 0 {
+		// A nonzero year or month component is what distinguishes the calendar case;
+		// intervals without one (including a zero interval) keep the zero-date normalization.
+		if (year != 0 || month != 0) && day == 0 && nano == 0 {
 			date.SetCoreTime(types.FromDate(0, int(goTime.Month()), goTime.Day(), hour, minute, second, goTime.Nanosecond()/1000))
 		} else {
 			date.SetCoreTime(types.FromDate(0, 0, 0, hour, minute, second, goTime.Nanosecond()/1000))

--- a/pkg/expression/builtin_time_test.go
+++ b/pkg/expression/builtin_time_test.go
@@ -2396,6 +2396,9 @@ func TestDateArithFuncs(t *testing.T) {
 		{"2001-02-28", -1, "2000-02-28"},
 		{"2004-02-29", 1, "2005-02-28"},
 		{"2005-02-28", -1, "2004-02-28"},
+		// A YEAR interval that drives the year down to 0 keeps the month and day,
+		// matching MySQL instead of zeroing them out. See issue #59789.
+		{"1000-01-01", -1000, "0000-01-01"},
 	}
 
 	for _, test := range testYears {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59789

Problem Summary:

`DATE_SUB('1000-01-01', INTERVAL 1000 YEAR)` returned `0000-00-00`, while MySQL returns `0000-01-01`. When an interval drives the resulting year down to 0, `addDate` cleared the month and day unconditionally.

### What changed and how does it work?

The year-0 handling was added for day/time intervals that underflow past the minimum datetime, where MySQL does return a zero date and keeps the wrapped time (e.g. `DATE_ADD('0001-01-01 00:00:00', INTERVAL -2 HOUR)` -> `0000-00-00 22:00:00`, issue #11329). Year/month intervals instead do calendar arithmetic, so MySQL preserves the month and day.

`ParseDurationValue` yields `day == 0 && nano == 0` only for YEAR/MONTH/QUARTER intervals; DAY/WEEK and all time units set `day` or `nano`. Gating the clearing on `day == 0 && nano == 0` keeps the month/day for calendar intervals and leaves the existing day/time underflow behaviour untouched.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix `DATE_ADD`/`DATE_SUB` returning `0000-00-00` instead of `0000-MM-DD` when a YEAR or MONTH interval brings the year down to 0, matching MySQL.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date arithmetic edge cases when year-based calculations reach year zero.
  * When using year/month-style intervals without day/sub-second components, the resulting month and day are now preserved (MySQL-compatible), instead of being incorrectly cleared.
  * Extended test coverage to validate the new behavior for `1000-01-01` with a `-1000` year interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->