### PR TITLE
br: support legacy log restore blocklist files

### DIFF
--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//pkg/util",
         "//pkg/util/codec",
         "@com_github_coreos_go_semver//semver",
+        "@com_github_gogo_protobuf//proto",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",

--- a/br/pkg/restore/misc.go
+++ b/br/pkg/restore/misc.go
@@ -64,7 +64,7 @@ type LogRestoreTableIDsBlocklistFile struct {
 	// RestoreCommitTs records the timestamp after PITR restore done. Only the later PITR restore from the log backup of the cluster,
 	// whose BackupTS is not less than it, can ignore the restore table IDs blocklist recorded in the file.
 	RestoreCommitTs uint64 `protobuf:"varint,1,opt,name=restore_commit_ts,proto3"`
-	// SnapshotBackupTs is kept for decoding legacy blocklist files only.
+	// Deprecated: SnapshotBackupTs is kept for decoding legacy blocklist files only.
 	// New blocklist files must leave it as zero and use RestoreStartTs.
 	SnapshotBackupTs uint64 `protobuf:"varint,2,opt,name=snapshot_backup_ts,proto3"`
 	// RestoreStartTs records the restore start timestamp. PITR operations restoring to an earlier time can ignore this blocklist.

--- a/br/pkg/restore/misc.go
+++ b/br/pkg/restore/misc.go
@@ -64,6 +64,9 @@ type LogRestoreTableIDsBlocklistFile struct {
 	// RestoreCommitTs records the timestamp after PITR restore done. Only the later PITR restore from the log backup of the cluster,
 	// whose BackupTS is not less than it, can ignore the restore table IDs blocklist recorded in the file.
 	RestoreCommitTs uint64 `protobuf:"varint,1,opt,name=restore_commit_ts,proto3"`
+	// SnapshotBackupTs is kept for decoding legacy blocklist files only.
+	// New blocklist files must leave it as zero and use RestoreStartTs.
+	SnapshotBackupTs uint64 `protobuf:"varint,2,opt,name=snapshot_backup_ts,proto3"`
 	// RestoreStartTs records the restore start timestamp. PITR operations restoring to an earlier time can ignore this blocklist.
 	RestoreStartTs uint64 `protobuf:"varint,7,opt,name=restore_start_ts,proto3"`
 	// RewriteTs records the rewritten timestamp of the meta kvs in this PITR restore.
@@ -79,6 +82,18 @@ type LogRestoreTableIDsBlocklistFile struct {
 func (m *LogRestoreTableIDsBlocklistFile) Reset()         { *m = LogRestoreTableIDsBlocklistFile{} }
 func (m *LogRestoreTableIDsBlocklistFile) String() string { return proto.CompactTextString(m) }
 func (m *LogRestoreTableIDsBlocklistFile) ProtoMessage()  {}
+
+type logRestoreTableIDsBlocklistFileFormat uint8
+
+const (
+	logRestoreTableIDsBlocklistFileFormatCurrent logRestoreTableIDsBlocklistFileFormat = iota
+	logRestoreTableIDsBlocklistFileFormatLegacy
+)
+
+type decodedLogRestoreTableIDsBlocklistFile struct {
+	file   *LogRestoreTableIDsBlocklistFile
+	format logRestoreTableIDsBlocklistFileFormat
+}
 
 func (m *LogRestoreTableIDsBlocklistFile) filename() string {
 	return fmt.Sprintf("%s/R%016X_S%016X.meta", logRestoreTableIDBlocklistFilePrefix, m.RestoreCommitTs, m.RestoreStartTs)
@@ -110,10 +125,10 @@ func parseLogRestoreTableIDsBlocklistFileName(filename string) (restoreCommitTs,
 	return restoreCommitTs, restoreStartTs, true
 }
 
-func (m *LogRestoreTableIDsBlocklistFile) checksumLogRestoreTableIDsBlocklistFile() []byte {
+func (m *LogRestoreTableIDsBlocklistFile) checksumWithRangeTs(rangeTs uint64) []byte {
 	hasher := sha256.New()
 	hasher.Write(binary.LittleEndian.AppendUint64(nil, m.RestoreCommitTs))
-	hasher.Write(binary.LittleEndian.AppendUint64(nil, m.RestoreStartTs))
+	hasher.Write(binary.LittleEndian.AppendUint64(nil, rangeTs))
 	hasher.Write(binary.LittleEndian.AppendUint64(nil, m.RewriteTs))
 	for _, tableId := range m.TableIds {
 		hasher.Write(binary.LittleEndian.AppendUint64(nil, uint64(tableId)))
@@ -125,7 +140,7 @@ func (m *LogRestoreTableIDsBlocklistFile) checksumLogRestoreTableIDsBlocklistFil
 }
 
 func (m *LogRestoreTableIDsBlocklistFile) setChecksumLogRestoreTableIDsBlocklistFile() {
-	m.Checksum = m.checksumLogRestoreTableIDsBlocklistFile()
+	m.Checksum = m.checksumWithRangeTs(m.RestoreStartTs)
 }
 
 // MarshalLogRestoreTableIDsBlocklistFile generates an Blocklist file and marshals it. It returns its filename and the marshaled data.
@@ -146,33 +161,80 @@ func MarshalLogRestoreTableIDsBlocklistFile(restoreCommitTs, restoreStartTs, rew
 	return filename, data, nil
 }
 
-// unmarshalLogRestoreTableIDsBlocklistFile unmarshals the given blocklist file.
-func unmarshalLogRestoreTableIDsBlocklistFile(data []byte) (*LogRestoreTableIDsBlocklistFile, error) {
+func checksumMismatchError(calculatedChecksum, recordedChecksum []byte) error {
+	return errors.Errorf(
+		"checksum mismatch (calculated checksum is %s but the recorded checksum is %s), the log restore table IDs blocklist file may be corrupted",
+		base64.StdEncoding.EncodeToString(calculatedChecksum),
+		base64.StdEncoding.EncodeToString(recordedChecksum),
+	)
+}
+
+func decodeLogRestoreTableIDsBlocklistFile(data []byte) (*decodedLogRestoreTableIDsBlocklistFile, error) {
 	blocklistFile := &LogRestoreTableIDsBlocklistFile{}
 	if err := proto.Unmarshal(data, blocklistFile); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if !bytes.Equal(blocklistFile.checksumLogRestoreTableIDsBlocklistFile(), blocklistFile.Checksum) {
-		return nil, errors.Errorf(
-			"checksum mismatch (calculated checksum is %s but the recorded checksum is %s), the log restore table IDs blocklist file may be corrupted",
-			base64.StdEncoding.EncodeToString(blocklistFile.checksumLogRestoreTableIDsBlocklistFile()),
-			base64.StdEncoding.EncodeToString(blocklistFile.Checksum),
+
+	switch {
+	case blocklistFile.SnapshotBackupTs != 0 && blocklistFile.RestoreStartTs != 0:
+		return nil, errors.New(
+			"ambiguous log restore table IDs blocklist file format: snapshot backup ts and restore start ts are both set",
 		)
+	case blocklistFile.SnapshotBackupTs != 0:
+		calculatedChecksum := blocklistFile.checksumWithRangeTs(blocklistFile.SnapshotBackupTs)
+		if !bytes.Equal(calculatedChecksum, blocklistFile.Checksum) {
+			return nil, checksumMismatchError(calculatedChecksum, blocklistFile.Checksum)
+		}
+		return &decodedLogRestoreTableIDsBlocklistFile{
+			file:   blocklistFile,
+			format: logRestoreTableIDsBlocklistFileFormatLegacy,
+		}, nil
+	default:
+		// A legacy SnapshotBackupTs is a non-zero TSO in practice. If it were zero,
+		// the wire data and checksum could not distinguish it from a current file
+		// whose RestoreStartTs is zero, so classify that theoretical case as current.
+		calculatedChecksum := blocklistFile.checksumWithRangeTs(blocklistFile.RestoreStartTs)
+		if !bytes.Equal(calculatedChecksum, blocklistFile.Checksum) {
+			return nil, checksumMismatchError(calculatedChecksum, blocklistFile.Checksum)
+		}
+		return &decodedLogRestoreTableIDsBlocklistFile{
+			file:   blocklistFile,
+			format: logRestoreTableIDsBlocklistFileFormatCurrent,
+		}, nil
 	}
-	return blocklistFile, nil
+}
+
+// unmarshalLogRestoreTableIDsBlocklistFile unmarshals the given blocklist file.
+func unmarshalLogRestoreTableIDsBlocklistFile(data []byte) (*LogRestoreTableIDsBlocklistFile, error) {
+	decoded, err := decodeLogRestoreTableIDsBlocklistFile(data)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return decoded.file, nil
+}
+
+func (d *decodedLogRestoreTableIDsBlocklistFile) filterOutForRepeatPITR(startTs, restoredTs uint64) bool {
+	if startTs >= d.file.RestoreCommitTs {
+		return true
+	}
+	if d.format == logRestoreTableIDsBlocklistFileFormatLegacy {
+		return restoredTs <= d.file.SnapshotBackupTs
+	}
+	return restoredTs < d.file.RestoreStartTs
 }
 
 func fastWalkLogRestoreTableIDsBlocklistFile(
 	ctx context.Context,
 	s storeapi.Storage,
-	filterOutFn func(restoreCommitTs, restoreStartTs uint64) bool,
-	executionFn func(ctx context.Context, filename string, restoreCommitTs, restoreStartTs, rewriteTs uint64, tableIds, dbIds []int64) error,
+	filenameFilterOutFn func(restoreCommitTs, rangeTs uint64) bool,
+	decodedFilterOutFn func(*decodedLogRestoreTableIDsBlocklistFile) bool,
+	executionFn func(context.Context, string, *decodedLogRestoreTableIDsBlocklistFile) error,
 ) error {
 	filenames := make([]string, 0)
 	if err := s.WalkDir(ctx, &storeapi.WalkOption{SubDir: logRestoreTableIDBlocklistFilePrefix}, func(path string, _ int64) error {
-		restoreCommitTs, restoreStartTs, parsed := parseLogRestoreTableIDsBlocklistFileName(path)
+		restoreCommitTs, rangeTs, parsed := parseLogRestoreTableIDsBlocklistFileName(path)
 		if parsed {
-			if filterOutFn(restoreCommitTs, restoreStartTs) {
+			if filenameFilterOutFn(restoreCommitTs, rangeTs) {
 				return nil
 			}
 		}
@@ -192,14 +254,22 @@ func fastWalkLogRestoreTableIDsBlocklistFile(
 			if err != nil {
 				return errors.Trace(err)
 			}
-			blocklistFile, err := unmarshalLogRestoreTableIDsBlocklistFile(data)
+			blocklistFile, err := decodeLogRestoreTableIDsBlocklistFile(data)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if filterOutFn(blocklistFile.RestoreCommitTs, blocklistFile.RestoreStartTs) {
+			if blocklistFile.format == logRestoreTableIDsBlocklistFileFormatLegacy {
+				log.Info(
+					"read legacy log restore table IDs blocklist file",
+					zap.String("filename", filename),
+					zap.Uint64("restore commit ts", blocklistFile.file.RestoreCommitTs),
+					zap.Uint64("snapshot backup ts", blocklistFile.file.SnapshotBackupTs),
+				)
+			}
+			if decodedFilterOutFn(blocklistFile) {
 				return nil
 			}
-			err = executionFn(ectx, filename, blocklistFile.RestoreCommitTs, blocklistFile.RestoreStartTs, blocklistFile.RewriteTs, blocklistFile.TableIds, blocklistFile.DbIds)
+			err = executionFn(ectx, filename, blocklistFile)
 			return errors.Trace(err)
 		})
 	}
@@ -218,37 +288,57 @@ func CheckTableTrackerContainsTableIDsFromBlocklistFiles(
 	checkDBIdlost func(dbId int64) bool,
 	cleanError func(rewriteTs uint64),
 ) error {
-	err := fastWalkLogRestoreTableIDsBlocklistFile(ctx, s, func(restoreCommitTs, restoreStartTs uint64) bool {
+	err := fastWalkLogRestoreTableIDsBlocklistFile(ctx, s, func(restoreCommitTs, rangeTs uint64) bool {
 		// Skip if this restore's commit time is after our start time
-		// or the restored time is before last restore start time.
-		return startTs >= restoreCommitTs || restoredTs < restoreStartTs
-	}, func(_ context.Context, _ string, restoreCommitTs, restoreStartTs, rewriteTs uint64, tableIds, dbIds []int64) error {
-		for _, tableId := range tableIds {
+		// or the restored time is before the range timestamp. Equality must be
+		// checked after decoding because legacy and current files differ there.
+		return startTs >= restoreCommitTs || restoredTs < rangeTs
+	}, func(blocklistFile *decodedLogRestoreTableIDsBlocklistFile) bool {
+		return blocklistFile.filterOutForRepeatPITR(startTs, restoredTs)
+	}, func(_ context.Context, _ string, blocklistFile *decodedLogRestoreTableIDsBlocklistFile) error {
+		file := blocklistFile.file
+		for _, tableId := range file.TableIds {
 			if tracker.ContainsTableId(tableId) || tracker.ContainsPartitionId(tableId) {
+				if blocklistFile.format == logRestoreTableIDsBlocklistFileFormatLegacy {
+					return errors.Errorf(
+						"cannot restore the table(Id=%d, name=%s at %d) because it is included in a legacy log restore blocklist "+
+							"(restore committed at %d from snapshot backup at %d). Please respecify the filter that does not contain "+
+							"the table, use a newer snapshot backup(BackupTS >= %d), or use an older restored ts(RestoreTS <= %d).",
+						tableId, tableNameByTableId(tableId), restoredTs, file.RestoreCommitTs, file.SnapshotBackupTs,
+						file.RestoreCommitTs, file.SnapshotBackupTs)
+				}
 				return errors.Errorf(
 					"cannot restore the table(Id=%d, name=%s at %d) because it is log restored(at %d) after snapshot backup(at %d). "+
 						"Please respecify the filter that does not contain the table or replace with a newer snapshot backup(BackupTS > %d) "+
 						"or older restored ts(RestoreTS < %d).",
-					tableId, tableNameByTableId(tableId), restoredTs, restoreCommitTs, startTs, restoreCommitTs, restoreStartTs)
+					tableId, tableNameByTableId(tableId), restoredTs, file.RestoreCommitTs, startTs, file.RestoreCommitTs, file.RestoreStartTs)
 			}
 			// the meta kv may not be backed by log restore
 			if checkTableIdLost(tableId) {
 				log.Warn("the table is lost in the log backup storage, so that it can not be restored.", zap.Int64("table id", tableId))
 			}
 		}
-		for _, dbId := range dbIds {
+		for _, dbId := range file.DbIds {
 			if tracker.ContainsDB(dbId) {
+				if blocklistFile.format == logRestoreTableIDsBlocklistFileFormatLegacy {
+					return errors.Errorf(
+						"cannot restore the database(Id=%d, name %s at %d) because it is included in a legacy log restore blocklist "+
+							"(restore committed at %d from snapshot backup at %d). Please respecify the filter that does not contain "+
+							"the database, use a newer snapshot backup(BackupTS >= %d), or use an older restored ts(RestoreTS <= %d).",
+						dbId, dbNameByDbId(dbId), restoredTs, file.RestoreCommitTs, file.SnapshotBackupTs,
+						file.RestoreCommitTs, file.SnapshotBackupTs)
+				}
 				return errors.Errorf(
 					"cannot restore the database(Id=%d, name %s at %d) because it is log restored(at %d) before snapshot backup(at %d). "+
 						"Please respecify the filter that does not contain the database or replace with a newer snapshot backup.",
-					dbId, dbNameByDbId(dbId), restoredTs, restoreCommitTs, startTs)
+					dbId, dbNameByDbId(dbId), restoredTs, file.RestoreCommitTs, startTs)
 			}
 			// the meta kv may not be backed by log restore
 			if checkDBIdlost(dbId) {
 				log.Warn("the database is lost in the log backup storage, so that it can not be restored.", zap.Int64("database id", dbId))
 			}
 		}
-		cleanError(rewriteTs)
+		cleanError(file.RewriteTs)
 		return nil
 	})
 	return errors.Trace(err)
@@ -260,9 +350,11 @@ func TruncateLogRestoreTableIDsBlocklistFiles(
 	s storeapi.Storage,
 	untilTs uint64,
 ) error {
-	err := fastWalkLogRestoreTableIDsBlocklistFile(ctx, s, func(restoreCommitTs, restoreTargetTs uint64) bool {
+	err := fastWalkLogRestoreTableIDsBlocklistFile(ctx, s, func(restoreCommitTs, _ uint64) bool {
 		return untilTs < restoreCommitTs
-	}, func(ctx context.Context, filename string, _, _, _ uint64, _, _ []int64) error {
+	}, func(blocklistFile *decodedLogRestoreTableIDsBlocklistFile) bool {
+		return untilTs < blocklistFile.file.RestoreCommitTs
+	}, func(ctx context.Context, filename string, _ *decodedLogRestoreTableIDsBlocklistFile) error {
 		return s.DeleteFile(ctx, filename)
 	})
 	return errors.Trace(err)

--- a/br/pkg/restore/misc_test.go
+++ b/br/pkg/restore/misc_test.go
@@ -17,6 +17,8 @@ package restore_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -24,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/failpoint"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
@@ -42,6 +45,101 @@ import (
 	tikvclient "github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/pd/client/opt"
 )
+
+const (
+	blocklistFixtureRestoreCommitTs = 100
+	blocklistFixtureRangeTs         = 50
+	blocklistFixtureRewriteTs       = 30
+)
+
+// blocklistWireFixture is a test-only wire schema. Keep its protobuf field
+// numbers independent from restore.LogRestoreTableIDsBlocklistFile so that the
+// compatibility tests fail if the production schema accidentally changes.
+type blocklistWireFixture struct {
+	RestoreCommitTs  uint64  `protobuf:"varint,1,opt,name=restore_commit_ts,proto3"`
+	SnapshotBackupTs uint64  `protobuf:"varint,2,opt,name=snapshot_backup_ts,proto3"`
+	TableIds         []int64 `protobuf:"varint,3,rep,packed,name=table_ids,proto3"`
+	Checksum         []byte  `protobuf:"bytes,4,opt,name=checksum,proto3"`
+	DbIds            []int64 `protobuf:"varint,5,rep,packed,name=db_ids,proto3"`
+	RewriteTs        uint64  `protobuf:"varint,6,opt,name=rewrite_ts,proto3"`
+	RestoreStartTs   uint64  `protobuf:"varint,7,opt,name=restore_start_ts,proto3"`
+}
+
+func (m *blocklistWireFixture) Reset()         { *m = blocklistWireFixture{} }
+func (m *blocklistWireFixture) String() string { return proto.CompactTextString(m) }
+func (*blocklistWireFixture) ProtoMessage()    {}
+
+func blocklistFixtureChecksum(
+	restoreCommitTs, rangeTs, rewriteTs uint64,
+	tableIds, dbIds []int64,
+) []byte {
+	hasher := sha256.New()
+	hasher.Write(binary.LittleEndian.AppendUint64(nil, restoreCommitTs))
+	hasher.Write(binary.LittleEndian.AppendUint64(nil, rangeTs))
+	hasher.Write(binary.LittleEndian.AppendUint64(nil, rewriteTs))
+	for _, tableId := range tableIds {
+		hasher.Write(binary.LittleEndian.AppendUint64(nil, uint64(tableId)))
+	}
+	for _, dbId := range dbIds {
+		hasher.Write(binary.LittleEndian.AppendUint64(nil, uint64(dbId)))
+	}
+	return hasher.Sum(nil)
+}
+
+func marshalBlocklistFixture(t *testing.T, legacy bool) (string, []byte) {
+	t.Helper()
+	tableIds := []int64{1, 2, 3}
+	dbIds := []int64{10}
+	fixture := &blocklistWireFixture{
+		RestoreCommitTs: blocklistFixtureRestoreCommitTs,
+		RewriteTs:       blocklistFixtureRewriteTs,
+		TableIds:        tableIds,
+		DbIds:           dbIds,
+	}
+	if legacy {
+		// This is the schema written before #64465: SnapshotBackupTs is field 2.
+		fixture.SnapshotBackupTs = blocklistFixtureRangeTs
+	} else {
+		// This is the current schema: RestoreStartTs is field 7.
+		fixture.RestoreStartTs = blocklistFixtureRangeTs
+	}
+	fixture.Checksum = blocklistFixtureChecksum(
+		fixture.RestoreCommitTs,
+		blocklistFixtureRangeTs,
+		fixture.RewriteTs,
+		fixture.TableIds,
+		fixture.DbIds,
+	)
+	data, err := proto.Marshal(fixture)
+	require.NoError(t, err)
+	filename := fmt.Sprintf(
+		"v1/log_restore_tables_blocklists/R%016X_S%016X.meta",
+		fixture.RestoreCommitTs,
+		blocklistFixtureRangeTs,
+	)
+	return filename, data
+}
+
+// legacyBlocklistFixture reproduces the blocklist writer at
+// 28f2f4b1bc6989bfc0212806fbbaa46b15b8a24e (the parent of #64465).
+func legacyBlocklistFixture(t *testing.T) (string, []byte) {
+	t.Helper()
+	return marshalBlocklistFixture(t, true)
+}
+
+// currentBlocklistFixture reproduces the blocklist writer at
+// cee586b7ac0577904c8073019644b8f8207a2d59 (the pre-fix master baseline).
+func currentBlocklistFixture(t *testing.T) (string, []byte) {
+	t.Helper()
+	return marshalBlocklistFixture(t, false)
+}
+
+func marshalBlocklistForTest(t *testing.T, blocklist *restore.LogRestoreTableIDsBlocklistFile) []byte {
+	t.Helper()
+	data, err := proto.Marshal(blocklist)
+	require.NoError(t, err)
+	return data
+}
 
 func TestTransferBoolToValue(t *testing.T) {
 	require.Equal(t, "ON", restore.TransferBoolToValue(true))
@@ -168,6 +266,9 @@ func TestLogRestoreTableIDsBlocklistFile(t *testing.T) {
 	base := t.TempDir()
 	stg, err := objstore.NewLocalStorage(base)
 	require.NoError(t, err)
+	legacyFixtureName, legacyFixtureData := legacyBlocklistFixture(t)
+	currentFixtureName, currentFixtureData := currentBlocklistFixture(t)
+	require.Equal(t, legacyFixtureName, currentFixtureName)
 	name, data, err := restore.MarshalLogRestoreTableIDsBlocklistFile(0xFFFFFCDEFFFFF, 0xFFFFFFABCFFFF, 0xFFFFFCCCFFFFF, []int64{1, 2, 3}, []int64{4})
 	require.NoError(t, err)
 	restoreCommitTs, restoreStartTs, parsed := restore.ParseLogRestoreTableIDsBlocklistFileName(name)
@@ -185,6 +286,94 @@ func TestLogRestoreTableIDsBlocklistFile(t *testing.T) {
 	require.Equal(t, uint64(0xFFFFFCCCFFFFF), blocklist.RewriteTs)
 	require.Equal(t, []int64{1, 2, 3}, blocklist.TableIds)
 	require.Equal(t, []int64{4}, blocklist.DbIds)
+
+	t.Run("current writer remains byte compatible", func(t *testing.T) {
+		name, data, err := restore.MarshalLogRestoreTableIDsBlocklistFile(
+			100, 50, 30, []int64{1, 2, 3}, []int64{10},
+		)
+		require.NoError(t, err)
+		require.Equal(t, currentFixtureName, name)
+		require.Equal(t, currentFixtureData, data)
+
+		blocklist, err := restore.UnmarshalLogRestoreTableIDsBlocklistFile(currentFixtureData)
+		require.NoError(t, err)
+		require.Zero(t, blocklist.SnapshotBackupTs)
+		require.Equal(t, uint64(50), blocklist.RestoreStartTs)
+	})
+
+	t.Run("legacy fixture", func(t *testing.T) {
+		blocklist, err := restore.UnmarshalLogRestoreTableIDsBlocklistFile(legacyFixtureData)
+		require.NoError(t, err)
+		require.Equal(t, uint64(100), blocklist.RestoreCommitTs)
+		require.Equal(t, uint64(50), blocklist.SnapshotBackupTs)
+		require.Zero(t, blocklist.RestoreStartTs)
+		require.Equal(t, uint64(30), blocklist.RewriteTs)
+		require.Equal(t, []int64{1, 2, 3}, blocklist.TableIds)
+		require.Equal(t, []int64{10}, blocklist.DbIds)
+	})
+
+	t.Run("wire-valid payload corruption", func(t *testing.T) {
+		fixtures := map[string][]byte{
+			"legacy":  legacyFixtureData,
+			"current": currentFixtureData,
+		}
+		for name, fixture := range fixtures {
+			t.Run(name, func(t *testing.T) {
+				blocklist := &restore.LogRestoreTableIDsBlocklistFile{}
+				require.NoError(t, proto.Unmarshal(fixture, blocklist))
+				blocklist.RewriteTs++
+				corruptedData := marshalBlocklistForTest(t, blocklist)
+
+				wireDecoded := &restore.LogRestoreTableIDsBlocklistFile{}
+				require.NoError(t, proto.Unmarshal(corruptedData, wireDecoded))
+				_, err := restore.UnmarshalLogRestoreTableIDsBlocklistFile(corruptedData)
+				require.ErrorContains(t, err, "checksum mismatch")
+			})
+		}
+	})
+
+	t.Run("wire-valid recorded checksum corruption", func(t *testing.T) {
+		blocklist := &restore.LogRestoreTableIDsBlocklistFile{}
+		require.NoError(t, proto.Unmarshal(legacyFixtureData, blocklist))
+		blocklist.Checksum[0] ^= 0xff
+		corruptedData := marshalBlocklistForTest(t, blocklist)
+
+		wireDecoded := &restore.LogRestoreTableIDsBlocklistFile{}
+		require.NoError(t, proto.Unmarshal(corruptedData, wireDecoded))
+		_, err := restore.UnmarshalLogRestoreTableIDsBlocklistFile(corruptedData)
+		require.ErrorContains(t, err, "checksum mismatch")
+	})
+
+	t.Run("both range fields are ambiguous", func(t *testing.T) {
+		testCases := map[string]struct {
+			fixture []byte
+			mutate  func(*restore.LogRestoreTableIDsBlocklistFile)
+		}{
+			"legacy checksum matches": {
+				fixture: legacyFixtureData,
+				mutate: func(blocklist *restore.LogRestoreTableIDsBlocklistFile) {
+					blocklist.RestoreStartTs = blocklist.SnapshotBackupTs + 1
+				},
+			},
+			"current checksum matches": {
+				fixture: currentFixtureData,
+				mutate: func(blocklist *restore.LogRestoreTableIDsBlocklistFile) {
+					blocklist.SnapshotBackupTs = blocklist.RestoreStartTs + 1
+				},
+			},
+		}
+		for name, testCase := range testCases {
+			t.Run(name, func(t *testing.T) {
+				blocklist := &restore.LogRestoreTableIDsBlocklistFile{}
+				require.NoError(t, proto.Unmarshal(testCase.fixture, blocklist))
+				testCase.mutate(blocklist)
+				_, err := restore.UnmarshalLogRestoreTableIDsBlocklistFile(
+					marshalBlocklistForTest(t, blocklist),
+				)
+				require.ErrorContains(t, err, "ambiguous")
+			})
+		}
+	})
 }
 
 func writeBlocklistFile(
@@ -195,6 +384,27 @@ func writeBlocklistFile(
 	require.NoError(t, err)
 	err = s.WriteFile(ctx, name, data)
 	require.NoError(t, err)
+}
+
+func writeRawBlocklistFile(ctx context.Context, t *testing.T, s storeapi.Storage, filename string, data []byte) {
+	t.Helper()
+	require.NoError(t, s.WriteFile(ctx, filename, data))
+}
+
+func blocklistFileNames(ctx context.Context, t *testing.T, s storeapi.Storage) []string {
+	t.Helper()
+	filenames := make([]string, 0)
+	err := s.WalkDir(
+		ctx,
+		&storeapi.WalkOption{SubDir: restore.LogRestoreTableIDBlocklistFilePrefix},
+		func(path string, _ int64) error {
+			filenames = append(filenames, path)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	slices.Sort(filenames)
+	return filenames
 }
 
 func fakeTrackerID(tableIds []int64) *utils.PiTRIdTracker {
@@ -254,37 +464,108 @@ func TestCheckTableTrackerContainsTableIDsFromBlocklistFiles(t *testing.T) {
 	err = restore.CheckTableTrackerContainsTableIDsFromBlocklistFiles(ctx, stg, fakeTrackerID([]int64{100, 101, 102}), 1, 25, tableNameByTableId, dbNameByDbId, checkTableIDLost, checkTableIDLost, cleanErr)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "table_100")
-}
 
-func filesCount(ctx context.Context, s storeapi.Storage) int {
-	count := 0
-	s.WalkDir(ctx, &storeapi.WalkOption{SubDir: restore.LogRestoreTableIDBlocklistFilePrefix}, func(path string, size int64) error {
-		count += 1
-		return nil
+	t.Run("mixed legacy and current files use their own boundary", func(t *testing.T) {
+		base := t.TempDir()
+		stg, err := objstore.NewLocalStorage(base)
+		require.NoError(t, err)
+		legacyFixtureName, legacyFixtureData := legacyBlocklistFixture(t)
+		writeRawBlocklistFile(
+			ctx,
+			t,
+			stg,
+			legacyFixtureName,
+			legacyFixtureData,
+		)
+		currentFilename, currentData, err := restore.MarshalLogRestoreTableIDsBlocklistFile(
+			200, 50, 60, []int64{4}, nil,
+		)
+		require.NoError(t, err)
+		writeRawBlocklistFile(ctx, t, stg, currentFilename, currentData)
+		require.Equal(t, []string{legacyFixtureName, currentFilename}, blocklistFileNames(ctx, t, stg))
+
+		err = restore.CheckTableTrackerContainsTableIDsFromBlocklistFiles(
+			ctx,
+			stg,
+			fakeTrackerID([]int64{1, 4}),
+			0,
+			50,
+			tableNameByTableId,
+			dbNameByDbId,
+			checkTableIDLost,
+			checkTableIDLost,
+			func(uint64) {},
+		)
+		require.ErrorContains(t, err, "table_4")
+		require.NotContains(t, err.Error(), "table_1")
 	})
-	return count
 }
 
 func TestTruncateLogRestoreTableIDsBlocklistFiles(t *testing.T) {
 	ctx := context.Background()
-	base := t.TempDir()
-	stg, err := objstore.NewLocalStorage(base)
-	require.NoError(t, err)
-	writeBlocklistFile(ctx, t, stg, 100, 10, 50, []int64{100, 101, 102}, []int64{103})
-	writeBlocklistFile(ctx, t, stg, 200, 20, 60, []int64{200, 201, 202}, []int64{203})
-	writeBlocklistFile(ctx, t, stg, 300, 30, 70, []int64{300, 301, 302}, []int64{303})
 
-	err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 50)
-	require.NoError(t, err)
-	require.Equal(t, 3, filesCount(ctx, stg))
+	t.Run("mixed legacy and current files", func(t *testing.T) {
+		base := t.TempDir()
+		stg, err := objstore.NewLocalStorage(base)
+		require.NoError(t, err)
+		legacyFixtureName, legacyFixtureData := legacyBlocklistFixture(t)
+		writeRawBlocklistFile(
+			ctx,
+			t,
+			stg,
+			legacyFixtureName,
+			legacyFixtureData,
+		)
+		current200, data200, err := restore.MarshalLogRestoreTableIDsBlocklistFile(
+			200, 20, 60, []int64{200, 201, 202}, []int64{203},
+		)
+		require.NoError(t, err)
+		writeRawBlocklistFile(ctx, t, stg, current200, data200)
+		current300, data300, err := restore.MarshalLogRestoreTableIDsBlocklistFile(
+			300, 30, 70, []int64{300, 301, 302}, []int64{303},
+		)
+		require.NoError(t, err)
+		writeRawBlocklistFile(ctx, t, stg, current300, data300)
+		allFiles := []string{legacyFixtureName, current200, current300}
+		slices.Sort(allFiles)
 
-	err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 250)
-	require.NoError(t, err)
-	require.Equal(t, 1, filesCount(ctx, stg))
+		err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 50)
+		require.NoError(t, err)
+		require.Equal(t, allFiles, blocklistFileNames(ctx, t, stg))
 
-	err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 350)
-	require.NoError(t, err)
-	require.Equal(t, 0, filesCount(ctx, stg))
+		err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 100)
+		require.NoError(t, err)
+		require.Equal(t, []string{current200, current300}, blocklistFileNames(ctx, t, stg))
+
+		err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 250)
+		require.NoError(t, err)
+		require.Equal(t, []string{current300}, blocklistFileNames(ctx, t, stg))
+
+		err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 350)
+		require.NoError(t, err)
+		require.Empty(t, blocklistFileNames(ctx, t, stg))
+	})
+
+	t.Run("corrupted legacy file remains a hard error", func(t *testing.T) {
+		base := t.TempDir()
+		stg, err := objstore.NewLocalStorage(base)
+		require.NoError(t, err)
+		legacyFixtureName, legacyFixtureData := legacyBlocklistFixture(t)
+		blocklist := &restore.LogRestoreTableIDsBlocklistFile{}
+		require.NoError(t, proto.Unmarshal(legacyFixtureData, blocklist))
+		blocklist.RewriteTs++
+		writeRawBlocklistFile(
+			ctx,
+			t,
+			stg,
+			legacyFixtureName,
+			marshalBlocklistForTest(t, blocklist),
+		)
+
+		err = restore.TruncateLogRestoreTableIDsBlocklistFiles(ctx, stg, 100)
+		require.ErrorContains(t, err, "checksum mismatch")
+		require.Equal(t, []string{legacyFixtureName}, blocklistFileNames(ctx, t, stg))
+	})
 }
 
 type fakeMetaClient struct {
@@ -574,6 +855,65 @@ func TestFilteringBoundaryConditions(t *testing.T) {
 		80, 49, // restoredTs == restoreStartTs - 1
 		tableNameByTableId, dbNameByDbId, checkIDLost, checkIDLost, cleanErr)
 	require.NoError(t, err, "should filter when restoredTs < restoreStartTs")
+
+	t.Run("legacy boundaries", func(t *testing.T) {
+		base := t.TempDir()
+		stg, err := objstore.NewLocalStorage(base)
+		require.NoError(t, err)
+		legacyFixtureName, legacyFixtureData := legacyBlocklistFixture(t)
+		writeRawBlocklistFile(
+			ctx,
+			t,
+			stg,
+			legacyFixtureName,
+			legacyFixtureData,
+		)
+		check := func(startTs, restoredTs uint64) error {
+			return restore.CheckTableTrackerContainsTableIDsFromBlocklistFiles(
+				ctx,
+				stg,
+				fakeTrackerID([]int64{1}),
+				startTs,
+				restoredTs,
+				tableNameByTableId,
+				dbNameByDbId,
+				checkIDLost,
+				checkIDLost,
+				cleanErr,
+			)
+		}
+
+		require.NoError(t, check(100, 51), "should filter legacy file when startTs == restoreCommitTs")
+		require.NoError(t, check(80, 49), "should filter legacy file when restoredTs < SnapshotBackupTs")
+		require.NoError(t, check(80, 50), "should filter legacy file when restoredTs == SnapshotBackupTs")
+		err = check(80, 51)
+		require.ErrorContains(t, err, "table_1")
+		require.ErrorContains(t, err, "legacy log restore blocklist")
+		require.ErrorContains(t, err, "snapshot backup at 50")
+		require.ErrorContains(t, err, "BackupTS >= 100")
+	})
+
+	t.Run("zero restore start ts remains current", func(t *testing.T) {
+		base := t.TempDir()
+		stg, err := objstore.NewLocalStorage(base)
+		require.NoError(t, err)
+		writeBlocklistFile(ctx, t, stg, 100, 0, 30, []int64{1}, nil)
+
+		err = restore.CheckTableTrackerContainsTableIDsFromBlocklistFiles(
+			ctx,
+			stg,
+			fakeTrackerID([]int64{1}),
+			80,
+			0,
+			tableNameByTableId,
+			dbNameByDbId,
+			checkIDLost,
+			checkIDLost,
+			cleanErr,
+		)
+		require.ErrorContains(t, err, "table_1")
+		require.NotContains(t, err.Error(), "legacy")
+	})
 }
 
 func TestBlocklistWithEmptyArrays(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70137

Problem Summary:

Blocklist files written before #64465 store `SnapshotBackupTs` in protobuf field 2 and include that value in the checksum. After #64465, the reader only recognized `RestoreStartTs` in field 7, so it decoded the legacy range timestamp as zero and rejected valid legacy files with a checksum mismatch. This broke repeat PITR checks and `br log truncate` after upgrading BR.

### What changed and how does it work?

- Restore protobuf field 2 as a decode-only `SnapshotBackupTs`; new files continue to write only field 7.
- Detect legacy and current files before checksum validation and validate each format with its own range timestamp.
- Preserve the legacy `restoredTs <= SnapshotBackupTs` boundary while keeping the current `restoredTs < RestoreStartTs` behavior.
- Reject files that set both range fields as ambiguous, and keep checksum failures as hard errors, including in `br log truncate`.
- Add independently generated legacy/current wire fixtures and regression coverage for repeat PITR, truncate, boundary conditions, corruption, and ambiguous payloads.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Unit test:

```shell
./tools/check/failpoint-go-test.sh br/pkg/restore \
  -run '^(TestLogRestoreTableIDsBlocklistFile|TestCheckTableTrackerContainsTableIDsFromBlocklistFiles|TestTruncateLogRestoreTableIDsBlocklistFiles|TestFilteringBoundaryConditions)$' \
  -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where blocklist files written by older BR versions could not be read after upgrading, which broke repeat point-in-time recovery and `br log truncate`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for restoring both legacy and current blocklist file formats.
  * Improved validation of ambiguous, corrupted, and mixed-format blocklist files.
  * Added clearer errors for repeated point-in-time recovery attempts and checksum failures.
  * Improved blocklist filtering, processing, and truncation behavior.

* **Tests**
  * Added comprehensive coverage for legacy compatibility, corruption handling, boundary conditions, checksum validation, and mixed-format processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->