### PR TITLE
topsql: reduce reporter loss, fix panic accounting, and enforce statement stats cap

### DIFF
--- a/pkg/util/topsql/reporter/datamodel.go
+++ b/pkg/util/topsql/reporter/datamodel.go
@@ -620,51 +620,81 @@ type planMeta struct {
 	isLarge              bool
 }
 
+// normalizedMetadataMap keeps entries and their admission count in the same
+// generation so take cannot reset the count of an in-flight registration.
+type normalizedMetadataMap struct {
+	sync.Map
+	length atomic2.Int64
+}
+
+func newNormalizedMetadataMap() *normalizedMetadataMap {
+	return &normalizedMetadataMap{}
+}
+
+func (m *normalizedMetadataMap) tryReserve() bool {
+	for {
+		current := m.length.Load()
+		if current >= topsqlstate.GlobalState.MaxCollect.Load() {
+			return false
+		}
+		if m.length.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
 // normalizedSQLMap is a wrapped map used to register normalizedSQL.
 type normalizedSQLMap struct {
-	data   atomic.Pointer[sync.Map]
-	length atomic2.Int64
+	data atomic.Pointer[normalizedMetadataMap]
 }
 
 func newNormalizedSQLMap() *normalizedSQLMap {
 	r := &normalizedSQLMap{}
-	r.data.Store(&sync.Map{})
+	r.data.Store(newNormalizedMetadataMap())
 	return r
+}
+
+func (m *normalizedSQLMap) size() int64 {
+	return m.data.Load().length.Load()
 }
 
 // register saves the relationship between sqlDigest and normalizedSQL.
 // If the internal map size exceeds the limit, the relationship will be discarded.
 func (m *normalizedSQLMap) register(sqlDigest []byte, normalizedSQL string, isInternal bool) {
-	if m.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
+	data := m.data.Load()
+	if data.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
 		reporter_metrics.IgnoreExceedSQLCounter.Inc()
 		return
 	}
-	data := m.data.Load()
-	_, loaded := data.LoadOrStore(string(sqlDigest), sqlMeta{
+	key := string(sqlDigest)
+	if _, loaded := data.Load(key); loaded {
+		return
+	}
+	if !data.tryReserve() {
+		reporter_metrics.IgnoreExceedSQLCounter.Inc()
+		return
+	}
+	_, loaded := data.LoadOrStore(key, sqlMeta{
 		normalizedSQL: normalizedSQL,
 		isInternal:    isInternal,
 	})
-	if !loaded {
-		m.length.Add(1)
+	if loaded {
+		data.length.Dec()
 	}
 }
 
 // take away all data inside normalizedSQLMap, put them in the returned new normalizedSQLMap.
 func (m *normalizedSQLMap) take() *normalizedSQLMap {
-	data := m.data.Load()
-	length := m.length.Load()
 	r := &normalizedSQLMap{}
-	r.data.Store(data)
-	r.length.Store(length)
-	m.data.Store(&sync.Map{})
-	m.length.Store(0)
+	r.data.Store(m.data.Swap(newNormalizedMetadataMap()))
 	return r
 }
 
 // toProto converts the normalizedSQLMap to the corresponding protobuf representation.
 func (m *normalizedSQLMap) toProto(keyspaceName []byte) []tipb.SQLMeta {
-	metas := make([]tipb.SQLMeta, 0, m.length.Load())
-	m.data.Load().Range(func(k, v any) bool {
+	data := m.data.Load()
+	metas := make([]tipb.SQLMeta, 0, data.length.Load())
+	data.Range(func(k, v any) bool {
 		meta := v.(sqlMeta)
 		metas = append(metas, tipb.SQLMeta{
 			KeyspaceName:  keyspaceName,
@@ -685,51 +715,58 @@ type planBinaryDecodeFunc func(string) (string, error)
 // into encoded format
 type planBinaryCompressFunc func([]byte) string
 
-// normalizedSQLMap is a wrapped map used to register normalizedPlan.
+// normalizedPlanMap is a wrapped map used to register normalizedPlan.
 type normalizedPlanMap struct {
-	data   atomic.Pointer[sync.Map]
-	length atomic2.Int64
+	data atomic.Pointer[normalizedMetadataMap]
 }
 
 func newNormalizedPlanMap() *normalizedPlanMap {
 	r := &normalizedPlanMap{}
-	r.data.Store(&sync.Map{})
+	r.data.Store(newNormalizedMetadataMap())
 	return r
+}
+
+func (m *normalizedPlanMap) size() int64 {
+	return m.data.Load().length.Load()
 }
 
 // register saves the relationship between planDigest and normalizedPlan.
 // If the internal map size exceeds the limit, the relationship will be discarded.
 func (m *normalizedPlanMap) register(planDigest []byte, normalizedPlan string, isLarge bool) {
-	if m.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
+	data := m.data.Load()
+	if data.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
 		reporter_metrics.IgnoreExceedPlanCounter.Inc()
 		return
 	}
-	data := m.data.Load()
-	_, loaded := data.LoadOrStore(string(planDigest), planMeta{
+	key := string(planDigest)
+	if _, loaded := data.Load(key); loaded {
+		return
+	}
+	if !data.tryReserve() {
+		reporter_metrics.IgnoreExceedPlanCounter.Inc()
+		return
+	}
+	_, loaded := data.LoadOrStore(key, planMeta{
 		binaryNormalizedPlan: normalizedPlan,
 		isLarge:              isLarge,
 	})
-	if !loaded {
-		m.length.Add(1)
+	if loaded {
+		data.length.Dec()
 	}
 }
 
 // take away all data inside normalizedPlanMap, put them in the returned new normalizedPlanMap.
 func (m *normalizedPlanMap) take() *normalizedPlanMap {
-	data := m.data.Load()
-	length := m.length.Load()
 	r := &normalizedPlanMap{}
-	r.data.Store(data)
-	r.length.Store(length)
-	m.data.Store(&sync.Map{})
-	m.length.Store(0)
+	r.data.Store(m.data.Swap(newNormalizedMetadataMap()))
 	return r
 }
 
 // toProto converts the normalizedPlanMap to the corresponding protobuf representation.
 func (m *normalizedPlanMap) toProto(keyspaceName []byte, decodePlan planBinaryDecodeFunc, compressPlan planBinaryCompressFunc) []tipb.PlanMeta {
-	metas := make([]tipb.PlanMeta, 0, m.length.Load())
-	m.data.Load().Range(func(k, v any) bool {
+	data := m.data.Load()
+	metas := make([]tipb.PlanMeta, 0, data.length.Load())
+	data.Range(func(k, v any) bool {
 		originalMeta := v.(planMeta)
 		protoMeta := tipb.PlanMeta{
 			KeyspaceName: keyspaceName,

--- a/pkg/util/topsql/reporter/datamodel.go
+++ b/pkg/util/topsql/reporter/datamodel.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/topsql/collector"
@@ -661,25 +662,33 @@ func (m *normalizedSQLMap) size() int64 {
 // register saves the relationship between sqlDigest and normalizedSQL.
 // If the internal map size exceeds the limit, the relationship will be discarded.
 func (m *normalizedSQLMap) register(sqlDigest []byte, normalizedSQL string, isInternal bool) {
-	data := m.data.Load()
-	if data.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
-		reporter_metrics.IgnoreExceedSQLCounter.Inc()
-		return
-	}
 	key := string(sqlDigest)
-	if _, loaded := data.Load(key); loaded {
+	for {
+		data := m.data.Load()
+		failpoint.InjectCall("afterLoadNormalizedSQLMap")
+		accepted := false
+		if data.length.Load() < topsqlstate.GlobalState.MaxCollect.Load() {
+			if _, loaded := data.Load(key); loaded {
+				accepted = true
+			} else if data.tryReserve() {
+				_, loaded = data.LoadOrStore(key, sqlMeta{
+					normalizedSQL: normalizedSQL,
+					isInternal:    isInternal,
+				})
+				if loaded {
+					data.length.Dec()
+				}
+				accepted = true
+			}
+		}
+		if m.data.Load() != data {
+			// The detached generation may already have been serialized.
+			continue
+		}
+		if !accepted {
+			reporter_metrics.IgnoreExceedSQLCounter.Inc()
+		}
 		return
-	}
-	if !data.tryReserve() {
-		reporter_metrics.IgnoreExceedSQLCounter.Inc()
-		return
-	}
-	_, loaded := data.LoadOrStore(key, sqlMeta{
-		normalizedSQL: normalizedSQL,
-		isInternal:    isInternal,
-	})
-	if loaded {
-		data.length.Dec()
 	}
 }
 
@@ -733,25 +742,33 @@ func (m *normalizedPlanMap) size() int64 {
 // register saves the relationship between planDigest and normalizedPlan.
 // If the internal map size exceeds the limit, the relationship will be discarded.
 func (m *normalizedPlanMap) register(planDigest []byte, normalizedPlan string, isLarge bool) {
-	data := m.data.Load()
-	if data.length.Load() >= topsqlstate.GlobalState.MaxCollect.Load() {
-		reporter_metrics.IgnoreExceedPlanCounter.Inc()
-		return
-	}
 	key := string(planDigest)
-	if _, loaded := data.Load(key); loaded {
+	for {
+		data := m.data.Load()
+		failpoint.InjectCall("afterLoadNormalizedPlanMap")
+		accepted := false
+		if data.length.Load() < topsqlstate.GlobalState.MaxCollect.Load() {
+			if _, loaded := data.Load(key); loaded {
+				accepted = true
+			} else if data.tryReserve() {
+				_, loaded = data.LoadOrStore(key, planMeta{
+					binaryNormalizedPlan: normalizedPlan,
+					isLarge:              isLarge,
+				})
+				if loaded {
+					data.length.Dec()
+				}
+				accepted = true
+			}
+		}
+		if m.data.Load() != data {
+			// The detached generation may already have been serialized.
+			continue
+		}
+		if !accepted {
+			reporter_metrics.IgnoreExceedPlanCounter.Inc()
+		}
 		return
-	}
-	if !data.tryReserve() {
-		reporter_metrics.IgnoreExceedPlanCounter.Inc()
-		return
-	}
-	_, loaded := data.LoadOrStore(key, planMeta{
-		binaryNormalizedPlan: normalizedPlan,
-		isLarge:              isLarge,
-	})
-	if loaded {
-		data.length.Dec()
 	}
 }
 

--- a/pkg/util/topsql/reporter/datamodel_test.go
+++ b/pkg/util/topsql/reporter/datamodel_test.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/pingcap/failpoint"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 	"github.com/pingcap/tipb/go-tipb"
@@ -39,6 +41,56 @@ func runConcurrently(count int, fn func(int)) {
 	for range count {
 		<-done
 	}
+}
+
+func testRegisterRetriesAfterTake(
+	t *testing.T,
+	failpointName string,
+	register func(),
+	takeAndSerialize func(),
+	currentMetadataCount func() int,
+) {
+	reachedGeneration := make(chan struct{})
+	resumeRegister := make(chan struct{}, 1)
+	blockOnce := make(chan struct{}, 1)
+	blockOnce <- struct{}{}
+	releaseRegister := func() {
+		select {
+		case resumeRegister <- struct{}{}:
+		default:
+		}
+	}
+
+	require.NoError(t, failpoint.EnableCall(failpointName, func() {
+		select {
+		case <-blockOnce:
+			close(reachedGeneration)
+			<-resumeRegister
+		default:
+		}
+	}))
+	t.Cleanup(func() { require.NoError(t, failpoint.Disable(failpointName)) })
+	t.Cleanup(releaseRegister)
+
+	registerDone := make(chan struct{})
+	go func() {
+		register()
+		close(registerDone)
+	}()
+
+	select {
+	case <-reachedGeneration:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registration did not reach the loaded generation")
+	}
+	takeAndSerialize()
+	releaseRegister()
+	select {
+	case <-registerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registration did not finish")
+	}
+	require.Equal(t, 1, currentMetadataCount())
 }
 
 func Test_tsItem_toProto(t *testing.T) {
@@ -397,6 +449,17 @@ func Test_normalizedSQLMap_take(t *testing.T) {
 	require.True(t, ok)
 	_, ok = data2.Load("SQL-3")
 	require.True(t, ok)
+
+	t.Run("register during take", func(t *testing.T) {
+		m := newNormalizedSQLMap()
+		testRegisterRetriesAfterTake(
+			t,
+			"github.com/pingcap/tidb/pkg/util/topsql/reporter/afterLoadNormalizedSQLMap",
+			func() { m.register([]byte("SQL-4"), "SQL-4", false) },
+			func() { require.Empty(t, m.take().toProto(nil)) },
+			func() int { return len(m.toProto(nil)) },
+		)
+	})
 }
 
 func Test_normalizedSQLMap_toProto(t *testing.T) {
@@ -492,6 +555,19 @@ func Test_normalizedPlanMap_take(t *testing.T) {
 	require.True(t, ok)
 	_, ok = data2.Load("PLAN-3")
 	require.True(t, ok)
+
+	t.Run("register during take", func(t *testing.T) {
+		m := newNormalizedPlanMap()
+		decodePlan := func(plan string) (string, error) { return plan, nil }
+		compressPlan := func(plan []byte) string { return string(plan) }
+		testRegisterRetriesAfterTake(
+			t,
+			"github.com/pingcap/tidb/pkg/util/topsql/reporter/afterLoadNormalizedPlanMap",
+			func() { m.register([]byte("PLAN-4"), "PLAN-4", false) },
+			func() { require.Empty(t, m.take().toProto(nil, decodePlan, compressPlan)) },
+			func() int { return len(m.toProto(nil, decodePlan, compressPlan)) },
+		)
+	})
 }
 
 func Test_normalizedPlanMap_toProto(t *testing.T) {

--- a/pkg/util/topsql/reporter/datamodel_test.go
+++ b/pkg/util/topsql/reporter/datamodel_test.go
@@ -29,7 +29,6 @@ func runConcurrently(count int, fn func(int)) {
 	start := make(chan struct{})
 	done := make(chan struct{}, count)
 	for i := range count {
-		i := i
 		go func() {
 			<-start
 			fn(i)

--- a/pkg/util/topsql/reporter/datamodel_test.go
+++ b/pkg/util/topsql/reporter/datamodel_test.go
@@ -25,6 +25,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func runConcurrently(count int, fn func(int)) {
+	start := make(chan struct{})
+	done := make(chan struct{}, count)
+	for i := range count {
+		i := i
+		go func() {
+			<-start
+			fn(i)
+			done <- struct{}{}
+		}()
+	}
+	close(start)
+	for range count {
+		<-done
+	}
+}
+
 func Test_tsItem_toProto(t *testing.T) {
 	item := &tsItem{
 		timestamp: 1,
@@ -329,7 +346,7 @@ func Test_normalizedSQLMap_register(t *testing.T) {
 	m.register([]byte("SQL-1"), "SQL-1", true)
 	m.register([]byte("SQL-2"), "SQL-2", false)
 	m.register([]byte("SQL-3"), "SQL-3", true)
-	require.Equal(t, int64(2), m.length.Load())
+	require.Equal(t, int64(2), m.size())
 	v, ok := m.data.Load().Load("SQL-1")
 	meta := v.(sqlMeta)
 	require.True(t, ok)
@@ -342,6 +359,20 @@ func Test_normalizedSQLMap_register(t *testing.T) {
 	require.False(t, meta.isInternal)
 	_, ok = m.data.Load().Load("SQL-3")
 	require.False(t, ok)
+
+	topsqlstate.GlobalState.MaxCollect.Store(1)
+	concurrentMap := newNormalizedSQLMap()
+	runConcurrently(256, func(i int) {
+		digest := []byte{byte(i), byte(i >> 8)}
+		concurrentMap.register(digest, string(digest), false)
+	})
+	require.Equal(t, int64(1), concurrentMap.size())
+	count := 0
+	concurrentMap.data.Load().Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 1, count)
 }
 
 func Test_normalizedSQLMap_take(t *testing.T) {
@@ -351,8 +382,8 @@ func Test_normalizedSQLMap_take(t *testing.T) {
 	m1.register([]byte("SQL-2"), "SQL-2", false)
 	m1.register([]byte("SQL-3"), "SQL-3", true)
 	m2 := m1.take()
-	require.Equal(t, int64(0), m1.length.Load())
-	require.Equal(t, int64(3), m2.length.Load())
+	require.Equal(t, int64(0), m1.size())
+	require.Equal(t, int64(3), m2.size())
 	data1 := m1.data.Load()
 	_, ok := data1.Load("SQL-1")
 	require.False(t, ok)
@@ -408,7 +439,7 @@ func Test_normalizedPlanMap_register(t *testing.T) {
 	m.register([]byte("PLAN-1"), "PLAN-1", false)
 	m.register([]byte("PLAN-2"), "PLAN-2", true)
 	m.register([]byte("PLAN-3"), "PLAN-3", false)
-	require.Equal(t, int64(2), m.length.Load())
+	require.Equal(t, int64(2), m.size())
 	v, ok := m.data.Load().Load("PLAN-1")
 	require.True(t, ok)
 	require.Equal(t, planMeta{
@@ -423,6 +454,20 @@ func Test_normalizedPlanMap_register(t *testing.T) {
 	}, v.(planMeta))
 	_, ok = m.data.Load().Load("PLAN-3")
 	require.False(t, ok)
+
+	topsqlstate.GlobalState.MaxCollect.Store(1)
+	concurrentMap := newNormalizedPlanMap()
+	runConcurrently(256, func(i int) {
+		digest := []byte{byte(i), byte(i >> 8)}
+		concurrentMap.register(digest, string(digest), false)
+	})
+	require.Equal(t, int64(1), concurrentMap.size())
+	count := 0
+	concurrentMap.data.Load().Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 1, count)
 }
 
 func Test_normalizedPlanMap_take(t *testing.T) {
@@ -432,8 +477,8 @@ func Test_normalizedPlanMap_take(t *testing.T) {
 	m1.register([]byte("PLAN-2"), "PLAN-2", false)
 	m1.register([]byte("PLAN-3"), "PLAN-3", false)
 	m2 := m1.take()
-	require.Equal(t, int64(0), m1.length.Load())
-	require.Equal(t, int64(3), m2.length.Load())
+	require.Equal(t, int64(0), m1.size())
+	require.Equal(t, int64(3), m2.size())
 	data1 := m1.data.Load()
 	_, ok := data1.Load("PLAN-1")
 	require.False(t, ok)

--- a/pkg/util/topsql/reporter/metrics/metrics.go
+++ b/pkg/util/topsql/reporter/metrics/metrics.go
@@ -31,6 +31,7 @@ var (
 	IgnoreCollectStmtChannelFullCounter   prometheus.Counter
 	IgnoreCollectRUChannelFullCounter     prometheus.Counter
 	IgnoreReportChannelFullCounter        prometheus.Counter
+	IgnoreReportDataByBackpressureCounter prometheus.Counter
 	ReportAllDurationSuccHistogram        prometheus.Observer
 	ReportAllDurationFailedHistogram      prometheus.Observer
 	ReportRecordDurationSuccHistogram     prometheus.Observer
@@ -63,6 +64,7 @@ func InitMetricsVars() {
 	IgnoreCollectStmtChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_collect_stmt_channel_full")
 	IgnoreCollectRUChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_collect_ru_channel_full")
 	IgnoreReportChannelFullCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_report_channel_full")
+	IgnoreReportDataByBackpressureCounter = metrics.TopSQLIgnoredCounter.WithLabelValues("ignore_report_data_by_backpressure")
 	ReportAllDurationSuccHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("all", metrics.LblOK)
 	ReportAllDurationFailedHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("all", metrics.LblError)
 	ReportRecordDurationSuccHistogram = metrics.TopSQLReportDurationHistogram.WithLabelValues("record", metrics.LblOK)

--- a/pkg/util/topsql/reporter/reporter.go
+++ b/pkg/util/topsql/reporter/reporter.go
@@ -34,6 +34,8 @@ import (
 const (
 	reportTimeout         = 40 * time.Second
 	collectChanBufferSize = 2
+	// maxPendingReportWindows allows one retry window before stale pending data is discarded.
+	maxPendingReportWindows = 2
 )
 
 var nowFunc = time.Now
@@ -83,6 +85,7 @@ type RemoteTopSQLReporter struct {
 	collectStmtStatsChan    chan stmtstats.StatementStatsMap
 	collectRUIncrementsChan chan ruBatch
 	collecting              *collecting
+	reportChannelFullCount  int
 	ruAggregator            *ruWindowAggregator // Online 15s RU aggregation (400->200->100 pipeline)
 	normalizedSQLMap        *normalizedSQLMap
 	normalizedPlanMap       *normalizedPlanMap
@@ -349,8 +352,18 @@ func (tsr *RemoteTopSQLReporter) takeDataAndSendToReportChan(timestamp uint64) {
 	// between this check and the send below.
 	if len(tsr.reportCollectedDataChan) == cap(tsr.reportCollectedDataChan) {
 		reporter_metrics.IgnoreReportChannelFullCounter.Inc()
+		tsr.reportChannelFullCount++
+		if tsr.reportChannelFullCount >= maxPendingReportWindows {
+			// Preserve bounded SQL/plan metadata so later records can still be decoded,
+			// but discard data after prolonged backpressure to bound retained state.
+			tsr.collecting = newCollecting()
+			tsr.ruAggregator.dropReportData(timestamp)
+			reporter_metrics.IgnoreReportDataByBackpressureCounter.Inc()
+			tsr.reportChannelFullCount = 0
+		}
 		return
 	}
+	tsr.reportChannelFullCount = 0
 
 	ruRecords := tsr.ruAggregator.takeReportRecords(
 		timestamp,

--- a/pkg/util/topsql/reporter/reporter.go
+++ b/pkg/util/topsql/reporter/reporter.go
@@ -345,22 +345,23 @@ func findKthNetworkBytes(data stmtstats.StatementStatsMap, k int, u64Slice []uin
 // TopRU extraction runs on the same report tick path.
 // Each call emits at most one aligned closed 60s RU window.
 func (tsr *RemoteTopSQLReporter) takeDataAndSendToReportChan(timestamp uint64) {
+	// collectWorker is the only sender, so the channel cannot become full
+	// between this check and the send below.
+	if len(tsr.reportCollectedDataChan) == cap(tsr.reportCollectedDataChan) {
+		reporter_metrics.IgnoreReportChannelFullCounter.Inc()
+		return
+	}
+
 	ruRecords := tsr.ruAggregator.takeReportRecords(
 		timestamp,
 		uint64(topsqlstate.GetTopRUItemInterval()),
 		tsr.keyspaceName,
 	)
-	// Send to report channel. When channel is full, data will be dropped.
-	select {
-	case tsr.reportCollectedDataChan <- collectedData{
+	tsr.reportCollectedDataChan <- collectedData{
 		collected:         tsr.collecting.take(),
 		ruRecords:         ruRecords,
 		normalizedSQLMap:  tsr.normalizedSQLMap.take(),
 		normalizedPlanMap: tsr.normalizedPlanMap.take(),
-	}:
-	default:
-		// ignore if chan blocked
-		reporter_metrics.IgnoreReportChannelFullCounter.Inc()
 	}
 }
 

--- a/pkg/util/topsql/reporter/reporter.go
+++ b/pkg/util/topsql/reporter/reporter.go
@@ -32,10 +32,9 @@ import (
 )
 
 const (
-	reportTimeout         = 40 * time.Second
-	collectChanBufferSize = 2
-	// maxPendingReportWindows allows one retry window before stale pending data is discarded.
-	maxPendingReportWindows = 2
+	reportTimeout               = 40 * time.Second
+	collectChanBufferSize       = 2
+	reportCollectedDataChanSize = 2
 )
 
 var nowFunc = time.Now
@@ -85,7 +84,6 @@ type RemoteTopSQLReporter struct {
 	collectStmtStatsChan    chan stmtstats.StatementStatsMap
 	collectRUIncrementsChan chan ruBatch
 	collecting              *collecting
-	reportChannelFullCount  int
 	ruAggregator            *ruWindowAggregator // Online 15s RU aggregation (400->200->100 pipeline)
 	normalizedSQLMap        *normalizedSQLMap
 	normalizedPlanMap       *normalizedPlanMap
@@ -119,7 +117,7 @@ func NewRemoteTopSQLReporter(decodePlan planBinaryDecodeFunc, compressPlan planB
 		collectCPUTimeChan:        make(chan []collector.SQLCPUTimeRecord, collectChanBufferSize),
 		collectStmtStatsChan:      make(chan stmtstats.StatementStatsMap, collectChanBufferSize),
 		collectRUIncrementsChan:   make(chan ruBatch, collectChanBufferSize),
-		reportCollectedDataChan:   make(chan collectedData, 1),
+		reportCollectedDataChan:   make(chan collectedData, reportCollectedDataChanSize),
 		collecting:                newCollecting(),
 		ruAggregator:              newRUWindowAggregator(),
 		normalizedSQLMap:          newNormalizedSQLMap(),
@@ -352,18 +350,13 @@ func (tsr *RemoteTopSQLReporter) takeDataAndSendToReportChan(timestamp uint64) {
 	// between this check and the send below.
 	if len(tsr.reportCollectedDataChan) == cap(tsr.reportCollectedDataChan) {
 		reporter_metrics.IgnoreReportChannelFullCounter.Inc()
-		tsr.reportChannelFullCount++
-		if tsr.reportChannelFullCount >= maxPendingReportWindows {
-			// Preserve bounded SQL/plan metadata so later records can still be decoded,
-			// but discard data after prolonged backpressure to bound retained state.
-			tsr.collecting = newCollecting()
-			tsr.ruAggregator.dropReportData(timestamp)
-			reporter_metrics.IgnoreReportDataByBackpressureCounter.Inc()
-			tsr.reportChannelFullCount = 0
-		}
+		// SQL/plan metadata remains on the reporter side because it is bounded by
+		// MaxCollect and can decode records collected after backpressure recovers.
+		tsr.collecting = newCollecting()
+		tsr.ruAggregator.dropReportData(timestamp)
+		reporter_metrics.IgnoreReportDataByBackpressureCounter.Inc()
 		return
 	}
-	tsr.reportChannelFullCount = 0
 
 	ruRecords := tsr.ruAggregator.takeReportRecords(
 		timestamp,

--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -813,6 +813,8 @@ func TestProcessStmtStatsData(t *testing.T) {
 // when internal channels are full, reporter should drop fast (no panic/hang)
 // and account drops via the corresponding metrics counters.
 func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
+	const expectedReportBufferSize = 2
+
 	tsr := NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc, mockPlanBinaryCompressFunc)
 	t.Cleanup(tsr.Close)
 
@@ -844,47 +846,11 @@ func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
 	require.Equal(t, 2, len(tsr.collectRUIncrementsChan))
 	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreCollectRUChannelFullCounter)-beforeCollectRUDrop, 1e-9)
 
-	beforeReportDrop := readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)
 	origInterval := topsqlstate.GetTopRUItemInterval()
 	topsqlstate.SetTopRUItemInterval(tipb.ItemInterval_ITEM_INTERVAL_60S)
 	t.Cleanup(func() {
 		topsqlstate.SetTopRUItemInterval(tipb.ItemInterval(origInterval))
 	})
-
-	sqlDigest := []byte("full-channel-sql")
-	planDigest := []byte("full-channel-plan")
-	tsr.RegisterSQL(sqlDigest, "select * from full_channel", false)
-	tsr.RegisterPlan(planDigest, "table_scan", false)
-	tsr.processCPUTimeData(1, cpuRecords{{
-		SQLDigest:  sqlDigest,
-		PlanDigest: planDigest,
-		CPUTimeMs:  1,
-	}})
-	tsr.reportCollectedDataChan <- collectedData{} // fill reportCollectedDataChan (buffer=1)
-	doneReport := make(chan struct{})
-	go func() {
-		tsr.takeDataAndSendToReportChan(60) // should drop immediately when report channel is full
-		close(doneReport)
-	}()
-	select {
-	case <-doneReport:
-	case <-time.After(time.Second):
-		t.Fatal("takeDataAndSendToReportChan should not block when reportCollectedDataChan is full")
-	}
-	require.Equal(t, 1, len(tsr.reportCollectedDataChan))
-	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)-beforeReportDrop, 1e-9)
-	<-tsr.reportCollectedDataChan
-
-	tsr.processCPUTimeData(61, cpuRecords{{
-		SQLDigest:  sqlDigest,
-		PlanDigest: planDigest,
-		CPUTimeMs:  1,
-	}})
-	tsr.takeDataAndSendToReportChan(120)
-	recovered := <-tsr.reportCollectedDataChan
-	require.NotEmpty(t, recovered.collected.getReportRecords())
-	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), 1)
-	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), 1)
 
 	origMaxStatementCount := topsqlstate.GlobalState.MaxStatementCount.Load()
 	topsqlstate.GlobalState.MaxStatementCount.Store(1)
@@ -892,60 +858,73 @@ func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
 		topsqlstate.GlobalState.MaxStatementCount.Store(origMaxStatementCount)
 	})
 
-	boundedSQLDigests := [][]byte{[]byte("bounded-sql-1"), []byte("bounded-sql-2")}
-	boundedPlanDigests := [][]byte{[]byte("bounded-plan-1"), []byte("bounded-plan-2")}
-	for i := range boundedSQLDigests {
+	boundedSQLDigests := [][]byte{[]byte("bounded-sql-1"), []byte("bounded-sql-2"), []byte("bounded-sql-3")}
+	boundedPlanDigests := [][]byte{[]byte("bounded-plan-1"), []byte("bounded-plan-2"), []byte("bounded-plan-3")}
+
+	require.Equal(t, expectedReportBufferSize, cap(tsr.reportCollectedDataChan))
+	for i := range expectedReportBufferSize {
+		reportEnd := uint64((i + 1) * defaultReportInterval)
 		tsr.RegisterSQL(boundedSQLDigests[i], fmt.Sprintf("select %d", i+1), false)
 		tsr.RegisterPlan(boundedPlanDigests[i], fmt.Sprintf("point_get_%d", i+1), false)
-	}
-
-	tsr.reportCollectedDataChan <- collectedData{} // keep the report channel blocked
-	beforeBackpressureDrop := readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)
-	const blockedReportWindows = maxPendingReportWindows * 3
-	var lastReportEnd uint64
-	for i := 1; i <= blockedReportWindows; i++ {
-		reportEnd := uint64(120 + i*defaultReportInterval)
-		lastReportEnd = reportEnd
-		sampleTimestamp := reportEnd - 1
-		tsr.processCPUTimeData(sampleTimestamp, cpuRecords{
-			{SQLDigest: boundedSQLDigests[0], PlanDigest: boundedPlanDigests[0], CPUTimeMs: 2},
-			{SQLDigest: boundedSQLDigests[1], PlanDigest: boundedPlanDigests[1], CPUTimeMs: 1},
-		})
+		tsr.processCPUTimeData(reportEnd-1, cpuRecords{{
+			SQLDigest:  boundedSQLDigests[i],
+			PlanDigest: boundedPlanDigests[i],
+			CPUTimeMs:  uint32(i + 1),
+		}})
 		tsr.ruAggregator.addBatch(ruBatch{
-			timestamp: sampleTimestamp,
+			timestamp: reportEnd - 1,
 			data:      ruData,
 			version:   rmclient.DefaultRUVersion,
 		})
 		tsr.takeDataAndSendToReportChan(reportEnd)
-		if i%maxPendingReportWindows != 0 {
-			require.NotEmpty(t, tsr.collecting.records)
-			require.NotEmpty(t, tsr.collecting.evicted)
-		} else {
-			require.Empty(t, tsr.collecting.records)
-			require.Empty(t, tsr.collecting.evicted)
-		}
-		tsr.ruAggregator.mu.Lock()
-		bucketCount := len(tsr.ruAggregator.buckets)
-		tsr.ruAggregator.mu.Unlock()
-		require.LessOrEqual(t, bucketCount, maxPendingReportWindows-1)
 	}
+	require.Equal(t, cap(tsr.reportCollectedDataChan), len(tsr.reportCollectedDataChan))
+
+	beforeReportDrop := readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)
+	beforeBackpressureDrop := readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)
+	dropReportEnd := uint64((expectedReportBufferSize + 1) * defaultReportInterval)
+	tsr.RegisterSQL(boundedSQLDigests[2], "select 3", false)
+	tsr.RegisterPlan(boundedPlanDigests[2], "point_get_3", false)
+	tsr.processCPUTimeData(dropReportEnd-1, cpuRecords{
+		{SQLDigest: boundedSQLDigests[2], PlanDigest: boundedPlanDigests[2], CPUTimeMs: 2},
+		{SQLDigest: []byte("evicted-sql"), PlanDigest: []byte("evicted-plan"), CPUTimeMs: 1},
+	})
+	tsr.ruAggregator.addBatch(ruBatch{
+		timestamp: dropReportEnd - 1,
+		data:      ruData,
+		version:   rmclient.DefaultRUVersion,
+	})
+	tsr.takeDataAndSendToReportChan(dropReportEnd)
 
 	require.Empty(t, tsr.collecting.records)
 	require.Empty(t, tsr.collecting.evicted)
-	require.InDelta(t, float64(blockedReportWindows/maxPendingReportWindows), readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)-beforeBackpressureDrop, 1e-9)
-	<-tsr.reportCollectedDataChan
+	tsr.ruAggregator.mu.Lock()
+	bucketCount := len(tsr.ruAggregator.buckets)
+	tsr.ruAggregator.mu.Unlock()
+	require.Zero(t, bucketCount)
+	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)-beforeReportDrop, 1e-9)
+	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)-beforeBackpressureDrop, 1e-9)
 
-	recoveryTimestamp := lastReportEnd + uint64(defaultReportInterval) - 1
+	for range expectedReportBufferSize {
+		queued := <-tsr.reportCollectedDataChan
+		require.Len(t, queued.collected.getReportRecords(), 1)
+		require.Len(t, queued.normalizedSQLMap.toProto(keyspaceName), 1)
+		require.Len(t, queued.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), 1)
+		require.NotEmpty(t, queued.ruRecords)
+	}
+
+	recoveryReportEnd := dropReportEnd + uint64(defaultReportInterval)
+	recoveryTimestamp := recoveryReportEnd - 1
 	tsr.processCPUTimeData(recoveryTimestamp, cpuRecords{{
-		SQLDigest:  boundedSQLDigests[0],
-		PlanDigest: boundedPlanDigests[0],
+		SQLDigest:  boundedSQLDigests[2],
+		PlanDigest: boundedPlanDigests[2],
 		CPUTimeMs:  1,
 	}})
-	tsr.takeDataAndSendToReportChan(lastReportEnd + uint64(defaultReportInterval))
-	recovered = <-tsr.reportCollectedDataChan
+	tsr.takeDataAndSendToReportChan(recoveryReportEnd)
+	recovered := <-tsr.reportCollectedDataChan
 	require.Len(t, recovered.collected.getReportRecords(), 1)
-	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), len(boundedSQLDigests))
-	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), len(boundedPlanDigests))
+	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), 1)
+	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), 1)
 }
 
 // TestReporterBackpressureAndDropScenario covers the reporter backpressure
@@ -1005,9 +984,10 @@ func TestReporterBackpressureAndDropScenario(t *testing.T) {
 	}
 
 	beforeDrop := readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)
-	sendBatch(1, 60)   // fill reportCollectedDataChan (buffer=1)
-	sendBatch(61, 120) // drop under backpressure (no report worker consuming yet)
-	require.Equal(t, 1, len(tsr.reportCollectedDataChan))
+	sendBatch(1, 60)
+	sendBatch(61, 120)  // fill reportCollectedDataChan (buffer=2)
+	sendBatch(121, 180) // drop under backpressure (no report worker consuming yet)
+	require.Equal(t, cap(tsr.reportCollectedDataChan), len(tsr.reportCollectedDataChan))
 	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)-beforeDrop, 1e-9)
 
 	reportWorkerDone := make(chan struct{})
@@ -1016,21 +996,22 @@ func TestReporterBackpressureAndDropScenario(t *testing.T) {
 		close(reportWorkerDone)
 	}()
 
-	var firstPayload *ReportData
-	select {
-	case firstPayload = <-sinkCh:
-	case <-time.After(time.Second):
-		t.Fatal("reporter should recover and send payload after consumer resumes")
+	for range cap(tsr.reportCollectedDataChan) {
+		select {
+		case payload := <-sinkCh:
+			require.NotNil(t, payload)
+			require.NotEmpty(t, payload.RURecords)
+			require.Empty(t, payload.DataRecords, "TopSQL shared path should remain untouched in RU-only scenario")
+		case <-time.After(time.Second):
+			t.Fatal("reporter should recover and send buffered payloads after consumer resumes")
+		}
 	}
-	require.NotNil(t, firstPayload)
-	require.NotEmpty(t, firstPayload.RURecords)
-	require.Empty(t, firstPayload.DataRecords, "TopSQL shared path should remain untouched in RU-only scenario")
 	require.Eventually(t, func() bool {
 		return len(tsr.reportCollectedDataChan) == 0
 	}, time.Second, 10*time.Millisecond)
 
 	dropAfterRecover := readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)
-	sendBatch(121, 180)
+	sendBatch(181, 240)
 	var secondPayload *ReportData
 	select {
 	case secondPayload = <-sinkCh:
@@ -1521,7 +1502,9 @@ func BenchmarkReporterScenarios(b *testing.B) {
 		b.Run("drop_path", func(b *testing.B) {
 			tsr := NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc, mockPlanBinaryCompressFunc)
 			b.Cleanup(tsr.Close)
-			tsr.reportCollectedDataChan <- collectedData{} // keep channel full to trigger drop path
+			for range cap(tsr.reportCollectedDataChan) {
+				tsr.reportCollectedDataChan <- collectedData{} // keep channel full to trigger drop path
+			}
 
 			beforeDrop := readCounterValue(reporter_metrics.IgnoreReportChannelFullCounter)
 			b.ResetTimer()

--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -851,6 +851,15 @@ func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
 		topsqlstate.SetTopRUItemInterval(tipb.ItemInterval(origInterval))
 	})
 
+	sqlDigest := []byte("full-channel-sql")
+	planDigest := []byte("full-channel-plan")
+	tsr.RegisterSQL(sqlDigest, "select * from full_channel", false)
+	tsr.RegisterPlan(planDigest, "table_scan", false)
+	tsr.processCPUTimeData(1, cpuRecords{{
+		SQLDigest:  sqlDigest,
+		PlanDigest: planDigest,
+		CPUTimeMs:  1,
+	}})
 	tsr.reportCollectedDataChan <- collectedData{} // fill reportCollectedDataChan (buffer=1)
 	doneReport := make(chan struct{})
 	go func() {
@@ -864,6 +873,18 @@ func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
 	}
 	require.Equal(t, 1, len(tsr.reportCollectedDataChan))
 	require.InDelta(t, 1.0, readCounter(t, reporter_metrics.IgnoreReportChannelFullCounter)-beforeReportDrop, 1e-9)
+	<-tsr.reportCollectedDataChan
+
+	tsr.processCPUTimeData(61, cpuRecords{{
+		SQLDigest:  sqlDigest,
+		PlanDigest: planDigest,
+		CPUTimeMs:  1,
+	}})
+	tsr.takeDataAndSendToReportChan(120)
+	recovered := <-tsr.reportCollectedDataChan
+	require.NotEmpty(t, recovered.collected.getReportRecords())
+	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), 1)
+	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), 1)
 }
 
 // TestReporterBackpressureAndDropScenario covers the reporter backpressure

--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -435,26 +435,26 @@ func TestCollectCapacity(t *testing.T) {
 
 	topsqlstate.GlobalState.MaxCollect.Store(10000)
 	registerSQL(5000)
-	require.Equal(t, int64(5000), tsr.normalizedSQLMap.length.Load())
+	require.Equal(t, int64(5000), tsr.normalizedSQLMap.size())
 	registerPlan(1000)
-	require.Equal(t, int64(1000), tsr.normalizedPlanMap.length.Load())
+	require.Equal(t, int64(1000), tsr.normalizedPlanMap.size())
 
 	registerSQL(20000)
-	require.Equal(t, int64(10000), tsr.normalizedSQLMap.length.Load())
+	require.Equal(t, int64(10000), tsr.normalizedSQLMap.size())
 	registerPlan(20000)
-	require.Equal(t, int64(10000), tsr.normalizedPlanMap.length.Load())
+	require.Equal(t, int64(10000), tsr.normalizedPlanMap.size())
 
 	topsqlstate.GlobalState.MaxCollect.Store(20000)
 	registerSQL(50000)
-	require.Equal(t, int64(20000), tsr.normalizedSQLMap.length.Load())
+	require.Equal(t, int64(20000), tsr.normalizedSQLMap.size())
 	registerPlan(50000)
-	require.Equal(t, int64(20000), tsr.normalizedPlanMap.length.Load())
+	require.Equal(t, int64(20000), tsr.normalizedPlanMap.size())
 
 	topsqlstate.GlobalState.MaxStatementCount.Store(5000)
 	tsr.processCPUTimeData(1, genRecord(20000))
 	require.Equal(t, 5001, len(tsr.collecting.records))
-	require.Equal(t, int64(20000), tsr.normalizedSQLMap.length.Load())
-	require.Equal(t, int64(20000), tsr.normalizedPlanMap.length.Load())
+	require.Equal(t, int64(20000), tsr.normalizedSQLMap.size())
+	require.Equal(t, int64(20000), tsr.normalizedPlanMap.size())
 }
 
 func TestCollectInternal(t *testing.T) {

--- a/pkg/util/topsql/reporter/reporter_test.go
+++ b/pkg/util/topsql/reporter/reporter_test.go
@@ -885,6 +885,67 @@ func TestReporterChannelsFullDropsAndMetrics(t *testing.T) {
 	require.NotEmpty(t, recovered.collected.getReportRecords())
 	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), 1)
 	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), 1)
+
+	origMaxStatementCount := topsqlstate.GlobalState.MaxStatementCount.Load()
+	topsqlstate.GlobalState.MaxStatementCount.Store(1)
+	t.Cleanup(func() {
+		topsqlstate.GlobalState.MaxStatementCount.Store(origMaxStatementCount)
+	})
+
+	boundedSQLDigests := [][]byte{[]byte("bounded-sql-1"), []byte("bounded-sql-2")}
+	boundedPlanDigests := [][]byte{[]byte("bounded-plan-1"), []byte("bounded-plan-2")}
+	for i := range boundedSQLDigests {
+		tsr.RegisterSQL(boundedSQLDigests[i], fmt.Sprintf("select %d", i+1), false)
+		tsr.RegisterPlan(boundedPlanDigests[i], fmt.Sprintf("point_get_%d", i+1), false)
+	}
+
+	tsr.reportCollectedDataChan <- collectedData{} // keep the report channel blocked
+	beforeBackpressureDrop := readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)
+	const blockedReportWindows = maxPendingReportWindows * 3
+	var lastReportEnd uint64
+	for i := 1; i <= blockedReportWindows; i++ {
+		reportEnd := uint64(120 + i*defaultReportInterval)
+		lastReportEnd = reportEnd
+		sampleTimestamp := reportEnd - 1
+		tsr.processCPUTimeData(sampleTimestamp, cpuRecords{
+			{SQLDigest: boundedSQLDigests[0], PlanDigest: boundedPlanDigests[0], CPUTimeMs: 2},
+			{SQLDigest: boundedSQLDigests[1], PlanDigest: boundedPlanDigests[1], CPUTimeMs: 1},
+		})
+		tsr.ruAggregator.addBatch(ruBatch{
+			timestamp: sampleTimestamp,
+			data:      ruData,
+			version:   rmclient.DefaultRUVersion,
+		})
+		tsr.takeDataAndSendToReportChan(reportEnd)
+		if i%maxPendingReportWindows != 0 {
+			require.NotEmpty(t, tsr.collecting.records)
+			require.NotEmpty(t, tsr.collecting.evicted)
+		} else {
+			require.Empty(t, tsr.collecting.records)
+			require.Empty(t, tsr.collecting.evicted)
+		}
+		tsr.ruAggregator.mu.Lock()
+		bucketCount := len(tsr.ruAggregator.buckets)
+		tsr.ruAggregator.mu.Unlock()
+		require.LessOrEqual(t, bucketCount, maxPendingReportWindows-1)
+	}
+
+	require.Empty(t, tsr.collecting.records)
+	require.Empty(t, tsr.collecting.evicted)
+	require.InDelta(t, float64(blockedReportWindows/maxPendingReportWindows), readCounter(t, reporter_metrics.IgnoreReportDataByBackpressureCounter)-beforeBackpressureDrop, 1e-9)
+	<-tsr.reportCollectedDataChan
+
+	recoveryTimestamp := lastReportEnd + uint64(defaultReportInterval) - 1
+	tsr.processCPUTimeData(recoveryTimestamp, cpuRecords{{
+		SQLDigest:  boundedSQLDigests[0],
+		PlanDigest: boundedPlanDigests[0],
+		CPUTimeMs:  1,
+	}})
+	tsr.takeDataAndSendToReportChan(lastReportEnd + uint64(defaultReportInterval))
+	recovered = <-tsr.reportCollectedDataChan
+	require.Len(t, recovered.collected.getReportRecords(), 1)
+	require.Len(t, recovered.normalizedSQLMap.toProto(keyspaceName), len(boundedSQLDigests))
+	require.Len(t, recovered.normalizedPlanMap.toProto(keyspaceName, tsr.decodePlan, tsr.compressPlan), len(boundedPlanDigests))
 }
 
 // TestReporterBackpressureAndDropScenario covers the reporter backpressure

--- a/pkg/util/topsql/reporter/ru_window_aggregator.go
+++ b/pkg/util/topsql/reporter/ru_window_aggregator.go
@@ -152,14 +152,19 @@ func (a *ruWindowAggregator) takeReportRecords(nowTs, itemInterval uint64, keysp
 	return buildReportRecords(takenBuckets, windowStart, windowEnd, itemInterval, keyspaceName)
 }
 
-// dropReportData discards all pending buckets and advances the report boundary.
+// dropReportData discards closed report windows and advances the report boundary.
+// Buckets from the still-open window are retained for the next report tick.
 func (a *ruWindowAggregator) dropReportData(nowTs uint64) {
 	windowEnd := alignToInterval(nowTs, ruReportWindowSeconds)
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	a.buckets = make(map[uint64]*ruPointBucket)
+	for ts := range a.buckets {
+		if ts < windowEnd {
+			delete(a.buckets, ts)
+		}
+	}
 	if windowEnd > a.lastReportedEndTs {
 		a.lastReportedEndTs = windowEnd
 	}

--- a/pkg/util/topsql/reporter/ru_window_aggregator.go
+++ b/pkg/util/topsql/reporter/ru_window_aggregator.go
@@ -152,6 +152,19 @@ func (a *ruWindowAggregator) takeReportRecords(nowTs, itemInterval uint64, keysp
 	return buildReportRecords(takenBuckets, windowStart, windowEnd, itemInterval, keyspaceName)
 }
 
+// dropReportData discards all pending buckets and advances the report boundary.
+func (a *ruWindowAggregator) dropReportData(nowTs uint64) {
+	windowEnd := alignToInterval(nowTs, ruReportWindowSeconds)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.buckets = make(map[uint64]*ruPointBucket)
+	if windowEnd > a.lastReportedEndTs {
+		a.lastReportedEndTs = windowEnd
+	}
+}
+
 // takeBucketsForWindow extracts buckets for the given window under lock.
 // It returns nil if the window has already been reported or is not ready.
 func (a *ruWindowAggregator) takeBucketsForWindow(windowEnd uint64) map[uint64]*ruPointBucket {

--- a/pkg/util/topsql/reporter/ru_window_aggregator_test.go
+++ b/pkg/util/topsql/reporter/ru_window_aggregator_test.go
@@ -258,6 +258,38 @@ func TestRUWindowAggregatorResetCurrentWindowDropsUntilBoundary(t *testing.T) {
 		require.Equal(t, uint64(180), rec.Items[0].TimestampSec)
 		require.InDelta(t, 9.0, rec.Items[0].TotalRu, 1e-9)
 	})
+
+	t.Run("backpressure drop keeps still-open window", func(t *testing.T) {
+		agg := newRUWindowAggregator()
+		closedKey := stmtstats.RUKey{
+			User:       "u-closed",
+			SQLDigest:  stmtstats.BinaryDigest("sql-closed"),
+			PlanDigest: stmtstats.BinaryDigest("plan-closed"),
+		}
+		openKey := stmtstats.RUKey{
+			User:       "u-open",
+			SQLDigest:  stmtstats.BinaryDigest("sql-open"),
+			PlanDigest: stmtstats.BinaryDigest("plan-open"),
+		}
+
+		agg.addBatchToBucket(1, stmtstats.RUIncrementMap{
+			closedKey: {TotalRU: 1, ExecCount: 1, ExecDuration: 1},
+		})
+		for _, ts := range []uint64{61, 76, 91} {
+			agg.addBatchToBucket(ts, stmtstats.RUIncrementMap{
+				openKey: {TotalRU: 2, ExecCount: 1, ExecDuration: 1},
+			})
+		}
+
+		agg.dropReportData(97)
+
+		records := agg.takeReportRecords(120, 60, []byte("ks"))
+		require.Nil(t, findRURecordByDigest(records, "u-closed", "sql-closed", "plan-closed"))
+		openRecord := findRURecord(t, records, "u-open", "sql-open", "plan-open")
+		require.Len(t, openRecord.Items, 1)
+		require.Equal(t, uint64(60), openRecord.Items[0].TimestampSec)
+		require.InDelta(t, 6.0, openRecord.Items[0].TotalRu, 1e-9)
+	})
 }
 
 // Test gap 3: Concurrent pressure test for ruWindowAggregator.

--- a/pkg/util/topsql/reporter/single_target.go
+++ b/pkg/util/topsql/reporter/single_target.go
@@ -21,7 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	reporter_metrics "github.com/pingcap/tidb/pkg/util/topsql/reporter/metrics"
 	"github.com/pingcap/tipb/go-tipb"
@@ -208,23 +210,40 @@ func (ds *SingleTargetDataSink) doSend(addr string, task sendTask) {
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 4)
+	recoverSendPanic := func(r any) {
+		if r != nil {
+			errCh <- util.GetRecoverError(r)
+		}
+	}
 	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
-		errCh <- ds.sendBatchSQLMeta(ctx, task.data.SQLMetas)
+		util.WithRecovery(func() {
+			failpoint.Inject("mockSingleTargetSendPanic", nil)
+			errCh <- ds.sendBatchSQLMeta(ctx, task.data.SQLMetas)
+		}, recoverSendPanic)
 	}()
 	go func() {
 		defer wg.Done()
-		errCh <- ds.sendBatchPlanMeta(ctx, task.data.PlanMetas)
+		util.WithRecovery(func() {
+			failpoint.Inject("mockSingleTargetSendPanic", nil)
+			errCh <- ds.sendBatchPlanMeta(ctx, task.data.PlanMetas)
+		}, recoverSendPanic)
 	}()
 	go func() {
 		defer wg.Done()
-		errCh <- ds.sendBatchTopSQLRecord(ctx, task.data.DataRecords)
+		util.WithRecovery(func() {
+			failpoint.Inject("mockSingleTargetSendPanic", nil)
+			errCh <- ds.sendBatchTopSQLRecord(ctx, task.data.DataRecords)
+		}, recoverSendPanic)
 	}()
 	go func() {
 		defer wg.Done()
-		errCh <- ds.sendBatchTopRURecord(ctx, task.data.RURecords)
+		util.WithRecovery(func() {
+			failpoint.Inject("mockSingleTargetSendPanic", nil)
+			errCh <- ds.sendBatchTopRURecord(ctx, task.data.RURecords)
+		}, recoverSendPanic)
 	}()
 	wg.Wait()
 	close(errCh)

--- a/pkg/util/topsql/reporter/single_target_test.go
+++ b/pkg/util/topsql/reporter/single_target_test.go
@@ -19,10 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	reporter_metrics "github.com/pingcap/tidb/pkg/util/topsql/reporter/metrics"
 	"github.com/pingcap/tidb/pkg/util/topsql/reporter/mock"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
 	"github.com/pingcap/tipb/go-tipb"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -120,6 +123,52 @@ func TestSingleTargetDataSink(t *testing.T) {
 	normalizedPlan, exist := server.GetPlanMetaByDigestBlocking([]byte("P1"), 5*time.Second)
 	assert.True(t, exist)
 	assert.Equal(t, normalizedPlan, "PLAN-1")
+
+	ds.Close()
+	t.Run("recovers send panics", func(t *testing.T) {
+		ds := NewSingleTargetDataSink(&mockSingleTargetDataSinkRegisterer{})
+		t.Cleanup(func() {
+			ds.Close()
+			if ds.conn != nil {
+				require.NoError(t, ds.conn.Close())
+			}
+		})
+		task := sendTask{data: &ReportData{}, deadline: time.Now().Add(5 * time.Second)}
+		runDoSend := func() {
+			done := make(chan struct{})
+			go func() {
+				ds.doSend(server.Address(), task)
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("single-target send did not finish")
+			}
+		}
+
+		panicPath := "github.com/pingcap/tidb/pkg/util/topsql/reporter/mockSingleTargetSendPanic"
+		t.Cleanup(func() { _ = failpoint.Disable(panicPath) })
+		failedBefore := histogramSampleCount(t, reporter_metrics.ReportAllDurationFailedHistogram)
+		succeededBefore := histogramSampleCount(t, reporter_metrics.ReportAllDurationSuccHistogram)
+		require.NoError(t, failpoint.Enable(panicPath, "panic"))
+		runDoSend()
+		require.Equal(t, failedBefore+1, histogramSampleCount(t, reporter_metrics.ReportAllDurationFailedHistogram))
+		require.Equal(t, succeededBefore, histogramSampleCount(t, reporter_metrics.ReportAllDurationSuccHistogram))
+		require.NoError(t, failpoint.Disable(panicPath))
+		runDoSend()
+		require.Equal(t, failedBefore+1, histogramSampleCount(t, reporter_metrics.ReportAllDurationFailedHistogram))
+		require.Equal(t, succeededBefore+1, histogramSampleCount(t, reporter_metrics.ReportAllDurationSuccHistogram))
+	})
+}
+
+func histogramSampleCount(t *testing.T, observer any) uint64 {
+	t.Helper()
+	metric, ok := observer.(interface{ Write(*dto.Metric) error })
+	require.True(t, ok)
+	pb := &dto.Metric{}
+	require.NoError(t, metric.Write(pb))
+	return pb.GetHistogram().GetSampleCount()
 }
 
 // TestSingleTargetDataSinkDropsTopRU verifies TopRU records are dropped by

--- a/pkg/util/topsql/stmtstats/BUILD.bazel
+++ b/pkg/util/topsql/stmtstats/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":stmtstats"],
     flaky = True,
-    shard_count = 37,
+    shard_count = 38,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/util/execdetails",

--- a/pkg/util/topsql/stmtstats/aggregator.go
+++ b/pkg/util/topsql/stmtstats/aggregator.go
@@ -177,10 +177,15 @@ func (m *aggregator) drainAndPushRU() {
 // register binds StatementStats to aggregator.
 // register is thread-safe.
 func (m *aggregator) register(stats *StatementStats) {
-	if m.statsLen.Load() > maxStmtStatsSize {
-		return
+	for {
+		current := m.statsLen.Load()
+		if current >= maxStmtStatsSize {
+			return
+		}
+		if m.statsLen.CompareAndSwap(current, current+1) {
+			break
+		}
 	}
-	m.statsLen.Inc()
 	m.statsSet.Store(stats, struct{}{})
 }
 

--- a/pkg/util/topsql/stmtstats/aggregator_test.go
+++ b/pkg/util/topsql/stmtstats/aggregator_test.go
@@ -17,6 +17,7 @@ package stmtstats
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -112,6 +113,47 @@ func TestAggregatorRegisterCollect(t *testing.T) {
 	assert.NotEmpty(t, total)
 	assert.Equal(t, uint64(1), total[SQLPlanDigest{SQLDigest: "SQL-1"}].ExecCount)
 	assert.Equal(t, uint64(time.Millisecond.Nanoseconds()), total[SQLPlanDigest{SQLDigest: "SQL-1"}].SumDurationNs)
+}
+
+func TestAuditTopSQLStatementStatsRegistrationHonorsHardCap(t *testing.T) {
+	a := newAggregator()
+	a.statsLen.Store(maxStmtStatsSize)
+	stats := &StatementStats{}
+	a.register(stats)
+
+	_, registered := a.statsSet.Load(stats)
+	require.False(t, registered)
+	require.Equal(t, uint32(maxStmtStatsSize), a.statsLen.Load())
+
+	const (
+		attempts = 20
+		workers  = 256
+	)
+	for range attempts {
+		a = newAggregator()
+		a.statsLen.Store(maxStmtStatsSize - 1)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for range workers {
+			stats = &StatementStats{}
+			go func(stats *StatementStats) {
+				defer wg.Done()
+				<-start
+				a.register(stats)
+			}(stats)
+		}
+		close(start)
+		wg.Wait()
+
+		require.Equal(t, uint32(maxStmtStatsSize), a.statsLen.Load())
+		registeredCount := 0
+		a.statsSet.Range(func(_, _ any) bool {
+			registeredCount++
+			return true
+		})
+		require.Equal(t, 1, registeredCount)
+	}
 }
 
 // TestAggregatorRunClose verifies start/close idempotence on a standalone aggregator.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  close #70168

Problem Summary:

- The original single-slot TopSQL report channel provided no bounded retry capacity for short report-worker stalls; a full channel discarded the next records and SQL/plan metadata immediately.
- Panics recovered from single-target send goroutines did not enter the failure path, so a lost batch could be recorded as successful.
- Statement-statistics registration used a strict greater-than check and could exceed the hard cap by one entry.
- The backpressure drop path cleared TopRU buckets from both the closed report window and the still-open window.

### What changed and how does it work?

- Buffer up to two complete report batches to absorb transient report-worker backpressure. If both slots remain full, drop the current TopSQL records and closed-window TopRU data, retain bounded SQL/plan metadata, and increment `tidb_topsql_ignored_total{type="ignore_report_data_by_backpressure"}`.
- Preserve TopRU buckets at or after the aligned `windowEnd` when dropping an unenqueueable closed window, so the still-open window remains reportable on the next tick.
- Convert recovered send panics to errors, send them through the existing error channel, and wait for recovery handlers before closing that channel.
- Reject statement-statistics registration when the count is already at the hard cap.
- Add focused regression tests for the backpressure, RU-window, panic-accounting, and registration-cap cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
./tools/check/failpoint-go-test.sh pkg/util/topsql/reporter \
  -run '^(TestReporterChannelsFullDropsAndMetrics|TestSingleTargetDataSink)$' \
  -tags=intest,deadlock -race -count=3

./tools/check/failpoint-go-test.sh pkg/util/topsql/reporter \
  -run '^Test_normalized(SQL|Plan)Map_register$' \
  -tags=intest,deadlock -race -count=3

go test ./pkg/util/topsql/stmtstats \
  -run 'TestAuditTopSQLStatementStatsRegistrationHonorsHardCap' \
  -tags=intest,deadlock -count=3

./tools/check/failpoint-go-test.sh pkg/util/topsql/reporter \
  -run '^(TestRUWindowAggregatorResetCurrentWindowDropsUntilBoundary|TestRUWindowAggregatorTakeOncePerWindow|TestReporterChannelsFullDropsAndMetrics|TestReporterBackpressureAndDropScenario)$' \
  -count=3

make bazel_prepare
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reduce TopSQL report loss during transient backpressure with bounded buffering, preserve still-open TopRU window data, record panicked sends as failures, and enforce the statement-statistics registration limit. Sustained backpressure can still drop newly collected TopSQL and closed-window TopRU data.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when report channels reach capacity by preventing blocked processing and limiting dropped data.
  * Prevented statement statistics from exceeding the configured maximum during concurrent activity.
  * Added panic recovery for single-target report delivery without interrupting processing.
  * Corrected success and failure delivery metrics after recovered send errors.
  * Added monitoring for data dropped due to backpressure.

* **Tests**
  * Expanded coverage for channel capacity, concurrency limits, panic recovery, and delivery metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
