### PR TITLE
lightning: optimize CSV field unescaping

### DIFF
--- a/pkg/lightning/mydump/csv_parser.go
+++ b/pkg/lightning/mydump/csv_parser.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -50,12 +49,11 @@ type CSVParser struct {
 	blockParser
 	cfg *config.CSVConfig
 
-	comma          []byte
-	quote          []byte
-	newLine        []byte
-	startingBy     []byte
-	escapedBy      string
-	unescapeRegexp *regexp.Regexp
+	comma      []byte
+	quote      []byte
+	newLine    []byte
+	startingBy []byte
+	escapedBy  string
 
 	charsetConvertor *CharsetConvertor
 	// These variables are used with IndexAnyByte to search a byte slice for the
@@ -144,7 +142,6 @@ func NewCSVParser(
 	}
 
 	escFlavor := escapeFlavorNone
-	var r *regexp.Regexp
 	if len(cfg.FieldsEscapedBy) > 0 {
 		escFlavor = escapeFlavorMySQL
 		quoteStopSet = append(quoteStopSet, cfg.FieldsEscapedBy[0])
@@ -152,10 +149,6 @@ func NewCSVParser(
 		// we need special treatment of the NULL value \N, used by MySQL.
 		if !cfg.NotNull && slices.Contains(cfg.FieldNullDefinedBy, cfg.FieldsEscapedBy+`N`) {
 			escFlavor = escapeFlavorMySQLWithNull
-		}
-		r, err = regexp.Compile(`(?s)` + regexp.QuoteMeta(cfg.FieldsEscapedBy) + `.`)
-		if err != nil {
-			return nil, errors.Trace(err)
 		}
 	}
 	metrics, _ := metric.FromContext(ctx)
@@ -168,7 +161,6 @@ func NewCSVParser(
 		newLine:           []byte(lineTerminator),
 		startingBy:        []byte(cfg.LinesStartingBy),
 		escapedBy:         cfg.FieldsEscapedBy,
-		unescapeRegexp:    r,
 		escFlavor:         escFlavor,
 		quoteByteSet:      makeByteSet(quoteStopSet),
 		unquoteByteSet:    makeByteSet(unquoteStopSet),
@@ -210,7 +202,7 @@ func (parser *CSVParser) unescapeString(input field) (unescaped string, isNull b
 		return input.content, true, nil
 	}
 	if len(parser.escapedBy) > 0 {
-		unescaped = unescape(unescaped, "", parser.escFlavor, parser.escapedBy[0], parser.unescapeRegexp)
+		unescaped = unescape(unescaped, "", parser.escFlavor, parser.escapedBy[0])
 	}
 	if !(len(parser.quote) > 0 && parser.quotedNullIsText && input.quoted) {
 		// this branch represents "quote is not configured" or "quoted null is null" or "this field has no quote"

--- a/pkg/lightning/mydump/csv_parser_test.go
+++ b/pkg/lightning/mydump/csv_parser_test.go
@@ -549,6 +549,9 @@ func TestCustomEscapeChar(t *testing.T) {
 
 	require.ErrorIs(t, errors.Cause(parser.ReadRow()), io.EOF)
 
+	// `*` is deliberately a regexp metacharacter: the byte scanner must treat it
+	// as an ordinary escape byte, with none of the quoting the regexp-based
+	// implementation needed.
 	cfg.FieldsEscapedBy = `*`
 	cfg.FieldNullDefinedBy = []string{`*N`}
 	parser, err = mydump.NewCSVParser(
@@ -1526,7 +1529,7 @@ func BenchmarkCSVParserUnescape(b *testing.B) {
 			row:       `1,"{!"id!":123,!"name!":!"alice!",!"nested!":{!"enabled!":true,!"items!":[!"a!",!"b!",!"c!"]}}",3` + "\n",
 		},
 		{
-			name:      "CustomRegexpMetaDense",
+			name:      "CustomStarDense",
 			escapedBy: `*`,
 			row:       `1,"{*"id*":123,*"name*":*"alice*",*"nested*":{*"enabled*":true,*"items*":[*"a*",*"b*",*"c*"]}}",3` + "\n",
 		},

--- a/pkg/lightning/mydump/csv_parser_test.go
+++ b/pkg/lightning/mydump/csv_parser_test.go
@@ -549,6 +549,30 @@ func TestCustomEscapeChar(t *testing.T) {
 
 	require.ErrorIs(t, errors.Cause(parser.ReadRow()), io.EOF)
 
+	cfg.FieldsEscapedBy = `*`
+	cfg.FieldNullDefinedBy = []string{`*N`}
+	parser, err = mydump.NewCSVParser(
+		context.Background(),
+		&cfg,
+		mydump.NewStringReader(`"*0*b*n*r*t*Z***q",*N,**N`),
+		int64(config.ReadBlockSize),
+		ioWorkersForCSV,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, parser.ReadRow())
+	require.Equal(t, parsedef.Row{
+		RowID: 1,
+		Row: []types.Datum{
+			types.NewStringDatum(string([]byte{0, '\b', '\n', '\r', '\t', 26, '*', 'q'})),
+			nullDatum,
+			types.NewStringDatum(`*N`),
+		},
+		Length: 21,
+	}, parser.LastRow())
+	require.ErrorIs(t, errors.Cause(parser.ReadRow()), io.EOF)
+
 	cfg = config.CSVConfig{
 		FieldsTerminatedBy: ",",
 		FieldsEnclosedBy:   `"`,
@@ -1476,6 +1500,75 @@ func TestCharsetConversion(t *testing.T) {
 	}
 
 	runTestCasesCSV(t, &cfg, 1, testCases)
+}
+
+func BenchmarkCSVParserUnescape(b *testing.B) {
+	const rowsPerParser = 4096
+
+	testCases := []struct {
+		name      string
+		escapedBy string
+		row       string
+	}{
+		{
+			name:      "NoEscape",
+			escapedBy: `\`,
+			row:       "1,plain-text,3\n",
+		},
+		{
+			name:      "BackslashDense",
+			escapedBy: `\`,
+			row:       `1,"{\"id\":123,\"name\":\"alice\",\"nested\":{\"enabled\":true,\"items\":[\"a\",\"b\",\"c\"]}}",3` + "\n",
+		},
+		{
+			name:      "CustomBangDense",
+			escapedBy: `!`,
+			row:       `1,"{!"id!":123,!"name!":!"alice!",!"nested!":{!"enabled!":true,!"items!":[!"a!",!"b!",!"c!"]}}",3` + "\n",
+		},
+		{
+			name:      "CustomRegexpMetaDense",
+			escapedBy: `*`,
+			row:       `1,"{*"id*":123,*"name*":*"alice*",*"nested*":{*"enabled*":true,*"items*":[*"a*",*"b*",*"c*"]}}",3` + "\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		b.Run(testCase.name, func(b *testing.B) {
+			input := strings.Repeat(testCase.row, rowsPerParser)
+			cfg := config.CSVConfig{
+				FieldsTerminatedBy: ",",
+				FieldsEnclosedBy:   `"`,
+				LinesTerminatedBy:  "\n",
+				FieldsEscapedBy:    testCase.escapedBy,
+			}
+			newParser := func() *mydump.CSVParser {
+				parser, err := mydump.NewCSVParser(
+					context.Background(),
+					&cfg,
+					mydump.NewStringReader(input),
+					int64(config.ReadBlockSize),
+					ioWorkersForCSV,
+					false,
+					nil,
+				)
+				require.NoError(b, err)
+				return parser
+			}
+
+			b.SetBytes(int64(len(testCase.row)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var parser *mydump.CSVParser
+			for i := 0; i < b.N; i++ {
+				if i%rowsPerParser == 0 {
+					parser = newParser()
+				}
+				require.NoError(b, parser.ReadRow())
+				parser.RecycleRow(parser.LastRow())
+			}
+		})
+	}
 }
 
 // Run `go test github.com/pingcap/pkg/lightning/mydump -check.b -check.bmem -test.v` to get benchmark result.

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -364,7 +364,7 @@ func unescapeByChar(input string, escChar byte) string {
 
 	remaining := input[first:]
 	for len(remaining) > 1 {
-		result.WriteByte(unescapedByte(remaining[1]))
+		result.WriteByte(escapedCharToByte(remaining[1]))
 		remaining = remaining[2:]
 
 		next := strings.IndexByte(remaining, escChar)
@@ -380,7 +380,7 @@ func unescapeByChar(input string, escChar byte) string {
 	return result.String()
 }
 
-func unescapedByte(input byte) byte {
+func escapedCharToByte(input byte) byte {
 	switch input {
 	case '0':
 		return 0

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -335,14 +334,11 @@ func (parser *blockParser) readBlock() error {
 	}
 }
 
-var chunkParserUnescapeRegexp = regexp.MustCompile(`(?s)\\.`)
-
 func unescape(
 	input string,
 	delim string,
 	escFlavor escapeFlavor,
 	escChar byte,
-	unescapeRegexp *regexp.Regexp,
 ) string {
 	if len(delim) > 0 {
 		delim2 := delim + delim
@@ -350,36 +346,66 @@ func unescape(
 			input = strings.ReplaceAll(input, delim2, delim)
 		}
 	}
-	if escFlavor != escapeFlavorNone && strings.IndexByte(input, escChar) != -1 {
-		input = unescapeRegexp.ReplaceAllStringFunc(input, func(substr string) string {
-			switch substr[1] {
-			case '0':
-				return "\x00"
-			case 'b':
-				return "\b"
-			case 'n':
-				return "\n"
-			case 'r':
-				return "\r"
-			case 't':
-				return "\t"
-			case 'Z':
-				return "\x1a"
-			default:
-				return substr[1:]
-			}
-		})
+	if escFlavor != escapeFlavorNone {
+		input = unescapeByChar(input, escChar)
 	}
 	return input
+}
+
+func unescapeByChar(input string, escChar byte) string {
+	first := strings.IndexByte(input, escChar)
+	if first < 0 || first+1 == len(input) {
+		return input
+	}
+
+	var result strings.Builder
+	result.Grow(len(input) - 1)
+	result.WriteString(input[:first])
+
+	remaining := input[first:]
+	for len(remaining) > 1 {
+		result.WriteByte(unescapedByte(remaining[1]))
+		remaining = remaining[2:]
+
+		next := strings.IndexByte(remaining, escChar)
+		if next < 0 {
+			result.WriteString(remaining)
+			return result.String()
+		}
+		result.WriteString(remaining[:next])
+		remaining = remaining[next:]
+	}
+
+	result.WriteString(remaining)
+	return result.String()
+}
+
+func unescapedByte(input byte) byte {
+	switch input {
+	case '0':
+		return 0
+	case 'b':
+		return '\b'
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	case 'Z':
+		return '\x1a'
+	default:
+		return input
+	}
 }
 
 func (parser *ChunkParser) unescapeString(input string) string {
 	if len(input) >= 2 {
 		switch input[0] {
 		case '\'', '"':
-			return unescape(input[1:len(input)-1], input[:1], parser.escFlavor, '\\', chunkParserUnescapeRegexp)
+			return unescape(input[1:len(input)-1], input[:1], parser.escFlavor, '\\')
 		case '`':
-			return unescape(input[1:len(input)-1], "`", escapeFlavorNone, '\\', chunkParserUnescapeRegexp)
+			return unescape(input[1:len(input)-1], "`", escapeFlavorNone, '\\')
 		}
 	}
 	return input

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -352,6 +352,10 @@ func unescape(
 	return input
 }
 
+// unescapeByChar rewrites every escChar-prefixed pair in input. An escChar with
+// no byte after it is left as-is, whether it is the only one or the last of
+// several: an escape sequence is two bytes, and a single trailing byte cannot
+// form one.
 func unescapeByChar(input string, escChar byte) string {
 	first := strings.IndexByte(input, escChar)
 	if first < 0 || first+1 == len(input) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70382

Problem Summary:

Lightning's CSV parser used a regular expression for every escaped field. From a customer CPU profile, we can see that `CSVParser.unescapeString` consumed 8.08 seconds (16.56% of all CPU samples), including 7.19 seconds in `regexp.ReplaceAllStringFunc`. This becomes expensive for escape-heavy CSV imports.

### What changed and how does it work?

- Replace regexp-based unescaping with a single-pass byte scanner.
- Continue to honor the runtime `fields_escaped_by` byte, including regexp metacharacters such as `*`.
- Preserve the existing MySQL escape mappings, NULL recognition, delimiter handling, and charset-conversion order.
- Add coverage for all supported escape mappings, custom escape bytes, and escaped `N` edge cases.
- Add an end-to-end parser benchmark for unescaped and escape-heavy fields.

For escape-heavy benchmark cases, median runtime decreased from about 1.50 us/op to 0.65-0.66 us/op, allocations from 8 to 2 per operation, and allocated bytes from 604 to 353 per operation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test on aws cluster with three dataset, from left to right:

| Dataset | Escape sequences per field | Escape bytes | Decoded payload |
|---------|----------------------------|--------------|-----------------|
| esc48   | 48                         | 50%          | 144 chars       |
| esc12   | 12                         | 12.5%        | 180 chars       |
| esc00   | 0                          | 0%           | 192 chars       |

<img width="1608" height="568" alt="image" src="https://github.com/user-attachments/assets/4328c51b-6abe-4919-98b7-f34665afcb2c" />

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve CSV import performance when fields contain many escaped characters.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved CSV escape-sequence parsing, including support for `*` escape characters.
* Preserved correct handling of null markers, escaped literals, delimiter doubling, trailing escapes, and backquoted strings.
* Improved performance when processing rows with dense escape sequences.

## Tests
* Added coverage for additional escape formats and parsing scenarios.
* Added benchmarks for escape-processing performance across multiple escape patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->