### PR TITLE
tests: stabilize cross-keyspace runtime GC test

### DIFF
--- a/tests/realtikvtest/sessiontest/cross_ks_gc_test.go
+++ b/tests/realtikvtest/sessiontest/cross_ks_gc_test.go
@@ -37,10 +37,18 @@ func TestCrossKSRuntimeGCLoopStartedBySystemDomain(t *testing.T) {
 			*idleTimeout = 100 * time.Millisecond
 		})
 
-	const targetKS = "keyspace1"
+	const targetKS = "keyspace2"
 	_, systemDom := realtikvtest.CreateMockStoreAndDomainAndSetup(t,
 		realtikvtest.WithKeyspaceName(keyspace.System),
 		realtikvtest.WithAllocPort(true))
+	// Bootstrap the target keyspace so its runtime can be acquired, then release the bootstrap domain
+	// before the GC loop opens and closes its own runtime.
+	t.Run("bootstrap target keyspace", func(t *testing.T) {
+		realtikvtest.CreateMockStoreAndDomainAndSetup(t,
+			realtikvtest.WithKeyspaceName(targetKS),
+			realtikvtest.WithKeepSystemStore(true),
+			realtikvtest.WithAllocPort(true))
+	})
 
 	handle, err := systemDom.AcquireKSRuntime(targetKS, "test/cross-ks-gc-loop")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70330

Problem Summary:

`TestCrossKSRuntimeGCLoopStartedBySystemDomain` only bootstrapped the `SYSTEM` keyspace before acquiring the runtime for `keyspace1`. The test passed when another Bazel shard had already bootstrapped TiDB metadata in `keyspace1`, but failed with `system database not found` when it ran first.

### What changed and how does it work?

Use `keyspace2`, which is preallocated but otherwise unused by the `sessiontest` package, as this test's target. Explicitly bootstrap that keyspace in a subtest so the temporary bootstrap domain is released before the system domain opens and closes its own runtime through the GC loop. Keep the parent system store alive while the bootstrap subtest is cleaned up.

This makes the test own its prerequisites instead of depending on the execution order of another shard.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

The failure was reproduced before the fix with:

```bash
./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -tags=intest,deadlock,nextgen -run '^TestCrossKSRuntimeGCLoopStartedBySystemDomain$' -count=1
```

The fix was verified with:

```bash
./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -tags=intest,deadlock,nextgen -run '^TestCrossKSRuntimeGCLoopStartedBySystemDomain$' -count=3
./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -tags=intest,deadlock,nextgen -race -run '^TestCrossKSRuntimeGCLoopStartedBySystemDomain$' -count=1
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated keyspace garbage-collection coverage to use the intended test keyspace.
  * Added explicit setup for the keyspace before validating runtime acquisition and garbage collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->