### PR TITLE
sessionctx, config: gate FK shared-lock sysvar on next-gen

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1068,8 +1068,8 @@ type IsolationRead struct {
 type Experimental struct {
 	// Whether enable creating expression index.
 	AllowsExpressionIndex bool `toml:"allow-expression-index" json:"allow-expression-index"`
-	// Whether allow foreign key checks to use shared locks on next-gen TiKV.
-	AllowForeignKeyCheckInSharedLock bool `toml:"allow-foreign-key-check-in-shared-lock" json:"allow-foreign-key-check-in-shared-lock"`
+	// Whether SQL users can enable tidb_foreign_key_check_in_shared_lock on next-gen TiKV.
+	AllowEnableForeignKeyCheckInSharedLock bool `toml:"allow-enable-foreign-key-check-in-shared-lock" json:"allow-enable-foreign-key-check-in-shared-lock"`
 	// Whether enable charset feature.
 	EnableNewCharset bool `toml:"enable-new-charset" json:"-"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1068,6 +1068,8 @@ type IsolationRead struct {
 type Experimental struct {
 	// Whether enable creating expression index.
 	AllowsExpressionIndex bool `toml:"allow-expression-index" json:"allow-expression-index"`
+	// Whether allow foreign key checks to use shared locks on next-gen TiKV.
+	AllowForeignKeyCheckInSharedLock bool `toml:"allow-foreign-key-check-in-shared-lock" json:"allow-foreign-key-check-in-shared-lock"`
 	// Whether enable charset feature.
 	EnableNewCharset bool `toml:"enable-new-charset" json:"-"`
 }

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -430,8 +430,8 @@ pessimistic-auto-commit = false
 # enable creating expression index.
 allow-expression-index = false
 
-# allow foreign key checks to use shared locks on next-gen TiKV.
-allow-foreign-key-check-in-shared-lock = false
+# allow SQL users to enable tidb_foreign_key_check_in_shared_lock on next-gen TiKV.
+allow-enable-foreign-key-check-in-shared-lock = false
 
 # server level isolation read by engines and labels
 [isolation-read]

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -430,6 +430,9 @@ pessimistic-auto-commit = false
 # enable creating expression index.
 allow-expression-index = false
 
+# allow foreign key checks to use shared locks on next-gen TiKV.
+allow-foreign-key-check-in-shared-lock = false
+
 # server level isolation read by engines and labels
 [isolation-read]
 # engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -430,9 +430,6 @@ pessimistic-auto-commit = false
 # enable creating expression index.
 allow-expression-index = false
 
-# allow SQL users to enable tidb_foreign_key_check_in_shared_lock on next-gen TiKV.
-allow-enable-foreign-key-check-in-shared-lock = false
-
 # server level isolation read by engines and labels
 [isolation-read]
 # engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -449,6 +449,9 @@ allow-expression-index = false
 # api-endpoint = ""
 # api-key-path = ""
 
+# allow foreign key checks to use shared locks on next-gen TiKV.
+allow-foreign-key-check-in-shared-lock = false
+
 # server level isolation read by engines and labels
 [isolation-read]
 # engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -449,8 +449,8 @@ allow-expression-index = false
 # api-endpoint = ""
 # api-key-path = ""
 
-# allow foreign key checks to use shared locks on next-gen TiKV.
-allow-foreign-key-check-in-shared-lock = false
+# allow SQL users to enable tidb_foreign_key_check_in_shared_lock on next-gen TiKV.
+allow-enable-foreign-key-check-in-shared-lock = false
 
 # server level isolation read by engines and labels
 [isolation-read]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1053,6 +1053,7 @@ keys-limit=123
 total-key-size-limit=1024
 [experimental]
 allow-expression-index = true
+allow-foreign-key-check-in-shared-lock = true
 [isolation-read]
 engines = ["tiflash"]
 [labels]
@@ -1124,6 +1125,7 @@ max_connections = 200
 	require.True(t, conf.PessimisticTxn.PessimisticAutoCommit.Load())
 	require.Equal(t, "127.0.0.1:10100", conf.TopSQL.ReceiverAddress)
 	require.True(t, conf.Experimental.AllowsExpressionIndex)
+	require.True(t, conf.Experimental.AllowForeignKeyCheckInSharedLock)
 	require.Equal(t, uint(20), conf.Status.GRPCKeepAliveTime)
 	require.Equal(t, uint(10), conf.Status.GRPCKeepAliveTimeout)
 	require.Equal(t, uint(2048), conf.Status.GRPCConcurrentStreams)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1053,7 +1053,7 @@ keys-limit=123
 total-key-size-limit=1024
 [experimental]
 allow-expression-index = true
-allow-foreign-key-check-in-shared-lock = true
+allow-enable-foreign-key-check-in-shared-lock = true
 [isolation-read]
 engines = ["tiflash"]
 [labels]
@@ -1125,7 +1125,7 @@ max_connections = 200
 	require.True(t, conf.PessimisticTxn.PessimisticAutoCommit.Load())
 	require.Equal(t, "127.0.0.1:10100", conf.TopSQL.ReceiverAddress)
 	require.True(t, conf.Experimental.AllowsExpressionIndex)
-	require.True(t, conf.Experimental.AllowForeignKeyCheckInSharedLock)
+	require.True(t, conf.Experimental.AllowEnableForeignKeyCheckInSharedLock)
 	require.Equal(t, uint(20), conf.Status.GRPCKeepAliveTime)
 	require.Equal(t, uint(10), conf.Status.GRPCKeepAliveTimeout)
 	require.Equal(t, uint(2048), conf.Status.GRPCConcurrentStreams)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -139,7 +139,7 @@ func allowSetForeignKeyCheckInSharedLock() bool {
 	if !kerneltype.IsNextGen() {
 		return true
 	}
-	return config.GetGlobalConfig().Experimental.AllowForeignKeyCheckInSharedLock
+	return config.GetGlobalConfig().Experimental.AllowEnableForeignKeyCheckInSharedLock
 }
 
 func getForeignKeyCheckInSharedLockSession(s *SessionVars) (string, error) {

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -135,6 +135,34 @@ func newExecConcurrencySysVar(name string, defValue int, setter concurrencySette
 	return sv
 }
 
+func allowForeignKeyCheckInSharedLock() bool {
+	if !kerneltype.IsNextGen() {
+		return true
+	}
+	return config.GetGlobalConfig().Experimental.AllowForeignKeyCheckInSharedLock
+}
+
+func effectiveForeignKeyCheckInSharedLock(val string) string {
+	if TiDBOptOn(val) && !allowForeignKeyCheckInSharedLock() {
+		return vardef.Off
+	}
+	return val
+}
+
+func getForeignKeyCheckInSharedLockSession(s *SessionVars) (string, error) {
+	if val, ok := s.systems[vardef.TiDBForeignKeyCheckInSharedLock]; ok {
+		return effectiveForeignKeyCheckInSharedLock(val), nil
+	}
+	if s.GlobalVarsAccessor != nil {
+		val, err := s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
+		if err != nil {
+			return val, err
+		}
+		return effectiveForeignKeyCheckInSharedLock(val), nil
+	}
+	return effectiveForeignKeyCheckInSharedLock(BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock)), nil
+}
+
 // All system variables declared here are ordered by their scopes, which follow the order of scopes below:
 //
 //	[NONE, SESSION, INSTANCE, GLOBAL, GLOBAL & SESSION]
@@ -2101,9 +2129,25 @@ var defaultSysVars = []*SysVar{
 		}
 		return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(vardef.ForeignKeyChecks, originalValue)
 	}},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBForeignKeyCheckInSharedLock, Value: BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
-		s.ForeignKeyCheckInSharedLock = TiDBOptOn(val)
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBForeignKeyCheckInSharedLock, Value: BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock), Type: vardef.TypeBool, Validation: func(_ *SessionVars, normalizedValue string, originalValue string, _ vardef.ScopeFlag) (string, error) {
+		if TiDBOptOn(normalizedValue) && !allowForeignKeyCheckInSharedLock() {
+			return vardef.Off, ErrWrongValueForVar.GenWithStackByArgs(vardef.TiDBForeignKeyCheckInSharedLock, originalValue)
+		}
+		return normalizedValue, nil
+	}, SetSession: func(s *SessionVars, val string) error {
+		s.ForeignKeyCheckInSharedLock = TiDBOptOn(effectiveForeignKeyCheckInSharedLock(val))
 		return nil
+	}, GetSession: func(s *SessionVars) (string, error) {
+		return getForeignKeyCheckInSharedLockSession(s)
+	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+		if s.GlobalVarsAccessor == nil {
+			return effectiveForeignKeyCheckInSharedLock(BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock)), nil
+		}
+		val, err := s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
+		if err != nil {
+			return val, err
+		}
+		return effectiveForeignKeyCheckInSharedLock(val), nil
 	}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBEnableForeignKey, Value: BoolToOnOff(true), Type: vardef.TypeBool, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		vardef.EnableForeignKey.Store(TiDBOptOn(val))

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -135,32 +135,21 @@ func newExecConcurrencySysVar(name string, defValue int, setter concurrencySette
 	return sv
 }
 
-func allowForeignKeyCheckInSharedLock() bool {
+func allowSetForeignKeyCheckInSharedLock() bool {
 	if !kerneltype.IsNextGen() {
 		return true
 	}
 	return config.GetGlobalConfig().Experimental.AllowForeignKeyCheckInSharedLock
 }
 
-func effectiveForeignKeyCheckInSharedLock(val string) string {
-	if TiDBOptOn(val) && !allowForeignKeyCheckInSharedLock() {
-		return vardef.Off
-	}
-	return val
-}
-
 func getForeignKeyCheckInSharedLockSession(s *SessionVars) (string, error) {
 	if val, ok := s.systems[vardef.TiDBForeignKeyCheckInSharedLock]; ok {
-		return effectiveForeignKeyCheckInSharedLock(val), nil
+		return val, nil
 	}
 	if s.GlobalVarsAccessor != nil {
-		val, err := s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
-		if err != nil {
-			return val, err
-		}
-		return effectiveForeignKeyCheckInSharedLock(val), nil
+		return s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
 	}
-	return effectiveForeignKeyCheckInSharedLock(BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock)), nil
+	return BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock), nil
 }
 
 // All system variables declared here are ordered by their scopes, which follow the order of scopes below:
@@ -2130,24 +2119,20 @@ var defaultSysVars = []*SysVar{
 		return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(vardef.ForeignKeyChecks, originalValue)
 	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBForeignKeyCheckInSharedLock, Value: BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock), Type: vardef.TypeBool, Validation: func(_ *SessionVars, normalizedValue string, originalValue string, _ vardef.ScopeFlag) (string, error) {
-		if TiDBOptOn(normalizedValue) && !allowForeignKeyCheckInSharedLock() {
-			return vardef.Off, ErrWrongValueForVar.GenWithStackByArgs(vardef.TiDBForeignKeyCheckInSharedLock, originalValue)
+		if TiDBOptOn(normalizedValue) && !allowSetForeignKeyCheckInSharedLock() {
+			return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(vardef.TiDBForeignKeyCheckInSharedLock, originalValue)
 		}
 		return normalizedValue, nil
 	}, SetSession: func(s *SessionVars, val string) error {
-		s.ForeignKeyCheckInSharedLock = TiDBOptOn(effectiveForeignKeyCheckInSharedLock(val))
+		s.ForeignKeyCheckInSharedLock = TiDBOptOn(val)
 		return nil
 	}, GetSession: func(s *SessionVars) (string, error) {
 		return getForeignKeyCheckInSharedLockSession(s)
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		if s.GlobalVarsAccessor == nil {
-			return effectiveForeignKeyCheckInSharedLock(BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock)), nil
+			return BoolToOnOff(vardef.DefTiDBForeignKeyCheckInSharedLock), nil
 		}
-		val, err := s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
-		if err != nil {
-			return val, err
-		}
-		return effectiveForeignKeyCheckInSharedLock(val), nil
+		return s.GlobalVarsAccessor.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
 	}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBEnableForeignKey, Value: BoolToOnOff(true), Type: vardef.TypeBool, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		vardef.EnableForeignKey.Store(TiDBOptOn(val))

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1640,6 +1640,114 @@ func TestGlobalSystemVariableInitialValue(t *testing.T) {
 	}
 }
 
+func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
+	ctx := context.Background()
+	restore := config.RestoreFunc()
+	t.Cleanup(restore)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Experimental.AllowForeignKeyCheckInSharedLock = false
+	})
+
+	vars := NewSessionVars(nil)
+	mock := NewMockGlobalAccessor4Tests()
+	mock.SessionVars = vars
+	vars.GlobalVarsAccessor = mock
+
+	if !kerneltype.IsNextGen() {
+		for _, val := range []string{vardef.On, "1"} {
+			require.NoError(t, vars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, val), val)
+			require.True(t, vars.ForeignKeyCheckInSharedLock)
+			sessionVal, err := vars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+			require.NoError(t, err)
+			require.Equal(t, vardef.On, sessionVal)
+			require.NoError(t, vars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+		}
+
+		for _, val := range []string{vardef.On, "1"} {
+			require.NoError(t, mock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, val), val)
+			globalVal, err := vars.GetGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+			require.NoError(t, err)
+			require.Equal(t, vardef.On, globalVal)
+			require.NoError(t, mock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+		}
+		return
+	}
+
+	for _, val := range []string{vardef.On, "1"} {
+		err := vars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, val)
+		require.Error(t, err, val)
+		require.True(t, ErrWrongValueForVar.Equal(err), err)
+		require.False(t, vars.ForeignKeyCheckInSharedLock)
+		sessionVal, err := vars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+		require.NoError(t, err)
+		require.Equal(t, vardef.Off, sessionVal)
+	}
+
+	require.NoError(t, vars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+	require.False(t, vars.ForeignKeyCheckInSharedLock)
+
+	for _, val := range []string{vardef.On, "1"} {
+		err := mock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, val)
+		require.Error(t, err, val)
+		require.True(t, ErrWrongValueForVar.Equal(err), err)
+		rawGlobalVal, err := mock.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
+		require.NoError(t, err)
+		require.Equal(t, vardef.Off, rawGlobalVal)
+	}
+
+	require.NoError(t, mock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+	rawGlobalVal, err := mock.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.Off, rawGlobalVal)
+
+	require.NoError(t, mock.SetGlobalSysVarOnly(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.On, true))
+	globalVal, err := vars.GetGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.Off, globalVal)
+
+	fallbackVars := NewSessionVars(nil)
+	fallbackMock := NewMockGlobalAccessor4Tests()
+	fallbackMock.SessionVars = fallbackVars
+	fallbackVars.GlobalVarsAccessor = fallbackMock
+	require.NoError(t, fallbackMock.SetGlobalSysVarOnly(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.On, true))
+	sessionVal, err := fallbackVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.Off, sessionVal)
+	require.False(t, fallbackVars.ForeignKeyCheckInSharedLock)
+
+	initVars := NewSessionVars(nil)
+	require.NoError(t, initVars.SetSystemVarWithRelaxedValidation(vardef.TiDBForeignKeyCheckInSharedLock, vardef.On))
+	require.False(t, initVars.ForeignKeyCheckInSharedLock)
+	sessionVal, err = initVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.Off, sessionVal)
+
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Experimental.AllowForeignKeyCheckInSharedLock = true
+	})
+
+	enabledVars := NewSessionVars(nil)
+	enabledMock := NewMockGlobalAccessor4Tests()
+	enabledMock.SessionVars = enabledVars
+	enabledVars.GlobalVarsAccessor = enabledMock
+	for _, val := range []string{vardef.On, "1"} {
+		require.NoError(t, enabledVars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, val), val)
+		require.True(t, enabledVars.ForeignKeyCheckInSharedLock)
+		sessionVal, err = enabledVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+		require.NoError(t, err)
+		require.Equal(t, vardef.On, sessionVal)
+		require.NoError(t, enabledVars.SetSystemVar(vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+	}
+
+	for _, val := range []string{vardef.On, "1"} {
+		require.NoError(t, enabledMock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, val), val)
+		globalVal, err = enabledVars.GetGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+		require.NoError(t, err)
+		require.Equal(t, vardef.On, globalVal)
+		require.NoError(t, enabledMock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
+	}
+}
+
 func TestTiDBOptTxnAutoRetry(t *testing.T) {
 	sv := GetSysVar(vardef.TiDBDisableTxnAutoRetry)
 	vars := NewSessionVars(nil)

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1703,7 +1703,7 @@ func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
 	require.NoError(t, mock.SetGlobalSysVarOnly(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.On, true))
 	globalVal, err := vars.GetGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
 	require.NoError(t, err)
-	require.Equal(t, vardef.Off, globalVal)
+	require.Equal(t, vardef.On, globalVal)
 
 	fallbackVars := NewSessionVars(nil)
 	fallbackMock := NewMockGlobalAccessor4Tests()
@@ -1712,15 +1712,15 @@ func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
 	require.NoError(t, fallbackMock.SetGlobalSysVarOnly(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.On, true))
 	sessionVal, err := fallbackVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
 	require.NoError(t, err)
-	require.Equal(t, vardef.Off, sessionVal)
+	require.Equal(t, vardef.On, sessionVal)
 	require.False(t, fallbackVars.ForeignKeyCheckInSharedLock)
 
 	initVars := NewSessionVars(nil)
 	require.NoError(t, initVars.SetSystemVarWithRelaxedValidation(vardef.TiDBForeignKeyCheckInSharedLock, vardef.On))
-	require.False(t, initVars.ForeignKeyCheckInSharedLock)
+	require.True(t, initVars.ForeignKeyCheckInSharedLock)
 	sessionVal, err = initVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
 	require.NoError(t, err)
-	require.Equal(t, vardef.Off, sessionVal)
+	require.Equal(t, vardef.On, sessionVal)
 
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Experimental.AllowForeignKeyCheckInSharedLock = true

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1645,7 +1645,7 @@ func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
 	restore := config.RestoreFunc()
 	t.Cleanup(restore)
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Experimental.AllowForeignKeyCheckInSharedLock = false
+		conf.Experimental.AllowEnableForeignKeyCheckInSharedLock = false
 	})
 
 	vars := NewSessionVars(nil)
@@ -1723,7 +1723,7 @@ func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
 	require.Equal(t, vardef.On, sessionVal)
 
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Experimental.AllowForeignKeyCheckInSharedLock = true
+		conf.Experimental.AllowEnableForeignKeyCheckInSharedLock = true
 	})
 
 	enabledVars := NewSessionVars(nil)

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1746,6 +1746,17 @@ func TestTiDBForeignKeyCheckInSharedLockGate(t *testing.T) {
 		require.Equal(t, vardef.On, globalVal)
 		require.NoError(t, enabledMock.SetGlobalSysVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.Off))
 	}
+
+	require.NoError(t, enabledMock.SetGlobalSysVarOnly(ctx, vardef.TiDBForeignKeyCheckInSharedLock, vardef.On, true))
+	rawGlobalVal, err = enabledMock.GetGlobalSysVar(vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.On, rawGlobalVal)
+	enabledInitVars := NewSessionVars(nil)
+	require.NoError(t, enabledInitVars.SetSystemVarWithRelaxedValidation(vardef.TiDBForeignKeyCheckInSharedLock, rawGlobalVal))
+	require.True(t, enabledInitVars.ForeignKeyCheckInSharedLock)
+	sessionVal, err = enabledInitVars.GetSessionOrGlobalSystemVar(ctx, vardef.TiDBForeignKeyCheckInSharedLock)
+	require.NoError(t, err)
+	require.Equal(t, vardef.On, sessionVal)
 }
 
 func TestTiDBOptTxnAutoRetry(t *testing.T) {

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -38,7 +38,7 @@ func allowForeignKeyCheckInSharedLockForTest(t *testing.T) {
 	restore := config.RestoreFunc()
 	t.Cleanup(restore)
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Experimental.AllowForeignKeyCheckInSharedLock = true
+		conf.Experimental.AllowEnableForeignKeyCheckInSharedLock = true
 	})
 }
 

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/tests/realtikvtest"
@@ -32,10 +33,20 @@ func prepareForeignKeyTables(tk *testkit.TestKit) {
 	tk.MustExec("insert into parent values (1), (2)")
 }
 
+func allowForeignKeyCheckInSharedLockForTest(t *testing.T) {
+	t.Helper()
+	restore := config.RestoreFunc()
+	t.Cleanup(restore)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Experimental.AllowForeignKeyCheckInSharedLock = true
+	})
+}
+
 func TestForeignKeySharedLockOptimisticReverseReferenceOrder(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk1 := testkit.NewTestKit(t, store)
@@ -71,6 +82,7 @@ func TestForeignKeySharedLockPessimisticReverseReferenceOrder(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk1 := testkit.NewTestKit(t, store)
@@ -105,6 +117,7 @@ func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -163,6 +176,7 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -219,6 +233,7 @@ func TestSharedLockChildTableConflict(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -323,6 +338,7 @@ func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -360,6 +376,7 @@ func TestSharedLockLockView(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -458,6 +475,7 @@ func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/66154

Problem Summary:

This ports #69167 from `release-nextgen-202603` back to `master`.

`tidb_foreign_key_check_in_shared_lock` exposes an FK shared-lock path that is still a non-GA PoC. Users on next-gen TiKV should not be able to newly enable this path through SQL unless the deployment explicitly opts in.

Without a TiDB config gate, any user with permission to set the sysvar can turn the PoC feature on directly, which risks running unsupported shared-lock FK behavior in next-gen deployments.

### What changed and how does it work?

Next-gen deployments now require the experimental TiDB configuration `allow-enable-foreign-key-check-in-shared-lock` before SQL users can set `tidb_foreign_key_check_in_shared_lock` to `ON`.

The default prevents accidental new SQL-level activation on next-gen TiKV. Existing persisted or restored sysvar values still decide whether FK shared locks are used, so a deployment that already enabled the global sysvar keeps its behavior after upgrade. Non-nextgen deployments keep the existing sysvar behavior.

Compared with the release-branch version, the RealTiKV setup is also applied to the additional FK shared-lock tests that now exist on `master`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:

```bash
./tools/check/failpoint-go-test.sh pkg/sessionctx/variable -run TestTiDBForeignKeyCheckInSharedLockGate -count=1
./tools/check/failpoint-go-test.sh pkg/sessionctx/variable -run TestTiDBForeignKeyCheckInSharedLockGate -count=1 -tags=nextgen,intest,deadlock
go test -tags=intest,deadlock ./pkg/config -run TestConfig -count=1
go test -tags=nextgen,intest,deadlock ./pkg/config -run TestConfig -count=1

tiup playground --mode tikv-slim --tag realtikvtest
./tools/check/failpoint-go-test.sh tests/realtikvtest/txntest -run '^(TestForeignKeySharedLockOptimisticReverseReferenceOrder|TestForeignKeySharedLockPessimisticReverseReferenceOrder|TestSharedLockBlockedByExclusiveLock|TestSharedLockBlockExclusiveLock|TestSharedLockChildTableConflict|TestSharedLockCascadeUpdateExplicitPessimisticTxn|TestSharedLockLockView|TestSharedLockDataLockWaitsFromStorageWaitTable)$' -count=1 -timeout=15m -with-real-tikv

make bazel_prepare
make tidy
make lint
git diff --check upstream/master...HEAD
```

The next-gen regression test was also verified to fail when the new gate was temporarily bypassed and to pass after the gate was restored.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
On next-gen TiKV, newly enabling foreign-key shared-lock checks through SQL now requires the experimental TiDB configuration `allow-enable-foreign-key-check-in-shared-lock`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental configuration option to allow SQL sessions to enable foreign-key checks in shared-lock mode on next-generation TiKV.
  * The option is disabled by default and supports TOML and JSON configuration formats.
  * Added validation for session and global settings to prevent unsupported changes.

* **Tests**
  * Added coverage for configuration loading, permission checks, and shared-lock behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->