### PR TITLE
*: bump client-go to tidb-8.5 head

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3905,8 +3905,8 @@ def go_deps():
         build_tags = ["intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:QqAqswvU8jg2wN0Jg45KOymElrz09aAP/1wZft41NXI=",
-        version = "v2.0.8-0.20260615130046-a2b634d170d9",
+        sum = "h1:1WCvEFubCqIkvKQo8q8SGsQce0dXp+lAWKoSFsww1MM=",
+        version = "v2.0.8-0.20260803075849-c3b50791b9fb",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9
+	github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb
 	github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9 h1:QqAqswvU8jg2wN0Jg45KOymElrz09aAP/1wZft41NXI=
-github.com/tikv/client-go/v2 v2.0.8-0.20260615130046-a2b634d170d9/go.mod h1:YPzsPK+ddC0f0f2WHNfLJb5qM/glF1XSR/HUQvuS4yA=
+github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb h1:1WCvEFubCqIkvKQo8q8SGsQce0dXp+lAWKoSFsww1MM=
+github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb/go.mod h1:k4+YEInCqMCM0hE0KJBbXytXzAQ8rBAtvpXtdDmy8eA=
 github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b h1:F5B0hA1WnmrOXP+ix1j17mjIl6XWnVr9GWJW/H9Ip6Q=
 github.com/tikv/pd/client v0.0.0-20260609141937-b01426f6b08b/go.mod h1:KtMhV0wfNF4KGgeQSRacPAXVqjAKuLtqAaHEHhUhhUc=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=

--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -97,7 +97,7 @@ go_test(
     embed = [":importinto"],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//br/pkg/storage",
         "//pkg/ddl",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -174,6 +174,7 @@ go_test(
         "//pkg/parser/terror",
         "//pkg/planner/core/resolve",
         "//pkg/resourcegroup",
+        "//pkg/server/err",
         "//pkg/server/internal",
         "//pkg/server/internal/column",
         "//pkg/server/internal/handshake",

--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
 
 go_test(
     name = "sqlkiller_test",
+    timeout = "short",
     srcs = ["sqlkiller_test.go"],
     embed = [":sqlkiller"],
+    flaky = True,
 )


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/69335

Problem Summary:

The `tidb-8.5` branch of client-go has upgraded its Go version to 1.25.12. TiDB release-8.5 needs to consume that merged client-go commit so the two repositories use aligned toolchain requirements.

### What changed and how does it work?

- Bump `github.com/tikv/client-go/v2` from `a2b634d170d9` to `c3b50791b9fb` (`v2.0.8-0.20260803075849-c3b50791b9fb`).
- Refresh `go.sum` and the Bazel dependency metadata in `DEPS.bzl`.
- Regenerate affected `BUILD.bazel` files with `make bazel_prepare`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `GOTOOLCHAIN=go1.25.12 go test -count=1 -p=1 -tags=intest ./pkg/store/...`
  - `GOTOOLCHAIN=go1.25.12 go mod verify`
  - `make check-bazel-prepare`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying system components to incorporate the latest maintenance improvements.
  - Refined build configuration to support smoother development and release workflows.

- **Tests**
  - Improved test distribution for more efficient execution.
  - Enhanced test configuration and coverage for server-related behavior.
  - Added safeguards for tests that may occasionally experience timing-related instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->