### PR TITLE
privilege, executor: fix visibility for information_schema.user_attributes

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -386,6 +386,16 @@ func (e *memtableRetriever) setDataForUserAttributes(ctx context.Context, sctx s
 	if len(chunkRows) == 0 {
 		return nil
 	}
+	var filter privileges.UserAttrFilter
+	viewer := sctx.GetSessionVars().User
+	if viewer != nil {
+		filter = privileges.NewUserAttrFilter(
+			sctx.GetSessionVars().ActiveRoles,
+			viewer.Username,
+			viewer.Hostname,
+			privilege.GetPrivilegeManager(sctx),
+		)
+	}
 	rows := make([][]types.Datum, 0, len(chunkRows))
 	for _, chunkRow := range chunkRows {
 		if chunkRow.Len() != 3 {
@@ -393,6 +403,9 @@ func (e *memtableRetriever) setDataForUserAttributes(ctx context.Context, sctx s
 		}
 		user := chunkRow.GetString(0)
 		host := chunkRow.GetString(1)
+		if filter != nil && !filter.Visible(user, host) {
+			continue
+		}
 		// Compatible with results in MySQL
 		var attribute any
 		if attribute = chunkRow.GetString(2); attribute == "" {

--- a/pkg/privilege/privileges/BUILD.bazel
+++ b/pkg/privilege/privileges/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "errors.go",
         "privileges.go",
         "tidb_auth_token.go",
+        "user_attributes_filter.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/privilege/privileges",
     visibility = ["//visibility:public"],

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -1541,12 +1541,14 @@ func TestInfoSchemaUserAttributes(t *testing.T) {
 	store := createStoreAndPrepareDB(t)
 
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("CREATE USER uanobody, uaroot, uaselectonmysqluser, uaselectonmysql")
+	tk.MustExec("CREATE USER uanobody, uaroot, uaselectonmysqluser, uaselectonmysql, uacreateonly, uasystemholder")
 	tk.MustExec(`CREATE USER uavictim@'%' ATTRIBUTE '{"secret": "victim-data"}'`)
 	tk.MustExec(`ALTER USER root@'%' ATTRIBUTE '{"secret": "root-data"}'`)
 	tk.MustExec("GRANT SUPER ON *.* TO uaroot")
 	tk.MustExec("GRANT SELECT ON mysql.user TO uaselectonmysqluser")
 	tk.MustExec("GRANT SELECT ON mysql.* TO uaselectonmysql")
+	tk.MustExec("GRANT CREATE USER ON *.* TO uacreateonly")
+	tk.MustExec("GRANT SYSTEM_USER ON *.* TO uasystemholder")
 
 	authLocalhost := func(user string) {
 		tk.Session().Auth(&auth.UserIdentity{
@@ -1563,12 +1565,18 @@ func TestInfoSchemaUserAttributes(t *testing.T) {
 
 	authLocalhost("uaselectonmysqluser")
 	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows(
-		"root", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uavictim",
+		"root", "uacreateonly", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uasystemholder", "uavictim",
 	))
 
 	authLocalhost("uaselectonmysql")
 	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows(
-		"root", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uavictim",
+		"root", "uacreateonly", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uasystemholder", "uavictim",
+	))
+
+	// CREATE USER without SYSTEM_USER: visible for self and all non-SYSTEM_USER accounts.
+	authLocalhost("uacreateonly")
+	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows(
+		"uacreateonly", "uanobody", "uaselectonmysql", "uaselectonmysqluser", "uavictim",
 	))
 }
 

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -1535,6 +1535,43 @@ func TestInfoSchemaUserPrivileges(t *testing.T) {
 	tk.MustQuery(`SELECT * FROM information_schema.user_privileges WHERE grantee = "'isselectonmysqluser'@'%'"`).Check(testkit.Rows("'isselectonmysqluser'@'%' def USAGE NO"))
 }
 
+func TestInfoSchemaUserAttributes(t *testing.T) {
+	// USER_ATTRIBUTES visibility follows MySQL 8.0.22+ rules and requires SELECT or UPDATE
+	// on mysql.user to see all rows. SUPER alone is not sufficient.
+	store := createStoreAndPrepareDB(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE USER uanobody, uaroot, uaselectonmysqluser, uaselectonmysql")
+	tk.MustExec(`CREATE USER uavictim@'%' ATTRIBUTE '{"secret": "victim-data"}'`)
+	tk.MustExec(`ALTER USER root@'%' ATTRIBUTE '{"secret": "root-data"}'`)
+	tk.MustExec("GRANT SUPER ON *.* TO uaroot")
+	tk.MustExec("GRANT SELECT ON mysql.user TO uaselectonmysqluser")
+	tk.MustExec("GRANT SELECT ON mysql.* TO uaselectonmysql")
+
+	authLocalhost := func(user string) {
+		tk.Session().Auth(&auth.UserIdentity{
+			Username: user,
+			Hostname: "localhost",
+		}, nil, nil, nil)
+	}
+
+	authLocalhost("uanobody")
+	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows("uanobody"))
+
+	authLocalhost("uaroot")
+	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows("uaroot"))
+
+	authLocalhost("uaselectonmysqluser")
+	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows(
+		"root", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uavictim",
+	))
+
+	authLocalhost("uaselectonmysql")
+	tk.MustQuery(`SELECT user FROM information_schema.user_attributes ORDER BY user`).Check(testkit.Rows(
+		"root", "uanobody", "uaroot", "uaselectonmysql", "uaselectonmysqluser", "uavictim",
+	))
+}
+
 // Issues https://github.com/pingcap/tidb/issues/25972 and https://github.com/pingcap/tidb/issues/26451
 func TestGrantOptionAndRevoke(t *testing.T) {
 	store := createStoreAndPrepareDB(t)

--- a/pkg/privilege/privileges/user_attributes_filter.go
+++ b/pkg/privilege/privileges/user_attributes_filter.go
@@ -1,0 +1,104 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privileges
+
+import (
+	"github.com/pingcap/tidb/pkg/parser/auth"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/privilege"
+)
+
+type attrVisMode int
+
+const (
+	attrVisAll attrVisMode = iota
+	attrVisNonSystem
+	attrVisSelf
+)
+
+// UserAttrFilter filters USER_ATTRIBUTES rows by MySQL 8.0.22+ visibility rules.
+type UserAttrFilter interface {
+	Visible(user, host string) bool
+}
+
+type userAttrFilter struct {
+	priv       *MySQLPrivilege
+	viewerUser string
+	viewerHost string
+	mode       attrVisMode
+}
+
+func (f *userAttrFilter) Visible(user, host string) bool {
+	switch f.mode {
+	case attrVisAll:
+		return true
+	case attrVisSelf, attrVisNonSystem:
+		record := f.priv.matchUser(user, host)
+		if record != nil && record.match(f.viewerUser, f.viewerHost) {
+			return true
+		}
+		if f.mode == attrVisSelf {
+			return false
+		}
+		return !f.priv.RequestDynamicVerification(nil, user, host, "SYSTEM_USER", false)
+	default:
+		return false
+	}
+}
+
+// NewUserAttrFilter builds a row filter for INFORMATION_SCHEMA.USER_ATTRIBUTES.
+// See https://dev.mysql.com/doc/refman/8.4/en/information-schema-user-attributes-table.html
+func NewUserAttrFilter(
+	activeRoles []*auth.RoleIdentity,
+	viewerUser, viewerHost string,
+	pm privilege.Manager,
+) UserAttrFilter {
+	if SkipWithGrant || pm == nil || (viewerUser == "" && viewerHost == "") {
+		return &userAttrFilter{mode: attrVisAll}
+	}
+	userPriv, ok := pm.(*UserPrivileges)
+	if !ok {
+		return &userAttrFilter{mode: attrVisAll}
+	}
+	priv := userPriv.Handle.Get()
+
+	// If the viewer has SELECT or UPDATE privileges on the "user" table, return a filter that allows all rows.
+	if priv.RequestVerification(activeRoles, viewerUser, viewerHost, mysql.SystemDB, "user", "", mysql.SelectPriv) ||
+		priv.RequestVerification(activeRoles, viewerUser, viewerHost, mysql.SystemDB, "user", "", mysql.UpdatePriv) {
+		return &userAttrFilter{priv: priv, mode: attrVisAll}
+	}
+
+	if priv.RequestVerification(activeRoles, viewerUser, viewerHost, "", "", "", mysql.CreateUserPriv) {
+		// If the viewer has CREATE_USER and SYSTEM_USER privileges, return a filter that allows all rows.
+		if priv.RequestDynamicVerification(activeRoles, viewerUser, viewerHost, "SYSTEM_USER", false) {
+			return &userAttrFilter{priv: priv, mode: attrVisAll}
+		}
+		// If the viewer has CREATE_USER but no SYSTEM_USER privileges, return a filter that allows rows for non-system users.
+		return &userAttrFilter{
+			priv:       priv,
+			viewerUser: viewerUser,
+			viewerHost: viewerHost,
+			mode:       attrVisNonSystem,
+		}
+	}
+
+	// If the viewer has no privileges above, return a filter that allows self-only.
+	return &userAttrFilter{
+		priv:       priv,
+		viewerUser: viewerUser,
+		viewerHost: viewerHost,
+		mode:       attrVisSelf,
+	}
+}

--- a/tests/integrationtest/r/executor/simple.result
+++ b/tests/integrationtest/r/executor/simple.result
@@ -408,9 +408,7 @@ attribute
 {"age": 20, "name": "Tom"}
 SELECT user, host, attribute FROM information_schema.user_attributes where user in ('testuser', 'testuser1', 'testuser2') ORDER BY user;
 user	host	attribute
-testuser	%	{"comment": "1234"}
 testuser1	%	{"age": 20, "name": "Tom"}
-testuser2	%	NULL
 SELECT user, host, user_attributes FROM mysql.user ORDER BY user;
 Error 1142 (42000): SELECT command denied to user 'testuser1'@'%' for table 'user'
 create user usr1@'%' identified by 'passord';

--- a/tests/integrationtest/t/executor/simple.test
+++ b/tests/integrationtest/t/executor/simple.test
@@ -440,8 +440,8 @@ SELECT attribute FROM information_schema.user_attributes WHERE user = 'testuser1
 ALTER USER testuser1 ATTRIBUTE '{"comment": null}';
 SELECT attribute FROM information_schema.user_attributes WHERE user = 'testuser1';
 
-## Non-root users could access COMMENT or ATTRIBUTE of all users via the view,
-## but not via the mysql.user table.
+## Non-root users can only see their own row in information_schema.user_attributes
+## (MySQL 8.0.22+), and cannot read mysql.user directly.
 connect (conn1, localhost, testuser1,,);
 SELECT user, host, attribute FROM information_schema.user_attributes where user in ('testuser', 'testuser1', 'testuser2') ORDER BY user;
 -- error 1142

--- a/tests/integrationtest/t/executor/simple.test
+++ b/tests/integrationtest/t/executor/simple.test
@@ -440,7 +440,7 @@ SELECT attribute FROM information_schema.user_attributes WHERE user = 'testuser1
 ALTER USER testuser1 ATTRIBUTE '{"comment": null}';
 SELECT attribute FROM information_schema.user_attributes WHERE user = 'testuser1';
 
-## Non-root users can only see their own row in information_schema.user_attributes
+## Users without elevated privileges can only see their own row in information_schema.user_attributes.
 ## (MySQL 8.0.22+), and cannot read mysql.user directly.
 connect (conn1, localhost, testuser1,,);
 SELECT user, host, attribute FROM information_schema.user_attributes where user in ('testuser', 'testuser1', 'testuser2') ORDER BY user;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70277

Problem Summary:
TiDB exposes information_schema.user_attributes as a virtual information_schema table backed by mysql.user.user_attributes. A normal authenticated user with only USAGE can query this table and read other users' ATTRIBUTE values, including root's metadata.

### What changed and how does it work?
Add privilege check for information_schema.user_attributes, same as https://dev.mysql.com/doc/refman/8.4/en/information-schema-user-attributes-table.html

```
- [USER_ATTRIBUTES](https://dev.mysql.com/doc/refman/8.4/en/information-schema-user-attributes-table.html) contents are accessible as follows:

  - All rows are accessible if:

    - The current thread is a replica thread.

    - The access control system has not been initialized (for example, the server was started with the [--skip-grant-tables](https://dev.mysql.com/doc/refman/8.4/en/server-options.html#option_mysqld_skip-grant-tables) option).

    - The currently authenticated account has the [UPDATE](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_update) or [SELECT](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_select) privilege for the mysql.user system table.

    - The currently authenticated account has the [CREATE USER](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_create-user) and [SYSTEM_USER](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_system-user) privileges.

  - Otherwise, the currently authenticated account can see the row for that account. Additionally, if the account has the [CREATE USER](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_create-user) privilege but not the [SYSTEM_USER](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_system-user) privilege, it can see rows for all other accounts that do not have the [SYSTEM_USER](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html#priv_system-user) privilege.
```


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix the bug that normal users can read all users' attributes through information_schema.user_attributes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility controls for user attributes in the information schema.
  * Regular users can see only their own attributes.
  * Authorized administrators can view user attributes according to their privileges.
  * Added coverage for visibility behavior across common privilege levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->