### PR TITLE
br: processing empty metadata (#69640)

### DIFF
--- a/br/pkg/restore/log_client/log_file_manager.go
+++ b/br/pkg/restore/log_client/log_file_manager.go
@@ -172,6 +172,11 @@ func (lm *LogFileManager) ShiftTS() uint64 {
 	return lm.shiftStartTS
 }
 
+func isEmptyTaggedBackupMeta(path string) bool {
+	parsedName, err := stream.TryParseTaggedBackupMetaFileNameWrapper(path)
+	return err == nil && parsedName.IsEmpty()
+}
+
 func (lm *LogFileManager) loadShiftTS(ctx context.Context) error {
 	shiftTS := struct {
 		sync.Mutex
@@ -189,6 +194,9 @@ func (lm *LogFileManager) loadShiftTS(ctx context.Context) error {
 			parsedName, err := stream.TryParseTaggedBackupMetaFileNameWrapper(filename)
 			if err != nil {
 				return false
+			}
+			if parsedName.IsEmpty() {
+				return true
 			}
 			ts, status := parsedName.CalculateShiftTS(lm.startTS, lm.restoreTS)
 			switch status {
@@ -257,6 +265,9 @@ func (lm *LogFileManager) createMetaIterOver(ctx context.Context, s storeapi.Sto
 	names := []string{}
 	err := s.WalkDir(ctx, opt, func(path string, size int64) error {
 		if !strings.HasSuffix(path, ".meta") {
+			return nil
+		}
+		if isEmptyTaggedBackupMeta(path) {
 			return nil
 		}
 		newPath := stream.FilterPathByTs(path, lm.shiftStartTS, lm.restoreTS)

--- a/br/pkg/restore/log_client/log_file_manager_test.go
+++ b/br/pkg/restore/log_client/log_file_manager_test.go
@@ -273,6 +273,42 @@ func TestReadMetaBetweenTS(t *testing.T) {
 	t.Run("MetaV2", func(t *testing.T) { testReadMetaBetweenTSWithVersion(t, m2) })
 }
 
+func TestLogFileManagerSkipsEmptyMetaByName(t *testing.T) {
+	ctx := context.Background()
+	loc, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	normalMeta := m2(wr(10, 20, 5))
+	normalPayload, err := normalMeta.Marshal()
+	require.NoError(t, err)
+	normalPath := fmt.Sprintf(
+		"%s/%016X%016X-d%016Xl%016Xu%016Xp%016X.meta",
+		stream.GetStreamBackupMetaPrefix(), uint64(30), uint64(normalMeta.StoreId), uint64(5), uint64(10), uint64(20), uint64(0),
+	)
+	emptyPath := fmt.Sprintf(
+		"%s/%016X%016X-d%016Xl%016Xu%016Xp%016X.meta",
+		stream.GetStreamBackupMetaPrefix(), uint64(40), uint64(999), uint64(0), uint64(0), uint64(0), uint64(2),
+	)
+	require.NoError(t, loc.WriteFile(ctx, normalPath, normalPayload))
+	require.NoError(t, loc.WriteFile(ctx, emptyPath, []byte("invalid empty meta payload")))
+
+	fm, err := logclient.CreateLogFileManager(ctx, logclient.LogFileManagerInit{
+		StartTS:                   1,
+		RestoreTS:                 100,
+		Storage:                   loc,
+		MigrationsBuilder:         logclient.NewMigrationBuilder(0, 1, 100),
+		Migrations:                emptyMigrations(),
+		MetadataDownloadBatchSize: 32,
+	})
+	require.NoError(t, err)
+
+	metas, err := fm.ReadStreamMeta(ctx)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	require.Equal(t, normalMeta.StoreId, metas[0].Meta().StoreId)
+	require.NotEmpty(t, emptyPath)
+}
+
 func testReadFromMetadataWithVersion(t *testing.T, m metaMaker) {
 	type Case struct {
 		items    []*backuppb.Metadata

--- a/br/pkg/stream/backupmetas/parser.go
+++ b/br/pkg/stream/backupmetas/parser.go
@@ -37,6 +37,7 @@ const (
 
 const (
 	flagNoDDLFiles = 1 << iota
+	flagEmpty
 )
 
 var (
@@ -90,6 +91,10 @@ func (parsedName *ParsedName) HasDDLFiles() bool {
 		return true
 	}
 	return parsedName.Flags&flagNoDDLFiles == 0
+}
+
+func (parsedName *ParsedName) IsEmpty() bool {
+	return parsedName.HasFlags && parsedName.Flags&flagEmpty != 0
 }
 
 // TryParseTaggedBackupMetaFileName parses the tagged backupmeta file-name format.

--- a/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
+++ b/br/pkg/stream/crr/internal/checkpoint/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":checkpoint"],
     flaky = True,
-    shard_count = 23,
+    shard_count = 26,
     deps = [
         "//br/pkg/stream",
         "//br/pkg/streamhelper",

--- a/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
+++ b/br/pkg/stream/crr/internal/checkpoint/checkpoint_calculator_test.go
@@ -214,6 +214,48 @@ func TestCheckpointCalculatorUsesProvidedObjectSyncChecker(t *testing.T) {
 	require.Equal(t, record.FlushTS, calculator.SyncedTS())
 }
 
+func TestCheckpointCalculatorAdvancesWithEmptyMetaFlag(t *testing.T) {
+	ctx := context.Background()
+	upstream, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	const flushTS = uint64(20)
+	const checkpointTS = uint64(15)
+	const storeID = uint64(1)
+	metaPath := writeCheckpointEmptyMeta(ctx, t, upstream, flushTS, storeID)
+
+	pd := &fakePDMetaReader{}
+	pd.Set(checkpointTS, storeID)
+	observer := &recordingObserver{}
+	calculator, err := checkpoint.NewCalculator(
+		checkpoint.CalculatorDeps{
+			PD:       pd,
+			Upstream: upstream,
+			Sync:     checkpoint.NewExistenceSyncChecker(fileExistenceMap{}),
+		},
+		checkpoint.CheckpointCalculatorConfig{TaskName: "drr_test_task"},
+		observer,
+	)
+	require.NoError(t, err)
+
+	checkpointTSResult, err := calculator.ComputeNextCheckpoint(ctx)
+	require.NoError(t, err)
+	require.Equal(t, checkpointTS, checkpointTSResult)
+	require.Equal(t, flushTS, calculator.SyncedTS())
+
+	events := observer.Events()
+	require.Len(t, events, 3)
+	require.Equal(t, checkpoint.EventRoundPlanned, events[1].Type)
+	require.NotNil(t, events[1].Statistic)
+	require.Zero(t, events[1].Statistic.UpstreamReadMetaFileCount)
+	require.Zero(t, events[1].Statistic.EstimatedSyncLogFileCount)
+	require.Zero(t, events[1].PendingFileCount)
+	require.Equal(t, checkpoint.EventCheckpointAdvanced, events[2].Type)
+	require.NotNil(t, events[2].Statistic)
+	require.Zero(t, events[2].Statistic.DownstreamCheckFileCount)
+	require.NotEmpty(t, metaPath)
+}
+
 func TestCheckpointCalculatorFailsOnObjectSyncError(t *testing.T) {
 	ctx := context.Background()
 	boundaries, err := testutil.BuildRegionLayout(
@@ -576,4 +618,27 @@ func writeCheckpointTestMeta(
 	require.NoError(t, err)
 	require.NoError(t, storage.WriteFile(ctx, metaPath, payload))
 	return metaPath, logPath
+}
+
+func writeCheckpointEmptyMeta(
+	ctx context.Context,
+	t *testing.T,
+	storage storeapi.Storage,
+	flushTS uint64,
+	storeID uint64,
+) string {
+	t.Helper()
+
+	metaPath := fmt.Sprintf(
+		"%s/%016X%016X-d%016Xl%016Xu%016Xp%016X.meta",
+		stream.GetStreamBackupMetaPrefix(),
+		flushTS,
+		storeID,
+		uint64(0),
+		uint64(0),
+		uint64(0),
+		uint64(2),
+	)
+	require.NoError(t, storage.WriteFile(ctx, metaPath, []byte("invalid metadata payload")))
+	return metaPath
 }

--- a/br/pkg/stream/crr/internal/checkpoint/progress.go
+++ b/br/pkg/stream/crr/internal/checkpoint/progress.go
@@ -47,8 +47,10 @@ func newRoundPlan() roundPlan {
 }
 
 func (p *roundPlan) recordLoadedMeta(loadedMeta loadedMetaFile) {
-	p.statistic.UpstreamReadMetaFileCount++
-	p.recordPendingPath(loadedMeta.path)
+	if !loadedMeta.empty {
+		p.statistic.UpstreamReadMetaFileCount++
+		p.recordPendingPath(loadedMeta.path)
+	}
 	for _, logPath := range loadedMeta.dataFilePaths {
 		if p.recordPendingPath(logPath) {
 			p.statistic.EstimatedSyncLogFileCount++
@@ -130,9 +132,12 @@ func (c *Calculator) planRound(ctx context.Context) (roundPlan, error) {
 		eg.Go(func() error {
 			failpoint.InjectCall("before-read-meta", metaFile.path)
 
-			loadedMeta, err := loadMetaFile(egCtx, c.deps.Upstream, metaFile)
+			loadedMeta, ignored, err := loadMetaFile(egCtx, c.deps.Upstream, metaFile)
 			if err != nil {
 				return err
+			}
+			if ignored {
+				return nil
 			}
 
 			planMu.Lock()

--- a/br/pkg/stream/crr/internal/checkpoint/storage.go
+++ b/br/pkg/stream/crr/internal/checkpoint/storage.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/stream"
 	"github.com/pingcap/tidb/br/pkg/stream/backupmetas"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
+	"go.uber.org/zap"
 )
 
 const (
@@ -41,12 +43,14 @@ type parsedMetaFile struct {
 	path    string
 	flushTS uint64
 	storeID uint64
+	empty   bool
 }
 
 type loadedMetaFile struct {
 	path          string
 	flushTS       uint64
 	storeID       uint64
+	empty         bool
 	dataFilePaths []string
 }
 
@@ -106,6 +110,7 @@ func (c *Calculator) newMetaFileSeq(ctx context.Context) iter.Seq2[parsedMetaFil
 				path:    entry.path,
 				flushTS: parsed.FlushTS,
 				storeID: parsed.StoreID,
+				empty:   parsed.IsEmpty(),
 			}, nil) {
 				return
 			}
@@ -117,20 +122,39 @@ func loadMetaFile(
 	ctx context.Context,
 	storage UpstreamStorageReader,
 	metaFile parsedMetaFile,
-) (loadedMetaFile, error) {
+) (loadedMetaFile, bool, error) {
+	if metaFile.empty {
+		if metaFile.storeID == 0 {
+			log.Warn("ignore empty backupmeta with no store id in file name",
+				zap.String("path", metaFile.path),
+				zap.Uint64("flush-ts", metaFile.flushTS))
+			return loadedMetaFile{
+				path:    metaFile.path,
+				flushTS: metaFile.flushTS,
+				empty:   true,
+			}, true, nil
+		}
+		return loadedMetaFile{
+			path:    metaFile.path,
+			flushTS: metaFile.flushTS,
+			storeID: metaFile.storeID,
+			empty:   true,
+		}, false, nil
+	}
+
 	metaBytes, err := storage.ReadFile(ctx, metaFile.path)
 	if err != nil {
-		return loadedMetaFile{}, fmt.Errorf("read upstream backupmeta %s: %w", metaFile.path, err)
+		return loadedMetaFile{}, false, fmt.Errorf("read upstream backupmeta %s: %w", metaFile.path, err)
 	}
 
 	meta, err := parseBackupMetadata(metaBytes)
 	if err != nil {
-		return loadedMetaFile{}, fmt.Errorf("parse backupmeta %s: %w", metaFile.path, err)
+		return loadedMetaFile{}, false, fmt.Errorf("parse backupmeta %s: %w", metaFile.path, err)
 	}
 
 	storeID, err := resolveStoreID(metaFile.storeID, meta.GetStoreId(), metaFile.path)
 	if err != nil {
-		return loadedMetaFile{}, err
+		return loadedMetaFile{}, false, err
 	}
 
 	return loadedMetaFile{
@@ -138,7 +162,7 @@ func loadMetaFile(
 		flushTS:       metaFile.flushTS,
 		storeID:       storeID,
 		dataFilePaths: extractDataFilePaths(meta),
-	}, nil
+	}, false, nil
 }
 
 func parseBackupMetadata(rawMeta []byte) (*backuppb.Metadata, error) {

--- a/br/pkg/stream/crr/internal/checkpoint/storage_internal_test.go
+++ b/br/pkg/stream/crr/internal/checkpoint/storage_internal_test.go
@@ -16,6 +16,7 @@ package checkpoint
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"testing"
 
@@ -90,4 +91,58 @@ func TestMetaFileSeqIncludesUppercaseMetaNamesAfterSyncedTS(t *testing.T) {
 		got = append(got, metaFile.path)
 	}
 	require.ElementsMatch(t, metaPaths, got)
+}
+
+func TestLoadEmptyMetaFileSkipsContentRead(t *testing.T) {
+	ctx := context.Background()
+	upstream, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	const flushTS = uint64(0x06745D833D8C0014)
+	const storeID = uint64(1001)
+	metaPath := path.Join(
+		stream.GetStreamBackupMetaPrefix(),
+		fmt.Sprintf("%016X%016X-d%016Xl%016Xu%016Xp%016X.meta", flushTS, storeID, uint64(0), uint64(0), uint64(0), uint64(2)),
+	)
+	require.NoError(t, upstream.WriteFile(ctx, metaPath, []byte("invalid metadata payload")))
+
+	calc, err := NewCalculator(
+		CalculatorDeps{
+			PD:       stubPDMetaReader{},
+			Upstream: upstream,
+			Sync:     stubSyncChecker{},
+		},
+		CheckpointCalculatorConfig{TaskName: "task"},
+		nil,
+	)
+	require.NoError(t, err)
+
+	var parsed parsedMetaFile
+	for metaFile, err := range calc.newMetaFileSeq(ctx) {
+		require.NoError(t, err)
+		parsed = metaFile
+	}
+	require.True(t, parsed.empty)
+
+	loaded, ignored, err := loadMetaFile(ctx, upstream, parsed)
+	require.NoError(t, err)
+	require.False(t, ignored)
+	require.Equal(t, metaPath, loaded.path)
+	require.Equal(t, flushTS, loaded.flushTS)
+	require.Equal(t, storeID, loaded.storeID)
+	require.True(t, loaded.empty)
+	require.Empty(t, loaded.dataFilePaths)
+}
+
+func TestLoadEmptyMetaFileWithZeroStoreIDIsIgnored(t *testing.T) {
+	loaded, ignored, err := loadMetaFile(context.Background(), nil, parsedMetaFile{
+		path:    "v1/backupmeta/00000000000000140000000000000000-d0000000000000000l0000000000000000u0000000000000000p0000000000000002.meta",
+		flushTS: 20,
+		empty:   true,
+	})
+	require.NoError(t, err)
+	require.True(t, ignored)
+	require.True(t, loaded.empty)
+	require.Zero(t, loaded.storeID)
+	require.Empty(t, loaded.dataFilePaths)
 }

--- a/br/pkg/stream/stream_mgr_fuzz_test.go
+++ b/br/pkg/stream/stream_mgr_fuzz_test.go
@@ -59,6 +59,7 @@ func FuzzParseBackupMetaFileNameRoundTrip(f *testing.F) {
 			MaxTS:                 maxTs,
 		}, taggedParsed)
 		require.True(t, taggedParsed.HasDDLFiles())
+		require.False(t, taggedParsed.IsEmpty())
 
 		taggedNoDDLFileName := fmt.Sprintf(
 			"%016X%016X-d%016Xu%016Xl%016Xp%016X",
@@ -76,6 +77,25 @@ func FuzzParseBackupMetaFileNameRoundTrip(f *testing.F) {
 			HasFlags:              true,
 		}, taggedNoDDLParsed)
 		require.False(t, taggedNoDDLParsed.HasDDLFiles())
+		require.False(t, taggedNoDDLParsed.IsEmpty())
+
+		taggedEmptyFileName := fmt.Sprintf(
+			"%016X%016X-d%016Xu%016Xl%016Xp%016X",
+			flushTs, storeID, minBeginTsInDefaultCf, maxTs, minTs, uint64(3),
+		)
+		taggedEmptyParsed, err := backupmetas.ParseName(taggedEmptyFileName)
+		require.NoError(t, err)
+		require.Equal(t, backupmetas.ParsedName{
+			FlushTS:               flushTs,
+			StoreID:               storeID,
+			MinBeginTsInDefaultCf: minBeginTsInDefaultCf,
+			MinTS:                 minTs,
+			MaxTS:                 maxTs,
+			Flags:                 3,
+			HasFlags:              true,
+		}, taggedEmptyParsed)
+		require.False(t, taggedEmptyParsed.HasDDLFiles())
+		require.True(t, taggedEmptyParsed.IsEmpty())
 
 		taggedDefaultDDLFileName := fmt.Sprintf(
 			"%016X%016X-d%016Xu%016Xl%016Xp%016X",
@@ -84,6 +104,7 @@ func FuzzParseBackupMetaFileNameRoundTrip(f *testing.F) {
 		taggedDefaultDDLParsed, err := backupmetas.ParseName(taggedDefaultDDLFileName)
 		require.NoError(t, err)
 		require.True(t, taggedDefaultDDLParsed.HasDDLFiles())
+		require.False(t, taggedDefaultDDLParsed.IsEmpty())
 
 		tagValues := map[byte]uint64{
 			backupmetas.NameMinBeginTsInDefaultCfTag: minBeginTsInDefaultCf,

--- a/br/pkg/stream/stream_misc_test.go
+++ b/br/pkg/stream/stream_misc_test.go
@@ -273,6 +273,15 @@ func TestFilterPath(t *testing.T) {
 			expected: "",
 		},
 		{
+			name: "new format: empty flag is preserved by ts filter",
+			args: args{
+				path:         "v1/backupmeta/000000000000000A000000000000000B-d0000000000000000l0000000000000000u0000000000000000p0000000000000002.meta",
+				shiftStartTS: 5,
+				restoreTS:    10,
+			},
+			expected: "v1/backupmeta/000000000000000A000000000000000B-d0000000000000000l0000000000000000u0000000000000000p0000000000000002.meta",
+		},
+		{
 			name: "new format: invalid name should be preserved for compatibility",
 			args: args{
 				path:         "v1/backupmeta/000000000000000A000000000000000B-d0000000000000002l0000000000000003.meta",
@@ -298,4 +307,42 @@ func TestFilterPath(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestFastUnmarshalMetaDataSkipConditionCanSkipEmptyMeta(t *testing.T) {
+	ctx := context.Background()
+	s, err := objstore.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	emptyPath := fmt.Sprintf(
+		"%s/%016X%016X-d%016Xl%016Xu%016Xp%016X.meta",
+		stream.GetStreamBackupMetaPrefix(), uint64(20), uint64(1), uint64(0), uint64(0), uint64(0), uint64(2),
+	)
+	normalPath := fmt.Sprintf(
+		"%s/%016X%016X-d%016Xl%016Xu%016Xp%016X.meta",
+		stream.GetStreamBackupMetaPrefix(), uint64(30), uint64(1), uint64(5), uint64(10), uint64(20), uint64(0),
+	)
+	require.NoError(t, s.WriteFile(ctx, emptyPath, []byte("invalid empty meta payload")))
+	require.NoError(t, s.WriteFile(ctx, normalPath, []byte("normal meta payload")))
+
+	var readCount atomic.Int32
+	err = stream.FastUnmarshalMetaData(
+		ctx,
+		s,
+		0,
+		100,
+		1,
+		func(filename string) bool {
+			parsedName, err := stream.TryParseTaggedBackupMetaFileNameWrapper(filename)
+			return err == nil && parsedName.IsEmpty()
+		},
+		func(filename string, rawMetaData []byte) error {
+			readCount.Add(1)
+			require.Equal(t, normalPath, filename)
+			require.Equal(t, []byte("normal meta payload"), rawMetaData)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), readCount.Load())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69567

Problem Summary:
If the number of leader of one TiKV is 0, the TiKV won't flush metadata to external storage anymore, causing flush_ts to fail to be advanced.
### What changed and how does it work?
TiKV will flush empty metadata, so br need to processing the empty metdata.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty backup metadata entries are now recognized and skipped during restore and checkpoint processing.
  * Invalid empty metadata files no longer affect timestamp detection, metadata iteration, or checkpoint progress.
  * Empty entries without a valid store identifier are safely ignored.

* **Tests**
  * Added coverage for empty metadata parsing, filtering, restore behavior, and checkpoint advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->