### PR TITLE
planner: stop lower-casing regex patterns in information_schema predicate extractor (#70284)

### DIFF
--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -393,9 +393,9 @@ func (helper *extractHelper) extractLikePatternCol(
 		} else {
 			canBuildPattern, pattern = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
 		}
-		if canBuildPattern && toLower {
-			pattern = strings.ToLower(pattern)
-		}
+		// No need to lower-case the pattern: the caller compiles with (?i) prefix
+		// which handles case-insensitive matching. Lower-casing regex patterns
+		// corrupts case-sensitive classes ([A-Z]) and negated classes (\D, \S, etc.).
 		if canBuildPattern {
 			patterns = append(patterns, pattern)
 		} else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70284

Problem Summary:

The information_schema predicate extractor lower-cases REGEXP patterns before compiling them with the `(?i)` prefix. This corrupts patterns that contain:

- **Case-sensitive character classes**: `[A-Z]` → `[a-z]` — now matches lowercase letters too
- **Negated shorthand classes**: `\D` (non-digit) → `\d` (digit) — inverts semantics
- **Negated character classes**: `[^A-Z]` → `[^a-z]` — inverts semantics

For example:
```sql
SELECT table_name FROM information_schema.tables
WHERE table_schema = 'test' AND table_name REGEXP '^[A-Z]+$';
```
Expected: only `UPPERONLY`. Actual: also returns `MixedCaseTbl` and `lc_tbl`.

### What is changed and how it works

**Root cause**: In `extractLikePatternCol`, `strings.ToLower(pattern)` is applied to both LIKE-derived patterns and REGEXP patterns. For REGEXP patterns, this corrupts regex syntax because:

1. `[A-Z]` lower-cased to `[a-z]` — under `(?i)` prefix, matches any letter
2. `\D` lower-cased to `\d` — negated class becomes positive
3. `[^A-Z]` lower-cased to `[^a-z]` — negated class becomes positive

**Fix**: Remove the `strings.ToLower` call. The caller already compiles the pattern with `(?i)` prefix, which provides correct case-insensitive matching without corrupting the regex pattern.

### Check List

Tests
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (the reproduce steps in the issue)

### Release note

Fix information_schema REGEXP predicate being incorrectly lower-cased, which broke case-sensitive and negated character classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-insensitive pattern matching while preserving character classes and escape sequences.
  * Prevented unintended changes to generated pattern casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->