### PR TITLE
memory: mark approximate pool allocation reads as norace

### DIFF
--- a/pkg/util/memory/arbitrator.go
+++ b/pkg/util/memory/arbitrator.go
@@ -2261,7 +2261,7 @@ func (m *MemArbitrator) updateAvoidSize() {
 	)
 	m.avoidance.size.Store(avoidSize)
 
-	if delta := m.allocated() - m.limit() + avoidSize; delta > 0 && m.awaitFree.pool.allocated() > 0 {
+	if delta := m.allocated() - m.limit() + avoidSize; delta > 0 && m.awaitFree.pool.ApproxAllocated() > 0 {
 		reclaimed := int64(0)
 		poolReleased := int64(0)
 		for i := range len(m.awaitFree.budget.shards) {
@@ -2667,7 +2667,7 @@ func (m *MemArbitrator) tryShrinkAwaitFreePool(minRemain int64, utimeMilli int64
 }
 
 func (m *MemArbitrator) shrinkAwaitFreePool(minRemain int64, utimeMilli int64) {
-	if m.awaitFree.pool.allocated() <= 0 {
+	if m.awaitFree.pool.ApproxAllocated() <= 0 {
 		return
 	}
 

--- a/pkg/util/memory/pool.go
+++ b/pkg/util/memory/pool.go
@@ -475,6 +475,13 @@ func (p *ResourcePool) allocate(request int64) error {
 	return err
 }
 
+// ApproxAllocated returns the approximate allocated bytes of the resource pool
+//
+//go:norace
+func (p *ResourcePool) ApproxAllocated() int64 {
+	return p.allocated()
+}
+
 func (p *ResourcePool) allocated() int64 {
 	return p.mu.allocated
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70177

Problem Summary:

The memory arbitrator performs opportunistic checks of the await-free resource pool while session goroutines allocate from the pool. These checks only require an approximate value and tolerate stale reads, but the race detector reports the unsynchronized reads.

### What changed and how does it work?

Add `ResourcePool.ApproxAllocated` as an explicitly approximate, non-race-instrumented accessor and use it for the opportunistic checks in `updateAvoidSize` and `shrinkAwaitFreePool`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test command:

```bash
./tools/check/failpoint-go-test.sh pkg/util/memory -run 'Test(MemArbitrator|GlobalMemArbitrator)$' -race -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory pool reclamation decisions by using more accurate allocation estimates.
  * Helps ensure memory shrinking and cleanup occur reliably when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->