### PR TITLE
ddl: reject partial index add-ddl when using Job V1 (upgrade) (#70281)

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5182,6 +5182,9 @@ func (e *executor) createIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast
 		if len(conditionString) > 0 && !job.ReorgMeta.IsFastReorg {
 			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs("add partial index without fast reorg is not supported")
 		}
+		if len(conditionString) > 0 && model.GetJobVerInUse() == model.JobVersion1 {
+			return dbterror.ErrUnsupportedAddPartialIndex.GenWithStackByArgs("add partial index during upgrade is not supported")
+		}
 	}
 	args := &model.ModifyIndexArgs{
 		IndexArgs: []*model.IndexArg{{


### PR DESCRIPTION
## Description

When a partial index (`CREATE INDEX ... WHERE ...`) is submitted while the TiDB cluster is using DDL Job V1 (typically during a rolling upgrade from v7.5.x to v8.5.x), the `ConditionString` (the WHERE predicate) is silently lost.

### Root Cause

`ModifyIndexArgs.getArgsV1()` does not serialize `ConditionString`. When the job is paused during upgrade and later resumed, the V1 decoder reads the old 6-argument layout and produces an empty condition, creating a full index instead of a partial index.

### Fix

Add a guard that rejects partial index add-ddl when `model.GetJobVerInUse() == model.JobVersion1`. This prevents the silent data corruption — the user gets an actionable error instead of a silently changed index definition.

The error message is:
```
ERROR 8200 (HY000): Unsupported add partial index: add partial index during upgrade is not supported
```

### Alternative Considered

Adding `ConditionString` to the V1 argument serialization (`getArgsV1()` / `decodeAddIndexV1()`) was considered but rejected because:
1. It would change the V1 argument layout, breaking backward compatibility with already-persisted V1 jobs
2. The simpler guard provides a clear, actionable error and the user can retry after the upgrade completes

### Related Issues

Fixes #70281

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md)
- [x] I have checked the code compiles correctly
- [x] I have tested the change with a minimal reproduction
- [x] This PR addresses the issue as described


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partial indexes are now blocked when using the legacy job version, preventing unsupported index creation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->