### PR TITLE
server: limit accumulated COM_STMT_SEND_LONG_DATA size (release-7.5-20260724-v7.5.7) (#69694)  | tidb-test=release-7.5.7 tikv=v7.5.7  pd=v7.5.7  tiflash=v7.5.7 

### DIFF
--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -206,7 +206,10 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 			paramValues = data[pos+1:]
 		}
 
-		err = parse.ExecArgs(cc.ctx.GetSessionVars().StmtCtx, args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues, cc.inputDecoder)
+		err = stmt.CheckLongDataSize()
+		if err == nil {
+			err = parse.ExecArgs(cc.ctx.GetSessionVars().StmtCtx, args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues, cc.inputDecoder)
+		}
 		// This `.Reset` resets the arguments, so it's fine to just ignore the error (and the it'll be reset again in the following routine)
 		errReset := stmt.Reset()
 		if errReset != nil {

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	servererr "github.com/pingcap/tidb/pkg/server/err"
 	"github.com/pingcap/tidb/pkg/server/internal"
 	"github.com/pingcap/tidb/pkg/server/internal/column"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -527,6 +528,42 @@ func dispatchSendLongData(c *mockConn, stmtID int, paramIndex uint16, parameter 
 			parameter..., // the parameter
 		),
 	)
+}
+
+func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	c := CreateMockConn(t, srv).(*mockConn)
+	c.capability = mysql.ClientProtocol41
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	stmt, _, _, err := c.Context().Prepare("select ?, ?")
+	require.NoError(t, err)
+
+	c.Context().GetSessionVars().MaxAllowedPacket = 1024
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 1024)))
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 1, bytes.Repeat([]byte{'b'}, 1024)))
+	require.NoError(t, stmt.CheckLongDataSize())
+
+	err = dispatchSendLongData(c, stmt.ID(), 0, []byte{'c'})
+	require.NoError(t, err)
+	require.Len(t, stmt.BoundParams()[0], 1024)
+	require.Len(t, stmt.BoundParams()[1], 1024)
+
+	err = c.Dispatch(context.Background(), append(
+		binary.LittleEndian.AppendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		0x0, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x0,
+	))
+	require.ErrorIs(t, err, servererr.ErrNetPacketTooLarge)
+	require.Nil(t, stmt.BoundParams()[0])
+	require.Nil(t, stmt.BoundParams()[1])
+	require.NoError(t, stmt.CheckLongDataSize())
 }
 
 func TestCursorFetchSendLongData(t *testing.T) {

--- a/pkg/server/driver.go
+++ b/pkg/server/driver.go
@@ -41,6 +41,9 @@ type PreparedStatement interface {
 	// AppendParam appends parameter to the statement.
 	AppendParam(paramID int, data []byte) error
 
+	// CheckLongDataSize checks whether the statement has accumulated too much data through COM_STMT_SEND_LONG_DATA.
+	CheckLongDataSize() error
+
 	// NumParams returns number of parameters.
 	NumParams() int
 

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -64,8 +64,10 @@ type TiDBStatement struct {
 	id          uint32
 	numParams   int
 	boundParams [][]byte
-	paramsType  []byte
-	ctx         *TiDBContext
+	// boundParamsTooLarge tracks whether a single COM_STMT_SEND_LONG_DATA parameter has exceeded max_allowed_packet.
+	boundParamsTooLarge bool
+	paramsType          []byte
+	ctx                 *TiDBContext
 	// this result set should have been closed before stored here. Only the `rowIterator` are used here. This field is
 	// not moved out to reuse the logic inside functions `writeResultSet...`
 	// TODO: move the `fetchedRows` into the statement, and remove the `ResultSet` from statement.
@@ -105,7 +107,27 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	if len(data) == 0 {
 		ts.boundParams[paramID] = []byte{}
 	} else {
+		if uint64(len(ts.boundParams[paramID]))+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
+			// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
+			// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
+			ts.boundParamsTooLarge = true
+			return nil
+		}
 		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+	}
+	return nil
+}
+
+// CheckLongDataSize implements PreparedStatement CheckLongDataSize method.
+func (ts *TiDBStatement) CheckLongDataSize() error {
+	if ts.boundParamsTooLarge {
+		return servererr.ErrNetPacketTooLarge
+	}
+	maxAllowedPacket := ts.ctx.GetSessionVars().MaxAllowedPacket
+	for _, boundParam := range ts.boundParams {
+		if uint64(len(boundParam)) > maxAllowedPacket {
+			return servererr.ErrNetPacketTooLarge
+		}
 	}
 	return nil
 }
@@ -147,6 +169,7 @@ func (ts *TiDBStatement) Reset() error {
 	for i := range ts.boundParams {
 		ts.boundParams[i] = nil
 	}
+	ts.boundParamsTooLarge = false
 	ts.hasActiveCursor = false
 
 	if ts.rs != nil && ts.rs.GetRowContainerReader() != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #69693

Problem Summary:
Cherry-pick #69694 (limit accumulated `COM_STMT_SEND_LONG_DATA` size) to `release-7.5-20260724-v7.5.7`.

### What changed and how does it work?

Cherry-pick of ed2376acc6e0feeff9f3e2c38db489727933aa80. Conflict adaptations for 7.5:
- `pkg/server/conn_stmt.go`: kept 7.5's `parse.ExecArgs(...)` call (master uses `parseBinaryParams`), wrapped with the new `stmt.CheckLongDataSize()` guard so the semantics of the fix are preserved.
- `pkg/server/conn_stmt_test.go`: dropped the master-only `pkg/planner/core/resolve` import (unused on this branch).
`go vet ./pkg/server/` passes. See #69694 for the full description.

### Check List

Tests

- [x] Unit test

### Release note

```release-note
TiDB now limits the accumulated `COM_STMT_SEND_LONG_DATA` size for a prepared statement by `max_allowed_packet`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for data supplied to prepared statements through long-data parameters.
  - Prevents oversized parameter data from being executed and reports an appropriate packet-size error.
  - Ensures parameter data is safely cleared after an oversized payload is detected.
  - Preserves normal execution for data within the configured packet limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->