### PR TITLE
*: fix parser parentheses depth dos

### DIFF
--- a/pkg/parser/hintparser_test.go
+++ b/pkg/parser/hintparser_test.go
@@ -14,6 +14,7 @@
 package parser_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/parser"
@@ -515,4 +516,13 @@ func TestParseHint(t *testing.T) {
 		}
 		require.Equalf(t, tc.output, output, "input = %s,\n... output = %q", tc.input, output)
 	}
+}
+
+func TestMaxOptimizerHintDepth(t *testing.T) {
+	input := "/*+LEADING(" + strings.Repeat("(", 10000) + "t" + strings.Repeat(")", 10000) + ")*/"
+	mode, err := mysql.GetSQLMode(mysql.DefaultSQLMode)
+	require.NoError(t, err)
+	_, errs := parser.ParseHint(input, mode, parser.Pos{Line: 1})
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0].Error(), "parentheses nesting depth exceeds maximum 10000")
 }

--- a/pkg/parser/hintparserimpl.go
+++ b/pkg/parser/hintparserimpl.go
@@ -101,6 +101,9 @@ func (hs *hintScanner) updateSetVarValueState(tok int) {
 func (hs *hintScanner) Lex(lval *yyhintSymType) int {
 	tok, pos, lit := hs.scan()
 	hs.lastScanOffset = pos.Offset
+	if !hs.updateParenthesesDepth(tok) {
+		return hintInvalid
+	}
 	var errorTokenType string
 	returnToken := func(tok int) int {
 		hs.updateSetVarValueState(tok)

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -238,16 +238,10 @@ func (s *Scanner) Lex(v *yySymType) (tok int) {
 	var pos Pos
 	var lit string
 	tok, pos, lit = s.scan()
-	if tok == int('(') {
-		s.parenDepth++
-		if s.parenDepth > maxParenthesesDepth {
-			s.AppendError(ErrParse.GenWithStackByArgs("parentheses nesting depth exceeds maximum", strconv.Itoa(maxParenthesesDepth)))
-			return invalid
-		}
-	} else if tok == int(')') && s.parenDepth > 0 {
-		s.parenDepth--
-	}
 	s.lastScanOffset = pos.Offset
+	if !s.updateParenthesesDepth(tok) {
+		return invalid
+	}
 	s.lastKeyword3 = s.lastKeyword2
 	s.lastKeyword2 = s.lastKeyword
 	s.lastKeyword = 0
@@ -363,6 +357,19 @@ func (s *Scanner) Lex(v *yySymType) (tok int) {
 	}
 
 	return tok
+}
+
+func (s *Scanner) updateParenthesesDepth(tok int) bool {
+	if tok == int('(') {
+		s.parenDepth++
+		if s.parenDepth > maxParenthesesDepth {
+			s.AppendError(newParserDepthLimitError("parentheses nesting depth exceeds maximum", maxParenthesesDepth))
+			return false
+		}
+	} else if tok == int(')') && s.parenDepth > 0 {
+		s.parenDepth--
+	}
+	return true
 }
 
 // LexLiteral returns the value of the converted literal
@@ -1035,8 +1042,38 @@ func (s *Scanner) lastErrorAsWarn() {
 	if len(s.errs) == 0 {
 		return
 	}
+	if isParserDepthLimitError(s.errs[len(s.errs)-1]) {
+		return
+	}
 	s.warns = append(s.warns, s.errs[len(s.errs)-1])
 	s.errs = s.errs[:len(s.errs)-1]
+}
+
+type parserDepthLimitError struct {
+	err error
+}
+
+func newParserDepthLimitError(message string, maxDepth int) error {
+	return &parserDepthLimitError{
+		err: ErrParse.GenWithStackByArgs(message, strconv.Itoa(maxDepth)),
+	}
+}
+
+func (e *parserDepthLimitError) Error() string {
+	return e.err.Error()
+}
+
+func (e *parserDepthLimitError) Cause() error {
+	return e.err
+}
+
+func (e *parserDepthLimitError) Unwrap() error {
+	return e.err
+}
+
+func isParserDepthLimitError(err error) bool {
+	_, ok := err.(*parserDepthLimitError)
+	return ok
 }
 
 type reader struct {

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -28,6 +28,10 @@ import (
 
 var _ = yyLexer(&Scanner{})
 
+// maxParenthesesDepth bounds user-controlled nesting before it can build an
+// AST that is too deep for recursive visitors.
+const maxParenthesesDepth = 10000
+
 // Pos represents the position of a token.
 type Pos struct {
 	Line   int
@@ -84,6 +88,8 @@ type Scanner struct {
 
 	// keepHint, if true, Scanner will keep hint when normalizing .
 	keepHint bool
+
+	parenDepth int
 }
 
 // Errors returns the errors and warns during a scan.
@@ -103,6 +109,7 @@ func (s *Scanner) reset(sql string) {
 	s.inBangComment = false
 	s.lastKeyword = 0
 	s.identifierDot = false
+	s.parenDepth = 0
 }
 
 func (s *Scanner) stmtText() string {
@@ -231,6 +238,15 @@ func (s *Scanner) Lex(v *yySymType) (tok int) {
 	var pos Pos
 	var lit string
 	tok, pos, lit = s.scan()
+	if tok == int('(') {
+		s.parenDepth++
+		if s.parenDepth > maxParenthesesDepth {
+			s.AppendError(ErrParse.GenWithStackByArgs("parentheses nesting depth exceeds maximum", strconv.Itoa(maxParenthesesDepth)))
+			return invalid
+		}
+	} else if tok == int(')') && s.parenDepth > 0 {
+		s.parenDepth--
+	}
 	s.lastScanOffset = pos.Offset
 	s.lastKeyword3 = s.lastKeyword2
 	s.lastKeyword2 = s.lastKeyword

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -33,6 +33,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMaxParenthesesDepth(t *testing.T) {
+	p := parser.New()
+	nestedExpr := func(depth int) string {
+		return "select " + strings.Repeat("(", depth) + "1" + strings.Repeat(")", depth)
+	}
+
+	_, err := p.ParseOneStmt(nestedExpr(10000), "", "")
+	require.NoError(t, err)
+
+	_, err = p.ParseOneStmt(nestedExpr(10001), "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
+}
+
 func TestSimple(t *testing.T) {
 	p := parser.New()
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -38,6 +38,9 @@ func TestMaxParenthesesDepth(t *testing.T) {
 	nestedExpr := func(depth int) string {
 		return "select " + strings.Repeat("(", depth) + "1" + strings.Repeat(")", depth)
 	}
+	nestedFuncExpr := func(depth int) string {
+		return "select " + strings.Repeat("f(", depth) + "1" + strings.Repeat(")", depth)
+	}
 
 	_, err := p.ParseOneStmt(nestedExpr(10000), "", "")
 	require.NoError(t, err)
@@ -45,6 +48,38 @@ func TestMaxParenthesesDepth(t *testing.T) {
 	_, err = p.ParseOneStmt(nestedExpr(10001), "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
+
+	_, err = p.ParseOneStmt(nestedFuncExpr(10001), "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
+}
+
+func TestMaxASTDepth(t *testing.T) {
+	p := parser.New()
+	nestedCaseExpr := func(depth int) string {
+		return "select " + strings.Repeat("case when true then ", depth) + "1" + strings.Repeat(" else 0 end", depth)
+	}
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "binary operation chain",
+			sql:  "select " + strings.Repeat("1+", 11000) + "1",
+		},
+		{
+			name: "unary operation chain",
+			sql:  "select " + strings.Repeat("!", 11000) + "1",
+		},
+		{
+			name: "case expression chain",
+			sql:  nestedCaseExpr(11000),
+		},
+	} {
+		_, err := p.ParseOneStmt(tc.sql, "", "")
+		require.Error(t, err, tc.name)
+		require.Contains(t, err.Error(), "AST nesting depth exceeds maximum", tc.name)
+	}
 }
 
 func TestSimple(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -41,6 +41,9 @@ func TestMaxParenthesesDepth(t *testing.T) {
 	nestedFuncExpr := func(depth int) string {
 		return "select " + strings.Repeat("f(", depth) + "1" + strings.Repeat(")", depth)
 	}
+	nestedLeadingHint := func(depth int) string {
+		return "select /*+ LEADING(" + strings.Repeat("(", depth) + "t" + strings.Repeat(")", depth) + ") */ * from t"
+	}
 
 	_, err := p.ParseOneStmt(nestedExpr(10000), "", "")
 	require.NoError(t, err)
@@ -50,6 +53,10 @@ func TestMaxParenthesesDepth(t *testing.T) {
 	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
 
 	_, err = p.ParseOneStmt(nestedFuncExpr(10001), "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
+
+	_, err = p.ParseOneStmt(nestedLeadingHint(10000), "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parentheses nesting depth exceeds maximum 10000")
 }

--- a/pkg/parser/yy_parser.go
+++ b/pkg/parser/yy_parser.go
@@ -82,6 +82,14 @@ type ParserConfig struct {
 	SkipPositionRecording       bool
 }
 
+const (
+	// maxASTDepthStmtOverhead leaves room for statement wrapper nodes on the
+	// visitor path, for example SelectStmt -> FieldList -> SelectField.
+	maxASTDepthStmtOverhead = 64
+	// maxASTDepth bounds user-controlled AST nesting before recursive visitors run.
+	maxASTDepth = maxParenthesesDepth + maxASTDepthStmtOverhead
+)
+
 //revive:enable:exported
 
 // Parser represents a parser instance. Some temporary objects are stored in it to reduce object allocation during Parse function.
@@ -201,6 +209,9 @@ func (parser *Parser) ParseSQL(sql string, params ...ParseParam) (stmt []ast.Stm
 		return nil, warns, errors.Trace(errs[0])
 	}
 	for _, stmt := range parser.result {
+		if err := checkASTDepth(stmt); err != nil {
+			return nil, warns, errors.Trace(err)
+		}
 		ast.SetFlag(stmt)
 	}
 	return parser.result, warns, nil
@@ -214,6 +225,34 @@ func (parser *Parser) Parse(sql, charset, collation string) (stmt []ast.StmtNode
 
 func (parser *Parser) lastErrorAsWarn() {
 	parser.lexer.lastErrorAsWarn()
+}
+
+func checkASTDepth(stmt ast.StmtNode) error {
+	checker := astDepthChecker{}
+	_, _ = stmt.Accept(&checker)
+	if checker.exceeded {
+		return ErrParse.GenWithStackByArgs("AST nesting depth exceeds maximum", strconv.Itoa(maxASTDepth))
+	}
+	return nil
+}
+
+type astDepthChecker struct {
+	depth    int
+	exceeded bool
+}
+
+func (c *astDepthChecker) Enter(in ast.Node) (ast.Node, bool) {
+	c.depth++
+	if c.depth > maxASTDepth {
+		c.exceeded = true
+		return in, true
+	}
+	return in, false
+}
+
+func (c *astDepthChecker) Leave(in ast.Node) (ast.Node, bool) {
+	c.depth--
+	return in, !c.exceeded
 }
 
 // ParseOneStmt parses a query and returns an ast.StmtNode.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70192 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards against excessively nested parentheses in SQL expressions and optimizer hints.
  * Added protection against overly deep abstract syntax trees during parsing.
  * Parser now returns clear errors when nesting limits are exceeded, preventing potential resource exhaustion.
  * Depth-limit errors are preserved as errors rather than downgraded to warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->