### PR TITLE
planner, ddl: prevent partial indexes from implying global uniqueness

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4780,6 +4780,9 @@ func checkCreateGlobalIndex(ec errctx.Context, tblInfo *model.TableInfo, indexNa
 
 func (e *executor) CreatePrimaryKey(ctx sessionctx.Context, ti ast.Ident, indexName ast.CIStr,
 	indexPartSpecifications []*ast.IndexPartSpecification, indexOption *ast.IndexOption) error {
+	if indexOption != nil && indexOption.Condition != nil {
+		return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs("create an primary key with partial index is not supported")
+	}
 	if indexOption != nil && indexOption.PrimaryKeyTp == ast.PrimaryKeyTypeClustered {
 		return dbterror.ErrUnsupportedModifyPrimaryKey.GenWithStack("Adding clustered primary key is not supported. " +
 			"Please consider adding NONCLUSTERED primary key instead")

--- a/pkg/ddl/integration_test.go
+++ b/pkg/ddl/integration_test.go
@@ -106,6 +106,15 @@ func TestPartialIndex(t *testing.T) {
 		dbterror.ErrUnsupportedAddPartialIndex)
 	tk.MustExec("drop table t;")
 
+	// Test ALTER TABLE cannot silently discard a partial primary key condition.
+	tk.MustExec("create table t3 (a int not null);")
+	tk.MustGetDBError("alter table t3 add primary key(a) where a > 0;",
+		dbterror.ErrUnsupportedAddPartialIndex)
+
+	// A partial unique index is not an implicit primary key, even when every index column is NOT NULL.
+	tk.MustExec("create table t4 (a int not null, unique index uk(a) where a > 0);")
+	tk.MustExec("alter table t4 alter index uk invisible;")
+
 	checkColumnTypes := func(columnTypes []string, literals []string, shouldAllowed bool) {
 		for _, columnType := range columnTypes {
 			for _, literal := range literals {

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -1066,7 +1066,7 @@ func TableInfo2SchemaAndNames(ctx BuildContext, dbName ast.CIStr, tbl *model.Tab
 	}
 	keys := make([]KeyInfo, 0, len(tbl.Indices)+1)
 	for _, idx := range tbl.Indices {
-		if !idx.Unique || idx.State != model.StatePublic {
+		if !idx.Unique || idx.State != model.StatePublic || idx.HasCondition() {
 			continue
 		}
 		ok := true

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -296,6 +296,34 @@ func tableInfoToSchemaForTest(tableInfo *model.TableInfo) *Schema {
 	return schema
 }
 
+func TestTableInfo2SchemaAndNamesKeys(t *testing.T) {
+	ctx := createContext(t)
+	tblInfo := newTestTableBuilder("t").
+		add("partial_col", mysql.TypeLonglong, mysql.NotNullFlag).
+		add("regular_col", mysql.TypeLonglong, mysql.NotNullFlag).
+		build()
+	tblInfo.Indices = []*model.IndexInfo{
+		{
+			Name:                ast.NewCIStr("partial_unique"),
+			Columns:             []*model.IndexColumn{{Name: ast.NewCIStr("partial_col"), Offset: 0}},
+			State:               model.StatePublic,
+			Unique:              true,
+			ConditionExprString: "`partial_col` > 0",
+		},
+		{
+			Name:    ast.NewCIStr("regular_unique"),
+			Columns: []*model.IndexColumn{{Name: ast.NewCIStr("regular_col"), Offset: 1}},
+			State:   model.StatePublic,
+			Unique:  true,
+		},
+	}
+
+	schema, _, err := TableInfo2SchemaAndNames(ctx, ast.NewCIStr("test"), tblInfo)
+	require.NoError(t, err)
+	require.Len(t, schema.PKOrUK, 1)
+	require.Equal(t, tblInfo.Columns[1].ID, schema.PKOrUK[0][0].ID)
+}
+
 func TestEvalExpr(t *testing.T) {
 	ctx := createContext(t)
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -498,7 +498,7 @@ func (t *TableInfo) ClearPlacement() {
 // GetPrimaryKey extract the primary key in a table and return `IndexInfo`
 // The returned primary key could be explicit or implicit.
 // If there is no explicit primary key in table,
-// the first UNIQUE INDEX on NOT NULL columns will be the implicit primary key.
+// the first non-partial UNIQUE INDEX on NOT NULL columns will be the implicit primary key.
 // For more information about implicit primary key, see
 // https://dev.mysql.com/doc/refman/8.0/en/invisible-indexes.html
 func (t *TableInfo) GetPrimaryKey() *IndexInfo {
@@ -513,8 +513,8 @@ func (t *TableInfo) GetPrimaryKey() *IndexInfo {
 		if len(key.Columns) == 0 {
 			continue
 		}
-		// find the first unique key with NOT NULL columns
-		if implicitPK == nil && key.Unique {
+		// find the first non-partial unique key with NOT NULL columns
+		if implicitPK == nil && key.Unique && !key.HasCondition() {
 			// ensure all columns in unique key have NOT NULL flag
 			allColNotNull := true
 			skip := false

--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -394,6 +394,98 @@ func TestPartialIndexWithPlanCache(t *testing.T) {
 	})
 }
 
+func TestPartialUniqueIndexDoesNotImplyGlobalUniqueness(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, _, _ string) {
+		tk.MustExec("use test")
+		tk.MustExec(`create table partial_unique (
+			id bigint primary key,
+			domain varchar(253) not null,
+			deleted_at datetime null,
+			unique index uk_domain_active(domain) where deleted_at is null
+		)`)
+		tk.MustExec(`insert into partial_unique values
+			(1, 'example.com', null),
+			(2, 'example.com', '2026-01-01'),
+			(3, 'example.com', '2026-01-02'),
+			(4, 'example.com', '2026-01-03')`)
+
+		tk.MustQuery("select count(distinct domain) from partial_unique").Check(testkit.Rows("1"))
+		tk.MustQuery("explain format = 'plan_tree' select count(distinct domain) from partial_unique").
+			CheckContain("Agg")
+		tk.MustQuery("select distinct domain from partial_unique").Check(testkit.Rows("example.com"))
+		tk.MustQuery("explain format = 'plan_tree' select distinct domain from partial_unique").
+			CheckContain("Agg")
+		tk.MustQuery("select domain, count(*) from partial_unique group by domain").
+			Check(testkit.Rows("example.com 4"))
+		tk.MustQuery("explain format = 'plan_tree' select domain, count(*) from partial_unique group by domain").
+			CheckContain("Agg")
+
+		tk.MustExec("create table partial_outer (id bigint primary key, domain varchar(253) not null)")
+		tk.MustExec("insert into partial_outer values (1, 'example.com')")
+		tk.MustQuery(`select o.id
+			from partial_outer o
+			left join partial_unique i
+				on o.domain = i.domain and i.deleted_at is not null`).
+			Check(testkit.Rows("1", "1", "1"))
+		err := tk.QueryToErr(`select (
+				select i.id
+				from partial_unique i
+				where i.domain = o.domain and i.deleted_at is not null
+			)
+			from partial_outer o`)
+		require.EqualError(t, err, "[executor:1242]Subquery returns more than 1 row")
+		tk.MustQuery(`select o.id
+			from partial_outer o
+			left join partial_unique i on o.domain = i.domain
+			order by o.id
+			limit 2 offset 1`).
+			Check(testkit.Rows("1", "1"))
+
+		tk.MustExec("set @@session.sql_mode = 'ONLY_FULL_GROUP_BY'")
+		for _, enabled := range []string{"off", "on"} {
+			tk.MustExec("set @@session.tidb_enable_new_only_full_group_by_check = " + enabled)
+			tk.MustGetErrCode("select domain, id from partial_unique group by domain", 1055)
+		}
+
+		tk.MustQuery(`explain format = 'plan_tree'
+			select * from partial_unique use index(uk_domain_active)
+			where domain = 'example.com' and deleted_at is null`).
+			CheckContain("uk_domain_active")
+		tk.MustQuery(`select id from partial_unique use index(uk_domain_active)
+			where domain = 'example.com' and deleted_at is null`).
+			Check(testkit.Rows("1"))
+		tk.MustQuery(`explain format = 'plan_tree'
+			select * from partial_unique use index(uk_domain_active)
+			where domain = 'example.com'`).
+			CheckNotContain("uk_domain_active")
+		tk.MustQuery(`select id from partial_unique use index(uk_domain_active)
+			where domain = 'example.com' order by id`).
+			Check(testkit.Rows("1", "2", "3", "4"))
+
+		tk.MustExec(`create table partial_composite (
+			a int null,
+			b int not null,
+			c int,
+			unique index uk_ab_active(a, b) where c = 1
+		)`)
+		tk.MustExec("insert into partial_composite values (1, 1, 1), (1, 1, 2), (1, 1, 3), (null, 1, 1), (null, 1, 2)")
+		tk.MustQuery("select a, b, count(*) from partial_composite group by a, b order by a").
+			Check(testkit.Rows("<nil> 1 2", "1 1 3"))
+		tk.MustQuery("select a, b, count(*) from partial_composite where a is not null group by a, b").
+			Check(testkit.Rows("1 1 3"))
+
+		tk.MustExec("create table regular_keys (id int primary key, a int not null unique, payload int)")
+		tk.MustExec("insert into regular_keys values (1, 10, 100), (2, 20, 200)")
+		for _, enabled := range []string{"off", "on"} {
+			tk.MustExec("set @@session.tidb_enable_new_only_full_group_by_check = " + enabled)
+			tk.MustQuery("select a, payload from regular_keys group by a order by a").
+				Check(testkit.Rows("10 100", "20 200"))
+			tk.MustQuery("select id, payload from regular_keys group by id order by id").
+				Check(testkit.Rows("1 100", "2 200"))
+		}
+	})
+}
+
 func TestPartialIndexWithIndexPrune(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3579,7 +3579,7 @@ func checkColFuncDepend(
 	whereDependNames, joinDependNames map[*types.FieldName]*types.FieldName,
 ) bool {
 	for _, index := range tblInfo.Indices {
-		if !index.Unique {
+		if !index.Unique || index.HasCondition() {
 			continue
 		}
 		funcDepend := true

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -442,7 +442,7 @@ func (ds *DataSource) ExtractFD() *fd.FDSet {
 					continue
 				}
 			}
-			if idx.State != model.StatePublic {
+			if idx.State != model.StatePublic || idx.HasCondition() {
 				continue
 			}
 			for _, idxCol := range idx.Columns {

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -164,7 +164,9 @@ func CheckMaxOneRowCond(eqColIDs map[int64]struct{}, childSchema *expression.Sch
 
 // CheckIndexCanBeKey checks whether an Index can be a Key in schema.
 func CheckIndexCanBeKey(idx *model.IndexInfo, columns []*model.ColumnInfo, schema *expression.Schema) (uniqueKey, newKey expression.KeyInfo) {
-	if !idx.Unique {
+	// A partial unique index only guarantees uniqueness among the rows that satisfy its condition,
+	// so it cannot be used as an unconditional key of the relation.
+	if !idx.Unique || idx.HasCondition() {
 		return nil, nil
 	}
 	newKeyOK := true

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -278,7 +278,7 @@ func (*OuterJoinEliminator) isInnerJoinKeysContainIndex(innerPlan base.LogicalPl
 		return false, nil
 	}
 	for _, path := range ds.AllPossibleAccessPaths {
-		if path.IsIntHandlePath || !path.Index.Unique || len(path.IdxCols) == 0 {
+		if path.IsIntHandlePath || !path.Index.Unique || path.Index.HasCondition() || len(path.IdxCols) == 0 {
 			continue
 		}
 		joinKeysContainIndex := true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70261

Problem Summary:

`IndexInfo.Unique` on a partial index only guarantees uniqueness among index entries whose rows satisfy the index predicate. The planner nevertheless promoted that property to an unconditional relation key and functional dependency. This could incorrectly eliminate aggregation, DISTINCT, joins, or scalar-subquery cardinality checks and could also make `ONLY_FULL_GROUP_BY` accept invalid queries.

Two related metadata paths were inconsistent as well: `ALTER TABLE ... ADD PRIMARY KEY (...) WHERE ...` silently discarded the predicate, and a NOT NULL partial unique index could be selected as an implicit primary key.

### What changed and how does it work?

- Exclude partial unique indexes from unconditional schema keys and strict/lax functional dependencies.
- Exclude them from the legacy `ONLY_FULL_GROUP_BY` dependency check and the direct join-elimination index fallback.
- Keep `TableInfo2SchemaAndNames` from exposing a partial unique index as a relation key.
- Reject partial primary keys in `ALTER TABLE`, matching the existing `CREATE TABLE` behavior.
- Exclude partial unique indexes from implicit-primary-key selection.
- Preserve partial-index DML uniqueness and physical access paths whose predicates are proven by `CheckPartialIndexes`.
- Add regression coverage for aggregation and DISTINCT retention, join and scalar-subquery multiplicity, both `ONLY_FULL_GROUP_BY` implementations, predicate-implying access paths, nullable composite keys, ordinary unique/primary keys, and the DDL metadata gaps.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/index -run '^TestPartialUniqueIndexDoesNotImplyGlobalUniqueness$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestPartialIndex$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/expression -run '^TestTableInfo2SchemaAndNamesKeys$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect query results caused by treating partial unique indexes as globally unique, and reject partial primary keys added through ALTER TABLE instead of silently discarding their predicates.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partial primary-key definitions are now rejected with a clear unsupported-operation error.
  * Partial unique indexes no longer incorrectly imply global uniqueness or primary-key behavior.
  * Query planning now avoids using conditional indexes for key inference, functional dependencies, and outer-join elimination.
  * Regular unique indexes continue to support expected schema and query behavior.

* **Tests**
  * Expanded coverage for partial-index behavior across table alterations, grouping, joins, cardinality checks, and index selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->