### PR TITLE
dumpformat: track Parquet scan progress by source file offset

### DIFF
--- a/pkg/dumpformat/parquetfile/BUILD.bazel
+++ b/pkg/dumpformat/parquetfile/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
     data = glob(["testfiles/**"]),
     embed = [":parquetfile"],
     flaky = True,
-    shard_count = 27,
+    shard_count = 28,
     deps = [
         "//pkg/dumpformat/testutils",
         "//pkg/objstore",

--- a/pkg/dumpformat/parquetfile/parser.go
+++ b/pkg/dumpformat/parquetfile/parser.go
@@ -311,31 +311,6 @@ func (rgp *rowGroupParser) Close() error {
 	return onceErr.Get()
 }
 
-// scanProgress tracks the furthest data offset reached across column readers.
-// A *scanProgress is intentionally nil for metadata-only readers used to parse
-// the footer or read the row count. Its methods accept nil receivers so callers
-// can update progress without conditional checks.
-type scanProgress struct {
-	highWater atomic.Int64
-}
-
-func (p *scanProgress) advance(pos int64) {
-	if p == nil {
-		return
-	}
-	current := p.highWater.Load()
-	for current < pos && !p.highWater.CompareAndSwap(current, pos) {
-		current = p.highWater.Load()
-	}
-}
-
-func (p *scanProgress) current() int64 {
-	if p == nil {
-		return 0
-	}
-	return p.highWater.Load()
-}
-
 // Parser parses a parquet file for import
 type Parser struct {
 	fileMeta *metadata.FileMetaData
@@ -362,7 +337,6 @@ type Parser struct {
 
 	totalRows     int64 // total rows in this file
 	totalReadRows int64 // total rows read
-	progress      *scanProgress
 
 	lastRow parsedef.Row
 	logger  log.Logger
@@ -460,7 +434,7 @@ func (pp *Parser) getBuilder() (func(int) (readerAtSeekerCloser, error), error) 
 
 	base := pp.preloadBase
 	if base == nil && ranges.end-ranges.start <= int64(rowGroupInMemoryThreshold) {
-		base, err = newInMemoryReaderBase(pp.ctx, pp.store, pp.path, ranges, pp.progress)
+		base, err = newInMemoryReaderBase(pp.ctx, pp.store, pp.path, ranges)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -484,7 +458,7 @@ func (pp *Parser) getBuilder() (func(int) (readerAtSeekerCloser, error), error) 
 			&storeapi.ReaderOption{
 				StartOffset: &ranges.columnStarts[c],
 				EndOffset:   &ranges.columnEnds[c],
-			}, pp.progress)
+			})
 	}, nil
 }
 
@@ -550,16 +524,24 @@ func (pp *Parser) SetPos(pos int64, rowID int64) error {
 }
 
 // ScannedPos implements the Parser interface.
-// Parquet may read disjoint column ranges, so this returns the furthest data
-// offset reached by any reader rather than a single underlying reader position.
+// Parquet readers may preload or read ahead, so estimate source-byte progress
+// from the proportion of rows consumed by the parser.
 func (pp *Parser) ScannedPos() (int64, error) {
 	fileSize := max(pp.fileMeta.GetSourceFileSize(), int64(0))
-	if pp.totalReadRows == pp.totalRows {
-		// when all rows are read, return whole file size as progress might not
-		// track the footer.
+	if pp.totalRows <= 0 {
 		return fileSize, nil
 	}
-	return min(max(pp.progress.current(), int64(0)), fileSize), nil
+
+	readRows := min(pp.totalReadRows, pp.totalRows)
+	if readRows == 0 {
+		return 0, nil
+	}
+	if readRows == pp.totalRows {
+		return fileSize, nil
+	}
+
+	progress := float64(readRows) / float64(pp.totalRows)
+	return int64(progress * float64(fileSize)), nil
 }
 
 // Close closes the parquet file of the parser.
@@ -667,8 +649,7 @@ func NewParser(
 	meta FileMeta,
 ) (*Parser, error) {
 	logger := log.Wrap(logutil.Logger(ctx))
-	progress := &scanProgress{}
-	wrapper, preloadBase, r, err := prepareReader(ctx, store, openReader, path, fileSize, progress)
+	wrapper, preloadBase, r, err := prepareReader(ctx, store, openReader, path, fileSize)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -793,7 +774,6 @@ func NewParser(
 		logger:      logger,
 		rowPool:     &pool,
 		preloadBase: preloadBase,
-		progress:    progress,
 	}
 	if err := parser.Init(effectiveLoc); err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/dumpformat/parquetfile/parser.go
+++ b/pkg/dumpformat/parquetfile/parser.go
@@ -527,15 +527,12 @@ func (pp *Parser) SetPos(pos int64, rowID int64) error {
 // Parquet readers may preload or read ahead, so estimate source-byte progress
 // from the proportion of rows consumed by the parser.
 func (pp *Parser) ScannedPos() (int64, error) {
-	fileSize := max(pp.fileMeta.GetSourceFileSize(), int64(0))
+	fileSize := pp.fileMeta.GetSourceFileSize()
 	if pp.totalRows <= 0 {
 		return fileSize, nil
 	}
 
 	readRows := min(pp.totalReadRows, pp.totalRows)
-	if readRows == 0 {
-		return 0, nil
-	}
 	if readRows == pp.totalRows {
 		return fileSize, nil
 	}

--- a/pkg/dumpformat/parquetfile/parser.go
+++ b/pkg/dumpformat/parquetfile/parser.go
@@ -532,12 +532,11 @@ func (pp *Parser) ScannedPos() (int64, error) {
 		return fileSize, nil
 	}
 
-	readRows := min(pp.totalReadRows, pp.totalRows)
-	if readRows == pp.totalRows {
+	if pp.totalReadRows == pp.totalRows {
 		return fileSize, nil
 	}
 
-	progress := float64(readRows) / float64(pp.totalRows)
+	progress := float64(pp.totalReadRows) / float64(pp.totalRows)
 	return int64(progress * float64(fileSize)), nil
 }
 

--- a/pkg/dumpformat/parquetfile/parser.go
+++ b/pkg/dumpformat/parquetfile/parser.go
@@ -311,6 +311,31 @@ func (rgp *rowGroupParser) Close() error {
 	return onceErr.Get()
 }
 
+// scanProgress tracks the furthest data offset reached across column readers.
+// A *scanProgress is intentionally nil for metadata-only readers used to parse
+// the footer or read the row count. Its methods accept nil receivers so callers
+// can update progress without conditional checks.
+type scanProgress struct {
+	highWater atomic.Int64
+}
+
+func (p *scanProgress) advance(pos int64) {
+	if p == nil {
+		return
+	}
+	current := p.highWater.Load()
+	for current < pos && !p.highWater.CompareAndSwap(current, pos) {
+		current = p.highWater.Load()
+	}
+}
+
+func (p *scanProgress) current() int64 {
+	if p == nil {
+		return 0
+	}
+	return p.highWater.Load()
+}
+
 // Parser parses a parquet file for import
 type Parser struct {
 	fileMeta *metadata.FileMetaData
@@ -335,9 +360,9 @@ type Parser struct {
 	curRowGroup   int
 	totalRowGroup int
 
-	totalRows      int64 // total rows in this file
-	totalReadRows  int64 // total rows read
-	totalReadBytes int   // total bytes read, estimated by all the read datum.
+	totalRows     int64 // total rows in this file
+	totalReadRows int64 // total rows read
+	progress      *scanProgress
 
 	lastRow parsedef.Row
 	logger  log.Logger
@@ -435,7 +460,7 @@ func (pp *Parser) getBuilder() (func(int) (readerAtSeekerCloser, error), error) 
 
 	base := pp.preloadBase
 	if base == nil && ranges.end-ranges.start <= int64(rowGroupInMemoryThreshold) {
-		base, err = newInMemoryReaderBase(pp.ctx, pp.store, pp.path, ranges)
+		base, err = newInMemoryReaderBase(pp.ctx, pp.store, pp.path, ranges, pp.progress)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -459,7 +484,7 @@ func (pp *Parser) getBuilder() (func(int) (readerAtSeekerCloser, error), error) 
 			&storeapi.ReaderOption{
 				StartOffset: &ranges.columnStarts[c],
 				EndOffset:   &ranges.columnEnds[c],
-			})
+			}, pp.progress)
 	}, nil
 }
 
@@ -495,7 +520,6 @@ func (pp *Parser) readSingleRow(row []types.Datum) error {
 		return err
 	}
 
-	pp.totalReadBytes += estimateRowSize(row)
 	pp.totalReadRows++
 	return nil
 }
@@ -526,9 +550,16 @@ func (pp *Parser) SetPos(pos int64, rowID int64) error {
 }
 
 // ScannedPos implements the Parser interface.
-// For parquet we use the size of all read datum to estimate the scanned position.
+// Parquet may read disjoint column ranges, so this returns the furthest data
+// offset reached by any reader rather than a single underlying reader position.
 func (pp *Parser) ScannedPos() (int64, error) {
-	return int64(pp.totalReadBytes), nil
+	fileSize := max(pp.fileMeta.GetSourceFileSize(), int64(0))
+	if pp.totalReadRows == pp.totalRows {
+		// when all rows are read, return whole file size as progress might not
+		// track the footer.
+		return fileSize, nil
+	}
+	return min(max(pp.progress.current(), int64(0)), fileSize), nil
 }
 
 // Close closes the parquet file of the parser.
@@ -636,7 +667,8 @@ func NewParser(
 	meta FileMeta,
 ) (*Parser, error) {
 	logger := log.Wrap(logutil.Logger(ctx))
-	wrapper, preloadBase, r, err := prepareReader(ctx, store, openReader, path, fileSize)
+	progress := &scanProgress{}
+	wrapper, preloadBase, r, err := prepareReader(ctx, store, openReader, path, fileSize, progress)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -761,6 +793,7 @@ func NewParser(
 		logger:      logger,
 		rowPool:     &pool,
 		preloadBase: preloadBase,
+		progress:    progress,
 	}
 	if err := parser.Init(effectiveLoc); err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -294,7 +294,6 @@ func TestParquetScannedPosByReadRows(t *testing.T) {
 		totalRows int64
 		expected  int64
 	}{
-		{name: "negative-file-size", fileSize: -1, totalRows: 10, expected: 0},
 		{name: "no-rows-read", fileSize: 101, totalRows: 10, expected: 0},
 		{name: "partial", fileSize: 101, readRows: 4, totalRows: 10, expected: 40},
 		{name: "complete", fileSize: 101, readRows: 10, totalRows: 10, expected: 101},

--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -78,6 +78,14 @@ func newParquetS3StoreForTest(
 	return store, accessStats
 }
 
+type testReadSeekCloser struct {
+	io.ReadSeeker
+}
+
+func (*testReadSeekCloser) Close() error {
+	return nil
+}
+
 func newParquetParserForTest(
 	ctx context.Context,
 	t *testing.T,
@@ -188,6 +196,44 @@ func TestParquetParser(t *testing.T) {
 		_, statErr := os.Stat(filepath.Join(dir, fileName))
 		require.True(t, os.IsNotExist(statErr), "unexpected file state: %v", statErr)
 	})
+
+	t.Run("nil_scan_progress", func(t *testing.T) {
+		var progress *scanProgress
+		require.NotPanics(t, func() { progress.advance(1) })
+		require.Zero(t, progress.current())
+	})
+
+	t.Run("partial_streaming_read_tracks_progress", func(t *testing.T) {
+		progress := &scanProgress{}
+		wrapper := &readerWrapper{
+			ReadSeekCloser: &testReadSeekCloser{ReadSeeker: bytes.NewReader([]byte("abc"))},
+			skipBuf:        make([]byte, defaultBufSize),
+			progress:       progress,
+		}
+
+		n, err := wrapper.ReadAt(make([]byte, 4), 0)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.Equal(t, 3, n)
+		require.Equal(t, int64(3), wrapper.lastOff)
+		require.Equal(t, int64(3), progress.current())
+	})
+
+	t.Run("partial_streaming_gap_read_tracks_only_consumed_bytes", func(t *testing.T) {
+		progress := &scanProgress{}
+		wrapper := &readerWrapper{
+			ReadSeekCloser: &testReadSeekCloser{ReadSeeker: bytes.NewReader([]byte("ab"))},
+			skipBuf:        make([]byte, defaultBufSize),
+			progress:       progress,
+		}
+		buf := make([]byte, 1)
+
+		n, err := wrapper.ReadAt(buf, 4)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.Zero(t, n)
+		require.Equal(t, []byte{0}, buf)
+		require.Equal(t, int64(2), wrapper.lastOff)
+		require.Equal(t, int64(2), progress.current())
+	})
 }
 
 func TestParquetParserMultipleRowGroup(t *testing.T) {
@@ -202,6 +248,20 @@ func TestParquetParserMultipleRowGroup(t *testing.T) {
 				for i := range numRows {
 					defLevel[i] = 1
 					data[i] = int64(i)
+				}
+				return data, defLevel
+			},
+		},
+		{
+			Name:      "late_v",
+			Type:      parquet.Types.Int64,
+			Converted: schema.ConvertedTypes.Int64,
+			Gen: func(numRows int) (any, []int16) {
+				defLevel := make([]int16, numRows)
+				data := make([]int64, numRows)
+				for i := range numRows {
+					defLevel[i] = 1
+					data[i] = int64(i * 2)
 				}
 				return data, defLevel
 			},
@@ -222,25 +282,63 @@ func TestParquetParserMultipleRowGroup(t *testing.T) {
 	info, err := os.Stat(filepath.Join(dir, fileName))
 	require.NoError(t, err)
 	for _, tc := range []struct {
-		name     string
-		fileSize int64
+		name                  string
+		fileSize              int64
+		stream                bool
+		expectWholeFileLoaded bool
 	}{
 		{name: "row-group-preload"},
-		{name: "whole-file-preload", fileSize: info.Size()},
+		{name: "whole-file-preload", fileSize: info.Size(), expectWholeFileLoaded: true},
+		{name: "per-column-streaming", stream: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			parser := newParquetParserForTest(context.Background(), t, dir, fileName, tc.fileSize, FileMeta{})
-			require.Greater(t, parser.fileMeta.NumRowGroups(), 1)
-			if tc.fileSize > 0 {
-				require.NotNil(t, parser.preloadBase)
+			if tc.stream {
+				originalThreshold := rowGroupInMemoryThreshold
+				rowGroupInMemoryThreshold = 1
+				defer func() { rowGroupInMemoryThreshold = originalThreshold }()
 			}
 
+			parser := newParquetParserForTest(context.Background(), t, dir, fileName, tc.fileSize, FileMeta{})
+			require.Greater(t, parser.fileMeta.NumRowGroups(), 1)
+			firstRowGroupRange, err := rowGroupRangeFromMeta(parser.fileMeta, 0)
+			require.NoError(t, err)
+			if tc.expectWholeFileLoaded {
+				require.NotNil(t, parser.preloadBase)
+				scannedPos, err := parser.ScannedPos()
+				require.NoError(t, err)
+				require.Equal(t, info.Size(), scannedPos)
+			} else if !tc.stream {
+				scannedPos, err := parser.ScannedPos()
+				require.NoError(t, err)
+				require.Equal(t, firstRowGroupRange.end, scannedPos)
+			} else {
+				scannedPos, err := parser.ScannedPos()
+				require.NoError(t, err)
+				require.Less(t, scannedPos, info.Size(), "footer reads must not count as data progress")
+			}
+
+			previousScannedPos, err := parser.ScannedPos()
+			require.NoError(t, err)
 			for i := range 50 {
 				require.NoError(t, parser.ReadRow())
 				require.Equal(t, int64(i), parser.LastRow().Row[0].GetInt64())
+				require.Equal(t, int64(i*2), parser.LastRow().Row[1].GetInt64())
+
+				scannedPos, err := parser.ScannedPos()
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, scannedPos, previousScannedPos)
+				require.LessOrEqual(t, scannedPos, info.Size())
+				if tc.stream && i == 0 {
+					require.Greater(t, scannedPos, firstRowGroupRange.columnStarts[1])
+				}
+				previousScannedPos = scannedPos
+
 				last := parser.LastRow()
 				parser.RecycleRow(last)
 			}
+			finalScannedPos, err := parser.ScannedPos()
+			require.NoError(t, err)
+			require.Equal(t, info.Size(), finalScannedPos)
 			require.ErrorIs(t, parser.ReadRow(), io.EOF)
 		})
 	}

--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -298,7 +298,6 @@ func TestParquetScannedPosByReadRows(t *testing.T) {
 		{name: "partial", fileSize: 101, readRows: 4, totalRows: 10, expected: 40},
 		{name: "complete", fileSize: 101, readRows: 10, totalRows: 10, expected: 101},
 		{name: "empty-file", fileSize: 101, totalRows: 0, expected: 101},
-		{name: "past-end", fileSize: 101, readRows: 11, totalRows: 10, expected: 101},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fileMeta.SetSourceFileSize(tc.fileSize)
@@ -315,7 +314,7 @@ func TestParquetScannedPosByReadRows(t *testing.T) {
 	fileMeta.SetSourceFileSize(largeFileSize)
 	parser.totalRows = 97
 	previous := int64(0)
-	for readRows := int64(0); readRows <= parser.totalRows+1; readRows++ {
+	for readRows := int64(0); readRows <= parser.totalRows; readRows++ {
 		parser.totalReadRows = readRows
 		pos, err := parser.ScannedPos()
 		require.NoError(t, err)

--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -78,14 +78,6 @@ func newParquetS3StoreForTest(
 	return store, accessStats
 }
 
-type testReadSeekCloser struct {
-	io.ReadSeeker
-}
-
-func (*testReadSeekCloser) Close() error {
-	return nil
-}
-
 func newParquetParserForTest(
 	ctx context.Context,
 	t *testing.T,
@@ -196,44 +188,6 @@ func TestParquetParser(t *testing.T) {
 		_, statErr := os.Stat(filepath.Join(dir, fileName))
 		require.True(t, os.IsNotExist(statErr), "unexpected file state: %v", statErr)
 	})
-
-	t.Run("nil_scan_progress", func(t *testing.T) {
-		var progress *scanProgress
-		require.NotPanics(t, func() { progress.advance(1) })
-		require.Zero(t, progress.current())
-	})
-
-	t.Run("partial_streaming_read_tracks_progress", func(t *testing.T) {
-		progress := &scanProgress{}
-		wrapper := &readerWrapper{
-			ReadSeekCloser: &testReadSeekCloser{ReadSeeker: bytes.NewReader([]byte("abc"))},
-			skipBuf:        make([]byte, defaultBufSize),
-			progress:       progress,
-		}
-
-		n, err := wrapper.ReadAt(make([]byte, 4), 0)
-		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-		require.Equal(t, 3, n)
-		require.Equal(t, int64(3), wrapper.lastOff)
-		require.Equal(t, int64(3), progress.current())
-	})
-
-	t.Run("partial_streaming_gap_read_tracks_only_consumed_bytes", func(t *testing.T) {
-		progress := &scanProgress{}
-		wrapper := &readerWrapper{
-			ReadSeekCloser: &testReadSeekCloser{ReadSeeker: bytes.NewReader([]byte("ab"))},
-			skipBuf:        make([]byte, defaultBufSize),
-			progress:       progress,
-		}
-		buf := make([]byte, 1)
-
-		n, err := wrapper.ReadAt(buf, 4)
-		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-		require.Zero(t, n)
-		require.Equal(t, []byte{0}, buf)
-		require.Equal(t, int64(2), wrapper.lastOff)
-		require.Equal(t, int64(2), progress.current())
-	})
 }
 
 func TestParquetParserMultipleRowGroup(t *testing.T) {
@@ -300,25 +254,13 @@ func TestParquetParserMultipleRowGroup(t *testing.T) {
 
 			parser := newParquetParserForTest(context.Background(), t, dir, fileName, tc.fileSize, FileMeta{})
 			require.Greater(t, parser.fileMeta.NumRowGroups(), 1)
-			firstRowGroupRange, err := rowGroupRangeFromMeta(parser.fileMeta, 0)
-			require.NoError(t, err)
 			if tc.expectWholeFileLoaded {
 				require.NotNil(t, parser.preloadBase)
-				scannedPos, err := parser.ScannedPos()
-				require.NoError(t, err)
-				require.Equal(t, info.Size(), scannedPos)
-			} else if !tc.stream {
-				scannedPos, err := parser.ScannedPos()
-				require.NoError(t, err)
-				require.Equal(t, firstRowGroupRange.end, scannedPos)
-			} else {
-				scannedPos, err := parser.ScannedPos()
-				require.NoError(t, err)
-				require.Less(t, scannedPos, info.Size(), "footer reads must not count as data progress")
 			}
 
 			previousScannedPos, err := parser.ScannedPos()
 			require.NoError(t, err)
+			require.Zero(t, previousScannedPos)
 			for i := range 50 {
 				require.NoError(t, parser.ReadRow())
 				require.Equal(t, int64(i), parser.LastRow().Row[0].GetInt64())
@@ -326,11 +268,9 @@ func TestParquetParserMultipleRowGroup(t *testing.T) {
 
 				scannedPos, err := parser.ScannedPos()
 				require.NoError(t, err)
+				require.Equal(t, info.Size()*int64(i+1)/50, scannedPos)
 				require.GreaterOrEqual(t, scannedPos, previousScannedPos)
 				require.LessOrEqual(t, scannedPos, info.Size())
-				if tc.stream && i == 0 {
-					require.Greater(t, scannedPos, firstRowGroupRange.columnStarts[1])
-				}
 				previousScannedPos = scannedPos
 
 				last := parser.LastRow()
@@ -341,6 +281,48 @@ func TestParquetParserMultipleRowGroup(t *testing.T) {
 			require.Equal(t, info.Size(), finalScannedPos)
 			require.ErrorIs(t, parser.ReadRow(), io.EOF)
 		})
+	}
+}
+
+func TestParquetScannedPosByReadRows(t *testing.T) {
+	fileMeta := &metadata.FileMetaData{}
+	parser := &Parser{fileMeta: fileMeta}
+	for _, tc := range []struct {
+		name      string
+		fileSize  int64
+		readRows  int64
+		totalRows int64
+		expected  int64
+	}{
+		{name: "negative-file-size", fileSize: -1, totalRows: 10, expected: 0},
+		{name: "no-rows-read", fileSize: 101, totalRows: 10, expected: 0},
+		{name: "partial", fileSize: 101, readRows: 4, totalRows: 10, expected: 40},
+		{name: "complete", fileSize: 101, readRows: 10, totalRows: 10, expected: 101},
+		{name: "empty-file", fileSize: 101, totalRows: 0, expected: 101},
+		{name: "past-end", fileSize: 101, readRows: 11, totalRows: 10, expected: 101},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fileMeta.SetSourceFileSize(tc.fileSize)
+			parser.totalReadRows = tc.readRows
+			parser.totalRows = tc.totalRows
+
+			pos, err := parser.ScannedPos()
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, pos)
+		})
+	}
+
+	const largeFileSize = int64(10 << 30)
+	fileMeta.SetSourceFileSize(largeFileSize)
+	parser.totalRows = 97
+	previous := int64(0)
+	for readRows := int64(0); readRows <= parser.totalRows+1; readRows++ {
+		parser.totalReadRows = readRows
+		pos, err := parser.ScannedPos()
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, pos, previous)
+		require.LessOrEqual(t, pos, largeFileSize)
+		previous = pos
 	}
 }
 

--- a/pkg/dumpformat/parquetfile/reader_wrapper.go
+++ b/pkg/dumpformat/parquetfile/reader_wrapper.go
@@ -53,15 +53,14 @@ type readerAtSeekerCloser interface {
 // readerWrapper implements parquet.ReaderAtSeeker.
 type readerWrapper struct {
 	io.ReadSeekCloser
-	lastOff  int64
-	skipBuf  []byte
-	progress *scanProgress
+	lastOff int64
+	skipBuf []byte
 }
 
 func (p *readerWrapper) readNBytes(buf []byte) (int, error) {
 	n, err := io.ReadFull(p, buf)
 	if err != nil && err != io.EOF {
-		return n, errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 	if n != len(buf) {
 		return n, errors.Errorf("error reading %d bytes, only read %d bytes", len(buf), n)
@@ -80,20 +79,16 @@ func (p *readerWrapper) ReadAt(buf []byte, off int64) (int, error) {
 		}
 	} else {
 		p.skipBuf = p.skipBuf[:gap]
-		read, err := p.readNBytes(p.skipBuf)
-		p.lastOff += int64(read)
-		p.progress.advance(p.lastOff)
-		if err != nil {
-			return 0, err
+		if read, err := p.readNBytes(p.skipBuf); err != nil {
+			return read, err
 		}
 	}
 
 	read, err := p.readNBytes(buf)
-	p.lastOff = off + int64(read)
-	p.progress.advance(p.lastOff)
 	if err != nil {
 		return read, err
 	}
+	p.lastOff = off + int64(read)
 
 	return len(buf), nil
 }
@@ -114,7 +109,6 @@ func newReaderWrapper(
 	store storeapi.Storage,
 	path string,
 	opts *storeapi.ReaderOption,
-	progress *scanProgress,
 ) (*readerWrapper, error) {
 	reader, err := store.Open(ctx, path, opts)
 	if err != nil {
@@ -133,7 +127,6 @@ func newReaderWrapper(
 		ReadSeekCloser: reader,
 		lastOff:        lastOff,
 		skipBuf:        make([]byte, defaultBufSize),
-		progress:       progress,
 	}, nil
 }
 
@@ -163,17 +156,12 @@ func newInMemoryReaderBase(
 	store storeapi.Storage,
 	path string,
 	rowGroup rowGroupRange,
-	progress *scanProgress,
 ) (*inMemoryReaderBase, error) {
 	base := &inMemoryReaderBase{
 		rowGroup: rowGroup,
 		buffer:   make([]byte, rowGroup.end-rowGroup.start),
 	}
-	if err := base.loadRowGroup(ctx, store, path); err != nil {
-		return base, err
-	}
-	progress.advance(rowGroup.end)
-	return base, nil
+	return base, base.loadRowGroup(ctx, store, path)
 }
 
 func (r *inMemoryReaderBase) ReadAt(p []byte, off int64) (int, error) {
@@ -264,10 +252,9 @@ func prepareReader(
 	openReader func(context.Context) (io.ReadSeekCloser, error),
 	path string,
 	fileSize int64,
-	progress *scanProgress,
 ) (parquet.ReaderAtSeeker, *inMemoryReaderBase, io.ReadSeekCloser, error) {
 	if fileSize > 0 && fileSize <= int64(wholeFileInMemoryThreshold) {
-		base, err := newInMemoryReaderBase(ctx, store, path, rowGroupRange{start: 0, end: fileSize}, progress)
+		base, err := newInMemoryReaderBase(ctx, store, path, rowGroupRange{start: 0, end: fileSize})
 		if err != nil {
 			return nil, nil, nil, errors.Trace(err)
 		}
@@ -277,8 +264,6 @@ func prepareReader(
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
-	// This reader is used only to parse footer metadata. Tracking its reads would
-	// make construction look like all source data had already been scanned.
 	return &readerWrapper{ReadSeekCloser: r}, nil, r, nil
 }
 

--- a/pkg/dumpformat/parquetfile/reader_wrapper.go
+++ b/pkg/dumpformat/parquetfile/reader_wrapper.go
@@ -53,14 +53,15 @@ type readerAtSeekerCloser interface {
 // readerWrapper implements parquet.ReaderAtSeeker.
 type readerWrapper struct {
 	io.ReadSeekCloser
-	lastOff int64
-	skipBuf []byte
+	lastOff  int64
+	skipBuf  []byte
+	progress *scanProgress
 }
 
 func (p *readerWrapper) readNBytes(buf []byte) (int, error) {
 	n, err := io.ReadFull(p, buf)
 	if err != nil && err != io.EOF {
-		return 0, errors.Trace(err)
+		return n, errors.Trace(err)
 	}
 	if n != len(buf) {
 		return n, errors.Errorf("error reading %d bytes, only read %d bytes", len(buf), n)
@@ -79,16 +80,20 @@ func (p *readerWrapper) ReadAt(buf []byte, off int64) (int, error) {
 		}
 	} else {
 		p.skipBuf = p.skipBuf[:gap]
-		if read, err := p.readNBytes(p.skipBuf); err != nil {
-			return read, err
+		read, err := p.readNBytes(p.skipBuf)
+		p.lastOff += int64(read)
+		p.progress.advance(p.lastOff)
+		if err != nil {
+			return 0, err
 		}
 	}
 
 	read, err := p.readNBytes(buf)
+	p.lastOff = off + int64(read)
+	p.progress.advance(p.lastOff)
 	if err != nil {
 		return read, err
 	}
-	p.lastOff = off + int64(read)
 
 	return len(buf), nil
 }
@@ -109,6 +114,7 @@ func newReaderWrapper(
 	store storeapi.Storage,
 	path string,
 	opts *storeapi.ReaderOption,
+	progress *scanProgress,
 ) (*readerWrapper, error) {
 	reader, err := store.Open(ctx, path, opts)
 	if err != nil {
@@ -127,6 +133,7 @@ func newReaderWrapper(
 		ReadSeekCloser: reader,
 		lastOff:        lastOff,
 		skipBuf:        make([]byte, defaultBufSize),
+		progress:       progress,
 	}, nil
 }
 
@@ -156,12 +163,17 @@ func newInMemoryReaderBase(
 	store storeapi.Storage,
 	path string,
 	rowGroup rowGroupRange,
+	progress *scanProgress,
 ) (*inMemoryReaderBase, error) {
 	base := &inMemoryReaderBase{
 		rowGroup: rowGroup,
 		buffer:   make([]byte, rowGroup.end-rowGroup.start),
 	}
-	return base, base.loadRowGroup(ctx, store, path)
+	if err := base.loadRowGroup(ctx, store, path); err != nil {
+		return base, err
+	}
+	progress.advance(rowGroup.end)
+	return base, nil
 }
 
 func (r *inMemoryReaderBase) ReadAt(p []byte, off int64) (int, error) {
@@ -252,9 +264,10 @@ func prepareReader(
 	openReader func(context.Context) (io.ReadSeekCloser, error),
 	path string,
 	fileSize int64,
+	progress *scanProgress,
 ) (parquet.ReaderAtSeeker, *inMemoryReaderBase, io.ReadSeekCloser, error) {
 	if fileSize > 0 && fileSize <= int64(wholeFileInMemoryThreshold) {
-		base, err := newInMemoryReaderBase(ctx, store, path, rowGroupRange{start: 0, end: fileSize})
+		base, err := newInMemoryReaderBase(ctx, store, path, rowGroupRange{start: 0, end: fileSize}, progress)
 		if err != nil {
 			return nil, nil, nil, errors.Trace(err)
 		}
@@ -264,6 +277,8 @@ func prepareReader(
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
+	// This reader is used only to parse footer metadata. Tracking its reads would
+	// make construction look like all source data had already been scanned.
 	return &readerWrapper{ReadSeekCloser: r}, nil, r, nil
 }
 

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -141,7 +141,8 @@ type Parser interface {
 	// TODO: replace pos with a new structure to specify position offset and rows offset
 	Pos() (pos int64, rowID int64)
 	SetPos(pos int64, rowID int64) error
-	// ScannedPos always returns the current file reader pointer's location
+	// ScannedPos returns monotonic source-byte progress. A parser may estimate
+	// this when its physical reads do not correspond directly to parsed rows.
 	ScannedPos() (int64, error)
 	Close() error
 	ReadRow() error


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70306

Problem Summary:

The Parquet parser estimated scanned bytes from decoded datum sizes. Those sizes are independent of the original file's encoding, compression, metadata, and column layout, so byte progress and derived import metrics did not reflect the original file size. A 1,307-byte regression file, for example, reported only 400 bytes after every row had been read.

### What changed and how does it work?

- Track the high-water source-file offset reached across concurrent Parquet column readers.
- Advance progress for whole-file and row-group preloads while excluding metadata-only footer reads.
- Account for bytes consumed by partial streaming reads and clamp reported progress to the source file size.
- Report the exact original file size once all rows are read.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

3 parquet files, total size 5,040,619 bytes
before the `tidb_import_bytes{state="restored"}` metric is `48,000,024 bytes`, after this pr, it's `5,040,619`

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

The regression assertion failed at the base commit with `expected: 1307, actual: 400` in both row-group and whole-file preload modes, and passes with this change.

Validation commands:

```bash
./tools/check/failpoint-go-test.sh pkg/dumpformat/parquetfile -run '^(TestParquetParser|TestParquetParserMultipleRowGroup)$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where Parquet import progress metrics were calculated from decoded row sizes instead of the original source file size.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Parquet import progress tracking with smoother, monotonic scanned-position updates.
  * Progress estimates now remain accurate for empty, partially processed, completed, and very large files.

* **Reliability**
  * Improved handling of Parquet files with multiple row groups and columns across preload and streaming modes.

* **Documentation**
  * Clarified how scanned-position progress is reported during imports.

* **Tests**
  * Expanded coverage for column reading and progress reporting across varied file sizes and processing states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->