### PR TITLE
ddl: escape backticks in MODIFY COLUMN check SQL identifiers (#70285)

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -860,8 +860,8 @@ func buildCheckSQLFromModifyColumn(
 
 	var conditions []string
 	template := "SELECT %s FROM %s WHERE %s LIMIT 1"
-	checkColName := fmt.Sprintf("`%s`", oldCol.Name.O)
-	tableName := fmt.Sprintf("`%s`.`%s`", dbName.O, tblName.O)
+	checkColName := fmt.Sprintf("`%s`", strings.ReplaceAll(oldCol.Name.O, "`", "``"))
+	tableName := fmt.Sprintf("`%s`.`%s`", strings.ReplaceAll(dbName.O, "`", "``"), strings.ReplaceAll(tblName.O, "`", "``"))
 
 	if checkValueRange {
 		if mysql.IsIntegerType(oldTp) && mysql.IsIntegerType(changingTp) {
@@ -877,7 +877,7 @@ func buildCheckSQLFromModifyColumn(
 
 	if isNullToNotNullChange(oldCol, changingCol) {
 		if !(oldTp != mysql.TypeTimestamp && changingTp == mysql.TypeTimestamp) {
-			conditions = append(conditions, fmt.Sprintf("`%s` IS NULL", oldCol.Name.O))
+			conditions = append(conditions, fmt.Sprintf("`%s` IS NULL", strings.ReplaceAll(oldCol.Name.O, "`", "``")))
 		}
 	}
 
@@ -893,7 +893,7 @@ func buildCheckRangeForIntegerTypes(oldCol, changingCol *model.ColumnInfo) strin
 	changingTp := changingCol.GetType()
 	changingUnsigned := mysql.HasUnsignedFlag(changingCol.GetFlag())
 
-	columnName := fmt.Sprintf("`%s`", oldCol.Name.O)
+	columnName := fmt.Sprintf("`%s`", strings.ReplaceAll(oldCol.Name.O, "`", "``"))
 
 	if changingUnsigned {
 		upperBound := types.IntegerUnsignedUpperBound(changingTp)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70285

Problem Summary:

On the no-reorg `MODIFY COLUMN` path, TiDB builds an internal validation query by interpolating database, table, and column names without escaping embedded backticks. When one of these identifiers contains a backtick, the generated query is invalid and the DDL job rolls back.

### What changed and how does it work?

Escape embedded backticks in the database, table, and column identifiers used by the internal `MODIFY COLUMN` validation query before enclosing the identifiers in backticks. This covers range checks, nullability checks, and qualified table names.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `MODIFY COLUMN` could fail when a database, table, or column name contains a backtick.
```
