### PR TITLE
collate, expression: support latin1_swedish_ci

### DIFF
--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -1492,6 +1492,20 @@ func (b *builtinSubstringIndexSig) evalString(ctx EvalContext, row chunk.Row) (d
 	return strings.Join(substrs, delim), false, nil
 }
 
+// hasByteOrientedOffsets reports whether a byte offset into a string of this charset
+// is already a character offset, which holds for every single-byte charset.
+//
+// LOCATE and INSTR report character positions, so single-byte charsets must use the
+// byte-oriented signatures rather than the UTF-8 ones. Running latin1 data through
+// the UTF-8 signatures both miscounts positions, whenever the bytes happen to form a
+// valid UTF-8 sequence, and corrupts the data outright: the []rune round trip they
+// use to slice at a start position rewrites every byte that is not valid UTF-8 to
+// U+FFFD.
+func hasByteOrientedOffsets(cs string) bool {
+	info, ok := charset.CharacterSetInfos[cs]
+	return ok && info.Maxlen == 1
+}
+
 type locateFunctionClass struct {
 	baseFunctionClass
 }
@@ -1510,7 +1524,7 @@ func (c *locateFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	var sig builtinFunc
 	// Locate is multibyte safe.
-	useBinary := bf.collation == charset.CollationBin
+	useBinary := bf.collation == charset.CollationBin || hasByteOrientedOffsets(bf.charset)
 	switch {
 	case hasStartPos && useBinary:
 		sig = &builtinLocate3ArgsSig{bf}
@@ -1542,7 +1556,9 @@ func (b *builtinLocate2ArgsSig) Clone() builtinFunc {
 	return newSig
 }
 
-// evalInt evals LOCATE(substr,str), case-sensitive.
+// evalInt evals LOCATE(substr,str) over a charset whose byte offsets are character
+// offsets. Case-sensitive unless the collation is a case-insensitive single-byte one,
+// in which case both sides are folded first; see collate.FoldCase.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate2ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(ctx, row)
@@ -1552,6 +1568,10 @@ func (b *builtinLocate2ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
+	}
+	if collate.IsCICollation(b.collation) {
+		subStr = collate.FoldCase(b.collation, subStr)
+		str = collate.FoldCase(b.collation, str)
 	}
 	subStrLen := len(subStr)
 	if subStrLen == 0 {
@@ -1610,7 +1630,9 @@ func (b *builtinLocate3ArgsSig) Clone() builtinFunc {
 	return newSig
 }
 
-// evalInt evals LOCATE(substr,str,pos), case-sensitive.
+// evalInt evals LOCATE(substr,str,pos) over a charset whose byte offsets are
+// character offsets. Case-sensitive unless the collation is a case-insensitive
+// single-byte one, in which case both sides are folded first; see collate.FoldCase.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(ctx, row)
@@ -1620,6 +1642,10 @@ func (b *builtinLocate3ArgsSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 	str, isNull, err := b.args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
+	}
+	if collate.IsCICollation(b.collation) {
+		subStr = collate.FoldCase(b.collation, subStr)
+		str = collate.FoldCase(b.collation, str)
 	}
 	pos, isNull, err := b.args[2].EvalInt(ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
@@ -4054,7 +4080,7 @@ func (c *instrFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 		return nil, err
 	}
 	bf.tp.SetFlen(11)
-	if bf.collation == charset.CollationBin {
+	if bf.collation == charset.CollationBin || hasByteOrientedOffsets(bf.charset) {
 		sig := &builtinInstrSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Instr)
 		return sig, nil
@@ -4126,6 +4152,11 @@ func (b *builtinInstrSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, 
 	substr, IsNull, err := b.args[1].EvalString(ctx, row)
 	if IsNull || err != nil {
 		return 0, true, err
+	}
+
+	if collate.IsCICollation(b.collation) {
+		str = collate.FoldCase(b.collation, str)
+		substr = collate.FoldCase(b.collation, substr)
 	}
 
 	idx := strings.Index(str, substr)

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
@@ -1100,6 +1101,69 @@ func TestLocate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, f)
 		require.Equalf(t, c["Want"][0], got, "[%d]: args: %v", i, c["Args"])
+	}
+}
+
+// TestLocateAndInstrLatin1 pins the character positions LOCATE and INSTR report for
+// latin1, which is byte oriented: one byte is one character, whether or not the bytes
+// happen to form a valid UTF-8 sequence.
+//
+// The test data spells the interesting characters as raw cp1252 bytes rather than as
+// Go source literals, which the compiler would encode as UTF-8. "\xC3\xA9" is two
+// latin1 characters (Ã ©), and is the case that used to be miscounted as one.
+func TestLocateAndInstrLatin1(t *testing.T) {
+	// New collation is enabled for the whole package by collate's init, and toggling
+	// it here would leak the disabled state into every test that runs afterwards.
+	require.True(t, collate.NewCollationEnabled())
+	ctx := createContext(t)
+
+	const ci = "latin1_swedish_ci"
+	tbl := []struct {
+		fn        string
+		collation string
+		args      []any
+		want      int64
+	}{
+		// A latin1 byte that is not valid UTF-8 counts as one character, and so does
+		// each byte of a sequence that happens to be valid UTF-8.
+		{ast.Locate, charset.CollationLatin1, []any{"x", "\xC4x"}, 2},
+		{ast.Locate, charset.CollationLatin1, []any{"x", "\xC3\xA9x"}, 3},
+		{ast.Locate, ci, []any{"X", "\xC3\xA9x"}, 3},
+		// latin1_bin is case- and accent-sensitive, latin1_swedish_ci folds both.
+		{ast.Locate, charset.CollationLatin1, []any{"\xE4", "a\xC4b"}, 0},
+		{ast.Locate, ci, []any{"\xE4", "a\xC4b"}, 2},
+		{ast.Locate, charset.CollationLatin1, []any{"A", "abc"}, 0},
+		{ast.Locate, ci, []any{"A", "abc"}, 1},
+		// Distinct latin1 characters must stay distinct. Folding with strings.ToLower
+		// would map every byte >= 0x80 to U+FFFD and match these against each other:
+		// Ä (0xC4) weighs 0x5C and Ö (0xD6) weighs 0x5D.
+		{ast.Locate, ci, []any{"\xC4", "\xD6x"}, 0},
+		{ast.Locate, ci, []any{"\xD6", "\xC4x"}, 0},
+		// Three-argument LOCATE starts at a character position.
+		{ast.Locate, ci, []any{"\xE4", "a\xC4b\xC4", 3}, 4},
+		{ast.Locate, ci, []any{"x", "\xC3\xA9x", 3}, 3},
+		{ast.Instr, charset.CollationLatin1, []any{"\xC3\xA9x", "x"}, 3},
+		{ast.Instr, charset.CollationLatin1, []any{"a\xC4b", "\xE4"}, 0},
+		{ast.Instr, ci, []any{"a\xC4b", "\xE4"}, 2},
+		{ast.Instr, ci, []any{"\xD6x", "\xC4"}, 0},
+	}
+
+	for i, c := range tbl {
+		args := types.MakeDatums(c.args...)
+		exprs := datumsToConstants(args)
+		for _, e := range exprs {
+			if e.GetType(ctx).EvalType() != types.ETString {
+				continue
+			}
+			e.GetType(ctx).SetCharset(charset.CharsetLatin1)
+			e.GetType(ctx).SetCollate(c.collation)
+		}
+		f, err := funcs[c.fn].getFunction(ctx, exprs)
+		require.NoErrorf(t, err, "[%d]", i)
+		got, err := evalBuiltinFunc(f, ctx, chunk.Row{})
+		require.NoErrorf(t, err, "[%d]", i)
+		require.Equalf(t, c.want, got.GetInt64(),
+			"[%d]: %s(%q) under %s", i, c.fn, c.args, c.collation)
 	}
 }
 

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -1324,16 +1324,22 @@ func (b *builtinLocate2ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf0, buf1)
 	i64s := result.Int64s()
+	ci := collate.IsCICollation(b.collation)
 	for i := range n {
 		if result.IsNull(i) {
 			continue
 		}
 		subStr := buf0.GetString(i)
+		str := buf1.GetString(i)
+		if ci {
+			subStr = collate.FoldCase(b.collation, subStr)
+			str = collate.FoldCase(b.collation, str)
+		}
 		if len(subStr) == 0 {
 			i64s[i] = 1
 			continue
 		}
-		i64s[i] = int64(strings.Index(buf1.GetString(i), subStr) + 1)
+		i64s[i] = int64(strings.Index(str, subStr) + 1)
 	}
 	return nil
 }
@@ -1369,6 +1375,7 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 
 	result.MergeNulls(buf0, buf1)
 	i64s := result.Int64s()
+	ci := collate.IsCICollation(b.collation)
 	for i := range n {
 		if result.IsNull(i) {
 			continue
@@ -1378,6 +1385,10 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		pos--
 		subStr := buf0.GetString(i)
 		str := buf1.GetString(i)
+		if ci {
+			subStr = collate.FoldCase(b.collation, subStr)
+			str = collate.FoldCase(b.collation, str)
+		}
 		subStrLen := len(subStr)
 		if pos < 0 || pos > int64(len(str)-subStrLen) {
 			i64s[i] = 0
@@ -2208,12 +2219,17 @@ func (b *builtinInstrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	result.ResizeInt64(n, false)
 	result.MergeNulls(str, substr)
 	res := result.Int64s()
+	ci := collate.IsCICollation(b.collation)
 	for i := range n {
 		if result.IsNull(i) {
 			continue
 		}
 		strI := str.GetString(i)
 		substrI := substr.GetString(i)
+		if ci {
+			strI = collate.FoldCase(b.collation, strI)
+			substrI = collate.FoldCase(b.collation, substrI)
+		}
 		idx := strings.Index(strI, substrI)
 		res[i] = int64(idx + 1)
 	}

--- a/pkg/expression/builtin_string_vec_test.go
+++ b/pkg/expression/builtin_string_vec_test.go
@@ -163,8 +163,38 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 			retEvalType:   types.ETInt,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
 			childrenFieldTypes: []*types.FieldType{nil,
-				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetFlag(mysql.BinaryFlag).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP()},
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetFlag(mysql.BinaryFlag).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).BuildP(),
+			},
 			geners: []dataGenerator{newRandLenStrGener(0, 10), newRandLenStrGener(0, 20)},
+		},
+		// latin1 is byte oriented, so LOCATE takes the byte-oriented signatures. The
+		// generated data spells the interesting characters as raw cp1252 bytes, which
+		// are not valid UTF-8, to keep the two evaluation paths honest about offsets.
+		{
+			retEvalType:   types.ETInt,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString},
+			childrenFieldTypes: []*types.FieldType{
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate(charset.CollationLatin1).BuildP(),
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate(charset.CollationLatin1).BuildP(),
+			},
+			geners: []dataGenerator{
+				newSelectStringGener([]string{"a", "A", "\xC4", "\xE4", "\xC3\xA9"}),
+				newSelectStringGener([]string{"a\xC4b", "A\xE4B", "\xC3\xA9x", "abc"}),
+			},
+		},
+		{
+			retEvalType:   types.ETInt,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETInt},
+			childrenFieldTypes: []*types.FieldType{
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate("latin1_swedish_ci").BuildP(),
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate("latin1_swedish_ci").BuildP(),
+				nil,
+			},
+			geners: []dataGenerator{
+				newSelectStringGener([]string{"a", "A", "\xC4", "\xE4", "\xC3\xA9"}),
+				newSelectStringGener([]string{"a\xC4b", "A\xE4B", "\xC3\xA9x", "abc"}),
+				newRangeInt64Gener(-2, 6),
+			},
 		},
 		{
 			retEvalType:   types.ETInt,
@@ -467,6 +497,17 @@ var vecBuiltinStringCases2 = map[string][]vecExprBenchCase{
 	},
 	ast.Instr: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+		// See the latin1 note on ast.Locate above.
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString},
+			childrenFieldTypes: []*types.FieldType{
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate("latin1_swedish_ci").BuildP(),
+				types.NewFieldTypeBuilder().SetType(mysql.TypeString).SetCharset(charset.CharsetLatin1).SetCollate("latin1_swedish_ci").BuildP(),
+			},
+			geners: []dataGenerator{
+				newSelectStringGener([]string{"a\xC4b", "A\xE4B", "\xC3\xA9x", "abc"}),
+				newSelectStringGener([]string{"a", "A", "\xC4", "\xE4", "\xC3\xA9"}),
+			},
+		},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"test,case"}, &constStrGener{"case"}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"test,case"}, &constStrGener{"testcase"}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString},

--- a/pkg/expression/collation_test.go
+++ b/pkg/expression/collation_test.go
@@ -177,6 +177,85 @@ func TestInferCollation(t *testing.T) {
 			false,
 			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetBin, charset.CollationBin},
 		},
+		// latin1_bin mixed with latin1_swedish_ci. At equal coercibility the _bin
+		// collation wins regardless of argument order, so latin1_swedish_ci must be
+		// recognized as the non-bin side (see isBinCollation).
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1},
+		},
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1},
+		},
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"},
+		},
+		// An explicit COLLATE still beats the _bin collation, either way round.
+		{
+			[]Expression{
+				newExpression(CoercibilityExplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
+			},
+			false,
+			&ExprCollation{CoercibilityExplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"},
+		},
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
+				newExpression(CoercibilityExplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+			},
+			false,
+			&ExprCollation{CoercibilityExplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"},
+		},
+		// Two conflicting explicit collations cannot be aggregated.
+		{
+			[]Expression{
+				newExpression(CoercibilityExplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
+				newExpression(CoercibilityExplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+			},
+			true,
+			nil,
+		},
+		// latin1 is not a Unicode charset, so utf8mb4 wins at equal coercibility.
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB4),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB4},
+		},
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB4),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetUTF8MB4, charset.CollationUTF8MB4},
+		},
+		// binary takes precedence over latin1_swedish_ci at equal coercibility.
+		{
+			[]Expression{
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, "latin1_swedish_ci"),
+				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetBin, charset.CollationBin),
+			},
+			false,
+			&ExprCollation{CoercibilityImplicit, UNICODE, charset.CharsetBin, charset.CollationBin},
+		},
 		// binary charset with non-binary charset.
 		{
 			[]Expression{
@@ -829,6 +908,23 @@ func TestCompareString(t *testing.T) {
 	require.Equal(t, 0, types.CompareString("ß", "ss", "utf8mb4_0900_ai_ci"))
 	require.NotEqual(t, 0, types.CompareString("\U000FFFFE", "\U000FFFFF", "utf8mb4_0900_ai_ci"))
 	require.Equal(t, 0, types.CompareString("æ", "ae", "utf8mb4_0900_ai_ci"))
+
+	// latin1 collations are byte-oriented, so the arguments are spelled as cp1252
+	// bytes rather than as Go literals, which the compiler would encode as UTF-8.
+	require.Equal(t, 0, types.CompareString("a", "A", "latin1_swedish_ci"))
+	require.Equal(t, 0, types.CompareString("\xE9", "E", "latin1_swedish_ci"))
+	require.Equal(t, 0, types.CompareString("a ", "a  ", "latin1_swedish_ci"))
+	require.Equal(t, 0, types.CompareString("\xDC", "Y", "latin1_swedish_ci"))
+	// Å, Ä and Ö sort after Z rather than folding onto A and O.
+	require.NotEqual(t, 0, types.CompareString("\xC5", "A", "latin1_swedish_ci"))
+	require.NotEqual(t, 0, types.CompareString("\xD6", "O", "latin1_swedish_ci"))
+	require.Equal(t, 1, types.CompareString("\xC5", "Z", "latin1_swedish_ci"))
+	// ß folds to nothing here, unlike in the utf8 collations above.
+	require.NotEqual(t, 0, types.CompareString("\xDF", "s", "latin1_swedish_ci"))
+	require.NotEqual(t, 0, types.CompareString("\xDF", "ss", "latin1_swedish_ci"))
+
+	require.NotEqual(t, 0, types.CompareString("a", "A", "latin1_bin"))
+	require.Equal(t, 0, types.CompareString("a ", "a  ", "latin1_bin"))
 
 	require.NotEqual(t, 0, types.CompareString("a", "A", "binary"))
 	require.NotEqual(t, 0, types.CompareString("À", "A", "binary"))

--- a/pkg/expression/collation_test.go
+++ b/pkg/expression/collation_test.go
@@ -179,7 +179,9 @@ func TestInferCollation(t *testing.T) {
 		},
 		// latin1_bin mixed with latin1_swedish_ci. At equal coercibility the _bin
 		// collation wins regardless of argument order, so latin1_swedish_ci must be
-		// recognized as the non-bin side (see isBinCollation).
+		// recognized as the non-bin side (see isBinCollation). The collation is not
+		// registered yet and so cannot reach these paths from SQL; these cases pin the
+		// classification so it is not changed by accident before it can be.
 		{
 			[]Expression{
 				newExpression(CoercibilityImplicit, UNICODE, charset.CharsetLatin1, charset.CollationLatin1),
@@ -911,19 +913,11 @@ func TestCompareString(t *testing.T) {
 
 	// latin1 collations are byte-oriented, so the arguments are spelled as cp1252
 	// bytes rather than as Go literals, which the compiler would encode as UTF-8.
-	require.Equal(t, 0, types.CompareString("a", "A", "latin1_swedish_ci"))
-	require.Equal(t, 0, types.CompareString("\xE9", "E", "latin1_swedish_ci"))
-	require.Equal(t, 0, types.CompareString("a ", "a  ", "latin1_swedish_ci"))
-	require.Equal(t, 0, types.CompareString("\xDC", "Y", "latin1_swedish_ci"))
-	// Å, Ä and Ö sort after Z rather than folding onto A and O.
-	require.NotEqual(t, 0, types.CompareString("\xC5", "A", "latin1_swedish_ci"))
-	require.NotEqual(t, 0, types.CompareString("\xD6", "O", "latin1_swedish_ci"))
-	require.Equal(t, 1, types.CompareString("\xC5", "Z", "latin1_swedish_ci"))
-	// ß folds to nothing here, unlike in the utf8 collations above.
-	require.NotEqual(t, 0, types.CompareString("\xDF", "s", "latin1_swedish_ci"))
-	require.NotEqual(t, 0, types.CompareString("\xDF", "ss", "latin1_swedish_ci"))
-
+	// latin1_swedish_ci is not covered here because it is not registered yet, so
+	// CompareString would silently fall back to another collator; its semantics are
+	// tested directly in pkg/util/collate.
 	require.NotEqual(t, 0, types.CompareString("a", "A", "latin1_bin"))
+	require.NotEqual(t, 0, types.CompareString("\xE9", "E", "latin1_bin"))
 	require.Equal(t, 0, types.CompareString("a ", "a  ", "latin1_bin"))
 
 	require.NotEqual(t, 0, types.CompareString("a", "A", "binary"))

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -96,8 +96,19 @@ func (pc PbConverter) ExprToPB(expr Expression) *tipb.Expr {
 	return nil
 }
 
+// collationBlocksPushDown reports whether ft is collated with something the storage
+// layer cannot evaluate, so the expression has to be computed in TiDB. See
+// collate.SupportedByStorage for why this must be checked here rather than left to
+// the storage layer to reject.
+func collationBlocksPushDown(ft *types.FieldType) bool {
+	return !collate.SupportedByStorage(ft.GetCollate())
+}
+
 func (pc PbConverter) conOrCorColToPBExpr(expr Expression) *tipb.Expr {
 	ft := expr.GetType(pc.ctx)
+	if collationBlocksPushDown(ft) {
+		return nil
+	}
 	d, err := expr.Eval(pc.ctx, chunk.Row{})
 	if err != nil {
 		logutil.BgLogger().Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo(pc.ctx)), zap.Error(err))
@@ -227,6 +238,12 @@ func (pc PbConverter) columnToPBExpr(column *Column, checkType bool) *tipb.Expr 
 	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tipb.ExprType_ColumnRef)) {
 		return nil
 	}
+	// Checked regardless of checkType: a projection pushes bare columns down without
+	// type checks, and the storage layer would still read the collation off the field
+	// type it is handed.
+	if collationBlocksPushDown(column.GetType(pc.ctx)) {
+		return nil
+	}
 	if checkType {
 		switch column.GetType(pc.ctx).GetType() {
 		case mysql.TypeBit:
@@ -261,6 +278,12 @@ func (pc PbConverter) columnToPBExpr(column *Column, checkType bool) *tipb.Expr 
 }
 
 func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
+	// The arguments are checked by the recursive ExprToPB calls below, but a function
+	// can be collated with something its arguments are not, for example an explicit
+	// COLLATE on a cast.
+	if collationBlocksPushDown(expr.RetType) {
+		return nil
+	}
 	// Check whether this function has ProtoBuf signature.
 	pbCode := expr.Function.PbCode()
 	if pbCode <= tipb.ScalarFuncSig_Unspecified {

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1996,6 +1996,39 @@ func TestPushCollationDown(t *testing.T) {
 	}
 }
 
+// TestPushDownBlockedForCollationsMissingFromStorage pins that expressions collated
+// with latin1_swedish_ci stay in TiDB. TiKV and TiFlash have no collator for it, and
+// CollationToProto would quietly relabel it as the default collation rather than
+// refuse, so the storage layer would evaluate the expression under the wrong rules.
+func TestPushDownBlockedForCollationsMissingFromStorage(t *testing.T) {
+	ctx := mock.NewContext()
+	client := new(mock.Client)
+	pushDownCtx := NewPushDownContextFromSessionVars(ctx, ctx.GetSessionVars(), client)
+
+	for _, storeType := range []kv.StoreType{kv.UnSpecified, kv.TiKV, kv.TiFlash} {
+		// A bare column reference.
+		blocked := columnCollation(genColumn(mysql.TypeVarchar, 1), charset.CharsetLatin1, "latin1_swedish_ci")
+		pushed, remained := PushDownExprs(pushDownCtx, []Expression{blocked}, storeType)
+		require.Emptyf(t, pushed, "store %v", storeType)
+		require.Lenf(t, remained, 1, "store %v", storeType)
+
+		// A function over such a column, blocked through its argument.
+		eq, err := NewFunction(ctx, ast.EQ, types.NewFieldType(mysql.TypeUnspecified),
+			columnCollation(genColumn(mysql.TypeVarchar, 1), charset.CharsetLatin1, "latin1_swedish_ci"),
+			columnCollation(genColumn(mysql.TypeVarchar, 2), charset.CharsetLatin1, "latin1_swedish_ci"))
+		require.NoError(t, err)
+		pushed, remained = PushDownExprs(pushDownCtx, []Expression{eq}, storeType)
+		require.Emptyf(t, pushed, "store %v", storeType)
+		require.Lenf(t, remained, 1, "store %v", storeType)
+
+		// latin1_bin is understood by the storage layer and must still be pushed.
+		allowed := columnCollation(genColumn(mysql.TypeVarchar, 1), charset.CharsetLatin1, charset.CollationLatin1)
+		pushed, remained = PushDownExprs(pushDownCtx, []Expression{allowed}, storeType)
+		require.Lenf(t, pushed, 1, "store %v", storeType)
+		require.Emptyf(t, remained, "store %v", storeType)
+	}
+}
+
 func columnCollation(c *Column, chs, coll string) *Column {
 	c.RetType.SetCharset(chs)
 	c.RetType.SetCollate(coll)

--- a/pkg/util/collate/BUILD.bazel
+++ b/pkg/util/collate/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "gbk_chinese_ci.go",
         "gbk_chinese_ci_data.go",
         "general_ci.go",
+        "latin1_swedish_ci.go",
         "pinyin_tidb_as_cs.go",
         "unicode_0400_ci_generated.go",
         "unicode_0400_ci_impl.go",

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -251,7 +251,9 @@ func GetSupportedCollations() []*charset.Collation {
 		newSupportedCollations := make([]*charset.Collation, 0, len(newCollatorMap))
 		for name := range newCollatorMap {
 			// utf8mb4_zh_pinyin_tidb_as_cs is under developing, should not be shown to user.
-			if name == "utf8mb4_zh_pinyin_tidb_as_cs" {
+			// latin1_swedish_ci is under developing too: its sort key has no counterpart in
+			// TiKV/TiFlash yet, so pushed-down comparisons cannot reproduce it.
+			if name == "utf8mb4_zh_pinyin_tidb_as_cs" || name == "latin1_swedish_ci" {
 				continue
 			}
 			if coll, err := charset.GetCollationByName(name); err != nil {
@@ -311,7 +313,8 @@ func IsDefaultCollationForUTF8MB4(collate string) bool {
 func IsCICollation(collate string) bool {
 	return collate == "utf8_general_ci" || collate == "utf8mb4_general_ci" ||
 		collate == "utf8_unicode_ci" || collate == "utf8mb4_unicode_ci" || collate == "gbk_chinese_ci" ||
-		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci"
+		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci" ||
+		collate == "latin1_swedish_ci"
 }
 
 // ConvertAndGetBinCollation converts collation to binary collation
@@ -331,6 +334,8 @@ func ConvertAndGetBinCollation(collate string) string {
 		return "gbk_bin"
 	case "gb18030_chinese_ci":
 		return "gb18030_bin"
+	case "latin1_swedish_ci":
+		return "latin1_bin"
 	}
 
 	return collate
@@ -449,6 +454,8 @@ func init() {
 	newCollatorIDMap[CollationName2ID("ascii_bin")] = &binPaddingCollator{}
 	newCollatorMap["latin1_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("latin1_bin")] = &binPaddingCollator{}
+	newCollatorMap["latin1_swedish_ci"] = &latin1SwedishCICollator{}
+	newCollatorIDMap[CollationName2ID("latin1_swedish_ci")] = &latin1SwedishCICollator{}
 	newCollatorMap["utf8mb4_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("utf8mb4_bin")] = &binPaddingCollator{}
 	newCollatorMap["utf8_bin"] = &binPaddingCollator{}

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -251,9 +251,7 @@ func GetSupportedCollations() []*charset.Collation {
 		newSupportedCollations := make([]*charset.Collation, 0, len(newCollatorMap))
 		for name := range newCollatorMap {
 			// utf8mb4_zh_pinyin_tidb_as_cs is under developing, should not be shown to user.
-			// latin1_swedish_ci is under developing too: its sort key has no counterpart in
-			// TiKV/TiFlash yet, so pushed-down comparisons cannot reproduce it.
-			if name == "utf8mb4_zh_pinyin_tidb_as_cs" || name == "latin1_swedish_ci" {
+			if name == "utf8mb4_zh_pinyin_tidb_as_cs" {
 				continue
 			}
 			if coll, err := charset.GetCollationByName(name); err != nil {
@@ -313,8 +311,7 @@ func IsDefaultCollationForUTF8MB4(collate string) bool {
 func IsCICollation(collate string) bool {
 	return collate == "utf8_general_ci" || collate == "utf8mb4_general_ci" ||
 		collate == "utf8_unicode_ci" || collate == "utf8mb4_unicode_ci" || collate == "gbk_chinese_ci" ||
-		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci" ||
-		collate == "latin1_swedish_ci"
+		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci"
 }
 
 // ConvertAndGetBinCollation converts collation to binary collation
@@ -334,8 +331,6 @@ func ConvertAndGetBinCollation(collate string) string {
 		return "gbk_bin"
 	case "gb18030_chinese_ci":
 		return "gb18030_bin"
-	case "latin1_swedish_ci":
-		return "latin1_bin"
 	}
 
 	return collate
@@ -454,8 +449,6 @@ func init() {
 	newCollatorIDMap[CollationName2ID("ascii_bin")] = &binPaddingCollator{}
 	newCollatorMap["latin1_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("latin1_bin")] = &binPaddingCollator{}
-	newCollatorMap["latin1_swedish_ci"] = &latin1SwedishCICollator{}
-	newCollatorIDMap[CollationName2ID("latin1_swedish_ci")] = &latin1SwedishCICollator{}
 	newCollatorMap["utf8mb4_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("utf8mb4_bin")] = &binPaddingCollator{}
 	newCollatorMap["utf8_bin"] = &binPaddingCollator{}

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"unicode/utf8"
 
@@ -311,7 +312,49 @@ func IsDefaultCollationForUTF8MB4(collate string) bool {
 func IsCICollation(collate string) bool {
 	return collate == "utf8_general_ci" || collate == "utf8mb4_general_ci" ||
 		collate == "utf8_unicode_ci" || collate == "utf8mb4_unicode_ci" || collate == "gbk_chinese_ci" ||
-		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci"
+		collate == "utf8mb4_0900_ai_ci" || collate == "gb18030_chinese_ci" ||
+		collate == "latin1_swedish_ci"
+}
+
+// isByteOrientedCollation returns whether the collation weighs its input byte by
+// byte rather than rune by rune, so UTF-8 based helpers must not be applied to it.
+func isByteOrientedCollation(collate string) bool {
+	return collate == "latin1_swedish_ci"
+}
+
+// SupportedByStorage returns whether TiKV and TiFlash have a collator for the
+// collation, which decides whether expressions over it may be pushed down.
+//
+// TiDB can register a collation before the storage layer implements it. Pushing such
+// an expression down would silently produce wrong results rather than an error,
+// because CollationToProto does not reject a collation the storage layer is missing:
+// it falls back to the default collation ID and only logs a warning. Callers must
+// therefore keep these expressions in TiDB themselves.
+//
+// Index range scans are unaffected. TiDB computes the range bounds with its own
+// collator and the storage layer only scans the resulting raw byte range.
+func SupportedByStorage(coll string) bool {
+	// latin1_swedish_ci is evaluated by TiDB only. Remove it from here once TiKV and
+	// TiFlash ship a matching collator.
+	return coll != "latin1_swedish_ci"
+}
+
+// FoldCase returns str with the case differences of a case-insensitive collation
+// removed, so that callers can fall back to byte-wise search on the result. It is
+// only meaningful when IsCICollation reports true for coll.
+//
+// The fold preserves byte offsets, which callers such as LOCATE and INSTR rely on to
+// convert a byte index back into a character position. That is why byte-oriented
+// collations cannot use strings.ToLower: it assumes UTF-8, so every latin1 byte
+// >= 0x80 decodes to U+FFFD and distinct characters would compare equal, and the
+// 1 -> 3 byte inflation would silently shift every position it reports. Those
+// collations fold through the collation weight table instead, which maps one byte to
+// exactly one byte.
+func FoldCase(coll, str string) string {
+	if isByteOrientedCollation(coll) {
+		return string(GetCollator(coll).KeyWithoutTrimRightSpace(str))
+	}
+	return strings.ToLower(str)
 }
 
 // ConvertAndGetBinCollation converts collation to binary collation
@@ -331,6 +374,8 @@ func ConvertAndGetBinCollation(collate string) string {
 		return "gbk_bin"
 	case "gb18030_chinese_ci":
 		return "gb18030_bin"
+	case "latin1_swedish_ci":
+		return "latin1_bin"
 	}
 
 	return collate
@@ -449,6 +494,8 @@ func init() {
 	newCollatorIDMap[CollationName2ID("ascii_bin")] = &binPaddingCollator{}
 	newCollatorMap["latin1_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("latin1_bin")] = &binPaddingCollator{}
+	newCollatorMap["latin1_swedish_ci"] = &latin1SwedishCICollator{}
+	newCollatorIDMap[CollationName2ID("latin1_swedish_ci")] = &latin1SwedishCICollator{}
 	newCollatorMap["utf8mb4_bin"] = &binPaddingCollator{}
 	newCollatorIDMap[CollationName2ID("utf8mb4_bin")] = &binPaddingCollator{}
 	newCollatorMap["utf8_bin"] = &binPaddingCollator{}

--- a/pkg/util/collate/collate_test.go
+++ b/pkg/util/collate/collate_test.go
@@ -145,11 +145,10 @@ func TestUTF8CollatorKey(t *testing.T) {
 	testKeyTable(t, collations, tests)
 }
 
-// latin1_swedish_ci is deliberately not registered in newCollatorMap yet, so the
-// latin1 tests below construct it directly instead of going through GetCollator.
-// See the doc comment on latin1SwedishCICollator.
+// Both latin1 collators are resolved through GetCollator, so these tests also cover
+// the registration in newCollatorMap.
 func latin1TestCollators() (collators []Collator, names []string) {
-	return []Collator{GetCollator("latin1_bin"), &latin1SwedishCICollator{}},
+	return []Collator{GetCollator("latin1_bin"), GetCollator("latin1_swedish_ci")},
 		[]string{"latin1_bin", "latin1_swedish_ci"}
 }
 

--- a/pkg/util/collate/collate_test.go
+++ b/pkg/util/collate/collate_test.go
@@ -145,13 +145,21 @@ func TestUTF8CollatorKey(t *testing.T) {
 	testKeyTable(t, collations, tests)
 }
 
+// latin1_swedish_ci is deliberately not registered in newCollatorMap yet, so the
+// latin1 tests below construct it directly instead of going through GetCollator.
+// See the doc comment on latin1SwedishCICollator.
+func latin1TestCollators() (collators []Collator, names []string) {
+	return []Collator{GetCollator("latin1_bin"), &latin1SwedishCICollator{}},
+		[]string{"latin1_bin", "latin1_swedish_ci"}
+}
+
 // The latin1 collators are byte-oriented, so the test data below spells the
 // interesting characters as explicit cp1252 bytes ("\xC4" for Ä) rather than as Go
 // source literals, which the compiler would encode as UTF-8.
 func TestLatin1CollatorCompare(t *testing.T) {
 	SetNewCollationEnabledForTest(true)
 	defer SetNewCollationEnabledForTest(false)
-	collations := []string{"latin1_bin", "latin1_swedish_ci"}
+	collators, names := latin1TestCollators()
 	tests := []compareTable{
 		{"a", "b", []int{-1, -1}},
 		{"a", "A", []int{1, 0}},
@@ -187,13 +195,18 @@ func TestLatin1CollatorCompare(t *testing.T) {
 		// limitation rather than endorsing it.
 		{"\xC3\x84", "a\x84", []int{1, 0}},
 	}
-	testCompareTable(t, collations, tests)
+	for i, collator := range collators {
+		for _, table := range tests {
+			comment := fmt.Sprintf("Compare Left: %q Right: %q, Using %v", table.Left, table.Right, names[i])
+			require.Equal(t, table.Expect[i], collator.Compare(table.Left, table.Right), comment)
+		}
+	}
 }
 
 func TestLatin1CollatorKey(t *testing.T) {
 	SetNewCollationEnabledForTest(true)
 	defer SetNewCollationEnabledForTest(false)
-	collations := []string{"latin1_bin", "latin1_swedish_ci"}
+	collators, names := latin1TestCollators()
 	tests := []keyTable{
 		{"a", [][]byte{{0x61}, {0x41}}},
 		{"A", [][]byte{{0x41}, {0x41}}},
@@ -204,12 +217,14 @@ func TestLatin1CollatorKey(t *testing.T) {
 		{"\xFF\xDD", [][]byte{{0xFF, 0xDD}, {0xFF, 0x59}}},
 		{"", [][]byte{{}, {}}},
 	}
-	testKeyTable(t, collations, tests)
-
-	// One weight byte per input byte, so the sort key never outgrows the raw data.
-	collator := GetCollator("latin1_swedish_ci")
-	for _, test := range tests {
-		require.LessOrEqual(t, len(collator.Key(test.Str)), collator.MaxKeyLen(test.Str), test.Str)
+	for i, collator := range collators {
+		for _, test := range tests {
+			comment := fmt.Sprintf("key %q, using %v", test.Str, names[i])
+			require.Equal(t, test.Expect[i], collator.Key(test.Str), comment)
+			require.Equal(t, test.Expect[i], collator.ImmutableKey(test.Str), comment)
+			// One weight byte per input byte, so the sort key never outgrows the raw data.
+			require.LessOrEqual(t, len(collator.Key(test.Str)), collator.MaxKeyLen(test.Str), comment)
+		}
 	}
 }
 
@@ -232,7 +247,7 @@ func TestLatin1SwedishCIPattern(t *testing.T) {
 		{"a\\%b", '\\', "AxB", false},
 	}
 	for _, test := range tests {
-		pattern := GetCollator("latin1_swedish_ci").Pattern()
+		pattern := (&latin1SwedishCICollator{}).Pattern()
 		pattern.Compile(test.pattern, test.escape)
 		require.Equal(t, test.match, pattern.DoMatch(test.str),
 			fmt.Sprintf("pattern %q, str %q", test.pattern, test.str))
@@ -283,8 +298,6 @@ func TestGetCollator(t *testing.T) {
 	require.IsType(t, &unicodeCICollator{}, GetCollatorByID(192))
 	require.IsType(t, &unicode0900AICICollator{}, GetCollatorByID(255))
 	require.IsType(t, &zhPinyinTiDBASCSCollator{}, GetCollatorByID(2048))
-	require.IsType(t, &latin1SwedishCICollator{}, GetCollator("latin1_swedish_ci"))
-	require.IsType(t, &latin1SwedishCICollator{}, GetCollatorByID(8))
 	require.IsType(t, &binPaddingCollator{}, GetCollatorByID(9999))
 
 	SetNewCollationEnabledForTest(false)

--- a/pkg/util/collate/collate_test.go
+++ b/pkg/util/collate/collate_test.go
@@ -145,6 +145,100 @@ func TestUTF8CollatorKey(t *testing.T) {
 	testKeyTable(t, collations, tests)
 }
 
+// The latin1 collators are byte-oriented, so the test data below spells the
+// interesting characters as explicit cp1252 bytes ("\xC4" for Ä) rather than as Go
+// source literals, which the compiler would encode as UTF-8.
+func TestLatin1CollatorCompare(t *testing.T) {
+	SetNewCollationEnabledForTest(true)
+	defer SetNewCollationEnabledForTest(false)
+	collations := []string{"latin1_bin", "latin1_swedish_ci"}
+	tests := []compareTable{
+		{"a", "b", []int{-1, -1}},
+		{"a", "A", []int{1, 0}},
+		{"abc", "abc", []int{0, 0}},
+		{"abc", "ab", []int{1, 1}},
+		// Both latin1 collations are PAD SPACE.
+		{"a", "a ", []int{0, 0}},
+		{"a\t", "a", []int{1, 1}},
+		{"\xE9", "E", []int{1, 0}}, // é folds to E
+		{"\xE0\xE9", "AE", []int{1, 0}},
+		// Swedish letters sort after Z in the order Å, Ä, Ö instead of folding to A and O.
+		{"\xC5", "A", []int{1, 1}}, // Å
+		{"\xC5", "Z", []int{1, 1}},
+		{"\xC4", "\xC5", []int{-1, 1}}, // Ä after Å, opposite of the byte order
+		{"\xD6", "\xC4", []int{1, 1}},  // Ö after Ä
+		{"\xC6", "\xC4", []int{1, 0}},  // Æ collates as Ä
+		// MySQL quirks worth pinning down: Ü and Ý fold to Y but ÿ does not; ß folds to
+		// nothing, so it is equal to neither "s" nor "ss" (that is latin1_german2_ci);
+		// and Ø/ø fold to each other but not to O.
+		{"\xDC", "Y", []int{1, 0}},
+		{"\xDD", "y", []int{1, 0}},
+		{"\xFF", "Y", []int{1, 1}},
+		{"\xDF", "s", []int{1, 1}},
+		{"\xDF", "ss", []int{1, 1}},
+		{"\xDF", "\xDF", []int{0, 0}},
+		{"\xF8", "\xD8", []int{1, 0}},
+		{"\xD8", "O", []int{1, 1}},
+		// Bytes without a letter weight keep their own value, so they still compare
+		// equal to themselves.
+		{"\x80", "\x80", []int{0, 0}},
+		// UTF-8 data stored in a latin1 column is weighted byte by byte: "Ä" encoded as
+		// UTF-8 is 0xC3 0x84, whose leading byte folds to A. This documents the known
+		// limitation rather than endorsing it.
+		{"\xC3\x84", "a\x84", []int{1, 0}},
+	}
+	testCompareTable(t, collations, tests)
+}
+
+func TestLatin1CollatorKey(t *testing.T) {
+	SetNewCollationEnabledForTest(true)
+	defer SetNewCollationEnabledForTest(false)
+	collations := []string{"latin1_bin", "latin1_swedish_ci"}
+	tests := []keyTable{
+		{"a", [][]byte{{0x61}, {0x41}}},
+		{"A", [][]byte{{0x41}, {0x41}}},
+		{"a  ", [][]byte{{0x61}, {0x41}}},
+		{"Hello", [][]byte{{0x48, 0x65, 0x6C, 0x6C, 0x6F}, {0x48, 0x45, 0x4C, 0x4C, 0x4F}}},
+		{"\xC4\xC5\xD6", [][]byte{{0xC4, 0xC5, 0xD6}, {0x5C, 0x5B, 0x5D}}},
+		{"\xDF", [][]byte{{0xDF}, {0xDF}}},
+		{"\xFF\xDD", [][]byte{{0xFF, 0xDD}, {0xFF, 0x59}}},
+		{"", [][]byte{{}, {}}},
+	}
+	testKeyTable(t, collations, tests)
+
+	// One weight byte per input byte, so the sort key never outgrows the raw data.
+	collator := GetCollator("latin1_swedish_ci")
+	for _, test := range tests {
+		require.LessOrEqual(t, len(collator.Key(test.Str)), collator.MaxKeyLen(test.Str), test.Str)
+	}
+}
+
+func TestLatin1SwedishCIPattern(t *testing.T) {
+	SetNewCollationEnabledForTest(true)
+	defer SetNewCollationEnabledForTest(false)
+	tests := []struct {
+		pattern string
+		escape  byte
+		str     string
+		match   bool
+	}{
+		{"a%", '\\', "ABC", true},
+		{"A_C", '\\', "abc", true},
+		{"A_C", '\\', "abcd", false},
+		{"%\xC4%", '\\', "x\xE4y", true},  // Ä matches ä
+		{"%\xC4%", '\\', "x\xC5y", false}, // but not Å
+		{"\xDC", '\\', "y", true},         // Ü matches y, same as Compare
+		{"a\\%b", '\\', "A%B", true},      // the escaped wildcard is still a literal
+		{"a\\%b", '\\', "AxB", false},
+	}
+	for _, test := range tests {
+		pattern := GetCollator("latin1_swedish_ci").Pattern()
+		pattern.Compile(test.pattern, test.escape)
+		require.Equal(t, test.match, pattern.DoMatch(test.str),
+			fmt.Sprintf("pattern %q, str %q", test.pattern, test.str))
+	}
+}
+
 func TestSetNewCollateEnabled(t *testing.T) {
 	defer SetNewCollationEnabledForTest(false)
 
@@ -189,6 +283,8 @@ func TestGetCollator(t *testing.T) {
 	require.IsType(t, &unicodeCICollator{}, GetCollatorByID(192))
 	require.IsType(t, &unicode0900AICICollator{}, GetCollatorByID(255))
 	require.IsType(t, &zhPinyinTiDBASCSCollator{}, GetCollatorByID(2048))
+	require.IsType(t, &latin1SwedishCICollator{}, GetCollator("latin1_swedish_ci"))
+	require.IsType(t, &latin1SwedishCICollator{}, GetCollatorByID(8))
 	require.IsType(t, &binPaddingCollator{}, GetCollatorByID(9999))
 
 	SetNewCollationEnabledForTest(false)

--- a/pkg/util/collate/collate_test.go
+++ b/pkg/util/collate/collate_test.go
@@ -176,9 +176,9 @@ func TestLatin1CollatorCompare(t *testing.T) {
 		{"\xC4", "\xC5", []int{-1, 1}}, // Ä after Å, opposite of the byte order
 		{"\xD6", "\xC4", []int{1, 1}},  // Ö after Ä
 		{"\xC6", "\xC4", []int{1, 0}},  // Æ collates as Ä
-		// MySQL quirks worth pinning down: Ü and Ý fold to Y but ÿ does not; ß folds to
-		// nothing, so it is equal to neither "s" nor "ss" (that is latin1_german2_ci);
-		// and Ø/ø fold to each other but not to O.
+		// MySQL quirks worth pinning down: Ü and Ý fold to Y but ÿ does not; ß keeps its
+		// own weight 0xDF, so it is equal to neither "s" nor "ss" (the expansion to "ss"
+		// is latin1_german2_ci); and Ø/ø fold to each other but not to O.
 		{"\xDC", "Y", []int{1, 0}},
 		{"\xDD", "y", []int{1, 0}},
 		{"\xFF", "Y", []int{1, 1}},

--- a/pkg/util/collate/latin1_swedish_ci.go
+++ b/pkg/util/collate/latin1_swedish_ci.go
@@ -22,18 +22,15 @@ import (
 
 // latin1SwedishCICollator is the collator for latin1_swedish_ci.
 //
-// It is deliberately NOT registered in newCollatorMap/newCollatorIDMap yet, so
-// GetCollationByName still rejects the collation and no column can be created with
-// it. Enabling it needs three things that are not in place:
-//   - TiKV and TiFlash collators, so pushed-down expression evaluation agrees with
-//     the sort key TiDB writes, plus a guard that keeps expressions in TiDB until
-//     the storage layer understands the collation.
-//   - A byte-safe case fold for the collate.IsCICollation fast paths in
-//     pkg/expression. Those apply strings.ToLower, which assumes UTF-8 and maps
-//     every latin1 byte >= 0x80 to U+FFFD, making distinct characters compare equal.
-//   - The documentation updates tracked in the feature request.
+// The collation is evaluated by TiDB only: TiKV and TiFlash have no collator for it,
+// so expression push-down is blocked for it by collate.SupportedByStorage. Index range
+// scans are not affected, because TiDB computes the range bounds itself and the
+// storage layer only scans the resulting raw byte range. Remove the entry in
+// SupportedByStorage once the storage layer ships a matching collator.
 //
-// Until then this type stands alone and is exercised directly by its unit tests.
+// latin1 remains latin1_bin by default (charset.CollationLatin1). Changing the default
+// to match MySQL would silently re-collate every existing CHARSET latin1 column on
+// upgrade; it would have to go through a switch like the one GBK uses.
 //
 // Unlike the utf8mb4 collators this one is byte-oriented rather than rune-oriented.
 // MySQL defines latin1_swedish_ci as a 256-entry weight table indexed by the cp1252
@@ -51,6 +48,12 @@ import (
 // length as the (space-trimmed) input and index key sizes are unchanged relative to
 // latin1_bin. The sort key is not the raw data though, so latin1_swedish_ci columns
 // need restored data in indexes - see types.NeedRestoredDataWithCollate.
+//
+// One known gap: REGEXP is matched by a UTF-8 based engine, which collate.IsCICollation
+// only makes case-insensitive by handing it the "i" flag. That gives ASCII the right
+// answers but folds bytes >= 0x80 as if they were UTF-8, so accent folding does not
+// follow the weight table there. This matches the accuracy latin1_bin already offers
+// for REGEXP rather than adding a new divergence.
 type latin1SwedishCICollator struct{}
 
 // Compare implements Collator interface.

--- a/pkg/util/collate/latin1_swedish_ci.go
+++ b/pkg/util/collate/latin1_swedish_ci.go
@@ -1,0 +1,148 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collate
+
+import (
+	"cmp"
+
+	"github.com/pingcap/tidb/pkg/util/stringutil"
+)
+
+// latin1SwedishCICollator is the collator for latin1_swedish_ci.
+//
+// Unlike the utf8mb4 collators this one is byte-oriented rather than rune-oriented.
+// MySQL defines latin1_swedish_ci as a 256-entry weight table indexed by the cp1252
+// byte value (strings/ctype-latin1.c, sort_order_latin1), and TiDB's latin1 charset
+// stores whatever bytes the client sent: charset.EncodingLatin1Impl uses encoding.Nop
+// and a no-op Transform. Staying byte-oriented therefore matches both MySQL and the
+// existing latin1_bin collator for the same column.
+//
+// The consequence is that a multi-byte UTF-8 sequence stored in a latin1 column is
+// weighted byte by byte rather than as one character. That is the same treatment
+// latin1_bin already gives it, so it is not a new divergence, but it does mean the
+// collation is only MySQL-faithful for genuinely cp1252-encoded data.
+//
+// Because every input byte maps to exactly one weight byte, the sort key has the same
+// length as the (space-trimmed) input and index key sizes are unchanged relative to
+// latin1_bin. The sort key is not the raw data though, so latin1_swedish_ci columns
+// need restored data in indexes - see types.NeedRestoredDataWithCollate.
+type latin1SwedishCICollator struct{}
+
+// Compare implements Collator interface.
+func (*latin1SwedishCICollator) Compare(a, b string) int {
+	a = truncateTailingSpace(a)
+	b = truncateTailingSpace(b)
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if c := cmp.Compare(latin1SwedishCISortOrder[a[i]], latin1SwedishCISortOrder[b[i]]); c != 0 {
+			return c
+		}
+	}
+	return cmp.Compare(len(a), len(b))
+}
+
+// Key implements Collator interface.
+func (c *latin1SwedishCICollator) Key(str string) []byte {
+	return c.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+}
+
+// ImmutableKey implements Collator interface.
+func (c *latin1SwedishCICollator) ImmutableKey(str string) []byte {
+	return c.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+}
+
+// KeyWithoutTrimRightSpace implements Collator interface.
+func (*latin1SwedishCICollator) KeyWithoutTrimRightSpace(str string) []byte {
+	buf := make([]byte, 0, len(str))
+	for i := range len(str) {
+		buf = append(buf, latin1SwedishCISortOrder[str[i]])
+	}
+	return buf
+}
+
+// MaxKeyLen implements Collator interface.
+func (*latin1SwedishCICollator) MaxKeyLen(s string) int {
+	return len(s)
+}
+
+// Pattern implements Collator interface.
+func (*latin1SwedishCICollator) Pattern() WildcardPattern {
+	return &latin1SwedishCIPattern{}
+}
+
+// Clone implements Collator interface.
+func (*latin1SwedishCICollator) Clone() Collator {
+	return new(latin1SwedishCICollator)
+}
+
+type latin1SwedishCIPattern struct {
+	patChars []byte
+	patTypes []byte
+}
+
+// Compile implements WildcardPattern interface.
+func (p *latin1SwedishCIPattern) Compile(patternStr string, escape byte) {
+	p.patChars, p.patTypes = stringutil.CompilePatternBinary(patternStr, escape)
+}
+
+// DoMatch implements WildcardPattern interface.
+func (p *latin1SwedishCIPattern) DoMatch(str string) bool {
+	return stringutil.DoMatchCustomizedBinary(str, p.patChars, p.patTypes, func(a, b byte) bool {
+		return latin1SwedishCISortOrder[a] == latin1SwedishCISortOrder[b]
+	})
+}
+
+// latin1SwedishCISortOrder is MySQL's sort_order_latin1, transcribed verbatim from
+// strings/ctype-latin1.cc in mysql-server. That is the table my_charset_latin1
+// (collation id 8, latin1_swedish_ci) hands to my_collation_8bit_simple_ci_handler.
+//
+// The entries carrying the actual Swedish semantics, and the ones to check first if a
+// comparison looks wrong: Å (0xC5) -> 0x5B, Ä/Æ (0xC4/0xC6) -> 0x5C, Ö (0xD6) -> 0x5D.
+// These sit just above 'Z' (0x5A), so the Swedish letters sort after the ASCII
+// alphabet rather than folding into A and O.
+//
+// Several accented characters deliberately do not fold to a base letter, which is
+// easy to get wrong by reasoning from Unicode case folding instead of from this table:
+// Ü (0xDC) and Ý (0xDD) both fold to 'Y', but ÿ (0xFF) keeps weight 0xFF; ß (0xDF)
+// keeps weight 0xDF and is therefore NOT equal to 's' or "ss" (that expansion belongs
+// to latin1_german2_ci, which uses the separate sort_order_latin1_de table); and
+// Þ/þ and Ø/ø fold to each other but to no letter.
+var latin1SwedishCISortOrder = [256]byte{
+	// 0x00 - 0x3F: control characters, punctuation and digits keep their own value.
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+	0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
+	0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F,
+	// 0x40 - 0x5F: uppercase ASCII, unchanged.
+	0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F,
+	0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F,
+	// 0x60 - 0x7F: lowercase ASCII folds onto uppercase.
+	0x60, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F,
+	0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F,
+	// 0x80 - 0xBF: cp1252 extras and symbols keep their own value.
+	0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
+	0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F,
+	0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+	0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF,
+	// 0xC0 - 0xDF: accented uppercase letters.
+	// À Á Â Ã fold to A; Ä Å Æ take the Swedish weights; Ç -> C; È..Ë -> E; Ì..Ï -> I.
+	0x41, 0x41, 0x41, 0x41, 0x5C, 0x5B, 0x5C, 0x43, 0x45, 0x45, 0x45, 0x45, 0x49, 0x49, 0x49, 0x49,
+	// Ð -> D; Ñ -> N; Ò..Õ -> O; Ö -> 0x5D; × and Ø keep their own value;
+	// Ù..Û -> U; Ü and Ý -> Y; Þ and ß keep their own value.
+	0x44, 0x4E, 0x4F, 0x4F, 0x4F, 0x4F, 0x5D, 0xD7, 0xD8, 0x55, 0x55, 0x55, 0x59, 0x59, 0xDE, 0xDF,
+	// 0xE0 - 0xFF: accented lowercase letters, mirroring 0xC0 - 0xDF except for
+	// ÷ (0xF7) and ÿ (0xFF), which keep their own value.
+	0x41, 0x41, 0x41, 0x41, 0x5C, 0x5B, 0x5C, 0x43, 0x45, 0x45, 0x45, 0x45, 0x49, 0x49, 0x49, 0x49,
+	0x44, 0x4E, 0x4F, 0x4F, 0x4F, 0x4F, 0x5D, 0xF7, 0xD8, 0x55, 0x55, 0x55, 0x59, 0x59, 0xDE, 0xFF,
+}

--- a/pkg/util/collate/latin1_swedish_ci.go
+++ b/pkg/util/collate/latin1_swedish_ci.go
@@ -22,6 +22,19 @@ import (
 
 // latin1SwedishCICollator is the collator for latin1_swedish_ci.
 //
+// It is deliberately NOT registered in newCollatorMap/newCollatorIDMap yet, so
+// GetCollationByName still rejects the collation and no column can be created with
+// it. Enabling it needs three things that are not in place:
+//   - TiKV and TiFlash collators, so pushed-down expression evaluation agrees with
+//     the sort key TiDB writes, plus a guard that keeps expressions in TiDB until
+//     the storage layer understands the collation.
+//   - A byte-safe case fold for the collate.IsCICollation fast paths in
+//     pkg/expression. Those apply strings.ToLower, which assumes UTF-8 and maps
+//     every latin1 byte >= 0x80 to U+FFFD, making distinct characters compare equal.
+//   - The documentation updates tracked in the feature request.
+//
+// Until then this type stands alone and is exercised directly by its unit tests.
+//
 // Unlike the utf8mb4 collators this one is byte-oriented rather than rune-oriented.
 // MySQL defines latin1_swedish_ci as a 256-entry weight table indexed by the cp1252
 // byte value (strings/ctype-latin1.c, sort_order_latin1), and TiDB's latin1 charset

--- a/pkg/util/stringutil/string_util.go
+++ b/pkg/util/stringutil/string_util.go
@@ -286,6 +286,14 @@ func DoMatchBinary(str string, patChars, patTypes []byte) bool {
 	return doMatchInner(lenPatWeights, lenBytes, patTypes, func(a, b int) bool { return bytes[a] == patChars[b] })
 }
 
+// DoMatchCustomizedBinary is the byte-oriented counterpart of `DoMatchCustomized`:
+// it matches `str` one byte at a time using a caller-supplied comparator. It exists
+// for collations whose weights are defined per byte rather than per rune, such as
+// latin1_swedish_ci.
+func DoMatchCustomizedBinary(str string, patWeights, patTypes []byte, matcher func(a, b byte) bool) bool {
+	return doMatchInner(len(patWeights), len(str), patTypes, func(a, b int) bool { return matcher(str[a], patWeights[b]) })
+}
+
 // DoMatch is an adapter for `DoMatchCustomized`, `str` can be any unicode string.
 func DoMatch(str string, patChars []rune, patTypes []byte) bool {
 	return DoMatchCustomized(str, patChars, patTypes, matchRune)

--- a/tests/integrationtest/r/collation_misc_disabled.result
+++ b/tests/integrationtest/r/collation_misc_disabled.result
@@ -203,3 +203,62 @@ id	task	access object	operator info
 IndexReader	root		index:Selection
 └─Selection	cop[tikv]		eq(cd_test_utf8mb4_0900_bin.t.uuid, "7dce58ba-ba84-4297-94cf-c23cf3a39ed3")
   └─IndexRangeScan	cop[tikv]	table:t, index:idx_uuid(uuid)	range:["7dce58ba-ba84-4297-94cf-c23cf3a39ed3","7dce58ba-ba84-4297-94cf-c23cf3a39ed3"], keep order:false, stats:pseudo
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1);
+show create table t_latin1;
+Table	Create Table
+t_latin1	CREATE TABLE `t_latin1` (
+  `c` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1 collate latin1_swedish_ci, key(c));
+show create table t_latin1;
+Table	Create Table
+t_latin1	CREATE TABLE `t_latin1` (
+  `c` varchar(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  KEY `c` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+insert into t_latin1 values (_latin1 0x61), (_latin1 0x41), (_latin1 0xC4), (_latin1 0xE4), (_latin1 0xD6);
+select hex(c) from t_latin1 where c = _latin1 0x41 order by hex(c);
+hex(c)
+41
+select hex(c) from t_latin1 where c = _latin1 0xC4 order by hex(c);
+hex(c)
+C4
+select hex(c) from t_latin1 where c = _latin1 0xD6 order by hex(c);
+hex(c)
+D6
+select hex(c) from t_latin1 order by c, hex(c);
+hex(c)
+41
+61
+C4
+D6
+E4
+select hex(c) from t_latin1 where c like _latin1 0x41 order by hex(c);
+hex(c)
+41
+select count(distinct c) from t_latin1;
+count(distinct c)
+5
+drop table if exists t_latin1;
+drop table if exists t_latin1_pos;
+create table t_latin1_pos (c_bin varchar(10) charset latin1 collate latin1_bin, c_ci varchar(10) charset latin1 collate latin1_swedish_ci);
+insert into t_latin1_pos values (_latin1 0xC3A978, _latin1 0xC3A978), (_latin1 0x61C462, _latin1 0x61C462);
+select hex(c_bin), locate(_latin1 0x78, c_bin), locate(_latin1 0x78, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0x78, c_bin)	locate(_latin1 0x78, c_ci)
+61C462	0	0
+C3A978	3	3
+select hex(c_bin), instr(c_bin, _latin1 0x78), instr(c_ci, _latin1 0x78) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	instr(c_bin, _latin1 0x78)	instr(c_ci, _latin1 0x78)
+61C462	0	0
+C3A978	3	3
+select hex(c_bin), locate(_latin1 0x58, c_bin), locate(_latin1 0x58, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0x58, c_bin)	locate(_latin1 0x58, c_ci)
+61C462	0	0
+C3A978	0	0
+select hex(c_bin), locate(_latin1 0xE4, c_bin), locate(_latin1 0xE4, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0xE4, c_bin)	locate(_latin1 0xE4, c_ci)
+61C462	0	0
+C3A978	0	0
+drop table if exists t_latin1_pos;

--- a/tests/integrationtest/r/collation_misc_enabled.result
+++ b/tests/integrationtest/r/collation_misc_enabled.result
@@ -60,10 +60,10 @@ utf8_bin
 use cd_test_latin1;
 select @@character_set_database;
 @@character_set_database
-utf8
+latin1
 select @@collation_database;
 @@collation_database
-utf8_bin
+latin1_swedish_ci
 create database if not exists test_db CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 with cte as (select cast('2010-09-09' as date) a union select  '2010-09-09  ') select count(*) from cte;
 count(*)
@@ -97,6 +97,7 @@ gb18030	248	1
 gbk	87	1
 gbk	28	1
 latin1	47	1
+latin1	8	1
 utf8	83	1
 utf8	33	1
 utf8	192	8
@@ -126,6 +127,7 @@ gb18030_chinese_ci	gb18030	248	Yes	Yes	1	PAD SPACE
 gbk_bin	gbk	87		Yes	1	PAD SPACE
 gbk_chinese_ci	gbk	28	Yes	Yes	1	PAD SPACE
 latin1_bin	latin1	47	Yes	Yes	1	PAD SPACE
+latin1_swedish_ci	latin1	8		Yes	1	PAD SPACE
 utf8_bin	utf8	83	Yes	Yes	1	PAD SPACE
 utf8_general_ci	utf8	33		Yes	1	PAD SPACE
 utf8_unicode_ci	utf8	192		Yes	8	PAD SPACE
@@ -220,3 +222,65 @@ id	task	access object	operator info
 IndexReader	root		index:Selection
 └─Selection	cop[tikv]		eq(cd_test_utf8mb4_0900_bin.t.uuid, "7dce58ba-ba84-4297-94cf-c23cf3a39ed3")
   └─IndexRangeScan	cop[tikv]	table:t, index:idx_uuid(uuid)	range:["7dce58ba-ba84-4297-94cf-c23cf3a39ed3","7dce58ba-ba84-4297-94cf-c23cf3a39ed3"], keep order:false, stats:pseudo
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1);
+show create table t_latin1;
+Table	Create Table
+t_latin1	CREATE TABLE `t_latin1` (
+  `c` varchar(10) CHARACTER SET latin1 COLLATE latin1_bin DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1 collate latin1_swedish_ci, key(c));
+show create table t_latin1;
+Table	Create Table
+t_latin1	CREATE TABLE `t_latin1` (
+  `c` varchar(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,
+  KEY `c` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+insert into t_latin1 values (_latin1 0x61), (_latin1 0x41), (_latin1 0xC4), (_latin1 0xE4), (_latin1 0xD6);
+select hex(c) from t_latin1 where c = _latin1 0x41 order by hex(c);
+hex(c)
+41
+61
+select hex(c) from t_latin1 where c = _latin1 0xC4 order by hex(c);
+hex(c)
+C4
+E4
+select hex(c) from t_latin1 where c = _latin1 0xD6 order by hex(c);
+hex(c)
+D6
+select hex(c) from t_latin1 order by c, hex(c);
+hex(c)
+41
+61
+C4
+E4
+D6
+select hex(c) from t_latin1 where c like _latin1 0x41 order by hex(c);
+hex(c)
+41
+61
+select count(distinct c) from t_latin1;
+count(distinct c)
+3
+drop table if exists t_latin1;
+drop table if exists t_latin1_pos;
+create table t_latin1_pos (c_bin varchar(10) charset latin1 collate latin1_bin, c_ci varchar(10) charset latin1 collate latin1_swedish_ci);
+insert into t_latin1_pos values (_latin1 0xC3A978, _latin1 0xC3A978), (_latin1 0x61C462, _latin1 0x61C462);
+select hex(c_bin), locate(_latin1 0x78, c_bin), locate(_latin1 0x78, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0x78, c_bin)	locate(_latin1 0x78, c_ci)
+61C462	0	0
+C3A978	3	3
+select hex(c_bin), instr(c_bin, _latin1 0x78), instr(c_ci, _latin1 0x78) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	instr(c_bin, _latin1 0x78)	instr(c_ci, _latin1 0x78)
+61C462	0	0
+C3A978	3	3
+select hex(c_bin), locate(_latin1 0x58, c_bin), locate(_latin1 0x58, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0x58, c_bin)	locate(_latin1 0x58, c_ci)
+61C462	0	0
+C3A978	0	3
+select hex(c_bin), locate(_latin1 0xE4, c_bin), locate(_latin1 0xE4, c_ci) from t_latin1_pos order by hex(c_bin);
+hex(c_bin)	locate(_latin1 0xE4, c_bin)	locate(_latin1 0xE4, c_ci)
+61C462	0	2
+C3A978	0	0
+drop table if exists t_latin1_pos;

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -1066,6 +1066,7 @@ gb18030_chinese_ci	gb18030	248	Yes	Yes	1	PAD SPACE
 gbk_bin	gbk	87		Yes	1	PAD SPACE
 gbk_chinese_ci	gbk	28	Yes	Yes	1	PAD SPACE
 latin1_bin	latin1	47	Yes	Yes	1	PAD SPACE
+latin1_swedish_ci	latin1	8		Yes	1	PAD SPACE
 utf8_bin	utf8	83	Yes	Yes	1	PAD SPACE
 utf8_general_ci	utf8	33		Yes	1	PAD SPACE
 utf8_unicode_ci	utf8	192		Yes	8	PAD SPACE
@@ -1083,6 +1084,7 @@ gb18030_chinese_ci	gb18030	248	Yes	Yes	1	PAD SPACE
 gbk_bin	gbk	87		Yes	1	PAD SPACE
 gbk_chinese_ci	gbk	28	Yes	Yes	1	PAD SPACE
 latin1_bin	latin1	47	Yes	Yes	1	PAD SPACE
+latin1_swedish_ci	latin1	8		Yes	1	PAD SPACE
 utf8_bin	utf8	83	Yes	Yes	1	PAD SPACE
 utf8_general_ci	utf8	33		Yes	1	PAD SPACE
 utf8_unicode_ci	utf8	192		Yes	8	PAD SPACE
@@ -1110,6 +1112,7 @@ gb18030_chinese_ci	gb18030	248	Yes	Yes	1	PAD SPACE
 gbk_bin	gbk	87		Yes	1	PAD SPACE
 gbk_chinese_ci	gbk	28	Yes	Yes	1	PAD SPACE
 latin1_bin	latin1	47	Yes	Yes	1	PAD SPACE
+latin1_swedish_ci	latin1	8		Yes	1	PAD SPACE
 utf8_bin	utf8	83	Yes	Yes	1	PAD SPACE
 utf8_general_ci	utf8	33		Yes	1	PAD SPACE
 utf8_unicode_ci	utf8	192		Yes	8	PAD SPACE
@@ -1127,6 +1130,7 @@ gb18030_chinese_ci	gb18030	248	Yes	Yes	1	PAD SPACE
 gbk_bin	gbk	87		Yes	1	PAD SPACE
 gbk_chinese_ci	gbk	28	Yes	Yes	1	PAD SPACE
 latin1_bin	latin1	47	Yes	Yes	1	PAD SPACE
+latin1_swedish_ci	latin1	8		Yes	1	PAD SPACE
 utf8_bin	utf8	83	Yes	Yes	1	PAD SPACE
 utf8_general_ci	utf8	33		Yes	1	PAD SPACE
 utf8_unicode_ci	utf8	192		Yes	8	PAD SPACE

--- a/tests/integrationtest/t/collation_misc.test
+++ b/tests/integrationtest/t/collation_misc.test
@@ -129,3 +129,35 @@ drop table t;
 create table t (uuid varchar(36) charset utf8mb4 collate utf8mb4_bin, index idx_uuid(uuid));
 insert into t values ('7dce58ba-ba84-4297-94cf-c23cf3a39ed3');
 explain format='plan_tree' select * from t where uuid = cast('7dce58ba-ba84-4297-94cf-c23cf3a39ed3' as binary);
+# latin1_swedish_ci. latin1 still defaults to latin1_bin, so the collation has to be
+# asked for explicitly. The data is written as hex literals because latin1 stores the
+# client's bytes unchanged, and read back with HEX() so the results stay ASCII.
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1);
+show create table t_latin1;
+drop table if exists t_latin1;
+create table t_latin1 (c varchar(10) charset latin1 collate latin1_swedish_ci, key(c));
+show create table t_latin1;
+insert into t_latin1 values (_latin1 0x61), (_latin1 0x41), (_latin1 0xC4), (_latin1 0xE4), (_latin1 0xD6);
+# 'a' = 'A', and A-umlaut (0xC4) = a-umlaut (0xE4), but neither equals O-umlaut (0xD6).
+select hex(c) from t_latin1 where c = _latin1 0x41 order by hex(c);
+select hex(c) from t_latin1 where c = _latin1 0xC4 order by hex(c);
+select hex(c) from t_latin1 where c = _latin1 0xD6 order by hex(c);
+# The Swedish letters sort after the ASCII alphabet rather than folding into A and O.
+select hex(c) from t_latin1 order by c, hex(c);
+select hex(c) from t_latin1 where c like _latin1 0x41 order by hex(c);
+select count(distinct c) from t_latin1;
+drop table if exists t_latin1;
+# One latin1 byte is one character, including bytes that happen to form valid UTF-8:
+# 0xC3A978 is three latin1 characters, so 'x' sits at position 3 under both collations.
+# A literal on its own is latin1_bin, latin1 being a latin1_bin charset by default, so
+# the case-insensitive comparisons below have to come from the column side.
+drop table if exists t_latin1_pos;
+create table t_latin1_pos (c_bin varchar(10) charset latin1 collate latin1_bin, c_ci varchar(10) charset latin1 collate latin1_swedish_ci);
+insert into t_latin1_pos values (_latin1 0xC3A978, _latin1 0xC3A978), (_latin1 0x61C462, _latin1 0x61C462);
+select hex(c_bin), locate(_latin1 0x78, c_bin), locate(_latin1 0x78, c_ci) from t_latin1_pos order by hex(c_bin);
+select hex(c_bin), instr(c_bin, _latin1 0x78), instr(c_ci, _latin1 0x78) from t_latin1_pos order by hex(c_bin);
+# Only the latin1_swedish_ci column matches on case, or across the folded accents.
+select hex(c_bin), locate(_latin1 0x58, c_bin), locate(_latin1 0x58, c_ci) from t_latin1_pos order by hex(c_bin);
+select hex(c_bin), locate(_latin1 0xE4, c_bin), locate(_latin1 0xE4, c_ci) from t_latin1_pos order by hex(c_bin);
+drop table if exists t_latin1_pos;


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67198

Problem Summary:

TiDB has no `latin1_swedish_ci` collation, so any DDL naming it fails with
`Unsupported collation when new collation is enabled`. As #67198 describes,
databases migrated from MySQL 5.x commonly still carry `latin1_swedish_ci`
columns, and today they have to be rewritten to another collation before they can
land in TiDB, which forces manual schema changes under Lightning/DM and runs into
cross-charset comparison problems in sync-diff-inspector.

This PR implements the collation and turns it on, evaluated by TiDB only.

### What changed and how does it work?

**1. The collator.** `latin1SwedishCICollator` in
`pkg/util/collate/latin1_swedish_ci.go` is byte-oriented rather than
rune-oriented, which is a deliberate choice worth reviewing:

- MySQL defines the collation as a 256-entry weight table indexed by the cp1252
  byte value, driven through `my_collation_8bit_simple_ci_handler` with
  `strxfrm_multiply` 1 and `PAD_SPACE`.
- TiDB's latin1 charset stores whatever bytes the client sent:
  `charset.EncodingLatin1Impl` uses `encoding.Nop` with a no-op `Transform`.
- `latin1_bin`, the other collation available on the same column, is already
  byte-oriented (`binPaddingCollator`).

The trade-off is that a multi-byte UTF-8 sequence stored in a latin1 column is
weighted byte by byte rather than as one character. That is exactly what
`latin1_bin` already does with it, so this is not a new divergence, but it does
mean the collation is only MySQL-faithful for genuinely cp1252-encoded data.

Because one input byte yields exactly one weight byte, the sort key never
outgrows the raw data and index key sizes are unchanged relative to `latin1_bin`.
The sort key is not the raw data, though, so `latin1_swedish_ci` columns need
restored data in indexes via `types.NeedRestoredDataWithCollate` — an
`ALTER ... COLLATE latin1_swedish_ci` is correctly treated as needing a reorg.

Supporting change: `pkg/util/stringutil` gained `DoMatchCustomizedBinary`, the
byte-oriented counterpart of `DoMatchCustomized`, for the `LIKE` path.
`DoMatchBinary` only offers exact byte equality, which cannot express a
case-insensitive match.

**2. Registration.** The collator is registered in
`newCollatorMap`/`newCollatorIDMap`, which is the only gate that matters when new
collation is enabled: `collate.GetCollationByName` admits DDL from
`newCollatorIDMap`, and `collate.GetSupportedCollations` builds
`information_schema.COLLATIONS` from `newCollatorMap`.
`charset.supportedCollationNames` is deliberately left alone — it feeds only the
legacy `newCollationEnabled=false` path, where every collation degrades to byte
comparison.

**latin1 keeps `latin1_bin` as its default collation**, unlike MySQL. Adopting
MySQL's default would silently re-collate every existing `CHARSET latin1` column
on upgrade; if that is ever wanted it should go through a switch like the one GBK
uses. The collation is therefore reachable only via an explicit `COLLATE`.

**3. Push-down is blocked, not supported.** TiKV and TiFlash have no collator for
this collation, so `collate.SupportedByStorage` reports it as unsupported and
`collationBlocksPushDown` keeps such expressions in TiDB. It is checked in the
three `PbConverter` leaves (`columnToPBExpr`, `conOrCorColToPBExpr`,
`scalarFuncToPBExpr`), which covers both the planner's decision and the actual
conversion, because `canExprPushDown` delegates to those same leaves.

This guard has to live on the TiDB side. `CollationToProto` fails *open*: a
collation the storage layer does not know is not rejected, it silently falls back
to the default collation ID and only logs a warning, so the coprocessor would
evaluate the expression under the wrong rules rather than error. Index *range
scans* are unaffected — TiDB computes the bounds with its own collator and the
store scans a raw byte range. Removing the single entry in
`SupportedByStorage` is all that is needed once the storage layer ships a
collator.

**4. `LOCATE`/`INSTR` now take the byte-oriented signatures for single-byte
charsets** (`hasByteOrientedOffsets`, extending the existing `useBinary` test in
`locateFunctionClass` and `instrFunctionClass`). These builtins report *character*
positions, and in latin1 one byte is one character.

This also fixes a pre-existing bug affecting `latin1_bin`. Running latin1 through
the UTF-8 signatures miscounted every position after bytes that happen to form a
valid UTF-8 sequence, and corrupted data outright via the `[]rune` round trip used
to slice at a start position, which rewrites every byte that is not valid UTF-8 to
U+FFFD. For a latin1 column holding bytes `C3 A9 78` — three latin1 characters —
`LOCATE('x', c)` returned 2 and now returns 3, which is MySQL's answer.

Case-insensitivity inside those signatures folds through `collate.FoldCase`, which
maps one byte to exactly one byte for byte-oriented collations. `strings.ToLower`
cannot be used: it assumes UTF-8, so every latin1 byte >= 0x80 becomes the same
U+FFFD and distinct characters would compare equal, and its 1-to-3 byte inflation
would shift every position reported afterwards.

**On the weight table.** It is transcribed from `sort_order_latin1` in
`strings/ctype-latin1.cc` and was diffed entry by entry against that source, and
it also agrees with the `WEIGHT_STRING` extraction in #67198. Two entries are easy
to get wrong by reasoning from Unicode case folding instead of from the table, and
both are pinned by tests:

- `Ü` (0xDC) and `Ý` (0xDD) fold to `Y`, but `ÿ` (0xFF) does not.
- `ß` (0xDF) keeps its own weight, so it is equal to neither `'s'` nor `"ss"`.
  The expansion to `"ss"` belongs to `latin1_german2_ci`, which uses the separate
  `sort_order_latin1_de` table.

**Known gap.** `REGEXP` is matched by a UTF-8 based engine, which
`collate.IsCICollation` only makes case-insensitive by handing it the `i` flag.
That is right for ASCII but folds bytes >= 0x80 as if they were UTF-8, so accent
folding does not follow the weight table there. This matches the accuracy
`latin1_bin` already offers for `REGEXP` rather than adding a new divergence.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit tests: `pkg/util/collate/collate_test.go` (`TestLatin1CollatorCompare`,
`TestLatin1CollatorKey`, `TestLatin1SwedishCIPattern`, now resolved through
`GetCollator` so they also cover registration), `pkg/expression/collation_test.go`
(`TestInferCollation`, `TestCompareString`),
`pkg/expression/builtin_string_test.go` (`TestLocateAndInstrLatin1`),
`pkg/expression/expr_to_pb_test.go`
(`TestPushDownBlockedForCollationsMissingFromStorage`), plus latin1 cases added to
the existing `vecBuiltinStringCases` harness, which asserts the vectorized and
non-vectorized paths agree.

Integration tests: `tests/integrationtest/t/collation_misc.test`, recorded in both
collation modes.

```
go test -tags=intest ./pkg/util/collate/... ./pkg/util/stringutil/... -count=1
go test -tags=intest ./pkg/expression/ -count=1
cd pkg/parser && go test ./charset/... -count=1
cd tests/integrationtest && ./run-tests.sh -r collation_misc
cd tests/integrationtest && ./run-tests.sh -r executor/show
make bazel_prepare   # no metadata changes were produced
make lint
```

Both new tests were verified to fail without the corresponding source change, so
they are not vacuous: reverting the `LOCATE`/`INSTR` routing fails five rows of
`TestLocateAndInstrLatin1`, and reverting `expr_to_pb.go` fails
`TestPushDownBlockedForCollationsMissingFromStorage`. The coercibility cases were
mutation-checked separately: adding `latin1_swedish_ci` to `isBinCollation` makes
`TestInferCollation` fail.

Manual test: the recorded integration results show the behaviour end to end on
unistore — `order by c` over `('a'),('A'),(0xC4),(0xE4),(0xD6)` returns
`41, 61, C4, E4, D6`, so `Ä`/`ä` and `Ö` sort after the ASCII alphabet rather than
folding into `A` and `O`; `= 0x41` matches both cases; `= 0xC4` matches `0xE4`;
`like` and `count(distinct)` agree; and `locate`/`instr` return character positions
`3` on a latin1 value whose bytes form valid UTF-8. Note this ran on unistore,
which shares this Go code, so it says nothing about real TiKV — which is why
push-down is blocked rather than trusted.

Two recorded results change for reasons unrelated to the new test cases, both
expected:

- `SHOW COLLATION` and `information_schema.COLLATIONS` gain a `latin1_swedish_ci`
  row, with an empty `Default` column since latin1 still defaults to `latin1_bin`.
- `create database ... CHARACTER SET latin1 COLLATE latin1_swedish_ci` in
  `collation_misc` now succeeds where the test already tolerated error 1273
  (`--error 0,1273`), so `@@character_set_database` reports `latin1` instead of
  `utf8`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Not marked as breaking, but two behaviour changes are worth a reviewer's
attention. `LOCATE`/`INSTR` on **existing** `latin1_bin` columns now report
correct character positions where they previously miscounted values whose bytes
form valid UTF-8; this is a bug fix toward MySQL behaviour, but it does change
results. Expressions over `latin1_swedish_ci` columns are never pushed to the
coprocessor, so filters and aggregates on such columns are evaluated in TiDB.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

`latin1_swedish_ci` becomes available with an explicit `COLLATE`, moving TiDB
closer to MySQL. latin1's default collation intentionally stays `latin1_bin`,
which remains a divergence from MySQL. The user-facing collation documentation
requested in #67198 lives in `pingcap/docs` and is not part of this repository.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support the `latin1_swedish_ci` collation, which can be selected with an explicit `COLLATE` clause. The default collation for the `latin1` character set remains `latin1_bin`. Expressions on `latin1_swedish_ci` columns are evaluated by TiDB and are not pushed down to TiKV or TiFlash.
Fix `LOCATE` and `INSTR` returning wrong character positions for `latin1` columns holding bytes that form a valid UTF-8 sequence.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded Latin1 collation support for Swedish case-insensitive and binary comparison behavior.
  * Improved consistency for case folding, accented characters, trailing spaces, sorting, and wildcard matching.
  * Added support for collation-aware byte-level pattern comparisons.

* **Tests**
  * Added comprehensive coverage for collation precedence, charset selection, comparison behavior, generated sort keys, invalid byte handling, and escaped wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
