### PR TITLE
test: stabilize flaky TestPartitionIntFullCover

### DIFF
--- a/pkg/planner/core/casetest/plancache/plan_cache_partition_table_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_partition_table_test.go
@@ -84,7 +84,7 @@ func testPartitionFullCover(t *testing.T, tableDefSQL []partCoverStruct, partiti
 			if useStringPK {
 				id = randString(seededRand, 1, 20)
 			} else {
-				id = seededRand.Intn(maxID)
+				id = seededRand.Intn(maxID-1) + 1
 			}
 			lc = id
 			if !isCaseSensitive {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70212

Problem Summary:
Flaky test `TestPartitionIntFullCover` in `pkg/planner/core/casetest/plancache` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Random data could expect key 0, while AUTO_INCREMENT insert semantics stored that row under a generated positive key.

#### Fix

Excluding 0 removes harness noise while preserving the same positive-key point-get and batch-point-get plan-cache coverage.

#### Verification

Spec:
- target: `pkg/planner/core/casetest/plancache :: TestPartitionIntFullCover`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_acceptance passed.
package_acceptance passed.
build_gate passed.
lint_ready_gate passed.

Gate checklist:
- native_repro_loop: SKIPPED
- seed_233_repro: SKIPPED
- target_acceptance: PASS
- package_acceptance: PASS
- build_gate: PASS
- lint_ready_gate: PASS
- diff_hygiene: SKIPPED
- external_bazel_ci: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/plancache -run '^TestPartitionIntFullCover$' -count=1`
- `go test -json -tags=intest,deadlock ./pkg/planner/core/casetest/plancache -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated partition cache test data generation to use positive integer keys, improving coverage of partition-point retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->