### PR TITLE
planner, executor: fix Storage_from_mpp false positive for TiKV-only plans

### DIFF
--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -522,13 +522,24 @@ func TestStorageEnginesInSlowQuery(t *testing.T) {
 	tk.MustExec("select /*+ read_from_storage(tiflash[t_tiflash]) */ a from t_tiflash;")
 	checkStorageEngines(t, tk, "query like 'select%t_tiflash;'", "0 1")
 
+	// Table has an available TiFlash replica, but the chosen plan reads from TiKV only.
+	// Having TiFlash available must not set Storage_from_mpp. (issue #70296)
+	tk.MustExec("create table t_kv_with_tiflash (a int)")
+	tk.MustExec("alter table t_kv_with_tiflash set tiflash replica 1")
+	tbKV := external.GetTableByName(t, tk, "test", "t_kv_with_tiflash")
+	require.NoError(t, dom.DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tbKV.Meta().ID, true))
+	query := "select /*+ read_from_storage(tikv[t_kv_with_tiflash]) */ a from t_kv_with_tiflash"
+	require.False(t, tk.HasTiFlashPlan(query))
+	tk.MustExec(query)
+	checkStorageEngines(t, tk, "query like 'select%t_kv_with_tiflash;'", "1 0")
+
 	// Query that reads from both TiKV and TiFlash
 	tk.MustExec("select /*+ read_from_storage(tikv[t_tikv]) */ t_tikv.a, /*+ read_from_storage(tiflash[t_tiflash]) */ t_tiflash.a from t_tikv, t_tiflash")
 	checkStorageEngines(t, tk, "query like 'select%t_tikv, t_tiflash;'", "1 1")
 
 	// Point get queries should register as reading from TiKV
 	tk.MustExec("create table t_pointget (a int primary key)")
-	query := "select a from t_pointget where a = 1"
+	query = "select a from t_pointget where a = 1"
 	tk.MustHavePlan(query, "Point_Get")
 	tk.MustExec(query)
 	checkStorageEngines(t, tk, "query like 'select%t_pointget%;'", "1 0")

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4959,10 +4959,6 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		return nil, err
 	}
 	tableInfo := tbl.Meta()
-	if b.ctx.GetSessionVars().IsMPPAllowed() &&
-		tableInfo.TiFlashReplica != nil && tableInfo.TiFlashReplica.Count > 0 && tableInfo.TiFlashReplica.Available {
-		sessionVars.StmtCtx.IsTiFlash.Store(true)
-	}
 
 	if b.isCreateView && tableInfo.TempTableType == model.TempTableLocal {
 		return nil, plannererrors.ErrViewSelectTemporaryTable.GenWithStackByArgs(tn.Name)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70296

Problem Summary:

When a table has an available TiFlash replica, slow log / `INFORMATION_SCHEMA.SLOW_QUERY` can report `Storage_from_mpp: true` even if the final plan only reads from TiKV (`cop[tikv]`).

This started after #65250: logical plan building set `StmtCtx.IsTiFlash = true` whenever MPP was allowed and the table had an available TiFlash replica. That flag is later consumed by slow log / stmt summary / TiFlash success metrics, so a TiKV-only execution was incorrectly marked as reading from TiFlash.

### What changed and how does it work?

- Remove the premature `StmtCtx.IsTiFlash.Store(true)` from `buildDataSource` in the logical plan builder.
- Keep setting `IsTiFlash` only when the executor actually builds a TiFlash `TableReader` (`StoreType == TiFlash`).
- Table TiFlash capability for optimizer decisions continues to use the logical-plan `HasTiFlash` propagation introduced by #65250; this PR only stops leaking that capability signal into execution diagnostics.
- Add a regression case in `TestStorageEnginesInSlowQuery`: available TiFlash replica + `read_from_storage(tikv[...])` expects `storage_from_kv, storage_from_mpp = 1 0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
slowlog: fix Storage_from_mpp false positive when a TiKV-only query touches a table with TiFlash replica
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query planning so explicitly TiKV-planned queries use TiKV even when a TiFlash replica is available.
  * Prevented TiFlash usage from being reported when no TiFlash plan is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->