### PR TITLE
executor: fix the foreign key behavior after pessimistic retry.

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -798,7 +798,12 @@ func (a *ExecStmt) handleStmtForeignKeyTrigger(ctx context.Context, e exec.Execu
 		// then the fk cascade executor can't read the mem-buffer changed by the ExecStmt.
 		a.Ctx.StmtCommit(ctx)
 	}
-	err := a.handleForeignKeyTrigger(ctx, e, 1)
+	// ExplainExec owns result rendering, while its analyze DML owns the FK trigger state.
+	fkExecutor := e
+	if explain, ok := e.(*ExplainExec); ok && explain.getAnalyzeExecWithForeignKeyTrigger() != nil {
+		fkExecutor = explain.analyzeExec
+	}
+	err := a.handleForeignKeyTrigger(ctx, fkExecutor, 1)
 	if err != nil {
 		err1 := a.handleFKTriggerError(stmtCtx)
 		if err1 != nil {
@@ -1466,6 +1471,8 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 	if err = a.openExecutor(ctx, e); err != nil {
 		return nil, err
 	}
+	// Prepare a fresh FK cascade savepoint for the retried statement attempt.
+	a.prepareFKCascadeContext(e)
 	return e, nil
 }
 

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -811,8 +811,10 @@ func (a *ExecStmt) handleStmtForeignKeyTrigger(ctx context.Context, e exec.Execu
 		}
 		return err
 	}
-	if stmtCtx.ForeignKeyTriggerCtx.SavepointName != "" {
-		a.Ctx.GetSessionVars().TxnCtx.ReleaseSavepoint(stmtCtx.ForeignKeyTriggerCtx.SavepointName)
+	// In pessimistic DML, FK check locks can be deferred until after FK
+	// triggers, so keep the savepoint alive until those locks succeed.
+	if !a.Ctx.GetSessionVars().TxnCtx.IsPessimistic {
+		a.releaseFKCascadeSavepoint(stmtCtx)
 	}
 	return nil
 }
@@ -936,25 +938,38 @@ func (a *ExecStmt) prepareFKCascadeContext(e exec.Executor) {
 }
 
 func (a *ExecStmt) handleFKTriggerError(sc *stmtctx.StatementContext) error {
-	if sc.ForeignKeyTriggerCtx.SavepointName == "" {
+	savepointName := sc.ForeignKeyTriggerCtx.SavepointName
+	if savepointName == "" {
 		return nil
 	}
+	defer func() {
+		sc.ForeignKeyTriggerCtx.SavepointName = ""
+	}()
 	txn, err := a.Ctx.Txn(false)
 	if err != nil || !txn.Valid() {
 		return err
 	}
-	savepointRecord := a.Ctx.GetSessionVars().TxnCtx.RollbackToSavepoint(sc.ForeignKeyTriggerCtx.SavepointName)
+	savepointRecord := a.Ctx.GetSessionVars().TxnCtx.RollbackToSavepoint(savepointName)
 	if savepointRecord == nil {
 		// Normally should never run into here, but just in case, rollback the transaction.
 		err = txn.Rollback()
 		if err != nil {
 			return err
 		}
-		return errors.Errorf("foreign key cascade savepoint '%s' not found, transaction is rollback, should never happen", sc.ForeignKeyTriggerCtx.SavepointName)
+		return errors.Errorf("foreign key cascade savepoint '%s' not found, transaction is rollback, should never happen", savepointName)
 	}
 	txn.RollbackMemDBToCheckpoint(savepointRecord.MemDBCheckpoint)
-	a.Ctx.GetSessionVars().TxnCtx.ReleaseSavepoint(sc.ForeignKeyTriggerCtx.SavepointName)
+	a.Ctx.GetSessionVars().TxnCtx.ReleaseSavepoint(savepointName)
 	return nil
+}
+
+func (a *ExecStmt) releaseFKCascadeSavepoint(sc *stmtctx.StatementContext) {
+	savepointName := sc.ForeignKeyTriggerCtx.SavepointName
+	if savepointName == "" {
+		return
+	}
+	a.Ctx.GetSessionVars().TxnCtx.ReleaseSavepoint(savepointName)
+	sc.ForeignKeyTriggerCtx.SavepointName = ""
 }
 
 func (a *ExecStmt) handleNoDelay(ctx context.Context, e exec.Executor, isPessimistic bool) (handled bool, rs sqlexec.RecordSet, err error) {
@@ -1206,6 +1221,13 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 			err = err1
 		}
 	}()
+	// Registered after OnPessimisticStmtEnd so it runs first, matching the
+	// previous explicit release-before-return order.
+	defer func() {
+		if err == nil {
+			a.releaseFKCascadeSavepoint(sctx.GetSessionVars().StmtCtx)
+		}
+	}()
 
 	tryLockKeys := func(e exec.Executor, keys []kv.Key, shared bool) (exec.Executor, error) {
 		seVars := sctx.GetSessionVars()
@@ -1235,6 +1257,11 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 		}
 		if err == nil {
 			return nil, nil
+		}
+		// FK cascade writes may have been flushed by StmtCommit before this
+		// deferred lock phase, so rollback to the FK savepoint before retrying.
+		if err1 := a.handleFKTriggerError(seVars.StmtCtx); err1 != nil {
+			return nil, err1
 		}
 		e, err = a.handlePessimisticLockError(ctx, err)
 		if err != nil {

--- a/pkg/executor/test/fktest/BUILD.bazel
+++ b/pkg/executor/test/fktest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 27,
+    shard_count = 28,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/executor/test/fktest/foreign_key_test.go
+++ b/pkg/executor/test/fktest/foreign_key_test.go
@@ -1790,6 +1790,59 @@ func TestForeignKeyCascadePessimisticRetrySavepoint(t *testing.T) {
 		tk.MustQuery("select * from gift order by id").Check(testkit.Rows("2 2", "4 4"))
 		tk.MustQuery("select * from user_gift").Check(testkit.Rows("1 2"))
 	})
+
+	t.Run("deferred-fk-lock-retry-rolls-back-cascade-writes", func(t *testing.T) {
+		store := testkit.CreateMockStore(t)
+		tk1 := testkit.NewTestKit(t, store)
+		tk2 := testkit.NewTestKit(t, store)
+
+		tk1.MustExec("set @@global.tidb_enable_foreign_key=1")
+		tk1.MustExec("set @@foreign_key_checks=1")
+		tk1.MustExec("use test")
+		tk2.MustExec("set @@foreign_key_checks=1")
+		tk2.MustExec("use test")
+
+		tk1.MustExec("create table fk_guard (id int primary key)")
+		tk1.MustExec("create table fk_parent (" +
+			"id int primary key, guard_id int, v int, " +
+			"foreign key (guard_id) references fk_guard(id))")
+		tk1.MustExec("create table fk_child (" +
+			"id int primary key, parent_id int, " +
+			"foreign key (parent_id) references fk_parent(id) on update cascade)")
+		tk1.MustExec("insert into fk_guard values (1), (2)")
+		tk1.MustExec("insert into fk_parent values (1, 1, 0)")
+		tk1.MustExec("insert into fk_child values (1, 1)")
+
+		tk2.MustExec("begin pessimistic")
+		tk2.MustQuery("select * from fk_guard where id = 2 for update").Check(testkit.Rows("2"))
+
+		tk1.MustExec("begin pessimistic")
+		done := make(chan error, 1)
+		go func() {
+			done <- tk1.ExecToErr("update fk_parent set id = 2, guard_id = 2, v = v + 1 where id = 1")
+		}()
+
+		time.Sleep(200 * time.Millisecond)
+		tk2.MustExec("delete from fk_guard where id = 2")
+		tk2.MustExec("commit")
+
+		var err error
+		select {
+		case err = <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("update did not return after the conflicting transaction committed")
+		}
+		require.True(t, plannererrors.ErrNoReferencedRow2.Equal(err), err.Error())
+		require.True(t, tk1.Session().GetSessionVars().InTxn())
+		require.Empty(t, tk1.Session().GetSessionVars().TxnCtx.Savepoints)
+		tk1.MustQuery("select * from fk_parent order by id").Check(testkit.Rows("1 1 0"))
+		tk1.MustQuery("select * from fk_child order by id").Check(testkit.Rows("1 1"))
+		tk1.MustExec("rollback")
+
+		tk2.MustQuery("select * from fk_guard order by id").Check(testkit.Rows("1"))
+		tk2.MustQuery("select * from fk_parent order by id").Check(testkit.Rows("1 1 0"))
+		tk2.MustQuery("select * from fk_child order by id").Check(testkit.Rows("1 1"))
+	})
 }
 
 func TestForeignKeyOnUpdateCascade(t *testing.T) {

--- a/pkg/executor/test/fktest/foreign_key_test.go
+++ b/pkg/executor/test/fktest/foreign_key_test.go
@@ -1602,6 +1602,196 @@ func TestForeignKeyOnDeleteSetNull2(t *testing.T) {
 	tk.MustQuery("select count(*) from t2 where id is null").Check(testkit.Rows("32768"))
 }
 
+func TestForeignKeyCascadePessimisticRetrySavepoint(t *testing.T) {
+	const (
+		writeConflictFailpoint = "github.com/pingcap/tidb/pkg/store/mockstore/unistore/tikv/pessimisticLockReturnWriteConflict"
+		deadlockFailpoint      = "github.com/pingcap/tidb/pkg/store/mockstore/unistore/tikv/pessimisticLockReturnDeadlock"
+		cascadeErrorFailpoint  = "github.com/pingcap/tidb/pkg/executor/handleForeignKeyCascadeError"
+	)
+
+	newTestKit := func(t *testing.T, isolation string) *testkit.TestKit {
+		t.Helper()
+		store := testkit.CreateMockStore(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("set @@global.tidb_enable_foreign_key=1")
+		tk.MustExec("set @@foreign_key_checks=1")
+		tk.MustExec("set @@tidb_pessimistic_txn_fair_locking=0")
+		tk.MustExec("use test")
+		if isolation != "" {
+			tk.MustExec("set session transaction isolation level " + isolation)
+		}
+		return tk
+	}
+
+	prepareGiftSchema := func(t *testing.T, tk *testkit.TestKit) {
+		t.Helper()
+		tk.MustExec("create table gift (id bigint primary key, expires_at bigint)")
+		tk.MustExec("create table user_gift (" +
+			"id bigint primary key, gift_id bigint, index gift_id_idx(gift_id), " +
+			"constraint user_gift_fk foreign key (gift_id) references gift(id) on update cascade)")
+		tk.MustExec("insert into gift values (1, 1)")
+		tk.MustExec("insert into user_gift values (1, 1)")
+	}
+
+	enableRetryFailure := func(t *testing.T, lockFailpoint, lockExpression, cascadeExpression string) {
+		t.Helper()
+		testfailpoint.Enable(t, lockFailpoint, lockExpression)
+		testfailpoint.Enable(t, cascadeErrorFailpoint, cascadeExpression)
+	}
+
+	assertGiftRollback := func(t *testing.T, tk *testkit.TestKit, err error) {
+		t.Helper()
+		require.EqualError(t, err, "handleForeignKeyCascadeError")
+		require.True(t, tk.Session().GetSessionVars().InTxn())
+		require.Empty(t, tk.Session().GetSessionVars().TxnCtx.Savepoints)
+		tk.MustQuery("select * from gift").Check(testkit.Rows("1 1"))
+		tk.MustQuery("select * from user_gift").Check(testkit.Rows("1 1"))
+		tk.MustExec("rollback")
+	}
+
+	// issue:70197. Each subtest owns its failpoints so their cleanup runs
+	// before the next retry sequence starts.
+	cases := []struct {
+		name              string
+		isolation         string
+		lockFailpoint     string
+		lockExpression    string
+		cascadeExpression string
+	}{
+		{
+			name:              "write-conflict-repeatable-read",
+			lockFailpoint:     writeConflictFailpoint,
+			lockExpression:    "1*return(false)->1*return(true)->return(false)",
+			cascadeExpression: "1*return(false)->return(true)",
+		},
+		{
+			name:              "write-conflict-read-committed",
+			isolation:         "read committed",
+			lockFailpoint:     writeConflictFailpoint,
+			lockExpression:    "1*return(false)->1*return(true)->return(false)",
+			cascadeExpression: "1*return(false)->return(true)",
+		},
+		{
+			name:              "two-write-conflict-retries",
+			lockFailpoint:     writeConflictFailpoint,
+			lockExpression:    "1*return(false)->2*return(true)->return(false)",
+			cascadeExpression: "2*return(false)->return(true)",
+		},
+		{
+			name:              "retryable-deadlock",
+			lockFailpoint:     deadlockFailpoint,
+			lockExpression:    "1*return(false)->1*return(true)->return(false)",
+			cascadeExpression: "1*return(false)->return(true)",
+		},
+	}
+	for _, ca := range cases {
+		t.Run(ca.name, func(t *testing.T) {
+			tk := newTestKit(t, ca.isolation)
+			prepareGiftSchema(t, tk)
+			tk.MustExec("begin pessimistic")
+			enableRetryFailure(t, ca.lockFailpoint, ca.lockExpression, ca.cascadeExpression)
+			assertGiftRollback(t, tk, tk.ExecToErr("update gift set id=1, expires_at=2 where id=1"))
+		})
+	}
+
+	t.Run("multi-level-cascade", func(t *testing.T) {
+		tk := newTestKit(t, "")
+		tk.MustExec("create table fk_parent (id bigint primary key, v bigint)")
+		tk.MustExec("create table fk_child (" +
+			"id bigint primary key, parent_id bigint, unique index parent_id_idx(parent_id), " +
+			"foreign key (parent_id) references fk_parent(id) on update cascade)")
+		tk.MustExec("create table fk_grandchild (" +
+			"id bigint primary key, child_parent_id bigint, index child_parent_id_idx(child_parent_id), " +
+			"foreign key (child_parent_id) references fk_child(parent_id) on update cascade)")
+		tk.MustExec("insert into fk_parent values (1, 1)")
+		tk.MustExec("insert into fk_child values (1, 1)")
+		tk.MustExec("insert into fk_grandchild values (1, 1)")
+		tk.MustExec("begin pessimistic")
+
+		enableRetryFailure(t,
+			writeConflictFailpoint,
+			"1*return(false)->1*return(true)->return(false)",
+			"2*return(false)->return(true)")
+		err := tk.ExecToErr("update fk_parent set id=2, v=2 where id=1")
+		require.EqualError(t, err, "handleForeignKeyCascadeError")
+		require.True(t, tk.Session().GetSessionVars().InTxn())
+		require.Empty(t, tk.Session().GetSessionVars().TxnCtx.Savepoints)
+		tk.MustQuery("select * from fk_parent").Check(testkit.Rows("1 1"))
+		tk.MustQuery("select * from fk_child").Check(testkit.Rows("1 1"))
+		tk.MustQuery("select * from fk_grandchild").Check(testkit.Rows("1 1"))
+		tk.MustExec("rollback")
+	})
+
+	t.Run("prepared-statement", func(t *testing.T) {
+		tk := newTestKit(t, "")
+		prepareGiftSchema(t, tk)
+		tk.MustExec("prepare fk_retry_stmt from " +
+			"'update gift set id=?, expires_at=? where id=?'")
+		tk.MustExec("set @new_id=1, @expires_at=2, @old_id=1")
+		tk.MustExec("begin pessimistic")
+		enableRetryFailure(t,
+			writeConflictFailpoint,
+			"1*return(false)->1*return(true)->return(false)",
+			"1*return(false)->return(true)")
+		assertGiftRollback(t, tk,
+			tk.ExecToErr("execute fk_retry_stmt using @new_id, @expires_at, @old_id"))
+	})
+
+	t.Run("explain-analyze-dml", func(t *testing.T) {
+		tk := newTestKit(t, "")
+		prepareGiftSchema(t, tk)
+		tk.MustExec("begin pessimistic")
+		enableRetryFailure(t,
+			writeConflictFailpoint,
+			"1*return(false)->1*return(true)->return(false)",
+			"1*return(false)->return(true)")
+		assertGiftRollback(t, tk,
+			tk.ExecToErr("explain analyze update gift set id=1, expires_at=2 where id=1"))
+	})
+
+	t.Run("explain-analyze-dml-successful-retry", func(t *testing.T) {
+		tk := newTestKit(t, "")
+		prepareGiftSchema(t, tk)
+		tk.MustExec("begin pessimistic")
+		testfailpoint.Enable(t,
+			writeConflictFailpoint,
+			"1*return(false)->1*return(true)->return(false)")
+
+		require.NotEmpty(t,
+			tk.MustQuery("explain analyze update gift set id=2, expires_at=2 where id=1").Rows())
+		require.True(t, tk.Session().GetSessionVars().InTxn())
+		require.Empty(t, tk.Session().GetSessionVars().TxnCtx.Savepoints)
+		tk.MustQuery("select * from gift").Check(testkit.Rows("2 2"))
+		tk.MustQuery("select * from user_gift").Check(testkit.Rows("1 2"))
+		tk.MustExec("rollback")
+	})
+
+	t.Run("successful-retry-keeps-transaction-usable", func(t *testing.T) {
+		tk := newTestKit(t, "")
+		prepareGiftSchema(t, tk)
+		tk.MustExec("begin pessimistic")
+		testfailpoint.Enable(t,
+			writeConflictFailpoint,
+			"1*return(false)->1*return(true)->return(false)")
+
+		tk.MustExec("update gift set id=2, expires_at=expires_at+1 where id=1")
+		require.True(t, tk.Session().GetSessionVars().InTxn())
+		require.Empty(t, tk.Session().GetSessionVars().TxnCtx.Savepoints)
+		tk.MustQuery("select * from gift").Check(testkit.Rows("2 2"))
+		tk.MustQuery("select * from user_gift").Check(testkit.Rows("1 2"))
+
+		tk.MustExec("savepoint after_retry")
+		tk.MustExec("insert into gift values (3, 3)")
+		tk.MustExec("rollback to savepoint after_retry")
+		tk.MustQuery("select * from gift").Check(testkit.Rows("2 2"))
+		tk.MustExec("insert into gift values (4, 4)")
+		tk.MustExec("commit")
+		require.False(t, tk.Session().GetSessionVars().InTxn())
+		tk.MustQuery("select * from gift order by id").Check(testkit.Rows("2 2", "4 4"))
+		tk.MustQuery("select * from user_gift").Check(testkit.Rows("1 2"))
+	})
+}
+
 func TestForeignKeyOnUpdateCascade(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/store/mockstore/unistore/tikv/server.go
+++ b/pkg/store/mockstore/unistore/tikv/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore/tikv/kverrors"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore/tikv/pberror"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore/util/lockwaiter"
+	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
@@ -257,10 +258,14 @@ func (svr *Server) KvPessimisticLock(ctx context.Context, req *kvrpcpb.Pessimist
 	failpoint.Inject("pessimisticLockReturnDeadlock", func(val failpoint.Value) {
 		if val.(bool) && len(req.Mutations) > 0 {
 			key := req.Mutations[0].Key
+			// client-go determines whether a deadlock is retryable by hashing the
+			// original transaction keys, before API V2 adds the keyspace prefix. Keep
+			// LockKey encoded so the API V2 response decoder can decode it.
+			keyForDeadlockHash := rowcodec.RemoveKeyspacePrefix(key)
 			err := &kverrors.ErrDeadlock{
 				LockKey:         key,
 				LockTS:          req.StartVersion + 1,
-				DeadlockKeyHash: keysToHashVals(key)[0],
+				DeadlockKeyHash: keysToHashVals(keyForDeadlockHash)[0],
 			}
 			failpoint.Return(&kvrpcpb.PessimisticLockResponse{Errors: []*kvrpcpb.KeyError{convertToKeyError(err)}}, nil)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Issue Number: close #62621, close #70197, close #70402

Problem Summary:

We have two issues for foreign key in pessimistic retry:

1. After retry, the executor might be `ExplainExec`. In this case, the foreign key logic will not handle the trigger well.
2. After retry, the savepoint is not prepared again, so it might return error `savepoint not found`.

### What changed and how does it work?

1. Unpack the executor from the `ExplainExec` if needed.
2. Reprepare the savepoint for pessimistic retry.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreign-key cascade handling during pessimistic-lock retries.
  * Fixed retry behavior for cascades executed through analysis-wrapped statements.
  * Ensured failed cascades roll back cleanly and transaction savepoints remain usable afterward.
* **Tests**
  * Added coverage for multi-level cascades, prepared statements, isolation levels, deadlocks, write conflicts, and successful retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->