### PR TITLE
globalsort,ddl: divide merge-sort files by exact target counts

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -341,6 +341,11 @@ error = '''
 stream task has no storage
 '''
 
+["GlobalSort:TooManyDataFiles"]
+error = '''
+cannot merge %d data files with concurrency %d into at most %d target files
+'''
+
 ["Import:ErrCastValue"]
 error = '''
 Value conversion failed for column '%s'. Expected type: %s, received value: %s. Reason: %s.

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	goerrors "errors"
 	"fmt"
 	"math"
 	"sort"
@@ -35,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
 	diststorage "github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/ingestor/ingestctrl"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
@@ -261,8 +263,8 @@ func (*LitBackfillScheduler) GetEligibleInstances(_ context.Context, _ *proto.Ta
 }
 
 // IsRetryableErr implements scheduler.Extension interface.
-func (*LitBackfillScheduler) IsRetryableErr(error) bool {
-	return true
+func (*LitBackfillScheduler) IsRetryableErr(err error) bool {
+	return !goerrors.Is(err, errdef.ErrTooManyDataFiles)
 }
 
 // ModifyMeta implements scheduler.Extension interface.

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/expression/exprstatic"
+	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -66,10 +68,22 @@ func TestDoneTaskKeeper(t *testing.T) {
 	require.True(t, bytes.Equal(n.nextKey, kv.Key("h")))
 }
 
-func TestIndexInfoNotFoundIsNonRetryable(t *testing.T) {
-	err := errors.Annotatef(errIndexInfoNotFound, "index info not found: %d", 1)
-	require.True(t, isIndexInfoNotFoundErr(err))
-	require.False(t, (&backfillDistExecutor{}).IsRetryableError(err))
+func TestBackfillRetryableErrors(t *testing.T) {
+	t.Run("index info not found is non-retryable for executor", func(t *testing.T) {
+		err := errors.Annotatef(errIndexInfoNotFound, "index info not found: %d", 1)
+		require.True(t, isIndexInfoNotFoundErr(err))
+		require.False(t, (&backfillDistExecutor{}).IsRetryableError(err))
+	})
+
+	t.Run("too many data files is non-retryable for scheduler", func(t *testing.T) {
+		err := fmt.Errorf(
+			"generate merge-sort plan failed: %w",
+			errdef.ErrTooManyDataFiles.GenWithStackByArgs(1000, 1, 250),
+		)
+		sch := &LitBackfillScheduler{}
+		require.False(t, sch.IsRetryableErr(err))
+		require.True(t, sch.IsRetryableErr(errors.New("temporary scheduler error")))
+	})
 }
 
 func TestPickBackfillType(t *testing.T) {

--- a/pkg/ingestor/errdef/errors.go
+++ b/pkg/ingestor/errdef/errors.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/errors"
 )
 
-// errors of ingest API
+// Errors used by ingestor components.
 var (
 	ErrNoLeader              = errors.Normalize("region has no leader, region '%d'", errors.RFCCodeText("KV:ErrNoLeader"))
 	ErrKVEpochNotMatch       = errors.Normalize("epoch not match", errors.RFCCodeText("Ingest:EpochNotMatch"))
@@ -32,6 +32,7 @@ var (
 	ErrKVDiskFull            = errors.Normalize("store disk full", errors.RFCCodeText("Ingest:StoreDiskFull"))
 	ErrKVIngestFailed        = errors.Normalize("ingest tikv failed", errors.RFCCodeText("Ingest:ErrKVIngestFailed"))
 	ErrKVRaftProposalDropped = errors.Normalize("raft proposal dropped", errors.RFCCodeText("Ingest:ErrKVRaftProposalDropped"))
+	ErrTooManyDataFiles      = errors.Normalize("cannot merge %d data files with concurrency %d into at most %d target files", errors.RFCCodeText("GlobalSort:TooManyDataFiles"))
 )
 
 // IsKVDiskFullError returns whether err is caused by TiKV reporting disk full.

--- a/pkg/ingestor/globalsort/BUILD.bazel
+++ b/pkg/ingestor/globalsort/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/dxf/framework/taskexecutor/execute",
         "//pkg/dxf/operator",
         "//pkg/ingestor/engineapi",
+        "//pkg/ingestor/errdef",
         "//pkg/ingestor/simplesst",
         "//pkg/kv",
         "//pkg/lightning/common",
@@ -67,6 +68,7 @@ go_test(
     deps = [
         "//pkg/dxf/framework/taskexecutor/execute",
         "//pkg/ingestor/engineapi",
+        "//pkg/ingestor/errdef",
         "//pkg/ingestor/simplesst",
         "//pkg/ingestor/testutils",
         "//pkg/kv",

--- a/pkg/ingestor/globalsort/merge.go
+++ b/pkg/ingestor/globalsort/merge.go
@@ -212,13 +212,31 @@ func MergeOverlappingFiles(
 	return err
 }
 
+func getTargetDataFileCount(fileCount, concurrency int) int {
+	if fileCount == 0 {
+		return 0
+	}
+	shares := max((fileCount+MaxMergingFilesPerThread-1)/MaxMergingFilesPerThread, concurrency)
+	if fileCount < 2*concurrency {
+		shares = max(1, fileCount/2)
+	}
+	return shares
+}
+
+func getEvenlyDividedTargetDataFileCount(total, groups, concurrency int) int {
+	quotient := total / groups
+	remainder := total % groups
+	return remainder*getTargetDataFileCount(quotient+1, concurrency) +
+		(groups-remainder)*getTargetDataFileCount(quotient, concurrency)
+}
+
 // split input data files into multiple shares evenly, with the max number files
 // in each share MaxMergingFilesPerThread, if there are not enough files, merge at
 // least 2 files in one batch.
 func splitDataFiles(paths []string, concurrency int) [][]string {
-	shares := max((len(paths)+MaxMergingFilesPerThread-1)/MaxMergingFilesPerThread, concurrency)
-	if len(paths) < 2*concurrency {
-		shares = max(1, len(paths)/2)
+	shares := getTargetDataFileCount(len(paths), concurrency)
+	if shares == 0 {
+		return nil
 	}
 	dataFilesSlice := make([][]string, 0, shares)
 	batchCount := len(paths) / shares

--- a/pkg/ingestor/globalsort/merge.go
+++ b/pkg/ingestor/globalsort/merge.go
@@ -212,7 +212,7 @@ func MergeOverlappingFiles(
 	return err
 }
 
-func getTargetDataFileCount(fileCount, concurrency int) int {
+func getTargetFileCount(fileCount, concurrency int) int {
 	if fileCount == 0 {
 		return 0
 	}
@@ -223,18 +223,20 @@ func getTargetDataFileCount(fileCount, concurrency int) int {
 	return shares
 }
 
-func getEvenlyDividedTargetDataFileCount(total, groups, concurrency int) int {
-	quotient := total / groups
-	remainder := total % groups
-	return remainder*getTargetDataFileCount(quotient+1, concurrency) +
-		(groups-remainder)*getTargetDataFileCount(quotient, concurrency)
+// getGroupedTargetFileCount returns the total target file count when the input
+// files are divided as evenly as possible among groupCount groups.
+func getGroupedTargetFileCount(total, groupCount, concurrency int) int {
+	quotient := total / groupCount
+	remainder := total % groupCount
+	return remainder*getTargetFileCount(quotient+1, concurrency) +
+		(groupCount-remainder)*getTargetFileCount(quotient, concurrency)
 }
 
 // split input data files into multiple shares evenly, with the max number files
 // in each share MaxMergingFilesPerThread, if there are not enough files, merge at
 // least 2 files in one batch.
 func splitDataFiles(paths []string, concurrency int) [][]string {
-	shares := getTargetDataFileCount(len(paths), concurrency)
+	shares := getTargetFileCount(len(paths), concurrency)
 	if shares == 0 {
 		return nil
 	}

--- a/pkg/ingestor/globalsort/merge_test.go
+++ b/pkg/ingestor/globalsort/merge_test.go
@@ -121,7 +121,7 @@ func TestSplitDataFiles(t *testing.T) {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			result := splitDataFiles(c.paths, c.concurrency)
 			require.Equal(t, c.result, result)
-			require.Equal(t, len(result), getTargetDataFileCount(len(c.paths), c.concurrency))
+			require.Equal(t, len(result), getTargetFileCount(len(c.paths), c.concurrency))
 		})
 	}
 

--- a/pkg/ingestor/globalsort/merge_test.go
+++ b/pkg/ingestor/globalsort/merge_test.go
@@ -49,6 +49,11 @@ func TestSplitDataFiles(t *testing.T) {
 		result      [][]string
 	}{
 		{
+			paths:       nil,
+			concurrency: 1,
+			result:      nil,
+		},
+		{
 			paths:       allPaths[:1],
 			concurrency: 1,
 			result:      [][]string{allPaths[:1]},
@@ -116,6 +121,7 @@ func TestSplitDataFiles(t *testing.T) {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			result := splitDataFiles(c.paths, c.concurrency)
 			require.Equal(t, c.result, result)
+			require.Equal(t, len(result), getTargetDataFileCount(len(c.paths), c.concurrency))
 		})
 	}
 

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -295,6 +295,32 @@ func SubtaskMetaPath(taskID int64, subtaskID int64) string {
 // subtask. It balances groups in rounds of nodeCnt to use all available
 // resources. It also limits each group's input files and caps the total target
 // files so the following ingest step can read them all.
+// since we have a 4000 hard limit on the target file count, when the concurrency
+// is larger than 16 (4000/250), DivideMergeSortDataFiles might incorrectly return
+// ErrTooManyDataFiles on some input, such as:
+//
+//	file-count=940001 / nodeCnt=2 / concurrency=17
+//
+// the 4000 is an experience value which came from internal tests where the max
+// node spec we used is 16c, we haven't tested on 32c or 64c. maybe we can remove
+// this 4000 hard limit, and calculate the limit by concurrency * 250.
+//
+// suppose we have a 8c node with cpu:mem = 1:4, but on the node only 7c and
+// 26.9GiB memory is available to tidb-server, below table give the max supported
+// row KV size before reporting ErrTooManyDataFiles for different params. such
+// as for 1 secondary index, with concurrency=1, the max all supported row KV
+// size is from 29.56TiB (when each index kv size = row kv size) to 92.98 TiB
+// (when each index kv size = 0.1 * row kv size).
+//
+//	| Index Count | Concurrency 1 | Concurrency 3  |  Concurrency 7  |
+//	| ----------: | ------------: | -------------: | --------------: |
+//	|    No index |     121.6 TiB |      364.8 TiB |       851.2 TiB |
+//	|     1 index | 29.6–93.0 TiB | 88.7–279.0 TiB | 206.9–650.9 TiB |
+//	|  16 indexes |  6.7–18.5 TiB |  20.0–55.6 TiB |  46.7–129.6 TiB |
+//	| 128 indexes |   1.0–2.7 TiB |    2.9–8.1 TiB |    6.7–18.8 TiB |
+//
+// if the 8c node is with cpu:mem = 1:2, the max supported kv size is around
+// half of above table.
 func DivideMergeSortDataFiles(files []string, nodeCnt, concurrency int) ([][]string, error) {
 	if nodeCnt == 0 {
 		return nil, errors.Errorf("unsupported zero node count")

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -291,9 +291,10 @@ func SubtaskMetaPath(taskID int64, subtaskID int64) string {
 	return path.Join(strconv.FormatInt(taskID, 10), strconv.FormatInt(subtaskID, 10), metaName)
 }
 
-// DivideMergeSortDataFiles divides the data files into multiple groups for
-// merge sort. Each group will be assigned to a node for sorting.
-// The number of files in each group is limited to MaxMergeSortFileCountStep.
+// DivideMergeSortDataFiles divides data files into groups, one per merge-sort
+// subtask. It balances groups in rounds of nodeCnt to use all available
+// resources. It also limits each group's input files and caps the total target
+// files so the following ingest step can read them all.
 func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([][]string, error) {
 	if nodeCnt == 0 {
 		return nil, errors.Errorf("unsupported zero node count")
@@ -301,45 +302,45 @@ func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([
 	if len(dataFiles) == 0 {
 		return [][]string{}, nil
 	}
-	adjustedMergeSortFileCountStep := simplesst.GetAdjustedMergeSortFileCountStep(mergeConc)
-	dataFilesCnt := len(dataFiles)
-	result := make([][]string, 0, nodeCnt)
-	batches := len(dataFiles) / adjustedMergeSortFileCountStep
-	rounds := batches / nodeCnt
-	fullGroupCount := rounds * nodeCnt
-	for range fullGroupCount {
-		result = append(result, dataFiles[:adjustedMergeSortFileCountStep])
-		dataFiles = dataFiles[adjustedMergeSortFileCountStep:]
+	maxFiles := simplesst.GetAdjustedMergeSortFileCountStep(mergeConc)
+	fileCnt := len(dataFiles)
+	groups := make([][]string, 0, nodeCnt)
+	// Fill complete rounds first so every available subtask slot has work.
+	fullGroups := fileCnt / maxFiles / nodeCnt * nodeCnt
+	for range fullGroups {
+		groups = append(groups, dataFiles[:maxFiles])
+		dataFiles = dataFiles[maxFiles:]
 	}
-	targetFileCount := fullGroupCount * getTargetDataFileCount(adjustedMergeSortFileCountStep, mergeConc)
-	threshold := int(simplesst.GetAdjustedMergeSortOverlapThreshold(mergeConc))
-	remainder := dataFilesCnt - (fullGroupCount * adjustedMergeSortFileCountStep)
-	if remainder == 0 {
-		if targetFileCount > threshold {
-			return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(dataFilesCnt, mergeConc, threshold)
+	targetCnt := fullGroups * getTargetDataFileCount(maxFiles, mergeConc)
+	targetLimit := int(simplesst.GetAdjustedMergeSortOverlapThreshold(mergeConc))
+	remaining := fileCnt - fullGroups*maxFiles
+	if remaining == 0 {
+		if targetCnt > targetLimit {
+			return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, mergeConc, targetLimit)
 		}
-		return result, nil
+		return groups, nil
 	}
 
-	minimalFileCount := 32 // Each subtask should merge at least 32 files.
-	maxCandidateNodeCnt := max(min(remainder/minimalFileCount, nodeCnt), 1)
-	minCandidateNodeCnt := (remainder + adjustedMergeSortFileCountStep - 1) / adjustedMergeSortFileCountStep
-	selectedNodeCnt := 0
-	for candidateNodeCnt := maxCandidateNodeCnt; candidateNodeCnt >= minCandidateNodeCnt; candidateNodeCnt-- {
-		candidateTargetFileCount := targetFileCount + getEvenlyDividedTargetDataFileCount(remainder, candidateNodeCnt, mergeConc)
-		if candidateTargetFileCount <= threshold {
-			selectedNodeCnt = candidateNodeCnt
+	minFiles := 32 // Each subtask should merge at least 32 files.
+	maxGroups := max(min(remaining/minFiles, nodeCnt), 1)
+	minGroups := (remaining + maxFiles - 1) / maxFiles
+	remainingGroups := 0
+	// Prefer more groups for parallelism while staying within the ingest limit.
+	for candidateGroups := maxGroups; candidateGroups >= minGroups; candidateGroups-- {
+		finalTargetCnt := targetCnt + getEvenlyDividedTargetDataFileCount(remaining, candidateGroups, mergeConc)
+		if finalTargetCnt <= targetLimit {
+			remainingGroups = candidateGroups
 			break
 		}
 	}
-	if selectedNodeCnt == 0 {
-		return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(dataFilesCnt, mergeConc, threshold)
+	if remainingGroups == 0 {
+		return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, mergeConc, targetLimit)
 	}
 
-	sizes := mathutil.Divide2Batches(remainder, selectedNodeCnt)
-	for _, size := range sizes {
-		result = append(result, dataFiles[:size])
+	groupSizes := mathutil.Divide2Batches(remaining, remainingGroups)
+	for _, size := range groupSizes {
+		groups = append(groups, dataFiles[:size])
 		dataFiles = dataFiles[size:]
 	}
-	return result, nil
+	return groups, nil
 }

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -305,29 +305,44 @@ func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([
 	result := make([][]string, 0, nodeCnt)
 	batches := len(dataFiles) / adjustedMergeSortFileCountStep
 	rounds := batches / nodeCnt
-	for range rounds * nodeCnt {
+	fullGroupCount := rounds * nodeCnt
+	for range fullGroupCount {
 		result = append(result, dataFiles[:adjustedMergeSortFileCountStep])
 		dataFiles = dataFiles[adjustedMergeSortFileCountStep:]
 	}
-	remainder := dataFilesCnt - (nodeCnt * rounds * adjustedMergeSortFileCountStep)
+	targetFileCount := fullGroupCount * getTargetDataFileCount(adjustedMergeSortFileCountStep, mergeConc)
+	threshold := int(simplesst.GetAdjustedMergeSortOverlapThreshold(mergeConc))
+	remainder := dataFilesCnt - (fullGroupCount * adjustedMergeSortFileCountStep)
 	if remainder == 0 {
+		if targetFileCount > threshold {
+			return nil, errors.Errorf("too many merge sort target files, dataFiles=%d, nodeCnt=%d, mergeConc=%d, targetFiles=%d, threshold=%d",
+				dataFilesCnt, nodeCnt, mergeConc, targetFileCount, threshold)
+		}
 		return result, nil
 	}
-	// adjust node cnt for remainder files to avoid having too much target files.
-	adjustNodeCnt := nodeCnt
-	maxTargetFilesPerSubtask := max(simplesst.MergeSortMaxSubtaskTargetFiles, mergeConc)
-	for (rounds*nodeCnt*maxTargetFilesPerSubtask)+(adjustNodeCnt*maxTargetFilesPerSubtask) > int(simplesst.GetAdjustedMergeSortOverlapThreshold(mergeConc)) {
-		adjustNodeCnt--
-		if adjustNodeCnt == 0 {
-			return nil, errors.Errorf("unexpected zero node count, dataFiles=%d, nodeCnt=%d", dataFilesCnt, nodeCnt)
+
+	minimalFileCount := 32 // Each subtask should merge at least 32 files.
+	maxCandidateNodeCnt := max(min(remainder/minimalFileCount, nodeCnt), 1)
+	minCandidateNodeCnt := (remainder + adjustedMergeSortFileCountStep - 1) / adjustedMergeSortFileCountStep
+	minTargetFileCount := dataFilesCnt
+	selectedNodeCnt := 0
+	for candidateNodeCnt := maxCandidateNodeCnt; candidateNodeCnt >= minCandidateNodeCnt; candidateNodeCnt-- {
+		candidateTargetFileCount := targetFileCount + getEvenlyDividedTargetDataFileCount(remainder, candidateNodeCnt, mergeConc)
+		minTargetFileCount = min(minTargetFileCount, candidateTargetFileCount)
+		if candidateTargetFileCount <= threshold {
+			selectedNodeCnt = candidateNodeCnt
+			break
 		}
 	}
-	minimalFileCount := 32 // Each subtask should merge at least 32 files.
-	adjustNodeCnt = max(min(remainder/minimalFileCount, adjustNodeCnt), 1)
-	sizes := mathutil.Divide2Batches(remainder, adjustNodeCnt)
-	for _, s := range sizes {
-		result = append(result, dataFiles[:s])
-		dataFiles = dataFiles[s:]
+	if selectedNodeCnt == 0 {
+		return nil, errors.Errorf("too many merge sort target files, dataFiles=%d, nodeCnt=%d, mergeConc=%d, targetFiles=%d, threshold=%d",
+			dataFilesCnt, nodeCnt, mergeConc, minTargetFileCount, threshold)
+	}
+
+	sizes := mathutil.Divide2Batches(remainder, selectedNodeCnt)
+	for _, size := range sizes {
+		result = append(result, dataFiles[:size])
+		dataFiles = dataFiles[size:]
 	}
 	return result, nil
 }

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -295,52 +295,55 @@ func SubtaskMetaPath(taskID int64, subtaskID int64) string {
 // subtask. It balances groups in rounds of nodeCnt to use all available
 // resources. It also limits each group's input files and caps the total target
 // files so the following ingest step can read them all.
-func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([][]string, error) {
+func DivideMergeSortDataFiles(files []string, nodeCnt, concurrency int) ([][]string, error) {
 	if nodeCnt == 0 {
 		return nil, errors.Errorf("unsupported zero node count")
 	}
-	if len(dataFiles) == 0 {
+	if len(files) == 0 {
 		return [][]string{}, nil
 	}
-	maxFiles := simplesst.GetAdjustedMergeSortFileCountStep(mergeConc)
-	fileCnt := len(dataFiles)
+	maxFiles := simplesst.GetAdjustedMergeSortFileCountStep(concurrency)
+	fileCnt := len(files)
 	groups := make([][]string, 0, nodeCnt)
-	// Fill complete rounds first so every available subtask slot has work.
-	fullGroups := fileCnt / maxFiles / nodeCnt * nodeCnt
-	for range fullGroups {
-		groups = append(groups, dataFiles[:maxFiles])
-		dataFiles = dataFiles[maxFiles:]
+	// Part 1: Fill complete rounds of maximum-sized groups so every available
+	// subtask slot has work.
+	fullGroupCnt := fileCnt / maxFiles / nodeCnt * nodeCnt
+	for range fullGroupCnt {
+		groups = append(groups, files[:maxFiles])
+		files = files[maxFiles:]
 	}
-	targetCnt := fullGroups * getTargetDataFileCount(maxFiles, mergeConc)
-	targetLimit := int(simplesst.GetAdjustedMergeSortOverlapThreshold(mergeConc))
-	remaining := fileCnt - fullGroups*maxFiles
+	targetCnt := fullGroupCnt * getTargetDataFileCount(maxFiles, concurrency)
+	targetLimit := int(simplesst.GetAdjustedMergeSortOverlapThreshold(concurrency))
+	remaining := fileCnt - fullGroupCnt*maxFiles
 	if remaining == 0 {
 		if targetCnt > targetLimit {
-			return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, mergeConc, targetLimit)
+			return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, concurrency, targetLimit)
 		}
 		return groups, nil
 	}
 
+	// Part 2: Divide the remaining files evenly while preserving parallelism
+	// and keeping the target file count within the ingest limit.
 	minFiles := 32 // Each subtask should merge at least 32 files.
 	maxGroups := max(min(remaining/minFiles, nodeCnt), 1)
 	minGroups := (remaining + maxFiles - 1) / maxFiles
-	remainingGroups := 0
+	groupCnt := 0
 	// Prefer more groups for parallelism while staying within the ingest limit.
-	for candidateGroups := maxGroups; candidateGroups >= minGroups; candidateGroups-- {
-		finalTargetCnt := targetCnt + getEvenlyDividedTargetDataFileCount(remaining, candidateGroups, mergeConc)
-		if finalTargetCnt <= targetLimit {
-			remainingGroups = candidateGroups
+	for candidateCnt := maxGroups; candidateCnt >= minGroups; candidateCnt-- {
+		candidateTargetCnt := targetCnt + getEvenlyDividedTargetDataFileCount(remaining, candidateCnt, concurrency)
+		if candidateTargetCnt <= targetLimit {
+			groupCnt = candidateCnt
 			break
 		}
 	}
-	if remainingGroups == 0 {
-		return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, mergeConc, targetLimit)
+	if groupCnt == 0 {
+		return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(fileCnt, concurrency, targetLimit)
 	}
 
-	groupSizes := mathutil.Divide2Batches(remaining, remainingGroups)
-	for _, size := range groupSizes {
-		groups = append(groups, dataFiles[:size])
-		dataFiles = dataFiles[size:]
+	sizes := mathutil.Divide2Batches(remaining, groupCnt)
+	for _, size := range sizes {
+		groups = append(groups, files[:size])
+		files = files[size:]
 	}
 	return groups, nil
 }

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -295,6 +295,16 @@ func SubtaskMetaPath(taskID int64, subtaskID int64) string {
 // subtask. It balances groups in rounds of nodeCnt to use all available
 // resources. It also limits each group's input files and caps the total target
 // files so the following ingest step can read them all.
+//
+// Known issue: the target file count is exact only when merge execution uses
+// the same concurrency passed here. Distributed add-index and IMPORT INTO do
+// not persist that concurrency in merge subtask metadata; they derive it again
+// from the current execution resource. If the resource changes after planning,
+// the merge subtasks can produce more files than estimated here and exceed the
+// total file count expected by the ingest step. Fixing this requires pinning the
+// concurrency across planning, merge execution, and ingest, or revalidating and
+// regenerating all pending merge groups when it changes.
+//
 // since we have a 4000 hard limit on the target file count, when the concurrency
 // is larger than 16 (4000/250), DivideMergeSortDataFiles might incorrectly return
 // ErrTooManyDataFiles on some input, such as:

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
+	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/util/mathutil"
@@ -315,8 +316,7 @@ func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([
 	remainder := dataFilesCnt - (fullGroupCount * adjustedMergeSortFileCountStep)
 	if remainder == 0 {
 		if targetFileCount > threshold {
-			return nil, errors.Errorf("too many merge sort target files, dataFiles=%d, nodeCnt=%d, mergeConc=%d, targetFiles=%d, threshold=%d",
-				dataFilesCnt, nodeCnt, mergeConc, targetFileCount, threshold)
+			return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(dataFilesCnt, mergeConc, threshold)
 		}
 		return result, nil
 	}
@@ -324,19 +324,16 @@ func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([
 	minimalFileCount := 32 // Each subtask should merge at least 32 files.
 	maxCandidateNodeCnt := max(min(remainder/minimalFileCount, nodeCnt), 1)
 	minCandidateNodeCnt := (remainder + adjustedMergeSortFileCountStep - 1) / adjustedMergeSortFileCountStep
-	minTargetFileCount := dataFilesCnt
 	selectedNodeCnt := 0
 	for candidateNodeCnt := maxCandidateNodeCnt; candidateNodeCnt >= minCandidateNodeCnt; candidateNodeCnt-- {
 		candidateTargetFileCount := targetFileCount + getEvenlyDividedTargetDataFileCount(remainder, candidateNodeCnt, mergeConc)
-		minTargetFileCount = min(minTargetFileCount, candidateTargetFileCount)
 		if candidateTargetFileCount <= threshold {
 			selectedNodeCnt = candidateNodeCnt
 			break
 		}
 	}
 	if selectedNodeCnt == 0 {
-		return nil, errors.Errorf("too many merge sort target files, dataFiles=%d, nodeCnt=%d, mergeConc=%d, targetFiles=%d, threshold=%d",
-			dataFilesCnt, nodeCnt, mergeConc, minTargetFileCount, threshold)
+		return nil, errdef.ErrTooManyDataFiles.GenWithStackByArgs(dataFilesCnt, mergeConc, threshold)
 	}
 
 	sizes := mathutil.Divide2Batches(remainder, selectedNodeCnt)

--- a/pkg/ingestor/globalsort/util.go
+++ b/pkg/ingestor/globalsort/util.go
@@ -338,7 +338,7 @@ func DivideMergeSortDataFiles(files []string, nodeCnt, concurrency int) ([][]str
 		groups = append(groups, files[:maxFiles])
 		files = files[maxFiles:]
 	}
-	targetCnt := fullGroupCnt * getTargetDataFileCount(maxFiles, concurrency)
+	targetCnt := fullGroupCnt * getTargetFileCount(maxFiles, concurrency)
 	targetLimit := int(simplesst.GetAdjustedMergeSortOverlapThreshold(concurrency))
 	remaining := fileCnt - fullGroupCnt*maxFiles
 	if remaining == 0 {
@@ -356,7 +356,7 @@ func DivideMergeSortDataFiles(files []string, nodeCnt, concurrency int) ([][]str
 	groupCnt := 0
 	// Prefer more groups for parallelism while staying within the ingest limit.
 	for candidateCnt := maxGroups; candidateCnt >= minGroups; candidateCnt-- {
-		candidateTargetCnt := targetCnt + getEvenlyDividedTargetDataFileCount(remaining, candidateCnt, concurrency)
+		candidateTargetCnt := targetCnt + getGroupedTargetFileCount(remaining, candidateCnt, concurrency)
 		if candidateTargetCnt <= targetLimit {
 			groupCnt = candidateCnt
 			break

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -22,7 +22,9 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
+	"github.com/pingcap/tidb/pkg/ingestor/errdef"
 	"github.com/pingcap/tidb/pkg/ingestor/simplesst"
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
@@ -413,6 +415,15 @@ func TestExternalMetaPath(t *testing.T) {
 }
 
 func TestDivideMergeSortDataFilesBasic(t *testing.T) {
+	require.Equal(t, errors.RFCErrorCode("GlobalSort:TooManyDataFiles"), errdef.ErrTooManyDataFiles.RFCCode())
+
+	requireTooManyDataFiles := func(t *testing.T, err error, dataFileCnt, concurrency, threshold int) {
+		t.Helper()
+		expected := errdef.ErrTooManyDataFiles.GenWithStackByArgs(dataFileCnt, concurrency, threshold)
+		require.True(t, errors.ErrorEqual(err, expected))
+		require.EqualError(t, err, expected.Error())
+	}
+
 	testCases := []struct {
 		fileCnt       int
 		nodeCnt       int
@@ -472,29 +483,25 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 	t.Run("remainder exceeds target file threshold", func(t *testing.T) {
 		result, err := DivideMergeSortDataFiles(make([]string, 62501), 10, 1)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "targetFiles=251")
-		require.ErrorContains(t, err, "threshold=250")
+		requireTooManyDataFiles(t, err, 62501, 1, 250)
 	})
 
 	t.Run("full groups exceed target file threshold", func(t *testing.T) {
 		result, err := DivideMergeSortDataFiles(make([]string, 62750), 1, 1)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "targetFiles=251")
-		require.ErrorContains(t, err, "threshold=250")
+		requireTooManyDataFiles(t, err, 62750, 1, 250)
 	})
 
 	t.Run("fixed targets and remainder exceed target file threshold", func(t *testing.T) {
 		result, err := DivideMergeSortDataFiles(make([]string, 62751), 1, 1)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "targetFiles=252")
-		require.ErrorContains(t, err, "threshold=250")
+		requireTooManyDataFiles(t, err, 62751, 1, 250)
 	})
 
-	t.Run("reports minimum non-monotonic target file count", func(t *testing.T) {
+	t.Run("non-monotonic target file count exceeds threshold", func(t *testing.T) {
 		result, err := DivideMergeSortDataFiles(make([]string, 248128), 62, 64)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "targetFiles=4031")
-		require.ErrorContains(t, err, "threshold=4000")
+		requireTooManyDataFiles(t, err, 248128, 64, 4000)
 	})
 
 	t.Run("preserves maximum input files per subtask", func(t *testing.T) {
@@ -509,8 +516,7 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 
 		result, err = DivideMergeSortDataFiles(make([]string, 940001), 2, 17)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "targetFiles=4012")
-		require.ErrorContains(t, err, "threshold=4000")
+		requireTooManyDataFiles(t, err, 940001, 17, 4000)
 	})
 
 	t.Run("large node count", func(t *testing.T) {

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -543,20 +543,20 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 }
 
 func TestDivideMergeSortDataFilesSubtaskCount(t *testing.T) {
-	const mergeConc = 16
-	for _, fileCnt := range []int{3000, 4000, 40000, 400000, 712345, 1000000} {
-		for _, nodeCnt := range []int{1, 3, 7, 16, 30, 60, 97} {
-			dataFiles := make([]string, fileCnt)
-			groups, err := DivideMergeSortDataFiles(dataFiles, nodeCnt, mergeConc)
+	const Concurrency = 16
+	for _, fileCount := range []int{3000, 4000, 40000, 400000, 712345, 1000000} {
+		for _, nodeCount := range []int{1, 3, 7, 16, 30, 60, 97} {
+			dataFiles := make([]string, fileCount)
+			dataFilesGroup, err := DivideMergeSortDataFiles(dataFiles, nodeCount, Concurrency)
 			require.NoError(t, err)
-			var targetCnt int
-			for _, group := range groups {
-				targetCnt += len(splitDataFiles(group, mergeConc))
+			var totalTargetFileCount int
+			for _, group := range dataFilesGroup {
+				totalTargetFileCount += len(splitDataFiles(group, Concurrency))
 			}
 			t.Logf("node count: %d, file count: %d, group count: %d, target file count: %d",
-				nodeCnt, fileCnt, len(groups), targetCnt)
-			require.LessOrEqual(t, len(groups), 250)
-			require.LessOrEqual(t, targetCnt, 4000)
+				nodeCount, fileCount, len(dataFilesGroup), totalTargetFileCount)
+			require.LessOrEqual(t, len(dataFilesGroup), 250)
+			require.LessOrEqual(t, totalTargetFileCount, 4000)
 		}
 	}
 }

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -532,10 +532,10 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 250)
 		totalTargetFileCount := 0
-		adjustedMergeSortFileCountStep := simplesst.GetAdjustedMergeSortFileCountStep(16)
+		maxFiles := simplesst.GetAdjustedMergeSortFileCountStep(16)
 		for _, group := range result {
 			require.Len(t, group, 4000)
-			require.LessOrEqual(t, len(group), adjustedMergeSortFileCountStep)
+			require.LessOrEqual(t, len(group), maxFiles)
 			totalTargetFileCount += len(splitDataFiles(group, 16))
 		}
 		require.Equal(t, 4000, totalTargetFileCount)
@@ -543,20 +543,20 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 }
 
 func TestDivideMergeSortDataFilesSubtaskCount(t *testing.T) {
-	const Concurrency = 16
-	for _, fileCount := range []int{3000, 4000, 40000, 400000, 712345, 1000000} {
-		for _, nodeCount := range []int{1, 3, 7, 16, 30, 60, 97} {
-			dataFiles := make([]string, fileCount)
-			dataFilesGroup, err := DivideMergeSortDataFiles(dataFiles, nodeCount, Concurrency)
+	const mergeConc = 16
+	for _, fileCnt := range []int{3000, 4000, 40000, 400000, 712345, 1000000} {
+		for _, nodeCnt := range []int{1, 3, 7, 16, 30, 60, 97} {
+			dataFiles := make([]string, fileCnt)
+			groups, err := DivideMergeSortDataFiles(dataFiles, nodeCnt, mergeConc)
 			require.NoError(t, err)
-			var totalTargetFileCount int
-			for _, dataFiles := range dataFilesGroup {
-				totalTargetFileCount += len(splitDataFiles(dataFiles, Concurrency))
+			var targetCnt int
+			for _, group := range groups {
+				targetCnt += len(splitDataFiles(group, mergeConc))
 			}
-			t.Logf("nodeCount: %d, fileCount: %d, subtaskCount:%d, totalTargetFileCount: %d",
-				nodeCount, fileCount, len(dataFilesGroup), totalTargetFileCount)
-			require.LessOrEqual(t, len(dataFilesGroup), 250)
-			require.LessOrEqual(t, totalTargetFileCount, 4000)
+			t.Logf("node count: %d, file count: %d, group count: %d, target file count: %d",
+				nodeCnt, fileCnt, len(groups), targetCnt)
+			require.LessOrEqual(t, len(groups), 250)
+			require.LessOrEqual(t, targetCnt, 4000)
 		}
 	}
 }

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -443,6 +443,97 @@ func TestDivideMergeSortDataFilesBasic(t *testing.T) {
 			require.EqualValues(t, tc.expectedSizes, actualSizes)
 		})
 	}
+
+	t.Run("exact target file count", func(t *testing.T) {
+		items := make([]string, 4580)
+		result, err := DivideMergeSortDataFiles(items, 8, 1)
+		require.NoError(t, err)
+		require.Len(t, result, 24)
+		expectedSizes := append(slices.Repeat([]int{250}, 16), 73, 73, 73, 73, 72, 72, 72, 72)
+		totalTargetFileCount := 0
+		for i, group := range result {
+			require.Len(t, group, expectedSizes[i])
+			totalTargetFileCount += len(splitDataFiles(group, 1))
+		}
+		require.Equal(t, 24, totalTargetFileCount)
+		require.LessOrEqual(t, totalTargetFileCount, 250)
+	})
+
+	t.Run("at target file threshold", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 62500), 10, 1)
+		require.NoError(t, err)
+		totalTargetFileCount := 0
+		for _, group := range result {
+			totalTargetFileCount += len(splitDataFiles(group, 1))
+		}
+		require.Equal(t, 250, totalTargetFileCount)
+	})
+
+	t.Run("remainder exceeds target file threshold", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 62501), 10, 1)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "targetFiles=251")
+		require.ErrorContains(t, err, "threshold=250")
+	})
+
+	t.Run("full groups exceed target file threshold", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 62750), 1, 1)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "targetFiles=251")
+		require.ErrorContains(t, err, "threshold=250")
+	})
+
+	t.Run("fixed targets and remainder exceed target file threshold", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 62751), 1, 1)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "targetFiles=252")
+		require.ErrorContains(t, err, "threshold=250")
+	})
+
+	t.Run("reports minimum non-monotonic target file count", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 248128), 62, 64)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "targetFiles=4031")
+		require.ErrorContains(t, err, "threshold=4000")
+	})
+
+	t.Run("preserves maximum input files per subtask", func(t *testing.T) {
+		result, err := DivideMergeSortDataFiles(make([]string, 940000), 2, 17)
+		require.NoError(t, err)
+		totalTargetFileCount := 0
+		for _, group := range result {
+			require.LessOrEqual(t, len(group), 4000)
+			totalTargetFileCount += len(splitDataFiles(group, 17))
+		}
+		require.LessOrEqual(t, totalTargetFileCount, 4000)
+
+		result, err = DivideMergeSortDataFiles(make([]string, 940001), 2, 17)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "targetFiles=4012")
+		require.ErrorContains(t, err, "threshold=4000")
+	})
+
+	t.Run("large node count", func(t *testing.T) {
+		var result [][]string
+		var err error
+		allocs := testing.AllocsPerRun(1, func() {
+			result, err = DivideMergeSortDataFiles(make([]string, 32000), 32000, 16)
+		})
+		require.NoError(t, err)
+		require.Less(t, allocs, float64(100))
+
+		result, err = DivideMergeSortDataFiles(make([]string, 1000000), 1000000, 16)
+		require.NoError(t, err)
+		require.Len(t, result, 250)
+		totalTargetFileCount := 0
+		adjustedMergeSortFileCountStep := simplesst.GetAdjustedMergeSortFileCountStep(16)
+		for _, group := range result {
+			require.Len(t, group, 4000)
+			require.LessOrEqual(t, len(group), adjustedMergeSortFileCountStep)
+			totalTargetFileCount += len(splitDataFiles(group, 16))
+		}
+		require.Equal(t, 4000, totalTargetFileCount)
+	})
 }
 
 func TestDivideMergeSortDataFilesSubtaskCount(t *testing.T) {

--- a/pkg/ingestor/globalsort/util_test.go
+++ b/pkg/ingestor/globalsort/util_test.go
@@ -550,10 +550,10 @@ func TestDivideMergeSortDataFilesSubtaskCount(t *testing.T) {
 			dataFilesGroup, err := DivideMergeSortDataFiles(dataFiles, nodeCount, Concurrency)
 			require.NoError(t, err)
 			var totalTargetFileCount int
-			for _, group := range dataFilesGroup {
-				totalTargetFileCount += len(splitDataFiles(group, Concurrency))
+			for _, dataFiles := range dataFilesGroup {
+				totalTargetFileCount += len(splitDataFiles(dataFiles, Concurrency))
 			}
-			t.Logf("node count: %d, file count: %d, group count: %d, target file count: %d",
+			t.Logf("nodeCount: %d, fileCount: %d, subtaskCount:%d, totalTargetFileCount: %d",
 				nodeCount, fileCount, len(dataFilesGroup), totalTargetFileCount)
 			require.LessOrEqual(t, len(dataFilesGroup), 250)
 			require.LessOrEqual(t, totalTargetFileCount, 4000)

--- a/pkg/ingestor/simplesst/writer.go
+++ b/pkg/ingestor/simplesst/writer.go
@@ -90,7 +90,8 @@ func commonGetAdjustCount(isOverlapThreshold bool, concurrency int) int64 {
 		logutil.BgLogger().Error("concurrency is less than 0 or equal to 0, set to 1", zap.Int("concurrency", concurrency))
 		concurrency = 1
 	}
-	cnt := 250 * int64(concurrency)
+	const maxOpenedConnPerCore = 250
+	cnt := maxOpenedConnPerCore * int64(concurrency)
 	if isOverlapThreshold {
 		cnt = min(cnt, maxMergeSortOverlapThreshold)
 	} else {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65629

Problem Summary:

`DivideMergeSortDataFiles` estimated that every subtask would produce the maximum number of target files instead of calculating the number actually produced by `splitDataFiles`. For 4,580 input files, one node, and merge concurrency 1, this overestimate reduced the remainder group count to zero and returned `unexpected zero node count` even though the files could be merged within the ingest limit.

When a file set cannot satisfy the ingest limit, distributed DDL also treated the deterministic `GlobalSort:TooManyDataFiles` planning error as retryable. The scheduler would therefore regenerate the same invalid merge-sort plan instead of terminating the task with the planning error.

### What changed and how does it work?

- Share the target-file-count calculation with `splitDataFiles` so subtask planning uses the exact output count.
- Allocate full rounds of maximum-sized groups, then select the largest valid remainder group count that stays within the ingest target-file limit.
- Return the named `GlobalSort:TooManyDataFiles` error only when no valid grouping can satisfy the limit, and register it in the generated error catalog.
- Treat `GlobalSort:TooManyDataFiles` as non-retryable in the distributed DDL scheduler while preserving retry behavior for unrelated errors, including through wrapped error chains.
- Cover the reported low-concurrency case, threshold boundaries, large node counts, target-count invariants, and DDL retry classification with unit tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestBackfillRetryableErrors$' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run '^(TestSplitDataFiles|TestDivideMergeSortDataFiles(Basic|SubtaskCount))$' -count=1
./tools/check/check-errdoc.sh
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where global-sort operations might fail with an `unexpected zero node count` error when merge-sort concurrency is low, and prevent distributed DDL from repeatedly retrying merge-sort plans that exceed the supported file limit.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced data-file merge planning with balanced distribution across processing groups.
  * Improved handling of empty inputs, large file sets, and high concurrency.
  * Strengthened validation of merge limits while preserving parallel processing.
* **Bug Fixes**
  * Added a clear error when data-file counts exceed supported merge limits.
  * Improved retry handling so limit-related failures are not retried unnecessarily.
  * Replaced less specific limit handling with clearer threshold and projected-count checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
