### PR TITLE
planner: fix nil pointer panic in join reorder with forced non-cartesian join(#69986)

### DIFF
--- a/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_in.json
@@ -302,7 +302,14 @@
       // RIGHT JOIN + INNER: similar non-inner edge handling.
       "SELECT * FROM t1 RIGHT JOIN t2 ON t1.a = t2.a JOIN t3 ON t2.a = t3.a ORDER BY t2.a",
       // 4-table LEFT + INNER + LEFT chain.
-      "SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a JOIN t3 ON t1.a = t3.a LEFT JOIN t4 ON t3.a = t4.a ORDER BY t1.a"
+      "SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a JOIN t3 ON t1.a = t3.a LEFT JOIN t4 ON t3.a = t4.a ORDER BY t1.a",
+
+      // =============================================
+      // Group 5: makeBushyTree dead end
+      // =============================================
+      // Fragments have no connecting edge and cartesian fallback is blocked:
+      // makeJoinWithDetector returns (nil, nil), makeBushyTree propagates nil instead of error.
+      "SELECT /*+ set_var(tidb_opt_cartesian_join_order_threshold=0) */ t1.a FROM (SELECT 1 AS a FROM t1, t2) v0, t2 LEFT JOIN t1 ON t2.a = t1.a"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_out.json
@@ -1605,6 +1605,28 @@
           "1 10 1 100 1 1000 1 10000",
           "3 30 <nil> <nil> 3 3000 <nil> <nil>"
         ]
+      },
+      {
+        "SQL": "SELECT /*+ set_var(tidb_opt_cartesian_join_order_threshold=0) */ t1.a FROM (SELECT 1 AS a FROM t1, t2) v0, t2 LEFT JOIN t1 ON t2.a = t1.a",
+        "Plan": [
+          "HashJoin root  CARTESIAN inner join",
+          "├─HashJoin(Build) root  left outer join, left side:TableReader, equal:[eq(test.t2.a, test.t1.a)]",
+          "│ ├─TableReader(Build) root  data:Selection",
+          "│ │ └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "│ │   └─TableFullScan cop[tikv] table:t1 keep order:false",
+          "│ └─TableReader(Probe) root  data:TableFullScan",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false",
+          "└─HashJoin(Probe) root  CARTESIAN inner join",
+          "  ├─TableReader(Build) root  data:TableFullScan",
+          "  │ └─TableFullScan cop[tikv] table:t2 keep order:false",
+          "  └─TableReader(Probe) root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false"
+        ],
+        "Result": [
+          "1", "1", "1", "1", "1", "1", "1", "1", "1",
+          "2", "2", "2", "2", "2", "2", "2", "2", "2",
+          "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>"
+        ]
       }
     ]
   }

--- a/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/cdc_join_reorder_suite_xut.json
@@ -1605,6 +1605,28 @@
           "1 10 1 100 1 1000 1 10000",
           "3 30 <nil> <nil> 3 3000 <nil> <nil>"
         ]
+      },
+      {
+        "SQL": "SELECT /*+ set_var(tidb_opt_cartesian_join_order_threshold=0) */ t1.a FROM (SELECT 1 AS a FROM t1, t2) v0, t2 LEFT JOIN t1 ON t2.a = t1.a",
+        "Plan": [
+          "HashJoin root  CARTESIAN inner join",
+          "├─HashJoin(Build) root  left outer join, left side:TableReader, equal:[eq(test.t2.a, test.t1.a)]",
+          "│ ├─TableReader(Build) root  data:Selection",
+          "│ │ └─Selection cop[tikv]  not(isnull(test.t1.a))",
+          "│ │   └─TableFullScan cop[tikv] table:t1 keep order:false",
+          "│ └─TableReader(Probe) root  data:TableFullScan",
+          "│   └─TableFullScan cop[tikv] table:t2 keep order:false",
+          "└─HashJoin(Probe) root  CARTESIAN inner join",
+          "  ├─TableReader(Build) root  data:TableFullScan",
+          "  │ └─TableFullScan cop[tikv] table:t2 keep order:false",
+          "  └─TableReader(Probe) root  data:TableFullScan",
+          "    └─TableFullScan cop[tikv] table:t1 keep order:false"
+        ],
+        "Result": [
+          "1", "1", "1", "1", "1", "1", "1", "1", "1",
+          "2", "2", "2", "2", "2", "2", "2", "2", "2",
+          "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>", "<nil>"
+        ]
       }
     ]
   }

--- a/pkg/planner/core/joinorder/BUILD.bazel
+++ b/pkg/planner/core/joinorder/BUILD.bazel
@@ -37,9 +37,10 @@ go_test(
     ],
     embed = [":joinorder"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 4,
     deps = [
         "//pkg/domain",
+        "//pkg/planner/core/base",
         "//pkg/planner/core/operator/logicalop",
         "//pkg/planner/util/coretestsdk",
         "//pkg/util/intset",

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -945,6 +945,9 @@ func makeJoinWithDetector(detector *ConflictDetector, left, right *Node, vertexH
 	if !checkResult.Connected() {
 		checkResult = detector.TryCreateCartesianCheckResult(left, right)
 		if checkResult == nil {
+			// Dead end: no edge connects these fragments and cartesian
+			// fallback is unavailable (see #69986 for the nil-deref panic
+			// this would cause if we returned an error instead).
 			return nil, nil
 		}
 	}
@@ -989,6 +992,9 @@ func makeBushyTree(ctx base.PlanContext, detector *ConflictDetector, cartesianNo
 				return nil, err
 			}
 			if newJoin == nil {
+				// Dead end: no real edge spans these fragments and cartesian
+				// fallback is unavailable. Propagate nil to let the caller
+				// fall through to the partial plan already built.
 				return nil, nil
 			}
 			iterNodes = append(iterNodes, newJoin)

--- a/pkg/planner/core/joinorder/join_order.go
+++ b/pkg/planner/core/joinorder/join_order.go
@@ -945,7 +945,7 @@ func makeJoinWithDetector(detector *ConflictDetector, left, right *Node, vertexH
 	if !checkResult.Connected() {
 		checkResult = detector.TryCreateCartesianCheckResult(left, right)
 		if checkResult == nil {
-			return nil, errors.New("failed to construct bushy tree: no valid join edge found")
+			return nil, nil
 		}
 	}
 
@@ -987,6 +987,9 @@ func makeBushyTree(ctx base.PlanContext, detector *ConflictDetector, cartesianNo
 			}
 			if err != nil {
 				return nil, err
+			}
+			if newJoin == nil {
+				return nil, nil
 			}
 			iterNodes = append(iterNodes, newJoin)
 		}

--- a/pkg/planner/core/joinorder/join_order_test.go
+++ b/pkg/planner/core/joinorder/join_order_test.go
@@ -18,8 +18,10 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,4 +84,74 @@ func TestCloneNodesForGreedyStartIsolation(t *testing.T) {
 	cloned[0].p = logicalop.LogicalTableDual{RowCount: 1}.Init(ctx, 0)
 	require.Nil(t, original[0].p)
 	require.NotNil(t, cloned[0].p)
+}
+
+// TestMakeJoinWithDetectorDeadEnd verifies that makeJoinWithDetector
+// returns (nil, nil) when two nodes have no connecting edge — neither
+// a real join edge nor a valid cartesian fallback.
+// Returning an error in this case would incorrectly abort the caller's
+// plan construction, discarding partial results already computed by the
+// earlier optimization phase.
+func TestMakeJoinWithDetectorDeadEnd(t *testing.T) {
+	detector := &ConflictDetector{
+		allInnerJoin:  false,
+		innerEdges:    []*edge{},
+		nonInnerEdges: []*edge{},
+	}
+
+	left := &Node{
+		bitSet:    intset.NewFastIntSet(0),
+		usedEdges: map[uint64]struct{}{},
+	}
+	right := &Node{
+		bitSet:    intset.NewFastIntSet(1),
+		usedEdges: map[uint64]struct{}{},
+	}
+
+	result, err := makeJoinWithDetector(detector, left, right, nil)
+	require.NoError(t, err,
+		"makeJoinWithDetector must not return an error when fragments can't connect")
+	require.Nil(t, result,
+		"makeJoinWithDetector must return nil result when no connecting edge exists and allInnerJoin=false")
+}
+
+// TestMakeBushyTreeDeadEnd verifies that makeBushyTree returns (nil, nil)
+// when forest fragments cannot be pairwise stitched — real edges do not span
+// the current subset S and cartesian fallback is disabled by allInnerJoin=false.
+func TestMakeBushyTreeDeadEnd(t *testing.T) {
+	ctx := coretestsdk.MockContext()
+	t.Cleanup(func() {
+		domain.GetDomain(ctx).StatsHandle().Close()
+	})
+
+	detector := &ConflictDetector{
+		allInnerJoin: false,
+		innerEdges: []*edge{
+			{tes: intset.NewFastIntSet(0, 1), idx: 0, joinType: base.InnerJoin, skipRules: true},
+			{
+				tes:           intset.NewFastIntSet(0, 1, 2, 3),
+				idx:           2,
+				joinType:      base.InnerJoin,
+				skipRules:     true,
+				leftVertexes:  intset.NewFastIntSet(0, 1),
+				rightVertexes: intset.NewFastIntSet(2, 3),
+			},
+		},
+		nonInnerEdges: []*edge{
+			{tes: intset.NewFastIntSet(2, 3), idx: 1, joinType: base.LeftOuterJoin, skipRules: true,
+				leftVertexes: intset.NewFastIntSet(2), rightVertexes: intset.NewFastIntSet(3)},
+		},
+	}
+
+	forest := []*Node{
+		{bitSet: intset.NewFastIntSet(2, 3), usedEdges: map[uint64]struct{}{1: {}}},
+		{bitSet: intset.NewFastIntSet(0), usedEdges: map[uint64]struct{}{}},
+		{bitSet: intset.NewFastIntSet(1), usedEdges: map[uint64]struct{}{}},
+	}
+
+	result, err := makeBushyTree(ctx, detector, forest, nil, false)
+	require.NoError(t, err,
+		"makeBushyTree must not return an error when forest fragments can't connect")
+	require.Nil(t, result,
+		"makeBushyTree must return nil when forest fragments have a dead end")
 }

--- a/pkg/planner/core/joinorder/join_order_test.go
+++ b/pkg/planner/core/joinorder/join_order_test.go
@@ -127,18 +127,18 @@ func TestMakeBushyTreeDeadEnd(t *testing.T) {
 	detector := &ConflictDetector{
 		allInnerJoin: false,
 		innerEdges: []*edge{
-			{tes: intset.NewFastIntSet(0, 1), idx: 0, joinType: base.InnerJoin, skipRules: true},
+			{tes: intset.NewFastIntSet(0, 1), idx: 0, joinType: base.InnerJoin, skipRules: false},
 			{
 				tes:           intset.NewFastIntSet(0, 1, 2, 3),
 				idx:           2,
 				joinType:      base.InnerJoin,
-				skipRules:     true,
+				skipRules:     false,
 				leftVertexes:  intset.NewFastIntSet(0, 1),
 				rightVertexes: intset.NewFastIntSet(2, 3),
 			},
 		},
 		nonInnerEdges: []*edge{
-			{tes: intset.NewFastIntSet(2, 3), idx: 1, joinType: base.LeftOuterJoin, skipRules: true,
+			{tes: intset.NewFastIntSet(2, 3), idx: 1, joinType: base.LeftOuterJoin, skipRules: false,
 				leftVertexes: intset.NewFastIntSet(2), rightVertexes: intset.NewFastIntSet(3)},
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69986 

Problem Summary:

When a derived table is cross-joined with a LEFT JOIN and
`tidb_opt_cartesian_join_order_threshold=0` blocks the cartesian
fallback, makeJoinWithDetector returned an error when two forest
fragments had no connecting edge. This error propagated through
makeBushyTree and ultimately caused a nil pointer dereference in
the optimizer.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning for complex joins involving disconnected fragments, Cartesian joins, and left joins.
  * Prevented invalid join plans when no valid join path is available.
  * Preserved expected null handling and query results in affected cases.

* **Tests**
  * Added regression coverage for join ordering, fallback behavior, null-preserving joins, and expected query results.
  * Expanded validation for complex multi-table and subquery join scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->