### PR TITLE
metaservice: support CSE keyspace-level GC

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4493,8 +4493,8 @@ def go_deps():
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
         replace = "github.com/pingyu/client-go/v2",
-        sum = "h1:uBHv7Y7ZUwrCONnwvo/+zwmmIezHd7Wnibps4Lbhykk=",
-        version = "v2.0.1-0.20260803170505-11cb9ad8088b",
+        sum = "h1:vtHSY/KOd16FFxT0L8SJOkj0L2M5lpEUOxw4YI+Q9vc=",
+        version = "v2.0.1-0.20260805022548-e8984187ef67",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4492,8 +4492,9 @@ def go_deps():
         build_tags = ["nextgen", "intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:20uV3D/EvkPVkDvSGWcOg2+jZOKaCYpIoIkwSb7amJM=",
-        version = "v2.0.8-0.20260803074519-341d4692ec57",
+        replace = "github.com/pingyu/client-go/v2",
+        sum = "h1:uBHv7Y7ZUwrCONnwvo/+zwmmIezHd7Wnibps4Lbhykk=",
+        version = "v2.0.1-0.20260803170505-11cb9ad8088b",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/go.mod
+++ b/go.mod
@@ -364,6 +364,7 @@ replace (
 	cloud.google.com/go/storage => cloud.google.com/go/storage v1.39.1
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/pingcap/tidb/pkg/parser => ./pkg/parser
+	github.com/tikv/client-go/v2 => github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b
 	// TODO: `sourcegraph.com/sourcegraph/appdash` has been archived, and the original host has been removed.
 	// Please remove these dependencies.
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0

--- a/go.mod
+++ b/go.mod
@@ -364,7 +364,7 @@ replace (
 	cloud.google.com/go/storage => cloud.google.com/go/storage v1.39.1
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/pingcap/tidb/pkg/parser => ./pkg/parser
-	github.com/tikv/client-go/v2 => github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b
+	github.com/tikv/client-go/v2 => github.com/pingyu/client-go/v2 v2.0.1-0.20260805022548-e8984187ef67
 	// TODO: `sourcegraph.com/sourcegraph/appdash` has been archived, and the original host has been removed.
 	// Please remove these dependencies.
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0

--- a/go.sum
+++ b/go.sum
@@ -2187,6 +2187,8 @@ github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe h1:9I5GHZesmR+hv68t00
 github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b h1:uBHv7Y7ZUwrCONnwvo/+zwmmIezHd7Wnibps4Lbhykk=
 github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b/go.mod h1:kNePJmoqcbd+eTTzZmzZy40rX8LjI6qFYCzdV66cu18=
+github.com/pingyu/client-go/v2 v2.0.1-0.20260805022548-e8984187ef67 h1:vtHSY/KOd16FFxT0L8SJOkj0L2M5lpEUOxw4YI+Q9vc=
+github.com/pingyu/client-go/v2 v2.0.1-0.20260805022548-e8984187ef67/go.mod h1:kNePJmoqcbd+eTTzZmzZy40rX8LjI6qFYCzdV66cu18=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -2185,6 +2185,8 @@ github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeA
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
 github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe h1:9I5GHZesmR+hv68t00BO7tayKMFfywi+hlpn119GscM=
 github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
+github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b h1:uBHv7Y7ZUwrCONnwvo/+zwmmIezHd7Wnibps4Lbhykk=
+github.com/pingyu/client-go/v2 v2.0.1-0.20260803170505-11cb9ad8088b/go.mod h1:kNePJmoqcbd+eTTzZmzZy40rX8LjI6qFYCzdV66cu18=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -2357,8 +2359,6 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
-github.com/tikv/client-go/v2 v2.0.8-0.20260803074519-341d4692ec57 h1:20uV3D/EvkPVkDvSGWcOg2+jZOKaCYpIoIkwSb7amJM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260803074519-341d4692ec57/go.mod h1:kNePJmoqcbd+eTTzZmzZy40rX8LjI6qFYCzdV66cu18=
 github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 h1:OoBvgoeWmdNEXtS+eOlhysz/OvhA4GS0OdPVhTXteGA=
 github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3/go.mod h1:3/Bu91CJONgkDA+Y0v/cnbROSJnu5tQ09vv7JGybUBA=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=

--- a/pkg/metaservice/metamanager.go
+++ b/pkg/metaservice/metamanager.go
@@ -91,7 +91,7 @@ func GetGroup(keyspaceMeta *keyspacepb.KeyspaceMeta, pdAddrs []string) (*Group, 
 		if err := validateGroupID(groupID); err != nil {
 			return nil, err
 		}
-		if !pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) && !tikv.IsCESKeyspaceLevelGC(keyspaceMeta) {
+		if !pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) && !tikv.IsCSEKeyspaceLevelGC(keyspaceMeta) {
 			return nil, errors.Annotatef(
 				ErrKeyspaceLevelGCRequired,
 				"keyspace %q configured meta service group %q",

--- a/pkg/metaservice/metamanager.go
+++ b/pkg/metaservice/metamanager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/log"
+	"github.com/tikv/client-go/v2/tikv"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 )
@@ -90,7 +91,7 @@ func GetGroup(keyspaceMeta *keyspacepb.KeyspaceMeta, pdAddrs []string) (*Group, 
 		if err := validateGroupID(groupID); err != nil {
 			return nil, err
 		}
-		if !pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) {
+		if !pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) && !tikv.IsCESKeyspaceLevelGC(keyspaceMeta) {
 			return nil, errors.Annotatef(
 				ErrKeyspaceLevelGCRequired,
 				"keyspace %q configured meta service group %q",

--- a/pkg/metaservice/metamanager_test.go
+++ b/pkg/metaservice/metamanager_test.go
@@ -52,6 +52,18 @@ func TestGetGroup(t *testing.T) {
 
 	require.ElementsMatch(t, expectedAddrs, keyspaceMetaServiceGroup.Addrs)
 
+	keyspaceMeta = &keyspacepb.KeyspaceMeta{
+		Config: map[string]string{
+			metaservice.GroupIDKey:    "group1",
+			metaservice.GroupAddrsKey: expectedAddrsStr,
+			"safe_point_version":      "v2",
+		},
+	}
+	keyspaceMetaServiceGroup, err = metaservice.GetGroup(keyspaceMeta, pdAddrs)
+	require.NoError(t, err)
+	require.Equal(t, "group1", keyspaceMetaServiceGroup.GroupID)
+	require.ElementsMatch(t, expectedAddrs, keyspaceMetaServiceGroup.Addrs)
+
 	// Test case where the keyspace does not use keyspace-level GC.
 	keyspaceMeta = &keyspacepb.KeyspaceMeta{
 		Name: "ks-unified-gc",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what changed
2. *: what changed

-->

### What problem does this PR solve?

Issue Number: close #70332

Problem Summary:

Related PD issue: tikv/pd#11108

Related TiCDC incident: pingcap/ticdc#5785

Essential v1 keyspaces advertise keyspace-level GC with `safe_point_version=v2`. TiDB rejects dedicated meta service groups for those keyspaces because it only recognizes the native `gc_management_type=keyspace_level` metadata. client-go then cannot use the CSE keyspace-scoped transaction safepoint path, contributing to the safepoint mismatch that blocks TiCDC SchemaStore initialization and changefeed creation.

### What changed and how does it work?

- Use `tikv.IsCSEKeyspaceLevelGC` in addition to the native PD predicate when validating a dedicated meta service group.
- Add regression coverage for CSE metadata without `gc_management_type`.
- Temporarily pin the client-go fork for the stacked draft; remove the replacement after tikv/client-go#2040 merges.
- Regenerate `DEPS.bzl` so Bazel uses the same client-go fork replacement as `go.mod`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Commands run:

- `go test -run ^TestGetGroup$ -tags=intest,deadlock -count=1 -v` from `pkg/metaservice`
- `gopls check pkg/metaservice/metamanager.go pkg/metaservice/metamanager_test.go`
- `make bazel_prepare`
- `make check-bazel-prepare`
- `bazel test --define gotags=intest,deadlock //pkg/metaservice:metaservice_test`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Support dedicated meta service groups for Essential v1 keyspaces that use keyspace-level GC.
```