### PR TITLE
sessionctx: restore tidb_paging_size_bytes default to 0

### DIFF
--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1519,13 +1519,15 @@ const (
 	DefInitChunkSize                    = 32
 	DefMinPagingSize                    = int(paging.MinPagingSize)
 	DefMaxPagingSize                    = int(paging.MinAllowedMaxPagingSize)
-	// DefPagingSizeBytes defaults byte-budget paging to 4 MiB. It takes effect only when Resource Control
-	// is enabled and the active Resource Group is non-burstable (has limited burst).
+	// DefPagingSizeBytes defaults to 0 (byte-budget paging disabled).
+	// A non-zero value takes effect only when Resource Control is enabled and the active Resource Group
+	// is non-burstable (has limited burst).
 	// Regression tests across cap-bound and under-cap TPC-C, FullScan, and Join workloads found no
-	// material performance regression. Among the tested 1, 2, 4, 8, and 16 MiB candidates, 4 MiB
-	// provided the best overall balance of throughput, tail latency, RU stability, RPC overhead, CPU,
-	// and RU efficiency.
-	DefPagingSizeBytes                      = 4 * 1024 * 1024
+	// material performance regression with byte-budget paging. Among the tested 1, 2, 4, 8, and 16 MiB
+	// candidates, 4 MiB provided the best overall balance of throughput, tail latency, RU stability,
+	// RPC overhead, CPU, and RU efficiency. Consider setting this to 4 MiB (4194304) when enabling
+	// byte-budget paging for resource groups with limited burst.
+	DefPagingSizeBytes                      = 0
 	DefMaxChunkSize                         = 1024
 	DefDMLBatchSize                         = 0
 	DefMaxPreparedStmtCount                 = -1

--- a/tests/integrationtest/r/sessionctx/setvar.result
+++ b/tests/integrationtest/r/sessionctx/setvar.result
@@ -1102,11 +1102,11 @@ select /*+ set_var(tidb_paging_size_bytes=1048576) */ @@tidb_paging_size_bytes;
 1048576
 select @@tidb_paging_size_bytes;
 @@tidb_paging_size_bytes
-4194304
+0
 set @@tidb_paging_size_bytes=default;
 select @@tidb_paging_size_bytes;
 @@tidb_paging_size_bytes
-4194304
+0
 set @@tidb_paging_size_bytes=0;
 select @@tidb_paging_size_bytes;
 @@tidb_paging_size_bytes
@@ -1118,7 +1118,7 @@ select @@tidb_paging_size_bytes;
 set @@tidb_paging_size_bytes=default;
 select @@tidb_paging_size_bytes;
 @@tidb_paging_size_bytes
-4194304
+0
 select /*+ set_var(tidb_enable_cascades_planner=0) */ @@tidb_enable_cascades_planner;
 @@tidb_enable_cascades_planner
 0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68085

Problem Summary:

#69868 changed the default of `tidb_paging_size_bytes` from `0` to 4 MiB. After further consideration, keep byte-budget paging opt-in by default to avoid surprising behavior changes for clusters that have not explicitly enabled this path. Operators can still set a non-zero value when needed.

### What changed and how does it work?

- Restore `DefPagingSizeBytes` / `tidb_paging_size_bytes` default from 4 MiB back to `0` (disabled).
- Keep the comments that document:
  - when a non-zero value takes effect (Resource Control enabled and the active Resource Group is non-burstable);
  - the tested workload matrix and why 4 MiB is a good candidate when enabling the feature.
- Update integration-test expectations for the initial and reset-to-default values.

This intentionally does **not** remove the SET_VAR hint support or the
scope documentation introduced around #69868.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Restore the default of `tidb_paging_size_bytes` to `0` (byte-budget paging disabled). Set a non-zero value such as 4 MiB (4194304) to enable it for resource groups with limited burst.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default value of `tidb_paging_size_bytes` to `0`, disabling byte-budget paging by default.
  * Byte-budget paging now applies only when Resource Control is enabled and the active resource group is non-burstable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->