### PR TITLE
ddl: restore dynamic parameter adjustment for txn backfill

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -1125,6 +1125,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 			case <-doneCh:
 				break outer
 			case <-ticker.C:
+				reorgInfo.UpdateConfigFromSysTbl(ctx)
 				currentWorkerCnt := exec.currentWorkerSize()
 				targetWorkerCnt := reorgInfo.ReorgMeta.GetConcurrencyOrDefault(int(variable.GetDDLReorgWorkerCounter()))
 				if currentWorkerCnt != targetWorkerCnt {

--- a/tests/realtikvtest/addindextest4/integration_test.go
+++ b/tests/realtikvtest/addindextest4/integration_test.go
@@ -146,7 +146,6 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 			}
 
 			ch := make(chan struct{})
-			// Wait for a running worker so ADMIN ALTER exercises dynamic adjustment. See issue #70138.
 			workerStarted := make(chan struct{}, 1)
 			testfailpoint.EnableCall(t, tc.stuckFp, func() {
 				select {
@@ -159,6 +158,7 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 			wg.Run(func() {
 				tk1.MustExec(tc.sql)
 			})
+			// Wait for workers to start first, then adjust parameters and check.
 			<-workerStarted
 			var (
 				realWorkerCnt     atomic.Int64

--- a/tests/realtikvtest/addindextest4/integration_test.go
+++ b/tests/realtikvtest/addindextest4/integration_test.go
@@ -146,12 +146,6 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 			}
 
 			ch := make(chan struct{})
-			released := false
-			defer func() {
-				if !released {
-					close(ch)
-				}
-			}()
 			// Wait for a running worker so ADMIN ALTER exercises dynamic adjustment. See issue #70138.
 			workerStarted := make(chan struct{}, 1)
 			testfailpoint.EnableCall(t, tc.stuckFp, func() {
@@ -196,7 +190,6 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 				return realWorkerCnt.Load() == workerCnt && realBatchSize.Load() == batchSize && realMaxWriteSpeed.Load() == maxWriteSpeed
 			}, 30*time.Second, time.Millisecond*100)
 			close(ch)
-			released = true
 			wg.Wait()
 			if tc.revertVars != "" {
 				tk1.MustExec(tc.revertVars)

--- a/tests/realtikvtest/addindextest4/integration_test.go
+++ b/tests/realtikvtest/addindextest4/integration_test.go
@@ -146,13 +146,26 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 			}
 
 			ch := make(chan struct{})
+			released := false
+			defer func() {
+				if !released {
+					close(ch)
+				}
+			}()
+			// Wait for a running worker so ADMIN ALTER exercises dynamic adjustment. See issue #70138.
+			workerStarted := make(chan struct{}, 1)
 			testfailpoint.EnableCall(t, tc.stuckFp, func() {
+				select {
+				case workerStarted <- struct{}{}:
+				default:
+				}
 				<-ch
 			})
 			var wg util.WaitGroupWrapper
 			wg.Run(func() {
 				tk1.MustExec(tc.sql)
 			})
+			<-workerStarted
 			var (
 				realWorkerCnt     atomic.Int64
 				realBatchSize     atomic.Int64
@@ -183,6 +196,7 @@ func TestFixAdminAlterDDLJobs(t *testing.T) {
 				return realWorkerCnt.Load() == workerCnt && realBatchSize.Load() == batchSize && realMaxWriteSpeed.Load() == maxWriteSpeed
 			}, 30*time.Second, time.Millisecond*100)
 			close(ch)
+			released = true
 			wg.Wait()
 			if tc.revertVars != "" {
 				tk1.MustExec(tc.revertVars)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70138

Problem Summary:

**Caused by incorrect cherry-pick, master doesn't have this problem.**

On release-8.5, `ADMIN ALTER DDL JOBS ... THREAD/BATCH_SIZE` updates the persisted job configuration but does not affect an already-running transaction-mode backfill.

### What changed and how does it work?

Refresh the reorganization configuration from `mysql.tidb_ddl_job` on every transaction-mode worker-adjustment tick before comparing and resizing the worker pool.

The existing RealTiKV regression test now waits until the worker is running before issuing `ADMIN ALTER DDL JOBS`, ensuring it verifies dynamic adjustment instead of only job-start configuration.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
  - `go test -v -timeout 60s -run 'TestFixAdminAlterDDLJobs/github.com/pingcap/tidb/pkg/ddl/(mockUpdateColumnWorkerStuck|mockAddIndexTxnWorkerStuck)' -count=1 -tags=intest,deadlock ./tests/realtikvtest/addindextest4/... -args -with-real-tikv -tikv-path 'tikv://127.0.0.1:12379?disableGC=true'`
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `ADMIN ALTER DDL JOBS` could not dynamically adjust the thread or batch size of a running transaction-mode backfill.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic DDL adjustments so the latest worker configuration is applied reliably during ongoing operations.

* **Tests**
  * Strengthened integration coverage to verify worker-count changes while DDL operations are active and ensure completion checks remain reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->