### PR TITLE
executor: remove unnecessary ordering from full-sampling Analyze requests

### DIFF
--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/distsql"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -85,7 +86,9 @@ func (e *AnalyzeColumnsExec) open(ctx context.Context, ranges []*ranger.Range) e
 	e.memTracker = memory.NewTracker(int(e.ctx.GetSessionVars().PlanID.Load()), -1)
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	e.resultHandler = &tableResultHandler{}
-	firstPartRanges, secondPartRanges := distsql.SplitRangesAcrossInt64Boundary(ranges, true, false, !hasPkHist(e.handleCols))
+	// Full-sampling analyze restores handle order after collecting samples,
+	// so it can scan both sides of the unsigned integer boundary in one request.
+	firstPartRanges, secondPartRanges := distsql.SplitRangesAcrossInt64Boundary(ranges, false, false, !hasPkHist(e.handleCols))
 	firstResult, err := e.buildResp(ctx, firstPartRanges)
 	if err != nil {
 		return err
@@ -114,12 +117,11 @@ func (e *AnalyzeColumnsExec) buildResp(ctx context.Context, ranges []*ranger.Ran
 		startTS = e.snapshot
 		isoLevel = kv.SI
 	}
-	// Always set KeepOrder of the request to be true, in order to compute
-	// correct `correlation` of columns.
+	// Full-sampling analyze sorts collected samples by handle before computing
+	// correlation, so this request does not need KeepOrder.
 	kvReq, err := reqBuilder.
 		SetAnalyzeRequest(e.analyzePB, isoLevel).
 		SetStartTS(startTS).
-		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
 		SetMemTracker(e.memTracker).
 		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
@@ -128,6 +130,7 @@ func (e *AnalyzeColumnsExec) buildResp(ctx context.Context, ranges []*ranger.Ran
 	if err != nil {
 		return nil, err
 	}
+	failpoint.InjectCall("analyzeColumnsRequestBuilt", kvReq)
 	result, err := distsql.Analyze(ctx, e.ctx.GetClient(), kvReq, e.ctx.GetSessionVars().KVVars, e.ctx.GetSessionVars().InRestrictedSQL, e.ctx.GetDistSQLCtx())
 	if err != nil {
 		return nil, err

--- a/pkg/executor/analyze_test.go
+++ b/pkg/executor/analyze_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -58,6 +59,45 @@ func checkHistogram(sc *stmtctx.StatementContext, hg *statistics.Histogram) (boo
 		}
 	}
 	return true, nil
+}
+
+func TestAnalyzeBuildsSingleBatchableRequest(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	var requestCount atomic.Int64
+	var lastRequest atomic.Pointer[kv.Request]
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/analyzeColumnsRequestBuilt", func(req *kv.Request) {
+		lastRequest.Store(req)
+		requestCount.Add(1)
+	})
+
+	// Values at MaxInt64 and MaxInt64+1 exercise the unsigned-handle boundary.
+	// Full-sampling Analyze should cover them with one unordered request.
+	tk.MustExec("create table tu(a bigint unsigned primary key)")
+	tk.MustExec("insert into tu values (9223372036854775807), (9223372036854775808)")
+	tk.MustExec("analyze table tu with 1 samplerate, 0 topn, 2 buckets")
+	require.Equal(t, int64(1), requestCount.Load())
+	require.False(t, lastRequest.Load().KeepOrder)
+
+	bucketRows := tk.MustQuery("show stats_buckets where db_name = 'test' and table_name = 'tu' and column_name = 'a' and is_index = 0").Rows()
+	bounds := make(map[string]struct{}, 2*len(bucketRows))
+	for _, row := range bucketRows {
+		bounds[row[8].(string)] = struct{}{}
+		bounds[row[9].(string)] = struct{}{}
+	}
+	require.Contains(t, bounds, "9223372036854775807")
+	require.Contains(t, bounds, "9223372036854775808")
+
+	// An empty unsigned half must not stop the request before its signed range.
+	tk.MustExec("truncate table tu")
+	tk.MustExec("insert into tu values (1)")
+	tk.MustExec("analyze table tu with 1 samplerate, 0 topn, 2 buckets")
+	require.Equal(t, int64(2), requestCount.Load())
+	metaRows := tk.MustQuery("show stats_meta where db_name = 'test' and table_name = 'tu'").Rows()
+	require.Len(t, metaRows, 1)
+	require.Equal(t, "1", metaRows[0][5])
 }
 
 func TestAnalyzeIndexExtractTopN(t *testing.T) {

--- a/pkg/planner/core/casetest/planstats/BUILD.bazel
+++ b/pkg/planner/core/casetest/planstats/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
         "//pkg/statistics",
-        "//pkg/statistics/asyncload",
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/statistics/handle/types",
         "//pkg/testkit",

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -480,20 +480,22 @@ func (e *analyzeColumnsExec) Fields() []*resolve.ResultField {
 func (e *analyzeColumnsExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	e.req = req
-	err := e.reader.Scan(e.seekKey, e.endKey, math.MaxInt64, e.startTS, e)
-	if err != nil {
-		return err
-	}
-	if req.NumRows() < req.Capacity() {
+	for {
+		err := e.reader.Scan(e.seekKey, e.endKey, math.MaxInt64, e.startTS, e)
+		if err != nil {
+			return err
+		}
+		if req.NumRows() == req.Capacity() {
+			return nil
+		}
 		if e.curRan == len(e.ranges)-1 {
 			e.seekKey = e.endKey
-		} else {
-			e.curRan++
-			e.seekKey = e.ranges[e.curRan].StartKey
-			e.endKey = e.ranges[e.curRan].EndKey
+			return nil
 		}
+		e.curRan++
+		e.seekKey = e.ranges[e.curRan].StartKey
+		e.endKey = e.ranges[e.curRan].EndKey
 	}
-	return nil
 }
 
 func (e *analyzeColumnsExec) Process(key, value []byte, _ uint64) error {


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63579, ref #70059

Problem Summary:

After #66772 removed Analyze v1 collection, full-sampling Analyze still requests ordered scans and splits unsigned-PK ranges at `MaxInt64`, although it sorts collected samples by handle before computing correlation.

### What changed and how does it work?

- Stop setting `KeepOrder` and scan both unsigned-handle ranges in one request.
- Make Unistore continue when an earlier Analyze key range is empty.
- Add focused coverage for request shape, boundary values, and empty leading ranges.

Extracted from #69686 and #70055; follow-up to #66772.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved V2 full-sampling analysis across unsigned integer boundaries.
* Preserved correct sample ordering and histogram boundaries, including values around the signed integer limit.
* Improved scan completion and result batching when analyzing multiple ranges.

## Tests
* Added regression coverage for boundary handling, empty ranges, and analysis request behavior.

## Chores
* Removed an unused test build dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->