### PR TITLE
ddl: fix PRE_SPLIT_REGIONS for clustered multi-column primary keys [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/regionsplit"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -146,7 +147,19 @@ func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableS
 	for p := step; p < maxv; p += step {
 		recordID := p << shardFmt.IncrementalBits
 		recordPrefix := tablecodec.GenTableRecordPrefix(physicalID)
-		key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(recordID))
+		var key kv.Key
+		if tbInfo.IsCommonHandle {
+			encoded := codec.EncodeKey(nil, types.NewIntDatum(recordID))
+			ch, err := kv.NewCommonHandle(encoded)
+			if err != nil {
+				logutil.DDLLogger().Warn("pre split some table regions failed to create common handle",
+					zap.Stringer("table", tbInfo.Name), zap.Error(err))
+				continue
+			}
+			key = tablecodec.EncodeRecordKey(recordPrefix, ch)
+		} else {
+			key = tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(recordID))
+		}
 		splitTableKeys = append(splitTableKeys, key)
 	}
 	scatter, tableID := getScatterConfig(scatterScope, tbInfo.ID)


### PR DESCRIPTION
## Description

This PR fixes PRE_SPLIT_REGIONS having no effect on tables with a clustered multi-column primary key.

### Root Cause

`preSplitPhysicalTableByShardRowID()` computes pre-split boundaries using `IntHandle` encoding, which produces row keys in the `0x80...` key space. However, clustered multi-column primary keys (common handles) use `0x03...` encoded row keys. Since `0x03` < `0x80`, all row keys fall below the first pre-split boundary — every row lands in the first region, and the other pre-split regions stay empty forever.

### Fix

When the table has a common handle (`tbInfo.IsCommonHandle`), encode the split value as a datum using `codec.EncodeKey` and create a `CommonHandle` instead of using `IntHandle`. This places the split boundaries in the correct key space for common-handle row keys.

### Example

```sql
CREATE TABLE t (
  id  BIGINT NOT NULL AUTO_RANDOM(3),
  ts  DATETIME(6) NOT NULL,
  pad CHAR(200) NOT NULL,
  PRIMARY KEY (id, ts) CLUSTERED
) PRE_SPLIT_REGIONS = 3;
```

Before this fix: all 8 pre-split regions are created, but every row lands in the first region.

After this fix: rows are distributed across all 8 pre-split regions based on the AUTO_RANDOM shard bits.

Fixes #70291


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region pre-splitting for tables using common handles.
  * Invalid split keys are now skipped safely, while existing integer-handle tables continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->