### PR TITLE
dumpling: modernize manual GC lifetime warning

### DIFF
--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -1768,10 +1768,13 @@ func tidbStartGCSavepointUpdateService(d *Dumper) error {
 			go updateServiceSafePoint(tctx, d.tidbPDClientForGC, defaultDumpGCSafePointTTL, snapshotTS)
 		}
 	} else if si.ServerType == version.ServerTypeTiDB {
-		tctx.L().Warn("If the amount of data to dump is large, criteria: (data more than 60GB or dumped time more than 10 minutes)\n" +
-			"you'd better adjust the tikv_gc_life_time to avoid export failure due to TiDB GC during the dump process.\n" +
-			"Before dumping: run sql `update mysql.tidb set VARIABLE_VALUE = '720h' where VARIABLE_NAME = 'tikv_gc_life_time';` in tidb.\n" +
-			"After dumping: run sql `update mysql.tidb set VARIABLE_VALUE = '10m' where VARIABLE_NAME = 'tikv_gc_life_time';` in tidb.\n")
+		// Before TiDB v5.0.0, GC lifetime was configured through the tikv_gc_life_time
+		// row in mysql.tidb. Starting with v5.0.0, use the tidb_gc_life_time system variable.
+		tctx.L().Warn("If the amount of data to dump is large (more than 60 GB or expected to take more than 10 minutes),\n" +
+			"consider increasing tidb_gc_life_time to prevent historical data from being collected during the dump.\n" +
+			"Before dumping, record the current value with `SELECT @@GLOBAL.tidb_gc_life_time;`,\n" +
+			"then run `SET GLOBAL tidb_gc_life_time = '720h';`.\n" +
+			"After dumping, restore tidb_gc_life_time to the recorded value.\n")
 	}
 	return nil
 }

--- a/pkg/planner/core/casetest/planstats/BUILD.bazel
+++ b/pkg/planner/core/casetest/planstats/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
         "//pkg/statistics",
-        "//pkg/statistics/asyncload",
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/statistics/handle/types",
         "//pkg/testkit",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70273

Problem Summary:

When Dumpling cannot register automatic GC protection, its fallback warning recommends directly updating the internal `mysql.tidb` row and resetting the GC lifetime to a hard-coded `10m`. The guidance predates the `tidb_gc_life_time` system variable, does not work for users whose direct system-table access is restricted by SEM, and can overwrite a non-default original value.

### What changed and how does it work?

Update the fallback warning to use the public `tidb_gc_life_time` global system variable. The message now tells users to record the current value, temporarily set the lifetime to `720h`, and restore the recorded value after the dump. Dumpling's GC protection behavior and fallback conditions are unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```bash
./tools/check/failpoint-go-test.sh ./dumpling/export -run '^TestResolveKeyspaceMetaGCAPIChoice$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve Dumpling's fallback GC warning to recommend the `tidb_gc_life_time` system variable and restoring the original value after dumping.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TiDB GC lifetime guidance to use the current `tidb_gc_life_time` system variable.
  * Added instructions for recording, temporarily increasing, and restoring the setting during large data exports.
* **Tests**
  * Simplified test build dependencies without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->