### PR TITLE
ingestor: wait for region job workers to exit on cancellation

### DIFF
--- a/pkg/ingestor/ingestctrl/job_worker.go
+++ b/pkg/ingestor/ingestctrl/job_worker.go
@@ -83,7 +83,8 @@ type regionJobBaseWorker struct {
 // Besides, the worker must call jobWg.done() if it does not put the job into jobOutCh.
 func (w *regionJobBaseWorker) HandleTask(job *regionJob, _ func(*regionJob)) (err error) {
 	// As we need to call job.done() after panic, we recover here rather than in worker pool.
-	defer putil.Recover("fast_check_table", "handleTableScanTaskWithRecover", func() {
+	metricsLabel, funcInfo, _ := job.RecoverArgs()
+	defer putil.Recover(metricsLabel, funcInfo, func() {
 		err = errors.Errorf("region job worker panic")
 		job.done(w.jobWg)
 	}, false)

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1673,6 +1673,7 @@ func (local *Backend) doImport(
 	workGroup.Go(func() error {
 		pool.Start(wctx)
 		<-wctx.Done()
+		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
 		pool.Release()
 		return wctx.OperatorErr()
 	})

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1666,19 +1666,20 @@ func (local *Backend) doImport(
 		e.SetWorkerPool(pool)
 	}
 
+	skipStartWorker := false
 	failpoint.Inject("skipStartWorker", func() {
-		failpoint.Goto("afterStartWorker")
+		skipStartWorker = true
 	})
 
 	workGroup.Go(func() error {
-		pool.Start(wctx)
+		if !skipStartWorker {
+			pool.Start(wctx)
+		}
 		<-wctx.Done()
 		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
 		pool.Release()
 		return wctx.OperatorErr()
 	})
-
-	failpoint.Label("afterStartWorker")
 
 	workGroup.Go(func() error {
 		err := local.prepareAndSendJob(

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1673,6 +1673,7 @@ func (local *Backend) doImport(
 	workGroup.Go(func() error {
 		pool.Start(wctx)
 		<-wctx.Done()
+		pool.Release()
 		return wctx.OperatorErr()
 	})
 
@@ -1707,12 +1708,10 @@ func (local *Backend) doImport(
 			})
 		}
 
-		// Close the pool, as well as the channel.
+		// Notify the worker-pool goroutine that all jobs are finished. It will
+		// release the pool and close the result channel.
 		wctx.Cancel()
-		pool.Release()
-		// The worker may set operator error after jobWg.Wait() is unblocked. Re-check
-		// here to avoid losing worker errors due to cancellation ordering.
-		return wctx.OperatorErr()
+		return nil
 	})
 
 	err := workGroup.Wait()

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1678,6 +1678,7 @@ func (local *Backend) doImport(
 		<-wctx.Done()
 		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
 		pool.Release()
+		// Get OperatorErr after all workers have exited.
 		return wctx.OperatorErr()
 	})
 

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1654,15 +1654,15 @@ func (local *Backend) doImport(
 		clusterID = local.pdCli.GetClusterID(ctx)
 	}
 
+	// Workers must use wctx so OnError cancels their in-flight work before
+	// Release waits for them to exit.
+	wctx := workerpool.NewContext(workerCtx)
 	pool := getRegionJobWorkerPool(
-		workerCtx, &jobWg,
+		wctx, &jobWg,
 		local, balancer,
 		jobToWorkerCh, jobFromWorkerCh,
 		clusterID,
 	)
-	wctx := workerpool.NewContext(workerCtx)
-	// The normal and error paths release the pool at different points below.
-	releasePool := sync.OnceFunc(pool.Release)
 
 	if e, ok := engine.(*globalsort.Engine); ok {
 		e.SetWorkerPool(pool)
@@ -1672,14 +1672,20 @@ func (local *Backend) doImport(
 		failpoint.Goto("afterStartWorker")
 	})
 
-	workGroup.Go(func() error {
-		pool.Start(wctx)
-		<-wctx.Done()
-		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
-		return wctx.OperatorErr()
-	})
+	pool.Start(wctx)
 
 	failpoint.Label("afterStartWorker")
+
+	workGroup.Go(func() error {
+		<-wctx.Done()
+		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
+		pool.Release()
+		operatorErr := wctx.OperatorErr()
+		if operatorErr == nil && workerCtx.Err() == nil {
+			dispatcher.markAllJobsSucceeded()
+		}
+		return operatorErr
+	})
 
 	workGroup.Go(func() error {
 		err := local.prepareAndSendJob(
@@ -1711,26 +1717,10 @@ func (local *Backend) doImport(
 		}
 
 		wctx.Cancel()
-		// jobWg can reach zero before HandleTask returns and reports its error.
-		// Wait for all workers so OperatorErr is stable before closing the result
-		// channel, which the dispatcher treats as normal completion.
-		pool.Wait()
-		if err := wctx.OperatorErr(); err != nil {
-			return err
-		}
-		if err := workerCtx.Err(); err != nil {
-			return err
-		}
-
-		// Close the result channel only after all workers exit without error.
-		releasePool()
-		return nil
+		return wctx.OperatorErr()
 	})
 
 	err := workGroup.Wait()
-	// Error paths do not release the pool above. At this point, the dispatcher has
-	// exited through context cancellation, so it is safe to close the result channel.
-	releasePool()
 	if err != nil && !common.IsContextCanceledError(err) {
 		tidblogutil.Logger(ctx).Error("do import meets error", zap.Error(err))
 	}

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1661,26 +1661,24 @@ func (local *Backend) doImport(
 		clusterID,
 	)
 	wctx := workerpool.NewContext(workerCtx)
+	releasePool := sync.OnceFunc(pool.Release)
 
 	if e, ok := engine.(*globalsort.Engine); ok {
 		e.SetWorkerPool(pool)
 	}
 
-	skipStartWorker := false
 	failpoint.Inject("skipStartWorker", func() {
-		skipStartWorker = true
+		failpoint.Goto("afterStartWorker")
 	})
 
 	workGroup.Go(func() error {
-		if !skipStartWorker {
-			pool.Start(wctx)
-		}
+		pool.Start(wctx)
 		<-wctx.Done()
 		failpoint.InjectCall("beforeReleaseRegionJobWorkerPool")
-		pool.Release()
-		// Get OperatorErr after all workers have exited.
 		return wctx.OperatorErr()
 	})
+
+	failpoint.Label("afterStartWorker")
 
 	workGroup.Go(func() error {
 		err := local.prepareAndSendJob(
@@ -1711,13 +1709,22 @@ func (local *Backend) doImport(
 			})
 		}
 
-		// Notify the worker-pool goroutine that all jobs are finished. It will
-		// release the pool and close the result channel.
 		wctx.Cancel()
-		return wctx.OperatorErr()
+		pool.Wait()
+		if err := wctx.OperatorErr(); err != nil {
+			return err
+		}
+		if err := workerCtx.Err(); err != nil {
+			return err
+		}
+
+		// Close the result channel only after all workers exit without error.
+		releasePool()
+		return nil
 	})
 
 	err := workGroup.Wait()
+	releasePool()
 	if err != nil && !common.IsContextCanceledError(err) {
 		tidblogutil.Logger(ctx).Error("do import meets error", zap.Error(err))
 	}

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1714,7 +1714,7 @@ func (local *Backend) doImport(
 		// Notify the worker-pool goroutine that all jobs are finished. It will
 		// release the pool and close the result channel.
 		wctx.Cancel()
-		return nil
+		return wctx.OperatorErr()
 	})
 
 	err := workGroup.Wait()

--- a/pkg/ingestor/ingestctrl/local.go
+++ b/pkg/ingestor/ingestctrl/local.go
@@ -1661,6 +1661,7 @@ func (local *Backend) doImport(
 		clusterID,
 	)
 	wctx := workerpool.NewContext(workerCtx)
+	// The normal and error paths release the pool at different points below.
 	releasePool := sync.OnceFunc(pool.Release)
 
 	if e, ok := engine.(*globalsort.Engine); ok {
@@ -1710,6 +1711,9 @@ func (local *Backend) doImport(
 		}
 
 		wctx.Cancel()
+		// jobWg can reach zero before HandleTask returns and reports its error.
+		// Wait for all workers so OperatorErr is stable before closing the result
+		// channel, which the dispatcher treats as normal completion.
 		pool.Wait()
 		if err := wctx.OperatorErr(); err != nil {
 			return err
@@ -1724,6 +1728,8 @@ func (local *Backend) doImport(
 	})
 
 	err := workGroup.Wait()
+	// Error paths do not release the pool above. At this point, the dispatcher has
+	// exited through context cancellation, so it is safe to close the result channel.
 	releasePool()
 	if err != nil && !common.IsContextCanceledError(err) {
 		tidblogutil.Logger(ctx).Error("do import meets error", zap.Error(err))

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -1183,6 +1183,17 @@ func (m mockIngestData) DecRef() {}
 
 func (m mockIngestData) Finish(_, _ int64) {}
 
+type blockingDecRefIngestData struct {
+	mockIngestData
+	decRefStarted chan<- struct{}
+	allowDecRef   <-chan struct{}
+}
+
+func (m *blockingDecRefIngestData) DecRef() {
+	close(m.decRefStarted)
+	<-m.allowDecRef
+}
+
 var dummyRegionInfo = &split.RegionInfo{
 	Region: &metapb.Region{Id: 1, Peers: []*metapb.Peer{{Id: 1, StoreId: 1}}},
 	Leader: &metapb.Peer{Id: 1, StoreId: 1},
@@ -2177,6 +2188,108 @@ func TestDoImport(t *testing.T) {
 		}
 	})
 
+	t.Run("context cancellation waits for running workers", func(t *testing.T) {
+		testfailpoint.Enable(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/mockRunJobSucceed",
+			"return",
+		)
+		workerStarted := make(chan struct{})
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/beforeExecuteRegionJob",
+			func(ctx context.Context) {
+				close(workerStarted)
+				<-ctx.Done()
+			},
+		)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		allowDecRef := make(chan struct{})
+		var allowDecRefOnce sync.Once
+		releaseWorker := func() {
+			allowDecRefOnce.Do(func() {
+				close(allowDecRef)
+			})
+		}
+		t.Cleanup(func() {
+			cancel()
+			releaseWorker()
+		})
+
+		oldFakeRegionJobs := fakeRegionJobs
+		t.Cleanup(func() {
+			fakeRegionJobs = oldFakeRegionJobs
+		})
+
+		jobRange := engineapi.Range{Start: []byte{'a'}, End: []byte{'b'}}
+		decRefStarted := make(chan struct{})
+		data := &blockingDecRefIngestData{
+			mockIngestData: mockIngestData{
+				{[]byte{'a'}, []byte{'a'}},
+			},
+			decRefStarted: decRefStarted,
+			allowDecRef:   allowDecRef,
+		}
+		fakeRegionJobs = map[[2]string]struct {
+			jobs []*regionJob
+			err  error
+		}{
+			{"a", "b"}: {
+				jobs: []*regionJob{{
+					keyRange:   jobRange,
+					ingestData: data,
+					region:     dummyRegionInfo,
+				}},
+			},
+		}
+
+		mockEngine := &mockEngineWithData{
+			data:          data,
+			ranges:        []engineapi.Range{jobRange},
+			waitForCancel: true,
+		}
+		local := &Backend{
+			BackendConfig: BackendConfig{
+				WorkerConcurrency: toAtomic(1),
+			},
+		}
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- local.doImport(
+				ctx,
+				mockEngine,
+				[][]byte{jobRange.Start, jobRange.End},
+				int64(config.SplitRegionSize),
+				int64(config.SplitRegionKeys),
+			)
+		}()
+
+		select {
+		case <-workerStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for region job worker to start")
+		}
+		cancel()
+		select {
+		case <-decRefStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for region job worker to release ingest data")
+		}
+
+		select {
+		case err := <-errCh:
+			require.FailNow(t, "doImport returned before its running worker exited", "error: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		releaseWorker()
+		select {
+		case err := <-errCh:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for doImport to return")
+		}
+	})
+
 	t.Run("dispatcher propagates context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -3133,8 +3246,9 @@ func TestGenerateAndSendJobDoneAllRefedJobsOnCancel(t *testing.T) {
 
 // mockEngineWithData is a mock engine that implements engineapi.Engine
 type mockEngineWithData struct {
-	data   engineapi.IngestData
-	ranges []engineapi.Range
+	data          engineapi.IngestData
+	ranges        []engineapi.Range
+	waitForCancel bool
 }
 
 func (m *mockEngineWithData) ID() string {
@@ -3149,6 +3263,10 @@ func (m *mockEngineWithData) LoadIngestData(ctx context.Context, ch chan<- engin
 		Data:         m.data,
 		SortedRanges: m.ranges,
 	}:
+	}
+	if m.waitForCancel {
+		<-ctx.Done()
+		return ctx.Err()
 	}
 	// Don't close the channel here - generateAndSendJob will close it
 	return nil

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2220,11 +2220,6 @@ func TestDoImport(t *testing.T) {
 			releaseWorker,
 		)
 
-		oldFakeRegionJobs := fakeRegionJobs
-		t.Cleanup(func() {
-			fakeRegionJobs = oldFakeRegionJobs
-		})
-
 		jobRange := engineapi.Range{Start: []byte{'a'}, End: []byte{'b'}}
 		data := &blockingDecRefIngestData{
 			mockIngestData: mockIngestData{

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -1185,13 +1185,13 @@ func (m mockIngestData) Finish(_, _ int64) {}
 
 type blockingDecRefIngestData struct {
 	mockIngestData
-	decRefStarted chan<- struct{}
-	allowDecRef   <-chan struct{}
+	allowDecRef <-chan struct{}
+	decRefDone  chan<- struct{}
 }
 
 func (m *blockingDecRefIngestData) DecRef() {
-	close(m.decRefStarted)
 	<-m.allowDecRef
+	close(m.decRefDone)
 }
 
 var dummyRegionInfo = &split.RegionInfo{
@@ -2204,6 +2204,7 @@ func TestDoImport(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		allowDecRef := make(chan struct{})
+		decRefDone := make(chan struct{})
 		var allowDecRefOnce sync.Once
 		releaseWorker := func() {
 			allowDecRefOnce.Do(func() {
@@ -2214,6 +2215,10 @@ func TestDoImport(t *testing.T) {
 			cancel()
 			releaseWorker()
 		})
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/beforeReleaseRegionJobWorkerPool",
+			releaseWorker,
+		)
 
 		oldFakeRegionJobs := fakeRegionJobs
 		t.Cleanup(func() {
@@ -2221,13 +2226,12 @@ func TestDoImport(t *testing.T) {
 		})
 
 		jobRange := engineapi.Range{Start: []byte{'a'}, End: []byte{'b'}}
-		decRefStarted := make(chan struct{})
 		data := &blockingDecRefIngestData{
 			mockIngestData: mockIngestData{
 				{[]byte{'a'}, []byte{'a'}},
 			},
-			decRefStarted: decRefStarted,
-			allowDecRef:   allowDecRef,
+			allowDecRef: allowDecRef,
+			decRefDone:  decRefDone,
 		}
 		fakeRegionJobs = map[[2]string]struct {
 			jobs []*regionJob
@@ -2269,24 +2273,17 @@ func TestDoImport(t *testing.T) {
 			t.Fatal("timed out waiting for region job worker to start")
 		}
 		cancel()
-		select {
-		case <-decRefStarted:
-		case <-time.After(10 * time.Second):
-			t.Fatal("timed out waiting for region job worker to release ingest data")
-		}
 
-		select {
-		case err := <-errCh:
-			require.FailNow(t, "doImport returned before its running worker exited", "error: %v", err)
-		case <-time.After(100 * time.Millisecond):
-		}
-
-		releaseWorker()
 		select {
 		case err := <-errCh:
 			require.ErrorIs(t, err, context.Canceled)
 		case <-time.After(10 * time.Second):
 			t.Fatal("timed out waiting for doImport to return")
+		}
+		select {
+		case <-decRefDone:
+		default:
+			require.FailNow(t, "doImport returned before its running worker exited")
 		}
 	})
 

--- a/pkg/ingestor/ingestctrl/local_test.go
+++ b/pkg/ingestor/ingestctrl/local_test.go
@@ -2119,6 +2119,91 @@ func TestDoImport(t *testing.T) {
 	err = l.doImport(ctx, e, initRegionKeys, int64(config.SplitRegionSize), int64(config.SplitRegionKeys))
 	require.ErrorContains(t, err, "fatal error")
 
+	t.Run("worker error cancels other running workers", func(t *testing.T) {
+		const fatalErr = "worker fatal error"
+
+		var workerCount atomic.Int32
+		secondWorkerStarted := make(chan struct{})
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/beforeExecuteRegionJob",
+			func(ctx context.Context) {
+				switch workerCount.Add(1) {
+				case 1:
+					<-ctx.Done()
+				case 2:
+					close(secondWorkerStarted)
+				}
+			},
+		)
+
+		regionKeys := [][]byte{{'a'}, {'b'}}
+		jobRange := engineapi.Range{Start: regionKeys[0], End: regionKeys[1]}
+		fakeRegionJobs = map[[2]string]struct {
+			jobs []*regionJob
+			err  error
+		}{
+			{"a", "b"}: {
+				jobs: []*regionJob{
+					{
+						keyRange:   jobRange,
+						ingestData: &Engine{},
+						injected: []injectedBehaviour{{
+							write: injectedWriteBehaviour{err: errors.New(fatalErr)},
+						}},
+						region: dummyRegionInfo,
+					},
+					{
+						keyRange:   jobRange,
+						ingestData: &Engine{},
+						injected: []injectedBehaviour{{
+							write: injectedWriteBehaviour{err: errors.New(fatalErr)},
+						}},
+						region: dummyRegionInfo,
+					},
+				},
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		local := &Backend{
+			BackendConfig: BackendConfig{
+				WorkerConcurrency: toAtomic(2),
+			},
+		}
+		engine := &Engine{regionSplitKeysCache: regionKeys}
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- local.doImport(
+				ctx,
+				engine,
+				regionKeys,
+				int64(config.SplitRegionSize),
+				int64(config.SplitRegionKeys),
+			)
+		}()
+
+		select {
+		case <-secondWorkerStarted:
+		case <-time.After(10 * time.Second):
+			cancel()
+			t.Fatal("timed out waiting for both region workers to start")
+		}
+
+		select {
+		case err := <-errCh:
+			cancel()
+			require.ErrorContains(t, err, fatalErr)
+		case <-time.After(10 * time.Second):
+			cancel()
+			select {
+			case <-errCh:
+			case <-time.After(10 * time.Second):
+				t.Fatal("doImport remained blocked after canceling its parent context")
+			}
+			t.Fatal("doImport blocked waiting for another worker after a worker error")
+		}
+	})
+
 	t.Run("context canceled before import completes", func(t *testing.T) {
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ingestor/ingestctrl/skipStartWorker", "return()")
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ingestor/ingestctrl/injectVariables", "return()")
@@ -2287,6 +2372,23 @@ func TestDoImport(t *testing.T) {
 		cancel()
 
 		dispatcher := &dispatcher{workerCtx: ctx}
+		require.ErrorIs(t, dispatcher.run(), context.Canceled)
+	})
+
+	t.Run("dispatcher handles error shutdown when result channel closes", func(t *testing.T) {
+		workerCtx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/beforeWaitForRegionJobWorkerPoolOutcome",
+			cancel,
+		)
+
+		jobFromWorkerCh := make(chan *regionJob)
+		close(jobFromWorkerCh)
+		jobToWorkerCh := make(chan *regionJob)
+		retryer := newRegionJobRetryer(workerCtx, jobToWorkerCh, &sync.WaitGroup{})
+
+		dispatcher := newDispatcher(workerCtx, jobFromWorkerCh, &sync.WaitGroup{}, retryer)
 		require.ErrorIs(t, dispatcher.run(), context.Canceled)
 	})
 }

--- a/pkg/ingestor/ingestctrl/region_job.go
+++ b/pkg/ingestor/ingestctrl/region_job.go
@@ -938,6 +938,8 @@ type regionJobRetryer struct {
 
 type dispatcher struct {
 	workerCtx context.Context
+	// allJobsSucceeded distinguishes normal result-channel closure from error cleanup.
+	allJobsSucceeded chan struct{}
 
 	jobFromWorkerCh chan *regionJob
 	jobWg           *sync.WaitGroup
@@ -952,11 +954,16 @@ func newDispatcher(
 	retryer *regionJobRetryer,
 ) *dispatcher {
 	return &dispatcher{
-		workerCtx:       workerCtx,
-		jobFromWorkerCh: jobFromWorkerCh,
-		jobWg:           jobWg,
-		retryer:         retryer,
+		workerCtx:        workerCtx,
+		allJobsSucceeded: make(chan struct{}),
+		jobFromWorkerCh:  jobFromWorkerCh,
+		jobWg:            jobWg,
+		retryer:          retryer,
 	}
+}
+
+func (d *dispatcher) markAllJobsSucceeded() {
+	close(d.allJobsSucceeded)
 }
 
 func (d *dispatcher) run() error {
@@ -971,6 +978,12 @@ func (d *dispatcher) run() error {
 		case job, ok = <-d.jobFromWorkerCh:
 		}
 		if !ok {
+			failpoint.InjectCall("beforeWaitForRegionJobWorkerPoolOutcome")
+			select {
+			case <-d.workerCtx.Done():
+				return d.workerCtx.Err()
+			case <-d.allJobsSucceeded:
+			}
 			d.retryer.close()
 			return nil
 		}

--- a/pkg/resourcemanager/pool/workerpool/workerpool.go
+++ b/pkg/resourcemanager/pool/workerpool/workerpool.go
@@ -355,11 +355,6 @@ func (p *WorkerPool[T, R]) CloseAndWait() {
 	p.Release()
 }
 
-// Wait waits for all workers to exit without releasing the pool.
-func (p *WorkerPool[T, R]) Wait() {
-	p.wg.Wait()
-}
-
 // Release waits the pool to be released.
 // It will wait the input channel to be closed,
 // or the context being cancelled by business error.

--- a/pkg/resourcemanager/pool/workerpool/workerpool.go
+++ b/pkg/resourcemanager/pool/workerpool/workerpool.go
@@ -355,6 +355,11 @@ func (p *WorkerPool[T, R]) CloseAndWait() {
 	p.Release()
 }
 
+// Wait waits for all workers to exit without releasing the pool.
+func (p *WorkerPool[T, R]) Wait() {
+	p.wg.Wait()
+}
+
 // Release waits the pool to be released.
 // It will wait the input channel to be closed,
 // or the context being cancelled by business error.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70151

Problem Summary:

**Caused by https://github.com/pingcap/tidb/pull/62120.**

When an `IMPORT INTO` task is canceled, `doImport` can return before its region-job workers exit. Subsequent cleanup can destroy the ingest buffer pool while a worker is still releasing `MemoryIngestData`, causing a `send on closed channel` panic.

### What changed and how does it work?

- Release the region-job worker pool from its error-group goroutine after its context is canceled, so `doImport` waits for every worker on normal, error, and cancellation paths.
- Let the successful job producer cancel the worker context instead of releasing the pool concurrently.
- Use the region job's recovery metadata when recovering a worker panic.
- Add a regression test that blocks `IngestData.DecRef` and verifies that cancellation does not return before the worker exits.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run 'Test(DoImport|WorkerPoolWithErrors)$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -race -run 'TestDoImport/context_cancellation_waits_for_running_workers$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential panic during IMPORT INTO task cancellation when the ingest buffer pool is destroyed before region-job workers exit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import cancellation handling so active region-job workers finish and release ingest-data references before the import returns.
  * Refined worker-pool start/stop and cancellation/error propagation for more consistent behavior during interrupted imports.
  * Enhanced recovery diagnostics by using job-provided context for clearer labeling.

* **Tests**
  * Added deterministic test coverage to verify that import cancellation waits for running workers to complete ingest-data reference release before returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->