### PR TITLE
planner, util: restrict resource group SQL in TiDB X

### DIFF
--- a/.agents/skills/tidb-test-guidelines/references/planner-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/planner-case-map.md
@@ -101,7 +101,7 @@
 - `pkg/planner/core/plan_replayer_capture_test.go` - planner/core: Tests plan replayer capture table stats.
 - `pkg/planner/core/plan_test.go` - planner/core: Tests plan encode/decode, normalization/digest, explain hints, cop paging, agg final mode build, and IMPORT INTO planning.
 - `pkg/planner/core/plan_to_pb_test.go` - planner/core: Tests ColumnToProto collation, flags, and elems.
-- `pkg/planner/core/planbuilder_test.go` - planner/core: Tests plan builder utilities (SHOW schema, access paths, rewriter pool, clone, analyze options, privileges, admin/traffic).
+- `pkg/planner/core/planbuilder_test.go` - planner/core: Tests plan builder utilities (SHOW schema, access paths, rewriter pool, clone, analyze options, privileges, admin/traffic, and NextGen restricted SQL).
 - `pkg/planner/core/preprocess_test.go` - planner/core: Validates SQL/DDL preprocessing errors and constraints.
 - `pkg/planner/core/rule_generate_column_substitute_test.go` - planner/core: Benchmarks generated column expression substitution.
 - `pkg/planner/core/rule_join_reorder_dp_test.go` - planner/core: Tests DP reorder TPCH Q5.

--- a/.agents/skills/tidb-test-guidelines/references/util-case-map.md
+++ b/.agents/skills/tidb-test-guidelines/references/util-case-map.md
@@ -489,7 +489,7 @@
 
 ### Tests
 - `pkg/util/sem/v2/config_test.go` - util/sem/v2: Tests parse config with different format.
-- `pkg/util/sem/v2/sem_test.go` - util/sem/v2: Tests s e m methods.
+- `pkg/util/sem/v2/sem_test.go` - util/sem/v2: Tests SEM methods and built-in NextGen SQL restrictions.
 - `pkg/util/sem/v2/sql_rule_test.go` - util/sem/v2: Tests SQL rules.
 
 ## pkg/util/servermemorylimit

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -282,6 +282,7 @@ go_test(
         "//pkg/planner/util/costusage",
         "//pkg/planner/util/fixcontrol",
         "//pkg/planner/util/partitionpruning",
+        "//pkg/privilege",
         "//pkg/session",
         "//pkg/session/sessionapi",
         "//pkg/session/sessmgr",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6381,10 +6381,6 @@ func GetMaxWriteSpeedFromExpression(opt *AlterDDLJobOpt) (maxWriteSpeed int64, e
 }
 
 func (b *PlanBuilder) checkSEMStmt(stmt ast.Node) error {
-	if !semv2.IsEnabled() {
-		return nil
-	}
-
 	stmtNode, ok := stmt.(ast.StmtNode)
 	intest.Assert(ok, "node.Node should be ast.StmtNode, but got %T", stmt)
 	if !semv2.IsRestrictedSQL(stmtNode) {
@@ -6399,5 +6395,8 @@ func (b *PlanBuilder) checkSEMStmt(stmt ast.Node) error {
 		return nil
 	}
 
+	if semv2.IsNextGenRestrictedSQL(stmtNode) {
+		return plannererrors.ErrNotSupportedWithSem.GenWithStack("Feature '%s' is not supported in TiDB X", stmtNode.Text())
+	}
 	return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs(stmtNode.Text())
 }

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
@@ -43,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
@@ -57,6 +60,44 @@ type visit struct {
 	a1  unsafe.Pointer
 	a2  unsafe.Pointer
 	typ reflect.Type
+}
+
+type restrictedSQLPrivilegeManager struct {
+	privilege.Manager
+	allowed bool
+}
+
+func (m restrictedSQLPrivilegeManager) RequestDynamicVerification(_ []*auth.RoleIdentity, privName string, _ bool) bool {
+	return m.allowed && privName == "RESTRICTED_SQL_ADMIN"
+}
+
+func TestNextGenBuiltInResourceGroupSQLRestriction(t *testing.T) {
+	if !kerneltype.IsNextGen() {
+		t.Skip("built-in resource group SQL restrictions are only enabled in NextGen builds")
+	}
+
+	sctx := coretestsdk.MockContext()
+	p := parser.New()
+	for _, sql := range []string{
+		"CREATE RESOURCE GROUP rg RU_PER_SEC=1000",
+		"ALTER RESOURCE GROUP rg RU_PER_SEC=500",
+		"DROP RESOURCE GROUP rg",
+		"SET RESOURCE GROUP rg",
+		"SHOW CREATE RESOURCE GROUP rg",
+		"CALIBRATE RESOURCE",
+	} {
+		stmt, err := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, err)
+
+		privilege.BindPrivilegeManager(sctx, restrictedSQLPrivilegeManager{})
+		builder, _ := NewPlanBuilder().Init(sctx, nil, hint.NewQBHintHandler(nil))
+		err = builder.checkSEMStmt(stmt)
+		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem, sql)
+		require.ErrorContains(t, err, "is not supported in TiDB X", sql)
+
+		privilege.BindPrivilegeManager(sctx, restrictedSQLPrivilegeManager{allowed: true})
+		require.NoError(t, builder.checkSEMStmt(stmt), sql)
+	}
 }
 
 func TestShow(t *testing.T) {

--- a/pkg/util/sem/compat/sem_integration_test.go
+++ b/pkg/util/sem/compat/sem_integration_test.go
@@ -79,7 +79,11 @@ func TestRestrictedSQL(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
 		})
-		tk.MustContainErrMsg("ALTER RESOURCE GROUP rg RU_PER_SEC=500", "is not supported when security enhanced mode is enabled")
+		errMsg := "is not supported when security enhanced mode is enabled"
+		if kerneltype.IsNextGen() {
+			errMsg = "is not supported in TiDB X"
+		}
+		tk.MustContainErrMsg("ALTER RESOURCE GROUP rg RU_PER_SEC=500", errMsg)
 
 		require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "semuser", Hostname: "localhost"}, nil, nil, nil))
 		tk.MustExec("ALTER RESOURCE GROUP rg RU_PER_SEC=500")

--- a/pkg/util/sem/v2/BUILD.bazel
+++ b/pkg/util/sem/v2/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/util/sem/v2",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/objstore",
         "//pkg/parser/ast",
         "//pkg/parser/mysql",
@@ -34,6 +35,7 @@ go_test(
     embed = [":sem"],
     flaky = True,
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/parser",
         "//pkg/parser/charset",
         "//pkg/parser/mysql",

--- a/pkg/util/sem/v2/sem.go
+++ b/pkg/util/sem/v2/sem.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -90,11 +91,33 @@ func IsInvisibleStatusVar(varName string) bool {
 
 // IsRestrictedSQL checks if a SQL statement is restricted under SEM rules.
 func IsRestrictedSQL(stmt ast.StmtNode) bool {
+	if IsNextGenRestrictedSQL(stmt) {
+		return true
+	}
+
 	sem := globalSem.Load()
 	if sem == nil {
 		return false
 	}
 	return sem.isRestrictedSQL(stmt)
+}
+
+// IsNextGenRestrictedSQL checks if a SQL statement is restricted by the built-in NextGen policy.
+func IsNextGenRestrictedSQL(stmt ast.StmtNode) bool {
+	if !kerneltype.IsNextGen() {
+		return false
+	}
+
+	switch stmt.SEMCommand() {
+	case ast.AlterResourceGroupCommand,
+		ast.CalibrateResourceCommand,
+		ast.CreateResourceGroupCommand,
+		ast.DropResourceGroupCommand,
+		ast.SetResourceGroupCommand,
+		ast.ShowCreateResourceGroupCommand:
+		return true
+	}
+	return false
 }
 
 // Enable enables SEM.

--- a/pkg/util/sem/v2/sem_test.go
+++ b/pkg/util/sem/v2/sem_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -149,4 +151,36 @@ func TestEnableSEM(t *testing.T) {
 	// Test overrideRestrictedVariable
 	sysVar = variable.GetSysVar(vardef.TiDBEnableEnhancedSecurity)
 	require.Equal(t, sysVar.Value, "CONFIG")
+}
+
+func TestBuiltInResourceGroupSQLRestriction(t *testing.T) {
+	Disable()
+	t.Cleanup(Disable)
+
+	p := parser.New()
+	resourceGroupStatements := []string{
+		"CREATE RESOURCE GROUP rg RU_PER_SEC=1000",
+		"ALTER RESOURCE GROUP rg RU_PER_SEC=500",
+		"DROP RESOURCE GROUP rg",
+		"SET RESOURCE GROUP rg",
+		"SHOW CREATE RESOURCE GROUP rg",
+		"CALIBRATE RESOURCE",
+	}
+	for _, sql := range resourceGroupStatements {
+		stmt, err := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, err)
+		require.Equal(t, kerneltype.IsNextGen(), IsRestrictedSQL(stmt), sql)
+	}
+
+	stmt, err := p.ParseOneStmt("CREATE DATABASE db", "", "")
+	require.NoError(t, err)
+	require.False(t, IsRestrictedSQL(stmt))
+
+	require.NoError(t, EnableBy(&Config{
+		TiDBVersion: "v0.0.0",
+		RestrictedSQL: SQLRestriction{
+			SQL: []string{"CREATE DATABASE"},
+		},
+	}))
+	require.True(t, IsRestrictedSQL(stmt))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70298

Problem Summary:

TiDB X currently relies on control-plane-delivered SEM configuration to prevent users from managing resource groups. If that configuration is missing or incomplete, unsupported resource group statements can execute.

### What changed and how does it work?

- Add a built-in NextGen SEM policy that restricts `CREATE`, `ALTER`, `DROP`, `SET`, and `SHOW CREATE RESOURCE GROUP`, plus `CALIBRATE RESOURCE`, even when no external SEM configuration is loaded.
- Keep external SEM restrictions additive and preserve the existing `RESTRICTED_SQL_ADMIN` bypass.
- Leave Classic behavior unchanged and return a TiDB X-specific error for the built-in restriction.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
TiDB X now rejects user-managed resource group statements even when no external SEM configuration is present.
```
