### PR TITLE
import into: fix conflict cleanup after functional-index schema evolution

### DIFF
--- a/pkg/dxf/importinto/conflictedkv/handler.go
+++ b/pkg/dxf/importinto/conflictedkv/handler.go
@@ -153,7 +153,7 @@ func (h *BaseHandler) encodeAndHandleRow(ctx context.Context,
 	rowKey tidbkv.Key, handle tidbkv.Handle, val []byte) (err error) {
 	tblMeta := h.targetTable.Meta()
 	decodedData, _, err := tables.DecodeRawRowData(h.encoder.SessionCtx.GetExprCtx(),
-		h.targetTable, handle, h.targetTable.Cols(), val)
+		h.targetTable, handle, h.targetTable.VisibleCols(), val)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/dxf/importinto/conflictedkv/handler_test.go
+++ b/pkg/dxf/importinto/conflictedkv/handler_test.go
@@ -157,6 +157,93 @@ func TestHandler(t *testing.T) {
 		})
 	})
 
+	t.Run("data kv handler re-encodes visible columns after functional index", func(t *testing.T) {
+		tk.MustExec("drop table if exists tf")
+		tk.MustExec(`create table tf(
+			id bigint primary key clustered,
+			a int,
+			unique key uk_expr ((a + 1))
+		)`)
+		tk.MustExec("alter table tf add column tail int")
+		tk.MustExec("alter table tf add unique key uk_tail (tail)")
+		tbl, err := do.InfoSchema().TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("tf"))
+		require.NoError(t, err)
+
+		fixtureEncoder := getEncoder(t, tbl)
+		t.Cleanup(func() {
+			require.NoError(t, fixtureEncoder.Close())
+		})
+		fixturePairs, err := fixtureEncoder.Encode(
+			[]types.Datum{types.NewIntDatum(1), types.NewIntDatum(10), types.NewIntDatum(100)},
+			1,
+		)
+		require.NoError(t, err)
+
+		var tailIndexID int64
+		for _, idx := range tbl.Meta().Indices {
+			if idx.Name.L == "uk_tail" {
+				tailIndexID = idx.ID
+				break
+			}
+		}
+		require.NotZero(t, tailIndexID)
+
+		expectedKVs := make(map[string]string, len(fixturePairs.Pairs))
+		var (
+			recordKV        *simplesst.KVPair
+			expectedTailKey string
+		)
+		for _, pair := range fixturePairs.Pairs {
+			expectedKVs[string(pair.Key)] = string(pair.Val)
+			if tablecodec.IsRecordKey(pair.Key) {
+				recordKV = &simplesst.KVPair{
+					Key:   store.GetCodec().EncodeKey(append(tidbkv.Key(nil), pair.Key...)),
+					Value: append([]byte(nil), pair.Val...),
+				}
+				continue
+			}
+			indexID, err := tablecodec.DecodeIndexID(pair.Key)
+			require.NoError(t, err)
+			if indexID == tailIndexID {
+				expectedTailKey = string(pair.Key)
+			}
+		}
+		require.NotNil(t, recordKV)
+		require.NotEmpty(t, expectedTailKey)
+		fixturePairs.Clear()
+
+		handled := false
+		encodedRowHandler := mockHandleEncodedRowFn(func(
+			_ context.Context, _ tidbkv.Key, row []types.Datum, kvPairs *kv.Pairs,
+		) error {
+			handled = true
+			actualKVs := make(map[string]string, len(kvPairs.Pairs))
+			for _, pair := range kvPairs.Pairs {
+				actualKVs[string(pair.Key)] = string(pair.Val)
+			}
+			_, ok := actualKVs[expectedTailKey]
+			require.True(t, ok, "re-encoded KVs must contain uk_tail=100")
+			require.Equal(t, expectedKVs, actualKVs)
+			require.Len(t, row, 3)
+			require.Equal(t, int64(100), row[2].GetInt64())
+			return nil
+		})
+		dataKVHandler := conflictedkv.NewDataKVHandler(conflictedkv.NewBaseHandler(
+			tbl,
+			globalsort.DataKVGroup,
+			store.GetCodec(),
+			getEncoder(t, tbl),
+			encodedRowHandler,
+			nil,
+			logger,
+		))
+		t.Cleanup(func() {
+			require.NoError(t, dataKVHandler.Close(ctx))
+		})
+		require.NoError(t, dataKVHandler.Handle(ctx, recordKV))
+		require.True(t, handled)
+	})
+
 	t.Run("test index kv handler", func(t *testing.T) {
 		doTestFn := func(t *testing.T, tableName string, expectedKVs int) {
 			tbl := cleanupEnvFn(t, tableName)

--- a/tests/realtikvtest/importintotest4/conflict_resolution_test.go
+++ b/tests/realtikvtest/importintotest4/conflict_resolution_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/importinto"
@@ -36,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/pingcap/tidb/tests/realtikvtest/testutils"
 	"github.com/tikv/client-go/v2/util"
 	"google.golang.org/grpc/codes"
@@ -538,6 +541,50 @@ func (s *mockGCSSuite) TestGlobalSortDistinguishesCommonHandlesWithSameString() 
 		[]string{},
 		"checksum_table = 'required'",
 	)
+}
+
+func (s *mockGCSSuite) TestGlobalSortFunctionalIndexConflictAfterAddingVisibleColumn() {
+	if kerneltype.IsClassic() {
+		s.T().Skip("requires the NextGen MinIO object store")
+	}
+
+	sourceStore, err := handle.NewObjStore(s.ctx, realtikvtest.GetNextGenObjStoreURI("issue-70372"))
+	s.NoError(err)
+	s.T().Cleanup(func() {
+		s.NoError(sourceStore.DeleteFile(s.ctx, "issue-70372.csv"))
+		sourceStore.Close()
+	})
+	s.NoError(sourceStore.WriteFile(s.ctx, "issue-70372.csv", []byte("1,10,100\n2,10,200\n")))
+
+	s.prepareAndUseDB("issue_70372")
+	s.tk.MustExec(`create table t (
+		id bigint primary key clustered,
+		a int,
+		unique key uk_expr ((a + 1))
+	)`)
+	s.tk.MustExec("alter table t add column tail int")
+	s.tk.MustExec("alter table t add unique key uk_tail (tail)")
+
+	result := s.tk.MustQuery(fmt.Sprintf(`import into t from '%s'
+		with on_duplicate_key='capture', cloud_storage_uri='%s'`,
+		realtikvtest.GetNextGenObjStoreURI("issue-70372/*.csv"),
+		realtikvtest.GetNextGenObjStoreURI("issue-70372-sort"))).Rows()
+	s.Len(result, 1)
+	jobID, err := strconv.Atoi(result[0][0].(string))
+	s.NoError(err)
+
+	rows := s.tk.MustQuery("select summary from mysql.tidb_import_jobs where id = ?", jobID).Rows()
+	s.Len(rows, 1)
+	var summary importer.Summary
+	s.NoError(json.Unmarshal([]byte(rows[0][0].(string)), &summary))
+	s.Zero(summary.ImportedRows)
+	s.EqualValues(2, summary.ConflictRowCnt)
+
+	s.tk.MustQuery("select * from t").Check(testkit.Rows())
+	s.tk.MustExec("admin check table t")
+	s.tk.MustExec("insert into t values (3, 30, 100)")
+	s.tk.MustQuery("select * from t").Check(testkit.Rows("3 30 100"))
+	s.tk.MustExec("admin check table t")
 }
 
 func (s *mockGCSSuite) TestGlobalSortConflictResolutionMultipleSubtasks() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70372

Problem Summary:

When `IMPORT INTO ... WITH on_duplicate_key='capture'` resolves conflicts for a table whose functional-index hidden column physically precedes a later visible column, conflict cleanup decodes persisted rows using all table columns but re-encodes them as visible-column input. The positional mismatch can reconstruct and delete the wrong ordinary index keys. The import can then fail checksum validation after leaving ghost unique-index entries or removing live uniqueness protection.

### What changed and how does it work?

- Decode persisted conflict rows with `VisibleCols()` so the decoded datum slice uses the same positional domain as the duplicate-resolution encoder.
- Keep hidden functional-index columns out of parser-visible input; the existing table encoder continues to recompute their generated values.
- Add a handler regression that verifies the complete reconstructed KV set and the ordinary unique index added after a functional index.
- Add a NextGen RealTiKV regression covering global-sort import, conflict collection and deletion, checksum validation, `ADMIN CHECK TABLE`, and subsequent uniqueness enforcement.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation performed:

- `./tools/check/failpoint-go-test.sh pkg/dxf/importinto/conflictedkv -run '^TestHandler$' -count=1`
- `NEXT_GEN=1 go test -count=1 -v -run '^TestImportInto$/^TestGlobalSortFunctionalIndexConflictAfterAddingVisibleColumn$' -tags=intest,nextgen -timeout=40m ./tests/realtikvtest/importintotest4 -args -with-real-tikv -tikv-path 'tikv://127.0.0.1:2379?disableGC=true'`
- `make lint`
- Manual reproduction on a NextGen cluster with MinIO, PD, three TiKV stores, TiKV Worker, SYSTEM TiDB, and a user-keyspace TiDB. The fixed import finished with two captured conflicts, both `ADMIN CHECK TABLE` statements passed, and inserting a row using the formerly ghosted unique value succeeded.

The RealTiKV regression was also run against the old `Cols()` behavior and reproduced the checksum mismatch (`total_kvs: 2 vs 0`, `total_bytes: 80 vs 21`). The identical test passed with `VisibleCols()`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `IMPORT INTO` conflict cleanup could leave corrupt unique-index entries after adding visible columns to a table with a functional index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conflict handling during imports for tables with functional indexes and newly added visible or unique columns.
  * Ensured row data retains all expected key-value pairs and visible column values.
  * Prevented invalid duplicate functional-index rows from being imported.

* **Tests**
  * Added regression coverage for import conflict resolution and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->