### PR TITLE
ddl: reject TIMESTAMP comparisons in partial index conditions

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/ddl-case-map.md
@@ -45,7 +45,7 @@
 - `pkg/ddl/index_cop_test.go` - ddl: Tests add index fetch rows from coprocessor.
 - `pkg/ddl/index_modify_test.go` - ddl: Tests add primary key1.
 - `pkg/ddl/index_nokit_test.go` - ddl: Tests modify task param loop.
-- `pkg/ddl/integration_test.go` - ddl: Tests DDL statements back fill.
+- `pkg/ddl/integration_test.go` - ddl: Tests DDL backfill and partial-index condition validation.
 - `pkg/ddl/job_scheduler_test.go` - ddl: Tests must reload schemas.
 - `pkg/ddl/job_scheduler_testkit_test.go` - ddl: Tests DDL scheduling.
 - `pkg/ddl/job_submitter_test.go` - ddl: Tests gen ID and insert jobs with retry.

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -4149,12 +4149,16 @@ func checkIndexCondition(tblInfo *model.TableInfo, indexCondition ast.ExprNode) 
 			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs(
 				fmt.Sprintf("generated column %s cannot be used in partial index condition", columnName.Name.Name.L))
 		}
-
 		// The another side must be a literal value, and it must have the same type as the column.
 		constantExpr, ok := anotherSide.(ast.ValueExpr)
 		if !ok {
 			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs(
 				"partial index condition must include a literal value on the other side of the binary operation")
+		}
+		if columnInfo.GetType() == mysql.TypeTimestamp {
+			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs(
+				fmt.Sprintf("TIMESTAMP column `%s` does not support comparison operators in partial index condition",
+					columnName.Name.Name.L))
 		}
 		// Reference `types.DefaultTypeForValue`, they are all possible types for literal values.
 		// However, this switch-case still includes more types than the ones we have in that function

--- a/pkg/ddl/integration_test.go
+++ b/pkg/ddl/integration_test.go
@@ -142,8 +142,16 @@ func TestPartialIndex(t *testing.T) {
 		}
 	}
 
+	// A TIMESTAMP partial index condition is time zone dependent because its literal is evaluated
+	// without the writer session's time zone. See issue #70099.
+	tk.MustGetDBError(
+		"create table t_timestamp (id int primary key, k int, ts timestamp, unique index uk(k) where ts >= '2025-01-01 00:00:00')",
+		dbterror.ErrUnsupportedAddPartialIndex)
+	tk.MustExec("create table t_timestamp (id int primary key, k int, ts timestamp, index idx(k) where ts is null)")
+	tk.MustExec("drop table t_timestamp")
+
 	// test comparing between time column and string constant is allowed.
-	timeColumnTypes := []string{"timestamp", "datetime", "date", "time"}
+	timeColumnTypes := []string{"datetime", "date", "time"}
 	allowedLiterals := []string{"'2025-07-28 12:34:56'", "'2025-07-28'", "'12:34:56'"}
 	notAllowedLiterals := []string{"1", "1.0", "true", "null"}
 	checkColumnTypes(timeColumnTypes, allowedLiterals, true)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70099

Problem Summary:

Partial-index comparison predicates on `TIMESTAMP` columns are evaluated without the writer session's time zone. As a result, index membership can depend on which session writes a row, causing inconsistent table and index row sets and wrong query or DELETE results.

### What changed and how does it work?

Reject comparison predicates on `TIMESTAMP` columns when validating a partial-index condition. Time-zone-independent `IS NULL` and `IS NOT NULL` predicates remain supported.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```text
./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestPartialIndex$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

New partial indexes can no longer use comparison predicates on `TIMESTAMP` columns. This restriction prevents creation of indexes whose membership can vary by session time zone.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Disallow comparison predicates on TIMESTAMP columns in partial indexes to prevent time zone-dependent index inconsistency.
```
