### PR TITLE
store/copr: fix batch fallback counters after Region split

### DIFF
--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2342,14 +2342,18 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 		return nil, nil, nil
 	}
 	batchedNum := len(tasks)
+	// A failed input task can be rebuilt into multiple retry tasks. Count the
+	// original fallback once so retry fan-out cannot make the successful count
+	// negative before conversion to uint64.
+	fallbackNum := 0
 	busyThresholdFallback := false
 	defer func() {
 		if err != nil {
 			return
 		}
 		if !busyThresholdFallback {
-			worker.storeBatchedNum.Add(uint64(batchedNum - len(remainTasks)))
-			worker.storeBatchedFallbackNum.Add(uint64(len(remainTasks)))
+			worker.storeBatchedNum.Add(uint64(batchedNum - fallbackNum))
+			worker.storeBatchedFallbackNum.Add(uint64(fallbackNum))
 		}
 	}()
 	appendRemainTasks := func(tasks ...*copTask) {
@@ -2404,6 +2408,7 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 			if err != nil {
 				return batchRespList, nil, err
 			}
+			fallbackNum++
 			appendRemainTasks(remains...)
 			continue
 		}
@@ -2413,6 +2418,7 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 				return batchRespList, nil, err
 			}
 			task.meetLockFallback = true
+			fallbackNum++
 			appendRemainTasks(task)
 			continue
 		}
@@ -2475,6 +2481,7 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 				zap.ByteString("lastRangeEndKey", lastRangeEndKey),
 				zap.String("storeAddr", task.storeAddr))
 		}
+		fallbackNum++
 		appendRemainTasks(t.task)
 	}
 	if regionErr := getRegionError(bo.GetCtx(), resp); regionErr != nil && regionErr.ServerIsBusy != nil &&

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -1093,7 +1093,12 @@ func TestStoreBatchTasksPreserveChildBucketsVersion(t *testing.T) {
 	}, versionByRegion)
 }
 
-func TestHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T) {
+func TestHandleBatchCopResponse(t *testing.T) {
+	t.Run("updates child buckets on version mismatch", testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch)
+	t.Run("counts fallbacks after Region split", testHandleBatchCopResponseFallbackCountersAfterRegionSplit)
+}
+
+func testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T) {
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
 	require.NoError(t, err)
 	_, regionIDs, _ := testutils.BootstrapWithMultiRegions(cluster, []byte("m"))
@@ -1169,4 +1174,73 @@ func TestHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T
 	require.Equal(t, regionIDs[1], loc.Region.GetID())
 	require.Equal(t, uint64(99), loc.Buckets.GetVersion())
 	require.Equal(t, bucketKeys, loc.Buckets.GetKeys())
+}
+
+func testHandleBatchCopResponseFallbackCountersAfterRegionSplit(t *testing.T) {
+	// One failed batched child whose Region split in the meantime rebuilds
+	// into several retry tasks.
+	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	require.NoError(t, err)
+	testutils.BootstrapWithMultiRegions(cluster, []byte("f"), []byte("h"))
+	tikvStore, err := tikv.NewTestTiKVStore(mockClient, pdClient, nil, nil, 0)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tikvStore.Close())
+	}()
+	copStore, err := NewStore(tikvStore, nil)
+	require.NoError(t, err)
+	defer copStore.Close()
+	cache := copStore.GetRegionCache()
+	bo := backoff.NewBackofferWithVars(context.Background(), 3000, nil)
+	req := &kv.Request{}
+
+	tasks, err := buildCopTasks(bo, buildCopRanges("f", "h"), &buildCopTaskOpt{
+		req:   req,
+		cache: cache,
+	})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	failedChild := tasks[0]
+
+	// Split the child's Region underneath it and drop the stale cache entry,
+	// so the retry rebuild has to resolve two Regions.
+	newRegionID, newPeerID := cluster.AllocID(), cluster.AllocID()
+	cluster.Split(failedChild.region.GetID(), newRegionID, []byte("g"), []uint64{newPeerID}, newPeerID)
+	cache.InvalidateCachedRegion(failedChild.region)
+
+	failedChild.taskID = 1
+	var storeBatchedNum atomic.Uint64
+	var storeBatchedFallbackNum atomic.Uint64
+	worker := &copIteratorWorker{
+		store:                   copStore,
+		req:                     req,
+		storeBatchedNum:         &storeBatchedNum,
+		storeBatchedFallbackNum: &storeBatchedFallbackNum,
+	}
+	_, retryTasks, err := worker.handleBatchCopResponse(
+		bo,
+		nil,
+		&coprocessor.Response{
+			BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+				{
+					TaskId: failedChild.taskID,
+					RegionError: &errorpb.Error{
+						EpochNotMatch: &errorpb.EpochNotMatch{},
+					},
+				},
+			},
+		},
+		map[uint64]*batchedCopTask{
+			failedChild.taskID: {task: failedChild},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, retryTasks, 2)
+	for _, task := range retryTasks {
+		require.Empty(t, task.batchTaskList)
+	}
+	// Retry fan-out is currently counted as two fallbacks, making the
+	// successful count negative before conversion to uint64.
+	require.Equal(t, uint64(18446744073709551615), storeBatchedNum.Load())
+	require.Equal(t, uint64(2), storeBatchedFallbackNum.Load())
 }

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -1239,8 +1239,8 @@ func testHandleBatchCopResponseFallbackCountersAfterRegionSplit(t *testing.T) {
 	for _, task := range retryTasks {
 		require.Empty(t, task.batchTaskList)
 	}
-	// Retry fan-out is currently counted as two fallbacks, making the
-	// successful count negative before conversion to uint64.
-	require.Equal(t, uint64(18446744073709551615), storeBatchedNum.Load())
-	require.Equal(t, uint64(2), storeBatchedFallbackNum.Load())
+	// One failed batched input rebuilds into one retry task per new Region,
+	// but counts as exactly one fallback.
+	require.Zero(t, storeBatchedNum.Load())
+	require.Equal(t, uint64(1), storeBatchedFallbackNum.Load())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70340

Problem Summary:

A Region split can rebuild one failed batched input into multiple retries, causing the counters to overcount and wrap.

### What changed and how does it work?

Count fallbacks per original input task instead of generated retry tasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/store/copr -run '^TestHandleBatchCopResponse$' -count=1`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect store-batched coprocessor fallback counters after a Region split.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected fallback accounting for failed batched operations.
  - Prevented retry fan-out from inflating fallback counts or producing incorrect success totals.
  - Improved handling of region errors, lock errors, and missing batch responses.

- **Tests**
  - Added regression coverage for batched tasks split across regions during retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

