### PR TITLE
[WIP] planner: fix IN subquery with OR FALSE producing SemiApply instead of…

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -674,7 +674,9 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			er.tryFoldCounter++
 		}
 	case *ast.BinaryOperationExpr:
-		er.asScalar = true
+		if !(v.Op == opcode.LogicOr && (isFalseConstant(v.L) || isFalseConstant(v.R))) {
+			er.asScalar = true
+		}
 		if v.Op == opcode.LogicAnd || v.Op == opcode.LogicOr {
 			er.tryFoldCounter++
 		}
@@ -710,6 +712,26 @@ func (er *expressionRewriter) canTreatInSubqueryAsExistsForFilter(planCtx *exprR
 		}
 	}
 	return true
+}
+
+// isFalseConstant checks whether an AST expression node is the constant FALSE
+// (or integer 0). NULL is explicitly excluded — it is NOT treated as FALSE.
+func isFalseConstant(expr ast.ExprNode) bool {
+	ve, ok := expr.(ast.ValueExpr)
+	if !ok {
+		return false
+	}
+	v := ve.GetValue()
+	if v == nil {
+		return false // NULL is not FALSE
+	}
+	switch val := v.(type) {
+	case int64:
+		return val == 0
+	case uint64:
+		return val == 0
+	}
+	return false
 }
 
 // inDirectMatchBooleanContext reports whether the MATCH...AGAINST currently
@@ -1747,7 +1769,32 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		if v.Op == opcode.LogicAnd || v.Op == opcode.LogicOr {
 			er.tryFoldCounter--
 		}
-		er.binaryOpToExpression(v)
+		// Simplify `expr OR FALSE` (and `FALSE OR expr`) to just `expr`.
+		// This is always semantically valid (OR with FALSE/0 is the identity).
+		// When the non-FALSE operand was an IN subquery rewritten to InnerJoin+Distinct,
+		// it won't have a ctxStack entry, and only the FALSE constant is on the stack;
+		// in that case we just pop the FALSE to leave the ctxStack empty (the plan
+		// already encodes the filter).
+		if v.Op == opcode.LogicOr && (isFalseConstant(v.L) || isFalseConstant(v.R)) {
+			stkLen := len(er.ctxStack)
+			if stkLen <= 1 {
+				// The non-FALSE operand was consumed by the plan (e.g., IN subquery
+				// rewritten to InnerJoin+Distinct). Pop the FALSE constant if present.
+				if stkLen == 1 {
+					er.ctxStackPop(1)
+				}
+			} else {
+				// Both operands on the stack: keep the non-FALSE one.
+				if isFalseConstant(v.R) {
+					er.ctxStackPop(1)
+				} else {
+					er.ctxStack[stkLen-2] = er.ctxStack[stkLen-1]
+					er.ctxStackPop(1)
+				}
+			}
+		} else {
+			er.binaryOpToExpression(v)
+		}
 	case *ast.BetweenExpr:
 		er.betweenToExpression(v)
 	case *ast.CaseExpr:

--- a/pkg/planner/core/issue_69919_test.go
+++ b/pkg/planner/core/issue_69919_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue69919 verifies that `expr IN (subquery) OR FALSE` produces the same
+// plan and results as bare `expr IN (subquery)`. Without the fix, the OR FALSE
+// wrapper forces asScalar=true which blocks the InnerJoin+Distinct rewrite,
+// causing the build phase to pick SemiApply (LeftOuterSemiJoin) instead.
+// The PredicateSimplification rule runs too late to undo this decision.
+func TestIssue69919(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t2")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t values (1), (2), (3), (4), (5)")
+	tk.MustExec("insert into t2 values (1), (2), (3)")
+
+	// Disable correlated subquery mode to test the base rewrite path deterministically.
+	tk.MustExec("set session tidb_opt_enable_correlated_subquery = off")
+
+	type testCase struct {
+		name     string
+		query    string
+		refQuery string
+	}
+	cases := []testCase{
+		{
+			"IN OR FALSE",
+			"select * from t where (a in (select a from t2)) or false",
+			"select * from t where a in (select a from t2)",
+		},
+		{
+			"FALSE OR IN",
+			"select * from t where false or (a in (select a from t2))",
+			"select * from t where a in (select a from t2)",
+		},
+		{
+			"parenthesized IN OR FALSE",
+			"select * from t where ((a in (select a from t2)) or false)",
+			"select * from t where a in (select a from t2)",
+		},
+		{
+			"IN OR FALSE AND extra condition",
+			"select * from t where ((a in (select a from t2)) or false) and a > 0",
+			"select * from t where (a in (select a from t2)) and a > 0",
+		},
+		{
+			"IN OR FALSE in HAVING",
+			"select a from t group by a having (a in (select a from t2)) or false",
+			"select a from t group by a having a in (select a from t2)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Compare plan operator name (col 0) and operator info (col 4, e.g. join mode).
+			refRows := tk.MustQuery("explain format='brief' " + c.refQuery).Rows()
+			planRows := tk.MustQuery("explain format='brief' " + c.query).Rows()
+
+			require.Equal(t, len(refRows), len(planRows),
+				"plan line count mismatch for %s", c.query)
+			for i := range refRows {
+				require.Equal(t, fmt.Sprintf("%v", refRows[i][0]), fmt.Sprintf("%v", planRows[i][0]),
+					"plan operator mismatch at line %d for %s", i, c.query)
+				require.Equal(t, fmt.Sprintf("%v", refRows[i][4]), fmt.Sprintf("%v", planRows[i][4]),
+					"plan operator info mismatch at line %d for %s", i, c.query)
+			}
+
+			// Compare results.
+			refRes := tk.MustQuery(c.refQuery).Sort().Rows()
+			res := tk.MustQuery(c.query).Sort().Rows()
+			require.Equal(t, refRes, res)
+		})
+	}
+}
+
+// TestIssue69919_NullIsNotFalse verifies that NULL is never treated as FALSE.
+func TestIssue69919_NullIsNotFalse(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+
+	// (a=1 OR NULL) OR FALSE = a=1 OR NULL → 1 OR NULL = 1 → row returned.
+	rows := tk.MustQuery("select * from t where ((a = 1 or null) or false)").Sort().Rows()
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, "1", fmt.Sprintf("%v", rows[0][0]))
+
+	// (a=2 AND NULL) = NULL (falsy), OR FALSE = NULL OR FALSE = NULL (still falsy) → no row.
+	rows = tk.MustQuery("select * from t where ((a = 2 and null) or false)").Sort().Rows()
+	require.Equal(t, 0, len(rows))
+
+	// Verify projected NULL (not FALSE) — SELECT exposes NULL semantics that WHERE hides.
+	// (a = 1) OR NULL → 1 OR NULL = 1; (a = 999) OR NULL → NULL
+	rows = tk.MustQuery("select a, (a = 1) or null from t order by a").Rows()
+	require.Equal(t, 3, len(rows))
+	require.Equal(t, "1", fmt.Sprintf("%v", rows[0][0]))
+	require.Equal(t, "1", fmt.Sprintf("%v", rows[0][1]))
+	require.Equal(t, "2", fmt.Sprintf("%v", rows[1][0]))
+	require.Equal(t, "<nil>", fmt.Sprintf("%v", rows[1][1]))
+	require.Equal(t, "3", fmt.Sprintf("%v", rows[2][0]))
+	require.Equal(t, "<nil>", fmt.Sprintf("%v", rows[2][1]))
+}
+
+// TestIssue69919_SelectList verifies SELECT-list subqueries with OR FALSE retain
+// correct scalar behavior (the fix only applies in filter contexts).
+func TestIssue69919_SelectList(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t2")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+	tk.MustExec("insert into t2 values (2), (3)")
+
+	ref := tk.MustQuery("select a, a in (select a from t2) from t order by a").Rows()
+	got := tk.MustQuery("select a, (a in (select a from t2)) or false from t order by a").Rows()
+	require.Equal(t, ref, got)
+}
+
+// TestIssue69919_NotIn verifies NOT IN with OR FALSE is unchanged.
+func TestIssue69919_NotIn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t2")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+	tk.MustExec("insert into t2 values (2)")
+
+	ref := tk.MustQuery("select * from t where a not in (select a from t2)").Sort().Rows()
+	got := tk.MustQuery("select * from t where (a not in (select a from t2)) or false").Sort().Rows()
+	require.Equal(t, ref, got)
+}
+


### PR DESCRIPTION
Issue Number: ref #69919

The expression rewriter's Enter handler for BinaryOperationExpr unconditionally sets asScalar=true, which flows to handleInSubquery and blocks the InnerJoin+Distinct rewrite via the !asScalar guard in canRewriteToJoinAgg. When the binary op is `expr IN (subquery) OR FALSE`, the OR FALSE is a semantic no-op but the asScalar flag still forces LeftOuterSemiJoin, and the subsequent PredicateSimplification rule runs too late to undo this decision.

The fix detects the OR FALSE pattern in Enter(BinaryOperationExpr) and skips setting asScalar=true. Since WHERE/HAVING/ON initialize asScalar=false, this allows handleInSubquery to naturally select InnerJoin+Distinct. In Leave, the FALSE constant is popped from ctxStack. SELECT-list subqueries are unaffected because they initialize asScalar=true.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boolean query rewriting for identities like `expr OR FALSE` / `FALSE OR expr`, simplifying expressions while preserving the correct non-`FALSE` operand behavior.
  - Ensured `NULL` handling remains correct for `(... OR false)` so `NULL` values are not incorrectly treated as `FALSE`.

- **Tests**
  - Added regression coverage for `IN`/`NOT IN` subqueries wrapped with `OR false`, verifying unchanged results and plan characteristics across WHERE/filtering, SELECT-list, and HAVING contexts, including operand reordering and additional predicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->