### PR TITLE
server: limit the size for COM_STMT_SEND_LONG_DATA in each connection

### DIFF
--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/pkg/config"
@@ -38,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/arena"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/stretchr/testify/require"
@@ -651,6 +653,57 @@ func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
 	require.Nil(t, stmt.BoundParams()[0])
 	require.Nil(t, stmt.BoundParams()[1])
 	require.NoError(t, stmt.CheckLongDataSize())
+}
+
+func TestStmtSendLongDataMemQuotaQuery(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	c := CreateMockConn(t, srv).(*mockConn)
+	c.capability = mysql.ClientProtocol41
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	stmt, _, _, err := c.Context().Prepare("select ?")
+	require.NoError(t, err)
+
+	vars := c.Context().GetSessionVars()
+	vars.MaxAllowedPacket = 64 << 20
+	require.NoError(t, vars.SetSystemVar("tidb_mem_quota_query", "1024"))
+	require.Equal(t, int64(1024), vars.MemQuotaQuery)
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+
+	base := vars.MemTracker.BytesConsumed()
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 600)))
+	require.Equal(t, base+600, vars.MemTracker.BytesConsumed())
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+	require.NoError(t, stmt.CheckLongDataSize())
+
+	// Further long-data that would reach/exceed tidb_mem_quota_query is refused.
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'b'}, 500)))
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+	require.Len(t, stmt.BoundParams()[0], 600)
+	require.Equal(t, base+600, vars.MemTracker.BytesConsumed())
+
+	err = c.Dispatch(context.Background(), append(
+		binary.LittleEndian.AppendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		0x0, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x0,
+	))
+	require.Error(t, err)
+	require.True(t, exeerrors.ErrMemoryExceedForQuery.Equal(err) ||
+		exeerrors.ErrMemoryExceedForQuery.Equal(errors.Cause(err)))
+	require.Equal(t, base, vars.MemTracker.BytesConsumed())
+
+	// After release, the session can accept long-data again within the quota.
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'c'}, 1023)))
+	require.Len(t, stmt.BoundParams()[0], 1023)
+	require.Equal(t, base+1023, vars.MemTracker.BytesConsumed())
+	require.NoError(t, stmt.Close())
+	require.Equal(t, base, vars.MemTracker.BytesConsumed())
 }
 
 func TestCursorFetchSendLongData(t *testing.T) {

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
+	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 )
@@ -71,8 +72,14 @@ type TiDBStatement struct {
 	boundParams [][]byte
 	// boundParamsTooLarge tracks whether a single COM_STMT_SEND_LONG_DATA parameter has exceeded max_allowed_packet.
 	boundParamsTooLarge bool
-	paramsType          []byte
-	ctx                 *TiDBContext
+	// boundParamsMemQuotaExceeded tracks whether further COM_STMT_SEND_LONG_DATA
+	// was refused because the session MemTracker would exceed tidb_mem_quota_query.
+	boundParamsMemQuotaExceeded bool
+	// boundLongDataBytes is the number of COM_STMT_SEND_LONG_DATA bytes currently
+	// held by this statement and charged to the session MemTracker.
+	boundLongDataBytes int64
+	paramsType         []byte
+	ctx                *TiDBContext
 	// this result set should have been closed before stored here. Only the `rowIterator` are used here. This field is
 	// not moved out to reuse the logic inside functions `writeResultSet...`
 	// TODO: move the `fetchedRows` into the statement, and remove the `ResultSet` from statement.
@@ -111,20 +118,44 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
 		ts.boundParams[paramID] = []byte{}
-	} else {
-		if uint64(len(ts.boundParams[paramID]))+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
-			// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
-			// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
-			ts.boundParamsTooLarge = true
-			return nil
-		}
-		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+		return nil
 	}
+	// Once either limit has been exceeded for this statement, keep SEND_LONG_DATA
+	// silent and refuse further growth until RESET/EXECUTE clears the buffers.
+	if ts.boundParamsTooLarge || ts.boundParamsMemQuotaExceeded {
+		return nil
+	}
+
+	chunkSize := int64(len(data))
+	vars := ts.ctx.GetSessionVars()
+	if uint64(len(ts.boundParams[paramID]))+uint64(chunkSize) > vars.MaxAllowedPacket {
+		// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
+		// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
+		ts.boundParamsTooLarge = true
+		return nil
+	}
+
+	// Charge COM_STMT_SEND_LONG_DATA to the session MemTracker so it counts toward
+	// tidb_mem_quota_query. Refuse before Consume to avoid triggering OOM actions
+	// on a protocol command that has no response packet.
+	memTracker := vars.MemTracker
+	quota := vars.MemQuotaQuery
+	if quota > 0 && memTracker.BytesConsumed()+chunkSize >= quota {
+		ts.boundParamsMemQuotaExceeded = true
+		return nil
+	}
+
+	memTracker.Consume(chunkSize)
+	ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+	ts.boundLongDataBytes += chunkSize
 	return nil
 }
 
 // CheckLongDataSize implements PreparedStatement CheckLongDataSize method.
 func (ts *TiDBStatement) CheckLongDataSize() error {
+	if ts.boundParamsMemQuotaExceeded {
+		return exeerrors.ErrMemoryExceedForQuery.GenWithStackByArgs(ts.ctx.GetSessionVars().ConnectionID)
+	}
 	if ts.boundParamsTooLarge {
 		return servererr.ErrNetPacketTooLarge
 	}
@@ -135,6 +166,18 @@ func (ts *TiDBStatement) CheckLongDataSize() error {
 		}
 	}
 	return nil
+}
+
+func (ts *TiDBStatement) releaseBoundLongData() {
+	if ts.boundLongDataBytes > 0 {
+		ts.ctx.GetSessionVars().MemTracker.Consume(-ts.boundLongDataBytes)
+		ts.boundLongDataBytes = 0
+	}
+	for i := range ts.boundParams {
+		ts.boundParams[i] = nil
+	}
+	ts.boundParamsTooLarge = false
+	ts.boundParamsMemQuotaExceeded = false
 }
 
 // NumParams implements PreparedStatement NumParams method.
@@ -171,10 +214,7 @@ func (ts *TiDBStatement) GetResultSet() resultset.CursorResultSet {
 
 // Reset implements PreparedStatement Reset method.
 func (ts *TiDBStatement) Reset() error {
-	for i := range ts.boundParams {
-		ts.boundParams[i] = nil
-	}
-	ts.boundParamsTooLarge = false
+	ts.releaseBoundLongData()
 	ts.hasActiveCursor = false
 
 	resultset.ReportCursorRUV2Delta(ts.rs, 0)
@@ -201,6 +241,8 @@ func (ts *TiDBStatement) Reset() error {
 
 // Close implements PreparedStatement Close method.
 func (ts *TiDBStatement) Close() error {
+	ts.releaseBoundLongData()
+
 	resultset.ReportCursorRUV2Delta(ts.rs, 0)
 	if ts.rs != nil && ts.rs.GetRowIterator() != nil {
 		ts.rs.GetRowIterator().Close()

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -117,16 +117,13 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	}
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
+		released := int64(len(ts.boundParams[paramID]))
+		if released > 0 {
+			ts.ctx.GetSessionVars().MemTracker.Consume(-released)
+			ts.boundLongDataBytes -= released
+		}
 		ts.boundParams[paramID] = []byte{}
-if len(data) == 0 {
-	released := int64(len(ts.boundParams[paramID]))
-	if released > 0 {
-		ts.ctx.GetSessionVars().MemTracker.Consume(-released)
-		ts.boundLongDataBytes -= released
-	}
-	ts.boundParams[paramID] = []byte{}
-	return nil
-}
+		return nil
 	}
 	// Once either limit has been exceeded for this statement, keep SEND_LONG_DATA
 	// silent and refuse further growth until RESET/EXECUTE clears the buffers.

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -118,7 +118,15 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
 		ts.boundParams[paramID] = []byte{}
-		return nil
+if len(data) == 0 {
+	released := int64(len(ts.boundParams[paramID]))
+	if released > 0 {
+		ts.ctx.GetSessionVars().MemTracker.Consume(-released)
+		ts.boundLongDataBytes -= released
+	}
+	ts.boundParams[paramID] = []byte{}
+	return nil
+}
 	}
 	// Once either limit has been exceeded for this statement, keep SEND_LONG_DATA
 	// silent and refuse further growth until RESET/EXECUTE clears the buffers.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70349

Problem Summary:
https://github.com/pingcap/tidb/issues/69693 only limits the size of a single COM_STMT_SEND_LONG_DATA, but it does limit the size for each statement, connection, user, or instance.

### What changed and how does it work?
- Attach the param memory to the session memory tracker.
- If the session memory exceeds the quota, do not append the param and report an error in the ComExecute.
- Release the memory after the statement closes or resets.

Note that it only limits memory on the connection level, not the user or instance level, but it's enough for most cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prepared statements now correctly enforce query memory quotas for long-data parameters.
  * Additional data is rejected when memory or packet limits are reached.
  * Memory used by long-data parameters is released after execution failures and when statements are reset or closed.
  * Subsequent statements can reuse released memory without retaining stale parameter data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->