### PR TITLE
ddl: skip backfilling the clustered PRIMARY KEY in REORGANIZE PARTITION

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3795,6 +3795,12 @@ func doPartitionReorgWork(w *worker, jobCtx *jobContext, job *model.Job, tbl tab
 	var elements []*meta.Element
 	indices := make([]*model.IndexInfo, 0, len(tbl.Meta().Indices))
 	for _, index := range tbl.Meta().Indices {
+		if index.Primary && tbl.Meta().HasClusteredIndex() {
+			// A clustered PRIMARY KEY has no index KV of its own, the record written
+			// by the data copy phase is the index. Backfilling it would write entries
+			// that no reader uses and that DML never maintains.
+			continue
+		}
 		if isNew, ok := tbl.Meta().GetPartitionInfo().DDLChangedIndex[index.ID]; ok && !isNew {
 			// Skip old replaced indexes, but rebuild all other indexes
 			continue

--- a/pkg/ddl/tests/partition/reorg_partition_test.go
+++ b/pkg/ddl/tests/partition/reorg_partition_test.go
@@ -1054,6 +1054,48 @@ func TestPartitionIssue56634(t *testing.T) {
 	tk.MustExec("alter table t partition by range(a) (partition p1 values less than (20))")
 }
 
+// TestReorgPartitionPrimaryKeyIndexEntries tests that REORGANIZE PARTITION only
+// backfills a PRIMARY KEY that actually has index entries of its own. A clustered
+// one does not, so backfilling it wrote entries that nothing read and that DML
+// never maintained, see issue #70379.
+func TestReorgPartitionPrimaryKeyIndexEntries(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	for _, tc := range []struct {
+		tblName       string
+		pkType        string
+		wantPKEntries bool
+	}{
+		{"tClustered", "clustered", false},
+		{"tNonClustered", "nonclustered", true},
+	} {
+		tk.MustExec(fmt.Sprintf(`create table %s (a int, b int, c int, primary key (a,b) %s, key idx_c (c))`+
+			` partition by range (b)`+
+			` (partition p0 values less than (10), partition pMax values less than (MAXVALUE))`,
+			tc.tblName, tc.pkType))
+		tk.MustExec(fmt.Sprintf(`insert into %s values (1,11,1),(2,12,2),(3,13,3),(4,14,4)`, tc.tblName))
+		tk.MustExec(fmt.Sprintf(`alter table %s reorganize partition pMax into`+
+			` (partition p1 values less than (20), partition pMax values less than (MAXVALUE))`, tc.tblName))
+
+		tblInfo := external.GetTableByName(t, tk, "test", tc.tblName).Meta()
+		pid := tblInfo.GetPartitionInfo().GetPartitionIDByName("p1")
+		require.NotEqual(t, int64(-1), pid)
+		pkInfo := tblInfo.FindIndexByName("primary")
+		require.NotNil(t, pkInfo)
+		idxInfo := tblInfo.FindIndexByName("idx_c")
+		require.NotNil(t, idxInfo)
+
+		require.Equal(t, tc.wantPKEntries, HaveEntriesForTableIndex(t, tk, pid, pkInfo.ID), tc.tblName)
+		require.True(t, HaveEntriesForTableIndex(t, tk, pid, idxInfo.ID), tc.tblName)
+
+		tk.MustExec(`admin check table ` + tc.tblName)
+		tk.MustQuery(fmt.Sprintf(`select a,b,c from %s order by a`, tc.tblName)).
+			Check(testkit.Rows("1 11 1", "2 12 2", "3 13 3", "4 14 4"))
+	}
+}
+
 func TestReorgPartitionFailuresPlacementPolicy(t *testing.T) {
 	create := `create table t (a int unsigned PRIMARY KEY, b varchar(255), c int, key (b), key (c,b))` +
 		` partition by range (a) ` +


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70379

Problem Summary:

`doPartitionReorgWork` passed every `IndexInfo` to the index backfill, including the `PRIMARY KEY` of a clustered table. A clustered `PRIMARY KEY` has no index KV of its own, the record written by the data copy phase is the index, so the backfill wrote a full set of unique index entries that nothing reads and that DML never maintains.

Scanning the KV range before and after `REORGANIZE PARTITION` on the reported schema, with 50 rows:

```
BEFORE  pmax (id 118): records=50  PRIMARY(id 1)=0   idx_pad(id 2)=50
AFTER   p1   (id 120): records=50  PRIMARY(id 1)=50  idx_pad(id 2)=50
baseline table with the same data, never reorganized: PRIMARY(id 1)=0
```

Those entries go stale on the first DML after the reorg, since `AddRecord` and friends skip the primary index for clustered tables, and they stay behind until the partition is dropped or truncated.

`ALTER TABLE ... PARTITION BY` and `ALTER TABLE ... REMOVE PARTITIONING` share this code path and copy the whole table, so they were affected too.

### What changed and how does it work?

Skip the `PRIMARY KEY` element when building the backfill element list for a clustered table.

A clustered `PRIMARY KEY` can never be a global index, so there is no global-index case to preserve: a clustered `PRIMARY KEY` that does not cover the partitioning columns is rejected with `[ddl:1503]`, and `PRIMARY KEY ... CLUSTERED GLOBAL` with `[ddl:8200]`. `PKIsHandle` tables carry no `PRIMARY` `IndexInfo` at all, so they are unaffected either way. A `NONCLUSTERED` `PRIMARY KEY` is a real index and is still backfilled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `REORGANIZE PARTITION` unnecessarily backfills the clustered `PRIMARY KEY` as if it were a secondary index, which slows down the DDL and leaves unused index entries in the new partitions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition reorganization for tables with clustered primary keys.
  * Ensured clustered primary-key data remains correctly stored with table rows while nonclustered and secondary index entries are preserved.
  * Confirmed that all rows remain accessible and table consistency is maintained after reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->