### PR TITLE
*: bump client-go to include the busy-leader probe fix (#2041) (#2044)

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4278,8 +4278,8 @@ def go_deps():
         build_tags = ["intest"],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:1WCvEFubCqIkvKQo8q8SGsQce0dXp+lAWKoSFsww1MM=",
-        version = "v2.0.8-0.20260803075849-c3b50791b9fb",
+        sum = "h1:55geXMSPKxe12hkhjfpDSRddDyMFYtrkUT6nv0G4CKM=",
+        version = "v2.0.8-0.20260806041825-494edbd79be9",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb
+	github.com/tikv/client-go/v2 v2.0.8-0.20260806041825-494edbd79be9
 	github.com/tikv/pd/client v0.0.0-20260804033407-85a975a5ca78
 	github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -863,8 +863,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb h1:1WCvEFubCqIkvKQo8q8SGsQce0dXp+lAWKoSFsww1MM=
-github.com/tikv/client-go/v2 v2.0.8-0.20260803075849-c3b50791b9fb/go.mod h1:k4+YEInCqMCM0hE0KJBbXytXzAQ8rBAtvpXtdDmy8eA=
+github.com/tikv/client-go/v2 v2.0.8-0.20260806041825-494edbd79be9 h1:55geXMSPKxe12hkhjfpDSRddDyMFYtrkUT6nv0G4CKM=
+github.com/tikv/client-go/v2 v2.0.8-0.20260806041825-494edbd79be9/go.mod h1:k4+YEInCqMCM0hE0KJBbXytXzAQ8rBAtvpXtdDmy8eA=
 github.com/tikv/pd/client v0.0.0-20260804033407-85a975a5ca78 h1:QvsJcN4iEicVrTKY42NbrNW/WjBcNCHRmiwEZ1NulCg=
 github.com/tikv/pd/client v0.0.0-20260804033407-85a975a5ca78/go.mod h1:kZRj/e7FPSwZFOzU/M3ds3pn3A6y5LPRdef2J0JhcoA=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=


### PR DESCRIPTION
### What problem does this PR solve?

Bump `github.com/tikv/client-go/v2` from `v2.0.8-0.20260803075849-c3b50791b9fb` to `v2.0.8-0.20260806041825-494edbd79be9` on tidb-8.5, on top of the previous bump in #70303.

This brings the busy-leader probe fix (tikv/client-go#2041, cherry-picked as tikv/client-go#2044) which addresses tikv/client-go#2028: when a TiKV store's unified read pool is wedged, leader reads are rejected with `ServerIsBusy(EstimatedWaitMs=0)` at the pool entrance, so the request never reaches the raft layer and no `NotLeader` error is returned even if PD has already moved the leader away. The client then retries the stale cached leader indefinitely. After 2 consecutive such rejections within one selector, the client now probes a follower once with unchanged leader-read semantics; the follower's `NotLeader` reply with the real leader hint heals the shared region cache.

### What is changed and how it works?

- `go.mod` / `go.sum`: client-go version bump (3 files, 5 lines changed total)
- `DEPS.bzl`: bazel dependency entry for the new version

Go toolchain was already bumped to 1.25.12 by #70219 / #70303; no code changes needed.

### Check List

Tests:
- [x] Unit test: `go build ./...` passes (only the pre-existing unrelated `tools/patch-go` / `plugin/conn_ip_example` noise)
- [ ] Integration test (CI)

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TiKV client dependency to a newer version.
  * Synchronized dependency metadata to ensure consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->