### PR TITLE
executor: skip assertion for prefix indexes in rebuildIndexRanges

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -182,7 +182,19 @@ func rebuildIndexRanges(ectx expression.BuildContext, rctx *rangerctx.RangerCont
 	//     Selection / table-side filter; rebuilding only the access ranges here is safe.
 	// The assert below is a regression guard in case a future planner change introduces a
 	// shouldReserve case that isn't covered by one of these two mechanisms.
-	intest.Assert(len(remainedConds) == 0, "rebuildIndexRanges: detacher returned residuals on correlated-access path")
+	// For prefix indexes, the detacher may return residuals on the prefix column
+	// (shouldReserve), but the planner already retains the predicate as a parent
+	// Selection, so this is safe.
+	hasPrefixCol := false
+	for _, cl := range colLens {
+		if cl > 0 {
+			hasPrefixCol = true
+			break
+		}
+	}
+	if !hasPrefixCol {
+		intest.Assert(len(remainedConds) == 0, "rebuildIndexRanges: detacher returned residuals on correlated-access path")
+	}
 	return ranges, nil
 }
 


### PR DESCRIPTION
## Description

Fixes #70245

The `rebuildIndexRanges` assertion in `pkg/executor/distsql.go` fires for prefix indexes when a correlated equality condition is used. The assertion checks that `DetachSimpleCondAndBuildRangeForIndex` returns no residual conditions, but for prefix columns, the detacher returns the condition in `remainedConds` because of `shouldReserve`.

### Root Cause

The `colLens` parameter contains column lengths — values > 0 indicate a prefix index (e.g., `KEY ip (name(5), id)`). When `shouldReserve` is true for a prefix column, the detacher leaves the condition in `remainedConds`. The comment above the assertion already lists prefix indexes as a safe case (the planner retains the predicate as a `Selection`), but the assertion doesn't account for this.

### Fix

Add a prefix column check before the assertion. If any column in the index has a prefix length > 0, skip the assertion — the planner already retains the predicate as a parent `Selection` / table-side filter, making this safe.

### Reproduction

```sql
CREATE TABLE tp (name varchar(64) NOT NULL, id int NOT NULL, KEY ip (name(5), id));
INSERT INTO tp VALUES ('abcdefg',1),('abcdeXY',2),('zzz',3);

SELECT (SELECT /*+ NO_DECORRELATE() */ MIN(t2.id)
        FROM tp t2 USE INDEX (ip)
        WHERE t2.name = t1.name) FROM tp t1;
```

This query fails with `assert failed, rebuildIndexRanges: detacher returned residuals on correlated-access path` in builds with assertions enabled (`intest` / `enableassert`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index range handling for prefix-index queries with additional filter conditions.
  * Preserved existing validation for non-prefix index queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->