### PR TITLE
br: ignore only default cf ssts (#69719)

### DIFF
--- a/br/pkg/restore/snap_client/import.go
+++ b/br/pkg/restore/snap_client/import.go
@@ -954,7 +954,7 @@ func (importer *SnapFileImporter) batchDownloadNewestVersionSST(
 			}
 			downloadReq.Ssts[req.Name] = &sstMeta
 		}
-		if downloadReq != nil {
+		if downloadReq != nil && hasWriteCF {
 			downloadReqs = append(downloadReqs, downloadReq)
 		}
 	}

--- a/br/pkg/restore/snap_client/import_test.go
+++ b/br/pkg/restore/snap_client/import_test.go
@@ -373,13 +373,17 @@ func (client *blockingBatchDownloadImporterClient) CheckBatchDownloadSupport(ctx
 }
 
 func makeCompactedFileSets(fileGroupCount, filesPerGroup int) []restore.BackupFileSet {
+	return makeCompactedFileSetsWithCF(fileGroupCount, filesPerGroup, restoreutils.WriteCFName)
+}
+
+func makeCompactedFileSetsWithCF(fileGroupCount, filesPerGroup int, cf string) []restore.BackupFileSet {
 	fileSets := make([]restore.BackupFileSet, 0, fileGroupCount)
 	for i := 0; i < fileGroupCount; i++ {
 		files := make([]*backuppb.File, 0, filesPerGroup)
 		for j := 0; j < filesPerGroup; j++ {
 			files = append(files, &backuppb.File{
-				Name:     fmt.Sprintf("file-%d-%d_write.sst", i, j),
-				Cf:       restoreutils.WriteCFName,
+				Name:     fmt.Sprintf("file-%d-%d_%s.sst", i, j, cf),
+				Cf:       cf,
 				StartKey: tablecodec.EncodeTablePrefix(100),
 				EndKey:   append(tablecodec.EncodeTablePrefix(100), 'z'),
 			})
@@ -395,6 +399,31 @@ func makeCompactedFileSets(fileGroupCount, filesPerGroup int) []restore.BackupFi
 		})
 	}
 	return fileSets
+}
+
+type countingLatestMVCCImporterClient struct {
+	fakeImporterClient
+
+	calls atomic.Int32
+}
+
+func newCountingLatestMVCCImporterClient() *countingLatestMVCCImporterClient {
+	return &countingLatestMVCCImporterClient{
+		fakeImporterClient: *newFakeImporterClient(),
+	}
+}
+
+func (client *countingLatestMVCCImporterClient) BatchDownloadLatestMVCC(
+	ctx context.Context,
+	storeID uint64,
+	req *import_sstpb.DownloadRequest,
+) (*import_sstpb.DownloadResponse, error) {
+	client.calls.Add(1)
+	sst := req.Sst
+	return &import_sstpb.DownloadResponse{
+		Range: *req.Sst.GetRange(),
+		Ssts:  []*import_sstpb.SSTMeta{&sst},
+	}, nil
 }
 
 type retryDownloadImporterClient struct {
@@ -612,6 +641,42 @@ func TestBatchDownloadLatestMVCCParallelizesFileGroupsPerPeer(t *testing.T) {
 	}()
 	waitForConcurrentDownloads(t, importClient, errCh)
 	unblocked = true
+}
+
+func TestBatchDownloadLatestMVCCSkipsDefaultOnlyFileGroups(t *testing.T) {
+	ctx := context.Background()
+	splitClient := split.NewFakeSplitClient()
+	splitClient.AppendPdRegion(&pd.Region{
+		Meta: &metapb.Region{
+			Id:       1,
+			StartKey: codec.EncodeBytes(nil, tablecodec.EncodeTablePrefix(1)),
+			EndKey:   codec.EncodeBytes(nil, tablecodec.EncodeTablePrefix(2)),
+			Peers:    []*metapb.Peer{{StoreId: 1}},
+		},
+		Leader: &metapb.Peer{StoreId: 1},
+	})
+	importClient := newCountingLatestMVCCImporterClient()
+	opt := snapclient.NewSnapFileImporterOptions(
+		nil,
+		splitClient,
+		importClient,
+		nil,
+		snapclient.RewriteModeKeyspace,
+		[]*metapb.Store{{Id: 1, State: metapb.StoreState_Up}},
+		1,
+		0,
+		true,
+		nil,
+		nil,
+	)
+	importer, err := snapclient.NewSnapFileImporter(ctx, kvrpcpb.APIVersion_V1, snapclient.TiDBCompacted, opt)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, importer.Close())
+	}()
+
+	require.NoError(t, importer.Import(ctx, makeCompactedFileSetsWithCF(1, 2, restoreutils.DefaultCFName)...))
+	require.Equal(t, int32(0), importClient.calls.Load())
 }
 
 func TestBatchDownloadSSTParallelizesFileGroupsPerPeer(t *testing.T) {

--- a/br/pkg/restore/snap_client/import_test.go
+++ b/br/pkg/restore/snap_client/import_test.go
@@ -646,7 +646,7 @@ func TestBatchDownloadLatestMVCCParallelizesFileGroupsPerPeer(t *testing.T) {
 func TestBatchDownloadLatestMVCCSkipsDefaultOnlyFileGroups(t *testing.T) {
 	ctx := context.Background()
 	splitClient := split.NewFakeSplitClient()
-	splitClient.AppendPdRegion(&pd.Region{
+	splitClient.AppendPdRegion(&router.Region{
 		Meta: &metapb.Region{
 			Id:       1,
 			StartKey: codec.EncodeBytes(nil, tablecodec.EncodeTablePrefix(1)),


### PR DESCRIPTION
close pingcap/tidb#64308

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64308 

Problem Summary:
the download request with only default cf ssts will be rejected by TiKV-server.
### What changed and how does it work?
ignore only default cf ssts
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration handling for compacted data containing only Default CF files.
  * Prevented unnecessary newest-version download requests when no Write CF files are available.
  * Added coverage to verify that no redundant download requests are made in this scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->