### PR TITLE
planner: skip the descending scan factor for a scan bounded by a small limit

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -284,6 +284,7 @@ go_test(
         "//pkg/parser/terror",
         "//pkg/planner",
         "//pkg/planner/core/base",
+        "//pkg/planner/core/cost",
         "//pkg/planner/core/joinorder",
         "//pkg/planner/core/operator/logicalop",
         "//pkg/planner/core/operator/physicalop",

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/core/cost"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
@@ -1332,13 +1333,21 @@ func getTaskScanFactorVer2(p base.PhysicalPlan, storeType kv.StoreType, taskType
 		return defaultVer2Factors.TiFlashScan
 	default: // TiKV
 		var desc bool
+		var prop *property.PhysicalProperty
 		if indexScan, ok := p.(*physicalop.PhysicalIndexScan); ok {
-			desc = indexScan.Desc
+			desc, prop = indexScan.Desc, indexScan.Prop
 		}
 		if tableScan, ok := p.(*physicalop.PhysicalTableScan); ok {
-			desc = tableScan.Desc
+			desc, prop = tableScan.Desc, tableScan.Prop
 		}
-		if desc {
+		// The descending factor models reverse iteration being slower per row read. A scan
+		// bounded by a small limit reads few rows, so charging the premium over the whole
+		// estimated range makes an ordered descending scan lose to sorting that same range.
+		// Cost model ver1 has skipped the factor in this case since it was introduced; see
+		// cost.SmallScanThreshold and getPlanCostVer14PhysicalTableScan. Unlike ver1, the
+		// premium is kept when the required property is unknown, since the scan is then not
+		// known to be bounded.
+		if desc && (prop == nil || prop.ExpectedCnt >= cost.SmallScanThreshold) {
 			return defaultVer2Factors.TiKVDescScan
 		}
 		return defaultVer2Factors.TiKVScan

--- a/pkg/planner/core/plan_cost_ver2_test.go
+++ b/pkg/planner/core/plan_cost_ver2_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/core/cost"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util/costusage"
@@ -976,4 +977,64 @@ func TestHashAggMemCostGatedOnFreeOrdering(t *testing.T) {
 		require.NotRegexp(t, hashAggMemPattern, traceJoin,
 			"HashAgg over a join output must NOT include the memory penalty (gated on free ordering), got: %s", traceJoin)
 	})
+}
+
+// TestDescScanFactorSkippedUnderSmallLimit checks that a descending scan bounded by a small limit
+// is not charged the reverse-iteration premium, while a descending scan that may read a large
+// number of rows still is. Cost model ver1 has always drawn the line at cost.SmallScanThreshold
+// (see getPlanCostVer14PhysicalTableScan); this pins the same behaviour for ver2, so that an
+// ordered descending scan is not priced out of plans like MAX(col) or ORDER BY col DESC LIMIT n.
+func TestDescScanFactorSkippedUnderSmallLimit(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null, primary key (a, b) clustered)")
+	var values strings.Builder
+	for i := range 3000 {
+		if i > 0 {
+			values.WriteString(",")
+		}
+		fmt.Fprintf(&values, "(%d,%d)", i%3, i)
+	}
+	tk.MustExec("insert into t values " + values.String())
+	tk.MustExec("analyze table t all columns")
+
+	// scanCostAndRows returns the estimated cost and row count of the table range scan of an
+	// ordered plan. ORDER_INDEX keeps the ordered scan in the plan regardless of what the
+	// comparison below is measuring.
+	scanCostAndRows := func(desc bool, limit int) (float64, float64) {
+		t.Helper()
+		direction := ""
+		if desc {
+			direction = "desc"
+		}
+		sql := fmt.Sprintf("explain format='verbose' select /*+ ORDER_INDEX(t, `primary`) */ b "+
+			"from t where a = 1 order by b %s limit %d", direction, limit)
+		for _, row := range tk.MustQuery(sql).Rows() {
+			if !strings.Contains(fmt.Sprintf("%v", row[0]), "TableRangeScan") {
+				continue
+			}
+			rows, err := strconv.ParseFloat(fmt.Sprintf("%v", row[1]), 64)
+			require.NoError(t, err)
+			cost, err := strconv.ParseFloat(fmt.Sprintf("%v", row[2]), 64)
+			require.NoError(t, err)
+			return cost, rows
+		}
+		require.FailNow(t, "no TableRangeScan in plan", sql)
+		return 0, 0
+	}
+
+	// A limit far below the threshold: the scan reads few rows either way, so reading them
+	// backwards must cost the same as reading them forwards.
+	ascCost, ascRows := scanCostAndRows(false, 1)
+	descCost, descRows := scanCostAndRows(true, 1)
+	require.Equal(t, ascRows, descRows, "the two directions must scan the same estimated rows")
+	require.Equal(t, ascCost, descCost, "a descending scan under a small limit must not be charged the desc factor")
+
+	// Above the threshold the premium still applies, so the descending scan stays more expensive.
+	largeLimit := 2 * int(cost.SmallScanThreshold)
+	ascCost, ascRows = scanCostAndRows(false, largeLimit)
+	descCost, descRows = scanCostAndRows(true, largeLimit)
+	require.Equal(t, ascRows, descRows, "the two directions must scan the same estimated rows")
+	require.Greater(t, descCost, ascCost, "a descending scan that may read many rows keeps the desc factor")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70240

Problem Summary:

`getTaskScanFactorVer2` charges `tikv_desc_scan_factor` (61.05) instead of `tikv_scan_factor`
(40.70) whenever a scan is descending, and the factor is applied to the whole estimated range even
when a limit stops the scan after a few rows. The premium models reverse iteration being slower per
row read, so charging it for rows that are never read prices an ordered descending scan out of
plans where the ascending equivalent is chosen.

Cost model ver1 has drawn this line since the factor was introduced — it applies the descending
factor only when `ExpectedCnt` reaches `cost.SmallScanThreshold` (`getPlanCostVer14PhysicalTableScan`,
`getPlanCostVer14PhysicalIndexScan`), and the comment on the threshold states the intent: *"So when
a limit exists, we don't apply the DescScanFactor."* Ver2, which is the default, never got the rule.

### What changed and how does it work?

Apply the same rule in ver2:

```go
if desc && (prop == nil || prop.ExpectedCnt >= cost.SmallScanThreshold) {
    return defaultVer2Factors.TiKVDescScan
}
return defaultVer2Factors.TiKVScan
```

Unlike ver1, the premium is kept when the required property is unknown, since the scan is then not
known to be bounded. Only scans with a known small `ExpectedCnt` change cost, which keeps the
behavioural delta as small as possible.

Effect on a bounded scan — both directions estimate the same rows, so the difference was purely the
factor:

| `LIMIT` | ascending estCost | descending estCost before | descending estCost after |
| --- | --- | --- | --- |
| 1 | 2236.47 | 3354.70 | 2236.47 |
| 20000 | 203500.00 | 305250.00 | 305250.00 |

The premium still applies above the threshold, where the scan may really read many rows.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New test `TestDescScanFactorSkippedUnderSmallLimit` in `pkg/planner/core/plan_cost_ver2_test.go`
asserts the cost directly rather than a plan shape, so it pins exactly what changed regardless of
which plan wins: under a small limit the two directions cost the same, and above
`cost.SmallScanThreshold` the descending scan stays more expensive. Both cases also assert the two
directions estimate the same rows, so a failure is not ambiguous. Verified failing before the change
(`expected: 2236.47, actual: 3354.7`) and passing after.

```bash
go test -tags=intest ./pkg/planner/core/ -run TestDescScanFactorSkippedUnderSmallLimit
go test -tags=intest ./pkg/planner/core/casetest/physicalplantest/ ./pkg/planner/core/casetest/cascades/... ./pkg/planner/core/issuetest/
make integrationtest
make lint
bazel build //pkg/planner/core:all --//build:with_nogo_flag=true
```

`make integrationtest` passes with no recorded result file changed, so no existing plan in that
suite moves.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a cost estimation issue where a descending index or table scan bounded by a small `LIMIT` was
estimated as more expensive than it is, which could make the optimizer sort the matched rows instead
of reading them in descending order from the index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query cost estimates for descending TiKV scans.
  * Small-result scans now avoid an unnecessary descending-scan cost premium, improving plan selection accuracy.
  * Larger scans continue to account for the additional cost of descending scans.

* **Tests**
  * Added coverage to verify cost estimates for both small and large scan limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->