### PR TITLE
planner: recognize order by correlated equality | tidb-test=pr/2770

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1766,6 +1766,91 @@ func TestCorColRangePredicateAccess(t *testing.T) {
 	})
 }
 
+// TestCorColEqProvidesIndexOrder verifies that an `index_col = correlated_col` access condition
+// pins that column to a single value per execution, so the index columns after it can satisfy an
+// ORDER BY. The inner subquery of the correlated scalar aggregate should then read one row with a
+// Limit over an ordered scan instead of sorting the whole range with a TopN.
+func TestCorColEqProvidesIndexOrder(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists tc")
+	tk.MustExec(`create table tc (
+		k1 bigint unsigned not null,
+		k2 bigint unsigned not null,
+		v int not null,
+		primary key (k1, k2) clustered,
+		key ik (k1, v, k2))`)
+	tk.MustExec("insert into tc values (1,10,1),(1,20,1),(2,30,1),(2,40,0),(3,50,0)")
+
+	// explainOf returns the operator info of the explain output, one entry per row.
+	explainOf := func(sql string) []string {
+		rows := tk.MustQuery("explain format='plan_tree' " + sql).Rows()
+		infos := make([]string, 0, len(rows))
+		for _, row := range rows {
+			infos = append(infos, fmt.Sprintf("%v %v", row[0], row[3]))
+		}
+		return infos
+	}
+	// hasOperator reports whether any explain row matches all the given substrings.
+	hasOperator := func(infos []string, substrs ...string) bool {
+		for _, row := range infos {
+			matched := true
+			for _, substr := range substrs {
+				if !strings.Contains(row, substr) {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return true
+			}
+		}
+		return false
+	}
+
+	// MIN over the clustered primary key (k1, k2). The correlated equality on k1 makes the
+	// rebuilt range a single point on k1, so the scan already returns k2 in order.
+	minOverPK := "select (select /*+ NO_DECORRELATE() */ min(t2.k2) from tc t2 use index (`primary`) " +
+		"where t1.k1 = t2.k1) from tc t1"
+	infos := explainOf(minOverPK)
+	require.True(t, hasOperator(infos, "TableRangeScan", "keep order:true"),
+		"the table range scan should keep order: %v", infos)
+	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	tk.MustQuery(minOverPK + " order by 1").Check(testkit.Rows("10", "10", "30", "30", "50"))
+
+	// Same for a secondary index ik(k1, v, k2), where k1 is pinned by the correlated equality
+	// and v by a literal equality.
+	minOverIdx := "select (select /*+ NO_DECORRELATE() */ min(t2.k2) from tc t2 use index (ik) " +
+		"where t1.k1 = t2.k1 and t2.v = 1) from tc t1"
+	infos = explainOf(minOverIdx)
+	require.True(t, hasOperator(infos, "IndexRangeScan", "keep order:true"),
+		"the index range scan should keep order: %v", infos)
+	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	tk.MustQuery(minOverIdx + " order by 1").Check(testkit.Rows("<nil>", "10", "10", "30", "30"))
+
+	// An explicit ORDER BY ... LIMIT inside the correlated subquery benefits the same way.
+	limitOverPK := "select (select /*+ NO_DECORRELATE() */ t2.k2 from tc t2 use index (`primary`) " +
+		"where t1.k1 = t2.k1 order by t2.k2 limit 1) from tc t1"
+	infos = explainOf(limitOverPK)
+	require.True(t, hasOperator(infos, "TableRangeScan", "keep order:true"),
+		"the table range scan should keep order: %v", infos)
+	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	tk.MustQuery(limitOverPK + " order by 1").Check(testkit.Rows("10", "10", "30", "30", "50"))
+
+	// A correlated *range* predicate does not pin its column to a single value, so the columns
+	// after it are not ordered and the TopN must be kept.
+	tk.MustExec("drop table if exists tr")
+	tk.MustExec("create table tr (a int, b int, c int, d int, key idx (b, c, d))")
+	tk.MustExec("insert into tr values (1,1,1,4),(2,1,2,3),(3,1,3,2),(4,2,1,1)")
+	minAfterRange := "select (select /*+ NO_DECORRELATE() */ min(t2.d) from tr t2 use index (idx) " +
+		"where t2.b = t1.b and t2.c < t1.c) from tr t1"
+	infos = explainOf(minAfterRange)
+	require.True(t, hasOperator(infos, "TopN"),
+		"a correlated range predicate must not claim order on later columns: %v", infos)
+	tk.MustQuery(minAfterRange + " order by 1").Check(testkit.Rows("<nil>", "<nil>", "3", "4"))
+}
+
 // TestExplainAnalyzeDMLCommit covers the issue #37373.
 func TestExplainAnalyzeDMLCommit(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -1783,12 +1783,12 @@ func TestCorColEqProvidesIndexOrder(t *testing.T) {
 		key ik (k1, v, k2))`)
 	tk.MustExec("insert into tc values (1,10,1),(1,20,1),(2,30,1),(2,40,0),(3,50,0)")
 
-	// explainOf returns the operator info of the explain output, one entry per row.
+	// explainOf returns the operator name, task and operator info of each explain row.
 	explainOf := func(sql string) []string {
 		rows := tk.MustQuery("explain format='plan_tree' " + sql).Rows()
 		infos := make([]string, 0, len(rows))
 		for _, row := range rows {
-			infos = append(infos, fmt.Sprintf("%v %v", row[0], row[3]))
+			infos = append(infos, fmt.Sprintf("%v %v %v", row[0], row[1], row[3]))
 		}
 		return infos
 	}
@@ -1808,15 +1808,27 @@ func TestCorColEqProvidesIndexOrder(t *testing.T) {
 		}
 		return false
 	}
+	// requireEarlyStopPlan asserts the subquery reads a single row from an ordered scan rather
+	// than sorting the whole matched range. Keeping order is not enough on its own: an
+	// aggregate over an ordered full-range scan also has no TopN, so the Limit that stops the
+	// read after one row must be there too, both in the coprocessor and at the root.
+	requireEarlyStopPlan := func(infos []string, scanOp string) {
+		t.Helper()
+		require.True(t, hasOperator(infos, scanOp, "keep order:true"),
+			"%s should keep order: %v", scanOp, infos)
+		require.True(t, hasOperator(infos, "Limit", "cop[tikv]", "count:1"),
+			"the coprocessor read should stop after one row: %v", infos)
+		require.True(t, hasOperator(infos, "Limit", "root", "count:1"),
+			"the plan should keep a root Limit of one row: %v", infos)
+		require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	}
 
 	// MIN over the clustered primary key (k1, k2). The correlated equality on k1 makes the
 	// rebuilt range a single point on k1, so the scan already returns k2 in order.
 	minOverPK := "select (select /*+ NO_DECORRELATE() */ min(t2.k2) from tc t2 use index (`primary`) " +
 		"where t1.k1 = t2.k1) from tc t1"
 	infos := explainOf(minOverPK)
-	require.True(t, hasOperator(infos, "TableRangeScan", "keep order:true"),
-		"the table range scan should keep order: %v", infos)
-	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	requireEarlyStopPlan(infos, "TableRangeScan")
 	tk.MustQuery(minOverPK + " order by 1").Check(testkit.Rows("10", "10", "30", "30", "50"))
 
 	// Same for a secondary index ik(k1, v, k2), where k1 is pinned by the correlated equality
@@ -1824,18 +1836,14 @@ func TestCorColEqProvidesIndexOrder(t *testing.T) {
 	minOverIdx := "select (select /*+ NO_DECORRELATE() */ min(t2.k2) from tc t2 use index (ik) " +
 		"where t1.k1 = t2.k1 and t2.v = 1) from tc t1"
 	infos = explainOf(minOverIdx)
-	require.True(t, hasOperator(infos, "IndexRangeScan", "keep order:true"),
-		"the index range scan should keep order: %v", infos)
-	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	requireEarlyStopPlan(infos, "IndexRangeScan")
 	tk.MustQuery(minOverIdx + " order by 1").Check(testkit.Rows("<nil>", "10", "10", "30", "30"))
 
 	// An explicit ORDER BY ... LIMIT inside the correlated subquery benefits the same way.
 	limitOverPK := "select (select /*+ NO_DECORRELATE() */ t2.k2 from tc t2 use index (`primary`) " +
 		"where t1.k1 = t2.k1 order by t2.k2 limit 1) from tc t1"
 	infos = explainOf(limitOverPK)
-	require.True(t, hasOperator(infos, "TableRangeScan", "keep order:true"),
-		"the table range scan should keep order: %v", infos)
-	require.False(t, hasOperator(infos, "TopN"), "the sort should be eliminated: %v", infos)
+	requireEarlyStopPlan(infos, "TableRangeScan")
 	tk.MustQuery(limitOverPK + " order by 1").Check(testkit.Rows("10", "10", "30", "30", "50"))
 
 	// A correlated *range* predicate does not pin its column to a single value, so the columns

--- a/pkg/planner/util/path.go
+++ b/pkg/planner/util/path.go
@@ -50,6 +50,8 @@ type AccessPath struct {
 	IdxCols        []*expression.Column
 	IdxColLens     []int
 	// ConstCols indicates whether the column is constant under the given conditions for all index columns.
+	// A column is also marked when an access condition restricts it to a single value only at execution
+	// time, i.e. `index_col = correlated_col`. See markConstCol.
 	ConstCols []bool
 	Ranges    []*ranger.Range
 	// CountAfterAccess is the row count after we apply range seek and before we use other filter to filter data.
@@ -243,6 +245,8 @@ func (path *AccessPath) IsTiFlashSimpleTablePath() bool {
 // It also supports a trailing range predicate (LT/GT/LE/GE) with a correlated column on the last
 // access column, e.g. `idx_col_1 = cor_col AND idx_col_2 < cor_col`.
 // It enables more index columns to be considered. The range will be rebuilt in 'ResolveCorrelatedColumns'.
+// Each equality it moves also marks the matched index column in AccessPath.ConstCols, so that the
+// order the remaining index columns provide can be recognized. See markConstCol for the reasoning.
 func (path *AccessPath) SplitCorColAccessCondFromFilters(ctx planctx.PlanContext, eqOrInCount int) (access, remained []expression.Expression) {
 	access = make([]expression.Expression, len(path.IdxCols)-eqOrInCount)
 	used := make([]bool, len(path.TableFilters))
@@ -274,6 +278,7 @@ func (path *AccessPath) SplitCorColAccessCondFromFilters(ctx planctx.PlanContext
 			if path.IdxColLens[i] == types.UnspecifiedLength {
 				used[j] = true
 				usedCnt++
+				path.markConstCol(i)
 			}
 			break
 		}
@@ -312,6 +317,28 @@ func (path *AccessPath) SplitCorColAccessCondFromFilters(ctx planctx.PlanContext
 		}
 	}
 	return access, remained
+}
+
+// markConstCol records that path.IdxCols[idx] is restricted to a single value by an access
+// condition, so callers that reason about index order (matchProperty) may skip over it.
+//
+// The ranger cannot build a range for `index_col = correlated_col` at plan time, so such a
+// column is neither point-ranged in path.Ranges nor marked in ConstCols by
+// DetachCondAndBuildRangeForIndex. The range is instead rebuilt per execution of the inner
+// subtree in ResolveCorrelatedColumns/rebuildIndexRanges, and because the condition is an
+// equality that rebuilt range is always a single point on this column. Hence the index columns
+// after it stay sorted, exactly as they would be for a literal equality, and an ORDER BY on
+// them can be satisfied by the scan order instead of a sort.
+//
+// Only full-length columns may be marked: on a prefix column the stored value is truncated, so
+// an equality does not pin the column to one value.
+func (path *AccessPath) markConstCol(idx int) {
+	if path.ConstCols == nil {
+		path.ConstCols = make([]bool, len(path.IdxCols))
+	}
+	if idx < len(path.ConstCols) {
+		path.ConstCols[idx] = true
+	}
 }
 
 // isColEqConstant checks if the expression is eq function that one side is column and the other side is constant.

--- a/tests/integrationtest/r/planner/core/lateral_join.result
+++ b/tests/integrationtest/r/planner/core/lateral_join.result
@@ -322,7 +322,7 @@ CTE_0	root		Recursive CTE
   └─Apply	root		CARTESIAN inner join
     ├─Selection(Build)	root		lt(Column, 3)
     │ └─CTETable	root		Scan on CTE_0
-    └─TopN(Probe)	root		planner__core__lateral_join.category.sort_order, offset:0, count:2
-      └─IndexReader	root		index:TopN
-        └─TopN	cop[tikv]		planner__core__lateral_join.category.sort_order, offset:0, count:2
-          └─IndexRangeScan	cop[tikv]	table:category, index:idx_parent(parent_id, sort_order, name)	range: decided by [eq(planner__core__lateral_join.category.parent_id, planner__core__lateral_join.category.id)], keep order:false, stats:pseudo
+    └─Limit(Probe)	root		offset:0, count:2
+      └─IndexReader	root		index:Limit
+        └─Limit	cop[tikv]		offset:0, count:2
+          └─IndexRangeScan	cop[tikv]	table:category, index:idx_parent(parent_id, sort_order, name)	range: decided by [eq(planner__core__lateral_join.category.parent_id, planner__core__lateral_join.category.id)], keep order:true, stats:pseudo


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70216

Problem Summary:

`matchProperty` can only skip a leading index column when it is flagged in `AccessPath.ConstCols` or
is a point range in `AccessPath.Ranges`. Both come from `ranger.DetachCondAndBuildRangeForIndex`, and
the ranger only accepts `*expression.Constant` — never a `CorrelatedColumn`. So for
`index_col = correlated_col` the path keeps a full range with no const column, and an `ORDER BY` on
the index columns after it needs an explicit sort.

For a correlated scalar aggregate such as

```sql
SELECT (SELECT MIN(s2.id) FROM t s2 WHERE s1.ns_id = s2.ns_id) FROM t s1
```

on `PRIMARY KEY (ns_id, id)`, `MaxMinEliminator` rewrites `MIN(id)` into `Sort + Limit 1` expecting
index order to absorb the sort. Because the order went unrecognized, the plan kept a `TopN` and
sorted the whole `ns_id` range on every execution of the inner subtree instead of reading one row.

### What changed and how does it work?

`AccessPath.SplitCorColAccessCondFromFilters` already moves such equalities into `AccessConds`, and
the range is rebuilt per execution in `ResolveCorrelatedColumns` / `rebuildIndexRanges`. Since the
condition is an equality, that rebuilt range is always a single point on the column, so the index
columns after it stay sorted exactly as they would for a literal equality. This PR marks those
columns in `ConstCols` (new `markConstCol` helper, where the reasoning is documented), which lets the
existing `matchProperty` const-column case skip over them.

Two restrictions keep the marking sound:

- Only full-length columns are marked. On a prefix column the stored value is truncated, so an
  equality does not pin the column to one value.
- A trailing correlated **range** predicate (`LT`/`GT`/`LE`/`GE`), which the same function also moves
  into `AccessConds`, is not marked — it does not restrict the column to one value, so the columns
  after it are not ordered.

The marking is only reachable when a correlated equality is present, which is exactly the case where
ranges are rebuilt at execution time, so the plan-time flag and the executed ranges cannot disagree.
The merge-sort case (`PropMatchedNeedMergeSort`) stays consistent because all three readers regroup
`GroupedRanges` after the correlated range rebuild.

Effect on the reproducer — `TopN` becomes `Limit` and the scan keeps order:

```
    └─MaxOneRow(Probe)                                       └─MaxOneRow(Probe)
      └─StreamAgg      funcs:min(...)                          └─StreamAgg      funcs:min(...)
-       └─TopN         test.t.k2, offset:0, count:1     =>    +  └─Limit        offset:0, count:1
-         └─TableReader  data:TopN                            +    └─TableReader  data:Limit
-           └─TopN       cop[tikv] test.t.k2, count:1         +      └─Limit      cop[tikv] count:1
-             └─TableRangeScan  ... keep order:false          +        └─TableRangeScan ... keep order:true
```

`tests/integrationtest` independently surfaced the same win in an existing recorded plan: a
recursive-CTE `LATERAL` case (`WHERE parent_id = tree.id ORDER BY sort_order LIMIT 2` over
`idx_parent(parent_id, sort_order, name)`) also moved from `TopN` to `Limit` with `keep order:true`,
so `tests/integrationtest/r/planner/core/lateral_join.result` is re-recorded here.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New test `TestCorColEqProvidesIndexOrder` in `pkg/planner/core/integration_test.go` covers `MIN` over
a clustered primary key, `MIN` over a secondary index where one column is pinned by the correlated
equality and another by a literal, an explicit `ORDER BY ... LIMIT` inside the subquery, and a
negative case asserting a correlated range predicate still keeps its `TopN`. Each case checks query
results as well as the plan. Verified failing before the fix and passing after.

```bash
go test -tags=intest ./pkg/planner/core/ -run TestCorColEqProvidesIndexOrder
go test -tags=intest ./pkg/planner/util/ ./pkg/planner/core/issuetest/
go test -tags=intest ./pkg/planner/core/casetest/physicalplantest/
make integrationtest
make lint
bazel build //pkg/planner/core:all //pkg/planner/util:all --//build:with_nogo_flag=true
bazel test //pkg/planner/util:util_test //pkg/planner/core:core_test --define gotags=deadlock,intest --test_filter='TestCorCol'
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve the plan for correlated subqueries whose predicate equates an index prefix column to a column
from the outer query. Such a query with `MIN`/`MAX` or `ORDER BY ... LIMIT` on the following index
columns can now read the rows it needs directly from the index order instead of sorting the matched
range on every execution.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning for correlated equality predicates to preserve index order, pin constant index-prefix columns, and avoid unnecessary TopN sorts.
  * Updated lateral join execution planning so recursive CTEs use ordered index scans with limit-based early stopping.

* **Tests**
  * Expanded integration coverage for correlated scalar-subquery index ordering (clustered primary-key and secondary-index paths), including early-stop behavior.
  * Updated expected plan outputs for recursive CTE lateral joins to match the revised ordered limit strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->