### PR TITLE
planner: support LEFT JOIN LATERAL

### DIFF
--- a/pkg/planner/core/lateral_join_test.go
+++ b/pkg/planner/core/lateral_join_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
@@ -45,9 +46,9 @@ func TestLateralJoinPlanBuilding(t *testing.T) {
 			expectApply: true,
 		},
 		{
-			name:        "LATERAL with LEFT JOIN not yet supported",
+			name:        "LATERAL with LEFT JOIN builds LogicalApply",
 			sql:         "SELECT * FROM t LEFT JOIN LATERAL (SELECT t.b) AS dt ON true",
-			expectError: true,
+			expectApply: true,
 		},
 		{
 			name:        "LATERAL with CROSS JOIN builds LogicalApply",
@@ -333,9 +334,9 @@ func TestLateralJoinErrorPaths(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "LEFT JOIN with LATERAL not yet supported",
+			name:        "LEFT JOIN with LATERAL is valid",
 			sql:         "SELECT * FROM t LEFT JOIN LATERAL (SELECT t.a) AS dt ON true",
-			expectError: true,
+			expectError: false,
 		},
 		{
 			name:        "CROSS JOIN with LATERAL is valid",
@@ -562,6 +563,43 @@ func TestLateralJoinDecorrelateWithUSINGAndON(t *testing.T) {
 	require.NotNil(t, apply, "Expected LogicalApply to survive decorrelation")
 	require.Greater(t, len(apply.CorCols), 0,
 		"CorCols must not be empty; the LATERAL subquery references a merged USING column")
+}
+
+// TestLeftJoinLateralBuildsOuterApply verifies that LEFT JOIN LATERAL produces a
+// LeftOuterJoin Apply whose inner columns are nullable: the LATERAL subquery may
+// return no row for an outer row, and that row is then NULL-extended.
+func TestLeftJoinLateralBuildsOuterApply(t *testing.T) {
+	s := coretestsdk.CreatePlannerSuiteElems()
+	defer s.Close()
+	ctx := context.Background()
+
+	// t.a is NOT NULL in the test schema, so the inner side carries the flag until
+	// the outer join clears it.
+	sql := "SELECT * FROM t AS t1 LEFT JOIN LATERAL (SELECT a FROM t AS t2 WHERE t2.a=t1.a) AS dt ON TRUE"
+	stmt, err := s.GetParser().ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+
+	nodeW := resolve.NewNodeW(stmt)
+	p, err := BuildLogicalPlanForTest(ctx, s.GetSCtx(), nodeW, s.GetIS())
+	require.NoError(t, err)
+
+	lp, ok := p.(base.LogicalPlan)
+	require.True(t, ok)
+	apply := findFirstLogicalApply(lp)
+	require.NotNil(t, apply, "LEFT JOIN LATERAL must build a LogicalApply")
+	require.Equal(t, base.LeftOuterJoin, apply.JoinType)
+	require.True(t, apply.IsLateral)
+
+	outerLen := apply.Children()[0].Schema().Len()
+	for i := outerLen; i < apply.Schema().Len(); i++ {
+		require.False(t, mysql.HasNotNullFlag(apply.Schema().Columns[i].RetType.GetFlag()),
+			"inner column %d of a LEFT JOIN LATERAL must be nullable", i)
+	}
+	require.NotNil(t, apply.FullSchema)
+	for i := outerLen; i < apply.FullSchema.Len(); i++ {
+		require.False(t, mysql.HasNotNullFlag(apply.FullSchema.Columns[i].RetType.GetFlag()),
+			"inner FullSchema column %d of a LEFT JOIN LATERAL must be nullable", i)
+	}
 }
 
 // Helper functions

--- a/pkg/planner/core/lateral_join_test.go
+++ b/pkg/planner/core/lateral_join_test.go
@@ -595,8 +595,15 @@ func TestLeftJoinLateralBuildsOuterApply(t *testing.T) {
 		require.False(t, mysql.HasNotNullFlag(apply.Schema().Columns[i].RetType.GetFlag()),
 			"inner column %d of a LEFT JOIN LATERAL must be nullable", i)
 	}
+	// FullSchema's left half is the left child's own FullSchema, which is longer than
+	// Children()[0].Schema() when the outer side is a USING/NATURAL join, so it needs its
+	// own offset, derived the way buildLateralJoin derives it.
 	require.NotNil(t, apply.FullSchema)
-	for i := outerLen; i < apply.FullSchema.Len(); i++ {
+	outerFullLen := outerLen
+	if lFullSchema, _ := findJoinFullSchema(apply.Children()[0]); lFullSchema != nil {
+		outerFullLen = lFullSchema.Len()
+	}
+	for i := outerFullLen; i < apply.FullSchema.Len(); i++ {
 		require.False(t, mysql.HasNotNullFlag(apply.FullSchema.Columns[i].RetType.GetFlag()),
 			"inner FullSchema column %d of a LEFT JOIN LATERAL must be nullable", i)
 	}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -981,12 +981,15 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 	corCols := coreusage.ExtractCorColumnsBySchema4LogicalPlan(rightPlan, outerSchema)
 
 	// Determine join type based on AST.
-	// Currently supports INNER JOIN and comma syntax (which the parser represents as CrossJoin).
-	// LEFT/RIGHT JOIN will be added in a follow-up PR.
+	// Supports INNER JOIN, comma syntax (which the parser represents as CrossJoin) and LEFT JOIN.
+	// RIGHT JOIN will be added in a follow-up PR.
 	var joinType base.JoinType
 	switch joinNode.Tp {
 	case ast.LeftJoin:
-		return nil, plannererrors.ErrInvalidLateralJoin.GenWithStackByArgs("LEFT JOIN is not supported with LATERAL")
+		joinType = base.LeftOuterJoin
+		// Once the Apply is decorrelated into a plain LogicalJoin it becomes a candidate
+		// for the outer-join simplification rules, same as a non-LATERAL LEFT JOIN.
+		b.optFlag = b.optFlag | rule.FlagEliminateOuterJoin | rule.FlagOuterJoinToSemiJoin
 	case ast.RightJoin:
 		return nil, plannererrors.ErrInvalidLateralJoin.GenWithStackByArgs("RIGHT JOIN is not supported with LATERAL")
 	default:
@@ -1012,8 +1015,11 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 	ap.SetChildren(leftPlan, rightPlan)
 	ap.SetSchema(expression.MergeSchema(leftPlan.Schema(), rightPlan.Schema()))
 
-	// Note: nullability adjustment is not needed for InnerJoin (the only type supported currently).
-	// When LEFT/RIGHT JOIN support is added, ResetNotNullFlag must be called here.
+	// A LEFT JOIN null-extends the inner (right) side when the LATERAL subquery
+	// produces no row for an outer row, so its columns lose any NOT NULL flag.
+	if joinType == base.LeftOuterJoin {
+		util.ResetNotNullFlag(ap.Schema(), leftPlan.Schema().Len(), ap.Schema().Len())
+	}
 
 	// Clone output names to avoid sharing FieldName structs that might be mutated later.
 	// Do NOT override DBName here: derived-table outputs already carry DBName="" from
@@ -1055,8 +1061,11 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 
 	ap.FullSchema = expression.MergeSchema(lFullSchema, rFullSchema)
 
-	// Note: FullSchema nullability adjustment is not needed for InnerJoin.
-	// When LEFT/RIGHT JOIN support is added, ResetNotNullFlag must be called here.
+	// Mirror the schema adjustment above on FullSchema, which additionally carries the
+	// redundant USING/NATURAL columns of the two sides.
+	if joinType == base.LeftOuterJoin {
+		util.ResetNotNullFlag(ap.FullSchema, lFullSchema.Len(), ap.FullSchema.Len())
+	}
 
 	ap.FullNames = make([]*types.FieldName, 0, len(lFullNames)+len(rFullNames))
 	for _, lName := range lFullNames {
@@ -1085,8 +1094,6 @@ func (b *PlanBuilder) buildLateralJoin(ctx context.Context, leftPlan, rightPlan 
 		onCondition := expression.SplitCNFItems(onExpr)
 		ap.AttachOnConds(onCondition)
 	}
-
-	// Note: nullability reset for outer joins not needed for InnerJoin.
 
 	// Merge handle maps (copied from buildJoin)
 	handleMap1 := b.handleHelper.popMap()

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -424,6 +424,14 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 
 						join := &apply.LogicalJoin
 						defaultValueMap := s.aggDefaultValueMap(agg)
+						// The default values only describe a *scalar* aggregation, which yields one row
+						// over an empty input. An aggregation carrying an explicit GROUP BY yields no row
+						// at all for an outer row with no matching group, and the outer join's NULL
+						// extension is then the correct answer. This is reachable from LEFT JOIN LATERAL,
+						// where the inner subquery is not wrapped in a MaxOneRow.
+						if len(agg.GroupByItems) > 0 {
+							defaultValueMap = nil
+						}
 						// `defaultValueMap` means this scalar aggregation subquery should return a non-NULL
 						// default value (e.g. COUNT -> 0) when the subquery's input is empty.
 						//

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -189,6 +189,12 @@ func pruneRedundantApply(p base.LogicalPlan, groupByColumn map[*expression.Colum
 		for {
 			child := finalResult.Children()[0]
 			nextApply, ok := child.(*logicalop.LogicalApply)
+			if ok && nextApply.IsLateral {
+				// The IsLateral guard above only covers the topmost Apply, but this loop drops
+				// every Apply it walks through. A LATERAL Apply nested below a prunable one may
+				// still return several rows per outer row, so pruning the chain would lose them.
+				return nil, false
+			}
 			if !ok {
 				if len(groupByColumn) == 0 {
 					return child, true
@@ -423,14 +429,14 @@ func (s *DecorrelateSolver) optimize(ctx context.Context, p base.LogicalPlan, gr
 						var appendedAggFuncs []*aggregation.AggFuncDesc
 
 						join := &apply.LogicalJoin
-						defaultValueMap := s.aggDefaultValueMap(agg)
 						// The default values only describe a *scalar* aggregation, which yields one row
 						// over an empty input. An aggregation carrying an explicit GROUP BY yields no row
 						// at all for an outer row with no matching group, and the outer join's NULL
 						// extension is then the correct answer. This is reachable from LEFT JOIN LATERAL,
 						// where the inner subquery is not wrapped in a MaxOneRow.
-						if len(agg.GroupByItems) > 0 {
-							defaultValueMap = nil
+						var defaultValueMap map[int]*expression.Constant
+						if len(agg.GroupByItems) == 0 {
+							defaultValueMap = s.aggDefaultValueMap(agg)
 						}
 						// `defaultValueMap` means this scalar aggregation subquery should return a non-NULL
 						// default value (e.g. COUNT -> 0) when the subquery's input is empty.
@@ -598,11 +604,31 @@ func skipDecorrelateProjectionForLeftOuterApply(apply *logicalop.LogicalApply, p
 	// If proj.Exprs are all from outerPlan, we cannot make sure the output row of projection is always null,
 	// which may break the semantics of LeftOuterJoin.
 	// Because the right side of output row of LeftOuterJoin is always null when join conditions are not met.
-	// TODO: should also disable decorrelate when proj.Exprs use columns from innerPlan and its expression is not null-rejective.
 	outerPlan := apply.Children()[0]
 	for _, expr := range proj.Exprs {
 		cols := expression.ExtractColumns(expr)
 		if outerPlan.Schema().ColumnsIndices(cols) != nil {
+			return true
+		}
+	}
+
+	// Pulling the projection above the join means it is evaluated on the null-extended rows too,
+	// so an expression over inner columns must still produce NULL once those columns are NULL.
+	// A non-null-preserving expression such as ifnull(b, 'z') or `b IS NULL` would otherwise turn
+	// a non-match into a real value. Reachable from LEFT JOIN LATERAL, whose inner side is not
+	// wrapped in a LogicalMaxOneRow.
+	// proj.Exprs are written against the projection's input, not its own output schema.
+	innerSchema := proj.Children()[0].Schema()
+	for _, expr := range proj.Exprs {
+		if expression.ExtractColumnSet(expr).IsEmpty() {
+			continue
+		}
+		nullResult, err := expression.EvaluateExprWithNull(apply.SCtx().GetExprCtx(), innerSchema, expr, true)
+		if err != nil {
+			return true
+		}
+		con, ok := nullResult.(*expression.Constant)
+		if !ok || con.DeferredExpr != nil || con.ParamMarker != nil || !con.Value.IsNull() {
 			return true
 		}
 	}

--- a/tests/integrationtest/r/planner/core/lateral_join.result
+++ b/tests/integrationtest/r/planner/core/lateral_join.result
@@ -21,10 +21,168 @@ a	cnt
 drop table if exists t1, t2;
 create table t1 (a int);
 create table t2 (a int, b varchar(10));
-select * from t1 left join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true order by t1.a;
-Error 3809 (HY000): Invalid use of LATERAL: LEFT JOIN is not supported with LATERAL
+select * from t1 right join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true order by t1.a;
+Error 3809 (HY000): Invalid use of LATERAL: RIGHT JOIN is not supported with LATERAL
+select * from t1 natural join lateral (select b from t2 where t2.a = t1.a) as lat;
+Error 3809 (HY000): Invalid use of LATERAL: NATURAL JOIN is not supported with LATERAL
 select * from t1 cross join lateral (select b from t2 where t2.a = t1.a) as lat;
 a	b
+drop table if exists t1, t2, t3;
+create table t1 (a int, x int);
+create table t2 (a int not null, b varchar(10) not null);
+create table t3 (a int primary key, b varchar(10));
+insert into t1 values (1, 10), (2, 20), (3, 30), (4, 40);
+insert into t2 values (1, 'a'), (2, 'c'), (3, 'd'), (3, 'e');
+insert into t3 values (1, 'p'), (2, 'q'), (3, 'r');
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.b;
+a	x	b
+1	10	a
+2	20	c
+3	30	d
+3	30	e
+4	40	NULL
+select t1.a, lat.b is null from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.b;
+a	lat.b is null
+1	0
+2	0
+3	0
+3	0
+4	1
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a order by b desc limit 1) as lat on true order by t1.a;
+a	x	b
+1	10	a
+2	20	c
+3	30	e
+4	40	NULL
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on lat.b > 'd' order by t1.a, lat.b;
+a	x	b
+1	10	NULL
+2	20	NULL
+3	30	e
+4	40	NULL
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on t1.a > 2 order by t1.a, lat.b;
+a	x	b
+1	10	NULL
+2	20	NULL
+3	30	d
+3	30	e
+4	40	NULL
+select * from t1 left join lateral (select count(*) as c from t2 where t2.a = t1.a) as lat on true order by t1.a;
+a	x	c
+1	10	1
+2	20	1
+3	30	2
+4	40	0
+select * from t1 left join lateral (select count(*) as c from t2 where t2.a = t1.a having count(*) > 1) as lat on true order by t1.a;
+a	x	c
+1	10	NULL
+2	20	NULL
+3	30	2
+4	40	NULL
+select * from t1 left join lateral (select a as ga, count(*) as c from t2 where t2.a = t1.a group by a) as lat on true order by t1.a;
+a	x	ga	c
+1	10	1	1
+2	20	2	1
+3	30	3	2
+4	40	NULL	NULL
+select * from t1 left join lateral (select a as ga, count(*) as c from t2 where t2.a = t1.a group by a having count(*) > 1) as lat on true order by t1.a;
+a	x	ga	c
+1	10	NULL	NULL
+2	20	NULL	NULL
+3	30	3	2
+4	40	NULL	NULL
+select * from t1 left join lateral (select b as gb, count(*) as c from t2 where t2.a = t1.a group by b) as lat on true order by t1.a, gb;
+a	x	gb	c
+1	10	a	1
+2	20	c	1
+3	30	d	1
+3	30	e	1
+4	40	NULL	NULL
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a;
+a
+1
+2
+3
+3
+4
+select t1.a from t1 left join lateral (select b from t3 where t3.a = t1.a) as lat on true order by t1.a;
+a
+1
+2
+3
+4
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where lat.b is not null order by t1.a, lat.b;
+a	x	b
+1	10	a
+2	20	c
+3	30	d
+3	30	e
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where lat.b is null order by t1.a;
+a	x	b
+4	40	NULL
+select count(lat.b), count(*) from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true;
+count(lat.b)	count(*)
+4	5
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a union all select b from t3 where t3.a = t1.a) as lat on true order by t1.a, lat.b;
+a	x	b
+1	10	a
+1	10	p
+2	20	c
+2	20	q
+3	30	d
+3	30	e
+3	30	r
+4	40	NULL
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as l1 on true left join lateral (select concat(l1.b, '!') as bb) as l2 on true order by t1.a, l1.b;
+a	x	b	bb
+1	10	a	a!
+2	20	c	c!
+3	30	d	d!
+3	30	e	e!
+4	40	NULL	NULL
+select * from t1 join t3 using (a) left join lateral (select b as lb from t2 where t2.a = t1.a) as lat on true order by a, lb;
+a	x	b	lb
+1	10	p	a
+2	20	q	c
+3	30	r	d
+3	30	r	e
+select * from t1 join lateral (select b from t2 where t2.a = t1.a) as i on true left join lateral (select b as b2 from t2 where t2.a = t1.a + 1) as o on true order by t1.a, i.b, o.b2;
+a	x	b	b2
+1	10	a	c
+2	20	c	d
+2	20	c	e
+3	30	d	NULL
+3	30	e	NULL
+select * from t1 left join lateral (select t1.x as xx) as lat on true order by t1.a;
+a	x	xx
+1	10	10
+2	20	20
+3	30	30
+4	40	40
+select * from t1 left join lateral (select 1 as one from t2 where t2.a = t1.a) as lat on true order by t1.a, one;
+a	x	one
+1	10	1
+2	20	1
+3	30	1
+3	30	1
+4	40	NULL
+explain format='plan_tree' select * from t1 left join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true;
+id	task	access object	operator info
+Apply	root		CARTESIAN left outer join, left side:TableReader
+├─TableReader(Build)	root		data:TableFullScan
+│ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Limit(Probe)	root		offset:0, count:1
+  └─TableReader	root		data:Limit
+    └─Limit	cop[tikv]		offset:0, count:1
+      └─Selection	cop[tikv]		eq(planner__core__lateral_join.t2.a, planner__core__lateral_join.t1.a)
+        └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+explain format='plan_tree' select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true;
+id	task	access object	operator info
+HashJoin	root		left outer join, left side:TableReader, equal:[eq(planner__core__lateral_join.t1.a, planner__core__lateral_join.t2.a)]
+├─TableReader(Build)	root		data:TableFullScan
+│ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─TableReader(Probe)	root		data:TableFullScan
+  └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 drop table if exists t1, t2;
 create table t1 (a int);
 create table t2 (a int, b varchar(10));

--- a/tests/integrationtest/r/planner/core/lateral_join.result
+++ b/tests/integrationtest/r/planner/core/lateral_join.result
@@ -183,6 +183,91 @@ HashJoin	root		left outer join, left side:TableReader, equal:[eq(planner__core__
 │ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─TableReader(Probe)	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+drop table if exists t4;
+create table t4 (a int);
+insert into t4 values (1);
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true
+where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+a
+1
+2
+3
+3
+4
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true
+where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+a
+1
+2
+3
+3
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true
+where t1.x > 0 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+a
+1
+2
+3
+3
+4
+select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	a
+2	c
+3	d
+3	e
+4	NULL
+select t1.a, lat.bz from t1 left join lateral (select coalesce(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	a
+2	c
+3	d
+3	e
+4	NULL
+select t1.a, lat.bz from t1 left join lateral (select b is null as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	0
+2	0
+3	0
+3	0
+4	NULL
+select t1.a, lat.bz from t1 left join lateral (select if(b > 'c', 'hi', 'lo') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	lo
+2	lo
+3	hi
+3	hi
+4	NULL
+select t1.a, lat.bz from t1 left join lateral (select (case when b is null then 'n' else b end) as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	a
+2	c
+3	d
+3	e
+4	NULL
+select t1.a, lat.bz from t1 left join lateral (select concat(b, '!') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+a	bz
+1	a!
+2	c!
+3	d!
+3	e!
+4	NULL
+explain format='plan_tree' select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true;
+id	task	access object	operator info
+Apply	root		CARTESIAN left outer join, left side:TableReader
+├─TableReader(Build)	root		data:TableFullScan
+│ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection(Probe)	root		ifnull(planner__core__lateral_join.t2.b, z)->Column
+  └─TableReader	root		data:Selection
+    └─Selection	cop[tikv]		eq(planner__core__lateral_join.t2.a, planner__core__lateral_join.t1.a)
+      └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+explain format='plan_tree' select t1.a, lat.bz from t1 left join lateral (select concat(b, '!') as bz from t2 where t2.a = t1.a) as lat on true;
+id	task	access object	operator info
+Projection	root		planner__core__lateral_join.t1.a, concat(planner__core__lateral_join.t2.b, !)->Column
+└─HashJoin	root		left outer join, left side:TableReader, equal:[eq(planner__core__lateral_join.t1.a, planner__core__lateral_join.t2.a)]
+  ├─TableReader(Build)	root		data:TableFullScan
+  │ └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─TableReader(Probe)	root		data:TableFullScan
+    └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
 drop table if exists t1, t2;
 create table t1 (a int);
 create table t2 (a int, b varchar(10));

--- a/tests/integrationtest/r/planner/core/lateral_join.result
+++ b/tests/integrationtest/r/planner/core/lateral_join.result
@@ -209,6 +209,44 @@ a
 3
 3
 4
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a;
+a
+1
+2
+3
+3
+select t1.a from t1 join t2 on t2.a = t1.a order by t1.a;
+a
+1
+2
+3
+3
+select t1.a from t1 left join t2 on t2.a = t1.a order by t1.a;
+a
+1
+2
+3
+3
+4
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true where t1.a >= 3 order by t1.a;
+a
+3
+3
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where t1.a >= 3 order by t1.a;
+a
+3
+3
+4
+select t1.a from t1 where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+a
+1
+2
+3
+4
+explain format='plan_tree' select t1.a from t1 where 1=1 or exists (select 1 from t4 where t4.a = t1.a);
+id	task	access object	operator info
+TableReader	root		data:TableFullScan
+└─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
 a	bz
 1	a

--- a/tests/integrationtest/t/planner/core/lateral_join.test
+++ b/tests/integrationtest/t/planner/core/lateral_join.test
@@ -19,12 +19,94 @@ drop table if exists t1, t2;
 create table t1 (a int);
 create table t2 (a int, b varchar(10));
 
-## LEFT JOIN LATERAL - not yet supported
+## RIGHT JOIN LATERAL - not yet supported
 --error 3809
-select * from t1 left join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true order by t1.a;
+select * from t1 right join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true order by t1.a;
+
+## NATURAL JOIN LATERAL - not supported
+--error 3809
+select * from t1 natural join lateral (select b from t2 where t2.a = t1.a) as lat;
 
 ## CROSS JOIN LATERAL - works (same as comma syntax)
 select * from t1 cross join lateral (select b from t2 where t2.a = t1.a) as lat;
+
+# TestLeftJoinLateral
+drop table if exists t1, t2, t3;
+create table t1 (a int, x int);
+create table t2 (a int not null, b varchar(10) not null);
+create table t3 (a int primary key, b varchar(10));
+insert into t1 values (1, 10), (2, 20), (3, 30), (4, 40);
+insert into t2 values (1, 'a'), (2, 'c'), (3, 'd'), (3, 'e');
+insert into t3 values (1, 'p'), (2, 'q'), (3, 'r');
+
+## Outer rows without a matching inner row are NULL-extended; t1.a=4 has no match
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.b;
+
+## The inner NOT NULL column becomes nullable
+select t1.a, lat.b is null from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.b;
+
+## LIMIT in the derived table keeps the Apply; still one row per outer row
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a order by b desc limit 1) as lat on true order by t1.a;
+
+## Non-trivial ON condition: rows failing it are non-matches, not filtered outer rows
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on lat.b > 'd' order by t1.a, lat.b;
+
+## ON condition referencing only the outer side
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on t1.a > 2 order by t1.a, lat.b;
+
+## A scalar aggregate always returns one row, so COUNT(*) is 0, not NULL
+select * from t1 left join lateral (select count(*) as c from t2 where t2.a = t1.a) as lat on true order by t1.a;
+
+## HAVING can remove that row again, and then NULL is correct
+select * from t1 left join lateral (select count(*) as c from t2 where t2.a = t1.a having count(*) > 1) as lat on true order by t1.a;
+
+## With an explicit GROUP BY the derived table returns no row, so COUNT(*) must be NULL
+select * from t1 left join lateral (select a as ga, count(*) as c from t2 where t2.a = t1.a group by a) as lat on true order by t1.a;
+
+## GROUP BY plus HAVING
+select * from t1 left join lateral (select a as ga, count(*) as c from t2 where t2.a = t1.a group by a having count(*) > 1) as lat on true order by t1.a;
+
+## Multiple groups per outer row
+select * from t1 left join lateral (select b as gb, count(*) as c from t2 where t2.a = t1.a group by b) as lat on true order by t1.a, gb;
+
+## An unused LATERAL output that can return several rows must not be eliminated
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a;
+
+## The same shape over a unique key returns one row per outer row
+select t1.a from t1 left join lateral (select b from t3 where t3.a = t1.a) as lat on true order by t1.a;
+
+## NULL-rejecting predicate above the join behaves like an inner join
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where lat.b is not null order by t1.a, lat.b;
+
+## IS NULL selects exactly the non-matching outer rows
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where lat.b is null order by t1.a;
+
+## Aggregates over the join must not count the NULL-extended rows
+select count(lat.b), count(*) from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true;
+
+## UNION ALL inside the LATERAL derived table
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a union all select b from t3 where t3.a = t1.a) as lat on true order by t1.a, lat.b;
+
+## Chained LATERAL joins: the second one sees the NULL-extended output of the first
+select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as l1 on true left join lateral (select concat(l1.b, '!') as bb) as l2 on true order by t1.a, l1.b;
+
+## LEFT JOIN LATERAL on the right of a USING join
+select * from t1 join t3 using (a) left join lateral (select b as lb from t2 where t2.a = t1.a) as lat on true order by a, lb;
+
+## LEFT JOIN LATERAL nested under an INNER JOIN LATERAL
+select * from t1 join lateral (select b from t2 where t2.a = t1.a) as i on true left join lateral (select b as b2 from t2 where t2.a = t1.a + 1) as o on true order by t1.a, i.b, o.b2;
+
+## A derived table that only projects outer columns always returns one row
+select * from t1 left join lateral (select t1.x as xx) as lat on true order by t1.a;
+
+## Apply is preserved when the projection is constant-only
+select * from t1 left join lateral (select 1 as one from t2 where t2.a = t1.a) as lat on true order by t1.a, one;
+
+## EXPLAIN: LIMIT prevents decorrelation, so the Apply is a left outer join
+explain format='plan_tree' select * from t1 left join lateral (select b from t2 where t2.a = t1.a limit 1) as lat on true;
+
+## EXPLAIN: the decorrelated form is a left outer hash join
+explain format='plan_tree' select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true;
 
 # TestLateralJoinExplain
 drop table if exists t1, t2;

--- a/tests/integrationtest/t/planner/core/lateral_join.test
+++ b/tests/integrationtest/t/planner/core/lateral_join.test
@@ -124,6 +124,21 @@ select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on 
 select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true
   where t1.x > 0 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
 
+## Cross-check the row counts above without relying on LATERAL at all: a LATERAL join whose
+## only correlation is an equality is semantically a plain join, so these must agree with the
+## always-true-WHERE results (INNER drops t1.a=4 and keeps t1.a=3 twice; LEFT keeps both).
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true order by t1.a;
+select t1.a from t1 join t2 on t2.a = t1.a order by t1.a;
+select t1.a from t1 left join t2 on t2.a = t1.a order by t1.a;
+
+## A real predicate must still filter after the always-true cases above
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true where t1.a >= 3 order by t1.a;
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true where t1.a >= 3 order by t1.a;
+
+## Pruning a redundant Apply must still happen when no LATERAL is involved
+select t1.a from t1 where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+explain format='plan_tree' select t1.a from t1 where 1=1 or exists (select 1 from t4 where t4.a = t1.a);
+
 ## An inner projection may only be pulled above the outer join when it stays NULL on the
 ## null-extended row. ifnull/coalesce/IS NULL must not turn a non-match into a real value.
 select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;

--- a/tests/integrationtest/t/planner/core/lateral_join.test
+++ b/tests/integrationtest/t/planner/core/lateral_join.test
@@ -108,6 +108,35 @@ explain format='plan_tree' select * from t1 left join lateral (select b from t2 
 ## EXPLAIN: the decorrelated form is a left outer hash join
 explain format='plan_tree' select * from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true;
 
+## An always-true WHERE above a non-LATERAL Apply must not prune the LATERAL Apply
+## nested underneath it: t1.a=3 matches two t2 rows and both must survive.
+drop table if exists t4;
+create table t4 (a int);
+insert into t4 values (1);
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true
+  where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+
+## Same shape with INNER JOIN LATERAL
+select t1.a from t1 join lateral (select b from t2 where t2.a = t1.a) as lat on true
+  where 1=1 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+
+## Control: a predicate that does not simplify away keeps the same row count
+select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) as lat on true
+  where t1.x > 0 or exists (select 1 from t4 where t4.a = t1.a) order by t1.a;
+
+## An inner projection may only be pulled above the outer join when it stays NULL on the
+## null-extended row. ifnull/coalesce/IS NULL must not turn a non-match into a real value.
+select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+select t1.a, lat.bz from t1 left join lateral (select coalesce(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+select t1.a, lat.bz from t1 left join lateral (select b is null as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+select t1.a, lat.bz from t1 left join lateral (select if(b > 'c', 'hi', 'lo') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+select t1.a, lat.bz from t1 left join lateral (select (case when b is null then 'n' else b end) as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+
+## Control: NULL-preserving expressions stay decorrelatable and still read NULL on a non-match
+select t1.a, lat.bz from t1 left join lateral (select concat(b, '!') as bz from t2 where t2.a = t1.a) as lat on true order by t1.a, lat.bz;
+explain format='plan_tree' select t1.a, lat.bz from t1 left join lateral (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) as lat on true;
+explain format='plan_tree' select t1.a, lat.bz from t1 left join lateral (select concat(b, '!') as bz from t2 where t2.a = t1.a) as lat on true;
+
 # TestLateralJoinExplain
 drop table if exists t1, t2;
 create table t1 (a int);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #40328, close #70725, close #70863

Problem Summary:

#67131 added optimizer support for LATERAL derived tables, but only for INNER JOIN, CROSS JOIN and comma syntax. `LEFT JOIN LATERAL` was rejected at plan-build time with `ERROR 3809 Invalid use of LATERAL: LEFT JOIN is not supported with LATERAL`. This PR is the next phase of that series and adds `LEFT JOIN LATERAL`. `RIGHT JOIN`, `NATURAL JOIN` and `USING` with `LATERAL` remain rejected.

### What changed and how does it work?

**`buildLateralJoin` (`pkg/planner/core/logical_plan_builder.go`)** now accepts `ast.LeftJoin` and builds the `LogicalApply` with `base.LeftOuterJoin`. Because the LATERAL subquery may return no row for a given outer row, that row is NULL-extended, so `util.ResetNotNullFlag` is applied to the inner half of both `Schema()` and `FullSchema` — the two places that already carried a note saying this would be needed once LEFT/RIGHT JOIN was added. `FlagEliminateOuterJoin` and `FlagOuterJoinToSemiJoin` are set so the decorrelated form is treated like any other LEFT JOIN.

Most of the supporting machinery was already in place from the earlier LATERAL PRs and needed no change: `LogicalApply.DeriveStats` already had an `IsLateral && (InnerJoin || LeftOuterJoin)` branch, `LogicalApply.PruneColumns` already refuses to eliminate a LATERAL Apply (its inner can return 0..N rows per outer row, and `pruneRedundantApply` does the same for the outermost Apply, though only for that one — see the review follow-ups below), and `NestedLoopApplyExec` already drives a `leftOuterJoiner` with `Outer: v.JoinType != base.InnerJoin`.

**`rule_decorrelate.go`** — this change exposes a latent wrong-result bug. When the decorrelation rule pulls an aggregate out of a `LeftOuterJoin` Apply, it applied `aggDefaultValueMap` (`COUNT` → 0) to the NULL-extended rows. That is only correct for a *scalar* aggregate, which yields one row over an empty input. An aggregate with an explicit `GROUP BY` yields no row at all when there is no matching group, so the outer join's NULL extension is the right answer:

```sql
select * from t1 left join lateral
  (select a as ga, count(*) c from t2 where t2.a = t1.a group by a) lat on true;
-- for an outer row with no matching group this returned (…, NULL, 0); MySQL returns (…, NULL, NULL)
```

The path was previously unreachable: a scalar subquery wraps its aggregate in a `MaxOneRow` that blocks the pull-up, and only `LEFT JOIN LATERAL` produces a `LeftOuterJoin` Apply without one. The fix is to compute `aggDefaultValueMap` only when the aggregate carries no `GROUP BY`, and it is a no-op for every plan shape reachable before this PR.

**Review follow-ups (`rule_decorrelate.go`)** — review turned up two further wrong-result bugs in the same rule.

`pruneRedundantApply` checked `IsLateral` only on the Apply directly beneath the `Selection`, but its traversal loop returns the deepest non-Apply child and so drops every Apply on the way down. A LATERAL Apply nested below a prunable one was discarded along with the rows it multiplies — for example when an `EXISTS` builds a `LeftOuterSemiJoin` Apply above the LATERAL one and the `WHERE` simplifies to a constant true:

```sql
select t1.a from t1 left join lateral (select b from t2 where t2.a = t1.a) lat on true
where 1=1 or exists (select 1 from t4 where t4.a = t1.a);
-- the plan collapsed to a bare TableFullScan on t1, losing the rows t2 contributes
```

`IsLateral` is now checked for every Apply the loop walks. Tracked as #70725.

**Note on scope:** this shape is already wrong on master for `INNER JOIN LATERAL`, which #67131 enabled; `LEFT JOIN LATERAL` merely reaches it as well. The fix therefore also corrects `INNER JOIN LATERAL`, which is slightly beyond the stated scope of this PR — it is filed separately as #70725, and happy to split it into its own PR if reviewers would rather keep this one to `LEFT JOIN LATERAL`.

#70725 needs both `pruneRedundantApply` (added by #58261, after `release-8.5` branched) and LATERAL support (#67131), so it reaches only `master` and `release-nextgen-202603` — both verified by running the query. `release-7.5`, `release-8.1`, `release-8.5`, the 9.0 betas and `release-nextgen-20251011` are all unaffected, `release-8.5` verified by running it there too. A cherry-pick to `release-nextgen-202603` is therefore worth considering separately from this PR.

`skipDecorrelateProjectionForLeftOuterApply` carried a `TODO` to also refuse the pull-up when a projection over inner columns is not null-preserving. Pulling such a projection above the join evaluates it on the NULL-extended rows, so a non-match yielded a real value instead of NULL:

```sql
select t1.a, lat.bz from t1 left join lateral
  (select ifnull(b, 'z') as bz from t2 where t2.a = t1.a) lat on true;
-- an outer row with no match returned 'z'; MySQL returns NULL
```

`ifnull`, `coalesce`, `IS NULL`, `if()` and `CASE` were all affected. The `TODO` is now implemented with `expression.EvaluateExprWithNull` over the projection's input schema, so genuinely null-preserving expressions such as `concat(b, '!')` keep decorrelating exactly as before. As with the aggregate guard above, only `LEFT JOIN LATERAL` reaches this branch: a scalar subquery keeps a `MaxOneRow` that holds the projection off it.

Behaviour was checked case by case against MySQL semantics, including: NULL extension, non-trivial and outer-only `ON` conditions, scalar-aggregate vs `GROUP BY` vs `HAVING` defaults, unused LATERAL output (must **not** be eliminated when the inner can return several rows, **is** eliminated over a unique key), `UNION ALL` inners, chained and nested laterals, `USING` joins on the left, views, CTEs, `UPDATE`/`DELETE`, prepared statements with plan-cache reuse, the Apply cache, and the `no_decorrelate` hint.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support `LEFT JOIN LATERAL` for LATERAL derived tables.
Fix a wrong result where a LATERAL join nested below another Apply could be dropped, losing rows. This also affected `INNER JOIN LATERAL`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `LEFT JOIN LATERAL` queries with correct `NULL` values for missing matches.
  * Expanded lateral join support for predicates, limits, aggregates, grouping, unions, nested references, correlated subqueries, and `CROSS JOIN LATERAL`.
  * Added broader query planning coverage for lateral joins and their decorrelated equivalents.

* **Bug Fixes**
  * Corrected grouped aggregate behavior so unmatched outer-join results remain `NULL`.
  * Preserved correct handling of null-sensitive expressions in lateral joins.
  * `RIGHT JOIN LATERAL` and `NATURAL JOIN LATERAL` remain unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


