### PR TITLE
util: adapt TiFlash MSLM scan context stats

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3154,8 +3154,8 @@ def go_deps():
         name = "com_github_pingcap_tipb",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/tipb",
-        sum = "h1:iN6xoHupQDHD4US1/vrrif7IZj+d4X8ecnjD7pwybsc=",
-        version = "v0.0.0-20260324015222-fe7badb76b66",
+        sum = "h1:kcMZfOWaLpeavDmcU7jr0EyChp1TMcRi1qxeDmh9WWs=",
+        version = "v0.0.0-20260730025657-3ab8dc22d495",
     )
     go_repository(
         name = "com_github_pkg_browser",

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20211011031125-9b13dc409c5e
-	github.com/pingcap/tipb v0.0.0-20260324015222-fe7badb76b66
+	github.com/pingcap/tipb v0.0.0-20260730025657-3ab8dc22d495
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,8 @@ github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGa
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeAhmOQHNPRRogMYxP13V7BkYw3ZsoSfE=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
-github.com/pingcap/tipb v0.0.0-20260324015222-fe7badb76b66 h1:iN6xoHupQDHD4US1/vrrif7IZj+d4X8ecnjD7pwybsc=
-github.com/pingcap/tipb v0.0.0-20260324015222-fe7badb76b66/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
+github.com/pingcap/tipb v0.0.0-20260730025657-3ab8dc22d495 h1:kcMZfOWaLpeavDmcU7jr0EyChp1TMcRi1qxeDmh9WWs=
+github.com/pingcap/tipb v0.0.0-20260730025657-3ab8dc22d495/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -821,36 +821,37 @@ func (e *basicCopRuntimeStats) mergeExecSummary(summary *tipb.ExecutorExecutionS
 			}
 		}
 		tmp := TiFlashScanContext{
-			dmfileDataScannedRows:     tiflashScanContext.GetDmfileDataScannedRows(),
-			dmfileDataSkippedRows:     tiflashScanContext.GetDmfileDataSkippedRows(),
-			dmfileMvccScannedRows:     tiflashScanContext.GetDmfileMvccScannedRows(),
-			dmfileMvccSkippedRows:     tiflashScanContext.GetDmfileMvccSkippedRows(),
-			dmfileLmFilterScannedRows: tiflashScanContext.GetDmfileLmFilterScannedRows(),
-			dmfileLmFilterSkippedRows: tiflashScanContext.GetDmfileLmFilterSkippedRows(),
-			totalDmfileRsCheckMs:      tiflashScanContext.GetTotalDmfileRsCheckMs(),
-			totalDmfileReadMs:         tiflashScanContext.GetTotalDmfileReadMs(),
-			totalBuildSnapshotMs:      tiflashScanContext.GetTotalBuildSnapshotMs(),
-			localRegions:              tiflashScanContext.GetLocalRegions(),
-			remoteRegions:             tiflashScanContext.GetRemoteRegions(),
-			totalLearnerReadMs:        tiflashScanContext.GetTotalLearnerReadMs(),
-			disaggReadCacheHitBytes:   tiflashScanContext.GetDisaggReadCacheHitBytes(),
-			disaggReadCacheMissBytes:  tiflashScanContext.GetDisaggReadCacheMissBytes(),
-			segments:                  tiflashScanContext.GetSegments(),
-			readTasks:                 tiflashScanContext.GetReadTasks(),
-			deltaRows:                 tiflashScanContext.GetDeltaRows(),
-			deltaBytes:                tiflashScanContext.GetDeltaBytes(),
-			mvccInputRows:             tiflashScanContext.GetMvccInputRows(),
-			mvccInputBytes:            tiflashScanContext.GetMvccInputBytes(),
-			mvccOutputRows:            tiflashScanContext.GetMvccOutputRows(),
-			lmSkipRows:                tiflashScanContext.GetLmSkipRows(),
-			totalBuildBitmapMs:        tiflashScanContext.GetTotalBuildBitmapMs(),
-			totalBuildInputStreamMs:   tiflashScanContext.GetTotalBuildInputstreamMs(),
-			staleReadRegions:          tiflashScanContext.GetStaleReadRegions(),
-			minLocalStreamMs:          tiflashScanContext.GetMinLocalStreamMs(),
-			maxLocalStreamMs:          tiflashScanContext.GetMaxLocalStreamMs(),
-			minRemoteStreamMs:         tiflashScanContext.GetMinRemoteStreamMs(),
-			maxRemoteStreamMs:         tiflashScanContext.GetMaxRemoteStreamMs(),
-			regionsOfInstance:         regionsOfInstance,
+			dmfileDataScannedRows:         tiflashScanContext.GetDmfileDataScannedRows(),
+			dmfileDataSkippedRows:         tiflashScanContext.GetDmfileDataSkippedRows(),
+			dmfileMvccScannedRows:         tiflashScanContext.GetDmfileMvccScannedRows(),
+			dmfileMvccSkippedRows:         tiflashScanContext.GetDmfileMvccSkippedRows(),
+			dmfileLmFilterScannedRows:     tiflashScanContext.GetDmfileLmFilterScannedRows(),
+			dmfileLmFilterSkippedRows:     tiflashScanContext.GetDmfileLmFilterSkippedRows(),
+			totalDmfileRsCheckMs:          tiflashScanContext.GetTotalDmfileRsCheckMs(),
+			totalDmfileReadMs:             tiflashScanContext.GetTotalDmfileReadMs(),
+			totalBuildSnapshotMs:          tiflashScanContext.GetTotalBuildSnapshotMs(),
+			localRegions:                  tiflashScanContext.GetLocalRegions(),
+			remoteRegions:                 tiflashScanContext.GetRemoteRegions(),
+			totalLearnerReadMs:            tiflashScanContext.GetTotalLearnerReadMs(),
+			disaggReadCacheHitBytes:       tiflashScanContext.GetDisaggReadCacheHitBytes(),
+			disaggReadCacheMissBytes:      tiflashScanContext.GetDisaggReadCacheMissBytes(),
+			segments:                      tiflashScanContext.GetSegments(),
+			readTasks:                     tiflashScanContext.GetReadTasks(),
+			deltaRows:                     tiflashScanContext.GetDeltaRows(),
+			deltaBytes:                    tiflashScanContext.GetDeltaBytes(),
+			mvccInputRows:                 tiflashScanContext.GetMvccInputRows(),
+			mvccInputBytes:                tiflashScanContext.GetMvccInputBytes(),
+			mvccOutputRows:                tiflashScanContext.GetMvccOutputRows(),
+			lmSkipRows:                    tiflashScanContext.GetLmSkipRows(),
+			totalBuildBitmapMs:            tiflashScanContext.GetTotalBuildBitmapMs(),
+			totalBuildInputStreamMs:       tiflashScanContext.GetTotalBuildInputstreamMs(),
+			staleReadRegions:              tiflashScanContext.GetStaleReadRegions(),
+			minLocalStreamMs:              tiflashScanContext.GetMinLocalStreamMs(),
+			maxLocalStreamMs:              tiflashScanContext.GetMaxLocalStreamMs(),
+			minRemoteStreamMs:             tiflashScanContext.GetMinRemoteStreamMs(),
+			maxRemoteStreamMs:             tiflashScanContext.GetMaxRemoteStreamMs(),
+			regionsOfInstance:             regionsOfInstance,
+			multiStageLateMaterialization: newTiFlashMSLMScanContext(tiflashScanContext.GetMultiStageLateMaterialization()),
 
 			totalVectorIdxLoadFromS3:           tiflashScanContext.GetTotalVectorIdxLoadFromS3(),
 			totalVectorIdxLoadFromDisk:         tiflashScanContext.GetTotalVectorIdxLoadFromDisk(),
@@ -1041,36 +1042,37 @@ type RuntimeStats interface {
 
 // TiFlashScanContext is used to express the table scan information in tiflash
 type TiFlashScanContext struct {
-	dmfileDataScannedRows     uint64
-	dmfileDataSkippedRows     uint64
-	dmfileMvccScannedRows     uint64
-	dmfileMvccSkippedRows     uint64
-	dmfileLmFilterScannedRows uint64
-	dmfileLmFilterSkippedRows uint64
-	totalDmfileRsCheckMs      uint64
-	totalDmfileReadMs         uint64
-	totalBuildSnapshotMs      uint64
-	localRegions              uint64
-	remoteRegions             uint64
-	totalLearnerReadMs        uint64
-	disaggReadCacheHitBytes   uint64
-	disaggReadCacheMissBytes  uint64
-	segments                  uint64
-	readTasks                 uint64
-	deltaRows                 uint64
-	deltaBytes                uint64
-	mvccInputRows             uint64
-	mvccInputBytes            uint64
-	mvccOutputRows            uint64
-	lmSkipRows                uint64
-	totalBuildBitmapMs        uint64
-	totalBuildInputStreamMs   uint64
-	staleReadRegions          uint64
-	minLocalStreamMs          uint64
-	maxLocalStreamMs          uint64
-	minRemoteStreamMs         uint64
-	maxRemoteStreamMs         uint64
-	regionsOfInstance         map[string]uint64
+	dmfileDataScannedRows         uint64
+	dmfileDataSkippedRows         uint64
+	dmfileMvccScannedRows         uint64
+	dmfileMvccSkippedRows         uint64
+	dmfileLmFilterScannedRows     uint64
+	dmfileLmFilterSkippedRows     uint64
+	totalDmfileRsCheckMs          uint64
+	totalDmfileReadMs             uint64
+	totalBuildSnapshotMs          uint64
+	localRegions                  uint64
+	remoteRegions                 uint64
+	totalLearnerReadMs            uint64
+	disaggReadCacheHitBytes       uint64
+	disaggReadCacheMissBytes      uint64
+	segments                      uint64
+	readTasks                     uint64
+	deltaRows                     uint64
+	deltaBytes                    uint64
+	mvccInputRows                 uint64
+	mvccInputBytes                uint64
+	mvccOutputRows                uint64
+	lmSkipRows                    uint64
+	totalBuildBitmapMs            uint64
+	totalBuildInputStreamMs       uint64
+	staleReadRegions              uint64
+	minLocalStreamMs              uint64
+	maxLocalStreamMs              uint64
+	minRemoteStreamMs             uint64
+	maxRemoteStreamMs             uint64
+	regionsOfInstance             map[string]uint64
+	multiStageLateMaterialization *tiflashMSLMScanContext
 
 	totalVectorIdxLoadFromS3           uint64
 	totalVectorIdxLoadFromDisk         uint64
@@ -1083,39 +1085,352 @@ type TiFlashScanContext struct {
 	totalVectorIdxReadOthersTimeMs     uint64
 }
 
+type tiflashMSLMScanContext struct {
+	streams            *uint64
+	lateModeBlocks     *uint64
+	directModeBlocks   *uint64
+	pushedFilterRead   *tiflashMSLMReadStageContext
+	candidateRead      *tiflashMSLMReadStageContext
+	finalRestRead      *tiflashMSLMReadStageContext
+	pushedFilter       *tiflashMSLMFilterContext
+	residualFilter     *tiflashMSLMFilterContext
+	runningTopN        *tiflashMSLMRunningTopNContext
+	finalRestInputRows *uint64
+}
+
+type tiflashMSLMReadStageContext struct {
+	dmfileScannedRows *uint64
+	dmfileSkippedRows *uint64
+	readBytes         *uint64
+	readTimeMs        *uint64
+}
+
+type tiflashMSLMFilterContext struct {
+	inputRows    *uint64
+	selectedRows *uint64
+	filteredRows *uint64
+}
+
+type tiflashMSLMRunningTopNContext struct {
+	inputRows                       *uint64
+	selectedRows                    *uint64
+	bypassRows                      *uint64
+	filteredRows                    *uint64
+	heapSizeSum                     *uint64
+	adaptiveWarmupRows              *uint64
+	adaptivePostWarmupInputRows     *uint64
+	adaptivePostWarmupCandidateRows *uint64
+	adaptiveDisabledStreams         *uint64
+}
+
+func cloneUint64Ptr(value *uint64) *uint64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func mergeUint64Ptr(dst **uint64, src *uint64) {
+	if src == nil {
+		return
+	}
+	if *dst == nil {
+		*dst = cloneUint64Ptr(src)
+		return
+	}
+	**dst += *src
+}
+
+func appendUint64Field(items []string, name string, value *uint64) []string {
+	if value == nil {
+		return items
+	}
+	return append(items, fmt.Sprintf("%s:%d", name, *value))
+}
+
+func newTiFlashMSLMScanContext(context *tipb.TiFlashMultiStageLateMaterializationScanContext) *tiflashMSLMScanContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMScanContext{
+		streams:            cloneUint64Ptr(context.Streams),
+		lateModeBlocks:     cloneUint64Ptr(context.LateModeBlocks),
+		directModeBlocks:   cloneUint64Ptr(context.DirectModeBlocks),
+		pushedFilterRead:   newTiFlashMSLMReadStageContext(context.PushedFilterRead),
+		candidateRead:      newTiFlashMSLMReadStageContext(context.CandidateRead),
+		finalRestRead:      newTiFlashMSLMReadStageContext(context.FinalRestRead),
+		pushedFilter:       newTiFlashMSLMFilterContext(context.PushedFilter),
+		residualFilter:     newTiFlashMSLMFilterContext(context.ResidualFilter),
+		runningTopN:        newTiFlashMSLMRunningTopNContext(context.RunningTopn),
+		finalRestInputRows: cloneUint64Ptr(context.FinalRestInputRows),
+	}
+}
+
+func newTiFlashMSLMReadStageContext(context *tipb.TiFlashMSLMReadStageContext) *tiflashMSLMReadStageContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMReadStageContext{
+		dmfileScannedRows: cloneUint64Ptr(context.DmfileScannedRows),
+		dmfileSkippedRows: cloneUint64Ptr(context.DmfileSkippedRows),
+		readBytes:         cloneUint64Ptr(context.ReadBytes),
+		readTimeMs:        cloneUint64Ptr(context.ReadTimeMs),
+	}
+}
+
+func newTiFlashMSLMFilterContext(context *tipb.TiFlashMSLMFilterContext) *tiflashMSLMFilterContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMFilterContext{
+		inputRows:    cloneUint64Ptr(context.InputRows),
+		selectedRows: cloneUint64Ptr(context.SelectedRows),
+		filteredRows: cloneUint64Ptr(context.FilteredRows),
+	}
+}
+
+func newTiFlashMSLMRunningTopNContext(context *tipb.TiFlashMSLMRunningTopNContext) *tiflashMSLMRunningTopNContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMRunningTopNContext{
+		inputRows:                       cloneUint64Ptr(context.InputRows),
+		selectedRows:                    cloneUint64Ptr(context.SelectedRows),
+		bypassRows:                      cloneUint64Ptr(context.BypassRows),
+		filteredRows:                    cloneUint64Ptr(context.FilteredRows),
+		heapSizeSum:                     cloneUint64Ptr(context.HeapSizeSum),
+		adaptiveWarmupRows:              cloneUint64Ptr(context.AdaptiveWarmupRows),
+		adaptivePostWarmupInputRows:     cloneUint64Ptr(context.AdaptivePostWarmupInputRows),
+		adaptivePostWarmupCandidateRows: cloneUint64Ptr(context.AdaptivePostWarmupCandidateRows),
+		adaptiveDisabledStreams:         cloneUint64Ptr(context.AdaptiveDisabledStreams),
+	}
+}
+
+func (context *tiflashMSLMScanContext) Clone() *tiflashMSLMScanContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMScanContext{
+		streams:            cloneUint64Ptr(context.streams),
+		lateModeBlocks:     cloneUint64Ptr(context.lateModeBlocks),
+		directModeBlocks:   cloneUint64Ptr(context.directModeBlocks),
+		pushedFilterRead:   context.pushedFilterRead.Clone(),
+		candidateRead:      context.candidateRead.Clone(),
+		finalRestRead:      context.finalRestRead.Clone(),
+		pushedFilter:       context.pushedFilter.Clone(),
+		residualFilter:     context.residualFilter.Clone(),
+		runningTopN:        context.runningTopN.Clone(),
+		finalRestInputRows: cloneUint64Ptr(context.finalRestInputRows),
+	}
+}
+
+func (context *tiflashMSLMReadStageContext) Clone() *tiflashMSLMReadStageContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMReadStageContext{
+		dmfileScannedRows: cloneUint64Ptr(context.dmfileScannedRows),
+		dmfileSkippedRows: cloneUint64Ptr(context.dmfileSkippedRows),
+		readBytes:         cloneUint64Ptr(context.readBytes),
+		readTimeMs:        cloneUint64Ptr(context.readTimeMs),
+	}
+}
+
+func (context *tiflashMSLMFilterContext) Clone() *tiflashMSLMFilterContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMFilterContext{
+		inputRows:    cloneUint64Ptr(context.inputRows),
+		selectedRows: cloneUint64Ptr(context.selectedRows),
+		filteredRows: cloneUint64Ptr(context.filteredRows),
+	}
+}
+
+func (context *tiflashMSLMRunningTopNContext) Clone() *tiflashMSLMRunningTopNContext {
+	if context == nil {
+		return nil
+	}
+	return &tiflashMSLMRunningTopNContext{
+		inputRows:                       cloneUint64Ptr(context.inputRows),
+		selectedRows:                    cloneUint64Ptr(context.selectedRows),
+		bypassRows:                      cloneUint64Ptr(context.bypassRows),
+		filteredRows:                    cloneUint64Ptr(context.filteredRows),
+		heapSizeSum:                     cloneUint64Ptr(context.heapSizeSum),
+		adaptiveWarmupRows:              cloneUint64Ptr(context.adaptiveWarmupRows),
+		adaptivePostWarmupInputRows:     cloneUint64Ptr(context.adaptivePostWarmupInputRows),
+		adaptivePostWarmupCandidateRows: cloneUint64Ptr(context.adaptivePostWarmupCandidateRows),
+		adaptiveDisabledStreams:         cloneUint64Ptr(context.adaptiveDisabledStreams),
+	}
+}
+
+func (context *tiflashMSLMScanContext) Merge(other *tiflashMSLMScanContext) {
+	if other == nil {
+		return
+	}
+	mergeUint64Ptr(&context.streams, other.streams)
+	mergeUint64Ptr(&context.lateModeBlocks, other.lateModeBlocks)
+	mergeUint64Ptr(&context.directModeBlocks, other.directModeBlocks)
+	context.pushedFilterRead = mergeTiFlashMSLMReadStageContext(context.pushedFilterRead, other.pushedFilterRead)
+	context.candidateRead = mergeTiFlashMSLMReadStageContext(context.candidateRead, other.candidateRead)
+	context.finalRestRead = mergeTiFlashMSLMReadStageContext(context.finalRestRead, other.finalRestRead)
+	context.pushedFilter = mergeTiFlashMSLMFilterContext(context.pushedFilter, other.pushedFilter)
+	context.residualFilter = mergeTiFlashMSLMFilterContext(context.residualFilter, other.residualFilter)
+	context.runningTopN = mergeTiFlashMSLMRunningTopNContext(context.runningTopN, other.runningTopN)
+	mergeUint64Ptr(&context.finalRestInputRows, other.finalRestInputRows)
+}
+
+func mergeTiFlashMSLMReadStageContext(dst, src *tiflashMSLMReadStageContext) *tiflashMSLMReadStageContext {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		return src.Clone()
+	}
+	mergeUint64Ptr(&dst.dmfileScannedRows, src.dmfileScannedRows)
+	mergeUint64Ptr(&dst.dmfileSkippedRows, src.dmfileSkippedRows)
+	mergeUint64Ptr(&dst.readBytes, src.readBytes)
+	mergeUint64Ptr(&dst.readTimeMs, src.readTimeMs)
+	return dst
+}
+
+func mergeTiFlashMSLMFilterContext(dst, src *tiflashMSLMFilterContext) *tiflashMSLMFilterContext {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		return src.Clone()
+	}
+	mergeUint64Ptr(&dst.inputRows, src.inputRows)
+	mergeUint64Ptr(&dst.selectedRows, src.selectedRows)
+	mergeUint64Ptr(&dst.filteredRows, src.filteredRows)
+	return dst
+}
+
+func mergeTiFlashMSLMRunningTopNContext(dst, src *tiflashMSLMRunningTopNContext) *tiflashMSLMRunningTopNContext {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		return src.Clone()
+	}
+	mergeUint64Ptr(&dst.inputRows, src.inputRows)
+	mergeUint64Ptr(&dst.selectedRows, src.selectedRows)
+	mergeUint64Ptr(&dst.bypassRows, src.bypassRows)
+	mergeUint64Ptr(&dst.filteredRows, src.filteredRows)
+	mergeUint64Ptr(&dst.heapSizeSum, src.heapSizeSum)
+	mergeUint64Ptr(&dst.adaptiveWarmupRows, src.adaptiveWarmupRows)
+	mergeUint64Ptr(&dst.adaptivePostWarmupInputRows, src.adaptivePostWarmupInputRows)
+	mergeUint64Ptr(&dst.adaptivePostWarmupCandidateRows, src.adaptivePostWarmupCandidateRows)
+	mergeUint64Ptr(&dst.adaptiveDisabledStreams, src.adaptiveDisabledStreams)
+	return dst
+}
+
+func (context *tiflashMSLMScanContext) String() string {
+	if context == nil {
+		return ""
+	}
+	var items []string
+	items = appendUint64Field(items, "streams", context.streams)
+	items = appendUint64Field(items, "late_mode_blocks", context.lateModeBlocks)
+	items = appendUint64Field(items, "direct_mode_blocks", context.directModeBlocks)
+	if context.pushedFilterRead != nil {
+		items = append(items, "pushed_filter_read:"+context.pushedFilterRead.String())
+	}
+	if context.candidateRead != nil {
+		items = append(items, "candidate_read:"+context.candidateRead.String())
+	}
+	if context.finalRestRead != nil {
+		items = append(items, "final_rest_read:"+context.finalRestRead.String())
+	}
+	if context.pushedFilter != nil {
+		items = append(items, "pushed_filter:"+context.pushedFilter.String())
+	}
+	if context.residualFilter != nil {
+		items = append(items, "residual_filter:"+context.residualFilter.String())
+	}
+	if context.runningTopN != nil {
+		items = append(items, "running_topn:"+context.runningTopN.String())
+	}
+	items = appendUint64Field(items, "final_rest_input_rows", context.finalRestInputRows)
+	return "{" + strings.Join(items, ", ") + "}"
+}
+
+func (context *tiflashMSLMReadStageContext) String() string {
+	if context == nil {
+		return ""
+	}
+	var items []string
+	items = appendUint64Field(items, "dmfile_scanned_rows", context.dmfileScannedRows)
+	items = appendUint64Field(items, "dmfile_skipped_rows", context.dmfileSkippedRows)
+	items = appendUint64Field(items, "read_bytes", context.readBytes)
+	items = appendUint64Field(items, "read_time_ms", context.readTimeMs)
+	return "{" + strings.Join(items, ", ") + "}"
+}
+
+func (context *tiflashMSLMFilterContext) String() string {
+	if context == nil {
+		return ""
+	}
+	var items []string
+	items = appendUint64Field(items, "input_rows", context.inputRows)
+	items = appendUint64Field(items, "selected_rows", context.selectedRows)
+	items = appendUint64Field(items, "filtered_rows", context.filteredRows)
+	return "{" + strings.Join(items, ", ") + "}"
+}
+
+func (context *tiflashMSLMRunningTopNContext) String() string {
+	if context == nil {
+		return ""
+	}
+	var items []string
+	items = appendUint64Field(items, "input_rows", context.inputRows)
+	items = appendUint64Field(items, "selected_rows", context.selectedRows)
+	items = appendUint64Field(items, "bypass_rows", context.bypassRows)
+	items = appendUint64Field(items, "filtered_rows", context.filteredRows)
+	items = appendUint64Field(items, "heap_size_sum", context.heapSizeSum)
+	items = appendUint64Field(items, "adaptive_warmup_rows", context.adaptiveWarmupRows)
+	items = appendUint64Field(items, "adaptive_post_warmup_input_rows", context.adaptivePostWarmupInputRows)
+	items = appendUint64Field(items, "adaptive_post_warmup_candidate_rows", context.adaptivePostWarmupCandidateRows)
+	items = appendUint64Field(items, "adaptive_disabled_streams", context.adaptiveDisabledStreams)
+	return "{" + strings.Join(items, ", ") + "}"
+}
+
 // Clone implements the deep copy of * TiFlashshScanContext
 func (context *TiFlashScanContext) Clone() TiFlashScanContext {
 	newContext := TiFlashScanContext{
-		dmfileDataScannedRows:     context.dmfileDataScannedRows,
-		dmfileDataSkippedRows:     context.dmfileDataSkippedRows,
-		dmfileMvccScannedRows:     context.dmfileMvccScannedRows,
-		dmfileMvccSkippedRows:     context.dmfileMvccSkippedRows,
-		dmfileLmFilterScannedRows: context.dmfileLmFilterScannedRows,
-		dmfileLmFilterSkippedRows: context.dmfileLmFilterSkippedRows,
-		totalDmfileRsCheckMs:      context.totalDmfileRsCheckMs,
-		totalDmfileReadMs:         context.totalDmfileReadMs,
-		totalBuildSnapshotMs:      context.totalBuildSnapshotMs,
-		localRegions:              context.localRegions,
-		remoteRegions:             context.remoteRegions,
-		totalLearnerReadMs:        context.totalLearnerReadMs,
-		disaggReadCacheHitBytes:   context.disaggReadCacheHitBytes,
-		disaggReadCacheMissBytes:  context.disaggReadCacheMissBytes,
-		segments:                  context.segments,
-		readTasks:                 context.readTasks,
-		deltaRows:                 context.deltaRows,
-		deltaBytes:                context.deltaBytes,
-		mvccInputRows:             context.mvccInputRows,
-		mvccInputBytes:            context.mvccInputBytes,
-		mvccOutputRows:            context.mvccOutputRows,
-		lmSkipRows:                context.lmSkipRows,
-		totalBuildBitmapMs:        context.totalBuildBitmapMs,
-		totalBuildInputStreamMs:   context.totalBuildInputStreamMs,
-		staleReadRegions:          context.staleReadRegions,
-		minLocalStreamMs:          context.minLocalStreamMs,
-		maxLocalStreamMs:          context.maxLocalStreamMs,
-		minRemoteStreamMs:         context.minRemoteStreamMs,
-		maxRemoteStreamMs:         context.maxRemoteStreamMs,
-		regionsOfInstance:         make(map[string]uint64),
+		dmfileDataScannedRows:         context.dmfileDataScannedRows,
+		dmfileDataSkippedRows:         context.dmfileDataSkippedRows,
+		dmfileMvccScannedRows:         context.dmfileMvccScannedRows,
+		dmfileMvccSkippedRows:         context.dmfileMvccSkippedRows,
+		dmfileLmFilterScannedRows:     context.dmfileLmFilterScannedRows,
+		dmfileLmFilterSkippedRows:     context.dmfileLmFilterSkippedRows,
+		totalDmfileRsCheckMs:          context.totalDmfileRsCheckMs,
+		totalDmfileReadMs:             context.totalDmfileReadMs,
+		totalBuildSnapshotMs:          context.totalBuildSnapshotMs,
+		localRegions:                  context.localRegions,
+		remoteRegions:                 context.remoteRegions,
+		totalLearnerReadMs:            context.totalLearnerReadMs,
+		disaggReadCacheHitBytes:       context.disaggReadCacheHitBytes,
+		disaggReadCacheMissBytes:      context.disaggReadCacheMissBytes,
+		segments:                      context.segments,
+		readTasks:                     context.readTasks,
+		deltaRows:                     context.deltaRows,
+		deltaBytes:                    context.deltaBytes,
+		mvccInputRows:                 context.mvccInputRows,
+		mvccInputBytes:                context.mvccInputBytes,
+		mvccOutputRows:                context.mvccOutputRows,
+		lmSkipRows:                    context.lmSkipRows,
+		totalBuildBitmapMs:            context.totalBuildBitmapMs,
+		totalBuildInputStreamMs:       context.totalBuildInputStreamMs,
+		staleReadRegions:              context.staleReadRegions,
+		minLocalStreamMs:              context.minLocalStreamMs,
+		maxLocalStreamMs:              context.maxLocalStreamMs,
+		minRemoteStreamMs:             context.minRemoteStreamMs,
+		maxRemoteStreamMs:             context.maxRemoteStreamMs,
+		regionsOfInstance:             make(map[string]uint64),
+		multiStageLateMaterialization: context.multiStageLateMaterialization.Clone(),
 
 		totalVectorIdxLoadFromS3:           context.totalVectorIdxLoadFromS3,
 		totalVectorIdxLoadFromDisk:         context.totalVectorIdxLoadFromDisk,
@@ -1171,6 +1486,10 @@ func (context *TiFlashScanContext) String() string {
 	if context.minRemoteStreamMs != 0 || context.maxRemoteStreamMs != 0 {
 		remoteStreamInfo = fmt.Sprintf("min_remote_stream:%dms, max_remote_stream:%dms, ", context.minRemoteStreamMs, context.maxRemoteStreamMs)
 	}
+	mslmInfo := ""
+	if context.multiStageLateMaterialization != nil {
+		mslmInfo = ", multi_stage_late_materialization:" + context.multiStageLateMaterialization.String()
+	}
 
 	// note: "tot" is short for "total"
 	output = append(output, fmt.Sprintf("tiflash_scan:{"+
@@ -1202,6 +1521,7 @@ func (context *TiFlashScanContext) String() string {
 		"tot_rs_index_check:%dms, "+
 		"tot_read:%dms"+
 		"%s}"+ // Disagg cache info of DMFile
+		"%s"+ // Multi-stage late materialization info
 		"}",
 		context.mvccInputRows,
 		context.mvccInputBytes,
@@ -1230,6 +1550,7 @@ func (context *TiFlashScanContext) String() string {
 		context.totalDmfileRsCheckMs,
 		context.totalDmfileReadMs,
 		dmfileDisaggInfo,
+		mslmInfo,
 	))
 
 	return strings.Join(output, ", ")
@@ -1292,6 +1613,13 @@ func (context *TiFlashScanContext) Merge(other TiFlashScanContext) {
 	for k, v := range other.regionsOfInstance {
 		context.regionsOfInstance[k] += v
 	}
+	if other.multiStageLateMaterialization != nil {
+		if context.multiStageLateMaterialization == nil {
+			context.multiStageLateMaterialization = other.multiStageLateMaterialization.Clone()
+		} else {
+			context.multiStageLateMaterialization.Merge(other.multiStageLateMaterialization)
+		}
+	}
 }
 
 // Empty check whether TiFlashScanContext is Empty, if scan no pack and skip no pack, we regard it as empty
@@ -1306,7 +1634,8 @@ func (context *TiFlashScanContext) Empty() bool {
 		context.remoteRegions == 0 &&
 		context.totalVectorIdxLoadFromDisk == 0 &&
 		context.totalVectorIdxLoadFromCache == 0 &&
-		context.totalVectorIdxLoadFromS3 == 0
+		context.totalVectorIdxLoadFromS3 == 0 &&
+		context.multiStageLateMaterialization == nil
 	return res
 }
 

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -284,6 +284,98 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 	rootStats := stats.GetRootStats(tableReaderID)
 	require.NotNil(t, rootStats)
 	require.True(t, stats.ExistsRootStats(tableReaderID))
+
+	uint64Ptr := func(v uint64) *uint64 {
+		return &v
+	}
+	mslmStats := NewRuntimeStatsColl(nil)
+	mslmTableScanID := 4
+	mslmSummary1 := mockExecutorExecutionSummaryForTiFlash(1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "tablescan_"+strconv.Itoa(mslmTableScanID))
+	mslmSummary1.GetTiflashScanContext().MultiStageLateMaterialization = &tipb.TiFlashMultiStageLateMaterializationScanContext{
+		Streams:          uint64Ptr(1),
+		LateModeBlocks:   uint64Ptr(2),
+		DirectModeBlocks: uint64Ptr(0),
+		PushedFilterRead: &tipb.TiFlashMSLMReadStageContext{
+			DmfileScannedRows: uint64Ptr(100),
+			DmfileSkippedRows: uint64Ptr(10),
+			ReadBytes:         uint64Ptr(1000),
+			ReadTimeMs:        uint64Ptr(3),
+		},
+		CandidateRead: &tipb.TiFlashMSLMReadStageContext{
+			ReadBytes: uint64Ptr(700),
+		},
+		PushedFilter: &tipb.TiFlashMSLMFilterContext{
+			InputRows:    uint64Ptr(1000),
+			SelectedRows: uint64Ptr(200),
+			FilteredRows: uint64Ptr(800),
+		},
+		ResidualFilter: &tipb.TiFlashMSLMFilterContext{
+			InputRows:    uint64Ptr(200),
+			SelectedRows: uint64Ptr(100),
+			FilteredRows: uint64Ptr(100),
+		},
+		RunningTopn: &tipb.TiFlashMSLMRunningTopNContext{
+			InputRows:                       uint64Ptr(100),
+			SelectedRows:                    uint64Ptr(10),
+			BypassRows:                      uint64Ptr(0),
+			FilteredRows:                    uint64Ptr(90),
+			HeapSizeSum:                     uint64Ptr(4),
+			AdaptiveWarmupRows:              uint64Ptr(16),
+			AdaptivePostWarmupInputRows:     uint64Ptr(80),
+			AdaptivePostWarmupCandidateRows: uint64Ptr(20),
+			AdaptiveDisabledStreams:         uint64Ptr(0),
+		},
+		FinalRestInputRows: uint64Ptr(10),
+	}
+	mslmSummary2 := mockExecutorExecutionSummaryForTiFlash(2, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "tablescan_"+strconv.Itoa(mslmTableScanID))
+	mslmSummary2.GetTiflashScanContext().MultiStageLateMaterialization = &tipb.TiFlashMultiStageLateMaterializationScanContext{
+		Streams:          uint64Ptr(2),
+		LateModeBlocks:   uint64Ptr(3),
+		DirectModeBlocks: uint64Ptr(1),
+		PushedFilterRead: &tipb.TiFlashMSLMReadStageContext{
+			DmfileScannedRows: uint64Ptr(50),
+			DmfileSkippedRows: uint64Ptr(5),
+			ReadBytes:         uint64Ptr(500),
+			ReadTimeMs:        uint64Ptr(4),
+		},
+		CandidateRead: &tipb.TiFlashMSLMReadStageContext{
+			ReadBytes:  uint64Ptr(300),
+			ReadTimeMs: uint64Ptr(2),
+		},
+		FinalRestRead: &tipb.TiFlashMSLMReadStageContext{
+			DmfileScannedRows: uint64Ptr(30),
+			DmfileSkippedRows: uint64Ptr(5),
+			ReadBytes:         uint64Ptr(600),
+			ReadTimeMs:        uint64Ptr(6),
+		},
+		PushedFilter: &tipb.TiFlashMSLMFilterContext{
+			InputRows:    uint64Ptr(400),
+			SelectedRows: uint64Ptr(100),
+			FilteredRows: uint64Ptr(300),
+		},
+		ResidualFilter: &tipb.TiFlashMSLMFilterContext{
+			InputRows:    uint64Ptr(100),
+			SelectedRows: uint64Ptr(40),
+			FilteredRows: uint64Ptr(60),
+		},
+		RunningTopn: &tipb.TiFlashMSLMRunningTopNContext{
+			InputRows:               uint64Ptr(40),
+			SelectedRows:            uint64Ptr(2),
+			BypassRows:              uint64Ptr(3),
+			FilteredRows:            uint64Ptr(35),
+			HeapSizeSum:             uint64Ptr(4),
+			AdaptiveDisabledStreams: uint64Ptr(1),
+		},
+		FinalRestInputRows: uint64Ptr(5),
+	}
+	mslmStats.RecordOneCopTask(mslmTableScanID, kv.TiFlash, mslmSummary1)
+	mslmStats.RecordOneCopTask(mslmTableScanID, kv.TiFlash, mslmSummary2)
+
+	mslmCopStats := mslmStats.GetCopStats(mslmTableScanID)
+	require.False(t, mslmCopStats.stats.tiflashStats.scanContext.Empty())
+	expectedMSLM := "multi_stage_late_materialization:{streams:3, late_mode_blocks:5, direct_mode_blocks:1, pushed_filter_read:{dmfile_scanned_rows:150, dmfile_skipped_rows:15, read_bytes:1500, read_time_ms:7}, candidate_read:{read_bytes:1000, read_time_ms:2}, final_rest_read:{dmfile_scanned_rows:30, dmfile_skipped_rows:5, read_bytes:600, read_time_ms:6}, pushed_filter:{input_rows:1400, selected_rows:300, filtered_rows:1100}, residual_filter:{input_rows:300, selected_rows:140, filtered_rows:160}, running_topn:{input_rows:140, selected_rows:12, bypass_rows:3, filtered_rows:125, heap_size_sum:8, adaptive_warmup_rows:16, adaptive_post_warmup_input_rows:80, adaptive_post_warmup_candidate_rows:20, adaptive_disabled_streams:1}, final_rest_input_rows:15}"
+	require.Contains(t, mslmCopStats.String(), expectedMSLM)
+	require.Contains(t, mslmCopStats.stats.Clone().String(), expectedMSLM)
 }
 
 func TestVectorSearchStats(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

TiFlash adds multi-stage late materialization scan context fields to report MSLM read/filter/running TopN runtime statistics. TiDB needs to consume these optional fields and include them in EXPLAIN ANALYZE output while keeping existing TiFlash scan statistics compatible.

### What changed and how does it work?

This PR:

- Updates `tipb` to the feature branch version that includes `TiFlashScanContext.multi_stage_late_materialization`.
- Parses the new MSLM scan context from TiFlash `ExecutorExecutionSummary`.
- Merges, clones, and formats MSLM scan context in TiDB runtime stats.
- Preserves optional-field semantics: absent read stages or reducers are not printed as zero-valued sections.
- Keeps existing single-stage LM / dtfile / vector index scan stats output unchanged when TiFlash does not report MSLM context.

### Check List

Tests

- [x] Unit test
  - `go test ./pkg/util/execdetails`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TiFlash multi-stage late materialization metrics to scan runtime statistics.
  * Combined metrics now preserve stage, filtering, Top-N, stream, and row-count details.
  * Runtime-stat outputs and cloned statistics include the new late-materialization information when available.

* **Bug Fixes**
  * Updated the TiFlash protocol dependency to a newer pinned version.

* **Tests**
  * Added coverage validating collection, merging, cloning, and display of late-materialization metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->