### PR TITLE
planner: collapse LeftOuterSemiJoin to SemiJoin when x IN (subquery) (#69919)

### DIFF
--- a/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_in.json
@@ -60,7 +60,19 @@
       "select A.id, B.id from A left join B on A.id < B.a_id where B.id is null",
       "select A.val, B.val from A left join B on A.val = B.val where B.non_null_col IS NULL",
       "select A.id, B.val from A left join B on A.id = B.a_id where B.val > 0",
-      "SELECT * FROM t1 LEFT JOIN (t2 LEFT JOIN t3 ON t3.i = t2.i) ON t2.i = t1.i WHERE t3.i IS NULL"
+      "SELECT * FROM t1 LEFT JOIN (t2 LEFT JOIN t3 ON t3.i = t2.i) ON t2.i = t1.i WHERE t3.i IS NULL",
+
+      // GROUP 9: issue:69919, `x IN (subquery)` used as a scalar operand of OR/AND builds a
+      // LeftOuterSemiJoin/AntiLeftOuterSemiJoin flag column; filtering directly on that flag
+      // column should collapse back to a plain SemiJoin/AntiSemiJoin (Positive cases).
+      "select A.id from A where (A.val in (select val from B)) or false",
+      "select A.id from A where (A.val in (select val from B)) or 1 = 0",
+      "select A.id from A where false or (A.val in (select val from B))",
+      "select A.id from A where (A.val not in (select val from B where val is not null)) or false",
+      "select A.id from A where (A.val in (select val from B)) and true",
+      // Negative case: the flag column is also projected, so SemiJoin cannot be used
+      // (it does not produce that column).
+      "select A.id, (A.val in (select val from B)) or false from A"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_out.json
@@ -666,6 +666,96 @@
           "3 3 <nil>",
           "2 <nil> <nil>"
         ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) or false",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) or 1 = 0",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where false or (A.val in (select val from B))",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val not in (select val from B where val is not null)) or false",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.b.val))",
+          "│   └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "2",
+          "4",
+          "<nil>"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) and true",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.a.val, test.b.val)]",
+          "├─HashAgg(Build) root  group by:test.b.val, funcs:firstrow(test.b.val)->test.b.val",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.b.val, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.b.val))",
+          "│       └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.a.val))",
+          "    └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id, (A.val in (select val from B)) or false from A",
+        "Plan": [
+          "Projection root  test.a.id, or(Column, 0)->Column",
+          "└─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.a.val, test.b.val)",
+          "  ├─TableReader(Build) root  data:TableFullScan",
+          "  │ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "  └─TableReader(Probe) root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 1",
+          "2 <nil>",
+          "3 <nil>",
+          "4 <nil>",
+          "<nil> <nil>"
+        ]
       }
     ]
   }

--- a/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_xut.json
@@ -666,6 +666,96 @@
           "3 3 <nil>",
           "2 <nil> <nil>"
         ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) or false",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) or 1 = 0",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where false or (A.val in (select val from B))",
+        "Plan": [
+          "HashJoin root  semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:TableFullScan",
+          "│ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val not in (select val from B where val is not null)) or false",
+        "Plan": [
+          "HashJoin root  Null-aware anti semi join, left side:TableReader, equal:[eq(test.a.val, test.b.val)]",
+          "├─TableReader(Build) root  data:Selection",
+          "│ └─Selection cop[tikv]  not(isnull(test.b.val))",
+          "│   └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:TableFullScan",
+          "  └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "2",
+          "4",
+          "<nil>"
+        ]
+      },
+      {
+        "SQL": "select A.id from A where (A.val in (select val from B)) and true",
+        "Plan": [
+          "HashJoin root  inner join, equal:[eq(test.a.val, test.b.val)]",
+          "├─HashAgg(Build) root  group by:test.b.val, funcs:firstrow(test.b.val)->test.b.val",
+          "│ └─TableReader root  data:HashAgg",
+          "│   └─HashAgg cop[tikv]  group by:test.b.val, ",
+          "│     └─Selection cop[tikv]  not(isnull(test.b.val))",
+          "│       └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "└─TableReader(Probe) root  data:Selection",
+          "  └─Selection cop[tikv]  not(isnull(test.a.val))",
+          "    └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select A.id, (A.val in (select val from B)) or false from A",
+        "Plan": [
+          "Projection root  test.a.id, or(Column, 0)->Column",
+          "└─HashJoin root  CARTESIAN left outer semi join, left side:TableReader, other cond:eq(test.a.val, test.b.val)",
+          "  ├─TableReader(Build) root  data:TableFullScan",
+          "  │ └─TableFullScan cop[tikv] table:B keep order:false, stats:pseudo",
+          "  └─TableReader(Probe) root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:A keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 1",
+          "2 <nil>",
+          "3 <nil>",
+          "4 <nil>",
+          "<nil> <nil>"
+        ]
       }
     ]
   }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5714,7 +5714,14 @@ func (b *PlanBuilder) buildApplyWithJoinType(outerPlan, innerPlan base.LogicalPl
 // buildSemiApply builds apply plan with outerPlan and innerPlan, which apply semi-join for every row from outerPlan and the whole innerPlan.
 func (b *PlanBuilder) buildSemiApply(outerPlan, innerPlan base.LogicalPlan, condition []expression.Expression,
 	asScalar, not, considerRewrite, markNoDecorrelate bool) (base.LogicalPlan, error) {
-	b.optFlag = b.optFlag | rule.FlagPredicatePushDown | rule.FlagBuildKeyInfo | rule.FlagDecorrelate
+	// When asScalar, this builds a LeftOuterSemiJoin/AntiLeftOuterSemiJoin with a trailing
+	// boolean flag column (e.g. `x IN (subquery)` used as a scalar operand of AND/OR).
+	// FlagOuterJoinToSemiJoin lets the optimizer collapse it back to a plain
+	// SemiJoin/AntiSemiJoin when a Selection directly filters on that flag column. It is set
+	// unconditionally (not just when asScalar) because b.optFlag is cumulative across the
+	// whole statement: conditioning it on this call's asScalar could flip whether the flag
+	// is present for unrelated sibling subqueries optimized later via the same PlanBuilder.
+	b.optFlag = b.optFlag | rule.FlagPredicatePushDown | rule.FlagBuildKeyInfo | rule.FlagDecorrelate | rule.FlagOuterJoinToSemiJoin
 
 	join, err := b.buildSemiJoin(outerPlan, innerPlan, condition, asScalar, not, considerRewrite)
 	if err != nil {

--- a/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
+++ b/pkg/planner/core/rule/rule_outer_join_to_semi_join.go
@@ -49,6 +49,14 @@ import (
 //
 // In both cases, the original `LogicalSelection` is eliminated, and the plan is rewritten to
 // `LogicalProjection -> LogicalJoin(AntiSemiJoin)`.
+//
+// A second, unrelated pattern handled by this rule (see canConvertOuterSemiJoinToSemiJoin) collapses
+// `LogicalSelection[flagCol] -> LeftOuterSemiJoin/AntiLeftOuterSemiJoin` into a plain
+// `SemiJoin`/`AntiSemiJoin`. This arises when `x IN (subquery)` is used as a scalar
+// boolean operand of AND/OR in a WHERE clause (e.g. `WHERE (x IN (subquery)) OR FALSE`):
+// the planner must build a LeftOuterSemiJoin with a trailing boolean flag column to
+// represent the three-valued result, but once that flag column is filtered directly by
+// the enclosing Selection, the outer join degenerates back to a plain semi join.
 type OuterJoinToSemiJoin struct{}
 
 // Optimize implements base.LogicalOptRule.<0th> interface.
@@ -106,6 +114,15 @@ func (o *OuterJoinToSemiJoin) dealWithSelection(p base.LogicalPlan, childIdx int
 }
 
 func (o *OuterJoinToSemiJoin) startConvertOuterJoinToSemiJoin(p base.LogicalPlan, childIdx int, sel *logicalop.LogicalSelection, join *logicalop.LogicalJoin) (base.LogicalPlan, bool) {
+	if canConvertOuterSemiJoinToSemiJoin(join, sel.Conditions, p) {
+		if p != nil {
+			p.SetChild(childIdx, join)
+		} else {
+			p = join
+		}
+		o.recursivePlan(join)
+		return p, true
+	}
 	proj, ok := canConvertAntiJoin(join, sel.Conditions, sel.Schema())
 	if ok {
 		var pChild base.LogicalPlan
@@ -125,6 +142,53 @@ func (o *OuterJoinToSemiJoin) startConvertOuterJoinToSemiJoin(p base.LogicalPlan
 	}
 	_, changed := o.recursivePlan(join)
 	return p, ok || changed
+}
+
+// canConvertOuterSemiJoinToSemiJoin detects the pattern:
+//
+//	Selection[flagCol] <- LeftOuterSemiJoin/AntiLeftOuterSemiJoin
+//
+// where flagCol is exactly the trailing boolean flag column the join appends
+// (e.g. the result of `x IN (subquery)` used as a scalar operand of AND/OR,
+// such as `WHERE (x IN (subquery)) OR FALSE`). A LeftOuterSemiJoin never
+// removes or duplicates outer rows; it only decides the flag's value, so
+// filtering WHERE flagCol (which keeps only the definitely-TRUE rows, per
+// three-valued WHERE semantics) is equivalent to requiring the semi-join
+// match to exist, i.e. a plain SemiJoin. Symmetrically for
+// AntiLeftOuterSemiJoin and AntiSemiJoin.
+//
+// This only fires when the flag column is not needed above the Selection,
+// since SemiJoin/AntiSemiJoin drop it from the schema entirely.
+func canConvertOuterSemiJoinToSemiJoin(join *logicalop.LogicalJoin, selectCond []expression.Expression, parent base.LogicalPlan) bool {
+	if join.JoinType != base.LeftOuterSemiJoin && join.JoinType != base.AntiLeftOuterSemiJoin {
+		return false
+	}
+	if len(selectCond) != 1 {
+		return false
+	}
+	flagCol, ok := selectCond[0].(*expression.Column)
+	if !ok {
+		return false
+	}
+	joinSchema := join.Schema()
+	flagColUniqueID := joinSchema.Columns[joinSchema.Len()-1].UniqueID
+	if flagCol.UniqueID != flagColUniqueID {
+		return false
+	}
+	// The flag column must not be required by anything above the Selection:
+	// SemiJoin/AntiSemiJoin do not produce it. Column identity is tracked by
+	// UniqueID and preserved across Schema.Clone(), so this check is valid
+	// even through intervening schema-preserving operators.
+	if parent != nil && parent.Schema().Contains(flagCol) {
+		return false
+	}
+	if join.JoinType == base.LeftOuterSemiJoin {
+		join.JoinType = base.SemiJoin
+	} else {
+		join.JoinType = base.AntiSemiJoin
+	}
+	join.MergeSchema()
+	return true
 }
 
 func ensureSelectionRoot(p base.LogicalPlan, sel *logicalop.LogicalSelection) base.LogicalPlan {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69919

Problem Summary:

`expr OR FALSE` is logically equivalent to `expr`, but when `expr` is `x IN (subquery)`, TiDB does not produce comparable plans for the two forms. In the reported repro, `WHERE b.v IN (SELECT v FROM b WHERE v <> 68)` and the same predicate wrapped as `WHERE (b.v IN (SELECT v FROM b WHERE v <> 68)) OR FALSE` return identical results but the second is ~66x slower — the first is rewritten into an `InnerJoin`/`SemiJoin` with null-rejecting predicates, while the second keeps a `Selection` filtering the boolean result of a `LeftOuterSemiJoin` sitting above a `LeftOuterJoin`.

The root cause is that `x IN (subquery)` is only eligible for the fast `InnerJoin + Agg` (or plain `SemiJoin`) rewrite when it is used as a bare, top-level filter. As soon as it becomes a scalar operand of `OR`/`AND` — even a no-op disjunct like `OR FALSE` — the rewriter must produce a `LeftOuterSemiJoin`/`AntiLeftOuterSemiJoin` carrying a trailing boolean flag column, since the subquery's truth value now has to participate in three-valued `OR`/`AND` evaluation instead of directly gating row inclusion. `OuterJoinToSemiJoin` already collapses an analogous shape — `LEFT/RIGHT JOIN ... WHERE inner_col IS NULL` — back down to a semi/anti-semi join once the null check makes the outer join redundant, but its optimizer flag was only ever armed when the query had a literal `LEFT JOIN`/`RIGHT JOIN` in the `FROM` clause. It never ran for `LeftOuterSemiJoin`s built from an `IN (subquery)`, so the flag column and the join it came from were never revisited even when the enclosing `Selection` had already reduced to a bare check on that flag.

### What changed and how does it work?

Added a narrow, additive collapse to `pkg/planner/core/rule/rule_outer_join_to_semi_join.go` and wired it up in `pkg/planner/core/logical_plan_builder.go`:

- `canConvertOuterSemiJoinToSemiJoin` recognizes the shape `Selection[flagCol] <- LeftOuterSemiJoin/AntiLeftOuterSemiJoin`, where `flagCol` is exactly the join's own trailing boolean output column, and rewrites it to a plain `SemiJoin`/`AntiSemiJoin` with the `Selection` dropped — the boolean flag becomes implicit in row presence, matching the semantics of the fast path a bare `IN (subquery)` already gets.
- `buildSemiApply` now always arms `rule.FlagOuterJoinToSemiJoin`, not only when the subquery is built as a scalar (`asScalar`), so the collapse rule actually gets a chance to run on `IN (subquery)`-derived joins. It's set unconditionally rather than gated on this one call's shape because `PlanBuilder.optFlag` accumulates across the whole statement — gating it here could leak the flag into, or mask it from, unrelated sibling subqueries built later off the same `PlanBuilder`.

Deliberately conservative — only this exact shape changes:

- The collapse is skipped whenever the flag column is still needed above the `Selection` (e.g. it's also projected out directly, as in `SELECT ..., x IN (subquery) FROM ...`), since `SemiJoin`/`AntiSemiJoin` don't carry that column at all.
- `x IN (subquery) AND TRUE` was already served by the existing `InnerJoin + Agg` fast path and is untouched; the fix only affects the `LeftOuterSemiJoin`/`AntiLeftOuterSemiJoin` shape that path doesn't reach.
- The pre-existing `IS NULL`-based anti-semi-join collapse in the same rule is untouched — this is an additional, independently-guarded case dispatched before it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Added regression cases (GROUP 9, issue:69919) to the existing `TestOuterToSemiJoin` suite (`pkg/planner/core/casetest/rule/testdata/outer_to_semi_join_suite_in.json`), asserting `EXPLAIN format='plan_tree'` output and query results: `x IN (subquery) OR FALSE`, `OR 1 = 0`, operand order swapped (`FALSE OR x IN (subquery)`), the `NOT IN` / anti-semi-join variant combined with `OR FALSE`, `x IN (subquery) AND TRUE` (pre-existing fast path, confirmed unaffected), and a negative case where the flag column is also projected (must not collapse, since `SemiJoin` can't produce it).

Commands:

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/rule -run TestOuterToSemiJoin -count=1
go test ./pkg/planner/core/casetest/rule/... ./pkg/planner/core/casetest/join/... ./pkg/planner/core/casetest/scalarsubquery/... -tags=intest,deadlock
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/correlated -run TestNaturalJoinWithCorrelatedSubquery
```

Confirmed the new cases reproduce the reported plan/timing regression without the fix and pass with it. Full `pkg/planner/core/casetest/rule`, `join`, and `scalarsubquery` suites pass (covers `TestOuter2InnerSuite`, `TestSemiJoinRewrite`, join-reorder, and predicate-simplification regressions in the same area). Also re-ran `TestNaturalJoinWithCorrelatedSubquery` (correlated-Apply / alternative-logical-plans failpoint suite) with failpoints enabled to confirm the change doesn't alter behavior for unrelated correlated-subquery plans built through the same `buildSemiApply` path.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where wrapping an `IN (subquery)` filter in a redundant `OR FALSE` (or any similarly no-op `OR`/`AND` operand) prevented the optimizer from collapsing the resulting outer semi join back to a plain semi join, causing significant unnecessary slowdown compared to the equivalent un-wrapped query.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query optimization for `IN` and `NOT IN` subqueries combined with `AND` and `OR` conditions.
  - Corrected semi-join and anti-semi-join planning in cases involving boolean expressions and null handling.
  - Preserved correct behavior when subquery membership results are included in query output.

- **Tests**
  - Added coverage for semi-join transformations, boolean combinations, anti-joins, and expected query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->