### PR TITLE
metrics: add hidden AP RU series to keyspace resource control dashboard

### DIFF
--- a/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.json
@@ -190,6 +190,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
@@ -376,6 +392,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m]))) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
@@ -469,6 +501,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
@@ -562,6 +610,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
@@ -655,6 +719,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],
@@ -748,6 +828,22 @@
                      "intervalFactor": 2,
                      "legendFormat": "total",
                      "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\", resource_group=~\"$resource_group\"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", resource_group=~\"$resource_group\"}[1m])) by (resource_group)",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-{{resource_group}}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=~\"|ap\"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m]))",
+                     "format": "time_series",
+                     "hide": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "ap-total",
+                     "refId": "D"
                   }
                ],
                "thresholds": [ ],

--- a/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.jsonnet
+++ b/pkg/metrics/nextgengrafana/tidb_resource_control_with_keyspace_name.jsonnet
@@ -229,6 +229,18 @@ local RUPanel = graphPanel.new(
     'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
     legendFormat="total",
   )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
+  )
 );
 
 local RUMaxPanel = graphPanel.new(
@@ -276,6 +288,18 @@ local RUPerQueryPanel = graphPanel.new(
     '(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
     legendFormat="total",
   )
+).addTarget(
+  prometheus.target(
+    '(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group)) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    '(sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m])) + sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m]))) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
+  )
 );
 
 local RRUPanel = graphPanel.new(
@@ -300,6 +324,18 @@ local RRUPanel = graphPanel.new(
   prometheus.target(
     'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
     legendFormat="total",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
   )
 );
 
@@ -326,6 +362,18 @@ local RRUPerQueryPanel = graphPanel.new(
     'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
     legendFormat="total",
   )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_read_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
+  )
 );
 
 local WRUPanel = graphPanel.new(
@@ -351,6 +399,18 @@ local WRUPanel = graphPanel.new(
     'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m]))',
     legendFormat="total",
   )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
+  )
 );
 
 local WRUPerQueryPanel = graphPanel.new(
@@ -375,6 +435,18 @@ local WRUPerQueryPanel = graphPanel.new(
   prometheus.target(
     'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|tp"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
     legendFormat="total",
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap", resource_group=~"$resource_group"}[1m])) by (resource_group) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", resource_group=~"$resource_group"}[1m])) by (resource_group)',
+    legendFormat="ap-{{resource_group}}",
+    hide=true,
+  )
+).addTarget(
+  prometheus.target(
+    'sum(rate(resource_manager_resource_unit_write_request_unit_sum{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", type=~"|ap"}[1m])) / sum(rate(tidb_session_resource_group_query_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[1m]))',
+    legendFormat="ap-total",
+    hide=true,
   )
 );
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70222

Problem Summary:

The `tidb_resource_control_with_keyspace_name` Resource Unit panels only plotted RU metrics with `type=~"|tp"`, so AP / TiFlash RU consumption was hard to inspect from the dashboard.

### What changed and how does it work?

Add hidden `type=~"|ap"` PromQL targets to these Resource Unit panels:

- RU
- RU Per Query
- RRU
- RRU Per Query
- WRU
- WRU Per Query

Each panel keeps the existing `|tp` series visible by default, and adds `ap-{{resource_group}}` / `ap-total` series with `hide=true` so operators can enable them when needed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
<img width="4998" height="1856" alt="image" src="https://github.com/user-attachments/assets/b925e153-75bf-444c-bf7e-af82e7209d45" />
<img width="3792" height="2482" alt="image" src="https://github.com/user-attachments/assets/9f11a322-3ec1-4c2a-8595-5003cb071aa7" />
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  > Only Grafana dashboard definition files under `pkg/metrics/nextgengrafana` were updated; no TiDB runtime code changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Resource Unit Grafana dashboards with additional AP resource usage metrics.
  * Added per-resource-group and total AP metric series across RU, RRU, WRU, and per-query panels.
  * Improved metric labeling with clearer AP-specific legends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->