### PR TITLE
test: stabilize flaky TestParallelAlterTable/add_index_then_modify_column

### DIFF
--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -942,36 +942,42 @@ func TestMultiSchemaModifyColumnWithIndex(t *testing.T) {
 }
 
 func TestParallelAlterTable(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	ctx := context.Background()
-	var wg util.WaitGroupWrapper
 
 	checkParallelDDL := func(t *testing.T, createSQL, firstSQL, secondSQL string) (err1, err2 error) {
-		var (
-			submitted     = make(chan struct{}, 16)
-			startSchedule = make(chan struct{})
-		)
+		var wg util.WaitGroupWrapper
 
 		tk := testkit.NewTestKit(t, store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
 		tk.MustExec(createSQL)
 
-		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeLoadAndDeliverJobs", func() {
-			<-startSchedule
-		})
+		require.True(t, dom.DDL().OwnerManager().IsOwner())
+		dom.DDL().OwnerManager().CampaignCancel()
+		ddlOwnerPaused := true
+		defer func() {
+			if ddlOwnerPaused {
+				require.NoError(t, dom.DDL().OwnerManager().CampaignOwner())
+			}
+			wg.Wait()
+		}()
+		require.Eventually(t, func() bool {
+			return !dom.DDL().OwnerManager().IsOwner()
+		}, 10*time.Second, 100*time.Millisecond)
 
-		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterGetJobFromLimitCh", func(ch chan *ddl.JobWrapper) {
-			submitted <- struct{}{}
-		})
 		wg.Run(func() {
 			tk1 := testkit.NewTestKit(t, store)
 			tk1.MustExec("use test")
 			_, err1 = tk1.Exec(firstSQL)
 		})
+		require.Eventually(t, func() bool {
+			gotJobs, err := ddl.GetAllDDLJobs(ctx, tk.Session())
+			require.NoError(t, err)
+			return len(gotJobs) == 1
+		}, 10*time.Second, 100*time.Millisecond)
+
 		wg.Run(func() {
-			// wait until first ddl is submitted
-			<-submitted
 			tk1 := testkit.NewTestKit(t, store)
 			tk1.MustExec("use test")
 			_, err2 = tk1.Exec(secondSQL)
@@ -982,7 +988,11 @@ func TestParallelAlterTable(t *testing.T) {
 			return len(gotJobs) == 2
 		}, 10*time.Second, 100*time.Millisecond)
 
-		close(startSchedule)
+		require.NoError(t, dom.DDL().OwnerManager().CampaignOwner())
+		ddlOwnerPaused = false
+		require.Eventually(t, func() bool {
+			return dom.DDL().OwnerManager().IsOwner()
+		}, 10*time.Second, 100*time.Millisecond)
 		wg.Wait()
 		return
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70141

Problem Summary:
Flaky test `TestParallelAlterTable/add_index_then_modify_column` in `pkg/ddl` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The flaky was caused by test synchronization on failpoint-only, pre-persistence DDL submission events instead of a stable persisted-job boundary.

#### Fix

Pausing the mock DDL owner and polling `ddl.GetAllDDLJobs` keeps both DDLs on the real submission path while making the queued-job precondition deterministic.

#### Verification

Spec:
- target: `pkg/ddl :: TestParallelAlterTable/add_index_then_modify_column`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_runtime passed.
related_parallel_surface passed.
build passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky_runtime: PASS
- related_parallel_surface: PASS
- package_sweep: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ddl -run '^TestParallelAlterTable/add_index_then_modify_column$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/ddl -run '^TestParallelAlterTable$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for concurrent `ALTER TABLE` execution and DDL ownership transitions.
  * Added validation that only the expected DDL job remains during temporary ownership changes.
  * Enhanced test cleanup and recovery checks to ensure DDL ownership resumes correctly after concurrent operations.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->