### PR TITLE
br: skip restore system tables in log restore instead of report error

### DIFF
--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1444,6 +1444,8 @@ func RunStreamRestore(
 		return errors.Trace(err)
 	}
 
+	warnSystemTablesForExplicitPiTRFilter(cfg)
+
 	taskInfo, err := generatePiTRTaskInfo(ctx, mgr, g, cfg, cfg.RestoreID)
 	if err != nil {
 		return errors.Trace(err)
@@ -1463,13 +1465,6 @@ func RunStreamRestore(
 	ddlFiles, err := logClient.LoadDDLFiles(ctx)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	// TODO: pitr filtered restore doesn't support restore system table yet
-	if cfg.ExplicitFilter {
-		if cfg.TableFilter.MatchSchema(mysql.SystemDB) || cfg.TableFilter.MatchSchema(mysql.SysDB) {
-			return errors.Annotatef(berrors.ErrInvalidArgument,
-				"PiTR doesn't support custom filter to include system db, consider to exclude system db")
-		}
 	}
 	metaInfoProcessor := logclient.NewMetaKVInfoProcessor(logClient)
 	// doesn't need to build if id map has been saved
@@ -2095,6 +2090,28 @@ func getExternalStorageOptions(cfg *Config, u *backuppb.StorageBackend) storeapi
 		SendCredentials: cfg.SendCreds,
 		HTTPClient:      httpClient,
 	}
+}
+
+func warnSystemTablesForExplicitPiTRFilter(cfg *RestoreConfig) bool {
+	if !cfg.ExplicitFilter || cfg.TableFilter == nil {
+		return false
+	}
+
+	matchedSystemDBs := make([]string, 0, 3)
+	for _, systemDB := range []string{mysql.SystemDB, mysql.SysDB, mysql.WorkloadSchema} {
+		if cfg.TableFilter.MatchSchema(systemDB) {
+			matchedSystemDBs = append(matchedSystemDBs, systemDB)
+		}
+	}
+	if len(matchedSystemDBs) == 0 {
+		return false
+	}
+
+	log.Warn("PiTR log restore does not support restoring system table changes; matched system schemas are restored only from snapshot backup when --with-sys-table is enabled",
+		zap.Strings("systemSchemas", matchedSystemDBs),
+		zap.Bool("withSysTable", cfg.WithSysTable),
+		zap.Strings("filter", cfg.FilterStr))
+	return true
 }
 
 func checkLogRange(restoreFromTS, restoreToTS, logMinTS, logMaxTS uint64) error {

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/utils/consts"
 	"github.com/pingcap/tidb/br/pkg/utils/iter"
 	"github.com/pingcap/tidb/pkg/objstore"
+	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 )
@@ -96,6 +97,87 @@ func TestMarkRestoreConcurrencyPerStoreAdjusted(t *testing.T) {
 
 	require.Equal(t, uint(132), cfg.ConcurrencyPerStore.Value)
 	require.True(t, cfg.ConcurrencyPerStore.Modified)
+}
+
+func TestWarnSystemTablesForExplicitPiTRFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		filterStr  []string
+		explicit   bool
+		withSys    bool
+		wantWarned bool
+	}{
+		{
+			name:       "default filter is not user explicit",
+			filterStr:  []string{"*.*"},
+			explicit:   false,
+			withSys:    true,
+			wantWarned: false,
+		},
+		{
+			name:       "user table filter keeps system table restore setting",
+			filterStr:  []string{"test.*"},
+			explicit:   true,
+			withSys:    true,
+			wantWarned: false,
+		},
+		{
+			name:       "wildcard explicit filter warns about system table log changes",
+			filterStr:  []string{"*.*"},
+			explicit:   true,
+			withSys:    true,
+			wantWarned: true,
+		},
+		{
+			name:       "specific mysql table filter warns about system table log changes",
+			filterStr:  []string{"mysql.user"},
+			explicit:   true,
+			withSys:    true,
+			wantWarned: true,
+		},
+		{
+			name:       "workload schema filter warns about system table log changes",
+			filterStr:  []string{"workload_schema.*"},
+			explicit:   true,
+			withSys:    true,
+			wantWarned: true,
+		},
+		{
+			name:       "explicit system exclusions do not trigger warning",
+			filterStr:  []string{"*.*", "!mysql.*", "!sys.*", "!workload_schema.*"},
+			explicit:   true,
+			withSys:    true,
+			wantWarned: false,
+		},
+		{
+			name:       "warning does not enable system table snapshot restore",
+			filterStr:  []string{"mysql.*"},
+			explicit:   true,
+			withSys:    false,
+			wantWarned: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tableFilter, err := filter.Parse(tt.filterStr)
+			require.NoError(t, err)
+
+			cfg := &RestoreConfig{
+				Config: Config{
+					ExplicitFilter: tt.explicit,
+					FilterStr:      tt.filterStr,
+					TableFilter:    tableFilter,
+				},
+				RestoreCommonConfig: RestoreCommonConfig{
+					WithSysTable: tt.withSys,
+				},
+			}
+
+			require.Equal(t, tt.wantWarned, warnSystemTablesForExplicitPiTRFilter(cfg))
+			require.Equal(t, tt.withSys, cfg.WithSysTable)
+		})
+	}
 }
 
 func TestCheckLogRange(t *testing.T) {

--- a/br/tests/br_pitr_table_filter/run.sh
+++ b/br/tests/br_pitr_table_filter/run.sh
@@ -92,6 +92,30 @@ verify_tables() {
     done
 }
 
+verify_system_users_restored_from_snapshot_only() {
+    users_result=$(run_sql "SELECT _tidb_rowid, user, host, authentication_string FROM mysql.user WHERE user IN ('test_user', 'post_backup_user')")
+    test_user_count=$(echo "$users_result" | grep -c "test_user" || true)
+
+    if [ "$test_user_count" -eq 0 ]; then
+        echo "Error: test_user not found in mysql.user table"
+        exit 1
+    elif [ "$test_user_count" -gt 1 ]; then
+        echo "Error: Found $test_user_count instances of test_user in mysql.user table, expected exactly 1"
+        echo "Full query result:"
+        echo "$users_result"
+        exit 1
+    fi
+
+    if echo "$users_result" | grep -q "post_backup_user"; then
+        echo "Error: post_backup_user found in mysql.user table but should not be restored"
+        echo "Full query result:"
+        echo "$users_result"
+        exit 1
+    fi
+
+    echo "Verified system tables restored from snapshot only: one test_user exists and post_backup_user does not"
+}
+
 rename_tables() {
     local db_name=$1       # database name
     local db_name_new=$2
@@ -658,48 +682,17 @@ test_system_tables() {
     run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full"
 
 
-    # verify system tables are restored from snapshot only
-    # only test_user should exist, post_backup_user should not exist
-    users_result=$(run_sql "SELECT _tidb_rowid, user, host, authentication_string FROM mysql.user WHERE user IN ('test_user', 'post_backup_user')")
+    verify_system_users_restored_from_snapshot_only
 
-    test_user_count=$(echo "$users_result" | grep -c "test_user" || true)
+    echo "Test 2: Verify explicit wildcard filter restores snapshot system tables and skips log system table changes"
+    restart_services || { echo "Failed to restart services"; exit 1; }
+    run_br --pd "$PD_ADDR" restore point -f "*.*" -s "local://$TEST_DIR/$TASK_NAME/log" --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full"
+    verify_system_users_restored_from_snapshot_only
 
-    # Verify there is exactly one test_user
-    if [ "$test_user_count" -eq 0 ]; then
-        echo "Error: test_user not found in mysql.user table"
-        exit 1
-    elif [ "$test_user_count" -gt 1 ]; then
-        echo "Error: Found $test_user_count instances of test_user in mysql.user table, expected exactly 1"
-        echo "Full query result:"
-        echo "$users_result"
-        exit 1
-    fi
-
-    # Check that post_backup_user does not exist (was created after snapshot)
-    if echo "$users_result" | grep -q "post_backup_user"; then
-        echo "Error: post_backup_user found in mysql.user table but should not be restored"
-        echo "Full query result:"
-        echo "$users_result"
-        exit 1
-    fi
-
-    echo "Default restore correctly restored system tables from snapshot only: verified one test_user exists"
-
-    echo "PiTR should error out when system tables are included with explicit filter"
-    restore_fail=0
-    run_br --pd "$PD_ADDR" restore point -f "*.*" -s "local://$TEST_DIR/$TASK_NAME/log" --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" || restore_fail=1
-    if [ $restore_fail -ne 1 ]; then
-        echo "Expected restore to fail when including system tables with filter"
-        exit 1
-    fi
-
-    # Also verify that specific system table filters fail
-    restore_fail=0
-    run_br --pd "$PD_ADDR" restore point -f "mysql.*" -s "local://$TEST_DIR/$TASK_NAME/log" --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" || restore_fail=1
-    if [ $restore_fail -ne 1 ]; then
-        echo "Expected restore to fail when explicitly filtering system tables"
-        exit 1
-    fi
+    echo "Test 3: Verify explicit system table filter restores snapshot system tables and skips log system table changes"
+    restart_services || { echo "Failed to restart services"; exit 1; }
+    run_br --pd "$PD_ADDR" restore point -f "mysql.*" -s "local://$TEST_DIR/$TASK_NAME/log" --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full"
+    verify_system_users_restored_from_snapshot_only
 
     rm -rf "$TEST_DIR/$TASK_NAME"
     echo "system tables test passed"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65352

Problem Summary:
After the pitr filter feature is introduced, the system table filter is forbidden. However, in the old version, it just skip system tables recovery in the log restore phase.
### What changed and how does it work?
This PR doesn't support the system tables recovery. It just keep the behaivor the same as before.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PiTR restores with explicit filters that include system schemas now proceed with a warning instead of failing.
  * Warnings identify matched system schemas, the system-table option, and the applied filter.
  * System-table restore behavior is now validated for default, wildcard, and explicit `mysql.*` filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->