### PR TITLE
ddl: fix release-7.5 multi-schema add-index test hang

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -143,6 +143,12 @@ func NewAddIndexIngestPipeline(
 	}
 	readerCnt, writerCnt := expectedIngestWorkerCnt()
 
+	failpoint.Inject("mockDMLExecutionBeforeScan", func(_ failpoint.Value) {
+		if MockDMLExecutionBeforeScan != nil {
+			MockDMLExecutionBeforeScan()
+		}
+	})
+
 	srcOp := NewTableScanTaskSource(ctx, store, tbl, startKey, endKey)
 	scanOp := NewTableScanOperator(ctx, sessPool, copCtx, srcChkPool, readerCnt)
 	ingestOp := NewIndexIngestOperator(ctx, copCtx, backendCtx, sessPool, tbl, indexes, engines, srcChkPool, writerCnt, reorgMeta)

--- a/tests/realtikvtest/addindextest4/integration_test.go
+++ b/tests/realtikvtest/addindextest4/integration_test.go
@@ -15,7 +15,6 @@
 package addindextest_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -55,33 +54,31 @@ func TestMultiSchemaChangeTwoIndexes(t *testing.T) {
 		tk1 := testkit.NewTestKit(t, store)
 		tk1.MustExec("use test;")
 
-		var hexKey string
 		ddl.MockDMLExecutionBeforeScan = func() {
-			rows := tk1.MustQuery("select tidb_encode_index_key('test', 't', 'b', 1, null);").Rows()
-			hexKey = rows[0][0].(string)
 			_, err := tk1.Exec("delete from t where id = 1;")
 			assert.NoError(t, err)
 			_, err = tk1.Exec("insert into t values (2,1,1);")
 			assert.NoError(t, err)
-			rs := tk.MustQuery(fmt.Sprintf("select tidb_mvcc_info('%s')", hexKey)).Rows()
-			t.Log("after first insertion", rs[0][0].(string))
 			_, err = tk1.Exec("delete from t where id = 2;")
 			assert.NoError(t, err)
-			rs = tk.MustQuery(fmt.Sprintf("select tidb_mvcc_info('%s')", hexKey)).Rows()
-			t.Log("after second insertion", rs[0][0].(string))
 		}
 		err := failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionBeforeScan", "1*return")
 		require.NoError(t, err)
 		ddl.MockDMLExecutionStateBeforeMerge = func() {
 			_, err := tk1.Exec("insert into t values (3, 1, 1);")
 			assert.NoError(t, err)
-			rs := tk.MustQuery(fmt.Sprintf("select tidb_mvcc_info('%s')", hexKey)).Rows()
-			t.Log("after third insertion", rs[0][0].(string))
 		}
 		err = failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionStateBeforeMerge", "1*return")
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionBeforeScan"))
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionStateBeforeMerge"))
+			ddl.MockDMLExecutionBeforeScan = nil
+			ddl.MockDMLExecutionStateBeforeMerge = nil
+		})
 
 		tk.MustExec(createIndexes[i])
 		tk.MustExec("admin check table t;")
+		tk.MustQuery("select * from t").Check(testkit.Rows("3 1 1"))
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70394

Problem Summary:

The release-7.5 backport of #61250 omitted the distributed-ingest before-scan test hook, while the backported real-TiKV test also uses diagnostic SQL functions that do not exist on release-7.5. As a result, `TestMultiSchemaChangeTwoIndexes` does not execute its intended DML before the scan and hangs in write reorganization after the stale merge hook fails from a background goroutine.

### What is changed and how it works?

- Invoke the existing `mockDMLExecutionBeforeScan` test hook at the distributed local-ingest scan boundary.
- Remove the release-7.5-unavailable diagnostic SQL calls from the real-TiKV test.
- Clean up the failpoints and callbacks after the test, and verify the final table contents.

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

The focused reproducer and the complete package both run against a fresh local TiUP Playground with 3 PD and 3 TiKV instances on v7.5.7:

```text
bazel test --config=ci --define gotags=deadlock,intest \
  //tests/realtikvtest/addindextest4:addindextest4_test \
  --test_output=errors --nocache_test_results \
  --flaky_test_attempts=1 --test_timeout=300 \
  --test_arg=-with-real-tikv \
  '--test_arg=-test.run=^TestMultiSchemaChangeTwoIndexes$' \
  --test_arg=-test.v --test_arg=-test.timeout=4m

# PASS: TestMultiSchemaChangeTwoIndexes (16.2s)

bazel test --config=ci --define gotags=deadlock,intest \
  //tests/realtikvtest/addindextest4:addindextest4_test \
  --test_output=errors --nocache_test_results \
  --flaky_test_attempts=1 --test_timeout=900 \
  --test_arg=-with-real-tikv --test_arg=-test.v \
  --test_arg=-test.timeout=12m

# PASS: 23 passing, 0 failing (118.0s)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved add-index integration test coverage and reliability.
  * Preserved validation of DML operations, index creation, table contents, and final row results.
* **Bug Fixes**
  * Added support for triggering a controlled test failpoint before table scanning during add-index operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->