### PR TITLE
planner: allow SET_VAR for join reorder through selection

### DIFF
--- a/pkg/planner/core/hint_test.go
+++ b/pkg/planner/core/hint_test.go
@@ -119,6 +119,13 @@ func TestHintSuite(t *testing.T) {
 			testKit.MustQuery(`select @@tidb_default_string_match_selectivity`).Check(testkit.Rows("0.8"))
 		})
 
+		t.Run("TestSetVarJoinReorderThroughSelection", func(t *testing.T) {
+			testKit.MustExec(`set @@tidb_opt_join_reorder_through_sel = off`)
+			testKit.MustQuery(`select /*+ set_var(tidb_opt_join_reorder_through_sel=on) */ @@tidb_opt_join_reorder_through_sel`).Check(testkit.Rows("1"))
+			testKit.MustQuery(`show warnings`).Check(testkit.Rows())
+			testKit.MustQuery(`select @@tidb_opt_join_reorder_through_sel`).Check(testkit.Rows("0"))
+		})
+
 		t.Run("TestSetVarHintsWithExplain", func(t *testing.T) {
 			testKit.MustExec(`set @@max_execution_time=2000;`)
 			testKit.MustExec(`explain select /*+ set_var(max_execution_time=100) */ @@max_execution_time;`)

--- a/pkg/sessionctx/variable/setvar_affect.go
+++ b/pkg/sessionctx/variable/setvar_affect.go
@@ -98,6 +98,7 @@ var isHintUpdatableVerified = map[string]struct{}{
 	"tidb_opt_projection_push_down":                   {},
 	"tidb_enable_vectorized_expression":               {},
 	"tidb_opt_join_reorder_threshold":                 {},
+	"tidb_opt_join_reorder_through_sel":               {},
 	"tidb_opt_enable_advanced_join_reorder":           {},
 	"tidb_enable_index_merge":                         {},
 	"tidb_enable_no_backslash_escapes_in_like":        {},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70356

Problem Summary:

`SET_VAR(tidb_opt_join_reorder_through_sel=...)` takes effect, but emits warning 3637 because the variable is missing from the verified SET_VAR allowlist. This contradicts the documented support for using the variable with `SET_VAR` and can make a valid hint appear unreliable.

### What changed and how does it work?

- Add `tidb_opt_join_reorder_through_sel` to `isHintUpdatableVerified`.
- Add a regression test verifying that the hinted value is visible inside the statement, the original session value is restored afterward, and `SHOW WARNINGS` is empty.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Manual validation on a TiDB v8.5.6 Playground confirmed that the hint already changes the join reorder plan despite warning 3637. The regression test failed on master with warning 3637 before the allowlist change and passed afterward.

```text
go test --tags=intest ./pkg/planner/core -run '^TestHintSuite$' -count=1
ok github.com/pingcap/tidb/pkg/planner/core
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the incorrect warning when the SET_VAR hint is used with tidb_opt_join_reorder_through_sel.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for temporarily enabling join reordering through selection with optimizer hints on individual queries.

* **Bug Fixes**
  * Ensured query-level hint changes do not alter the session setting or generate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->