### PR TITLE
planner: stop running cascades planner test rounds

### DIFF
--- a/pkg/testkit/mockstore.go
+++ b/pkg/testkit/mockstore.go
@@ -75,14 +75,13 @@ func WithCascades(on bool) TestOption {
 	}
 }
 
-// RunTestUnderCascades run the basic test body among two different planner mode.
+// RunTestUnderCascades runs the basic test body with the cascades planner disabled.
 func RunTestUnderCascades(t *testing.T, testFunc func(t *testing.T, tk *TestKit, cascades, caller string), opts ...mockstore.MockTiKVStoreOption) {
 	options := []struct {
 		name string
 		opt  TestOption
 	}{
 		{"off", WithCascades(false)},
-		{"on", WithCascades(true)},
 	}
 	// get func name
 	pc, _, _, ok := runtime.Caller(1)
@@ -101,14 +100,13 @@ func RunTestUnderCascades(t *testing.T, testFunc func(t *testing.T, tk *TestKit,
 	}
 }
 
-// RunTestUnderCascadesWithDomain run the basic test body among two different planner mode.
+// RunTestUnderCascadesWithDomain runs the basic test body with the cascades planner disabled.
 func RunTestUnderCascadesWithDomain(t *testing.T, testFunc func(t *testing.T, tk *TestKit, domain *domain.Domain, cascades, caller string), opts ...mockstore.MockTiKVStoreOption) {
 	options := []struct {
 		name string
 		opt  TestOption
 	}{
 		{"off", WithCascades(false)},
-		{"on", WithCascades(true)},
 	}
 	// get func name
 	pc, _, _, ok := runtime.Caller(1)
@@ -127,14 +125,13 @@ func RunTestUnderCascadesWithDomain(t *testing.T, testFunc func(t *testing.T, tk
 	}
 }
 
-// RunTestUnderCascadesAndDomainWithSchemaLease runs the basic test body among two different planner modes. It can be used to set schema lease and store options.
+// RunTestUnderCascadesAndDomainWithSchemaLease runs the basic test body with the cascades planner disabled. It can be used to set schema lease and store options.
 func RunTestUnderCascadesAndDomainWithSchemaLease(t *testing.T, lease time.Duration, opts []mockstore.MockTiKVStoreOption, testFunc func(t *testing.T, tk *TestKit, domain *domain.Domain, cascades, caller string)) {
 	options := []struct {
 		name string
 		opt  TestOption
 	}{
 		{"off", WithCascades(false)},
-		{"on", WithCascades(true)},
 	}
 	// get func name
 	pc, _, _, ok := runtime.Caller(1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66613

Problem Summary:

The Cascades planner is no longer being actively evolved, but planner tests wrapped by the shared testkit helpers still run once with Cascades disabled and once with it enabled. The additional round consumes CI resources and requires Cascades-specific test results to be maintained in parallel.

The Cascades and memo implementations remain useful as references or reusable building blocks for alternative optimizer work, so they should remain in the codebase.

### What changed and how does it work?

The three `RunTestUnderCascades*` testkit helpers now run only the `off` round. This stops shared planner tests from executing and maintaining a parallel Cascades round while preserving the Cascades optimizer, memo implementation, `WithCascades(true)`, and their dedicated unit tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/cascades -run '^TestCascadesTemplate$' -count=1 -v
make lint
```

The targeted test ran only `TestCascadesTemplate/off`; no `/on` subtest was created.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helpers to run only with cascades disabled.
  * Revised helper documentation to reflect the supported test mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->