### PR TITLE
store/copr: fix storeBatchedNum counter underflow on region split [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2348,8 +2348,16 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 			return
 		}
 		if !busyThresholdFallback {
-			worker.storeBatchedNum.Add(uint64(batchedNum - len(remainTasks)))
-			worker.storeBatchedFallbackNum.Add(uint64(len(remainTasks)))
+			if batchedNum >= len(remainTasks) {
+				worker.storeBatchedNum.Add(uint64(batchedNum - len(remainTasks)))
+				worker.storeBatchedFallbackNum.Add(uint64(len(remainTasks)))
+			} else {
+				// Region split: more retry tasks than original batched tasks.
+				// All original tasks fell back, so no successful tasks to report.
+				// The fallback counter reflects the original batched count, not the
+				// inflated retry task count, to avoid over-counting.
+				worker.storeBatchedFallbackNum.Add(uint64(batchedNum))
+			}
 		}
 	}()
 	appendRemainTasks := func(tasks ...*copTask) {


### PR DESCRIPTION
### Description

When a Region split occurs during a store-batched coprocessor request, the `handleBatchCopResponse` function can produce more retry tasks than the original batched task count. This causes the `storeBatchedNum` counter to underflow:

- `batchedNum = 1` (one original batched task)
- `len(remainTasks) = 2` (two retry tasks after Region split)
- `uint64(1 - 2) = 18446744073709551615` (uint64 underflow)

### Fix

Guard the counter arithmetic with a `batchedNum >= len(remainTasks)` check. When more retry tasks exist than original batched tasks (Region split or similar), all original tasks fell back — report 0 successful tasks and the original batched count as the fallback number.

### Related issue

Closes #70340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected coprocessor metrics for region-split retries.
  * Prevented fallback counts from being inflated when retries create additional tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->