### PR TITLE
planner: estimate index join probe-side row count from the join keys the access path can use

### DIFF
--- a/pkg/planner/core/casetest/join/BUILD.bazel
+++ b/pkg/planner/core/casetest/join/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -373,3 +373,40 @@ JOIN
 			where 5 >= issue66859_t0.c0`).Check(testkit.Rows("-1 <nil>"))
 	})
 }
+
+func TestIndexJoinInnerRowCountUsesUsableJoinKeys(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("create table t1 (k1 int not null, k2 int not null)")
+		tk.MustExec(`create table t2 (
+			k1 int not null,
+			id int not null,
+			k2 int not null,
+			pad varchar(100),
+			primary key (k1, id) clustered,
+			key idx_k1_k2 (k1, k2))`)
+		tk.MustExec("insert into t1 values (1, 1), (2, 1)")
+		// For each k1 value, 1000 rows share the same primary-key prefix; only one row matches each k2.
+		for _, k1 := range []int{1, 2} {
+			var sb strings.Builder
+			sb.WriteString("insert into t2 values ")
+			for n := 1; n <= 1000; n++ {
+				if n > 1 {
+					sb.WriteString(",")
+				}
+				fmt.Fprintf(&sb, "(%d, %d, %d, repeat('x', 50))", k1, n, n)
+			}
+			tk.MustExec(sb.String())
+		}
+		tk.MustExec("analyze table t1, t2")
+		// Issue 69974: the clustered PK can only use the k1 join key, so each probe scans ~1000 rows,
+		// while idx_k1_k2 covers both join keys and reads a single row per probe. The PK path used to
+		// be costed with the post-join cardinality (~1 row per probe) and win.
+		query := `select /*+ inl_hash_join(i) */ o.k1, i.pad from t1 o join t2 i on i.k1 = o.k1 and i.k2 = o.k2`
+		tk.MustQuery("explain format='plan_tree' " + query).CheckContain("idx_k1_k2")
+		// Disabling the fix restores the old estimation and the PK range-scan probe.
+		tk.MustExec("set tidb_opt_fix_control = '44855:OFF'")
+		tk.MustQuery("explain format='plan_tree' " + query).CheckNotContain("idx_k1_k2")
+		tk.MustExec("set tidb_opt_fix_control = ''")
+	})
+}

--- a/pkg/planner/core/casetest/join/join_test.go
+++ b/pkg/planner/core/casetest/join/join_test.go
@@ -375,38 +375,38 @@ JOIN
 }
 
 func TestIndexJoinInnerRowCountUsesUsableJoinKeys(t *testing.T) {
-	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
-		tk.MustExec("use test")
-		tk.MustExec("create table t1 (k1 int not null, k2 int not null)")
-		tk.MustExec(`create table t2 (
-			k1 int not null,
-			id int not null,
-			k2 int not null,
-			pad varchar(100),
-			primary key (k1, id) clustered,
-			key idx_k1_k2 (k1, k2))`)
-		tk.MustExec("insert into t1 values (1, 1), (2, 1)")
-		// For each k1 value, 1000 rows share the same primary-key prefix; only one row matches each k2.
-		for _, k1 := range []int{1, 2} {
-			var sb strings.Builder
-			sb.WriteString("insert into t2 values ")
-			for n := 1; n <= 1000; n++ {
-				if n > 1 {
-					sb.WriteString(",")
-				}
-				fmt.Fprintf(&sb, "(%d, %d, %d, repeat('x', 50))", k1, n, n)
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (k1 int not null, k2 int not null)")
+	tk.MustExec(`create table t2 (
+		k1 int not null,
+		id int not null,
+		k2 int not null,
+		pad varchar(100),
+		primary key (k1, id) clustered,
+		key idx_k1_k2 (k1, k2))`)
+	tk.MustExec("insert into t1 values (1, 1), (2, 1)")
+	// For each k1 value, 1000 rows share the same primary-key prefix; only one row matches each k2.
+	for _, k1 := range []int{1, 2} {
+		var sb strings.Builder
+		sb.WriteString("insert into t2 values ")
+		for n := 1; n <= 1000; n++ {
+			if n > 1 {
+				sb.WriteString(",")
 			}
-			tk.MustExec(sb.String())
+			fmt.Fprintf(&sb, "(%d, %d, %d, repeat('x', 50))", k1, n, n)
 		}
-		tk.MustExec("analyze table t1, t2")
-		// Issue 69974: the clustered PK can only use the k1 join key, so each probe scans ~1000 rows,
-		// while idx_k1_k2 covers both join keys and reads a single row per probe. The PK path used to
-		// be costed with the post-join cardinality (~1 row per probe) and win.
-		query := `select /*+ inl_hash_join(i) */ o.k1, i.pad from t1 o join t2 i on i.k1 = o.k1 and i.k2 = o.k2`
-		tk.MustQuery("explain format='plan_tree' " + query).CheckContain("idx_k1_k2")
-		// Disabling the fix restores the old estimation and the PK range-scan probe.
-		tk.MustExec("set tidb_opt_fix_control = '44855:OFF'")
-		tk.MustQuery("explain format='plan_tree' " + query).CheckNotContain("idx_k1_k2")
-		tk.MustExec("set tidb_opt_fix_control = ''")
-	})
+		tk.MustExec(sb.String())
+	}
+	tk.MustExec("analyze table t1, t2")
+	// Issue 69974: the clustered PK can only use the k1 join key, so each probe scans ~1000 rows,
+	// while idx_k1_k2 covers both join keys and reads a single row per probe. The PK path used to
+	// be costed with the post-join cardinality (~1 row per probe) and win.
+	query := `select /*+ inl_hash_join(i) */ o.k1, i.pad from t1 o join t2 i on i.k1 = o.k1 and i.k2 = o.k2`
+	tk.MustQuery("explain format='plan_tree' " + query).CheckContain("idx_k1_k2")
+	// Disabling the fix restores the old estimation and the PK range-scan probe.
+	tk.MustExec("set tidb_opt_fix_control = '44855:OFF'")
+	tk.MustQuery("explain format='plan_tree' " + query).CheckNotContain("idx_k1_k2")
+	tk.MustExec("set tidb_opt_fix_control = ''")
 }

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -699,11 +699,12 @@ func buildDataSource2IndexScanByIndexJoinProp(
 		return base.InvalidTask
 	}
 	rangeInfo, maxOneRow := indexJoinPathGetRangeInfoAndMaxOneRow(ds.SCtx(), prop.IndexJoinProp.OuterJoinKeys, indexJoinResult)
+	accessRowsFloor := indexJoinProbeAccessRowsFloor(ds, prop.IndexJoinProp, indexJoinResult)
 	var innerTask base.Task
 	if !prop.IsSortItemEmpty() && matchProperty(ds, indexJoinResult.chosenPath, prop) == property.PropMatched {
-		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, accessRowsFloor, maxOneRow)
 	} else {
-		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, accessRowsFloor, maxOneRow)
 	}
 	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
 	if innerTask == nil {
@@ -748,12 +749,13 @@ func buildDataSource2TableScanByIndexJoinProp(
 		}
 		// prepare the range info with outer join keys, it shows like: [xxx] decided by:
 		rangeInfo, maxOneRow := indexJoinPathGetRangeInfoAndMaxOneRow(ds.SCtx(), prop.IndexJoinProp.OuterJoinKeys, indexJoinResult)
+		accessRowsFloor := indexJoinProbeAccessRowsFloor(ds, prop.IndexJoinProp, indexJoinResult)
 		// construct the inner task with chosen path and ranges, note: it only for this leaf datasource.
 		// like the normal way, we need to check whether the chosen path is matched with the prop, if so, we will set the `keepOrder` to true.
 		if matchProperty(ds, indexJoinResult.chosenPath, prop) == property.PropMatched {
-			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, accessRowsFloor, maxOneRow)
 		} else {
-			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.chosenAccess, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, accessRowsFloor, maxOneRow)
 		}
 		ranges = indexJoinResult.chosenRanges
 	} else {
@@ -772,9 +774,11 @@ func buildDataSource2TableScanByIndexJoinProp(
 		maxOneRow := true
 		rangeInfo := indexJoinIntPKRangeInfo(ds.SCtx().GetExprCtx().GetEvalCtx(), newOuterJoinKeys)
 		if !prop.IsSortItemEmpty() && matchProperty(ds, chosenPath, prop) == property.PropMatched {
-			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			// The int handle is a single-column unique key, so the join key fully decides the range
+			// and no rows-after-access floor applies.
+			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, 0, maxOneRow)
 		} else {
-			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+			innerTask = constructDS2TableScanTask(ds, localRanges, ds.PushedDownConds, nil, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, 0, maxOneRow)
 		}
 	}
 	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
@@ -820,6 +824,44 @@ func completeIndexJoinFeedBackInfo(innerTask *physicalop.CopTask, indexJoinResul
 	innerTask.IndexJoinInfo = info
 }
 
+// indexJoinProbeAccessRowsFloor returns a lower bound on the rows-after-access of an index join
+// probe-side scan, or 0 when no adjustment applies. The row count passed to the inner scan tasks
+// is derived from the join output cardinality, which accounts for ALL equality join conditions.
+// When the chosen path builds ranges from only a subset of the join keys, the remaining equality
+// conditions are evaluated at the join rather than at the scan, so each probe still reads every
+// row matching the used key prefix: approximately (total row count / NDV of the used EQ columns).
+// See #69974.
+func indexJoinProbeAccessRowsFloor(ds *logicalop.DataSource, indexJoinProp *property.IndexJoinRuntimeProp, indexJoinResult *indexJoinPathResult) float64 {
+	if indexJoinResult == nil || ds.TableStats == nil || indexJoinResult.eqUsedColsNDV <= 0 {
+		return 0
+	}
+	// A range on the last used column narrows the scan beyond the EQ prefix, so the EQ-prefix NDV
+	// would overestimate the scanned rows. Skip the adjustment in that case.
+	if indexJoinResult.lastColIsRange || indexJoinResult.lastColManager != nil {
+		return 0
+	}
+	usedKeys := make(map[int]struct{}, len(indexJoinProp.InnerJoinKeys))
+	for idxOff, keyOff := range indexJoinResult.idxOff2KeyOff {
+		if idxOff >= indexJoinResult.usedColsLen {
+			break
+		}
+		if keyOff >= 0 {
+			usedKeys[keyOff] = struct{}{}
+		}
+	}
+	if len(usedKeys) >= len(indexJoinProp.InnerJoinKeys) {
+		return 0
+	}
+	// This adjustment shares the Fix44855 switch with the NDV-based upper bound in
+	// constructDS2IndexScanTask, but defaults to ON: setting 44855:OFF disables both.
+	enabled := fixcontrol.GetBoolWithDefault(ds.SCtx().GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix44855, true)
+	ds.SCtx().GetSessionVars().RecordRelevantOptFix(fixcontrol.Fix44855)
+	if !enabled {
+		return 0
+	}
+	return ds.TableStats.RowCount / indexJoinResult.eqUsedColsNDV
+}
+
 // constructDS2TableScanTask constructs the inner table scan task for index join.
 func constructDS2TableScanTask(
 	ds *logicalop.DataSource,
@@ -830,6 +872,7 @@ func constructDS2TableScanTask(
 	keepOrder bool,
 	desc bool,
 	rowCount float64,
+	accessRowsFloor float64,
 	maxOneRow bool,
 ) base.Task {
 	// If `ds.TableInfo.GetPartitionInfo() != nil`,
@@ -870,6 +913,9 @@ func constructDS2TableScanTask(
 		// i.e, rowCount equals to `countAfterAccess * selectivity`.
 		countAfterAccess = rowCount / selectivity
 	}
+	// The ranges only encode the join keys this path can use; equality conditions on the remaining
+	// join keys are evaluated at the join, so the scan reads at least the rows matching the used prefix.
+	countAfterAccess = math.Max(countAfterAccess, accessRowsFloor)
 	// Only apply the 1-row limit when we can guarantee at most one row per outer row.
 	// For CommonHandle, this requires matching ALL primary key columns with equality conditions.
 	// For prefix scans (e.g., only matching first column of a composite PK), we trust the statistical estimation.
@@ -1027,6 +1073,7 @@ func constructDS2IndexScanTask(
 	keepOrder bool,
 	desc bool,
 	rowCount float64,
+	accessRowsFloor float64,
 	maxOneRow bool,
 ) base.Task {
 	// If `ds.TableInfo.GetPartitionInfo() != nil`,
@@ -1191,6 +1238,16 @@ func constructDS2IndexScanTask(
 			cnt = math.Min(cnt, 1.0)
 		}
 		tmpPath.CountAfterAccess = cnt
+	}
+	// The ranges only encode the join keys this path can use; equality conditions on the remaining
+	// join keys are evaluated at the join, so the scan reads at least the rows matching the used prefix.
+	if !maxOneRow && accessRowsFloor > tmpPath.CountAfterAccess {
+		scale := 1.0
+		if tmpPath.CountAfterAccess > 0 {
+			scale = tmpPath.CountAfterIndex / tmpPath.CountAfterAccess
+		}
+		tmpPath.CountAfterAccess = accessRowsFloor
+		tmpPath.CountAfterIndex = accessRowsFloor * scale
 	}
 	is.SetStats(ds.TableStats.ScaleByExpectCnt(is.SCtx().GetSessionVars(), tmpPath.CountAfterAccess))
 	usedStats := ds.SCtx().GetSessionVars().StmtCtx.GetUsedStatsInfo(false)

--- a/pkg/planner/core/index_join_path.go
+++ b/pkg/planner/core/index_join_path.go
@@ -93,6 +93,7 @@ type indexJoinPathResult struct {
 	chosenRanges   ranger.MutableRanges    // the ranges used to access this index
 	usedColsLen    int                     // the number of columns used on this index, `t1.a=t2.a and t1.b=t2.b` can use 2 columns of index t1(a, b, c)
 	eqUsedColsNDV  float64                 // the estimated NDV of the EQ used columns on this index, the NDV of `t1(a, b)`, a,b are in EQ constraint.
+	lastColIsRange bool                    // whether the last used column is accessed by a range (non-EQ) condition, which is excluded from eqUsedColsNDV
 	idxOff2KeyOff  []int
 	lastColManager *physicalop.ColWithCmpFuncManager
 }
@@ -427,6 +428,7 @@ func indexJoinPathConstructResult(
 		candidate:      getIndexCandidateForIndexJoin(sctx, path, usedColsLen),
 		usedColsLen:    len(ranges.Range()[0].LowVal),
 		eqUsedColsNDV:  innerNDV,
+		lastColIsRange: lastColIsRange,
 		chosenRanges:   ranges,
 		chosenAccess:   accesses,
 		chosenRemained: remained,

--- a/pkg/planner/util/fixcontrol/get.go
+++ b/pkg/planner/util/fixcontrol/get.go
@@ -50,8 +50,13 @@ const (
 	Fix44830 uint64 = 44830
 	// Fix44823 controls the maximum number of parameters for a query that can be cached in the Plan Cache.
 	Fix44823 uint64 = 44823
-	// Fix44855 controls whether to use a more accurate upper bound when estimating row count of index
-	// range scan under inner side of index join.
+	// Fix44855 controls the row count estimation of the inner side of an index join:
+	//   - When ON (default OFF for this part), the estimated row count of an inner index scan is
+	//     clamped to the upper bound (total row count / NDV of the probed join key columns).
+	//   - When not explicitly OFF (default ON for this part), the estimated row count of the inner
+	//     scan is raised to (total row count / NDV of the used key prefix) when the chosen path can
+	//     only build ranges from a subset of the join keys, since the remaining equality conditions
+	//     are evaluated at the join rather than at the scan (see #69974).
 	Fix44855 uint64 = 44855
 	// Fix45132 controls whether to use access range row count to determine access path on the Skyline pruning.
 	Fix45132 uint64 = 45132


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69974

Problem Summary:

The row count used to cost an index join probe-side scan is derived from the join output cardinality (`AvgInnerRowCnt = EqualCondOutCnt / outerRows`), which accounts for **all** equality join conditions. When the chosen access path can only build ranges from a subset of the join keys, the remaining equality conditions are evaluated at the join rather than at the scan, so each probe still reads every row matching the used key prefix. Costing such a path with the post-join row count makes it look far cheaper than it is.

In the issue's reproduction, a clustered PK `(k1, id)` probe (usable join key: only `k1`, ~5,000 rows per probe) and a secondary index `idx_k1_k2` covering both join keys (1 row per probe) are both costed at ~1 row per probe, so the PK range scan wins and the query reads 10,000 rows instead of 2.

### What changed and how does it work?

When the chosen probe path uses only a subset of the equality join keys, raise its rows-after-access to at least `tableRows / NDV(used EQ prefix columns)`. The NDV comes from `eqUsedColsNDV`, which index join path selection already computes per candidate path from pre-filter table stats.

- `indexJoinProbeAccessRowsFloor` computes the floor; it applies to both the inner table-scan task (common-handle prefix scans, the issue's case) and the inner index-scan task.
- The adjustment is skipped when it cannot be trusted or cannot matter: pseudo stats (`eqUsedColsNDV = 0`), unique full-key matches (`maxOneRow`), a range condition on the last used column (its filtering is not captured by the EQ-prefix NDV), and int-handle paths (single-column unique key).
- The adjustment shares the `44855` fix-control switch with the existing NDV-based upper bound from #44855, but defaults to **ON**; setting `tidb_opt_fix_control = '44855:OFF'` disables both. The pre-existing upper-bound clamp keeps its default-OFF behavior.

With the fix, the optimizer assigns the PK path its real ~5,000-rows-per-probe estimate and chooses `idx_k1_k2` for the issue's query.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the optimizer could choose a poorly filtering access path for the inner side of an index join when the path can use only a subset of the equality join keys, by estimating the probe row count from the join keys the path can actually use. The adjustment is enabled by default and can be disabled together with the related upper-bound estimation via `tidb_opt_fix_control = '44855:OFF'`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyrcMzpvGA1rafdRP4m6HU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index join inner scan row-count estimates when join key access is limited to a prefix/subset.
  * Prevented underestimation by enforcing a minimum probe-side access floor; preserved correct behavior for range-based access.
  * Improved plan stability for partially matching clustered-key joins with covering secondary indexes.
* **Tests**
  * Added a regression test covering usable join keys and optimizer fix-control toggling.
  * Increased test sharding for broader execution distribution.
* **Documentation**
  * Clarified default behavior and ON/OFF effects of the related optimizer fix control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->