### PR TITLE
test: stabilize flaky TestCtxUsage

### DIFF
--- a/pkg/objstore/gcs_test.go
+++ b/pkg/objstore/gcs_test.go
@@ -635,7 +635,12 @@ func TestGCSShouldRetry(t *testing.T) {
 }
 
 func TestCtxUsage(t *testing.T) {
-	httpSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	httpSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_request","error_description":"subject_token must be nonempty."}`))
+		}
+	}))
 	defer httpSvr.Close()
 
 	ctx := context.Background()
@@ -650,7 +655,8 @@ func TestCtxUsage(t *testing.T) {
 	"type":"external_account",
 	"audience":"//iam.googleapis.com/projects/1234567890123/locations/global/workloadIdentityPools/my-pool/providers/my-provider",
 	"subject_token_type":"urn:ietf:params:oauth:token-type:access_token",
-	"credential_source":{"url":"%s"}
+	"token_url":"%[1]s/token",
+	"credential_source":{"url":"%[1]s"}
 }`, httpSvr.URL),
 	}
 	stg, err := NewGCSStorage(ctx, gcs, &storeapi.Options{})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70211

Problem Summary:
Flaky test `TestCtxUsage` in `pkg/objstore` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestCtxUsage accidentally depended on real Google STS timing while asserting an invalid_request credential error.

#### Fix

Local token_url preserves the same external-account credential exchange but makes the expected invalid_request deterministic.

#### Verification

Spec:
- target: `pkg/objstore :: TestCtxUsage`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: no
- submission decision: ALLOWED
- note: Required flaky case was not skipped.

Gate checklist:
- diagnostic_timing_repro: FAIL
- target_flaky_acceptance: BLOCKED
- package_failpoint_surface: BLOCKED
- raw_package_command_mismatch: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `HTTPS_PROXY=<local CONNECT proxy that stalls TLS after CONNECT> NO_PROXY=127.0.0.1,localhost go test -json -tags=intest,deadlock ./pkg/objstore -run '^TestCtxUsage$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and test coverage for failed Google Cloud token requests.
  * Ensured token endpoint errors clearly indicate when required credentials are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->