### PR TITLE
metrics: show Disconnection Count as a rate, split out undetermined

### DIFF
--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -3093,7 +3093,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (cumulative); right axis adds an ok/error disconnect rate view, and routes the undetermined cumulative counter to its own scale since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3141,7 +3141,7 @@
               "lines": false
             },
             {
-              "alias": "/-undetermined-total$/",
+              "alias": "/-undetermined$/",
               "stack": false,
               "yaxis": 2
             },
@@ -3169,14 +3169,6 @@
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}-rate",
               "refId": "B",
-              "step": 40
-            },
-            {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -3093,7 +3093,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3144,6 +3144,11 @@
               "alias": "/-undetermined-total$/",
               "stack": false,
               "yaxis": 2
+            },
+            {
+              "alias": "/-rate$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3151,7 +3156,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
@@ -3159,11 +3164,19 @@
               "step": 40
             },
             {
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{result}}-rate",
+              "refId": "B",
+              "step": 40
+            },
+            {
               "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "B",
+              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -3093,7 +3093,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts",
+          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3139,6 +3139,11 @@
               "alias": "total",
               "fill": 0,
               "lines": false
+            },
+            {
+              "alias": "/-undetermined-total$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3146,11 +3151,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, result)",
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
               "refId": "A",
+              "step": 40
+            },
+            {
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-undetermined-total",
+              "refId": "B",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3310,6 +3310,11 @@
               "alias": "/-undetermined-total$/",
               "stack": false,
               "yaxis": 2
+            },
+            {
+              "alias": "/-rate$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3317,7 +3322,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\"}) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
@@ -3325,11 +3330,19 @@
               "step": 40
             },
             {
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{result}}-rate",
+              "refId": "B",
+              "step": 40
+            },
+            {
               "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "B",
+              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts",
+          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3305,6 +3305,11 @@
               "alias": "total",
               "fill": 0,
               "lines": false
+            },
+            {
+              "alias": "/-undetermined-total$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3312,11 +3317,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\"}) by (instance, result)",
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
               "refId": "A",
+              "step": 40
+            },
+            {
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-undetermined-total",
+              "refId": "B",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (cumulative); right axis adds an ok/error disconnect rate view, and routes the undetermined cumulative counter to its own scale since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3307,7 +3307,7 @@
               "lines": false
             },
             {
-              "alias": "/-undetermined-total$/",
+              "alias": "/-undetermined$/",
               "stack": false,
               "yaxis": 2
             },
@@ -3335,14 +3335,6 @@
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}-rate",
               "refId": "B",
-              "step": 40
-            },
-            {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (cumulative); right axis adds an ok/error disconnect rate view, and routes the undetermined cumulative counter to its own scale since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3307,7 +3307,7 @@
               "lines": false
             },
             {
-              "alias": "/-undetermined-total$/",
+              "alias": "/-undetermined$/",
               "stack": false,
               "yaxis": 2
             },
@@ -3335,14 +3335,6 @@
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}-rate",
               "refId": "B",
-              "step": 40
-            },
-            {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
+          "description": "TiDB connection disconnected counts per result (left axis, cumulative); right axis adds an ok/error disconnect rate view and a dedicated cumulative counter for result=undetermined, since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3310,6 +3310,11 @@
               "alias": "/-undetermined-total$/",
               "stack": false,
               "yaxis": 2
+            },
+            {
+              "alias": "/-rate$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3317,7 +3322,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
@@ -3325,11 +3330,19 @@
               "step": 40
             },
             {
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{result}}-rate",
+              "refId": "B",
+              "step": 40
+            },
+            {
               "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-undetermined-total",
-              "refId": "B",
+              "refId": "C",
               "step": 40
             }
           ],

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -3259,7 +3259,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB connection disconnected counts",
+          "description": "TiDB connection disconnected rate per result (ok/error); undetermined is shown separately as a cumulative count on the right axis since any occurrence needs investigation",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -3305,6 +3305,11 @@
               "alias": "total",
               "fill": 0,
               "lines": false
+            },
+            {
+              "alias": "/-undetermined-total$/",
+              "stack": false,
+              "yaxis": 2
             }
           ],
           "spaceLength": 10,
@@ -3312,11 +3317,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, result)",
+              "expr": "sum(irate(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result!=\"undetermined\"}[30s])) by (instance, result)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{result}}",
               "refId": "A",
+              "step": 40
+            },
+            {
+              "expr": "sum(tidb_server_disconnection_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", result=\"undetermined\"}) by (instance)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-undetermined-total",
+              "refId": "B",
               "step": 40
             }
           ],


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70336

Problem Summary:

The `Server` row `Disconnection Count` panel in the TiDB Grafana dashboard plotted the raw cumulative `tidb_server_disconnection_total` counter. On a long-running production cluster this counter accumulates to very large numbers, so it stops being useful for spotting current connect/disconnect activity.

### What changed and how does it work?

- Switched the `ok`/`error` result series to `irate(...[30s])`, so the panel reflects disconnect frequency (and, transitively, connection churn / whether the workload looks long- or short-lived).
- Kept `result="undetermined"` as its own series, still a cumulative total, routed to the panel's right Y axis via a `seriesOverrides` entry (unstacked). Any nonzero `undetermined` count means a transaction was once left in a state TiDB could not automatically resolve and needs manual investigation, so it stays an absolute counter instead of being folded into a rate.
- Applied the same change to the two next-gen counterparts of this panel (`pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json`, `pkg/metrics/nextgengrafana/tidb_worker.json`) to keep all three dashboard definitions consistent.

Manually verified by loading all three dashboard JSON files into a local `tiup playground` Grafana instance and confirming the panel renders the rate view plus the separate right-axis `undetermined` series as expected.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Manually loaded the three modified dashboard JSON files into a local tiup playground Grafana instance (http://127.0.0.1:3000) and confirmed the `Disconnection Count` panel renders correctly.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated TiDB disconnection Grafana panels to show known-result disconnections as 30-second rates.
  * Displayed undetermined disconnections separately as cumulative counts on a secondary axis without stacking.
  * Improved panel descriptions and visualization settings to distinguish rates, cumulative totals, and undetermined results.
  * Applied consistent metric presentation across standard, keyspace-aware, and worker dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->