### PR TITLE
ddl: fix reorg metadata for modify-column MSC

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5123,7 +5123,7 @@ func initJobReorgMetaFromVariables(job *model.Job, sctx sessionctx.Context) erro
 				}
 			case model.ActionModifyColumn:
 				setReorgParam()
-				if job.NeedReorg {
+				if sub.NeedReorg {
 					err := setDistTaskParam()
 					if err != nil {
 						return err
@@ -5152,15 +5152,6 @@ func initJobReorgMetaFromVariables(job *model.Job, sctx sessionctx.Context) erro
 		zap.Int("maxNodeCount", m.MaxNodeCount),
 	)
 	return nil
-}
-
-func modifyColumnNeedReorg(jobCtxVars []any) bool {
-	if len(jobCtxVars) > 0 {
-		if v, ok := jobCtxVars[0].(bool); ok {
-			return v
-		}
-	}
-	return false
 }
 
 // LastReorgMetaFastReorgDisabled is used for test.

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -810,6 +810,35 @@ func TestMultiSchemaChangeModifyColumnOrderByStates(t *testing.T) {
 	tk.MustExec("alter table t1 modify column c2 int, drop column id;")
 }
 
+func TestMultiSchemaChangeModifyColumnReorgMeta(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t (a int);")
+
+	// Regression test for issue #70136.
+	originalFastReorg := variable.EnableFastReorg.Load()
+	originalDistTask := variable.EnableDistTask.Load()
+	t.Cleanup(func() {
+		variable.EnableFastReorg.Store(originalFastReorg)
+		variable.EnableDistTask.Store(originalDistTask)
+	})
+	variable.EnableFastReorg.Store(true)
+	variable.EnableDistTask.Store(true)
+
+	var fastReorgInitialized, distReorgInitialized bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeInitReorgMeta", func(m *model.DDLReorgMeta) {
+		fastReorgInitialized = m.IsFastReorg
+		distReorgInitialized = m.IsDistReorg
+		// Keep the test independent of the ingest backend.
+		m.IsFastReorg = false
+		m.IsDistReorg = false
+	})
+	tk.MustExec("alter table t modify column a char(10), add column b int;")
+	require.True(t, fastReorgInitialized)
+	require.True(t, distReorgInitialized)
+}
+
 func TestMultiSchemaChangeDMLUpdate(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70136

Problem Summary:

**Caused by wrong cherry-pick, master doesn't have such issue.**

On `release-8.5`, a multi-schema change containing a reorg-required modify-column subjob checks the parent job's unset `NeedReorg` flag. As a result, fast and distributed reorg metadata is not initialized, and the subjob silently falls back to transactional backfill.

### What changed and how does it work?

- Check `sub.NeedReorg` when initializing reorg metadata for a modify-column subjob.
- Remove the obsolete context-variable helper left by the earlier cherry-pick.
- Add a regression test that verifies both fast and distributed reorg metadata without depending on an ingest backend.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `tools/bin/failpoint-ctl enable pkg/ddl && (cd pkg/ddl && go test -run '^TestMultiSchemaChangeModifyColumnReorgMeta$' -count=5 -tags=intest,deadlock; test_rc=$?; cd ../..; tools/bin/failpoint-ctl disable pkg/ddl; exit $test_rc)`
  - Verified that the regression test fails before the fix and passes after the fix.
  - `make lint`
  - `make bazel_prepare`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where multi-schema changes that modify a column fall back to transactional backfill instead of using ingest or distributed backfill
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected reorganization handling for multi-schema column modifications.
  - Ensured the appropriate reorganization metadata is initialized for affected schema changes.

- **Tests**
  - Added regression coverage for fast and distributed reorganization metadata during combined column alterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->