### PR TITLE
*: use general approvers for BUILD.bazel files

### DIFF
--- a/br/OWNERS
+++ b/br/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-br
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-br

--- a/dumpling/OWNERS
+++ b/dumpling/OWNERS
@@ -1,7 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-dumpling
-labels:
-  - component/dumpling
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-dumpling
+    labels:
+      - component/dumpling

--- a/lightning/OWNERS
+++ b/lightning/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(tidb-lightning\\.toml)$":
     approvers:
       - sig-critical-approvers-tidb-lightning

--- a/lightning/cmd/tidb-lightning-ctl/OWNERS
+++ b/lightning/cmd/tidb-lightning-ctl/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-lightning
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-lightning

--- a/lightning/cmd/tidb-lightning/OWNERS
+++ b/lightning/cmd/tidb-lightning/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-lightning
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-lightning

--- a/pkg/autoid_service/OWNERS
+++ b/pkg/autoid_service/OWNERS
@@ -1,6 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-autoid-service
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-autoid-service
 

--- a/pkg/bindinfo/OWNERS
+++ b/pkg/bindinfo/OWNERS
@@ -1,7 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-planner
-labels:
-  - sig/planner
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-planner
+    labels:
+      - sig/planner

--- a/pkg/config/OWNERS
+++ b/pkg/config/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(OWNERS|config\\.go|config\\.toml\\.example)$":
     approvers:
       - sig-critical-approvers-tidb-server

--- a/pkg/ddl/OWNERS
+++ b/pkg/ddl/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-ddl
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-ddl

--- a/pkg/distsql/OWNERS
+++ b/pkg/distsql/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-distsql
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-distsql

--- a/pkg/domain/OWNERS
+++ b/pkg/domain/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-domain
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-domain

--- a/pkg/dumpformat/OWNERS
+++ b/pkg/dumpformat/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-dumpling
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-dumpling

--- a/pkg/dxf/OWNERS
+++ b/pkg/dxf/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-dxf
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-dxf

--- a/pkg/executor/OWNERS
+++ b/pkg/executor/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "analyze.*\\.go$":
     approvers:
       - sig-approvers-stats

--- a/pkg/executor/aggfuncs/OWNERS
+++ b/pkg/executor/aggfuncs/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/executor/aggregate/OWNERS
+++ b/pkg/executor/aggregate/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/executor/importer/OWNERS
+++ b/pkg/executor/importer/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor-import
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor-import

--- a/pkg/executor/join/OWNERS
+++ b/pkg/executor/join/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/executor/mppcoordmanager/OWNERS
+++ b/pkg/executor/mppcoordmanager/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/executor/sortexec/OWNERS
+++ b/pkg/executor/sortexec/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/executor/test/analyzetest/OWNERS
+++ b/pkg/executor/test/analyzetest/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-stats
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-stats

--- a/pkg/executor/unionexec/OWNERS
+++ b/pkg/executor/unionexec/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-executor
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-executor

--- a/pkg/expression/OWNERS
+++ b/pkg/expression/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-expression
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-expression

--- a/pkg/infoschema/OWNERS
+++ b/pkg/infoschema/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-infoschema
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-infoschema

--- a/pkg/ingestor/OWNERS
+++ b/pkg/ingestor/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-ddl
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-ddl

--- a/pkg/lightning/OWNERS
+++ b/pkg/lightning/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-lightning
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-lightning

--- a/pkg/lightning/config/OWNERS
+++ b/pkg/lightning/config/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-critical-approvers-tidb-lightning
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-critical-approvers-tidb-lightning

--- a/pkg/lock/OWNERS
+++ b/pkg/lock/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-lock
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-lock

--- a/pkg/meta/OWNERS
+++ b/pkg/meta/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-meta
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-meta

--- a/pkg/meta/metadef/OWNERS
+++ b/pkg/meta/metadef/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(OWNERS|system_tables_def\\.go)$":
     approvers:
       - sig-critical-approvers-tidb-server

--- a/pkg/metrics/OWNERS
+++ b/pkg/metrics/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-metrics
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-metrics

--- a/pkg/objstore/OWNERS
+++ b/pkg/objstore/OWNERS
@@ -1,6 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-br
-  - sig-approvers-lightning
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-br
+      - sig-approvers-lightning

--- a/pkg/owner/OWNERS
+++ b/pkg/owner/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-owner
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-owner

--- a/pkg/parser/OWNERS
+++ b/pkg/parser/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(parser\\.y)$":
     approvers:
       - sig-critical-approvers-parser

--- a/pkg/planner/OWNERS
+++ b/pkg/planner/OWNERS
@@ -1,7 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-planner
-labels:
-  - sig/planner
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-planner
+    labels:
+      - sig/planner

--- a/pkg/resourcemanager/OWNERS
+++ b/pkg/resourcemanager/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-resourcemanager
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-resourcemanager

--- a/pkg/session/OWNERS
+++ b/pkg/session/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(OWNERS|upgrade_def\\.go)$":
     approvers:
       - sig-critical-approvers-tidb-server

--- a/pkg/sessionctx/vardef/OWNERS
+++ b/pkg/sessionctx/vardef/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(OWNERS|(sysvar|tidb_vars)\\.go)$":
     approvers:
       - sig-critical-approvers-tidb-server

--- a/pkg/sessionctx/variable/OWNERS
+++ b/pkg/sessionctx/variable/OWNERS
@@ -2,6 +2,9 @@
 options:
   no_parent_owners: true
 filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
   "(OWNERS|(sysvar|session|tidb_vars)\\.go)$":
     approvers:
       - sig-critical-approvers-tidb-server

--- a/pkg/statistics/OWNERS
+++ b/pkg/statistics/OWNERS
@@ -1,8 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-stats
-labels:
-  - sig/planner
-  - component/statistics
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-stats
+    labels:
+      - sig/planner
+      - component/statistics

--- a/pkg/table/OWNERS
+++ b/pkg/table/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-table
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-table

--- a/pkg/tablecodec/OWNERS
+++ b/pkg/tablecodec/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-table
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-table

--- a/pkg/util/naming/OWNERS
+++ b/pkg/util/naming/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 options:
   no_parent_owners: true
-approvers:
-  - sig-approvers-ddl
+filters:
+  "(^|/)BUILD\\.bazel$":
+    approvers:
+      - sig-community-approvers
+  ".*":
+    approvers:
+      - sig-approvers-ddl


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70390

Problem Summary:

`make bazel_prepare` can update `BUILD.bazel` files in packages whose source code was not changed by a pull request. Since Prow uses the nearest matching `OWNERS` file, those generated updates can require unrelated package-specific approvals.

### What changed and how does it work?

Add an exact-basename `BUILD.bazel` filter to all 43 nested `OWNERS` files and assign `sig-community-approvers` to it. Prow unions approvers from matching filters, so package owners remain eligible while a general repository approver can approve generated Bazel files across packages.

For simple ownership configurations, move the existing approvers and labels unchanged under an `.*` filter. Existing options, special filters, labels, reviewers, and non-Bazel approval behavior are preserved.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual validation:

- Parsed every nested `OWNERS` file as YAML and compared its effective structure with the parent commit. The check verified that only the exact `BUILD.bazel` filter was added and all prior rules were preserved.
- Verified that the regular expression matches `BUILD.bazel` and nested `a/BUILD.bazel`, but not `NOTBUILD.bazel` or `BUILD.bazel.tmp`.
- Ran `git diff --check` and confirmed the change is limited to 43 nested `OWNERS` files.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules across multiple components to use path-specific approval requirements.
  * `BUILD.bazel` changes now require community approval.
  * Other files retain their existing component-specific approvers, labels, and ownership settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->