### PR TITLE
planner: fix nil map panic in LogicalUnionAll.ExtractFD() (#70248)

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_union_all.go
+++ b/pkg/planner/core/operator/logicalop/logical_union_all.go
@@ -206,7 +206,7 @@ func (p *LogicalUnionAll) ExtractFD() *fd.FDSet {
 		childFDs = append(childFDs, childFD)
 	}
 	// check the output columns' not-null property.
-	res := &fd.FDSet{}
+	res := &fd.FDSet{HashCodeToUniqueID: make(map[string]int)}
 	notNullCols := intset.NewFastIntSet()
 	for _, col := range p.Schema().Columns {
 		notNullCols.Insert(int(col.UniqueID))


### PR DESCRIPTION
## Description

This PR fixes a nil map panic in `LogicalUnionAll.ExtractFD()` that occurs when a `UNION ALL` relation is used in a correlated subquery with `IN` and `ALL` operators.

### Root Cause

`LogicalUnionAll.ExtractFD()` creates `res := &fd.FDSet{}` without initializing the `HashCodeToUniqueID` map. When this uninitialized FDSet is passed to `ExtractEquivalenceCols()` or `ExtractConstantCols()` via the parent operator's FD chain, calling `RegisterUniqueID()` panics with "assignment to entry in nil map".

### Fix

Initialize `HashCodeToUniqueID` in the `FDSet` created by `LogicalUnionAll.ExtractFD()`:

```go
res := &fd.FDSet{HashCodeToUniqueID: make(map[string]int)}
```

### Reproduction

```sql
CREATE TABLE t0 (id BIGINT);
CREATE VIEW u AS SELECT * FROM t0 UNION ALL SELECT * FROM t0;
SELECT 1 FROM u AS t1 WHERE (t1.id < ALL (SELECT 1)) IN (SELECT t1.id);
```

### Stack Trace

```
runtime.mapassign_faststr
    internal/runtime/maps/runtime_faststr.go:265
(*FDSet).RegisterUniqueID
    pkg/planner/funcdep/fd_graph.go:1227
ExtractEquivalenceCols
    pkg/planner/util/funcdep_misc.go:117
(*LogicalJoin).ExtractFDForInnerJoin
    pkg/planner/core/operator/logicalop/logical_join.go:879
(*LogicalJoin).ExtractFD
    pkg/planner/core/operator/logicalop/logical_join.go:708
(*LogicalJoin).ExtractFDForSemiJoin
    pkg/planner/core/operator/logicalop/logical_join.go:845
(*LogicalJoin).ExtractFD
    pkg/planner/core/operator/logicalop/logical_join.go:712
```

Fixes #70248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved functional-dependency handling for UNION ALL query planning, supporting more reliable query optimization and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->