### PR TITLE
planner: do not schema-qualify FROM-clause aliases when expanding wildcards

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -980,6 +980,47 @@ ORDER BY t1.a, t2.a, t3.a, var`
 		tk.MustQuery("SELECT /* issue:66706 */ ref0 FROM (SELECT v0.c0 AS ref0, SIGN(v0.c0) AS ref1 FROM v0) AS s WHERE ref1").Check(testkit.Rows("0.99"))
 		tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
 	})
+
+	// issue-69547-view-definition-no-schema-prefix-for-from-aliases
+	// Column references expanded from `alias.*` must not be qualified with the
+	// schema name, otherwise the SELECT text stored in the view definition is
+	// not replayable (`db`.`cte_alias`.`col` fails with Unknown column).
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec("drop database if exists db_a_cte_replay")
+		tk.MustExec("drop database if exists db_b_cte_replay")
+		tk.MustExec("create database db_a_cte_replay")
+		tk.MustExec("create database db_b_cte_replay")
+		tk.MustExec("create table db_a_cte_replay.tmp_table1 (id decimal(18,0) not null, row_1 varchar(255) default null, primary key (id))")
+		tk.MustExec("insert into db_a_cte_replay.tmp_table1 values (1, 'x')")
+
+		// CTE referenced through an alias.
+		tk.MustExec("create view db_a_cte_replay.view_test_v1 as (with rs1 as (select otn.* from db_a_cte_replay.tmp_table1 otn) select ojt.* from rs1 ojt)")
+		viewDef := tk.MustQuery("show create view db_a_cte_replay.view_test_v1").Rows()[0][1].(string)
+		require.Equal(t, "CREATE ALGORITHM=UNDEFINED DEFINER=``@`` SQL SECURITY DEFINER VIEW `view_test_v1` (`id`, `row_1`) AS "+
+			"(WITH `rs1` AS (SELECT `otn`.`id` AS `id`,`otn`.`row_1` AS `row_1` FROM `db_a_cte_replay`.`tmp_table1` AS `otn`) "+
+			"SELECT `ojt`.`id` AS `id`,`ojt`.`row_1` AS `row_1` FROM `rs1` AS `ojt`)", viewDef)
+		tk.MustQuery("select * from db_a_cte_replay.view_test_v1").Check(testkit.Rows("1 x"))
+		// The emitted DDL must be replayable in another schema.
+		tk.MustExec("use db_b_cte_replay")
+		tk.MustExec(viewDef)
+		tk.MustQuery("select * from db_b_cte_replay.view_test_v1").Check(testkit.Rows("1 x"))
+		tk.MustExec("use test")
+
+		// A plain table alias must not be schema-qualified either, while an
+		// unaliased table keeps the fully qualified column reference.
+		tk.MustExec("create view db_a_cte_replay.view_test_v2 as select otn.* from db_a_cte_replay.tmp_table1 otn")
+		require.Equal(t, "CREATE ALGORITHM=UNDEFINED DEFINER=``@`` SQL SECURITY DEFINER VIEW `view_test_v2` (`id`, `row_1`) AS "+
+			"SELECT `otn`.`id` AS `id`,`otn`.`row_1` AS `row_1` FROM `db_a_cte_replay`.`tmp_table1` AS `otn`",
+			tk.MustQuery("show create view db_a_cte_replay.view_test_v2").Rows()[0][1].(string))
+		tk.MustExec("create view db_a_cte_replay.view_test_v3 as select tmp_table1.* from db_a_cte_replay.tmp_table1")
+		require.Equal(t, "CREATE ALGORITHM=UNDEFINED DEFINER=``@`` SQL SECURITY DEFINER VIEW `view_test_v3` (`id`, `row_1`) AS "+
+			"SELECT `db_a_cte_replay`.`tmp_table1`.`id` AS `id`,`db_a_cte_replay`.`tmp_table1`.`row_1` AS `row_1` FROM `db_a_cte_replay`.`tmp_table1`",
+			tk.MustQuery("show create view db_a_cte_replay.view_test_v3").Rows()[0][1].(string))
+
+		tk.MustExec("drop database if exists db_a_cte_replay")
+		tk.MustExec("drop database if exists db_b_cte_replay")
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3176,7 +3176,7 @@ func (r *correlatedAggregateResolver) resolveSelect(sel *ast.SelectStmt) (err er
 
 	// similar to process in PlanBuilder.buildSelect
 	originalFields := sel.Fields.Fields
-	sel.Fields.Fields, err = r.b.unfoldWildStar(p, sel.Fields.Fields)
+	sel.Fields.Fields, err = r.b.unfoldWildStar(p, sel.Fields.Fields, sel.From)
 	if err != nil {
 		return err
 	}
@@ -4078,7 +4078,7 @@ func (b *PlanBuilder) rewriteGbyExprs(ctx context.Context, p base.LogicalPlan, g
 	return p, exprs, gby.Rollup, nil
 }
 
-func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.SelectField) (resultList []*ast.SelectField, err error) {
+func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.SelectField, from *ast.TableRefsClause) (resultList []*ast.SelectField, err error) {
 	// Extract FullSchema/FullNames from LogicalJoin or LogicalApply (which embeds LogicalJoin).
 	var fullSchema *expression.Schema
 	var fullNames types.NameSlice
@@ -4088,6 +4088,7 @@ func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.Selec
 	case *logicalop.LogicalApply:
 		fullSchema, fullNames = x.FullSchema, x.FullNames
 	}
+	tableAliases := collectTableAliasesInFrom(from)
 	resultList = make([]*ast.SelectField, 0, max(2, len(selectFields)))
 	for i, field := range selectFields {
 		if field.WildCard == nil {
@@ -4097,12 +4098,12 @@ func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.Selec
 		if field.WildCard.Table.L == "" && i > 0 {
 			return nil, plannererrors.ErrInvalidWildCard
 		}
-		list := unfoldWildStar(field, p.OutputNames(), p.Schema().Columns)
+		list := unfoldWildStar(field, p.OutputNames(), p.Schema().Columns, tableAliases)
 		// For sql like `select t1.*, t2.* from t1 join t2 using(a)` or `select t1.*, t2.* from t1 natual join t2`,
 		// the schema of the Join doesn't contain enough columns because the join keys are coalesced in this schema.
 		// We should collect the columns from the FullSchema.
 		if fullSchema != nil && field.WildCard.Table.L != "" {
-			list = unfoldWildStar(field, fullNames, fullSchema.Columns)
+			list = unfoldWildStar(field, fullNames, fullSchema.Columns, tableAliases)
 		}
 		if len(list) == 0 {
 			return nil, plannererrors.ErrBadTable.GenWithStackByArgs(field.WildCard.Table)
@@ -4112,7 +4113,33 @@ func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.Selec
 	return resultList, nil
 }
 
-func unfoldWildStar(field *ast.SelectField, outputName types.NameSlice, column []*expression.Column) (resultList []*ast.SelectField) {
+// collectTableAliasesInFrom collects the lower-case aliases introduced by `AS` in the FROM clause.
+func collectTableAliasesInFrom(from *ast.TableRefsClause) map[string]struct{} {
+	if from == nil {
+		return nil
+	}
+	aliases := make(map[string]struct{})
+	var collect func(node ast.ResultSetNode)
+	collect = func(node ast.ResultSetNode) {
+		switch x := node.(type) {
+		case *ast.Join:
+			if x.Left != nil {
+				collect(x.Left)
+			}
+			if x.Right != nil {
+				collect(x.Right)
+			}
+		case *ast.TableSource:
+			if x.AsName.L != "" {
+				aliases[x.AsName.L] = struct{}{}
+			}
+		}
+	}
+	collect(from.TableRefs)
+	return aliases
+}
+
+func unfoldWildStar(field *ast.SelectField, outputName types.NameSlice, column []*expression.Column, tableAliases map[string]struct{}) (resultList []*ast.SelectField) {
 	dbName := field.WildCard.Schema
 	tblName := field.WildCard.Table
 	for i, name := range outputName {
@@ -4123,9 +4150,18 @@ func unfoldWildStar(field *ast.SelectField, outputName types.NameSlice, column [
 		if (dbName.L == "" || dbName.L == name.DBName.L) &&
 			(tblName.L == "" || tblName.L == name.TblName.L) &&
 			col.ID != model.ExtraHandleID && col.ID != model.ExtraPhysTblID && col.ID != model.ExtraCommitTSID {
+			schemaName := name.DBName
+			if _, ok := tableAliases[name.TblName.L]; ok {
+				// name.TblName is an alias introduced in the FROM clause rather than a
+				// real table name. A column reference like `db`.`alias`.`col` cannot be
+				// resolved again when the rewritten statement text is restored (e.g. the
+				// SELECT statement stored in a view definition), so keep the reference
+				// unqualified. See https://github.com/pingcap/tidb/issues/69547.
+				schemaName = ast.CIStr{}
+			}
 			colName := &ast.ColumnNameExpr{
 				Name: &ast.ColumnName{
-					Schema: name.DBName,
+					Schema: schemaName,
 					Table:  name.TblName,
 					Name:   name.ColName,
 				}}
@@ -4345,7 +4381,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	}
 
 	originalFields := sel.Fields.Fields
-	sel.Fields.Fields, err = b.unfoldWildStar(p, sel.Fields.Fields)
+	sel.Fields.Fields, err = b.unfoldWildStar(p, sel.Fields.Fields, sel.From)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69547

Problem Summary:

When a view is created with a wildcard select over an aliased CTE (or an aliased table / derived table), `unfoldWildStar` expands `alias.*` into explicit column references and qualifies them with the schema name of the underlying table, producing references like ``` `db_a`.`ojt`.`id` ``` where `ojt` is a CTE alias. The rewritten SELECT text is stored in the view definition, so `SHOW CREATE VIEW` emits DDL that cannot be replayed: ``` `db`.`cte_alias`.`col` ``` fails with `ERROR 1054: Unknown column`.

### What changed and how does it work?

`unfoldWildStar` now collects the aliases introduced by `AS` in the FROM clause of the current query block. When the expanded column reference's table name is such an alias, the reference is kept unqualified (no schema prefix), because `db.alias.col` is not resolvable when the restored statement text is parsed again.

Behavior after the change (view definition column references):

- `... from tmp_table1 otn` + `otn.*` → ``` `otn`.`id` ``` (was ``` `db_a`.`otn`.`id` ```)
- `with rs1 as (...) select ojt.* from rs1 ojt` → ``` `ojt`.`id` ``` (was ``` `db_a`.`ojt`.`id` ```, non-replayable)
- Unaliased references are unchanged: `select tmp_table1.* from tmp_table1` still produces ``` `db_a`.`tmp_table1`.`id` ```, and wildcards over unaliased views/CTEs/derived tables keep their previous output.

This matches MySQL, which never schema-qualifies alias column references in stored view definitions.

The regression test also replays the DDL emitted by `SHOW CREATE VIEW` from a different schema and verifies the replayed view returns the same rows.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `SHOW CREATE VIEW` emits non-replayable DDL when the view is created with a wildcard select over an aliased CTE, table, or derived table, because the expanded column references were incorrectly qualified with the schema name
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed view definitions that use wildcard columns and table aliases so they can be replayed correctly across schemas.
  * Preserved appropriate schema qualification for aliased and unaliased table references.
  * Improved correctness for correlated subqueries using wildcard expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->