### PR TITLE
planner: fix noDecorrelate skipping outer-only aggregates (#70286)

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3038,8 +3038,14 @@ func (b *PlanBuilder) extractCorrelatedAggFuncs(ctx context.Context, p base.Logi
 			cols = append(cols, expression.ExtractColumns(expr)...)
 		}
 		// If decorrelation is disabled, don't extract correlated aggregates
+		// that reference both inner and outer columns. Aggregates that reference
+		// only outer columns (corCols > 0, cols == 0) are not decorrelation
+		// candidates and should still be hoisted to the outer aggregation.
 		if b.noDecorrelate && len(corCols) > 0 {
-			continue
+			if len(cols) > 0 {
+				corCols, cols = corCols[:0], cols[:0]
+				continue
+			}
 		}
 		if len(corCols) > 0 && len(cols) == 0 {
 			outer = append(outer, agg)


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #70286

Problem Summary:
When `tidb_opt_enable_no_decorrelate_in_select=1` is set, `extractCorrelatedAggFuncs` skips ALL aggregates that have correlated columns (`corCols > 0`), including aggregates that reference ONLY outer columns. Aggregates like `SUM(t1.b)` inside a correlated subquery's SELECT list that depend only on the outer query's group are not decorrelation candidates at all — they must be hoisted to the outer aggregation.

### What is changed and how it works

The fix narrows the skip condition: when `noDecorrelate` is enabled, only skip aggregates that reference **both** inner and outer columns (`len(cols) > 0`). Aggregates that reference only outer columns (`len(corCols) > 0 && len(cols) == 0`) are still hoisted to the outer aggregation as before.

Additionally, the `continue` statement previously skipped the slice reset (`corCols, cols = corCols[:0], cols[:0]`), causing stale correlated columns to leak into the next iteration. The fix resets the scratch slices before continuing.

### Check List

Tests

- [ ] Integration test (manual test reproduced the issue — the fix matches the root cause analysis in the issue)

### Release note

<!--
compatibility note(s)

A bugfix: `tidb_opt_enable_no_decorrelate_in_select=1` no longer suppresses
outer-only aggregates in correlated subqueries, preventing wrong results.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning when decorrelation is disabled.
  * Correctly handles correlated aggregate expressions, preventing unsupported mixed inner/outer references while retaining valid outer-only aggregates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->