### PR TITLE
ddl: fix alter index visibility suffix collision

### DIFF
--- a/pkg/ddl/db_change_test.go
+++ b/pkg/ddl/db_change_test.go
@@ -952,6 +952,26 @@ func TestParallelAlterIndex(t *testing.T) {
 		tk.MustExec("select * from t")
 	}
 	testControlParallelExecSQL(t, tk, store, dom, "", sql, sql, f)
+
+	// Regression test for issue 70049. Ordinary indexes with an underscore-delimited
+	// suffix must not be mistaken for temporary indexes created by modify column.
+	query := `select key_name, is_visible from information_schema.tidb_indexes
+		where table_schema = 'test_db_state' and table_name = '%s' order by key_name`
+	tk.MustExec("create table t_invisible (k int, key idx_k(k), key idx_k_1(k), key idx_k_copy(k))")
+	tk.MustExec("alter table t_invisible alter index idx_k invisible")
+	tk.MustQuery(fmt.Sprintf(query, "t_invisible")).Check(testkit.Rows(
+		"idx_k NO",
+		"idx_k_1 YES",
+		"idx_k_copy YES",
+	))
+
+	tk.MustExec("create table t_visible (k int, key idx_k(k) invisible, key idx_k_1(k) invisible, key idx_k_copy(k) invisible)")
+	tk.MustExec("alter table t_visible alter index idx_k visible")
+	tk.MustQuery(fmt.Sprintf(query, "t_visible")).Check(testkit.Rows(
+		"idx_k YES",
+		"idx_k_1 NO",
+		"idx_k_copy NO",
+	))
 }
 
 func TestParallelAlterModifyColumn(t *testing.T) {

--- a/pkg/ddl/db_change_test.go
+++ b/pkg/ddl/db_change_test.go
@@ -941,22 +941,14 @@ func TestShowIndex(t *testing.T) {
 	tk.MustQuery("select key_name, clustered from information_schema.tidb_indexes where table_name = 'tr' order by key_name").Check(testkit.Rows("PRIMARY NO", "vv NO"))
 }
 
-func TestParallelAlterIndex(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+// Regression test for issue 70049. Ordinary indexes with an underscore-delimited
+// suffix must not be mistaken for temporary indexes created by modify column.
+func TestAlterIndexVisibility(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("create database test_db_state default charset utf8 default collate utf8_bin")
-	sql := "alter table t alter index idx1 invisible;"
-	f := func(err1, err2 error) {
-		require.NoError(t, err1)
-		require.NoError(t, err2)
-		tk.MustExec("select * from t")
-	}
-	testControlParallelExecSQL(t, tk, store, dom, "", sql, sql, f)
-
-	// Regression test for issue 70049. Ordinary indexes with an underscore-delimited
-	// suffix must not be mistaken for temporary indexes created by modify column.
+	tk.MustExec("use test")
 	query := `select key_name, is_visible from information_schema.tidb_indexes
-		where table_schema = 'test_db_state' and table_name = '%s' order by key_name`
+		where table_schema = 'test' and table_name = '%s' order by key_name`
 	tk.MustExec("create table t_invisible (k int, key idx_k(k), key idx_k_1(k), key idx_k_copy(k))")
 	tk.MustExec("alter table t_invisible alter index idx_k invisible")
 	tk.MustQuery(fmt.Sprintf(query, "t_invisible")).Check(testkit.Rows(
@@ -972,6 +964,19 @@ func TestParallelAlterIndex(t *testing.T) {
 		"idx_k_1 NO",
 		"idx_k_copy NO",
 	))
+}
+
+func TestParallelAlterIndex(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database test_db_state default charset utf8 default collate utf8_bin")
+	sql := "alter table t alter index idx1 invisible;"
+	f := func(err1, err2 error) {
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		tk.MustExec("select * from t")
+	}
+	testControlParallelExecSQL(t, tk, store, dom, "", sql, sql, f)
 }
 
 func TestParallelAlterModifyColumn(t *testing.T) {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -739,7 +739,10 @@ func onAlterIndexVisibility(jobCtx *jobContext, job *model.Job) (ver int64, _ er
 
 func setIndexVisibility(tblInfo *model.TableInfo, name ast.CIStr, invisible bool) {
 	for _, idx := range tblInfo.Indices {
-		if idx.Name.L == name.L || idx.GetChangingOriginName() == name.O {
+		if idx.Name.L == name.L ||
+			(idx.IsChanging() &&
+				isTempIndex(idx, tblInfo) &&
+				strings.EqualFold(idx.GetChangingOriginName(), name.O)) {
 			idx.Invisible = invisible
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70049

Problem Summary:

Introduced by #63465, which makes `ALTER TABLE ... ALTER INDEX ... VISIBLE/INVISIBLE` incorrectly change the visibility of other indexes whose names shared the same underscore-delimited prefix. For example, altering `idx_k` also affected `idx_k_copy`, because normal indexes were incorrectly treated as temporary indexes created during a column change.

### What changed and how does it work?

The visibility update now matches an index by its original name only when it is an actual temporary changing index. It checks both `IsChanging()` and `isTempIndex()` before comparing the original index name.

Regression tests cover:

- Changing an index to `INVISIBLE`.
- Changing an index to `VISIBLE`.
- Numeric and non-numeric underscore suffixes, such as `idx_k_1` and `idx_k_copy`.

These similarly named indexes now retain their original visibility

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index visibility updates to correctly handle indexes with underscore-delimited name suffixes.
  * Improved visibility behavior when indexes are being renamed or transitioned between states.
  * Added regression test coverage to ensure only the intended index changes visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->