### PR TITLE
object storage: cache explicit AssumeRole credentials

### DIFF
--- a/pkg/objstore/s3store/s3_test.go
+++ b/pkg/objstore/s3store/s3_test.go
@@ -62,6 +62,21 @@ func createGetBucketRegionServer(region string, statusCode int, incHeader bool) 
 	}))
 }
 
+type rewriteRequestHostTransport struct {
+	targetHost string
+	base       http.RoundTripper
+}
+
+func (t *rewriteRequestHostTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	req := r.Clone(r.Context())
+	if req.Host == "" {
+		req.Host = r.URL.Host
+	}
+	req.URL.Scheme = "http"
+	req.URL.Host = t.targetHost
+	return t.base.RoundTrip(req)
+}
+
 func TestApply(t *testing.T) {
 	type testcase struct {
 		name      string
@@ -425,6 +440,71 @@ func TestS3Storage(t *testing.T) {
 	for i := range tests {
 		testFn(&tests[i], t)
 	}
+
+	t.Run("cache assumed role credentials", func(t *testing.T) {
+		const assumeRoleResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/test-role/test-session</Arn>
+      <AssumedRoleId>AROAEXAMPLE:test-session</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>assumed-access-key</AccessKeyId>
+      <SecretAccessKey>assumed-secret-access-key</SecretAccessKey>
+      <SessionToken>assumed-session-token</SessionToken>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>00000000-0000-0000-0000-000000000000</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>`
+
+		var assumeRoleCalls, s3Calls, assumedCredentialUses atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				assumeRoleCalls.Add(1)
+				w.Header().Set("Content-Type", "text/xml")
+				if _, err := fmt.Fprint(w, assumeRoleResponse); err != nil {
+					t.Errorf("write AssumeRole response: %v", err)
+				}
+				return
+			}
+
+			s3Calls.Add(1)
+			if strings.Contains(r.Header.Get("Authorization"), "Credential=assumed-access-key/") {
+				assumedCredentialUses.Add(1)
+			}
+			w.Header().Set(bucketRegionHeader, "us-west-2")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		httpClient := server.Client()
+		httpClient.Transport = &rewriteRequestHostTransport{
+			targetHost: strings.TrimPrefix(server.URL, "http://"),
+			base:       httpClient.Transport,
+		}
+		storage, err := NewS3Storage(context.Background(), &backuppb.S3{
+			Region:         "us-west-2",
+			Endpoint:       server.URL,
+			Provider:       "aws",
+			Bucket:         "bucket",
+			ForcePathStyle: true,
+			RoleArn:        "arn:aws:iam::123456789012:role/test-role",
+		}, &storeapi.Options{HTTPClient: httpClient})
+		require.NoError(t, err)
+
+		for range 2 {
+			exists, err := storage.FileExists(context.Background(), "object")
+			require.NoError(t, err)
+			require.True(t, exists)
+		}
+		require.GreaterOrEqual(t, s3Calls.Load(), int32(2))
+		require.Equal(t, s3Calls.Load(), assumedCredentialUses.Load())
+		require.Equal(t, int32(1), assumeRoleCalls.Load())
+	})
 }
 
 func TestS3URI(t *testing.T) {

--- a/pkg/objstore/s3store/store.go
+++ b/pkg/objstore/s3store/store.go
@@ -183,7 +183,7 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opti
 		}
 
 		// Update config with assume role credentials
-		cfg.Credentials = assumeRoleProvider
+		cfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
 	}
 
 	if opts.AccessRecording != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70225, ref #62541

Problem Summary:

The AWS SDK v2 migration in #64303 replaced the v1 `stscreds.NewCredentials` call with a bare v2 `stscreds.NewAssumeRoleProvider` for S3 backends configured with an explicit role ARN.

The v1 constructor returned a synchronized credentials cache around the provider. The v2 constructor returns only the provider, which does not cache or synchronize retrieved credentials. Because TiDB assigned that provider directly to `cfg.Credentials` after `config.LoadDefaultConfig`, every signed S3 SDK attempt could issue a new STS `AssumeRole` request instead of reusing temporary credentials.

Under concurrent `IMPORT INTO` source reads and multipart global-sort writes, the repeated role assumptions can exhaust the caller account's STS request quota and produce `HTTP 400 Throttling: Rate exceeded` errors.

### What changed and how does it work?

Wrap the explicit assume-role provider with `aws.NewCredentialsCache` before assigning it to the AWS configuration. The cache reuses unexpired temporary credentials and single-flights concurrent refreshes.

Add a regression test with fake STS and S3 endpoints. It performs multiple signed S3 requests, verifies that they use the assumed-role access key, and asserts that STS `AssumeRole` is called once while the returned credentials remain valid.

Before the production change, the regression test failed with three role assumptions instead of one. With the cache wrapper, the same test passes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

write a test to access real S3 with role-arn:
before this pr, we can see every S3 request calls `AssumeRole`
```
AWS API statistics:
S3/DeleteObject: 1
S3/GetObject: 10
S3/HeadBucket: 1
S3/HeadObject: 1
S3/PutObject: 1
STS/AssumeRole: 14
Total: 28
```
after
```
AWS API statistics:
S3/DeleteObject: 1
S3/GetObject: 10
S3/HeadBucket: 1
S3/HeadObject: 1
S3/PutObject: 1
STS/AssumeRole: 1
Total: 15
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validated with:

```text
./tools/check/failpoint-go-test.sh pkg/objstore/s3store -run '^TestS3Storage$/^cache_assumed_role_credentials$' -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix excessive AWS STS `AssumeRole` requests when S3 storage uses an explicit role ARN.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assumed-role credential handling for S3 storage.
  * Reuses cached credentials across repeated operations, reducing unnecessary role-assumption requests.

* **Tests**
  * Added coverage verifying credential reuse and authorization across multiple S3 operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->