### PR TITLE
executor, util/stmtsummary: fix panics and data races in stmt summary reads

### DIFF
--- a/pkg/executor/stmtsummary.go
+++ b/pkg/executor/stmtsummary.go
@@ -241,6 +241,11 @@ func (r *stmtSummaryRetrieverV2) initEvictedRowsReader(sctx sessionctx.Context) 
 }
 
 func (r *stmtSummaryRetrieverV2) initSummaryRowsReader(ctx context.Context, sctx sessionctx.Context) (*rowsReader, error) {
+	if isCumulativeTable(r.table.Name.O) {
+		return nil, plannererrors.ErrNotSupportedYet.GenWithStackByArgs(
+			"cumulative statement summary table with persistent mode (v2)")
+	}
+
 	vars := sctx.GetSessionVars()
 	user := vars.User
 	tz := vars.StmtCtx.TimeZone()

--- a/pkg/executor/stmtsummary_test.go
+++ b/pkg/executor/stmtsummary_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	stmtsummaryv2 "github.com/pingcap/tidb/pkg/util/stmtsummary/v2"
 	"github.com/stretchr/testify/require"
@@ -193,4 +194,58 @@ func TestStmtSummaryRetriverV2_TableStatementsSummaryHistory(t *testing.T) {
 		results = append(results, rows...)
 	}
 	require.Len(t, results, 7)
+}
+
+// TestStmtSummaryRetriverV2_TableTiDBStatementsStatsUnsupported verifies that
+// querying a cumulative statement summary table (TIDB_STATEMENTS_STATS) under
+// the v2 persistent path returns an explicit unsupported error instead of
+// panicking inside initSummaryRowsReader. The same guard fires for the
+// cluster cumulative variant (CLUSTER_TIDB_STATEMENTS_STATS), so both table
+// names are exercised.
+func TestStmtSummaryRetriverV2_TableTiDBStatementsStatsUnsupported(t *testing.T) {
+	cumulativeTables := []string{
+		infoschema.TableTiDBStatementsStats,
+		infoschema.ClusterTableTiDBStatementsStats,
+	}
+	for _, tableName := range cumulativeTables {
+		verifyCumulativeTableUnsupported(t, tableName)
+	}
+}
+
+// verifyCumulativeTableUnsupported builds a v2 retriever for the given
+// cumulative statement summary table and asserts the unsupported error is
+// returned instead of panicking. Defined as a helper so the stmtSummary
+// resource defer lives in its own scope, not inside the caller loop.
+func verifyCumulativeTableUnsupported(t *testing.T, tableName string) {
+	t.Helper()
+
+	data := infoschema.NewData()
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	infoSchemaBuilder := infoschema.NewBuilder(nil, schemaCacheSize, nil, data, schemaCacheSize > 0)
+	err := infoSchemaBuilder.InitWithDBInfos(nil, nil, nil, nil, 0)
+	require.NoError(t, err)
+	infoSchema := infoSchemaBuilder.Build(math.MaxUint64)
+	table, err := infoSchema.TableByName(context.Background(), metadef.InformationSchemaName, ast.NewCIStr(tableName))
+	require.NoError(t, err)
+	columns := table.Meta().Columns
+
+	stmtSummary := stmtsummaryv2.NewStmtSummary4Test(1)
+	defer stmtSummary.Close()
+
+	retriever := stmtSummaryRetrieverV2{
+		stmtSummary: stmtSummary,
+		table:       table.Meta(),
+		columns:     columns,
+	}
+	require.NoError(t, retriever.close())
+
+	ctx := context.Background()
+	sctx := mock.NewContext()
+	tz, _ := time.LoadLocation("Asia/Shanghai")
+	sctx.ResetSessionAndStmtTimeZone(tz)
+
+	_, err = retriever.retrieve(ctx, sctx)
+	require.True(t, plannererrors.ErrNotSupportedYet.Equal(err), "table %s", tableName)
+	require.ErrorContains(t, err, "cumulative statement summary table with persistent mode (v2)")
+	require.Nil(t, retriever.rowsReader)
 }

--- a/pkg/util/stmtsummary/BUILD.bazel
+++ b/pkg/util/stmtsummary/BUILD.bazel
@@ -40,7 +40,7 @@ go_test(
     ],
     embed = [":stmtsummary"],
     flaky = True,
-    shard_count = 33,
+    shard_count = 35,
     deps = [
         "//pkg/meta/model",
         "//pkg/metrics",

--- a/pkg/util/stmtsummary/evicted.go
+++ b/pkg/util/stmtsummary/evicted.go
@@ -186,23 +186,41 @@ func (seElement *stmtSummaryByDigestEvictedElement) matchAndAdd(digestKey *StmtD
 
 // ToEvictedCountDatum converts history evicted record to `evicted count` record's datum
 func (ssbde *stmtSummaryByDigestEvicted) ToEvictedCountDatum() [][]types.Datum {
+	type evictedCount struct {
+		beginTime int64
+		endTime   int64
+		count     int64
+	}
+
 	ssbde.Lock()
-	defer ssbde.Unlock()
-	records := make([][]types.Datum, 0, ssbde.history.Len())
+	evictedCounts := make([]evictedCount, 0, ssbde.history.Len())
 	for e := ssbde.history.Back(); e != nil; e = e.Prev() {
-		if record := e.Value.(*stmtSummaryByDigestEvictedElement).toEvictedCountDatum(); record != nil {
-			records = append(records, record)
-		}
+		element := e.Value.(*stmtSummaryByDigestEvictedElement)
+		evictedCounts = append(evictedCounts, evictedCount{
+			beginTime: element.beginTime,
+			endTime:   element.endTime,
+			count:     element.count,
+		})
+	}
+	ssbde.Unlock()
+
+	records := make([][]types.Datum, 0, len(evictedCounts))
+	for _, evicted := range evictedCounts {
+		records = append(records, evictedCountToDatum(evicted.beginTime, evicted.endTime, evicted.count))
 	}
 	return records
 }
 
 // toEvictedCountDatum converts evicted record to `EvictedCount` record's datum
 func (seElement *stmtSummaryByDigestEvictedElement) toEvictedCountDatum() []types.Datum {
+	return evictedCountToDatum(seElement.beginTime, seElement.endTime, seElement.count)
+}
+
+func evictedCountToDatum(beginTime, endTime, count int64) []types.Datum {
 	datum := types.MakeDatums(
-		types.NewTime(types.FromGoTime(time.Unix(seElement.beginTime, 0)), mysql.TypeTimestamp, 0),
-		types.NewTime(types.FromGoTime(time.Unix(seElement.endTime, 0)), mysql.TypeTimestamp, 0),
-		seElement.count,
+		types.NewTime(types.FromGoTime(time.Unix(beginTime, 0)), mysql.TypeTimestamp, 0),
+		types.NewTime(types.FromGoTime(time.Unix(endTime, 0)), mysql.TypeTimestamp, 0),
+		count,
 	)
 	return datum
 }

--- a/pkg/util/stmtsummary/evicted.go
+++ b/pkg/util/stmtsummary/evicted.go
@@ -186,6 +186,8 @@ func (seElement *stmtSummaryByDigestEvictedElement) matchAndAdd(digestKey *StmtD
 
 // ToEvictedCountDatum converts history evicted record to `evicted count` record's datum
 func (ssbde *stmtSummaryByDigestEvicted) ToEvictedCountDatum() [][]types.Datum {
+	ssbde.Lock()
+	defer ssbde.Unlock()
 	records := make([][]types.Datum, 0, ssbde.history.Len())
 	for e := ssbde.history.Back(); e != nil; e = e.Prev() {
 		if record := e.Value.(*stmtSummaryByDigestEvictedElement).toEvictedCountDatum(); record != nil {

--- a/pkg/util/stmtsummary/evicted_test.go
+++ b/pkg/util/stmtsummary/evicted_test.go
@@ -19,6 +19,7 @@ import (
 	"container/list"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -653,4 +654,40 @@ func getEvicted(ssbdee *stmtSummaryByDigestEvictedElement) string {
 	buf := bytes.NewBuffer(nil)
 	buf.WriteString(fmt.Sprintf("{begin: %v, end: %v, count: %v}", ssbdee.beginTime, ssbdee.endTime, ssbdee.count))
 	return buf.String()
+}
+
+// TestToEvictedCountDatumConcurrent verifies that ToEvictedCountDatum is safe
+// to call concurrently with AddEvicted (V1-11 data race fix).
+func TestToEvictedCountDatumConcurrent(t *testing.T) {
+	ssMap := newStmtSummaryByDigestMap()
+	ssMap.Clear()
+	now := time.Now().Unix()
+	interval := ssMap.refreshInterval()
+	ssMap.beginTimeForCurInterval = now + interval
+
+	err := ssMap.summaryMap.SetCapacity(1)
+	require.NoError(t, err)
+	ssMap.Clear()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			sei := generateAnyExecInfo()
+			sei.SchemaName = fmt.Sprintf("schema_%d", i)
+			ssMap.AddStatement(sei)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = ssMap.ToEvictedCountDatum()
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/util/stmtsummary/statement_summary.go
+++ b/pkg/util/stmtsummary/statement_summary.go
@@ -727,7 +727,8 @@ func newStmtSummaryStats(sei *StmtExecInfo) *stmtSummaryStats {
 	// because it compacts performance to update every time.
 	samplePlan, planHint, e := sei.LazyInfo.GetEncodedPlan()
 	if e != nil {
-		return nil
+		samplePlan = plancodec.PlanDiscardedEncoded
+		planHint = ""
 	}
 	if len(samplePlan) > MaxEncodedPlanSizeInBytes {
 		samplePlan = plancodec.PlanDiscardedEncoded

--- a/pkg/util/stmtsummary/statement_summary_test.go
+++ b/pkg/util/stmtsummary/statement_summary_test.go
@@ -2069,3 +2069,42 @@ func TestStmtDigestKeyBoundary(t *testing.T) {
 	legacy = append(legacy, hack.Slice("rg")...)
 	require.Equal(t, legacy, off.Hash())
 }
+
+type mockLazyInfoPlanError struct {
+	mockLazyInfo
+}
+
+func (*mockLazyInfoPlanError) GetEncodedPlan() (string, string, any) {
+	return "", "", "mock plan encoding error"
+}
+
+// TestAddStatementPlanEncodeError verifies that a plan encoding failure does not
+// cause a nil dereference panic. The statement summary should still record the
+// statement with a discarded plan marker.
+func TestAddStatementPlanEncodeError(t *testing.T) {
+	ssMap := newStmtSummaryByDigestMap()
+	now := time.Now().Unix()
+	ssMap.beginTimeForCurInterval = now + 60
+
+	sei := generateAnyExecInfo()
+	sei.LazyInfo = &mockLazyInfoPlanError{
+		mockLazyInfo: mockLazyInfo{
+			originalSQL: "select 1",
+		},
+	}
+
+	require.NotPanics(t, func() {
+		ssMap.AddStatement(sei)
+	})
+
+	key := &StmtDigestKey{}
+	key.Init(sei.SchemaName, sei.Digest, "", sei.PlanDigest, sei.ResourceGroupName, "")
+	value, ok := ssMap.summaryMap.Get(key)
+	require.True(t, ok)
+	ssbd := value.(*stmtSummaryByDigest)
+	ssbd.Lock()
+	elem := ssbd.history.Front().Value.(*stmtSummaryByDigestElement)
+	require.Equal(t, plancodec.PlanDiscardedEncoded, elem.samplePlan)
+	require.Equal(t, int64(1), elem.execCount)
+	ssbd.Unlock()
+}

--- a/pkg/util/stmtsummary/v2/BUILD.bazel
+++ b/pkg/util/stmtsummary/v2/BUILD.bazel
@@ -49,7 +49,7 @@ go_test(
     ],
     embed = [":stmtsummary"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/config",
         "//pkg/meta/model",

--- a/pkg/util/stmtsummary/v2/stmtsummary.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary.go
@@ -359,13 +359,14 @@ func (s *StmtSummary) Add(info *stmtsummary.StmtExecInfo) {
 func (s *StmtSummary) Evicted() []types.Datum {
 	s.windowLock.Lock()
 	count := int64(s.window.evicted.count())
+	begin := s.window.begin
 	s.windowLock.Unlock()
 	if count == 0 {
 		return nil
 	}
-	begin := types.NewTime(types.FromGoTime(s.window.begin), mysql.TypeTimestamp, 0)
+	beginTime := types.NewTime(types.FromGoTime(begin), mysql.TypeTimestamp, 0)
 	end := types.NewTime(types.FromGoTime(timeNow()), mysql.TypeTimestamp, 0)
-	return types.MakeDatums(begin, end, count)
+	return types.MakeDatums(beginTime, end, count)
 }
 
 // Clear clears all data in the current window, and the data that

--- a/pkg/util/stmtsummary/v2/stmtsummary_test.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -408,4 +409,40 @@ func TestDefaultConfig(t *testing.T) {
 
 	// Verify RefreshInterval (should be 1800 = 30 min)
 	require.Equal(t, uint32(1800), ss.RefreshInterval())
+}
+
+// TestEvictedConcurrentWithRotate verifies that Evicted() is safe to call
+// concurrently with rotate (V2-25 data race fix).
+func TestEvictedConcurrentWithRotate(t *testing.T) {
+	ss := NewStmtSummary4Test(2)
+	defer ss.Close()
+
+	ss.Add(GenerateStmtExecInfo4Test("digest1"))
+	ss.Add(GenerateStmtExecInfo4Test("digest2"))
+	ss.Add(GenerateStmtExecInfo4Test("digest3"))
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = ss.Evicted()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			ss.windowLock.Lock()
+			ss.rotate(timeNow())
+			ss.windowLock.Unlock()
+			ss.Add(GenerateStmtExecInfo4Test("digest_new"))
+			ss.Add(GenerateStmtExecInfo4Test("digest_new2"))
+			ss.Add(GenerateStmtExecInfo4Test("digest_new3"))
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70166

Problem Summary:

The statement summary subsystem panics or races on several error and
concurrent read paths. This PR fixes four defects affecting v1 and v2
evicted table reads plus v2 cumulative table queries. These are all error
paths or low-frequency read paths; they do not change the normal Add
aggregation semantics, so risk is low.

### What changed and how does it work?

Split into 4 fix commits, one per defect, for easier review, plus 2 commits
regenerating Bazel metadata for the new tests:

1. `executor/stmtsummary: return unsupported error for cumulative tables in v2 persistent mode`
   - v2 persistent mode querying a cumulative table panicked inside
     `stmtSummaryRetrieverV2.initSummaryRowsReader`. Return
     `ErrNotSupportedYet` so the query fails with a clear error instead of
     panicking for any projection on cumulative tables.
   - Regression test: `TestStmtSummaryRetriverV2_TableTiDBStatementsStatsUnsupported`
     verifies both `TIDB_STATEMENTS_STATS` and `CLUSTER_TIDB_STATEMENTS_STATS`
     fail with the unsupported error (and would panic without the guard).

2. `util/stmtsummary: avoid nil dereference when plan encoding fails`
   - `newStmtSummaryStats` returned `nil` when
     `sei.LazyInfo.GetEncodedPlan` errored, which led callers to
     dereference a nil `stmtSummaryStats` and panic. Keep the record and
     mark `samplePlan = PlanDiscardedEncoded` so the statement stats
     still land without a panic.

3. `util/stmtsummary: fix data race in v1 ToEvictedCountDatum`
   - `ToEvictedCountDatum` iterated `ssbde.history` without holding the
     lock, racing with concurrent `AddEvicted`. Snapshot the history
     under `ssbde.Lock()` so v1 EVICTED reads are safe.

4. `util/stmtsummary/v2: fix data race in Evicted() window read`
   - `StmtSummary.Evicted()` read `s.window.begin` outside
     `windowLock`, racing with `rotate()`. Snapshot `begin` and
     `count` under `windowLock`, then build the Datum outside the lock.

5. `util/stmtsummary: regenerate Bazel metadata for new tests` - `shard_count` 33 -> 35.
6. `util/stmtsummary/v2: regenerate Bazel metadata for new test` - `shard_count` 20 -> 21.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Added regression tests (per fix):
- `TestStmtSummaryRetriverV2_TableTiDBStatementsStatsUnsupported` (executor cumulative-table guard; fails with a panic before the fix)
- `TestToEvictedCountDatumConcurrent` (v1 race, run with `-race`)
- `TestAddStatementPlanEncodeError` (plan panic guard)
- `TestEvictedConcurrentWithRotate` (v2 race, run with `-race`)

Verified locally:
```
go build ./pkg/util/stmtsummary/... ./pkg/executor/...
go test -run 'TestStmtSummaryRetriverV2' ./pkg/executor/
go test -race -run 'TestToEvictedCountDatumConcurrent|TestAddStatementPlanEncodeError' ./pkg/util/stmtsummary/
go test -race -run 'TestEvictedConcurrentWithRotate' ./pkg/util/stmtsummary/v2/
make bazel_prepare   # regenerated shard_count: v1 33->35, v2 20->21
```

The `TestStmtSummaryRetriverV2_TableTiDBStatementsStatsUnsupported` test was
confirmed to fail (panic) before the cumulative-table guard and pass after.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Side effects note: v2 cumulative-table queries that previously panicked now
return `ErrNotSupportedYet`. This is a behavior change on an unsupported path
(panic -> clear error), improving observability and avoiding crashes.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix panic when querying cumulative statement summary tables under v2 persistent mode, nil-dereference panic when plan encoding fails, and data races in v1/v2 EVICTED table reads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statement-summary stability during concurrent eviction and window rotation.
  * Statement summaries are now retained when plan encoding fails, with the sample plan marked as discarded.
  * Persistent statement-summary mode (v2) now clearly rejects cumulative statement statistics tables.
* **Tests**
  * Added concurrency and plan-encoding regression coverage.
* **Chores**
  * Adjusted test shard counts for statement-summary targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
