### PR TITLE
executor: preserve TLS REQUIRE options when ALTER USER omits REQUIRE

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -2264,7 +2264,11 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			continue
 		}
 
-		if len(privData) > 0 {
+		// Only touch mysql.global_priv when the statement carries a REQUIRE clause
+		// that maps to a global_priv value; otherwise ALTER USER would clobber the
+		// existing TLS requirements (SUBJECT/SAN/ISSUER/CIPHER) with an empty value.
+		// A token-issuer-only REQUIRE yields empty privData and is stored elsewhere.
+		if len(s.AuthTokenOrTLSOptions) > 0 && len(privData) > 0 {
 			sql := new(strings.Builder)
 			sqlescape.MustFormatSQL(sql, "INSERT INTO %n.%n (Host, User, Priv) VALUES (%?,%?,%?) ON DUPLICATE KEY UPDATE Priv = values(Priv)", mysql.SystemDB, mysql.GlobalPrivTable, spec.User.Hostname, spec.User.Username, string(hack.String(privData)))
 			_, err := sqlExecutor.ExecuteInternal(ctx, sql.String())

--- a/pkg/executor/test/simpletest/BUILD.bazel
+++ b/pkg/executor/test/simpletest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -320,6 +320,8 @@ func TestMaxUserConnections(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
+	t.Run("AlterUserPreservesRequire", testAlterUserPreservesRequire)
+
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	// Make sure user test not in mysql.User.
@@ -527,6 +529,44 @@ func TestUser(t *testing.T) {
 
 	tk.MustQuery("select user from mysql.user where user='engineering' and host = 'india'").Check(testkit.Rows())
 	tk.MustQuery("select user from mysql.user where user='engineering' and host = 'us'").Check(testkit.Rows())
+}
+
+func testAlterUserPreservesRequire(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`CREATE USER 'require_user'@'%' REQUIRE SUBJECT '/C=US/O=Example/CN=TiDB' SAN 'DNS:foo'`)
+	priv := `{"ssl_type":3,"x509_subject":"/C=US/O=Example/CN=TiDB","san":"DNS:foo"}`
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
+
+	// ALTER USER without a REQUIRE clause must not wipe the TLS requirements.
+	tk.MustExec(`ALTER USER 'require_user'@'%' ACCOUNT LOCK`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
+	tk.MustQuery(`SELECT Account_locked FROM mysql.user WHERE User='require_user' AND Host='%'`).Check(testkit.Rows("Y"))
+	tk.MustQuery(`SHOW CREATE USER 'require_user'@'%'`).Check(testkit.Rows(
+		`CREATE USER 'require_user'@'%' IDENTIFIED WITH 'mysql_native_password' AS '' REQUIRE SUBJECT '/C=US/O=Example/CN=TiDB' SAN 'DNS:foo' PASSWORD EXPIRE DEFAULT ACCOUNT LOCK PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT`))
+
+	// A few more attribute-only ALTERs must also preserve the requirements.
+	tk.MustExec(`ALTER USER 'require_user'@'%' ACCOUNT UNLOCK`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
+	tk.MustExec(`ALTER USER 'require_user'@'%' PASSWORD EXPIRE`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
+
+	// An explicit REQUIRE clause is still honored.
+	tk.MustExec(`ALTER USER 'require_user'@'%' REQUIRE SSL`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(`{"ssl_type":1}`))
+	// REQUIRE NONE explicitly clears the requirements.
+	tk.MustExec(`ALTER USER 'require_user'@'%' REQUIRE NONE`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(`{}`))
+
+	// A token-issuer-only REQUIRE is stored in mysql.user, not global_priv, so it
+	// must not write an (empty) global_priv row.
+	tk.MustExec(`CREATE USER 'token_only'@'%' IDENTIFIED WITH 'tidb_auth_token' REQUIRE token_issuer 'issuer-abc'`)
+	tk.MustQuery(`SELECT count(*) FROM mysql.global_priv WHERE User='token_only' AND Host='%'`).Check(testkit.Rows("0"))
+	tk.MustExec(`ALTER USER 'token_only'@'%' ACCOUNT LOCK`)
+	tk.MustQuery(`SELECT count(*) FROM mysql.global_priv WHERE User='token_only' AND Host='%'`).Check(testkit.Rows("0"))
+	tk.MustQuery(`SHOW CREATE USER 'token_only'@'%'`).Check(testkit.Rows(
+		`CREATE USER 'token_only'@'%' IDENTIFIED WITH 'tidb_auth_token' AS '' REQUIRE NONE token_issuer issuer-abc PASSWORD EXPIRE DEFAULT ACCOUNT LOCK PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT`))
 }
 
 func TestSetPwd(t *testing.T) {

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -320,8 +320,6 @@ func TestMaxUserConnections(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
-	t.Run("AlterUserPreservesRequire", testAlterUserPreservesRequire)
-
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	// Make sure user test not in mysql.User.
@@ -531,7 +529,7 @@ func TestUser(t *testing.T) {
 	tk.MustQuery("select user from mysql.user where user='engineering' and host = 'us'").Check(testkit.Rows())
 }
 
-func testAlterUserPreservesRequire(t *testing.T) {
+func TestAlterUserPreservesRequire(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -549,6 +549,8 @@ func TestAlterUserPreservesRequire(t *testing.T) {
 	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
 	tk.MustExec(`ALTER USER 'require_user'@'%' PASSWORD EXPIRE`)
 	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
+	tk.MustExec(`ALTER USER 'require_user'@'%' COMMENT ''`)
+	tk.MustQuery(`SELECT Priv FROM mysql.global_priv WHERE User='require_user' AND Host='%'`).Check(testkit.Rows(priv))
 
 	// An explicit REQUIRE clause is still honored.
 	tk.MustExec(`ALTER USER 'require_user'@'%' REQUIRE SSL`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70269

Problem Summary:

An `ALTER USER` statement that omits a `REQUIRE` clause serializes the absent TLS options as `{}` and overwrites the user's existing TLS requirements in `mysql.global_priv`. As a result, attribute-only changes such as `ACCOUNT LOCK` silently clear `REQUIRE SUBJECT`, `SAN`, `ISSUER`, and `CIPHER` settings.

### What changed and how does it work?

Only update `mysql.global_priv` when `ALTER USER` contains a `REQUIRE` option that maps to a global privilege value. This preserves existing TLS requirements when the clause is omitted while retaining explicit `REQUIRE SSL` and `REQUIRE NONE` behavior. Token-issuer-only requirements continue to be stored in `mysql.user` without creating an empty global privilege row.

The regression coverage verifies attribute-only changes preserve TLS requirements, explicit requirements update or clear them, and token-issuer-only users do not get an empty `mysql.global_priv` row.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```text
env GOPATH=/tmp/tidb-external-pr-gopath ./tools/check/failpoint-go-test.sh pkg/executor/test/simpletest -run TestAlterUserPreservesRequire -count=1
env GOPATH=/tmp/tidb-external-pr-gopath make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug where an `ALTER USER` statement without a `REQUIRE` clause could clear the user's existing TLS requirements.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ALTER USER` so account status, password settings, and comments no longer unintentionally remove existing TLS or authentication requirements.
  * Explicit `REQUIRE SSL` now replaces prior requirements, while `REQUIRE NONE` clears them as expected.
  * Token-issuer requirements remain preserved when making unrelated account changes.

* **Tests**
  * Added coverage for preserving, replacing, and clearing authentication requirements across account updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->