### PR TITLE
ddl: fix ALTER TABLE ADD COLUMN dropping inline CHECK constraint (#69…

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -46,6 +47,7 @@ import (
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/zap"
@@ -101,6 +103,11 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		}
 		job.SchemaState = model.StateDeleteOnly
 	case model.StateDeleteOnly:
+		// Verify inline CHECK constraints before backfill.
+		if err := w.verifyAndAddInlineCheckConstraints(jobCtx, job, tblInfo, columnInfo); err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
 		// delete only -> write only
 		columnInfo.State = model.StateWriteOnly
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
@@ -147,6 +154,90 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 	}
 
 	return ver, errors.Trace(err)
+}
+
+// verifyAndAddInlineCheckConstraints verifies that the column default value satisfies
+// each inline CHECK constraint, then adds the verified constraints to the table info.
+// This runs before backfill (DeleteOnly → WriteOnly), so failure can cancel the job cheaply.
+func (w *worker) verifyAndAddInlineCheckConstraints(
+	jobCtx *jobContext,
+	job *model.Job,
+	tblInfo *model.TableInfo,
+	columnInfo *model.ColumnInfo,
+) error {
+	args, err := model.GetTableColumnArgs(job)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(args.Constraints) == 0 {
+		return nil
+	}
+
+	sctx, err := w.sessPool.Get()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer w.sessPool.Put(sctx)
+
+	// ExprString uses RestoreNameBackQuotes (no RestoreNameLowercase),
+	// so identifiers preserve original case. Use Name.O to match.
+	colIdent := sqlescape.MustEscapeSQL("%n", columnInfo.Name.O)
+
+	verified := make([]*model.ConstraintInfo, 0, len(args.Constraints))
+	for _, c := range args.Constraints {
+		if !c.Enforced {
+			verified = append(verified, c)
+			continue
+		}
+
+		var defaultLiteral string
+		if columnInfo.DefaultIsExpr {
+			defaultExpr, ok := columnInfo.GetDefaultValue().(string)
+			if !ok || defaultExpr == "" {
+				return dbterror.ErrCheckConstraintIsViolated.GenWithStackByArgs(c.Name.L)
+			}
+			defaultLiteral = defaultExpr
+		} else {
+			defaultValue := columnInfo.GetDefaultValue()
+			if defaultValue == nil {
+				// No default — existing rows get NULL. NULL passes every CHECK, skip check.
+				verified = append(verified, c)
+				continue
+			}
+			defaultLiteral = sqlescape.MustEscapeSQL("%?", defaultValue)
+		}
+
+		checkExpr := strings.ReplaceAll(c.ExprString, colIdent, "("+defaultLiteral+")")
+
+		var buf strings.Builder
+		sqlescape.MustFormatSQL(&buf, "select 1 from %n.%n where not (", job.SchemaName, tblInfo.Name.L)
+		buf.WriteString(checkExpr)
+		buf.WriteString(") limit 1")
+
+		ctx := kv.WithInternalSourceType(jobCtx.stepCtx, kv.InternalTxnDDL)
+		rows, _, err := sctx.GetRestrictedSQLExecutor().ExecRestrictedSQL(ctx, nil, buf.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(rows) > 0 {
+			return dbterror.ErrCheckConstraintIsViolated.GenWithStackByArgs(c.Name.L)
+		}
+
+		verified = append(verified, c)
+	}
+
+	// Add verified constraints to table info.
+	namesMap := map[string]bool{}
+	for _, c := range tblInfo.Constraints {
+		namesMap[c.Name.L] = true
+	}
+	setNameForConstraintInfo(tblInfo.Name.L, namesMap, verified)
+	for _, c := range verified {
+		c.ID = allocateConstraintID(tblInfo)
+		c.State = model.StatePublic
+		tblInfo.Constraints = append(tblInfo.Constraints, c)
+	}
+	return nil
 }
 
 func checkAndCreateNewColumn(ctx sessionctx.Context, ti ast.Ident, schema *model.DBInfo, spec *ast.AlterTableSpec, t table.Table, specNewColumn *ast.ColumnDef) (*table.Column, error) {

--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
@@ -47,6 +48,7 @@ import (
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/zap"
@@ -112,6 +114,11 @@ func (w *worker) onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err
 		}
 		job.SchemaState = model.StateDeleteOnly
 	case model.StateDeleteOnly:
+		// Verify inline CHECK constraints before backfill.
+		if err := w.verifyAndAddInlineCheckConstraints(jobCtx, job, tblInfo, columnInfo); err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
 		// delete only -> write only
 		columnInfo.State = model.StateWriteOnly
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
@@ -246,6 +253,91 @@ func syncMLogColumnsAfterAddColumn(tblInfo *model.TableInfo) {
 func isMLogMetaColumnName(name string) bool {
 	return name == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) ||
 		name == strings.ToLower(model.MaterializedViewLogOldNewColumnName)
+}
+
+
+// verifyAndAddInlineCheckConstraints verifies that the column default value satisfies
+// each inline CHECK constraint, then adds the verified constraints to the table info.
+// This runs before backfill (DeleteOnly → WriteOnly), so failure can cancel the job cheaply.
+func (w *worker) verifyAndAddInlineCheckConstraints(
+	jobCtx *jobContext,
+	job *model.Job,
+	tblInfo *model.TableInfo,
+	columnInfo *model.ColumnInfo,
+) error {
+	args, err := model.GetTableColumnArgs(job)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(args.Constraints) == 0 {
+		return nil
+	}
+
+	sctx, err := w.sessPool.Get()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer w.sessPool.Put(sctx)
+
+	// ExprString uses RestoreNameBackQuotes (no RestoreNameLowercase),
+	// so identifiers preserve original case. Use Name.O to match.
+	colIdent := sqlescape.MustEscapeSQL("%n", columnInfo.Name.O)
+
+	verified := make([]*model.ConstraintInfo, 0, len(args.Constraints))
+	for _, c := range args.Constraints {
+		if !c.Enforced {
+			verified = append(verified, c)
+			continue
+		}
+
+		var defaultLiteral string
+		if columnInfo.DefaultIsExpr {
+			defaultExpr, ok := columnInfo.GetDefaultValue().(string)
+			if !ok || defaultExpr == "" {
+				return dbterror.ErrCheckConstraintIsViolated.GenWithStackByArgs(c.Name.L)
+			}
+			defaultLiteral = defaultExpr
+		} else {
+			defaultValue := columnInfo.GetDefaultValue()
+			if defaultValue == nil {
+				// No default — existing rows get NULL. NULL passes every CHECK, skip check.
+				verified = append(verified, c)
+				continue
+			}
+			defaultLiteral = sqlescape.MustEscapeSQL("%?", defaultValue)
+		}
+
+		checkExpr := strings.ReplaceAll(c.ExprString, colIdent, "("+defaultLiteral+")")
+
+		var buf strings.Builder
+		sqlescape.MustFormatSQL(&buf, "select 1 from %n.%n where not (", job.SchemaName, tblInfo.Name.L)
+		buf.WriteString(checkExpr)
+		buf.WriteString(") limit 1")
+
+		ctx := kv.WithInternalSourceType(jobCtx.stepCtx, kv.InternalTxnDDL)
+		rows, _, err := sctx.GetRestrictedSQLExecutor().ExecRestrictedSQL(ctx, nil, buf.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(rows) > 0 {
+			return dbterror.ErrCheckConstraintIsViolated.GenWithStackByArgs(c.Name.L)
+		}
+
+		verified = append(verified, c)
+	}
+
+	// Add verified constraints to table info.
+	namesMap := map[string]bool{}
+	for _, c := range tblInfo.Constraints {
+		namesMap[c.Name.L] = true
+	}
+	setNameForConstraintInfo(tblInfo.Name.L, namesMap, verified)
+	for _, c := range verified {
+		c.ID = allocateConstraintID(tblInfo)
+		c.State = model.StatePublic
+		tblInfo.Constraints = append(tblInfo.Constraints, c)
+	}
+	return nil
 }
 
 func checkAndCreateNewColumn(ctx sessionctx.Context, ti ast.Ident, schema *model.DBInfo, spec *ast.AlterTableSpec, t table.Table, specNewColumn *ast.ColumnDef) (*table.Column, error) {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2272,13 +2272,64 @@ func (e *executor) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.Alt
 		SQLMode:        ctx.GetSessionVars().SQLMode,
 	}
 
+	constraintInfos, err := buildInlineCheckConstraints(tbInfo, specNewColumn)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	args := &model.TableColumnArgs{
 		Col:                col.ColumnInfo,
 		Pos:                spec.Position,
 		IgnoreExistenceErr: spec.IfNotExists,
+		Constraints:        constraintInfos,
 	}
 	err = e.doDDLJob2(ctx, job, args)
 	return errors.Trace(err)
+}
+
+// buildInlineCheckConstraints extracts CHECK constraint info from ADD COLUMN column definition.
+func buildInlineCheckConstraints(tblInfo *model.TableInfo, colDef *ast.ColumnDef) ([]*model.ConstraintInfo, error) {
+	if !vardef.EnableCheckConstraint.Load() {
+		return nil, nil
+	}
+	var constrs []*ast.Constraint
+	for _, opt := range colDef.Options {
+		if opt.Tp != ast.ColumnOptionCheck {
+			continue
+		}
+		constrs = append(constrs, &ast.Constraint{
+			Tp:           ast.ConstraintCheck,
+			Expr:         opt.Expr,
+			Enforced:     opt.Enforced,
+			Name:         opt.ConstraintName,
+			InColumn:     true,
+			InColumnName: colDef.Name.Name.O,
+		})
+	}
+	if len(constrs) == 0 {
+		return nil, nil
+	}
+	// Generate auto names for unnamed constraints.
+	namesMap := map[string]bool{}
+	for _, c := range tblInfo.Constraints {
+		namesMap[c.Name.L] = true
+	}
+	setEmptyCheckConstraintName(tblInfo.Name.L, namesMap, constrs)
+
+	infos := make([]*model.ConstraintInfo, 0, len(constrs))
+	for _, constr := range constrs {
+		dependedColsMap := findDependentColsInExpr(constr.Expr)
+		dependedCols := make([]ast.CIStr, 0, len(dependedColsMap))
+		for k := range dependedColsMap {
+			dependedCols = append(dependedCols, ast.NewCIStr(k))
+		}
+		info, err := buildConstraintInfo(tblInfo, dependedCols, constr, model.StatePublic)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		infos = append(infos, info)
+	}
+	setNameForConstraintInfo(tblInfo.Name.L, namesMap, infos)
+	return infos, nil
 }
 
 // AddTablePartitions will add a new partition to the table.

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2617,13 +2617,64 @@ func (e *executor) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.Alt
 		job.InvolvingSchemaInfo = involving
 	}
 
+	constraintInfos, err := buildInlineCheckConstraints(tbInfo, specNewColumn)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	args := &model.TableColumnArgs{
 		Col:                col.ColumnInfo,
 		Pos:                spec.Position,
 		IgnoreExistenceErr: spec.IfNotExists,
+		Constraints:        constraintInfos,
 	}
 	err = e.doDDLJob2(ctx, job, args)
 	return errors.Trace(err)
+}
+
+// buildInlineCheckConstraints extracts CHECK constraint info from ADD COLUMN column definition.
+func buildInlineCheckConstraints(tblInfo *model.TableInfo, colDef *ast.ColumnDef) ([]*model.ConstraintInfo, error) {
+	if !vardef.EnableCheckConstraint.Load() {
+		return nil, nil
+	}
+	var constrs []*ast.Constraint
+	for _, opt := range colDef.Options {
+		if opt.Tp != ast.ColumnOptionCheck {
+			continue
+		}
+		constrs = append(constrs, &ast.Constraint{
+			Tp:           ast.ConstraintCheck,
+			Expr:         opt.Expr,
+			Enforced:     opt.Enforced,
+			Name:         opt.ConstraintName,
+			InColumn:     true,
+			InColumnName: colDef.Name.Name.O,
+		})
+	}
+	if len(constrs) == 0 {
+		return nil, nil
+	}
+	// Generate auto names for unnamed constraints.
+	namesMap := map[string]bool{}
+	for _, c := range tblInfo.Constraints {
+		namesMap[c.Name.L] = true
+	}
+	setEmptyCheckConstraintName(tblInfo.Name.L, namesMap, constrs)
+
+	infos := make([]*model.ConstraintInfo, 0, len(constrs))
+	for _, constr := range constrs {
+		dependedColsMap := findDependentColsInExpr(constr.Expr)
+		dependedCols := make([]ast.CIStr, 0, len(dependedColsMap))
+		for k := range dependedColsMap {
+			dependedCols = append(dependedCols, ast.NewCIStr(k))
+		}
+		info, err := buildConstraintInfo(tblInfo, dependedCols, constr, model.StatePublic)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		infos = append(infos, info)
+	}
+	setNameForConstraintInfo(tblInfo.Name.L, namesMap, infos)
+	return infos, nil
 }
 
 // AddTablePartitions will add a new partition to the table.

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -765,6 +765,9 @@ type TableColumnArgs struct {
 	// it's shared by add/drop column.
 	IgnoreExistenceErr bool `json:"ignore_existence_err,omitempty"`
 
+	// Constraints are inline CHECK constraints from ADD COLUMN column definition.
+	Constraints []*ConstraintInfo `json:"constraints,omitempty"`
+
 	// for drop column.
 	// below 2 fields are filled during running, and PartitionIDs is only effective
 	// when len(IndexIDs) > 0.

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -870,6 +870,9 @@ type TableColumnArgs struct {
 	// it's shared by add/drop column.
 	IgnoreExistenceErr bool `json:"ignore_existence_err,omitempty"`
 
+	// Constraints are inline CHECK constraints from ADD COLUMN column definition.
+	Constraints []*ConstraintInfo `json:"constraints,omitempty"`
+
 	// for drop column.
 	// below 2 fields are filled during running, and PartitionIDs is only effective
 	// when len(IndexIDs) > 0.

--- a/tests/integrationtest/r/ddl/constraint.result
+++ b/tests/integrationtest/r/ddl/constraint.result
@@ -882,4 +882,32 @@ t1	CREATE TABLE `t1` (
   `c2` int DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 set @@global.tidb_enable_check_constraint = 1;
+drop table if exists t;
+create table t(a int);
+alter table t add column b int default 1 check (b > 0);
+show warnings;
+Level	Code	Message
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT '1',
+  CONSTRAINT `t_chk_1` CHECK ((`b` > 0))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+insert into t values(1, 0);
+Error 3819 (HY000): Check constraint 't_chk_1' is violated.
+insert into t values(1, 1);
+drop table t;
+drop table if exists t;
+create table t(a int);
+alter table t add column b timestamp default current_timestamp check (b > '2020-01-01');
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` timestamp DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `t_chk_1` CHECK ((`b` > '2020-01-01'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table t;
+set @@global.tidb_enable_check_constraint = 1;
 drop table if exists t1;

--- a/tests/integrationtest/r/ddl/constraint.result
+++ b/tests/integrationtest/r/ddl/constraint.result
@@ -882,4 +882,32 @@ t1	CREATE TABLE `t1` (
   `c2` int DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 set @@global.tidb_enable_check_constraint = 1;
+drop table if exists t;
+create table t(a int);
+alter table t add column b int default 1 check (b > 0);
+show warnings;
+Level	Code	Message
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT '1',
+  CONSTRAINT `t_chk_1` CHECK ((`b` > 0))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+insert into t values(1, 0);
+Error 3819 (HY000): Check constraint 't_chk_1' is violated.
+insert into t values(1, 1);
+drop table t;
+drop table if exists t;
+create table t(a int);
+alter table t add column b timestamp default current_timestamp check (b > '2020-01-01');
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` timestamp DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `t_chk_1` CHECK ((`b` > _utf8mb4'2020-01-01'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table t;
+set @@global.tidb_enable_check_constraint = 1;
 drop table if exists t1;

--- a/tests/integrationtest/t/ddl/constraint.test
+++ b/tests/integrationtest/t/ddl/constraint.test
@@ -710,6 +710,25 @@ alter table t1 drop check t1_chk_1;
 show create table t1;
 alter table t1 drop check t1_chk_2;
 show create table t1;
+# TestAlterTableAddColumnWithInlineCheckConstraint - Issue #69651
+set @@global.tidb_enable_check_constraint = 1;
+drop table if exists t;
+create table t(a int);
+alter table t add column b int default 1 check (b > 0);
+show warnings;
+show create table t;
+-- error 3819
+insert into t values(1, 0);
+insert into t values(1, 1);
+drop table t;
+
+# Test inline CHECK with expression default - Issue #69651
+drop table if exists t;
+create table t(a int);
+alter table t add column b timestamp default current_timestamp check (b > '2020-01-01');
+show create table t;
+drop table t;
+
 # Clean up
 set @@global.tidb_enable_check_constraint = 1;
 drop table if exists t1;


### PR DESCRIPTION
Issue Number:  ref #69651 

Extract CHECK constraints from specNewColumn.Options in executor, encode into TableColumnArgs, and handle in onAddColumn at DeleteOnly→WriteOnly. Verification runs before MarkNonRevertible, so failure cancels the job directly without backfill rollback. Column and constraint stay in a single atomic DDL job.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69651 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for inline `CHECK` constraints when adding columns with `ALTER TABLE ... ADD COLUMN` (when enabled).
  * Constraints appear in the resulting table definition and are enforced for new rows.

* **Bug Fixes**
  * Invalid defaults that violate inline `CHECK` constraints now cause the column-add operation to fail safely.

* **Tests**
  * Added coverage for standard and expression-based default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->