### PR TITLE
test only: add agent-test source probe

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -1243,6 +1243,7 @@ func printInfo() {
 	level := log.GetLevel()
 	log.SetLevel(zap.InfoLevel)
 	printer.PrintTiDBInfo()
+	log.Info("agent-test source probe", zap.String("marker", "tcms-code-test-v1"))
 	log.SetLevel(level)
 }
 


### PR DESCRIPTION
### What is changed and how it works?

This draft PR adds a startup log marker used only to validate the Agent-Test commit-pinned build and TCMS rollout workflow.

### Check List

- [x] Test-only instrumentation
- [x] Do not merge

### Release note

```release-note
None
```