### PR TITLE
session: retry waiting for SYSTEM keyspace bootstrap

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/session-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/session-case-map.md
@@ -12,7 +12,7 @@
 - `pkg/session/bench_test.go` - session: Tests basic.
 - `pkg/session/bootstrap_test.go` - session: Tests MySQL DB tables.
 - `pkg/session/main_test.go` - Configures default goleak settings and registers testdata.
-- `pkg/session/session_test.go` - session: Tests get start mode.
+- `pkg/session/session_test.go` - session: Tests start mode and bootstrap-version guards and retries.
 - `pkg/session/tidb_test.go` - session: Tests do map handle nil.
 - `pkg/session/upgrade_backfill_test.go` - session: Tests bootstrap upgrade backfills.
 - `pkg/session/upgrade_test.go` - session: Tests upgrade to ver functions check.

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -227,5 +227,6 @@ go_test(
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -113,6 +113,7 @@ go_library(
         "//pkg/types",
         "//pkg/types/parser_driver",
         "//pkg/util",
+        "//pkg/util/backoff",
         "//pkg/util/chunk",
         "//pkg/util/collate",
         "//pkg/util/dbterror",

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4929,6 +4929,13 @@ const (
 	notBootstrapped = 0
 )
 
+// User keyspace startup waits for the SYSTEM keyspace to finish bootstrapping;
+// on exhaustion, notBootstrapped is returned for bootstrapSessionImpl to reject.
+// Note: we will wait nearly 30 minutes as long as the inner txn reports retryable
+// error, and will not respond kill signal during this time. Since the caller
+// is using a background context and won't cancel on kill signal anyway, pass it
+// won't help here. And do kill during bootstrap seems not that common, we can
+// enhance it later.
 func waitSystemBootVersion() int64 {
 	store := kvstore.GetSystemStorage()
 	const (
@@ -4937,8 +4944,6 @@ func waitSystemBootVersion() int64 {
 	)
 	backoffer := backoff.NewExponential(time.Second, 2, maxInterval)
 	var ver int64
-	// User keyspace startup waits for the SYSTEM keyspace to finish bootstrapping; on exhaustion,
-	// notBootstrapped is returned for bootstrapSessionImpl to reject.
 	// total backoff time is around ∑(1, 2, 4, 5...) ~= 30 minutes
 	start := time.Now()
 	for i := range maxRetryCount {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4938,13 +4938,15 @@ func mustGetSystemBootVersion() int64 {
 	backoffer := backoff.NewExponential(time.Second, 2, maxInterval)
 	var ver int64
 	// total backoff time is around ∑(1, 2, 4, 5...) ~= 30 minutes
+	start := time.Now()
 	for i := range maxRetryCount {
 		ver = mustGetStoreBootstrapVersion(store)
 		if ver != notBootstrapped {
 			break
 		}
-		if i%5 == 0 {
-			logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
+		if (i+1)%5 == 0 {
+			logutil.BgLogger().Info("waiting for the SYSTEM keyspace bootstrap to complete",
+				zap.Duration("total-waited", time.Since(start)))
 		}
 		time.Sleep(backoffer.Backoff(i))
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -120,6 +120,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/telemetry"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/backoff"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
@@ -4409,7 +4410,7 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 	failpoint.InjectCall("afterGetStoreBootstrapVersion", ver)
 	if kv.IsUserKS(store) {
 		targetVer := currentBootstrapVersion
-		systemKSVer := mustGetSystemBootVersion(kvstore.GetSystemStorage())
+		systemKSVer := mustGetSystemBootVersion()
 		if systemKSVer == notBootstrapped {
 			logutil.BgLogger().Fatal("SYSTEM keyspace is not bootstrapped")
 		} else if targetVer > systemKSVer {
@@ -4925,10 +4926,30 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 }
 
 const (
-	notBootstrapped                         = 0
-	systemKeyspaceBootstrappedTimeout       = 30 * time.Minute
-	systemKeyspaceBootstrappedRetryInterval = 30 * time.Second
+	notBootstrapped = 0
 )
+
+func mustGetSystemBootVersion() int64 {
+	store := kvstore.GetSystemStorage()
+	const (
+		maxRetryCount = 360
+		maxInterval   = 5 * time.Second
+	)
+	backoffer := backoff.NewExponential(time.Second, 2, maxInterval)
+	var ver int64
+	// total backoff time is around ∑(1, 2, 4, 5...) ~= 30 minutes
+	for i := range maxRetryCount {
+		ver = mustGetStoreBootstrapVersion(store)
+		if ver != notBootstrapped {
+			break
+		}
+		if i%5 == 0 {
+			logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
+		}
+		time.Sleep(backoffer.Backoff(i))
+	}
+	return ver
+}
 
 func mustGetStoreBootstrapVersion(store kv.Storage) int64 {
 	var ver int64
@@ -4944,51 +4965,6 @@ func mustGetStoreBootstrapVersion(store kv.Storage) int64 {
 		logutil.BgLogger().Fatal("get store bootstrap version failed", zap.Error(err))
 	}
 	return ver
-}
-
-func mustGetSystemBootVersion(store kv.Storage) int64 {
-	return waitForSystemKeyspaceBootstrap(store, systemKeyspaceBootstrappedTimeout, systemKeyspaceBootstrappedRetryInterval)
-}
-
-func waitForSystemKeyspaceBootstrap(store kv.Storage, timeout, retryInterval time.Duration) int64 {
-	timeoutTimer := time.NewTimer(timeout)
-	retryTicker := time.NewTicker(retryInterval)
-	defer timeoutTimer.Stop()
-	defer retryTicker.Stop()
-
-	return waitForSystemKeyspaceBootstrapLoop(
-		func() int64 {
-			return mustGetStoreBootstrapVersion(store)
-		},
-		timeoutTimer.C,
-		retryTicker.C,
-		func() {
-			logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
-		},
-	)
-}
-
-func waitForSystemKeyspaceBootstrapLoop(getVersion func() int64, timeoutCh, retryCh <-chan time.Time, logWait func()) int64 {
-	var ver int64
-	for {
-		select {
-		case <-timeoutCh:
-			return ver
-		default:
-		}
-
-		ver = getVersion()
-		if ver != notBootstrapped {
-			return ver
-		}
-
-		select {
-		case <-retryCh:
-			logWait()
-		case <-timeoutCh:
-			return ver
-		}
-	}
 }
 
 func getStoreBootstrapVersionWithCache(store kv.Storage) int64 {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4409,7 +4409,7 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 	failpoint.InjectCall("afterGetStoreBootstrapVersion", ver)
 	if kv.IsUserKS(store) {
 		targetVer := currentBootstrapVersion
-		systemKSVer := mustGetStoreBootstrapVersion(kvstore.GetSystemStorage())
+		systemKSVer := mustGetSystemBootVersion(kvstore.GetSystemStorage())
 		if systemKSVer == notBootstrapped {
 			logutil.BgLogger().Fatal("SYSTEM keyspace is not bootstrapped")
 		} else if targetVer > systemKSVer {
@@ -4925,14 +4925,16 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 }
 
 const (
-	notBootstrapped = 0
+	notBootstrapped                         = 0
+	systemKeyspaceBootstrappedTimeout       = 30 * time.Minute
+	systemKeyspaceBootstrappedRetryInterval = 30 * time.Second
 )
 
 func mustGetStoreBootstrapVersion(store kv.Storage) int64 {
 	var ver int64
 	// check in kv store
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap)
-	err := kv.RunInNewTxn(ctx, store, false, func(_ context.Context, txn kv.Transaction) error {
+	err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
 		var err error
 		t := meta.NewReader(txn)
 		ver, err = t.GetBootstrapVersion()
@@ -4942,6 +4944,51 @@ func mustGetStoreBootstrapVersion(store kv.Storage) int64 {
 		logutil.BgLogger().Fatal("get store bootstrap version failed", zap.Error(err))
 	}
 	return ver
+}
+
+func mustGetSystemBootVersion(store kv.Storage) int64 {
+	return waitForSystemKeyspaceBootstrap(store, systemKeyspaceBootstrappedTimeout, systemKeyspaceBootstrappedRetryInterval)
+}
+
+func waitForSystemKeyspaceBootstrap(store kv.Storage, timeout, retryInterval time.Duration) int64 {
+	timeoutTimer := time.NewTimer(timeout)
+	retryTicker := time.NewTicker(retryInterval)
+	defer timeoutTimer.Stop()
+	defer retryTicker.Stop()
+
+	return waitForSystemKeyspaceBootstrapLoop(
+		func() int64 {
+			return mustGetStoreBootstrapVersion(store)
+		},
+		timeoutTimer.C,
+		retryTicker.C,
+		func() {
+			logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
+		},
+	)
+}
+
+func waitForSystemKeyspaceBootstrapLoop(getVersion func() int64, timeoutCh, retryCh <-chan time.Time, logWait func()) int64 {
+	var ver int64
+	for {
+		select {
+		case <-timeoutCh:
+			return ver
+		default:
+		}
+
+		ver = getVersion()
+		if ver != notBootstrapped {
+			return ver
+		}
+
+		select {
+		case <-retryCh:
+			logWait()
+		case <-timeoutCh:
+			return ver
+		}
+	}
 }
 
 func getStoreBootstrapVersionWithCache(store kv.Storage) int64 {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4410,7 +4410,7 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 	failpoint.InjectCall("afterGetStoreBootstrapVersion", ver)
 	if kv.IsUserKS(store) {
 		targetVer := currentBootstrapVersion
-		systemKSVer := mustGetSystemBootVersion()
+		systemKSVer := waitSystemBootVersion()
 		if systemKSVer == notBootstrapped {
 			logutil.BgLogger().Fatal("SYSTEM keyspace is not bootstrapped")
 		} else if targetVer > systemKSVer {
@@ -4929,7 +4929,7 @@ const (
 	notBootstrapped = 0
 )
 
-func mustGetSystemBootVersion() int64 {
+func waitSystemBootVersion() int64 {
 	store := kvstore.GetSystemStorage()
 	const (
 		maxRetryCount = 360
@@ -4937,6 +4937,8 @@ func mustGetSystemBootVersion() int64 {
 	)
 	backoffer := backoff.NewExponential(time.Second, 2, maxInterval)
 	var ver int64
+	// User keyspace startup waits for the SYSTEM keyspace to finish bootstrapping; on exhaustion,
+	// notBootstrapped is returned for bootstrapSessionImpl to reject.
 	// total backoff time is around ∑(1, 2, 4, 5...) ~= 30 minutes
 	start := time.Now()
 	for i := range maxRetryCount {

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
@@ -95,30 +96,50 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 		kvstore.SetSystemStorage(originSystemStore)
 	})
 
-	core, logs := observer.New(zap.InfoLevel)
-	restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
-	defer restoreLog()
+	t.Run("get the version after retry", func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+		defer restoreLog()
 
-	versionCh := make(chan int64, 1)
-	go func() {
-		versionCh <- mustGetSystemBootVersion()
-	}()
+		versionCh := make(chan int64, 1)
+		go func() {
+			versionCh <- mustGetSystemBootVersion()
+		}()
 
-	require.Eventually(t, func() bool {
-		return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
-	}, 5*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool {
+			return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
+		}, 30*time.Second, 10*time.Millisecond)
 
-	txn, err := store.Begin()
-	require.NoError(t, err)
-	require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
-	require.NoError(t, txn.Commit(context.Background()))
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
+		require.NoError(t, txn.Commit(context.Background()))
 
-	select {
-	case version := <-versionCh:
-		require.Equal(t, currentBootstrapVersion, version)
-	case <-time.After(5 * time.Second):
-		require.Fail(t, "timed out waiting for SYSTEM keyspace bootstrap version")
-	}
+		select {
+		case version := <-versionCh:
+			require.Equal(t, currentBootstrapVersion, version)
+		case <-time.After(30 * time.Second):
+			require.Fail(t, "timed out waiting for SYSTEM keyspace bootstrap version")
+		}
+	})
+
+	t.Run("exhaust all retry budget", func(t *testing.T) {
+		// reset the boot status
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		require.NoError(t, meta.NewMutator(txn).FinishBootstrap(0))
+		require.NoError(t, txn.Commit(context.Background()))
+
+		core, _ := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+		defer restoreLog()
+
+		synctest.Test(t, func(t *testing.T) {
+			start := time.Now()
+			require.Equal(t, int64(notBootstrapped), mustGetSystemBootVersion())
+			require.Greater(t, time.Since(start), 29*time.Minute)
+		})
+	})
 }
 
 func TestBootstrapSessionImplUserKSVersionGuard(t *testing.T) {

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -37,6 +37,7 @@ import (
 	kvstore "github.com/pingcap/tidb/pkg/store"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -92,7 +93,20 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 
 		versionCh := make(chan int64, 1)
 		go func() {
-			versionCh <- waitForSystemKeyspaceBootstrap(store, time.Second, 10*time.Millisecond)
+			timeoutTimer := time.NewTimer(time.Second)
+			retryTicker := time.NewTicker(10 * time.Millisecond)
+			defer timeoutTimer.Stop()
+			defer retryTicker.Stop()
+			versionCh <- waitForSystemKeyspaceBootstrapLoop(
+				func() int64 {
+					return mustGetStoreBootstrapVersion(store)
+				},
+				timeoutTimer.C,
+				retryTicker.C,
+				func() {
+					logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
+				},
+			)
 		}()
 
 		require.Eventually(t, func() bool {
@@ -123,8 +137,21 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 			require.NoError(t, store.Close())
 		})
 
+		timeoutTimer := time.NewTimer(50 * time.Millisecond)
+		retryTicker := time.NewTicker(10 * time.Millisecond)
+		defer timeoutTimer.Stop()
+		defer retryTicker.Stop()
 		require.Equal(t, int64(notBootstrapped),
-			waitForSystemKeyspaceBootstrap(store, 50*time.Millisecond, 10*time.Millisecond))
+			waitForSystemKeyspaceBootstrapLoop(
+				func() int64 {
+					return mustGetStoreBootstrapVersion(store)
+				},
+				timeoutTimer.C,
+				retryTicker.C,
+				func() {
+					logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
+				},
+			))
 	})
 
 	t.Run("does not start another read after timeout", func(t *testing.T) {

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -97,30 +97,53 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 	})
 
 	t.Run("get the version after retry", func(t *testing.T) {
-		core, logs := observer.New(zap.InfoLevel)
-		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
-		defer restoreLog()
-
-		versionCh := make(chan int64, 1)
+		// Unistore was opened outside the synctest bubble, so keep its write path
+		// outside too to avoid mixing its WaitGroups across the bubble boundary.
+		bootstrapCh := make(chan struct{})
+		bootstrapErrCh := make(chan error, 1)
+		stopCh := make(chan struct{})
+		defer close(stopCh)
 		go func() {
-			versionCh <- mustGetSystemBootVersion()
+			select {
+			case <-bootstrapCh:
+			case <-stopCh:
+				return
+			}
+
+			txn, err := store.Begin()
+			if err == nil {
+				err = meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion)
+			}
+			if err == nil {
+				err = txn.Commit(context.Background())
+			}
+			bootstrapErrCh <- err
 		}()
 
-		require.Eventually(t, func() bool {
-			return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
-		}, 30*time.Second, 10*time.Millisecond)
+		synctest.Test(t, func(t *testing.T) {
+			core, logs := observer.New(zap.InfoLevel)
+			restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+			defer restoreLog()
 
-		txn, err := store.Begin()
-		require.NoError(t, err)
-		require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
-		require.NoError(t, txn.Commit(context.Background()))
+			versionCh := make(chan int64, 1)
+			go func() {
+				versionCh <- mustGetSystemBootVersion()
+			}()
 
-		select {
-		case version := <-versionCh:
-			require.Equal(t, currentBootstrapVersion, version)
-		case <-time.After(30 * time.Second):
-			require.Fail(t, "timed out waiting for SYSTEM keyspace bootstrap version")
-		}
+			require.Eventually(t, func() bool {
+				return logs.FilterMessage("waiting for the SYSTEM keyspace bootstrap to complete").Len() > 0
+			}, 30*time.Second, 10*time.Millisecond)
+
+			bootstrapCh <- struct{}{}
+			require.NoError(t, <-bootstrapErrCh)
+
+			select {
+			case version := <-versionCh:
+				require.Equal(t, currentBootstrapVersion, version)
+			case <-time.After(30 * time.Second):
+				require.Fail(t, "timed out waiting for SYSTEM keyspace bootstrap version")
+			}
+		})
 	})
 
 	t.Run("exhaust all retry budget", func(t *testing.T) {

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -76,7 +76,7 @@ func TestMustGetStoreBootstrapVersionRetriesTransaction(t *testing.T) {
 	})
 }
 
-func TestMustGetSystemBootVersion(t *testing.T) {
+func TestWaitSystemBootVersion(t *testing.T) {
 	const systemKeyspaceID uint32 = 0xFFFFFF - 1
 	store, err := mockstore.NewMockStore(
 		mockstore.WithStoreType(mockstore.EmbedUnistore),
@@ -127,7 +127,7 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 
 			versionCh := make(chan int64, 1)
 			go func() {
-				versionCh <- mustGetSystemBootVersion()
+				versionCh <- waitSystemBootVersion()
 			}()
 
 			require.Eventually(t, func() bool {
@@ -159,7 +159,7 @@ func TestMustGetSystemBootVersion(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			start := time.Now()
-			require.Equal(t, int64(notBootstrapped), mustGetSystemBootVersion())
+			require.Equal(t, int64(notBootstrapped), waitSystemBootVersion())
 			require.Greater(t, time.Since(start), 29*time.Minute)
 		})
 	})

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -37,7 +37,6 @@ import (
 	kvstore "github.com/pingcap/tidb/pkg/store"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
-	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -77,104 +76,49 @@ func TestMustGetStoreBootstrapVersionRetriesTransaction(t *testing.T) {
 }
 
 func TestMustGetSystemBootVersion(t *testing.T) {
-	require.Equal(t, 30*time.Minute, systemKeyspaceBootstrappedTimeout)
-	require.Equal(t, 30*time.Second, systemKeyspaceBootstrappedRetryInterval)
+	const systemKeyspaceID uint32 = 0xFFFFFF - 1
+	store, err := mockstore.NewMockStore(
+		mockstore.WithStoreType(mockstore.EmbedUnistore),
+		mockstore.WithCurrentKeyspaceMeta(&keyspacepb.KeyspaceMeta{
+			Id:   systemKeyspaceID,
+			Name: keyspace.System,
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
 
-	t.Run("waits until SYSTEM keyspace is bootstrapped", func(t *testing.T) {
-		store, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, store.Close())
-		})
+	originSystemStore := kvstore.GetSystemStorage()
+	kvstore.SetSystemStorage(store)
+	t.Cleanup(func() {
+		kvstore.SetSystemStorage(originSystemStore)
+	})
 
-		core, logs := observer.New(zap.InfoLevel)
-		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
-		defer restoreLog()
+	core, logs := observer.New(zap.InfoLevel)
+	restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+	defer restoreLog()
 
-		versionCh := make(chan int64, 1)
-		go func() {
-			timeoutTimer := time.NewTimer(time.Second)
-			retryTicker := time.NewTicker(10 * time.Millisecond)
-			defer timeoutTimer.Stop()
-			defer retryTicker.Stop()
-			versionCh <- waitForSystemKeyspaceBootstrapLoop(
-				func() int64 {
-					return mustGetStoreBootstrapVersion(store)
-				},
-				timeoutTimer.C,
-				retryTicker.C,
-				func() {
-					logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
-				},
-			)
-		}()
+	versionCh := make(chan int64, 1)
+	go func() {
+		versionCh <- mustGetSystemBootVersion()
+	}()
 
-		require.Eventually(t, func() bool {
-			return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
-		}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
+	}, 5*time.Second, 10*time.Millisecond)
 
-		txn, err := store.Begin()
-		require.NoError(t, err)
-		require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
-		require.NoError(t, txn.Commit(context.Background()))
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
+	require.NoError(t, txn.Commit(context.Background()))
 
-		var version int64
-		require.Eventually(t, func() bool {
-			select {
-			case version = <-versionCh:
-				return true
-			default:
-				return false
-			}
-		}, time.Second, 10*time.Millisecond)
+	select {
+	case version := <-versionCh:
 		require.Equal(t, currentBootstrapVersion, version)
-	})
-
-	t.Run("returns zero after timeout", func(t *testing.T) {
-		store, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, store.Close())
-		})
-
-		timeoutTimer := time.NewTimer(50 * time.Millisecond)
-		retryTicker := time.NewTicker(10 * time.Millisecond)
-		defer timeoutTimer.Stop()
-		defer retryTicker.Stop()
-		require.Equal(t, int64(notBootstrapped),
-			waitForSystemKeyspaceBootstrapLoop(
-				func() int64 {
-					return mustGetStoreBootstrapVersion(store)
-				},
-				timeoutTimer.C,
-				retryTicker.C,
-				func() {
-					logutil.BgLogger().Info("waiting SYSTEM keyspace to be bootstrapped")
-				},
-			))
-	})
-
-	t.Run("does not start another read after timeout", func(t *testing.T) {
-		timeoutCh := make(chan time.Time)
-		retryCh := make(chan time.Time, 1)
-		retryCh <- time.Now()
-
-		readCount := 0
-		version := waitForSystemKeyspaceBootstrapLoop(
-			func() int64 {
-				readCount++
-				return notBootstrapped
-			},
-			timeoutCh,
-			retryCh,
-			func() {
-				close(timeoutCh)
-			},
-		)
-
-		require.Equal(t, int64(notBootstrapped), version)
-		require.Equal(t, 1, readCount)
-	})
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for SYSTEM keyspace bootstrap version")
+	}
 }
 
 func TestBootstrapSessionImplUserKSVersionGuard(t *testing.T) {

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/log"
@@ -35,10 +36,12 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	kvstore "github.com/pingcap/tidb/pkg/store"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestGetStartMode(t *testing.T) {
@@ -46,6 +49,105 @@ func TestGetStartMode(t *testing.T) {
 	require.Equal(t, ddl.Normal, getStartMode(currentBootstrapVersion+1))
 	require.Equal(t, ddl.Upgrade, getStartMode(currentBootstrapVersion-1))
 	require.Equal(t, ddl.Bootstrap, getStartMode(0))
+}
+
+func TestMustGetStoreBootstrapVersionRetriesTransaction(t *testing.T) {
+	store, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
+	require.NoError(t, txn.Commit(context.Background()))
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/kv/mockCommitErrorInNewTxn", `return("retry_once")`)
+	conf := new(log.Config)
+	lg, p, err := log.InitLogger(conf, zap.WithFatalHook(zapcore.WriteThenPanic))
+	require.NoError(t, err)
+	restoreLog := log.ReplaceGlobals(lg, p)
+	defer restoreLog()
+
+	require.NotPanics(t, func() {
+		require.Equal(t, currentBootstrapVersion, mustGetStoreBootstrapVersion(store))
+	})
+}
+
+func TestMustGetSystemBootVersion(t *testing.T) {
+	require.Equal(t, 30*time.Minute, systemKeyspaceBootstrappedTimeout)
+	require.Equal(t, 30*time.Second, systemKeyspaceBootstrappedRetryInterval)
+
+	t.Run("waits until SYSTEM keyspace is bootstrapped", func(t *testing.T) {
+		store, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, store.Close())
+		})
+
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{})
+		defer restoreLog()
+
+		versionCh := make(chan int64, 1)
+		go func() {
+			versionCh <- waitForSystemKeyspaceBootstrap(store, time.Second, 10*time.Millisecond)
+		}()
+
+		require.Eventually(t, func() bool {
+			return logs.FilterMessage("waiting SYSTEM keyspace to be bootstrapped").Len() > 0
+		}, time.Second, 10*time.Millisecond)
+
+		txn, err := store.Begin()
+		require.NoError(t, err)
+		require.NoError(t, meta.NewMutator(txn).FinishBootstrap(currentBootstrapVersion))
+		require.NoError(t, txn.Commit(context.Background()))
+
+		var version int64
+		require.Eventually(t, func() bool {
+			select {
+			case version = <-versionCh:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
+		require.Equal(t, currentBootstrapVersion, version)
+	})
+
+	t.Run("returns zero after timeout", func(t *testing.T) {
+		store, err := mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, store.Close())
+		})
+
+		require.Equal(t, int64(notBootstrapped),
+			waitForSystemKeyspaceBootstrap(store, 50*time.Millisecond, 10*time.Millisecond))
+	})
+
+	t.Run("does not start another read after timeout", func(t *testing.T) {
+		timeoutCh := make(chan time.Time)
+		retryCh := make(chan time.Time, 1)
+		retryCh <- time.Now()
+
+		readCount := 0
+		version := waitForSystemKeyspaceBootstrapLoop(
+			func() int64 {
+				readCount++
+				return notBootstrapped
+			},
+			timeoutCh,
+			retryCh,
+			func() {
+				close(timeoutCh)
+			},
+		)
+
+		require.Equal(t, int64(notBootstrapped), version)
+		require.Equal(t, 1, readCount)
+	})
 }
 
 func TestBootstrapSessionImplUserKSVersionGuard(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70084

Problem Summary:

In next-gen deployments, a user-keyspace TiDB can start before the SYSTEM-keyspace TiDB has completed bootstrap. The current bootstrap guard reads a zero SYSTEM bootstrap version and immediately terminates the user-keyspace TiDB, even when the SYSTEM-keyspace TiDB starts and becomes ready shortly afterward. This makes a temporary deployment startup-order difference require an avoidable external restart.

### What changed and how does it work?

- Retry reading the SYSTEM keyspace bootstrap version before applying the existing user-keyspace version guard.
- Use exponential backoff starting at one second and capped at five seconds. The bounded retry budget waits approximately 30 minutes, which should normally be enough for a later-starting SYSTEM-keyspace TiDB to complete bootstrap.
- Make the internal bootstrap-version transaction retryable so transient transaction or commit failures do not abort startup.
- Preserve the existing fatal checks when SYSTEM remains unbootstrapped after the retry budget or when the user-keyspace target bootstrap version is ahead of SYSTEM.
- Add unit coverage for transaction retry, delayed SYSTEM bootstrap, and the next-gen version guard.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

start tenant tidb only:
```
[2026/07/27 16:51:14.869 +08:00] [INFO] [session.go:4948] ["waiting for the SYSTEM keyspace bootstrap to complete"] [keyspaceName=keyspace1] [total-waited=12.028914958s]
[2026/07/27 16:51:39.889 +08:00] [INFO] [session.go:4948] ["waiting for the SYSTEM keyspace bootstrap to complete"] [keyspaceName=keyspace1] [total-waited=37.048591542s]
[2026/07/27 16:52:04.906 +08:00] [INFO] [session.go:4948] ["waiting for the SYSTEM keyspace bootstrap to complete"] [keyspaceName=keyspace1] [total-waited=1m2.065703208s]
```
then start system tidb, then the tenant tidb start to boot:
```
[2026/07/27 16:52:29.946 +08:00] [INFO] [bootstrap.go:374] ["bootstrap tables"] [keyspaceName=keyspace1] [currVer=0] [targetVer=1]
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```bash
./tools/check/failpoint-go-test.sh pkg/session -run '^TestMustGetSystemBootVersion$' -count=1
./tools/check/failpoint-go-test.sh pkg/session -run '^(TestMustGetStoreBootstrapVersionRetriesTransaction|TestMustGetSystemBootVersion|TestBootstrapSessionImplUserKSVersionGuard)$' -count=1 -tags=intest,deadlock,nextgen
make bazel_prepare
make lint
git diff --check master
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Allow next-gen user-keyspace TiDB instances to wait for approximately 30 minutes for the SYSTEM keyspace to finish bootstrap instead of exiting immediately.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by waiting for the SYSTEM keyspace bootstrap version before proceeding with user keyspace bootstrapping.
  * Added backoff-based polling and retry behavior when reading bootstrap version data.
  * Added periodic progress logging while waiting for the SYSTEM bootstrap version to become ready.
* **Tests**
  * Expanded coverage for bootstrap-version retry behavior, including transaction retry and wait/retry exhaustion scenarios with synchronized assertions and log-aware coordination.
* **Documentation**
  * Updated the session “Tests” reference entry to describe the expanded start-mode and retry behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->