### PR TITLE
kv: trigger release-nextgen-202603 CI without downstream cache

### DIFF
--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -53,6 +53,9 @@ import (
 // Append UnCommitIndexKVFlag to the value indicate the index key/value is no need to commit.
 const UnCommitIndexKVFlag byte = '1'
 
+// ReleaseNextGenCICacheProbe invalidates compiled package artifacts for the release branch CI probe.
+const ReleaseNextGenCICacheProbe = "release-nextgen-202603"
+
 // Those limits is enforced to make sure the transaction can be well handled by TiKV.
 var (
 	// TxnEntrySizeLimit is limit of single entry size (len(key) + len(value)).

--- a/pkg/store/copr/main_test.go
+++ b/pkg/store/copr/main_test.go
@@ -28,7 +28,7 @@ type main struct {
 
 func (m *main) Run() int {
 	c := m.m.Run()
-	// In order for MVCCLevelDB to close, we need to wait one second
+	// Wait one second for MVCCLevelDB to close.
 	time.Sleep(time.Second)
 	return c
 }

--- a/pkg/store/copr/main_test.go
+++ b/pkg/store/copr/main_test.go
@@ -28,7 +28,7 @@ type main struct {
 
 func (m *main) Run() int {
 	c := m.m.Run()
-	// Wait one second for MVCCLevelDB to close.
+	// In order for MVCCLevelDB to close, we need to wait one second
 	time.Sleep(time.Second)
 	return c
 }


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70067

Problem Summary:

The Bazel coverage CI for #70067 has repeatedly been killed. This PR provides a minimal control change on the same release branch to check whether the CI can complete independently of #70067's diff and without relying on cached downstream build artifacts.

### What changed and how does it work?

Add a cache-probe constant to the widely imported `pkg/kv` production package. The constant changes the package export data and compiled archive without adding runtime behavior, invalidating downstream Bazel action caches for packages that depend on `pkg/kv`.

This PR is only a CI control and is not intended to be merged.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```sh
bazel build --noremote_upload_local_results //pkg/kv:kv
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release tracking metadata for the next-generation CI cache rollout.
  * No changes to application functionality, interfaces, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->