### PR TITLE
planner: cost un/finished double reads as index lookups

### DIFF
--- a/pkg/bindinfo/testdata/binding_auto_suite_out.json
+++ b/pkg/bindinfo/testdata/binding_auto_suite_out.json
@@ -205,7 +205,7 @@
         "Fixes": "[45132 52869]"
       },
       {
-        "Vars": "[tidb_opt_index_lookup_cost_factor tidb_opt_index_scan_cost_factor tidb_opt_prefer_range_scan tidb_opt_table_range_scan_cost_factor tidb_opt_table_rowid_scan_cost_factor tidb_opt_topn_cost_factor]",
+        "Vars": "[tidb_opt_index_lookup_cost_factor tidb_opt_index_scan_cost_factor tidb_opt_prefer_range_scan tidb_opt_table_rowid_scan_cost_factor tidb_opt_topn_cost_factor]",
         "Fixes": "[52869]"
       },
       {

--- a/pkg/planner/core/casetest/cbotest/BUILD.bazel
+++ b/pkg/planner/core/casetest/cbotest/BUILD.bazel
@@ -6,10 +6,11 @@ go_test(
     srcs = [
         "cbo_test.go",
         "main_test.go",
+        "topn_double_read_cost_test.go",
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/domain",
         "//pkg/executor",

--- a/pkg/planner/core/casetest/cbotest/topn_double_read_cost_test.go
+++ b/pkg/planner/core/casetest/cbotest/topn_double_read_cost_test.go
@@ -31,6 +31,7 @@ func TestTopNChoosesGloballyCheaperDoubleReadPath(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_cost_model_version = 2")
 
 	tk.MustExec(`CREATE TABLE test.masked_event_journal (
 		rec_id BIGINT NOT NULL AUTO_INCREMENT,
@@ -88,12 +89,13 @@ func TestTopNChoosesGloballyCheaperDoubleReadPath(t *testing.T) {
 		  AND state_flag = 1
 		ORDER BY seen_at DESC
 		LIMIT 1`
-	plan := testdata.ConvertRowsToStrings(tk.MustQuery(explainSQL).Rows())
+	rows := tk.MustQuery(explainSQL).Rows()
+	plan := testdata.ConvertRowsToStrings(rows)
 	require.NotEmpty(t, plan)
 	require.Contains(t, plan[0], "TopN")
 
 	var hasProbeTopN, hasBuildTopN, hasTargetIndex bool
-	for _, row := range plan {
+	for i, row := range plan {
 		if strings.Contains(row, "TopN") && strings.Contains(row, "(Probe)") {
 			hasProbeTopN = true
 		}
@@ -102,15 +104,8 @@ func TestTopNChoosesGloballyCheaperDoubleReadPath(t *testing.T) {
 		}
 		if strings.Contains(row, "IndexRangeScan") && strings.Contains(row, "index:idx_event_shard_batch_route_state") {
 			hasTargetIndex = true
-			var estRows float64
-			var parsed bool
-			for _, field := range strings.Fields(row) {
-				if value, err := strconv.ParseFloat(field, 64); err == nil {
-					estRows, parsed = value, true
-					break
-				}
-			}
-			require.True(t, parsed)
+			estRows, err := strconv.ParseFloat(rows[i][1].(string), 64)
+			require.NoError(t, err)
 			require.Greater(t, estRows, 10000.0)
 		}
 	}

--- a/pkg/planner/core/casetest/cbotest/topn_double_read_cost_test.go
+++ b/pkg/planner/core/casetest/cbotest/topn_double_read_cost_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbotest
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopNChoosesGloballyCheaperDoubleReadPath(t *testing.T) {
+	// This regression covers the classic optimizer's DataSource candidate loop,
+	// so it intentionally does not run under the Cascades test wrapper.
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`CREATE TABLE test.masked_event_journal (
+		rec_id BIGINT NOT NULL AUTO_INCREMENT,
+		route_code VARCHAR(32) DEFAULT NULL,
+		state_flag INT NOT NULL DEFAULT 0,
+		seen_at DATETIME DEFAULT NULL,
+		event_code VARCHAR(64) DEFAULT NULL,
+		shard_no INT DEFAULT NULL,
+		batch_at DATETIME DEFAULT NULL,
+		extra_note VARCHAR(128) DEFAULT NULL,
+		PRIMARY KEY (rec_id) CLUSTERED,
+		KEY idx_route_state_seen (route_code, state_flag, seen_at),
+		KEY idx_event_shard_batch_route_state (event_code, shard_no, batch_at, route_code, state_flag)
+	)`)
+
+	tk.MustExec(`INSERT INTO test.masked_event_journal
+		(route_code, state_flag, seen_at, event_code, shard_no, batch_at, extra_note)
+	SELECT
+		CASE WHEN n % 32 = 0 THEN 'route_alpha' ELSE 'route_beta' END AS route_code,
+		CASE WHEN n % 2 = 0 THEN 1 ELSE 0 END AS state_flag,
+		TIMESTAMPADD(SECOND, n, '2026-01-01 00:00:00') AS seen_at,
+		CASE
+			WHEN n % 4 = 0 THEN 'event_target_314'
+			WHEN n % 7 = 0 THEN 'event_group_red'
+			ELSE 'event_group_blue'
+		END AS event_code,
+		n % 128 AS shard_no,
+		CASE
+			WHEN n % 1600 = 0 THEN '2026-06-27 11:56:03'
+			ELSE TIMESTAMPADD(SECOND, n % 86400, '2026-06-01 00:00:00')
+		END AS batch_at,
+		CONCAT('masked payload ', n) AS extra_note
+	FROM (
+		SELECT d0.i + d1.i * 10 + d2.i * 100 + d3.i * 1000 + d4.i * 10000 + 1 AS n
+		FROM
+			(SELECT 0 i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d0,
+			(SELECT 0 i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d1,
+			(SELECT 0 i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d2,
+			(SELECT 0 i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d3,
+			(SELECT 0 i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d4
+	) seq
+	WHERE n <= 100000`)
+
+	// Keep both ANALYZE statements to match the issue's supplied reproduction.
+	tk.MustExec("ANALYZE TABLE test.masked_event_journal")
+	tk.MustExec("ANALYZE TABLE test.masked_event_journal")
+	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+
+	const explainSQL = `EXPLAIN FORMAT='verbose'
+		SELECT rec_id, extra_note
+		FROM test.masked_event_journal
+		WHERE route_code = 'route_alpha'
+		  AND event_code = 'event_target_314'
+		  AND batch_at = '2026-06-27 11:56:03'
+		  AND state_flag = 1
+		ORDER BY seen_at DESC
+		LIMIT 1`
+	plan := testdata.ConvertRowsToStrings(tk.MustQuery(explainSQL).Rows())
+	require.NotEmpty(t, plan)
+	require.Contains(t, plan[0], "TopN")
+
+	var hasProbeTopN, hasBuildTopN, hasTargetIndex bool
+	for _, row := range plan {
+		if strings.Contains(row, "TopN") && strings.Contains(row, "(Probe)") {
+			hasProbeTopN = true
+		}
+		if strings.Contains(row, "TopN") && strings.Contains(row, "(Build)") {
+			hasBuildTopN = true
+		}
+		if strings.Contains(row, "IndexRangeScan") && strings.Contains(row, "index:idx_event_shard_batch_route_state") {
+			hasTargetIndex = true
+			var estRows float64
+			var parsed bool
+			for _, field := range strings.Fields(row) {
+				if value, err := strconv.ParseFloat(field, 64); err == nil {
+					estRows, parsed = value, true
+					break
+				}
+			}
+			require.True(t, parsed)
+			require.Greater(t, estRows, 10000.0)
+		}
+	}
+	require.True(t, hasTargetIndex)
+	require.True(t, hasProbeTopN)
+	require.False(t, hasBuildTopN)
+	require.Equal(t, plan, testdata.ConvertRowsToStrings(tk.MustQuery(explainSQL).Rows()))
+}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1533,7 +1533,8 @@ func applyLogicalAggregationHint(lp base.LogicalPlan, physicPlan base.PhysicalPl
 		}
 	} else if la.PreferAggToCop {
 		// If the aggregation is preferred to be pushed down to coprocessor, we will prefer it.
-		if _, ok := childTasks[0].(*physicalop.CopTask); ok {
+		if cop, ok := childTasks[0].(*physicalop.CopTask); ok &&
+			len(cop.RootTaskConds) == 0 && len(cop.IdxMergePartPlans) == 0 {
 			return true
 		}
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1532,7 +1532,9 @@ func applyLogicalAggregationHint(lp base.LogicalPlan, physicPlan base.PhysicalPl
 			}
 		}
 	} else if la.PreferAggToCop {
-		// If the aggregation is preferred to be pushed down to coprocessor, we will prefer it.
+		// Prefer a CopTask only when the current aggregation can be attached to its
+		// coprocessor side. Root-side conditions and IndexMerge partial plans force
+		// the aggregation to be attached after converting the task to root.
 		if cop, ok := childTasks[0].(*physicalop.CopTask); ok &&
 			len(cop.RootTaskConds) == 0 && len(cop.IdxMergePartPlans) == 0 {
 			return true

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -505,8 +505,8 @@ func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (c
 	return curCost < bestCost, nil
 }
 
-// compareDataSourceTaskCost compares local DataSource candidates. An unfinished
-// double-read candidate is costed as the IndexLookUpReader it will become.
+// compareDataSourceTaskCost compares local DataSource candidates. Double-read
+// candidates are costed as the IndexLookUpReader they will become.
 func compareDataSourceTaskCost(curTask, bestTask base.Task, costCache map[base.Task]taskCostResult) (curIsBetter bool, err error) {
 	return compareTaskCostWith(curTask, bestTask, func(t base.Task) (float64, bool, error) {
 		if result, ok := costCache[t]; ok {
@@ -521,8 +521,8 @@ func compareDataSourceTaskCost(curTask, bestTask base.Task, costCache map[base.T
 func getDataSourceTaskPlanCost(t base.Task) (float64, bool, error) {
 	if !t.Invalid() {
 		if cop, ok := t.(*physicalop.CopTask); ok &&
-			cop.IndexPlan != nil && cop.TablePlan != nil && !cop.IndexPlanFinished {
-			cost, err := getUnfinishedIndexLookUpCost(cop)
+			cop.IndexPlan != nil && cop.TablePlan != nil {
+			cost, err := getIndexLookUpReaderEquivalentCost(cop)
 			return cost, false, err
 		}
 	}
@@ -614,9 +614,9 @@ func getTaskPlanCost(t base.Task) (float64, bool, error) {
 	return cost + indexPartialCost, false, err
 }
 
-// getUnfinishedIndexLookUpCost estimates an unfinished double-read CopTask as an
+// getIndexLookUpReaderEquivalentCost estimates a double-read CopTask as an
 // IndexLookUpReader without changing the candidate task or its plan trees.
-func getUnfinishedIndexLookUpCost(cop *physicalop.CopTask) (float64, error) {
+func getIndexLookUpReaderEquivalentCost(cop *physicalop.CopTask) (float64, error) {
 	ctx := cop.IndexPlan.SCtx()
 	indexPlan, err := cop.IndexPlan.Clone(ctx)
 	if err != nil {
@@ -627,14 +627,16 @@ func getUnfinishedIndexLookUpCost(cop *physicalop.CopTask) (float64, error) {
 		return 0, err
 	}
 
-	// FinishIndexPlan makes the table side consume the rows produced by the index
-	// side while retaining its statistics version. Apply those semantics with an
-	// isolated StatsInfo value on the table clone.
-	tableStats := *indexPlan.StatsInfo()
-	if originalStats := tablePlan.StatsInfo(); originalStats != nil {
-		tableStats.StatsVersion = originalStats.StatsVersion
+	if !cop.IndexPlanFinished {
+		// FinishIndexPlan makes the table side consume the rows produced by the index
+		// side while retaining its statistics version. Apply those semantics with an
+		// isolated StatsInfo value on the table clone.
+		tableStats := *indexPlan.StatsInfo()
+		if originalStats := tablePlan.StatsInfo(); originalStats != nil {
+			tableStats.StatsVersion = originalStats.StatsVersion
+		}
+		tablePlan.SetStats(&tableStats)
 	}
-	tablePlan.SetStats(&tableStats)
 	input := indexLookUpCostInput{
 		ctx:         ctx,
 		indexPlan:   indexPlan,

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -618,6 +618,9 @@ func getTaskPlanCost(t base.Task) (float64, bool, error) {
 // IndexLookUpReader without changing the candidate task or its plan trees.
 func getIndexLookUpReaderEquivalentCost(cop *physicalop.CopTask) (float64, error) {
 	ctx := cop.IndexPlan.SCtx()
+	// This is a speculative comparison. Clones isolate both the temporary
+	// table-side stats adjustment below and plan-cost cache writes made while
+	// recalculating physical-plan costs.
 	indexPlan, err := cop.IndexPlan.Clone(ctx)
 	if err != nil {
 		return 0, err
@@ -646,10 +649,10 @@ func getIndexLookUpReaderEquivalentCost(cop *physicalop.CopTask) (float64, error
 	}
 	option := costusage.NewDefaultPlanCostOption().WithCostFlag(costusage.CostFlagRecalculate)
 	if ctx.GetSessionVars().CostModelVersion == modelVer2 {
-		cost, _, err := getPlanCostVer24IndexLookUpReader(input, property.CopMultiReadTaskType, option)
+		cost, _, err := getIndexLookUpReaderCostVer2(input, property.CopMultiReadTaskType, option)
 		return cost.GetCost(), err
 	}
-	cost, _, err := getPlanCostVer14IndexLookUpReader(input, option)
+	cost, _, err := getIndexLookUpReaderCostVer1(input, option)
 	return cost, err
 }
 

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -474,7 +474,9 @@ func iterateChildPlan4LogicalSequence(
 	return childTasks, nil
 }
 
-// compareTaskCost compares cost of curTask and bestTask and returns whether curTask's cost is smaller than bestTask's.
+// compareTaskCost compares tasks with the default task-cost model. DataSource
+// local candidate comparison uses compareDataSourceTaskCost for double-read
+// candidates that need IndexLookUpReader-equivalent costing.
 func compareTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) {
 	return compareTaskCostWith(curTask, bestTask, getTaskPlanCost)
 }

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -508,7 +508,11 @@ func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (c
 }
 
 // compareDataSourceTaskCost compares local DataSource candidates. Double-read
-// candidates are costed as the IndexLookUpReader they will become.
+// candidates are costed as the IndexLookUpReader they will become. A real
+// PhysicalIndexLookUpReader retains its plan cost, but do not materialize one
+// only to cache this speculative cost: the reader is not attached to the
+// candidate. Cache the resulting scalar locally for later comparisons against
+// the same incumbent instead.
 func compareDataSourceTaskCost(curTask, bestTask base.Task, costCache map[base.Task]taskCostResult) (curIsBetter bool, err error) {
 	return compareTaskCostWith(curTask, bestTask, func(t base.Task) (float64, bool, error) {
 		if result, ok := costCache[t]; ok {

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -489,6 +489,23 @@ type taskCostResult struct {
 	err     error
 }
 
+// dataSourceTask keeps DataSource-local candidate cost separate from the task.
+// A real PhysicalIndexLookUpReader retains its plan cost, but the reader used
+// for speculative double-read costing is not attached to the candidate.
+type dataSourceTask struct {
+	task           base.Task
+	costResult     taskCostResult
+	costCalculated bool
+}
+
+func (t *dataSourceTask) getCost() (float64, bool, error) {
+	if !t.costCalculated {
+		t.costResult.cost, t.costResult.invalid, t.costResult.err = getDataSourceTaskPlanCost(t.task)
+		t.costCalculated = true
+	}
+	return t.costResult.cost, t.costResult.invalid, t.costResult.err
+}
+
 func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (curIsBetter bool, err error) {
 	curCost, curInvalid, err := getCost(curTask)
 	if err != nil {
@@ -508,20 +525,23 @@ func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (c
 }
 
 // compareDataSourceTaskCost compares local DataSource candidates. Double-read
-// candidates are costed as the IndexLookUpReader they will become. A real
-// PhysicalIndexLookUpReader retains its plan cost, but do not materialize one
-// only to cache this speculative cost: the reader is not attached to the
-// candidate. Cache the resulting scalar locally for later comparisons against
-// the same incumbent instead.
-func compareDataSourceTaskCost(curTask, bestTask base.Task, costCache map[base.Task]taskCostResult) (curIsBetter bool, err error) {
-	return compareTaskCostWith(curTask, bestTask, func(t base.Task) (float64, bool, error) {
-		if result, ok := costCache[t]; ok {
-			return result.cost, result.invalid, result.err
-		}
-		cost, invalid, err := getDataSourceTaskPlanCost(t)
-		costCache[t] = taskCostResult{cost: cost, invalid: invalid, err: err}
-		return cost, invalid, err
-	})
+// candidates are costed as the IndexLookUpReader they will become.
+func compareDataSourceTaskCost(curTask, bestTask *dataSourceTask) (curIsBetter bool, err error) {
+	curCost, curInvalid, err := curTask.getCost()
+	if err != nil {
+		return false, err
+	}
+	bestCost, bestInvalid, err := bestTask.getCost()
+	if err != nil {
+		return false, err
+	}
+	if curInvalid {
+		return false, nil
+	}
+	if bestInvalid {
+		return true, nil
+	}
+	return curCost < bestCost, nil
 }
 
 func getDataSourceTaskPlanCost(t base.Task) (float64, bool, error) {
@@ -2206,7 +2226,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 	}
 
 	t = base.InvalidTask
-	dataSourceCostCache := make(map[base.Task]taskCostResult)
+	bestDataSourceTask := dataSourceTask{task: t}
 	candidates := skylinePruning(ds, prop)
 	pruningInfo := getPruningInfo(ds, candidates, prop)
 	defer func() {
@@ -2235,12 +2255,14 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareDataSourceTaskCost(idxMergeTask, t, dataSourceCostCache)
+			curDataSourceTask := dataSourceTask{task: idxMergeTask}
+			curIsBetter, err := compareDataSourceTaskCost(&curDataSourceTask, &bestDataSourceTask)
 			if err != nil {
 				return nil, err
 			}
 			if curIsBetter {
-				t = idxMergeTask
+				bestDataSourceTask = curDataSourceTask
+				t = bestDataSourceTask.task
 			}
 			continue
 		}
@@ -2333,12 +2355,14 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 					ds.SCtx().GetSessionVars().StmtCtx.SetSkipPlanCache("Batch/PointGet plans may be over-optimized")
 				}
 
-				curIsBetter, cerr := compareDataSourceTaskCost(pointGetTask, t, dataSourceCostCache)
+				curDataSourceTask := dataSourceTask{task: pointGetTask}
+				curIsBetter, cerr := compareDataSourceTaskCost(&curDataSourceTask, &bestDataSourceTask)
 				if cerr != nil {
 					return nil, cerr
 				}
 				if curIsBetter {
-					t = pointGetTask
+					bestDataSourceTask = curDataSourceTask
+					t = bestDataSourceTask.task
 					continue
 				}
 			}
@@ -2364,12 +2388,14 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareDataSourceTaskCost(tblTask, t, dataSourceCostCache)
+			curDataSourceTask := dataSourceTask{task: tblTask}
+			curIsBetter, err := compareDataSourceTaskCost(&curDataSourceTask, &bestDataSourceTask)
 			if err != nil {
 				return nil, err
 			}
 			if curIsBetter {
-				t = tblTask
+				bestDataSourceTask = curDataSourceTask
+				t = bestDataSourceTask.task
 			}
 			continue
 		}
@@ -2385,12 +2411,14 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 		if err != nil {
 			return nil, err
 		}
-		curIsBetter, err := compareDataSourceTaskCost(idxTask, t, dataSourceCostCache)
+		curDataSourceTask := dataSourceTask{task: idxTask}
+		curIsBetter, err := compareDataSourceTaskCost(&curDataSourceTask, &bestDataSourceTask)
 		if err != nil {
 			return nil, err
 		}
 		if curIsBetter {
-			t = idxTask
+			bestDataSourceTask = curDataSourceTask
+			t = bestDataSourceTask.task
 		}
 	}
 

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -476,11 +476,17 @@ func iterateChildPlan4LogicalSequence(
 
 // compareTaskCost compares cost of curTask and bestTask and returns whether curTask's cost is smaller than bestTask's.
 func compareTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) {
-	curCost, curInvalid, err := getTaskPlanCost(curTask)
+	return compareTaskCostWith(curTask, bestTask, getTaskPlanCost)
+}
+
+type taskCostGetter func(base.Task) (float64, bool, error)
+
+func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (curIsBetter bool, err error) {
+	curCost, curInvalid, err := getCost(curTask)
 	if err != nil {
 		return false, err
 	}
-	bestCost, bestInvalid, err := getTaskPlanCost(bestTask)
+	bestCost, bestInvalid, err := getCost(bestTask)
 	if err != nil {
 		return false, err
 	}
@@ -491,6 +497,23 @@ func compareTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) 
 		return true, nil
 	}
 	return curCost < bestCost, nil
+}
+
+// compareDataSourceTaskCost compares local DataSource candidates. An unfinished
+// double-read candidate is costed as the IndexLookUpReader it will become.
+func compareDataSourceTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) {
+	return compareTaskCostWith(curTask, bestTask, getDataSourceTaskPlanCost)
+}
+
+func getDataSourceTaskPlanCost(t base.Task) (float64, bool, error) {
+	if !t.Invalid() {
+		if cop, ok := t.(*physicalop.CopTask); ok &&
+			cop.IndexPlan != nil && cop.TablePlan != nil && !cop.IndexPlanFinished {
+			cost, err := getUnfinishedIndexLookUpCost(cop)
+			return cost, false, err
+		}
+	}
+	return getTaskPlanCost(t)
 }
 
 // getTaskPlanCost returns the cost of this task.
@@ -576,6 +599,43 @@ func getTaskPlanCost(t base.Task) (float64, bool, error) {
 	}
 	cost, err := getPlanCost(t.Plan(), taskType, costusage.NewDefaultPlanCostOption())
 	return cost + indexPartialCost, false, err
+}
+
+// getUnfinishedIndexLookUpCost estimates an unfinished double-read CopTask as an
+// IndexLookUpReader without changing the candidate task or its plan trees.
+func getUnfinishedIndexLookUpCost(cop *physicalop.CopTask) (float64, error) {
+	ctx := cop.IndexPlan.SCtx()
+	indexPlan, err := cop.IndexPlan.Clone(ctx)
+	if err != nil {
+		return 0, err
+	}
+	tablePlan, err := cop.TablePlan.Clone(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	// FinishIndexPlan makes the table side consume the rows produced by the index
+	// side while retaining its statistics version. Apply those semantics with an
+	// isolated StatsInfo value on the table clone.
+	tableStats := *indexPlan.StatsInfo()
+	if originalStats := tablePlan.StatsInfo(); originalStats != nil {
+		tableStats.StatsVersion = originalStats.StatsVersion
+	}
+	tablePlan.SetStats(&tableStats)
+	input := indexLookUpCostInput{
+		ctx:         ctx,
+		indexPlan:   indexPlan,
+		tablePlan:   tablePlan,
+		expectedCnt: cop.ExpectCnt,
+		keepOrder:   cop.KeepOrder,
+	}
+	option := costusage.NewDefaultPlanCostOption().WithCostFlag(costusage.CostFlagRecalculate)
+	if ctx.GetSessionVars().CostModelVersion == modelVer2 {
+		cost, _, err := getPlanCostVer24IndexLookUpReader(input, property.RootTaskType, option)
+		return cost.GetCost(), err
+	}
+	cost, _, err := getPlanCostVer14IndexLookUpReader(input, option)
+	return cost, err
 }
 
 // get the possible group expression and logical operator from common super pointer.
@@ -2150,7 +2210,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareTaskCost(idxMergeTask, t)
+			curIsBetter, err := compareDataSourceTaskCost(idxMergeTask, t)
 			if err != nil {
 				return nil, err
 			}
@@ -2248,7 +2308,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 					ds.SCtx().GetSessionVars().StmtCtx.SetSkipPlanCache("Batch/PointGet plans may be over-optimized")
 				}
 
-				curIsBetter, cerr := compareTaskCost(pointGetTask, t)
+				curIsBetter, cerr := compareDataSourceTaskCost(pointGetTask, t)
 				if cerr != nil {
 					return nil, cerr
 				}
@@ -2279,7 +2339,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareTaskCost(tblTask, t)
+			curIsBetter, err := compareDataSourceTaskCost(tblTask, t)
 			if err != nil {
 				return nil, err
 			}
@@ -2300,7 +2360,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 		if err != nil {
 			return nil, err
 		}
-		curIsBetter, err := compareTaskCost(idxTask, t)
+		curIsBetter, err := compareDataSourceTaskCost(idxTask, t)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -481,6 +481,12 @@ func compareTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) 
 
 type taskCostGetter func(base.Task) (float64, bool, error)
 
+type taskCostResult struct {
+	cost    float64
+	invalid bool
+	err     error
+}
+
 func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (curIsBetter bool, err error) {
 	curCost, curInvalid, err := getCost(curTask)
 	if err != nil {
@@ -501,8 +507,15 @@ func compareTaskCostWith(curTask, bestTask base.Task, getCost taskCostGetter) (c
 
 // compareDataSourceTaskCost compares local DataSource candidates. An unfinished
 // double-read candidate is costed as the IndexLookUpReader it will become.
-func compareDataSourceTaskCost(curTask, bestTask base.Task) (curIsBetter bool, err error) {
-	return compareTaskCostWith(curTask, bestTask, getDataSourceTaskPlanCost)
+func compareDataSourceTaskCost(curTask, bestTask base.Task, costCache map[base.Task]taskCostResult) (curIsBetter bool, err error) {
+	return compareTaskCostWith(curTask, bestTask, func(t base.Task) (float64, bool, error) {
+		if result, ok := costCache[t]; ok {
+			return result.cost, result.invalid, result.err
+		}
+		cost, invalid, err := getDataSourceTaskPlanCost(t)
+		costCache[t] = taskCostResult{cost: cost, invalid: invalid, err: err}
+		return cost, invalid, err
+	})
 }
 
 func getDataSourceTaskPlanCost(t base.Task) (float64, bool, error) {
@@ -631,7 +644,7 @@ func getUnfinishedIndexLookUpCost(cop *physicalop.CopTask) (float64, error) {
 	}
 	option := costusage.NewDefaultPlanCostOption().WithCostFlag(costusage.CostFlagRecalculate)
 	if ctx.GetSessionVars().CostModelVersion == modelVer2 {
-		cost, _, err := getPlanCostVer24IndexLookUpReader(input, property.RootTaskType, option)
+		cost, _, err := getPlanCostVer24IndexLookUpReader(input, property.CopMultiReadTaskType, option)
 		return cost.GetCost(), err
 	}
 	cost, _, err := getPlanCostVer14IndexLookUpReader(input, option)
@@ -2182,6 +2195,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 	}
 
 	t = base.InvalidTask
+	dataSourceCostCache := make(map[base.Task]taskCostResult)
 	candidates := skylinePruning(ds, prop)
 	pruningInfo := getPruningInfo(ds, candidates, prop)
 	defer func() {
@@ -2210,7 +2224,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareDataSourceTaskCost(idxMergeTask, t)
+			curIsBetter, err := compareDataSourceTaskCost(idxMergeTask, t, dataSourceCostCache)
 			if err != nil {
 				return nil, err
 			}
@@ -2308,7 +2322,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 					ds.SCtx().GetSessionVars().StmtCtx.SetSkipPlanCache("Batch/PointGet plans may be over-optimized")
 				}
 
-				curIsBetter, cerr := compareDataSourceTaskCost(pointGetTask, t)
+				curIsBetter, cerr := compareDataSourceTaskCost(pointGetTask, t, dataSourceCostCache)
 				if cerr != nil {
 					return nil, cerr
 				}
@@ -2339,7 +2353,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 			if err != nil {
 				return nil, err
 			}
-			curIsBetter, err := compareDataSourceTaskCost(tblTask, t)
+			curIsBetter, err := compareDataSourceTaskCost(tblTask, t, dataSourceCostCache)
 			if err != nil {
 				return nil, err
 			}
@@ -2360,7 +2374,7 @@ func findBestTask4LogicalDataSource(super base.LogicalPlan, prop *property.Physi
 		if err != nil {
 			return nil, err
 		}
-		curIsBetter, err := compareDataSourceTaskCost(idxTask, t)
+		curIsBetter, err := compareDataSourceTaskCost(idxTask, t, dataSourceCostCache)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/planner/core/plan_cost_ver1.go
+++ b/pkg/planner/core/plan_cost_ver1.go
@@ -130,9 +130,9 @@ func getCost4IndexLookUpReader(input indexLookUpCostInput, costFlag uint64) (cos
 	idxCst := indexRows * sessVars.GetCPUFactor()
 	// if the expectCnt is below the paging threshold, using paging API, recalculate idxCst.
 	// paging API reduces the count of index and table rows, however introduces more seek cost.
-	if ctx.GetSessionVars().EnablePaging && input.expectedCnt > 0 && input.expectedCnt <= paging.Threshold {
+	if sessVars.EnablePaging && input.expectedCnt > 0 && input.expectedCnt <= paging.Threshold {
 		usePaging = true
-		pagingCst := calcPagingCost(ctx, input.indexPlan, input.expectedCnt)
+		pagingCst := calcPagingCost(ctx, indexPlan, input.expectedCnt)
 		// prevent enlarging the cost because we take paging as a better plan,
 		// if the cost is enlarged, it'll be easier to go another plan.
 		idxCst = math.Min(idxCst, pagingCst)
@@ -176,7 +176,6 @@ func getPlanCostVer14PhysicalIndexLookUpReader(pp base.PhysicalPlan, _ property.
 		tablePlan:   p.TablePlan,
 		expectedCnt: p.ExpectedCnt,
 		keepOrder:   p.KeepOrder,
-		pushedLimit: p.PushedLimit,
 	}, option)
 	if err != nil {
 		return 0, err

--- a/pkg/planner/core/plan_cost_ver1.go
+++ b/pkg/planner/core/plan_cost_ver1.go
@@ -170,7 +170,7 @@ func getPlanCostVer14PhysicalIndexLookUpReader(pp base.PhysicalPlan, _ property.
 	if p.PlanCostInit && !hasCostFlag(costFlag, costusage.CostFlagRecalculate) {
 		return p.PlanCost, nil
 	}
-	planCost, usePaging, err := getPlanCostVer14IndexLookUpReader(indexLookUpCostInput{
+	planCost, usePaging, err := getIndexLookUpReaderCostVer1(indexLookUpCostInput{
 		ctx:         p.SCtx(),
 		indexPlan:   p.IndexPlan,
 		tablePlan:   p.TablePlan,
@@ -186,7 +186,7 @@ func getPlanCostVer14PhysicalIndexLookUpReader(pp base.PhysicalPlan, _ property.
 	return p.PlanCost, nil
 }
 
-func getPlanCostVer14IndexLookUpReader(input indexLookUpCostInput, option *costusage.PlanCostOption) (float64, bool, error) {
+func getIndexLookUpReaderCostVer1(input indexLookUpCostInput, option *costusage.PlanCostOption) (float64, bool, error) {
 	planCost := 0.0
 	// child's cost
 	for _, child := range []base.PhysicalPlan{input.indexPlan, input.tablePlan} {

--- a/pkg/planner/core/plan_cost_ver1.go
+++ b/pkg/planner/core/plan_cost_ver1.go
@@ -107,8 +107,20 @@ func getPlanCostVer14PhysicalProjection(pp base.PhysicalPlan, taskType property.
 // getCost4PhysicalIndexLookUpReader computes cost of index lookup operator itself.
 func getCost4PhysicalIndexLookUpReader(pp base.PhysicalPlan, costFlag uint64) (cost float64) {
 	p := pp.(*physicalop.PhysicalIndexLookUpReader)
-	indexPlan, tablePlan := p.IndexPlan, p.TablePlan
-	ctx := p.SCtx()
+	cost, usePaging := getCost4IndexLookUpReader(indexLookUpCostInput{
+		ctx:         p.SCtx(),
+		indexPlan:   p.IndexPlan,
+		tablePlan:   p.TablePlan,
+		expectedCnt: p.ExpectedCnt,
+		keepOrder:   p.KeepOrder,
+	}, costFlag)
+	p.Paging = p.Paging || usePaging
+	return cost
+}
+
+func getCost4IndexLookUpReader(input indexLookUpCostInput, costFlag uint64) (cost float64, usePaging bool) {
+	indexPlan, tablePlan := input.indexPlan, input.tablePlan
+	ctx := input.ctx
 	sessVars := ctx.GetSessionVars()
 	// Add cost of building table reader executors. Handles are extracted in batch style,
 	// each handle is a range, the CPU cost of building copTasks should be:
@@ -118,9 +130,9 @@ func getCost4PhysicalIndexLookUpReader(pp base.PhysicalPlan, costFlag uint64) (c
 	idxCst := indexRows * sessVars.GetCPUFactor()
 	// if the expectCnt is below the paging threshold, using paging API, recalculate idxCst.
 	// paging API reduces the count of index and table rows, however introduces more seek cost.
-	if ctx.GetSessionVars().EnablePaging && p.ExpectedCnt > 0 && p.ExpectedCnt <= paging.Threshold {
-		p.Paging = true
-		pagingCst := calcPagingCost(ctx, p.IndexPlan, p.ExpectedCnt)
+	if ctx.GetSessionVars().EnablePaging && input.expectedCnt > 0 && input.expectedCnt <= paging.Threshold {
+		usePaging = true
+		pagingCst := calcPagingCost(ctx, input.indexPlan, input.expectedCnt)
 		// prevent enlarging the cost because we take paging as a better plan,
 		// if the cost is enlarged, it'll be easier to go another plan.
 		idxCst = math.Min(idxCst, pagingCst)
@@ -144,11 +156,11 @@ func getCost4PhysicalIndexLookUpReader(pp base.PhysicalPlan, costFlag uint64) (c
 	tableRows := getCardinality(tablePlan, costFlag)
 	selectivity := tableRows / indexRows
 	batchSize = math.Min(indexLookupSize*selectivity, tableRows)
-	if p.KeepOrder && batchSize > 2 {
+	if input.keepOrder && batchSize > 2 {
 		sortCPUCost := (tableRows * math.Log2(batchSize) * sessVars.GetCPUFactor()) / numTblWorkers
 		cost += sortCPUCost
 	}
-	return
+	return cost, usePaging
 }
 
 // getPlanCostVer14PhysicalIndexLookUpReader calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -158,53 +170,70 @@ func getPlanCostVer14PhysicalIndexLookUpReader(pp base.PhysicalPlan, _ property.
 	if p.PlanCostInit && !hasCostFlag(costFlag, costusage.CostFlagRecalculate) {
 		return p.PlanCost, nil
 	}
+	planCost, usePaging, err := getPlanCostVer14IndexLookUpReader(indexLookUpCostInput{
+		ctx:         p.SCtx(),
+		indexPlan:   p.IndexPlan,
+		tablePlan:   p.TablePlan,
+		expectedCnt: p.ExpectedCnt,
+		keepOrder:   p.KeepOrder,
+		pushedLimit: p.PushedLimit,
+	}, option)
+	if err != nil {
+		return 0, err
+	}
+	p.PlanCost = planCost
+	p.Paging = p.Paging || usePaging
+	p.PlanCostInit = true
+	return p.PlanCost, nil
+}
 
-	p.PlanCost = 0
+func getPlanCostVer14IndexLookUpReader(input indexLookUpCostInput, option *costusage.PlanCostOption) (float64, bool, error) {
+	planCost := 0.0
 	// child's cost
-	for _, child := range []base.PhysicalPlan{p.IndexPlan, p.TablePlan} {
+	for _, child := range []base.PhysicalPlan{input.indexPlan, input.tablePlan} {
 		childCost, err := child.GetPlanCostVer1(property.CopMultiReadTaskType, option)
 		if err != nil {
-			return 0, err
+			return 0, false, err
 		}
-		p.PlanCost += childCost
+		planCost += childCost
 	}
 
 	// to keep compatible with the previous cost implementation, re-calculate table-scan cost by using index stats-count again (see copTask.finishIndexPlan).
 	// TODO: amend table-side cost here later
-	var tmp = p.TablePlan
+	var tmp = input.tablePlan
 	for len(tmp.Children()) > 0 {
 		tmp = tmp.Children()[0]
 	}
 	ts := tmp.(*physicalop.PhysicalTableScan)
 	tblCost, err := ts.GetPlanCostVer1(property.CopMultiReadTaskType, option)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	p.PlanCost -= tblCost
-	p.PlanCost += getCardinality(p.IndexPlan, costFlag) * ts.GetScanRowSize() * p.SCtx().GetSessionVars().GetScanFactor(ts.Table)
+	planCost -= tblCost
+	planCost += getCardinality(input.indexPlan, option.CostFlag) * ts.GetScanRowSize() * input.ctx.GetSessionVars().GetScanFactor(ts.Table)
 
 	// index-side net I/O cost: rows * row-size * net-factor
-	netFactor := getTableNetFactor(p.TablePlan)
-	rowSize := cardinality.GetAvgRowSize(p.SCtx(), physicalop.GetTblStats(p.IndexPlan), p.IndexPlan.Schema().Columns, true, false)
-	p.PlanCost += getCardinality(p.IndexPlan, costFlag) * rowSize * netFactor
+	netFactor := getTableNetFactor(input.tablePlan)
+	rowSize := cardinality.GetAvgRowSize(input.ctx, physicalop.GetTblStats(input.indexPlan), input.indexPlan.Schema().Columns, true, false)
+	planCost += getCardinality(input.indexPlan, option.CostFlag) * rowSize * netFactor
 
 	// index-side net seek cost
-	p.PlanCost += estimateNetSeekCost(p.IndexPlan)
+	planCost += estimateNetSeekCost(input.indexPlan)
 
 	// table-side net I/O cost: rows * row-size * net-factor
-	tblRowSize := cardinality.GetAvgRowSize(p.SCtx(), physicalop.GetTblStats(p.TablePlan), p.TablePlan.Schema().Columns, false, false)
-	p.PlanCost += getCardinality(p.TablePlan, costFlag) * tblRowSize * netFactor
+	tblRowSize := cardinality.GetAvgRowSize(input.ctx, physicalop.GetTblStats(input.tablePlan), input.tablePlan.Schema().Columns, false, false)
+	planCost += getCardinality(input.tablePlan, option.CostFlag) * tblRowSize * netFactor
 
 	// table-side seek cost
-	p.PlanCost += estimateNetSeekCost(p.TablePlan)
+	planCost += estimateNetSeekCost(input.tablePlan)
 
 	// consider concurrency
-	p.PlanCost /= float64(p.SCtx().GetSessionVars().DistSQLScanConcurrency())
+	planCost /= float64(input.ctx.GetSessionVars().DistSQLScanConcurrency())
 
 	// lookup-cpu-cost in TiDB
-	p.PlanCost += p.GetCost(costFlag)
-	p.PlanCostInit = true
-	return p.PlanCost, nil
+	lookupCost, usePaging := getCost4IndexLookUpReader(input, option.CostFlag)
+	planCost += lookupCost
+	return planCost, usePaging, nil
 }
 
 // getPlanCostVer14PhysicalIndexReader calculates the cost of the plan if it has not been calculated yet and returns the cost.

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -373,7 +373,7 @@ func getPlanCostVer24PhysicalIndexLookUpReader(pp base.PhysicalPlan, taskType pr
 	if p.PlanCostInit && !hasCostFlag(option.CostFlag, costusage.CostFlagRecalculate) {
 		return p.PlanCostVer2, nil
 	}
-	planCost, usePaging, err := getPlanCostVer24IndexLookUpReader(indexLookUpCostInput{
+	planCost, usePaging, err := getIndexLookUpReaderCostVer2(indexLookUpCostInput{
 		ctx:         p.SCtx(),
 		indexPlan:   p.IndexPlan,
 		tablePlan:   p.TablePlan,
@@ -390,7 +390,7 @@ func getPlanCostVer24PhysicalIndexLookUpReader(pp base.PhysicalPlan, taskType pr
 	return p.PlanCostVer2, nil
 }
 
-func getPlanCostVer24IndexLookUpReader(input indexLookUpCostInput, taskType property.TaskType, option *costusage.PlanCostOption) (costusage.CostVer2, bool, error) {
+func getIndexLookUpReaderCostVer2(input indexLookUpCostInput, taskType property.TaskType, option *costusage.PlanCostOption) (costusage.CostVer2, bool, error) {
 	indexRows := getCardinality(input.indexPlan, option.CostFlag)
 	tableRows := getCardinality(input.tablePlan, option.CostFlag)
 

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -348,6 +348,9 @@ func getPlanCostVer24PhysicalTableReader(pp base.PhysicalPlan, taskType property
 	return p.PlanCostVer2, nil
 }
 
+// indexLookUpCostInput carries the plan state needed to cost an IndexLookUpReader
+// without holding the physical operator. pushedLimit is only read by the v2
+// model; speculative unfinished CopTask costing leaves it nil.
 type indexLookUpCostInput struct {
 	ctx         base.PlanContext
 	indexPlan   base.PhysicalPlan

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -348,6 +348,15 @@ func getPlanCostVer24PhysicalTableReader(pp base.PhysicalPlan, taskType property
 	return p.PlanCostVer2, nil
 }
 
+type indexLookUpCostInput struct {
+	ctx         base.PlanContext
+	indexPlan   base.PhysicalPlan
+	tablePlan   base.PhysicalPlan
+	expectedCnt uint64
+	keepOrder   bool
+	pushedLimit *physicalop.PushedDownLimit
+}
+
 // getPlanCostVer24PhysicalIndexLookUpReader returns the plan-cost of this sub-plan, which is:
 // plan-cost = index-side-cost + (table-side-cost + double-read-cost) / double-read-concurrency
 // index-side-cost = (index-child-cost + index-net-cost) / dist-concurrency # same with IndexReader
@@ -361,37 +370,54 @@ func getPlanCostVer24PhysicalIndexLookUpReader(pp base.PhysicalPlan, taskType pr
 	if p.PlanCostInit && !hasCostFlag(option.CostFlag, costusage.CostFlagRecalculate) {
 		return p.PlanCostVer2, nil
 	}
+	planCost, usePaging, err := getPlanCostVer24IndexLookUpReader(indexLookUpCostInput{
+		ctx:         p.SCtx(),
+		indexPlan:   p.IndexPlan,
+		tablePlan:   p.TablePlan,
+		expectedCnt: p.ExpectedCnt,
+		keepOrder:   p.KeepOrder,
+		pushedLimit: p.PushedLimit,
+	}, taskType, option)
+	if err != nil {
+		return costusage.ZeroCostVer2, err
+	}
+	p.PlanCostVer2 = planCost
+	p.Paging = p.Paging || usePaging
+	p.PlanCostInit = true
+	return p.PlanCostVer2, nil
+}
 
-	indexRows := getCardinality(p.IndexPlan, option.CostFlag)
-	tableRows := getCardinality(p.TablePlan, option.CostFlag)
+func getPlanCostVer24IndexLookUpReader(input indexLookUpCostInput, taskType property.TaskType, option *costusage.PlanCostOption) (costusage.CostVer2, bool, error) {
+	indexRows := getCardinality(input.indexPlan, option.CostFlag)
+	tableRows := getCardinality(input.tablePlan, option.CostFlag)
 
-	if p.PushedLimit != nil { // consider pushed down limit clause
-		indexRows = min(indexRows, float64(p.PushedLimit.Count)) // rows returned from the index side
-		tableRows = min(tableRows, float64(p.PushedLimit.Count)) // rows to scan on the table side
+	if input.pushedLimit != nil { // consider pushed down limit clause
+		indexRows = min(indexRows, float64(input.pushedLimit.Count)) // rows returned from the index side
+		tableRows = min(tableRows, float64(input.pushedLimit.Count)) // rows to scan on the table side
 	}
 
-	indexRowSize := cardinality.GetAvgRowSize(p.SCtx(), physicalop.GetTblStats(p.IndexPlan), p.IndexPlan.Schema().Columns, true, false)
-	tableRowSize := cardinality.GetAvgRowSize(p.SCtx(), physicalop.GetTblStats(p.TablePlan), p.TablePlan.Schema().Columns, false, false)
-	cpuFactor := getTaskCPUFactorVer2(p, taskType)
-	netFactor := getTaskNetFactorVer2(p, taskType)
-	requestFactor := getTaskRequestFactorVer2(p, taskType)
-	distConcurrency := float64(p.SCtx().GetSessionVars().DistSQLScanConcurrency())
-	doubleReadConcurrency := float64(p.SCtx().GetSessionVars().IndexLookupConcurrency())
+	indexRowSize := cardinality.GetAvgRowSize(input.ctx, physicalop.GetTblStats(input.indexPlan), input.indexPlan.Schema().Columns, true, false)
+	tableRowSize := cardinality.GetAvgRowSize(input.ctx, physicalop.GetTblStats(input.tablePlan), input.tablePlan.Schema().Columns, false, false)
+	cpuFactor := getTaskCPUFactorVer2(input.indexPlan, taskType)
+	netFactor := getTaskNetFactorVer2(input.tablePlan, taskType)
+	requestFactor := getTaskRequestFactorVer2(input.tablePlan, taskType)
+	distConcurrency := float64(input.ctx.GetSessionVars().DistSQLScanConcurrency())
+	doubleReadConcurrency := float64(input.ctx.GetSessionVars().IndexLookupConcurrency())
 
 	// index-side
 	indexNetCost := netCostVer2(option, indexRows, indexRowSize, netFactor)
-	indexChildCost, err := p.IndexPlan.GetPlanCostVer2(property.CopMultiReadTaskType, option)
+	indexChildCost, err := input.indexPlan.GetPlanCostVer2(property.CopMultiReadTaskType, option)
 	if err != nil {
-		return costusage.ZeroCostVer2, err
+		return costusage.ZeroCostVer2, false, err
 	}
 	indexSideCost := costusage.DivCostVer2(costusage.SumCostVer2(indexNetCost, indexChildCost), distConcurrency)
 
 	// table-side
 	tableNetCost := netCostVer2(option, tableRows, tableRowSize, netFactor)
 	// set the isChildOfINL signal.
-	tableChildCost, err := p.TablePlan.GetPlanCostVer2(property.CopMultiReadTaskType, option, true)
+	tableChildCost, err := input.tablePlan.GetPlanCostVer2(property.CopMultiReadTaskType, option, true)
 	if err != nil {
-		return costusage.ZeroCostVer2, err
+		return costusage.ZeroCostVer2, false, err
 	}
 	tableSideCost := costusage.DivCostVer2(costusage.SumCostVer2(tableNetCost, tableChildCost), distConcurrency)
 
@@ -399,30 +425,29 @@ func getPlanCostVer24PhysicalIndexLookUpReader(pp base.PhysicalPlan, taskType pr
 	doubleReadCPUCost := costusage.NewCostVer2(option, cpuFactor,
 		indexRows*cpuFactor.Value,
 		func() string { return fmt.Sprintf("double-read-cpu(%v*%v)", doubleReadRows, cpuFactor) })
-	batchSize := float64(p.SCtx().GetSessionVars().IndexLookupSize)
+	batchSize := float64(input.ctx.GetSessionVars().IndexLookupSize)
 	taskPerBatch := 32.0 // TODO: remove this magic number
 	doubleReadTasks := doubleReadRows / batchSize * taskPerBatch
 	doubleReadRequestCost := doubleReadCostVer2(option, doubleReadTasks, requestFactor)
 	doubleReadCost := costusage.SumCostVer2(doubleReadCPUCost, doubleReadRequestCost)
 
-	p.PlanCostVer2 = costusage.SumCostVer2(indexSideCost, costusage.DivCostVer2(costusage.SumCostVer2(tableSideCost, doubleReadCost), doubleReadConcurrency))
+	planCost := costusage.SumCostVer2(indexSideCost, costusage.DivCostVer2(costusage.SumCostVer2(tableSideCost, doubleReadCost), doubleReadConcurrency))
 
-	if p.SCtx().GetSessionVars().EnablePaging && p.ExpectedCnt > 0 && p.ExpectedCnt <= paging.Threshold {
+	usePaging := input.ctx.GetSessionVars().EnablePaging && input.expectedCnt > 0 && input.expectedCnt <= paging.Threshold
+	if usePaging {
 		// if the expectCnt is below the paging threshold, using paging API
-		p.Paging = true // TODO: move this operation from cost model to physical optimization
-		p.PlanCostVer2 = costusage.MulCostVer2(p.PlanCostVer2, 0.6)
+		planCost = costusage.MulCostVer2(planCost, 0.6)
 	}
 
-	p.PlanCostInit = true
-	if p.PushedLimit != nil && tableRows <= float64(p.PushedLimit.Count) {
+	if input.pushedLimit != nil && tableRows <= float64(input.pushedLimit.Count) {
 		// Multiply by limit cost factor - defaults to 1, but can be increased/decreased to influence the cost model
-		p.PlanCostVer2 = costusage.MulCostVer2(p.PlanCostVer2, p.SCtx().GetSessionVars().LimitCostFactor)
-		p.SCtx().GetSessionVars().RecordRelevantOptVar(vardef.TiDBOptLimitCostFactor)
+		planCost = costusage.MulCostVer2(planCost, input.ctx.GetSessionVars().LimitCostFactor)
+		input.ctx.GetSessionVars().RecordRelevantOptVar(vardef.TiDBOptLimitCostFactor)
 	}
 	// Multiply by cost factor - defaults to 1, but can be increased/decreased to influence the cost model
-	p.PlanCostVer2 = costusage.MulCostVer2(p.PlanCostVer2, p.SCtx().GetSessionVars().IndexLookupCostFactor)
-	p.SCtx().GetSessionVars().RecordRelevantOptVar(vardef.TiDBOptIndexLookupCostFactor)
-	return p.PlanCostVer2, nil
+	planCost = costusage.MulCostVer2(planCost, input.ctx.GetSessionVars().IndexLookupCostFactor)
+	input.ctx.GetSessionVars().RecordRelevantOptVar(vardef.TiDBOptIndexLookupCostFactor)
+	return planCost, usePaging, nil
 }
 
 // GetPlanCostVer24PhysicalIndexMergeReader returns the plan-cost of this sub-plan, which is:

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -394,11 +394,11 @@ count(*)
 explain format='plan_tree' SELECT /*+ AGG_TO_COP() */ (NOT (`t`.`i`>=_UTF8MB4'j筧8') OR NOT (`t`.`i`=_UTF8MB4'暈lH忧ll6')) IS TRUE,MAX(`t`.`e`) AS `r0`,QUOTE(`t`.`i`) AS `r1` FROM `t` WHERE `t`.`h`>240817 OR `t`.`i` BETWEEN _UTF8MB4'WVz' AND _UTF8MB4'G#駧褉ZC領*lov' GROUP BY `t`.`i`;
 id	task	access object	operator info
 Projection	root		istrue(or(not(ge(executor__explain.t.i, j筧8)), not(eq(executor__explain.t.i, 暈lH忧ll6))))->Column, Column, quote(executor__explain.t.i)->Column
-└─HashAgg	root		group by:executor__explain.t.i, funcs:max(executor__explain.t.e)->Column, funcs:firstrow(executor__explain.t.i)->executor__explain.t.i
-  └─IndexMerge	root	partition:all	type: union
-    ├─TableRangeScan(Build)	cop[tikv]	table:t	range:(240817,+inf], keep order:false, stats:pseudo
-    ├─IndexFullScan(Build)	cop[tikv]	table:t, index:idx_25(h, i, e)	keep order:false, stats:pseudo
-    └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─HashAgg	root		group by:executor__explain.t.i, funcs:max(Column)->Column, funcs:firstrow(executor__explain.t.i)->executor__explain.t.i
+  └─TableReader	root	partition:all	data:HashAgg
+    └─HashAgg	cop[tikv]		group by:executor__explain.t.i, funcs:max(executor__explain.t.e)->Column
+      └─Selection	cop[tikv]		or(gt(executor__explain.t.h, 240817), and(ge(executor__explain.t.i, "WVz"), le(executor__explain.t.i, "G#駧褉ZC領*lov")))
+        └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
 select count(*) from (SELECT /*+ AGG_TO_COP() */ (NOT (`t`.`i`>=_UTF8MB4'j筧8') OR NOT (`t`.`i`=_UTF8MB4'暈lH忧ll6')) IS TRUE,MAX(`t`.`e`) AS `r0`,QUOTE(`t`.`i`) AS `r1` FROM `t` WHERE `t`.`h`>240817 OR `t`.`i` BETWEEN _UTF8MB4'WVz' AND _UTF8MB4'G#駧褉ZC領*lov' GROUP BY `t`.`i`) derived;
 count(*)
 16

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -394,11 +394,11 @@ count(*)
 explain format='plan_tree' SELECT /*+ AGG_TO_COP() */ (NOT (`t`.`i`>=_UTF8MB4'j筧8') OR NOT (`t`.`i`=_UTF8MB4'暈lH忧ll6')) IS TRUE,MAX(`t`.`e`) AS `r0`,QUOTE(`t`.`i`) AS `r1` FROM `t` WHERE `t`.`h`>240817 OR `t`.`i` BETWEEN _UTF8MB4'WVz' AND _UTF8MB4'G#駧褉ZC領*lov' GROUP BY `t`.`i`;
 id	task	access object	operator info
 Projection	root		istrue(or(not(ge(executor__explain.t.i, j筧8)), not(eq(executor__explain.t.i, 暈lH忧ll6))))->Column, Column, quote(executor__explain.t.i)->Column
-└─HashAgg	root		group by:executor__explain.t.i, funcs:max(Column)->Column, funcs:firstrow(executor__explain.t.i)->executor__explain.t.i
-  └─TableReader	root	partition:all	data:HashAgg
-    └─HashAgg	cop[tikv]		group by:executor__explain.t.i, funcs:max(executor__explain.t.e)->Column
-      └─Selection	cop[tikv]		or(gt(executor__explain.t.h, 240817), and(ge(executor__explain.t.i, "WVz"), le(executor__explain.t.i, "G#駧褉ZC領*lov")))
-        └─TableFullScan	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─HashAgg	root		group by:executor__explain.t.i, funcs:max(executor__explain.t.e)->Column, funcs:firstrow(executor__explain.t.i)->executor__explain.t.i
+  └─IndexMerge	root	partition:all	type: union
+    ├─TableRangeScan(Build)	cop[tikv]	table:t	range:(240817,+inf], keep order:false, stats:pseudo
+    ├─IndexFullScan(Build)	cop[tikv]	table:t, index:idx_25(h, i, e)	keep order:false, stats:pseudo
+    └─TableRowIDScan(Probe)	cop[tikv]	table:t	keep order:false, stats:pseudo
 select count(*) from (SELECT /*+ AGG_TO_COP() */ (NOT (`t`.`i`>=_UTF8MB4'j筧8') OR NOT (`t`.`i`=_UTF8MB4'暈lH忧ll6')) IS TRUE,MAX(`t`.`e`) AS `r0`,QUOTE(`t`.`i`) AS `r1` FROM `t` WHERE `t`.`h`>240817 OR `t`.`i` BETWEEN _UTF8MB4'WVz' AND _UTF8MB4'G#駧褉ZC領*lov' GROUP BY `t`.`i`) derived;
 count(*)
 16

--- a/tests/integrationtest/r/planner/core/plan_cost_ver2.result
+++ b/tests/integrationtest/r/planner/core/plan_cost_ver2.result
@@ -238,11 +238,13 @@ drop table if exists t;
 create table t(a int, b int, c int, d int, index ia(a), index ibc(b,c));
 explain select * from t where a between 1 and 5 and b != 200 and c = 20 limit 100000;
 id	estRows	task	access object	operator info
-Limit_8	1.00	root		offset:0, count:100000
-└─TableReader_14	1.00	root		data:Limit_13
-  └─Limit_13	1.00	cop[tikv]		offset:0, count:100000
-    └─Selection_12	1.00	cop[tikv]		eq(planner__core__plan_cost_ver2.t.c, 20), ge(planner__core__plan_cost_ver2.t.a, 1), le(planner__core__plan_cost_ver2.t.a, 5), ne(planner__core__plan_cost_ver2.t.b, 200)
-      └─TableFullScan_11	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Limit_9	1.00	root		offset:0, count:100000
+└─IndexLookUp_23	1.00	root		
+  ├─Selection_20(Build)	6.66	cop[tikv]		eq(planner__core__plan_cost_ver2.t.c, 20)
+  │ └─IndexRangeScan_18	6656.67	cop[tikv]	table:t, index:ibc(b, c)	range:[-inf,200), (200,+inf], keep order:false, stats:pseudo
+  └─Limit_22(Probe)	1.00	cop[tikv]		offset:0, count:100000
+    └─Selection_21	1.00	cop[tikv]		ge(planner__core__plan_cost_ver2.t.a, 1), le(planner__core__plan_cost_ver2.t.a, 5)
+      └─TableRowIDScan_19	6.66	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 create table t (a int);
 explain format='true_card_cost' select * from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #69518

`DataSource` used to compare an unfinished double-read `CopTask` by charging only its index-side plan. That is a local, incomplete view of a path that will later become an `IndexLookUpReader`: it omits the table-side lookup, the associated network work, and the DistSQL/index-lookup concurrency model. Consequently, a locally cheap index candidate could survive while a path with a lower complete reader cost was pruned before its final execution shape was known.

### Design and implementation

The goal is not to tune one observed winner by adding an ad-hoc multiplier to `CopTask`. The production seam is the `DataSource` skyline/local candidate comparison: this is the earliest point at which competing access paths are pruned, and it already knows when a candidate is a double-read task.

For every double-read candidate at that seam, the PR evaluates the candidate with the same cost model used by the `PhysicalIndexLookUpReader` it will become:

1. Clone the physical index and table plan trees, so speculative costing cannot mutate the retained candidate or allocate plan IDs.
2. For an unfinished index plan only, apply `FinishIndexPlan`-equivalent table-side cardinality semantics to the clone; a finished plan retains its existing table-side statistics.
3. Recalculate the complete v1/v2 IndexLookUp cost, including the existing DistSQL scan and index-lookup concurrency treatment.
4. Use that result only for the four local `DataSource` candidate comparisons. Generic task comparisons are unchanged.

The lookup formulas were extracted into shared pure helpers, so both ordinary `PhysicalIndexLookUpReader` costing and speculative comparison use one formula rather than two independently evolving approximations. This keeps the change small at the pruning boundary while making the decision reflect the eventual reader, instead of accepting an unavoidable local-optimum mismatch.

The #69518 reproducer now selects `TopN -> IndexLookUp` using `idx_event_shard_batch_route_state` with the default v2 cost model. The regression also proves that the target index scan still has more than 10,000 estimated rows and that no Build-side TopN is manufactured for the comparison.

### #69518 walkthrough: why this cost evaluation changes the winner

The debug screenshot in the issue shows two double-read access paths satisfying the same unordered `CopMultiRead` physical property:

- `idx_route_state_seen(route_code, state_flag, seen_at)` matches the two leading equality predicates and supplies `seen_at` order. `event_code` and `batch_at` remain table-side filters, so rows read through this path must be looked up before those predicates can reduce them.
- `idx_event_shard_batch_route_state(event_code, shard_no, batch_at, route_code, state_flag)` has the more selective predicates in its index. `shard_no` is unconstrained between `event_code` and `batch_at`, so it still scans a large event-code range and applies an index-side selection. That selection leaves only a very small row-ID set for the table side.

Before this PR, the two candidates were not measured in equivalent execution units. The first path had already finished its index plan, so local comparison charged `IndexPlan + TablePlan`. The second path was unfinished, so local comparison charged only the raw index-plan scan. In the screenshot, the raw scan is large enough that it loses even against the first path's partial `IndexPlan + TablePlan` estimate; the candidate is pruned before it can become an `IndexLookUpReader`.

The reader-equivalent evaluation puts both paths in the same execution unit. For an unfinished path it first supplies the missing `FinishIndexPlan` table-side cardinality on an isolated clone; for a finished path it retains the already-established table-side cardinality. It then charges both as readers: index-side scan and network cost are divided by DistSQL scan concurrency; table-side scan/network and double-read CPU/request cost are divided by index-lookup concurrency. Since the index-side selection has already reduced the row IDs reaching the table side, the second path's full reader cost is lower than the first path's cost with its table-side residual filters.

After this local winner is retained, normal operator attachment proceeds unchanged. The parent `TopN` is attached through the existing path and ends up on the table/probe side. The fix does **not** pretend that the index scan itself is limited to one row, and it does not attach `TopN` speculatively during DataSource comparison. It corrects the missing reader-level execution model at the one point where the alternative would otherwise be irreversibly pruned.

### Hint semantics preserved

The broader integration regression exposed a related guardrail: `AGG_TO_COP()` must prefer a path only when aggregation can actually be attached to coprocessor execution. An IndexMerge task is temporarily represented by a `CopTask`, but its `IdxMergePartPlans` require aggregation to be attached at root. The hint preference now excludes tasks with root-side conditions or index-merge part plans, matching the structural branch in `attach2Task4PhysicalHashAgg`. This preserves a genuine `HashAgg(cop)` path when the hint is present rather than preferring `HashAgg(root) -> IndexMerge(root)`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
  - `go test ./pkg/planner/core/casetest/cbotest -run "^TestTopNChoosesGloballyCheaperDoubleReadPath$" -count=1 -tags=intest,deadlock`
  - `go test ./pkg/planner/core/casetest/cbotest -count=1 -tags=intest,deadlock`
  - `./tests/integrationtest/run-tests.sh -b n -t executor/explain`
  - `make lint`
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
  - Affected double-read candidates clone and recalculate two physical plan trees during comparison. Optimizer CPU/allocation impact still needs benchmark coverage.
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query plan selection for TopN queries, including double-read index paths.
  * Refined cost estimation for index lookups, paging, network usage, and CPU work.
  * Prevented inappropriate preference for coprocessor aggregation plans in certain queries.

* **Tests**
  * Added regression coverage to verify deterministic and cost-effective TopN plan selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->