### PR TITLE
br: clean up global memory arbitrator before goleak check

### DIFF
--- a/br/cmd/br/BUILD.bazel
+++ b/br/cmd/br/BUILD.bazel
@@ -74,6 +74,8 @@ go_test(
     flaky = True,
     shard_count = 2,
     deps = [
+        "//pkg/testkit/testmain",
+        "//pkg/util/memory",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],

--- a/br/cmd/br/main_test.go
+++ b/br/cmd/br/main_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/testkit/testmain"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -38,7 +40,11 @@ func TestMain(m *testing.M) {
 	os.Args = newArgs
 
 	if !skipLeakTest {
-		goleak.VerifyTestMain(m,
+		cleanup := func(exitCode int) int {
+			memory.CleanupGlobalMemArbitratorForTest()
+			return exitCode
+		}
+		goleak.VerifyTestMain(testmain.WrapTestingM(m, cleanup),
 			goleak.IgnoreCurrent(),
 			goleak.IgnoreTopFunction("github.com/pingcap/tidb/br/pkg/utils.StartExitSingleListener.func1"),
 			goleak.IgnoreTopFunction("github.com/pingcap/tidb/br/pkg/utils.StartDynamicPProfListener.func1"),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70018

Problem Summary:

The BR integration test binary is built without the `intest` build tag. After global memory arbitration became enabled by default, the production startup path starts the global memory arbitrator's background goroutine. The BR test cases finish successfully, but `goleak.VerifyTestMain` reports that goroutine because it is still running when the leak check begins.

### What changed and how does it work?

Wrap `testing.M` with the existing `testmain.WrapTestingM` helper and stop the global memory arbitrator after the tests finish but before `goleak` checks for leaked goroutines.

This keeps the production-like startup path covered and avoids adding the arbitrator goroutine to the `goleak` ignore list.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```text
go test ./br/cmd/br -run '^TestCalculateMemoryLimit$' -count=1
make build_for_br_integration_test
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to release global memory resources after the test suite completes.
  * Enhanced test lifecycle handling to support more reliable leak detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->