### PR TITLE
memory: avoid panic when memory consumption races with tracker detachment

### DIFF
--- a/pkg/util/memory/global_arbitrator.go
+++ b/pkg/util/memory/global_arbitrator.go
@@ -369,8 +369,10 @@ func setGlobalMemArbitratorWorkModeText(str string) {
 
 // SetGlobalMemArbitratorWorkMode sets the work mode of the global memory arbitrator.
 func SetGlobalMemArbitratorWorkMode(str string) bool {
-	if intest.InTest && mockinitGlobalMemArbitrator == nil {
-		return false
+	if intest.InTest {
+		if mockinitGlobalMemArbitrator == nil {
+			return false
+		}
 	}
 
 	if !globalArbitrator.metrics.init.Load() {

--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -456,7 +456,7 @@ func (t *Tracker) Consume(bs int64) {
 		if tracker.IsRootTrackerOfSess {
 			sessionRootTracker = tracker
 		}
-		if m := tracker.MemArbitrator; m != nil {
+		if m := tracker.MemArbitrator; m != nil && m.state.Load() != memArbitratorStateDown {
 			if bs > 0 {
 				if m.useBigBudget() {
 					if m.addBigBudgetUsed(bs) > m.bigBudgetGrowThreshold() {
@@ -1095,6 +1095,10 @@ func (m *memArbitrator) intoBigBudget() bool {
 	m.budget.useBig.Lock()
 	defer m.budget.useBig.Unlock()
 
+	if m.state.Load() == memArbitratorStateDown {
+		return false
+	}
+
 	if m.useBigBudget() {
 		return false
 	}
@@ -1121,9 +1125,11 @@ func (m *memArbitrator) intoBigBudget() bool {
 
 	smallUsed := max(0, m.smallBudgetUsed())
 
-	if !m.RestartEntryByContext(root, m.ctx) || !m.state.CompareAndSwap(memArbitratorStateSmallBudget, memArbitratorStateIntoBigBudget) {
+	if !m.RestartEntryByContext(root, m.ctx) {
 		panic("failed to init mem pool")
 	}
+
+	m.state.Store(memArbitratorStateIntoBigBudget)
 
 	if maxMemHint := max(m.prevMaxMem, smallUsed); maxMemHint > m.buffer.size.Load() {
 		m.tryToUpdateBuffer(maxMemHint, m.approxUnixTimeSec())
@@ -1167,8 +1173,8 @@ func (m *memArbitrator) intoBigBudget() bool {
 
 	m.addBigBudgetUsed(m.cleanSmallBudget() - smallUsed)
 	m.budget.useBig.Store(true)
-
-	if m.state.CompareAndSwap(memArbitratorStateIntoBigBudget, memArbitratorStateBigBudget) {
+	{
+		m.state.Store(memArbitratorStateBigBudget)
 		globalArbitrator.metrics.pools.intoBig.Add(-1)
 		globalArbitrator.metrics.pools.big.Add(1)
 	}
@@ -1224,19 +1230,16 @@ func (m *memArbitrator) reset(exception bool, maxConsumed int64) bool {
 		return false
 	}
 
+	m.budget.useBig.Lock()
+	defer m.budget.useBig.Unlock()
+
 	switch oriState := m.state.Swap(memArbitratorStateDown); oriState {
 	case memArbitratorStateSmallBudget:
 		globalArbitrator.metrics.pools.small.Add(-1)
-	case memArbitratorStateIntoBigBudget, memArbitratorStateBigBudget:
-		if oriState == memArbitratorStateIntoBigBudget { // wait for intoBigBudget to finish
-			m.budget.useBig.Lock()
-
-			globalArbitrator.metrics.pools.intoBig.Add(-1)
-
-			m.budget.useBig.Unlock()
-		} else {
-			globalArbitrator.metrics.pools.big.Add(-1)
-		}
+	case memArbitratorStateIntoBigBudget:
+		globalArbitrator.metrics.pools.intoBig.Add(-1)
+	case memArbitratorStateBigBudget:
+		globalArbitrator.metrics.pools.big.Add(-1)
 	default:
 		return false
 	}

--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -461,8 +461,10 @@ func (t *Tracker) Consume(bs int64) {
 		}
 		if m := tracker.MemArbitrator; m != nil {
 			if m.state.Load() != memArbitratorStateDown {
-				if intest.InTest && mockConsumeAfterStateCheckInject != nil {
-					mockConsumeAfterStateCheckInject(m)
+				if intest.InTest {
+					if mockConsumeAfterStateCheckInject != nil {
+						mockConsumeAfterStateCheckInject(m)
+					}
 				}
 				if bs > 0 {
 					if m.useBigBudget() {

--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -134,7 +134,10 @@ var defaultQueryQuota = bytesLimits{
 // MemUsageTop1Tracker record the use memory top1 session's tracker for kill.
 var MemUsageTop1Tracker atomic.Pointer[Tracker]
 
-var mockDebugInject func()
+var (
+	mockDebugInject                  func()
+	mockConsumeAfterStateCheckInject func(*memArbitrator)
+)
 
 // InitTracker initializes a memory tracker.
 //  1. "label" is the label used in the usage string.
@@ -456,29 +459,39 @@ func (t *Tracker) Consume(bs int64) {
 		if tracker.IsRootTrackerOfSess {
 			sessionRootTracker = tracker
 		}
-		if m := tracker.MemArbitrator; m != nil && m.state.Load() != memArbitratorStateDown {
-			if bs > 0 {
-				if m.useBigBudget() {
-					if m.addBigBudgetUsed(bs) > m.bigBudgetGrowThreshold() {
-						m.growBigBudget()
-					}
-				} else { // fast path for small budget
-					if m.addSmallBudget(bs) > m.budget.smallLimit {
-						m.intoBigBudget()
-					} else {
-						b := m.smallBudget()
-						if t := m.approxUnixTimeSec(); b.getLastUsedTimeSec() != t {
-							b.setLastUsedTimeSec(t)
-						}
-						if b.Used.Load() > b.approxCapacity() && b.PullFromUpstream() != nil {
-							m.intoBigBudget()
-						}
-					}
+		if m := tracker.MemArbitrator; m != nil {
+			if m.state.Load() != memArbitratorStateDown {
+				if intest.InTest && mockConsumeAfterStateCheckInject != nil {
+					mockConsumeAfterStateCheckInject(m)
 				}
-			} else if m.useBigBudget() { // delta <= 0 && use big budget
-				m.addBigBudgetUsed(bs)
-			} else { // delta <= 0 && use small budget
-				m.addSmallBudget(bs)
+				if bs > 0 {
+					if m.useBigBudget() {
+						if m.addBigBudgetUsed(bs) > m.bigBudgetGrowThreshold() {
+							m.growBigBudget()
+						}
+					} else { // fast path for small budget
+						if m.addSmallBudget(bs) > m.budget.smallLimit {
+							m.intoBigBudget()
+						} else {
+							b := m.smallBudget()
+							if t := m.approxUnixTimeSec(); b.getLastUsedTimeSec() != t {
+								b.setLastUsedTimeSec(t)
+							}
+							if b.Used.Load() > b.approxCapacity() && b.PullFromUpstream() != nil {
+								m.intoBigBudget()
+							}
+						}
+					}
+				} else if m.useBigBudget() { // delta <= 0 && use big budget
+					m.addBigBudgetUsed(bs)
+				} else { // delta <= 0 && use small budget
+					m.addSmallBudget(bs)
+				}
+				if m.state.Load() == memArbitratorStateDown {
+					m.cleanSmallBudget()
+				}
+			} else if m.smallBudgetUsed() != 0 {
+				m.cleanSmallBudget()
 			}
 		}
 		bytesConsumed := atomic.AddInt64(&tracker.bytesConsumed, bs)
@@ -1222,10 +1235,6 @@ func (t *Tracker) DetachMemArbitrator(exception bool) bool {
 }
 
 func (m *memArbitrator) reset(exception bool, maxConsumed int64) bool {
-	if m.smallBudgetUsed() != 0 {
-		m.cleanSmallBudget()
-	}
-
 	if m.state.Load() == memArbitratorStateDown {
 		return false
 	}
@@ -1242,6 +1251,10 @@ func (m *memArbitrator) reset(exception bool, maxConsumed int64) bool {
 		globalArbitrator.metrics.pools.big.Add(-1)
 	default:
 		return false
+	}
+
+	if m.smallBudgetUsed() != 0 {
+		m.cleanSmallBudget()
 	}
 
 	if m.isInternal {

--- a/pkg/util/memory/tracker.go
+++ b/pkg/util/memory/tracker.go
@@ -960,17 +960,17 @@ type memArbitrator struct {
 			_         cpuCacheLinePad
 		}
 		smallLimit int64
-		useBig     struct {
-			sync.Mutex
-			atomic.Bool
-		}
+		useBig     atomic.Bool
 	}
 	uid         uint64
 	digestID    uint64 // identify the digest profile of root-pool / SQL
 	reserveSize int64
 	isInternal  bool
-	state       atomic.Int32 // states: the current state of memArbitrator
-	prevMaxMem  int64
+	state       struct {
+		sync.Mutex
+		atomic.Int32 // states: the current state of memArbitrator
+	}
+	prevMaxMem int64
 
 	AwaitAlloc struct {
 		TotalDur   atomic.Int64 // total time spent waiting for memory allocation in nanoseconds
@@ -1092,8 +1092,8 @@ func (m *memArbitrator) growBigBudget() {
 }
 
 func (m *memArbitrator) intoBigBudget() bool {
-	m.budget.useBig.Lock()
-	defer m.budget.useBig.Unlock()
+	m.state.Lock()
+	defer m.state.Unlock()
 
 	if m.state.Load() == memArbitratorStateDown {
 		return false
@@ -1230,8 +1230,8 @@ func (m *memArbitrator) reset(exception bool, maxConsumed int64) bool {
 		return false
 	}
 
-	m.budget.useBig.Lock()
-	defer m.budget.useBig.Unlock()
+	m.state.Lock()
+	defer m.state.Unlock()
 
 	switch oriState := m.state.Swap(memArbitratorStateDown); oriState {
 	case memArbitratorStateSmallBudget:

--- a/pkg/util/memory/tracker_test.go
+++ b/pkg/util/memory/tracker_test.go
@@ -1080,13 +1080,17 @@ func TestGlobalMemArbitrator(t *testing.T) {
 				require.True(t, t1.MemArbitrator != nil)
 				require.False(t, t1.DetachMemArbitrator(true))
 			})
-			for t1.MemArbitrator.state.Load() != memArbitratorStateDown {
+			// Detach removes the tracker from its parent before waiting for the
+			// ongoing small-to-big budget transition to finish.
+			for t1.getParent() != nil {
 				runtime.Gosched()
 			}
+			require.Equal(t, memArbitratorStateIntoBigBudget, t1.MemArbitrator.state.Load())
+			mockDebugInject = nil
 		}
 		t1.Consume(1e8)
 		wg.Wait()
-		mockDebugInject = nil
+		require.Equal(t, memArbitratorStateDown, t1.MemArbitrator.state.Load())
 		require.True(t, globalArbitrator.metrics.pools.internal.Load() == 0)
 		require.True(t, globalArbitrator.metrics.pools.internalSession.Load() == 1)
 
@@ -1136,13 +1140,20 @@ func TestGlobalMemArbitrator(t *testing.T) {
 			t3.InitMemArbitrator(m, t3.Killer, InvalidDigestID, ArbitrationPriorityMedium, false, 0, false))
 		t3.Detach()
 		require.True(t, t3.MemArbitrator.state.Load() == memArbitratorStateDown)
-		t3.Consume(1677) // mock reuse the tracker
-		require.True(t, m.awaitFreePoolUsed().quota == 1677)
+		reusedMem := m.poolAllocStats.SmallPoolLimit + 1
+		require.NotPanics(t, func() {
+			t3.Consume(reusedMem) // mock reuse the tracker
+		})
+		require.Equal(t, reusedMem, t3.BytesConsumed())
+		require.Equal(t, memArbitratorStateDown, t3.MemArbitrator.state.Load())
+		require.Equal(t, int64(0), t3.MemArbitrator.smallBudgetUsed())
+		require.Equal(t, int64(0), m.awaitFreePoolUsed().quota)
+		require.Nil(t, m.FindRootPool(t3.SessionID.Load()).entry)
 		InitTracker(t3, 1, -1, &actionWithPriority{})
 		t3.AttachTo(t0)
 		require.True(t,
 			t3.InitMemArbitrator(m, t3.Killer, InvalidDigestID, ArbitrationPriorityMedium, false, 0, false))
-		require.True(t, m.awaitFreePoolUsed().quota == 0) // reset previous mem-arbitrator
+		require.Equal(t, int64(0), m.awaitFreePoolUsed().quota)
 		t3.Detach()
 	}
 }

--- a/pkg/util/memory/tracker_test.go
+++ b/pkg/util/memory/tracker_test.go
@@ -1094,21 +1094,22 @@ func TestGlobalMemArbitrator(t *testing.T) {
 		require.True(t, globalArbitrator.metrics.pools.internal.Load() == 0)
 		require.True(t, globalArbitrator.metrics.pools.internalSession.Load() == 1)
 
-		// all budget released
+		// all allocated pool resources released
 		require.True(t, globalArbitrator.metrics.pools.big.Load() == 0)
 		require.True(t, globalArbitrator.metrics.pools.intoBig.Load() == 0)
 		require.True(t, m.awaitFreePoolUsed().quota == 0)
 		require.True(t, t1.MemArbitrator.useBigBudget())
 		require.True(t, t1.MemArbitrator.smallBudgetUsed() == 0)
 		require.True(t, t1.MemArbitrator.bigBudget().Pool.allocated() == 0)
-		used, growThreshold, capacity := t1.MemArbitrator.bigBudgetUsed(), t1.MemArbitrator.bigBudgetGrowThreshold(), t1.MemArbitrator.bigBudgetCap()
-		require.True(t, used == 0)
+		usedAfterDetach := t1.MemArbitrator.bigBudgetUsed()
+		growThreshold, capacity := t1.MemArbitrator.bigBudgetGrowThreshold(), t1.MemArbitrator.bigBudgetCap()
 		require.True(t, growThreshold == 0)
 		require.True(t, capacity == 0)
 
 		t1.Consume(1e8)
 
 		// can not use big budget after detach
+		require.Equal(t, usedAfterDetach, t1.MemArbitrator.bigBudgetUsed())
 		require.True(t, t1.MemArbitrator.bigBudgetGrowThreshold() == 0)
 		require.True(t, t1.MemArbitrator.bigBudgetCap() == 0)
 		require.True(t, t1.MemArbitrator.bigBudget().Pool.allocated() == 0)
@@ -1155,5 +1156,40 @@ func TestGlobalMemArbitrator(t *testing.T) {
 			t3.InitMemArbitrator(m, t3.Killer, InvalidDigestID, ArbitrationPriorityMedium, false, 0, false))
 		require.Equal(t, int64(0), m.awaitFreePoolUsed().quota)
 		t3.Detach()
+
+		// Simulate a Consume that passes the state check before detach, but
+		// updates the small budget after the mem-arbitrator is down.
+		t.Cleanup(func() {
+			mockConsumeAfterStateCheckInject = nil
+		})
+		for i, delta := range []int64{1, -1} {
+			tracker := newRootTrackerWithStmt(uint64(41 + i))
+			require.True(t,
+				tracker.InitMemArbitrator(m, tracker.Killer, InvalidDigestID, ArbitrationPriorityMedium, false, 0, false))
+			consumeAfterStateCheck := make(chan struct{})
+			resumeConsume := make(chan struct{})
+			consumeDone := make(chan struct{})
+			mockConsumeAfterStateCheckInject = func(arbitrator *memArbitrator) {
+				if arbitrator != tracker.MemArbitrator {
+					return
+				}
+				close(consumeAfterStateCheck)
+				<-resumeConsume
+			}
+			go func() {
+				tracker.Consume(delta)
+				close(consumeDone)
+			}()
+			<-consumeAfterStateCheck
+			tracker.Detach()
+			close(resumeConsume)
+			<-consumeDone
+			mockConsumeAfterStateCheckInject = nil
+
+			require.Equal(t, memArbitratorStateDown, tracker.MemArbitrator.state.Load())
+			require.Equal(t, int64(0), tracker.MemArbitrator.smallBudgetUsed())
+			require.Equal(t, memPoolQuotaUsage{}, m.awaitFreePoolUsed())
+			require.Nil(t, m.FindRootPool(tracker.SessionID.Load()).entry)
+		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58194

Problem Summary:

A transaction retry can reuse a statement memory tracker whose memory arbitrator has already been detached.

For a no-result DML statement such as `DELETE`, the following sequence can occur:

1. The initial statement execution initializes the memory arbitrator on the statement memory tracker.
2. After the executor finishes, `handleNoDelay` detaches the statement tracker from the session tracker. This resets its memory arbitrator to the `Down` state.
3. If the following transaction commit encounters a retryable error, `doCommitWithRetry` starts a transaction retry.
4. The retry path reuses the historical `StatementContext` and its `MemTracker`. `StatementContext.ResetForRetry` resets the statement execution state, but it does not reattach the tracker or reinitialize its memory arbitrator.
5. When the retried executor reports memory through `Tracker.Consume`, the tracker still holds a non-nil arbitrator whose state is `Down`.
6. The previous implementation did not reject the `Down` arbitrator before entering the small-to-big budget transition. Restarting an already detached root-pool entry or transitioning its state could fail, causing `intoBigBudget` to panic with:

```text
failed to init mem pool
```

A similar race can happen when an asynchronous worker continues reporting memory after its tracker has been detached, or when tracker detachment overlaps with an ongoing small-to-big budget transition.

### What changed and how does it work?

- Skip memory arbitration in `Tracker.Consume` when the arbitrator is already in the `Down` state, while continuing normal tracker memory accounting.
- Serialize `reset` and the small-to-big budget transition with the arbitrator state lifecycle mutex.
- Recheck the arbitrator state after acquiring the lifecycle mutex in `intoBigBudget`, preventing a detached arbitrator from recreating its root pool.
- Publish the `Down` state before performing the final small-budget cleanup.
- Recheck the state after a lock-free budget update and clean any small-budget usage concurrently reported after the arbitrator becomes `Down`.
- Extend the unit test to cover:
  - detaching a tracker during an ongoing small-to-big budget transition;
  - reusing a detached tracker and consuming more than the small-pool limit;
  - a concurrent `Consume` that passes the initial state check before detachment and reports positive or negative memory after detachment;
  - ensuring detached consumption does not panic, retain small-budget usage, or recreate arbitration resources;
  - reattaching and reinitializing the tracker for subsequent statement execution.

During the transaction retry window, the reused tracker continues recording normal memory usage, but global memory arbitration is disabled until a new arbitrator is initialized.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `cd pkg/util/memory && go test -run '^TestGlobalMemArbitrator$' -tags=intest,deadlock`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a TiDB panic caused by reusing a detached memory tracker during automatic transaction retries.
```
