### PR TITLE
dxf, importinto: stabilize flaky scheduler and global sort tests

### DIFF
--- a/pkg/dxf/framework/scheduler/scheduler_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_test.go
@@ -116,6 +116,7 @@ func deleteTasks(t *testing.T, store kv.Storage, taskID int64) {
 }
 
 func TestTaskFailInManager(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
 	store := testkit.CreateMockStore(t)
 	gtk := testkit.NewTestKit(t, store)
 	pool := pools.NewResourcePool(func() (pools.Resource, error) {
@@ -128,6 +129,7 @@ func TestTaskFailInManager(t *testing.T) {
 	ctx = util.WithInternalSourceType(ctx, "handle_test")
 
 	schManager, mgr := MockSchedulerManager(store, pool, scheduler.GetTestSchedulerExt(ctrl), nil)
+	require.NoError(t, mgr.InitMeta(ctx, ":4000", handle.GetTargetScope()))
 	scheduler.RegisterSchedulerFactory(proto.TaskTypeExample,
 		func(ctx context.Context, task *proto.Task, param scheduler.Param) scheduler.Scheduler {
 			mockScheduler := mock.NewMockScheduler(ctrl)

--- a/tests/realtikvtest/importintotest4/global_sort_test.go
+++ b/tests/realtikvtest/importintotest4/global_sort_test.go
@@ -323,6 +323,8 @@ func (s *mockGCSSuite) TestGlobalSortRecordedStepSummary() {
 		s.NoError(err)
 		return task.State == proto.TaskStateSucceed
 	}, 30*time.Second, 300*time.Millisecond)
+	var taskMeta importinto.TaskMeta
+	s.NoError(json.Unmarshal(task.Meta, &taskMeta))
 
 	s.tk.MustQuery("select * from t").Sort().Check(testkit.Rows(allData...))
 
@@ -341,13 +343,18 @@ func (s *mockGCSSuite) TestGlobalSortRecordedStepSummary() {
 	s.EqualValues(12, sum.PutReqCnt.Load())
 
 	sum = s.getStepSummary(ctx, taskManager, task.ID, proto.ImportStepWriteAndIngest)
-	s.EqualValues(sum.RowCnt.Load(), 10000)
+	logicalIngestSummary := taskMeta.Summary.IngestSummary
+	s.EqualValues(10000, logicalIngestSummary.RowCnt)
 	if kerneltype.IsClassic() {
-		s.EqualValues(sum.Processed.Load(), 2622604)
+		s.EqualValues(2622604, logicalIngestSummary.Bytes)
 	} else {
 		// There are total 10000 * 4 kv pairs, each with 4 bytes keyspace prefix.
-		s.EqualValues(sum.Processed.Load(), 2782604)
+		s.EqualValues(2782604, logicalIngestSummary.Bytes)
 	}
+	// Runtime write progress is retry-inclusive. An ingest retry can move a region
+	// job back to regionScanned and rewrite its KVs; the data KV group also recounts rows.
+	s.GreaterOrEqual(sum.RowCnt.Load(), logicalIngestSummary.RowCnt)
+	s.GreaterOrEqual(sum.Processed.Load(), logicalIngestSummary.Bytes)
 	s.EqualValues(20, sum.GetReqCnt.Load())
 	// No conflicts in this case, no need to rewrite the external subtask meta.
 	s.EqualValues(0, sum.PutReqCnt.Load())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69623, close #69622, close #70006

Problem Summary:

`TestImportInto/TestGlobalSortRecordedStepSummary` assumes that the runtime
WriteAndIngest progress counters equal the logical imported data size. Those
counters are retry-inclusive: after a retry moves a region job back to
`regionScanned`, writing the same KV group increments them again.

The pre-fix failure reported by issue #69623 from
[NextGen Jenkins job 5377](https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_integration_realcluster_test_next_gen/5377/)
recorded 3,480,594 runtime bytes for a 2,782,604-byte logical import:

```text
3,480,594 = 2,782,604 + 697,990
```

The 697,990-byte excess is exactly one rewritten index KV group. The table
contents, checksum, and logical import result were still correct.

Separately, `TestTaskFailInManager` creates an explicit scheduler manager on a
normal testkit Domain. The Domain's scheduler manager can immediately transfer
the failed tasks to history before the test's active-only `GetTaskByID` polling
observes them, causing `task not found` followed by `Condition never satisfied`.

### What changed and how does it work?

The global sort test now reads the completed task's independent logical
`IngestSummary` and continues to assert exact logical results:

- exactly 10,000 imported rows;
- exactly 2,622,604 bytes in Classic mode or 2,782,604 bytes in NextGen mode;
- unchanged exact table-data and object-store request-count checks.

Only the retry-inclusive runtime `RowCnt` and `Processed` counters use
lower-bound assertions against that logical summary.

This deliberately differs from closed PR #69634. That PR relaxed the processed
byte assertion directly and was closed because it could mask an incorrect
logical result. This change preserves exact assertions on an independent,
deterministic logical summary and relaxes only the counters whose implementation
explicitly counts rewritten KVs.

The scheduler test now disables the Domain's distributed-task framework before
creating the mock store, so only the explicit scheduler manager can operate on
the test tasks. It also initializes that manager's node metadata explicitly,
removing the setup dependency that the Domain previously satisfied implicitly.

Validation:

- Reproduced the scheduler failure before the fix:
  `./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run '^TestTaskFailInManager$' -count=20`
  failed with `task not found` at `scheduler_test.go:159`, followed by
  `Condition never satisfied` at line 157 (`97.762s`).
- Passed the scheduler regression test 20 consecutive times:
  `./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run '^TestTaskFailInManager$' -count=20`
  (`32.380s`).
- Passed the scheduler regression test in NextGen mode:
  `./tools/check/failpoint-go-test.sh pkg/dxf/framework/scheduler -run '^TestTaskFailInManager$' -count=1 -tags=intest,deadlock,nextgen`
  (`2.639s`).
- Passed Classic compile-only:
  `go test -run '^$' -tags=intest,deadlock ./tests/realtikvtest/importintotest4`
- Passed NextGen compile-only:
  `go test -run '^$' -tags=intest,deadlock,nextgen ./tests/realtikvtest/importintotest4`
- Passed targeted Classic RealTiKV:
  `go test -run '^TestImportInto/TestGlobalSortRecordedStepSummary$' -tags=intest,deadlock ./tests/realtikvtest/importintotest4/...`
  (`6.660s`). The isolated TiUP playground cleanup check also passed.
- Passed `make lint`.
- Passed `git diff --check` and focused diff review.
- `make bazel_prepare` was not required: there are no added, removed, renamed,
  or moved Go files; import changes; new top-level tests; dependency changes;
  Bazel changes; or module metadata changes.
- The targeted NextGen command
  `go test -count=1 -run '^TestImportInto/TestGlobalSortRecordedStepSummary$' -tags=intest,deadlock,nextgen ./tests/realtikvtest/importintotest4/...`
  did not pass against a nonstandard pre-existing local topology. It stalled in
  the first WriteAndIngest subtask before reaching the changed assertions and
  hit Go's default 10-minute timeout. Supported-topology NextGen CI is still
  required.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated ingest metrics validation to allow retry-inclusive runtime totals to exceed recorded values instead of requiring exact equality.
  * Improved coverage for task failure handling and scheduler startup scenarios.
  * Added validation that recorded ingest summaries accurately reflect task metadata and runtime metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
