### PR TITLE
crossks: stabilize cross-keyspace coordinator session test

### DIFF
--- a/pkg/domain/crossks/cross_ks.go
+++ b/pkg/domain/crossks/cross_ks.go
@@ -339,9 +339,13 @@ func (*Manager) createSessionManager(
 	mgr.wg.RunWithLog(func() {
 		isSyncer.MDLCheckLoop(ctx)
 	})
-	mgr.wg.RunWithLog(func() {
-		minJobIDRefresher.Start(ctx)
-	})
+	shouldRunMinJobIDRefresher := true
+	failpoint.InjectCall("skipMinJobIDRefresher", &shouldRunMinJobIDRefresher)
+	if shouldRunMinJobIDRefresher {
+		mgr.wg.RunWithLog(func() {
+			minJobIDRefresher.Start(ctx)
+		})
+	}
 
 	logutil.BgLogger().Info("create cross keyspace session manager",
 		zap.String("targetKS", ks), zap.Duration("cost", time.Since(startTime)))

--- a/pkg/domain/crossks/cross_ks_test.go
+++ b/pkg/domain/crossks/cross_ks_test.go
@@ -219,6 +219,13 @@ func TestManager(t *testing.T) {
 				*shouldCloseStore = false
 			},
 		)
+		skipMinJobIDRefresherCalled := false
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/skipMinJobIDRefresher",
+			func(shouldRun *bool) {
+				skipMinJobIDRefresherCalled = true
+				*shouldRun = false
+			},
+		)
 		userKS := "ksmdl"
 		userKSStore, _ := testkit.CreateMockStoreAndDomainForKS(t, userKS)
 		storeMap[userKS] = userKSStore
@@ -230,6 +237,7 @@ func TestManager(t *testing.T) {
 
 		pool, err := sysKSDom.GetKSSessPool(userKS)
 		require.NoError(t, err)
+		require.True(t, skipMinJobIDRefresherCalled)
 		t.Cleanup(func() {
 			// we have to close the cross keyspace session manager, as the
 			// store will be closed by testkit.CreateMockStoreAndDomainForKS
@@ -257,8 +265,7 @@ func TestManager(t *testing.T) {
 			})
 			require.EqualValues(t, 1, tableIDCount)
 			require.True(t, coordinator.ContainsInternalSession(se))
-			// current session, and the min-job-id refresher might also use a
-			// session, so >= 1.
+			// Other background tasks might also use a session, so >= 1.
 			require.GreaterOrEqual(t, coordinator.InternalSessionCount(), 1)
 			return nil
 		}))

--- a/pkg/domain/crossks/cross_ks_test.go
+++ b/pkg/domain/crossks/cross_ks_test.go
@@ -219,6 +219,7 @@ func TestManager(t *testing.T) {
 				*shouldCloseStore = false
 			},
 		)
+		// Disable the refresher so its session does not race with the initial session count assertion.
 		skipMinJobIDRefresherCalled := false
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/skipMinJobIDRefresher",
 			func(shouldRun *bool) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66831

Problem Summary:

The cross-keyspace session manager starts the min-job-ID refresher asynchronously before returning. The refresher can borrow an internal session before the coordinator test asserts that the initial session count is zero, making the assertion timing-dependent and flaky.

### What changed and how does it work?

- Add a `skipMinJobIDRefresher` failpoint around the refresher goroutine startup.
- Enable the failpoint only in the affected `TestManager` subtest and verify that the hook is reached before checking the initial coordinator state.
- Keep normal runtime behavior unchanged by running the refresher unless the failpoint callback explicitly disables it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
./tools/check/failpoint-go-test.sh pkg/domain/crossks -run '^TestManager$/^check_cross_keyspace_session_are_recorded_in_coordinator_and_contains_related_tables$' -count=5 -tags=intest,deadlock,nextgen
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session startup behavior by conditionally starting the background “min job ID” refresher, allowing it to be skipped when appropriate.
  * Reduced unrelated background activity during session coordination validation, improving test stability and consistency.
* **Tests**
  * Updated coverage to verify that the optional “min job ID” refresher path is exercised and that session counts remain valid under different background task activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->