### PR TITLE
ddl: fix REORGANIZE PARTITION skipping partitions when rebuilding global indexes

### DIFF
--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -320,6 +320,43 @@ func TestGetTableDataKeyRanges(t *testing.T) {
 	require.Equal(t, keyRanges[3].EndKey, tablecodec.EncodeTablePrefix(metadef.MaxUserGlobalID))
 }
 
+func TestFindNextNonTouchedPartitionID(t *testing.T) {
+	defs := func(ids ...int64) []model.PartitionDefinition {
+		res := make([]model.PartitionDefinition, 0, len(ids))
+		for _, id := range ids {
+			res = append(res, model.PartitionDefinition{ID: id})
+		}
+		return res
+	}
+	// p2 and p3 are reorganized into new partitions, i.e. they are in
+	// DroppingDefinitions, while p1, p4 and p5 are non-touched.
+	pi := &model.PartitionInfo{
+		Definitions:         defs(1, 2, 3, 4, 5),
+		DroppingDefinitions: defs(2, 3),
+	}
+	for _, c := range []struct {
+		curr int64
+		next int64
+	}{
+		{1, 4},
+		{2, 4},
+		{3, 4},
+		{4, 5},
+		{5, 0},
+	} {
+		require.Equal(t, c.next, findNextNonTouchedPartitionID(c.curr, pi), "curr %d", c.curr)
+	}
+	// Not a partition of the table.
+	require.Equal(t, int64(0), findNextNonTouchedPartitionID(6, pi))
+
+	// No non-touched partitions left after p1.
+	pi = &model.PartitionInfo{
+		Definitions:         defs(1, 2, 3),
+		DroppingDefinitions: defs(2, 3),
+	}
+	require.Equal(t, int64(0), findNextNonTouchedPartitionID(1, pi))
+}
+
 func TestMergeContinuousKeyRanges(t *testing.T) {
 	cases := []struct {
 		input  []keyRangeMayExclude

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3596,12 +3596,13 @@ func getNextPartitionInfo(reorg *reorgInfo, t table.PartitionedTable, currPhysic
 		} else {
 			// case 3 (or if not found AddingDefinitions; 4)
 			// check if recreating Global Index (during Reorg Partition)
-			pid, err = findNextPartitionID(currPhysicalTableID, pi.AddingDefinitions)
-			if err != nil {
+			var notAddingErr error
+			pid, notAddingErr = findNextPartitionID(currPhysicalTableID, pi.AddingDefinitions)
+			if notAddingErr != nil {
 				// case 4
 				// Not a partition in the AddingDefinitions, so it must be an existing
 				// non-touched partition, i.e. recreating Global Index for the non-touched partitions
-				pid, err = findNextNonTouchedPartitionID(currPhysicalTableID, pi)
+				pid = findNextNonTouchedPartitionID(currPhysicalTableID, pi)
 			}
 		}
 	} else if len(pi.DroppingDefinitions) == 0 {
@@ -3690,22 +3691,28 @@ func findNextPartitionID(currentPartition int64, defs []model.PartitionDefinitio
 	return 0, errors.Errorf("partition id not found %d", currentPartition)
 }
 
-func findNextNonTouchedPartitionID(currPartitionID int64, pi *model.PartitionInfo) (int64, error) {
+// findNextNonTouchedPartitionID finds the next partition after currPartitionID
+// that is not touched by the current DDL, i.e. the next partition in
+// pi.Definitions which is not in pi.DroppingDefinitions.
+// Returns 0 if there is no such partition left.
+func findNextNonTouchedPartitionID(currPartitionID int64, pi *model.PartitionInfo) int64 {
 	pid, err := findNextPartitionID(currPartitionID, pi.Definitions)
 	if err != nil {
-		return 0, err
+		// Should not happen, the reorg only runs on partitions of the table.
+		logutil.DDLLogger().Warn("current partition not found in the table definitions",
+			zap.Int64("partitionID", currPartitionID))
+		return 0
 	}
-	if pid == 0 {
-		return 0, nil
-	}
-	for _, notFoundErr := findNextPartitionID(pid, pi.DroppingDefinitions); notFoundErr == nil; {
-		// This can be optimized, but it is not frequently called, so keeping as-is
-		pid, err = findNextPartitionID(pid, pi.Definitions)
-		if pid == 0 {
-			break
+	for pid != 0 {
+		if _, notFoundErr := findNextPartitionID(pid, pi.DroppingDefinitions); notFoundErr != nil {
+			// Not in DroppingDefinitions, so it is a non-touched partition.
+			return pid
 		}
+		// This can be optimized, but it is not frequently called, so keeping as-is
+		// pid is from pi.Definitions, so it can always be found there.
+		pid, _ = findNextPartitionID(pid, pi.Definitions)
 	}
-	return pid, err
+	return 0
 }
 
 // AllocateIndexID allocates an index ID from TableInfo.

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -4244,7 +4244,8 @@ func (w *worker) reorgPartitionDataAndIndex(
 			return errors.Trace(err)
 		}
 	}
-	if _, err = findNextNonTouchedPartitionID(reorgInfo.PhysicalTableID, pi); err == nil {
+	if reorgInfo.PhysicalTableID != 0 {
+		// There are non-touched partitions to add to the new global indexes.
 		err = w.addTableIndex(jobCtx, t, reorgInfo)
 		if err != nil {
 			return errors.Trace(err)

--- a/pkg/ddl/tests/partition/reorg_partition_test.go
+++ b/pkg/ddl/tests/partition/reorg_partition_test.go
@@ -1195,3 +1195,24 @@ func TestPartitionByFailuresAddPlacementPolicyGlobalIndex(t *testing.T) {
 	afterResult := beforeResult
 	testReorganizePartitionFailures(t, create, alter, beforeDML, beforeResult, nil, afterResult)
 }
+
+func TestReorgPartitionGlobalIndexNonTouchedAfterDropped(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// pMax is a non-touched partition ordered after the reorganized partitions,
+	// so it must also be added to the recreated global index.
+	tk.MustExec(`create table t (a int, b int, unique key idx_b (b) global) partition by range (a) (` +
+		`partition p0 values less than (10),` +
+		`partition p1 values less than (20),` +
+		`partition p2 values less than (30),` +
+		`partition pMax values less than (maxvalue))`)
+	tk.MustExec(`insert into t values (1,10),(12,120),(25,250),(30,300)`)
+	tk.MustExec(`alter table t reorganize partition p1,p2 into (partition p1a values less than (15), partition p1b values less than (30))`)
+	tk.MustExec(`admin check table t`)
+	expected := testkit.Rows("1:10,12:120,25:250,30:300")
+	tk.MustQuery(`select group_concat(concat(a,":",b) order by b) from t use index(idx_b) where b >= 0`).Check(expected)
+	tk.MustQuery(`select group_concat(concat(a,":",b) order by b) from t ignore index(idx_b) where b >= 0`).Check(expected)
+	// A missing global index entry would also stop the unique constraint from being enforced.
+	tk.MustContainErrMsg(`insert into t values (31,300)`, "Duplicate entry")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70023

Problem Summary:

`ALTER TABLE ... REORGANIZE PARTITION` recreates all global indexes, which means every live row in every live partition must be backfilled into the new index, including the partitions that are not part of the reorganization.

The backfill of those non-touched partitions stops too early. `findNextNonTouchedPartitionID()` was written as:

```go
for _, notFoundErr := findNextPartitionID(pid, pi.DroppingDefinitions); notFoundErr == nil; {
        pid, err = findNextPartitionID(pid, pi.Definitions)
        if pid == 0 {
                break
        }
}
```

`notFoundErr` is only evaluated once, in the init statement, and is never updated in the loop, so the only way out of the loop is `pid == 0`. As soon as the partition following the current one is a partition being reorganized away, the loop walks to the end of `pi.Definitions` and returns 0, which the caller reads as "no more partitions, backfill done". Every non-touched partition ordered after the reorganized ones is silently skipped.

The resulting global index is missing entries for those rows, so queries using the index return fewer rows than the same query using the table, the unique constraint is no longer enforced for the missing values, and `ADMIN CHECK TABLE` reports error 8223.

The bug needs a non-touched partition to be followed by a reorganized partition, with at least one more non-touched partition after it, which is why `REORGANIZE PARTITION` of the first or the last partitions is not affected.

### What changed and how does it work?

`findNextNonTouchedPartitionID()` now re-checks `pi.DroppingDefinitions` for every candidate, so it keeps walking `pi.Definitions` until it finds a partition that is not being reorganized away, and only returns 0 when there is none left.

The return values are simplified while at it. The function used to return an error which was really "the current partition ID is not a partition of this table", and `reorgPartitionDataAndIndex()` used that error as a predicate for whether to run the non-touched backfill phase at all. It now returns only the next partition ID, with 0 meaning "nothing left", and the caller tests `reorgInfo.PhysicalTableID != 0` directly, which is the condition it actually cares about. The should-not-happen case is logged instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `ALTER TABLE ... REORGANIZE PARTITION` could leave the recreated global indexes without the rows from partitions ordered after the reorganized partitions, resulting in missing rows in queries using such an index and in unique constraints not being enforced for those rows.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed partition reorganization so global indexes retain entries from non-touched partitions after partitions are dropped or reorganized.
  - Improved partition traversal and handling of partition definitions during reorganization.
  - Preserved unique-index enforcement and correct query results after partition changes.

- **Tests**
  - Added coverage for partition traversal and global-index behavior following partition reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->