### PR TITLE
statistics: report sync load failure regardless of result arrival order

### DIFF
--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     srcs = ["stats_syncload_test.go"],
     flaky = True,
     race = "on",
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         ":syncload",
         "//pkg/config",

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -198,7 +198,12 @@ func (*statsSyncLoad) SyncWaitStatsLoad(sc *stmtctx.StatementContext) error {
 		metrics.SyncLoadHistogram.Observe(float64(time.Since(sc.StatsLoad.LoadStartTime).Milliseconds()))
 		return nil
 	}
-	return nil
+	// Some items were not delivered within the wait window, e.g. the singleflight request timed
+	// out before any worker picked it up, or the request channel was full. It must be reported as
+	// an error just like the timer branch above, so the caller marks this statement as sync-load
+	// failed no matter which of the two timeouts fires first.
+	metrics.SyncLoadTimeoutCounter.Inc()
+	return errors.New("sync load stats failed: some requested items are not loaded in time")
 }
 
 // removeHistLoadedColumns removed having-hist columns based on neededColumns and statsCache.

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -372,6 +372,56 @@ func TestSendLoadRequestsWaitTooLong(t *testing.T) {
 	}
 }
 
+// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests the behavior of SyncWaitStatsLoad when a
+// sync load request failed and the failed result was delivered to the result channel before
+// SyncWaitStatsLoad's own timer fires. Currently the failure is only logged and SyncWaitStatsLoad
+// returns nil, so whether a timed-out sync load is reported to the caller depends on which of the
+// two timers (the request's and the waiter's) fires first. See issue #67629.
+func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
+	originConfig := config.GetGlobalConfig()
+	newConfig := config.NewConfig()
+	newConfig.Performance.StatsLoadConcurrency = -1 // no worker to consume channel
+	newConfig.Performance.StatsLoadQueueSize = 1
+	config.StoreGlobalConfig(newConfig)
+	defer config.StoreGlobalConfig(originConfig)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, primary key(a))")
+	tk.MustExec("insert into t values (1,1),(2,2),(3,3)")
+
+	oriLease := dom.StatsHandle().Lease()
+	dom.StatsHandle().SetLease(1)
+	defer func() {
+		dom.StatsHandle().SetLease(oriLease)
+	}()
+	tk.MustExec("analyze table t all columns")
+	h := dom.StatsHandle()
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	neededColumns := []model.StatsLoadItem{
+		{TableItemID: model.TableItemID{TableID: tableInfo.ID, ID: tableInfo.Columns[1].ID, IsIndex: false}, FullLoad: true},
+	}
+	timeout := 50 * time.Millisecond
+	stmtCtx := stmtctx.NewStmtCtx()
+	require.NoError(t, h.SendLoadRequests(stmtCtx, neededColumns, timeout))
+	// Send the same request from an observer statement context. It normally joins the singleflight
+	// call above, so once the observer receives the errored result, the same result has already
+	// been sent to stmtCtx's result channel. Even if the observer starts a new singleflight call,
+	// receiving its result still guarantees the first call has finished delivery.
+	observerCtx := stmtctx.NewStmtCtx()
+	require.NoError(t, h.SendLoadRequests(observerCtx, neededColumns, timeout))
+	require.Len(t, observerCtx.StatsLoad.ResultCh, 1)
+	rs := <-observerCtx.StatsLoad.ResultCh[0]
+	require.Error(t, rs.Err) // no worker handles the request, so it times out
+	// The errored result is waiting in stmtCtx's result channel, so SyncWaitStatsLoad consumes it
+	// instead of hitting its own timer. The failure is currently swallowed and reported as success.
+	require.NoError(t, h.SyncWaitStatsLoad(stmtCtx))
+}
+
 func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -372,11 +372,12 @@ func TestSendLoadRequestsWaitTooLong(t *testing.T) {
 	}
 }
 
-// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests the behavior of SyncWaitStatsLoad when a
-// sync load request failed and the failed result was delivered to the result channel before
-// SyncWaitStatsLoad's own timer fires. Currently the failure is only logged and SyncWaitStatsLoad
-// returns nil, so whether a timed-out sync load is reported to the caller depends on which of the
-// two timers (the request's and the waiter's) fires first. See issue #67629.
+// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests that SyncWaitStatsLoad reports an error
+// when a sync load request failed, even if the failed result was delivered to the result channel
+// before SyncWaitStatsLoad's own timer fires. Otherwise the outcome of a timed-out sync load would
+// depend on which of the two timers (the request's and the waiter's) fires first, and the statement
+// would randomly miss the sync-load-failed handling such as skipping the plan cache. See issue
+// #67629.
 func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
 	originConfig := config.GetGlobalConfig()
 	newConfig := config.NewConfig()
@@ -418,8 +419,8 @@ func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
 	rs := <-observerCtx.StatsLoad.ResultCh[0]
 	require.Error(t, rs.Err) // no worker handles the request, so it times out
 	// The errored result is waiting in stmtCtx's result channel, so SyncWaitStatsLoad consumes it
-	// instead of hitting its own timer. The failure is currently swallowed and reported as success.
-	require.NoError(t, h.SyncWaitStatsLoad(stmtCtx))
+	// instead of hitting its own timer. It must still report the failure.
+	require.Error(t, h.SyncWaitStatsLoad(stmtCtx))
 }
 
 func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -372,6 +372,56 @@ func TestSendLoadRequestsWaitTooLong(t *testing.T) {
 	}
 }
 
+// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests the behavior of SyncWaitStatsLoad when a
+// sync load request failed and the failed result was delivered to the result channel before
+// SyncWaitStatsLoad's own timer fires. Currently the failure is only logged and SyncWaitStatsLoad
+// returns nil, so whether a timed-out sync load is reported to the caller depends on which of the
+// two timers (the request's and the waiter's) fires first. See issue #67629.
+func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
+	originConfig := config.GetGlobalConfig()
+	newConfig := config.NewConfig()
+	newConfig.Performance.StatsLoadConcurrency = -1 // no worker to consume channel
+	newConfig.Performance.StatsLoadQueueSize = 1
+	config.StoreGlobalConfig(newConfig)
+	defer config.StoreGlobalConfig(originConfig)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, primary key(a))")
+	tk.MustExec("insert into t values (1,1),(2,2),(3,3)")
+
+	oriLease := dom.StatsHandle().Lease()
+	dom.StatsHandle().SetLease(1)
+	defer func() {
+		dom.StatsHandle().SetLease(oriLease)
+	}()
+	tk.MustExec("analyze table t")
+	h := dom.StatsHandle()
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	neededColumns := []model.StatsLoadItem{
+		{TableItemID: model.TableItemID{TableID: tableInfo.ID, ID: tableInfo.Columns[1].ID, IsIndex: false}, FullLoad: true},
+	}
+	timeout := 50 * time.Millisecond
+	stmtCtx := stmtctx.NewStmtCtx()
+	require.NoError(t, h.SendLoadRequests(stmtCtx, neededColumns, timeout))
+	// Send the same request from an observer statement context. It normally joins the singleflight
+	// call above, so once the observer receives the errored result, the same result has already
+	// been sent to stmtCtx's result channel. Even if the observer starts a new singleflight call,
+	// receiving its result still guarantees the first call has finished delivery.
+	observerCtx := stmtctx.NewStmtCtx()
+	require.NoError(t, h.SendLoadRequests(observerCtx, neededColumns, timeout))
+	require.Len(t, observerCtx.StatsLoad.ResultCh, 1)
+	rs := <-observerCtx.StatsLoad.ResultCh[0]
+	require.Error(t, rs.Err) // no worker handles the request, so it times out
+	// The errored result is waiting in stmtCtx's result channel, so SyncWaitStatsLoad consumes it
+	// instead of hitting its own timer. The failure is currently swallowed and reported as success.
+	require.NoError(t, h.SyncWaitStatsLoad(stmtCtx))
+}
+
 func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -372,11 +372,9 @@ func TestSendLoadRequestsWaitTooLong(t *testing.T) {
 	}
 }
 
-// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests the behavior of SyncWaitStatsLoad when a
-// sync load request failed and the failed result was delivered to the result channel before
-// SyncWaitStatsLoad's own timer fires. Currently the failure is only logged and SyncWaitStatsLoad
-// returns nil, so whether a timed-out sync load is reported to the caller depends on which of the
-// two timers (the request's and the waiter's) fires first. See issue #67629.
+// TestSyncWaitStatsLoadWithFailedResultBeforeTimer tests that SyncWaitStatsLoad still reports an
+// error when the failed result arrives before its own timer fires, so the outcome of a timed-out
+// sync load does not depend on which of the two racing timers fires first. See issue #67629.
 func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
 	originConfig := config.GetGlobalConfig()
 	newConfig := config.NewConfig()
@@ -418,8 +416,8 @@ func TestSyncWaitStatsLoadWithFailedResultBeforeTimer(t *testing.T) {
 	rs := <-observerCtx.StatsLoad.ResultCh[0]
 	require.Error(t, rs.Err) // no worker handles the request, so it times out
 	// The errored result is waiting in stmtCtx's result channel, so SyncWaitStatsLoad consumes it
-	// instead of hitting its own timer. The failure is currently swallowed and reported as success.
-	require.NoError(t, h.SyncWaitStatsLoad(stmtCtx))
+	// instead of hitting its own timer. It must still report the failure.
+	require.Error(t, h.SyncWaitStatsLoad(stmtCtx))
 }
 
 func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #67629

Problem Summary:

A timed-out sync stats load races two timers with the same timeout. If the waiter's timer in `SyncWaitStatsLoad` fires first, the statement is marked as sync-load failed; if the errored result arrives first, the failure is only logged and swallowed, so a plan built on pseudo stats can enter the plan cache (defeating #67411). The scheduling-dependent ordering is why `TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback` is flaky.

### What changed and how does it work?

`SyncWaitStatsLoad` now returns an error whenever needed items were not delivered within the wait window, so both orderings report the failure. Commit 1 pins the buggy behavior in a deterministic test; commit 2 fixes it and flips the expectation.

With `tidb_stats_load_pseudo_timeout = OFF`, a timed-out load now fails the statement in both orderings.

Verification: `GOMAXPROCS=1 go test -run TestPreparedPlanCacheInvalidatedAfterSyncLoadTimeoutFallback -count=30` — 4/30 failures before, 0/30 after.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that a plan built on pseudo statistics might enter the plan cache when synchronous statistics loading timed out but the failure was not reported
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous statistics loading now reports an error when requested items remain unavailable after all results are processed.
  * Timeout metrics are incremented consistently for unresolved synchronous-load requests.
  * Improved handling of failed results received before the timeout.

* **Tests**
  * Added coverage for failed synchronous-load results and duplicate requests.
  * Expanded test sharding for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
