### PR TITLE
rust: align hparser integration parity runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 TiDB (/’taɪdiːbi:/, "Ti" stands for Titanium) is an open-source, cloud-native, distributed SQL database designed for high availability, horizontal and vertical scalability, strong consistency, and high performance.
 
 - [Key Features](#key-features)
+- [Rust SQL Runtime Validation (Draft)](#rust-sql-runtime-validation-draft)
 - [Quick Start](#quick-start)
 - [Need Help?](#need-help)
 - [Architecture](#architecture)
@@ -25,6 +26,89 @@ TiDB (/’taɪdiːbi:/, "Ti" stands for Titanium) is an open-source, cloud-nativ
 - [License](#license)
 - [See Also](#see-also)
 - [Acknowledgments](#acknowledgments)
+
+## Rust SQL Runtime Validation (Draft)
+
+This branch tracks the Rust SQL runtime parity effort that keeps PD, TiProxy,
+and TiKV on nightly builds and treats Go TiDB as the planner and executor
+oracle. The hard gate is plan parity first, then benchmark acceptance. Current
+evidence is split accordingly:
+
+| Evidence | Matched | Mismatched | Errors | Coverage |
+| --- | ---: | ---: | ---: | --- |
+| TPCC prepare plans | 1,037 | 0 | 0 | complete |
+| TPCC run plans | 63 | 0 | 0 | complete |
+| TPCC check plans | 12 | 0 | 0 | complete |
+| Sysbench prepare plans | 32 | 0 | 0 | complete |
+| Sysbench run plans | 13,952 | 0 | 0 | complete |
+
+The plan gate and its SQL inventory are documented in
+[`rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md`](rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md).
+Reproduce the gate from the repository root with:
+
+```bash
+python3 -m py_compile rust/scripts/plan-parity.py \
+  rust/scripts/generate-plan-manifest.py \
+  rust/scripts/test-plan-parity.py
+python3 rust/scripts/generate-plan-manifest.py --check
+python3 rust/scripts/test-plan-parity.py
+```
+
+### TPCC status versus the frozen baseline
+
+The only accepted throughput evidence currently retained for this branch was
+captured before the latest rebase onto `hparser-integration`. It used one
+nightly PD, one nightly TiProxy, three nightly TiKV stores, three Rust SQL
+runtime instances, three replicas, 100 warehouses, and 16 clients. The frozen
+three-store nightly TPCC baseline used 32 clients, so the comparison below is
+directional only and is not a formal acceptance result.
+
+| Metric | Current retained evidence | Frozen baseline | Relative to baseline |
+| --- | ---: | ---: | ---: |
+| Topology | 3 Rust SQL + 3 TiKV + PD + TiProxy | 3 Go TiDB + 3 TiKV + PD + TiProxy | same process layout |
+| Clients | 16 | 32 | thread mismatch |
+| Measurement tpmC | 5,766.0 | 41,011.5 | 0.141x |
+| Delivery P99 | 335.5 ms | 121.6 ms | 2.759x higher |
+| New Order P99 | 159.4 ms | 37.7 ms | 4.228x higher |
+| Payment P99 | 58.7 ms | 30.4 ms | 1.931x higher |
+| Order Status P99 | 65.0 ms | 19.9 ms | 3.266x higher |
+| Stock Level P99 | 159.4 ms | 23.1 ms | 6.900x higher |
+
+A longer 180-second stability rerun on the same pre-rebase binary sustained
+5,886.6 tpmC with zero workload error lines in the retained log. This branch
+therefore has execution-plan parity, but it does not yet have benchmark parity
+with the frozen baseline.
+
+### Sysbench status versus the frozen baseline
+
+The frozen Sysbench baseline remains the nightly `3 TiDB + 3 TiKV` topology on
+32 tables with 10,000,000 rows per table, a 300-second warm-up, and a
+600-second measurement. The current branch has complete plan parity for both
+prepare and run SQL, but it does not yet have a fresh post-rebase throughput
+matrix to compare against these baseline numbers:
+
+| Workload | Baseline TPS at 16 threads | Baseline P99 | Current branch status |
+| --- | ---: | ---: | --- |
+| `oltp_read_write.lua` | 764.82 | 28.67 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_read_only.lua` | 1,205.83 | 18.61 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_write_only.lua` | 2,394.87 | 10.84 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_point_select.lua` | 22,532.20 | 0.94 ms | plan parity complete; throughput not rerun after rebase |
+| `select_random_points.lua` | 9,353.30 | 3.13 ms | plan parity complete; throughput not rerun after rebase |
+| `select_random_ranges.lua` | 10,095.54 | 2.30 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_insert.lua` | 5,909.70 | 4.25 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_update_index.lua` | 4,897.50 | 5.09 ms | plan parity complete; throughput not rerun after rebase |
+| `oltp_update_non_index.lua` | 7,366.31 | 3.02 ms | plan parity complete; throughput not rerun after rebase |
+| `bulk_insert.lua` | 105,491.26 | 0.00 ms | plan parity complete; throughput not rerun after rebase |
+
+For the 32-table, 10-million-row prepare path, the frozen nightly baseline
+completed in 3,296.03 seconds. The rebased Rust branch has plan parity for the
+prepare SQL, but no fresh post-rebase prepare timing is checked in yet.
+
+The latest rebased source head is `e8acf3a34732976a3d882cf42c34f8a19191e044`.
+Its rebased tree has passed the plan gate and formatting checks, but the
+throughput evidence above still belongs to the pre-rebase binary retained in
+the benchmark archive. A fresh TPCC and Sysbench benchmark cycle is still
+required before claiming performance alignment with the nightly baseline.
 
 ## Key Features
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "subtle",
  "tidb-ast",
  "tidb-chunk",
+ "tidb-codec",
  "tidb-config",
  "tidb-datatype",
  "tidb-distsql",

--- a/rust/PESSIMISTIC_CLUSTER_SESSION_EXEC_PLAN.md
+++ b/rust/PESSIMISTIC_CLUSTER_SESSION_EXEC_PLAN.md
@@ -1,0 +1,187 @@
+# Make wide SQL cluster sessions execute pessimistic transactions correctly
+
+This ExecPlan is a living document. Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` up to date as work proceeds.
+
+Reference: `PLANS.md` at repository root. This plan follows the repository-wide rules in `AGENTS.md`, including the regression-test requirement for bug fixes and the WIP/Ready validation profiles.
+
+## Purpose / Big Picture
+
+The Rust TiDB wide-SQL server currently accepts `BEGIN PESSIMISTIC` and `SELECT ... FOR UPDATE`, but the production cluster-session path always opens an optimistic transaction. The SQL statement returns rows without taking TiKV pessimistic locks. Under TPC-C, concurrent updates therefore reach optimistic Prewrite and surface error 9007 instead of waiting and serializing like Go TiDB. This is both a compatibility defect and a throughput defect because go-tpc loses transactions that TiDB should complete.
+
+After this plan is complete, a wide-SQL connection whose transaction mode is pessimistic will read, lock, retry, and commit through a real `RealPessimisticTransaction`. A second writer to a row held by `SELECT ... FOR UPDATE` or DML will block until the first transaction commits or rolls back. If a newer committed version is discovered while locking, the whole SQL statement will be retried after advancing `for_update_ts`, and every retry read will use that new timestamp. TPC-C at 16 threads will report no 9007 errors caused by the missing pessimistic path. PD, TiProxy, and TiKV remain unmodified nightly binaries, and no client SQL, transaction boundary, batching, or retry behavior is changed.
+
+## Progress
+
+- [x] (2026-08-08) Reproduced the user-visible TPC-C symptom through TiProxy: the 16-thread, one-warehouse smoke completed with about 14 distinct 9007 optimistic write-conflict events.
+- [x] (2026-08-08) Removed TiProxy from the hypothesis: the same conflict behavior reproduces by connecting directly to a Rust TiDB node.
+- [x] (2026-08-08) Built the minimal lock probe: connection 1 holds `BEGIN; SELECT ... FOR UPDATE` for five seconds while connection 2 updates the same row. Connection 2 completed in 44 ms instead of blocking.
+- [x] (2026-08-08) Traced the production path to `RealClusterTransactions::begin`, which unconditionally creates the optimistic `tidb_exec::cluster_table_storage::SessionTransaction`.
+- [x] (2026-08-08) Confirmed the lower transaction tier already has PessimisticLock, pessimistic rollback, pessimistic Prewrite actions, fair locking, lock TTL keep-alive, and statement-error classification.
+- [ ] Add a deterministic, agent-runnable regression around the cluster-session transaction seam that fails because the mode and lock request are currently discarded.
+- [ ] Add read-at-`for_update_ts` support to the transaction coordinator with targeted tests proving a retry sees the version that caused the conflict.
+- [ ] Extract or deepen the existing `MultiStatementTransaction` pessimistic lifecycle so both the bounded real-TiKV node and the wide-SQL transaction worker use one implementation.
+- [ ] Pass `SessionTxnMode` from parsed `BEGIN` and the autocommit-off path into `ClusterTransactions::begin`.
+- [ ] Collect the raw row and index keys a wide-SQL statement must lock without changing SQL execution semantics.
+- [ ] Run DML and locking reads through statement-scoped lock acquisition; on a retryable conflict restore the statement buffer image, advance `for_update_ts`, bind a new snapshot at that timestamp, and rerun the whole statement.
+- [ ] Release only locks newly acquired by a statement that fails, while preserving locks and staged mutations from earlier successful statements.
+- [ ] Stop lock keep-alive before commit or rollback, and commit with pessimistic actions for every locked mutation.
+- [ ] Turn the two-connection real-cluster probe green: the contender must remain blocked until the holder ends.
+- [ ] Run targeted Rust tests, `cargo fmt --all -- --check`, scoped Clippy with `-D warnings`, and a release build on `i4i-test-4` only.
+- [ ] Roll the release binary to the three Rust TiDB nodes and repeat the 16-thread TPC-C smoke; accept only with zero missing-lock 9007 events.
+- [ ] Capture CPU profiles through TiProxy under the corrected TPC-C workload and rank the remaining StockLevel and Delivery costs before performance edits.
+
+## Surprises & Discoveries
+
+- Observation: SQL mode parsing is not the defect. Bare `BEGIN` resolves to the `pessimistic` default, and explicit `BEGIN PESSIMISTIC` is represented by `SessionTxnMode::Pessimistic` in the bounded node.
+  Evidence: `rust/crates/tidb-server/src/session_transaction.rs` stores the mode and its targeted tests pass.
+
+- Observation: there are two explicit-transaction implementations. `rust/crates/tidb-exec/src/multi_statement_transaction.rs` supports optimistic and pessimistic transactions but is bound to one `ConfiguredTable` with integer clustered handles. `rust/crates/tidb-exec/src/cluster_table_storage.rs::SessionTransaction` serves the wide-SQL cluster path but is optimistic-only.
+  Evidence: `RealClusterTransactions::begin` calls the latter unconditionally, while `real_tikv_node` calls `MultiStatementTransaction::begin(mode, ...)`.
+
+- Observation: merely calling `PessimisticLock` after a statement is not correct. `RealPessimisticTransaction::advance_for_update_ts` advances the lock timestamp, but its current snapshot API delegates to the optimistic coordinator, whose Get and Scan requests are fixed at `start_ts`.
+  Evidence: `transaction/coordinator/snapshot_read.rs` writes `version: self.start_ts` into both request types. A lock-conflict retry that reused this snapshot could overwrite the winning value after computing from an old version.
+
+- Observation: the wide executor already stages exact TiKV-format record and index keys in `MutationBuffer`, and statement rollback already restores a byte-for-byte `BufferImage`.
+  Evidence: `rust/crates/tidb-executor/src/cluster_storage.rs` stores a key-ordered `BTreeMap<Key, Option<Vec<u8>>>`; cluster-session tests already assert statement-level restoration.
+
+- Observation: the one-warehouse smoke is diagnostic only. Its `tpmC: 42.1` and approximately 15.8-second StockLevel latency cannot be used as a formal benchmark result.
+  Evidence: `/mnt/nvme/hparser-bench/evidence/hparser-tpcc-16f5635e-t16-w1-20260808T173740Z` on `i4i-test-4`.
+
+## Decision Log
+
+- Decision: do not add client retries, rewrite single UPDATE statements into batch updates, or alter go-tpc transaction boundaries.
+  Rationale: those changes would hide the server compatibility defect and alter TPC-C semantics.
+  Date/Author: 2026-08-09, Codex.
+
+- Decision: keep PD, TiProxy, and TiKV on unmodified nightly binaries.
+  Rationale: the `hparser-integration` objective is strict Go TiDB compatibility; the defect and fix belong in Rust TiDB.
+  Date/Author: 2026-08-09, Codex.
+
+- Decision: reuse and deepen the pessimistic lifecycle already exercised by `MultiStatementTransaction` rather than create a second independent coordinator policy in `tidb-server`.
+  Rationale: lock retry, fair-lock conflict handling, lock rollback, TTL keep-alive, and Prewrite actions are consistency policy. Duplicating them would let the bounded and wide paths drift.
+  Date/Author: 2026-08-09, Codex.
+
+- Decision: statement retry surrounds SQL execution, buffer staging, lock acquisition, and snapshot binding as one unit.
+  Rationale: after a lock conflict, values computed before the lock are stale. Retrying only PessimisticLock or Prewrite can produce a lost update.
+  Date/Author: 2026-08-09, Codex.
+
+- Decision: all Rust editing, formatting, compilation, tests, release builds, and deployment validation run on `i4i-test-4:/mnt/nvme/src/tidb-hparser-integration`; Cargo commands are serialized.
+  Rationale: this is the user-requested fast repair environment and avoids divergent local artifacts.
+  Date/Author: 2026-08-09, Codex.
+
+## Outcomes & Retrospective
+
+The planner fixes and release deployment preceding this plan are complete, and the TPC-C smoke now reaches real transaction contention instead of failing on prepared statements, decoding, unsupported expressions, or panics. The remaining correctness blocker is the missing pessimistic transaction connection described here. No completion claim is made until the real-cluster lock probe blocks correctly and the 16-thread TPC-C smoke reaches zero missing-lock 9007 events.
+
+## Context and Orientation
+
+The production binary boots `ClusterSessionFactory` from `rust/crates/tidb-server/src/cluster_session_node/boot.rs`. Each connection becomes `ClusterServerSession` in `cluster_session_node/mod.rs`. It owns a `MutationBuffer`, a shared `SwappableSnapshot`, and an optional `OpenClusterTransaction`. `with_statement` binds a snapshot, takes a buffer image, executes the SQL driver, unbinds the snapshot, and either publishes or restores staged writes.
+
+The transaction seam is `rust/crates/tidb-server/src/cluster_session_node/transactions.rs`. `ClusterTransactions` opens autocommit snapshots, commits autocommit buffers, and begins an explicit transaction. `OpenClusterTransaction` currently exposes only `snapshot`, `commit`, and `rollback`; it cannot accept a mode or lock keys. `RealClusterTransactions` currently wraps the optimistic-only transaction-thread implementation in `rust/crates/tidb-exec/src/cluster_table_storage.rs`.
+
+The usable pessimistic engine is `rust/crates/tidb-txnkv/src/transaction/pessimistic.rs::RealPessimisticTransaction`. A `for_update_ts` is the timestamp used by a pessimistic statement to check and acquire locks. It starts equal to transaction `start_ts` and advances when a newer commit wins. The SQL statement must reread at the advanced timestamp before recomputing its mutations. A pessimistic action is the per-mutation Prewrite marker telling TiKV to verify an existing pessimistic lock instead of repeating an optimistic conflict check.
+
+`rust/crates/tidb-exec/src/multi_statement_transaction.rs` is the existing consumer of that engine. It already selects optimistic or pessimistic mode, performs lock acquisition, keeps a primary lock alive, releases statement-added locks on failure, and commits with pessimistic actions. Its table/handle-specific planning responsibilities must be separated from its general transaction lifecycle before the wide session reuses it.
+
+The existing red end-to-end probe uses the deployed cluster: TiProxy listens on `i4i-test-4:6000`; Rust TiDB nodes listen on port 4000 on `i4i-test-1`, `i4i-test-2`, and `i4i-test-3`. The probe must also be runnable by direct connection to one Rust node so TiProxy remains excluded from the verdict.
+
+## Plan of Work
+
+First, add a coordinator-level read method that takes an explicit snapshot version while retaining the existing transaction start timestamp for commit state and lock ownership. Refactor the existing Get and Scan bodies so `snapshot_get` and `snapshot_scan` remain exact-start-ts wrappers, while pessimistic statement reads call the versioned helpers with current `for_update_ts`. Lock resolution and GC visibility checks must use the read version, not transaction `start_ts`. Add focused transaction tests that build two committed versions around a timestamp advancement and prove the versioned read returns the newer value while the original snapshot API remains repeatable at `start_ts`.
+
+Second, isolate the general lifecycle from `MultiStatementTransaction`: mode selection, current statement read timestamp, raw-key lock acquisition, lock-failure classification, advancing `for_update_ts`, statement-added-lock rollback, primary-lock TTL keep-alive, pessimistic Prewrite plan, and commit/rollback. Keep configured-table row decoding and prepared-write planning in `MultiStatementTransaction`. Both the bounded node and wide transaction worker must call the shared lifecycle.
+
+Third, deepen `ClusterTransactions::begin` so it receives `SessionTxnMode`, fair-locking configuration, and commit protocol. Deepen `OpenClusterTransaction` so one statement can obtain a snapshot at the transaction's current statement timestamp and submit a deterministic raw-key lock set. Preserve optimistic behavior when the selected mode is optimistic.
+
+Fourth, add a per-statement lock journal at the storage/executor boundary. It must identify raw record and index keys read or mutated by the statement and distinguish keys already held before the statement. DML uses blocking wait semantics. `SELECT ... FOR UPDATE` carries the parsed `NOWAIT` or `WAIT n` policy and locks the returned row keys before rows are returned to the client. Plain SELECT statements collect no locks. Avoid parsing SQL strings with ad hoc text matching; carry structured lock intent from the parser/planner/session.
+
+Fifth, place the pessimistic retry loop in `ClusterServerSession::with_bound_statement`. Each attempt starts from the same pre-statement buffer image and auto-id retry state, binds a snapshot at the transaction's current statement timestamp, executes the SQL, then locks the collected keys. A retryable lock conflict restores the buffer image and session statement state, advances `for_update_ts`, rebuilds/rebinds, and reruns the closure. A nonretryable statement failure releases only locks added by that attempt and leaves the explicit transaction usable. A transaction-scoped failure abandons the transaction and resets the buffer.
+
+Sixth, extend mock-cluster tests to assert mode propagation, lock-key ordering and deduplication, full-statement retry after a simulated conflict, survival of earlier locks and writes, and cleanup of only the failed statement's additions. Add an ignored-by-default real-cluster test or agent-runnable script for the two-connection blocking probe. Run it red before the implementation and green after it.
+
+Finally, run the WIP checks after each milestone and the Ready checks before any completion claim. Build a release binary, record its SHA-256, roll it across the three Rust TiDB nodes one at a time, verify one listener per node, and rerun the diagnostic TPC-C smoke through TiProxy. Only after transaction correctness is green should CPU profiling drive StockLevel and Delivery optimization.
+
+## Concrete Steps
+
+All commands below run on `i4i-test-4`. Enter the Rust workspace and load Cargo into non-login shells:
+
+    cd /mnt/nvme/src/tidb-hparser-integration/rust
+    source "$HOME/.cargo/env"
+
+Run the tight cluster-session unit feedback loop with the exact new test filter recorded when the regression is added:
+
+    cargo test -p tidb-server cluster_session_node::tests::transactions::<new_pessimistic_test>
+
+Run coordinator tests after read-version work:
+
+    cargo test -p tidb-txnkv <new_for_update_read_test>
+
+Run the full targeted transaction surfaces, serially:
+
+    cargo test -p tidb-server cluster_session_node::tests::transactions
+    cargo test -p tidb-server cluster_session_node::tests::prepared_transactions
+    cargo test -p tidb-server cluster_session_node::tests::autocommit_transactions
+    cargo test -p tidb-exec multi_statement_transaction
+    cargo test -p tidb-txnkv transaction::pessimistic
+    cargo test -p tidb-txnkv transaction::coordinator
+
+Run the Rust quality gates:
+
+    cargo fmt --all -- --check
+    cargo clippy -p tidb-txnkv -p tidb-exec -p tidb-executor -p tidb-session -p tidb-server --all-targets -- -D warnings
+    cargo build --release -p tidb-server
+
+Run the 16-thread diagnostic smoke without changing go-tpc semantics:
+
+    tiup bench:v1.12.0 tpcc run -H 127.0.0.1 -P 6000 -U root -D tpcc_rowid_fix_t16 -T 16 --warehouses 1 --time 30s
+
+Preserve command lines, exit codes, error counts, latency/throughput output, binary hashes, and process/listener checks under a new timestamped directory in `/mnt/nvme/hparser-bench/evidence`.
+
+## Validation and Acceptance
+
+The regression test must fail before the implementation because no lock request reaches a transaction, then pass after the implementation. The coordinator regression must prove a statement retry reads at advanced `for_update_ts`; checking only that a timestamp number advanced is insufficient.
+
+The real-cluster holder/contender probe is green only when the contender remains blocked while the holder owns the lock and completes after holder commit or rollback. A fast 9007, a fast successful overwrite, or a five-second transport timeout are all failures.
+
+Existing optimistic transaction tests must remain green: `BEGIN OPTIMISTIC` retains repeatable reads and reports its conflicts at commit. Autocommit point-get max-ts behavior must remain unchanged. Prepared and text transaction-control statements must select identical modes.
+
+The diagnostic TPC-C run must use 16 threads, preserve stock go-tpc SQL and transaction boundaries, exit zero, and contain zero prepared-statement errors, decode errors, unsupported-expression errors, panics, and missing-lock 9007 events. The one-warehouse result remains diagnostic and is not copied into a formal benchmark comparison.
+
+## Idempotence and Recovery
+
+Targeted tests, formatting, Clippy, release builds, probes, and TPC-C runs are safe to repeat. Never use `git reset`, `git checkout`, or any command that discards the existing staged or unstaged remote work. Before each source edit, inspect both `git diff` and `git diff --cached` for the target file and apply a minimal patch on top.
+
+Release deployment is rolling. Copy the current binary to a distinct backup path before replacing it, stop and start only the one node being updated, verify its SHA and listener, then continue. If a new node fails its health query, restore that node's immediately preceding binary without changing the other two.
+
+A failed statement must be recoverable without reconnecting: restore its `BufferImage`, release its newly acquired locks, and keep earlier transaction state. A transaction-scoped coordinator or keep-alive failure is not recoverable at statement scope; abandon it and return the exact client-visible error.
+
+## Artifacts and Notes
+
+Current deployed candidate SHA-256:
+
+    16f5635ec773677ff52cf2ad6ed68547c4b53939fe94f06237cbe0153979848f
+
+Current diagnostic TPC-C evidence:
+
+    /mnt/nvme/hparser-bench/evidence/hparser-tpcc-16f5635e-t16-w1-20260808T173740Z
+
+Current manual lock-probe logs:
+
+    /tmp/for-update-holder.log
+    /tmp/for-update-contender.log
+
+The observed contender duration before the fix is 44 ms while the holder sleeps for five seconds.
+
+## Interfaces and Dependencies
+
+`tidb-txnkv` remains the only layer that emits PessimisticLock, PessimisticRollback, CheckTxnStatus/heartbeat, and pessimistic Prewrite RPC fields. Its versioned snapshot read API must preserve transaction ownership at `start_ts` while accepting a separate read version for pessimistic statements.
+
+`tidb-exec` owns the shared explicit-transaction lifecycle because both server modes already depend on it. The lifecycle accepts raw TiKV keys and structured wait policy; it must not depend on a single table or integer handle.
+
+`tidb-executor` owns `MutationBuffer`, `BufferImage`, `ClusterTableStorage`, and the per-statement access journal because this is where raw keys cross between SQL execution and storage.
+
+`tidb-session` carries structured transaction mode and locking-read intent from parsed AST. It must not send TiKV RPCs.
+
+`tidb-server` owns the connection lifecycle: selecting the mode, binding the per-attempt snapshot, rerunning the statement, deciding whether an error is statement- or transaction-scoped, and exposing exact MySQL errors.
+
+Revision note (2026-08-09): created from the confirmed missing-lock reproduction and current deployed TPC-C evidence; no implementation has yet been claimed.

--- a/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
+++ b/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
@@ -76,9 +76,10 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
 - [x] (2026-08-09) Isolated the upstream rebase in
   `/mnt/nvme/src/tidb-hparser-integration-rebased` on branch
   `codex/hparser-integration-parity`, based on upstream commit
-  `854c784e7216d709d294ca08529c4e908444d012`. Six textual conflicts were
-  reconciled with upstream ownership and APIs taking precedence; the original
-  dirty detached worktree remains untouched.
+  `8b28739bf921a34f3c3dc98035aa9dab46641d02`. The latest 27 upstream commits
+  rebased without conflict; the earlier six conflict resolutions already gave
+  upstream ownership and APIs precedence. The original dirty detached
+  worktree remains untouched.
 - [x] (2026-08-09) Restored exact parity for all 63 TPCC transaction plans and
   all 13,984 expanded Sysbench run-plan cases. Receipts are
   `tpcc-run-63-after-index-join.json` and
@@ -96,10 +97,15 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
   TiPB lowering regression passes 1/1. Receipt:
   `tpcc-check-03-exact.json`; candidate SHA-256
   `b3f530c87aeb101874c0545561a87e7ff94a3d73c70f9585110d7a1c894155ac`.
+- [x] (2026-08-09) Matched TPCC conditions 01, 02, and 04 exactly without
+  regressing 03, 05, or 07. Condition 02 now executes Go's covering
+  `idx_order` range, partial/final StreamAgg, ordered MergeJoin pair,
+  source-column lineage, retained join-key NDV, and POWER real-argument casts.
+  The complete check receipt is `tpcc-check-after-condition02-full.json`;
+  candidate SHA-256 is
+  `e2856b07a5b06b36775050a42c92386bc98e8976c93ee23d0b4113b5834079e1`.
 - [ ] (2026-08-09) Match the remaining TPCC consistency plans (completed:
-  3/12 exact and 0 protocol errors; remaining: grouped StreamAgg/partial-final
-  aggregation, derived-table decorrelation, and index-join families in
-  conditions 01-04, 06, and 08-12).
+  6/12 exact and 0 protocol errors; remaining: conditions 06 and 08-12).
 - [ ] Promote the generated manifest from `incomplete` to `complete` only after
   source and runtime coverage both prove no unknown or unreachable SQL shapes.
 - [ ] Implement Go-faithful coprocessor `IndexLookUp` execution and plan text
@@ -108,7 +114,8 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
 - [ ] Bootstrap clean formal TPCC and Sysbench datasets and run correctness,
   prepare-time, throughput, latency, health, and CPU-profile measurements.
 - [ ] Update the branch README, run the Ready validation profile, self-review,
-  commit with signoff, and push `hparser-integration`.
+  commit with signoff, push the feature branch, and create a Draft PR targeting
+  `pingcap/tidb:hparser-integration`.
 
 ## Surprises & Discoveries
 
@@ -282,7 +289,7 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
 No final outcome yet. The cluster is operational. The differential gate now
 expands to 15,248 SQL shapes and remains explicitly incomplete pending runtime
 coverage. All 63 TPCC transaction plans and 13,984 expanded Sysbench run plans
-match; TPCC checks are at 3/12 with no protocol errors. Formal datasets and
+match; TPCC checks are at 6/12 with no protocol errors. Formal datasets and
 benchmark results remain blocked on complete plan parity.
 
 ## Context and Orientation
@@ -290,7 +297,7 @@ benchmark results remain blocked on complete plan parity.
 The active source worktree is
 `/mnt/nvme/src/tidb-hparser-integration-rebased` on `i4i-test-4`, branch
 `codex/hparser-integration-parity`, based on upstream commit
-`854c784e7216d709d294ca08529c4e908444d012`. The original detached worktree at
+`8b28739bf921a34f3c3dc98035aa9dab46641d02`. The original detached worktree at
 `/mnt/nvme/src/tidb-hparser-integration` and its pre-existing local changes are
 preserved untouched. The Rust workspace is `rust/`.
 

--- a/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
+++ b/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
@@ -1,0 +1,502 @@
+# Match Go TiDB plans before benchmarking TPCC and Sysbench
+
+This ExecPlan is a living document. Keep `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` current as work proceeds.
+
+Reference: `PLANS.md` at the repository root. This plan follows the root
+`AGENTS.md`; all Rust edits, builds, tests, and benchmarks run on the EC2 host
+`i4i-test-4`, and all deployed database processes run on the four AI-Sandbox
+EC2 instances described below.
+
+## Purpose / Big Picture
+
+The Rust SQL node on branch `hparser-integration` must be evaluated as a
+drop-in replacement for Go TiDB in a distributed nightly cluster. Before a
+throughput number is accepted, every SQL template emitted by the pinned TPCC
+and Sysbench clients must have the same physical execution plan as Go TiDB.
+The observable result is a checked plan-parity report with no missing SQL
+templates and no physical-plan mismatches, followed by correctness checks and
+16-client benchmark results against the frozen nightly baseline.
+
+This is a release-blocking compatibility gate, not a best-effort performance
+comparison. Go TiDB is the sole plan oracle. Plans are compared with the same
+schema, data, statistics, bindings, session variables, parameter values, and
+transaction context. A semantically equivalent or faster Rust plan still
+fails the gate when its protected physical-plan fields differ from Go.
+
+Plan parity means the same physical operator type and tree, root versus
+`cop[tikv]` task boundary, access object, index or table ranges, ordering
+property, join/aggregation algorithm, and pushed Selection/Limit placement.
+Only generated plan-node numeric suffixes and internal `Column#N` ordinals may
+be normalized. A faster query reached through a different plan is a failure.
+
+The benchmark topology is one nightly PD, one nightly TiProxy, three nightly
+TiKV stores, three Rust TiDB nodes, three replicas, no TiFlash, and exactly 16
+total benchmark threads. Frozen baseline results and benchmark procedure come
+from CSE branch `codex/table-group-m1`; the baseline is not rerun.
+
+## Progress
+
+- [x] (2026-08-09 01:13Z) Restored BatchMode public-key SSH to all four
+  `i4i-test-1` through `i4i-test-4` hosts and verified `/mnt/nvme`.
+- [x] (2026-08-09 01:21Z) Rolled the tested Rust TiDB binary SHA-256
+  `2b793eb9f0aef7f6e6d895b021837ce5660e368413a57c3c2bce48362e5126fe`
+  to all three SQL nodes while keeping nightly PD, TiKV, and TiProxy unchanged.
+- [x] (2026-08-09 01:24Z) Pinned official go-tpc v1.0.12, source commit
+  `688d62f3be7ea6b68c2bb5fbbeb925bde681fb05`, and verified binary SHA-256
+  `864cf82c57ffdfb74a8d75644dcf3b4943ca264e16f684618f340bb0e9ce719d`.
+- [x] (2026-08-09 01:40Z) Minimized the first plan/performance mismatch to
+  the TPCC `history` aggregate and captured Go/Rust EXPLAIN evidence.
+- [x] (2026-08-09) Promoted complete Go/Rust physical-plan parity to a hard
+  prerequisite for dataset preparation, correctness acceptance, and every
+  formal TPCC/Sysbench benchmark result.
+- [x] (2026-08-09) Proved prepared-plan extraction on both servers by sending
+  `EXPLAIN FORMAT='brief' <original SQL with ?>` through MySQL binary
+  prepare/bind/execute; captured the first Go/Rust mismatch with bound values.
+- [x] (2026-08-09 02:50Z) Added the fail-closed differential runner, generated
+  candidate manifest, exact MySQL parameter encoders, protected-field diff,
+  source commit/digest pins, JSON/Markdown receipts, and focused unit tests.
+- [x] (2026-08-09 02:51Z) Ran 87 candidate plan cases with zero collection
+  errors in TPCC run and Sysbench run: TPCC run matched 14/63, TPCC checks
+  matched 0/12 with two compatibility errors, and Sysbench run matched 2/12.
+- [ ] (2026-08-09 03:32Z) Complete TPCC prepare/cleanup and Sysbench
+  prepare/cleanup/bulk-batching inventory (completed: exact default TPCC DDL,
+  32-table Sysbench DDL/split/cleanup, 32 common prepared-table variants,
+  16 worker-local variants, and every 1..851 bulk width; remaining: runtime
+  coverage receipts and execution compatibility for non-plan statements).
+- [x] (2026-08-09 03:34Z) Expanded the fail-closed manifest from 92 candidate
+  statements to 563 static cases plus 57 dynamic families, or 15,248 expanded
+  SQL shapes, while retaining `coverage_status=incomplete`.
+- [x] (2026-08-09 03:38Z) Created all 32 empty Sysbench diagnostic tables
+  through a temporary localhost-only Go DDL owner, verified both Go and Rust
+  see 32 tables, stopped the owner, and verified port 4200 is closed.
+- [x] (2026-08-09 03:42Z) Established a four-second deterministic point-get
+  differential loop: Go emits one `Point_Get`; Rust emits
+  `Projection -> Selection -> Point_Get` for the same prepared statement.
+- [x] (2026-08-09) Isolated the upstream rebase in
+  `/mnt/nvme/src/tidb-hparser-integration-rebased` on branch
+  `codex/hparser-integration-parity`, based on upstream commit
+  `854c784e7216d709d294ca08529c4e908444d012`. Six textual conflicts were
+  reconciled with upstream ownership and APIs taking precedence; the original
+  dirty detached worktree remains untouched.
+- [x] (2026-08-09) Restored exact parity for all 63 TPCC transaction plans and
+  all 13,984 expanded Sysbench run-plan cases. Receipts are
+  `tpcc-run-63-after-index-join.json` and
+  `sysbench-static-after-post-filter.json` under the plan-parity evidence
+  directory.
+- [x] (2026-08-09) Matched TPCC consistency conditions 05 and 07 exactly.
+  Condition 07 now proves the result set, common-handle range access on both
+  leaves, MergeJoin ordering, and the cross-leaf `other cond`; the complete
+  join-focused WIP suite passes 11/11.
+- [x] (2026-08-09) Matched TPCC condition 03 exactly with the executed
+  `Projection -> root StreamAgg -> TableReader -> cop StreamAgg ->
+  TableRangeScan` package. The common-handle prefix range carries
+  `keep order:true`; TiKV lowers grouped MAX/MIN/COUNT(1), and the root final
+  stage merges the partial columns. Focused aggregate tests pass 9/9 and the
+  TiPB lowering regression passes 1/1. Receipt:
+  `tpcc-check-03-exact.json`; candidate SHA-256
+  `b3f530c87aeb101874c0545561a87e7ff94a3d73c70f9585110d7a1c894155ac`.
+- [ ] (2026-08-09) Match the remaining TPCC consistency plans (completed:
+  3/12 exact and 0 protocol errors; remaining: grouped StreamAgg/partial-final
+  aggregation, derived-table decorrelation, and index-join families in
+  conditions 01-04, 06, and 08-12).
+- [ ] Promote the generated manifest from `incomplete` to `complete` only after
+  source and runtime coverage both prove no unknown or unreachable SQL shapes.
+- [ ] Implement Go-faithful coprocessor `IndexLookUp` execution and plan text
+  for the first mismatch; keep staged-write and transaction semantics exact.
+- [ ] Iterate plan families until the complete TPCC/Sysbench manifest passes.
+- [ ] Bootstrap clean formal TPCC and Sysbench datasets and run correctness,
+  prepare-time, throughput, latency, health, and CPU-profile measurements.
+- [ ] Update the branch README, run the Ready validation profile, self-review,
+  commit with signoff, and push `hparser-integration`.
+
+## Surprises & Discoveries
+
+- Observation: the retained cluster and all four instances survived the SSH
+  interruption. Three PD stores report `Up`, and TiProxy reports all three
+  Rust TiDB backends healthy.
+  Evidence: PD store addresses `172.31.45.253`, `172.31.41.190`, and
+  `172.31.39.241` each have 67 Regions and state `Up`.
+- Observation: an ordered common-handle range built below an aggregate did
+  not carry its cost estimate into `TableScanExec`. The trace therefore named
+  the correct range while the executor rejected partial aggregation as an
+  uncosted source. Passing the estimate at the physical-path commit boundary
+  made the partial offer truthful; the focused test moved from
+  `TableFullScan`, to `TableRangeScan`, to the exact partial/final tree.
+  Evidence: `tpcc-check-03-grouped-stream.json` then
+  `tpcc-check-03-exact.json`.
+- Observation: the prior smoke database was not a valid correctness fixture,
+  so a fresh one-warehouse dataset was loaded with the pinned official client.
+- Observation: one TPCC check query remained active after client disconnect,
+  MySQL `KILL`, and graceful server shutdown. The affected test-only Rust TiDB
+  process required a forced restart. Query cancellation is a separate
+  compatibility gap and must not be hidden by the plan fix.
+- Observation: the first slow query is not caused by missing schema indexes.
+  Go and Rust both choose `idx_h_c_w_id`, but Rust executes the double read at
+  root and performs one point get per index row. `IGNORE INDEX` makes Rust use
+  its coprocessor table scan and reduces the diagnostic query from a repeatable
+  5-second timeout to 0.14 seconds; this is diagnostic evidence only and must
+  never enter the benchmark SQL.
+- Observation: `crates/tidb-executor/src/access_path.rs` already documents and
+  tests the known gap as `the_double_read_issues_one_point_get_per_index_row`.
+  The test currently asserts 50 gets where Go performs one batched table-reader
+  task, so it is the correct red-capable regression seam.
+- Observation: neither Go nor Rust accepts SQL text in the form
+  `EXPLAIN FORMAT='brief' EXECUTE statement USING ...`; both return a syntax
+  error. Both do accept `EXPLAIN FORMAT='brief' <SQL containing ?>` as a
+  COM_STMT_PREPARE request and return the plan through COM_STMT_EXECUTE after
+  parameters are bound. This exercises the binary prepared path without
+  rewriting placeholders into literals.
+  Evidence: for the `history` aggregate with `(1, 1, 1)`, prepared EXPLAIN
+  returns Go's `StreamAgg -> IndexLookUp -> cop Build/Probe` tree and Rust's
+  `HashAgg -> root Selection -> root IndexRangeScan` tree.
+- Observation: the first generated candidate inventory contains 92 accounted
+  statements: 75 physical-plan cases and five transaction-control statements,
+  plus 12 TPCC consistency-check plans. All New-Order item/stock/order-line
+  forms from width 5 through 15 are explicit cases. Formal mode refuses this
+  manifest because prepare/cleanup, dynamic Sysbench bulk batching, and runtime
+  coverage remain incomplete.
+- Observation: among TPCC transaction plans, only the 14 INSERT cases currently
+  match. The other 49 differ in protected fields. Representative gaps include
+  Go `Point_Get` versus Rust `Projection -> Selection -> Point_Get`, Go
+  `Batch_Point_Get` versus the same extra root wrappers, Go coprocessor readers
+  versus root scans, and Go `IndexJoin` versus Rust root `HashJoin`.
+- Observation: TPCC checks produced ten mismatches and two hard errors. Rust
+  rejects condition 5 with `this join's plan is not supported yet`; condition
+  10 did not return its prepared EXPLAIN within the five-second protocol bound.
+  Neither left an active query after the client disconnected.
+- Observation: the 12 materialized Sysbench event plan cases matched only the
+  prepared insert-after-delete and direct `oltp_insert` shapes. Point/range
+  reads, aggregates, UPDATE, DELETE, random point-IN, and random range-OR all
+  mismatch Go.
+- Observation: the diagnostic Go TiDB on port 4100 intentionally runs with
+  `--run-ddl=false`; DDL submitted there remains queued. A temporary Go DDL
+  owner bound only to `127.0.0.1:4200` cancelled the diagnostic job, created a
+  one-row Sysbench plan fixture, was stopped after both endpoints read it, and
+  left port 4200 closed. This process must never be present during a formal run.
+- Observation: the original Sysbench candidate inventory covered only
+  `sbtest1`, but the pinned harness prepares common OLTP statements for all 32
+  tables and 16 workers execute worker-local SQL against tables 1 through 16.
+  The access object is protected plan state, so one representative table cannot
+  prove workload-wide parity.
+  Evidence: the expanded manifest contains 563 static cases, 57 compact
+  dynamic families, and 15,248 expanded shapes; unit tests reject a seventeenth
+  worker-local table.
+- Observation: direct multi-row INSERT plans match at the tested extremes, but
+  query plans do not become equivalent merely because schemas are isomorphic.
+  Evidence: TPCC order-line widths 1 and 1024, Sysbench prepare width 1000, and
+  bulk widths 1 and 851 matched; `sbtest32` point select and `sbtest16`
+  random-points still mismatched.
+- Observation: the minimal prepared point-select mismatch is deterministic
+  across repeated runs and does not involve handle recognition.
+  Evidence: Go prints `Point_Get ... table:sbtest32 handle:1`; Rust prints
+  `Projection -> Selection(eq(id,1)) -> Point_Get ... handle:1`.
+- Observation: a common-handle scan ordered by `(w_id,d_id,o_id,...)` was
+  rejected for a MergeJoin asking only for the `(w_id,d_id,o_id)` prefix
+  because the leaf compared the vectors for equality instead of testing a
+  prefix. That forced condition 07's `order_line` leaf back to a full scan.
+  Evidence: after changing the physical-delivery test to `starts_with`, both
+  Go and Rust print `TableRangeScan range:[1,1], keep order:true`.
+- Observation: condition 07's disjunction references both join children. It
+  had been removed from the root residual inventory without being admitted to
+  the join because predicate pushdown retained only bare column equalities.
+  The executor therefore under-filtered the row set and EXPLAIN omitted Go's
+  `other cond`.
+  Evidence: the volatility-screened spanning-condition path now executes the
+  disjunction at the lowest inner join; `tpcc-check-07-exact.json` reports one
+  match, zero mismatches, and zero errors.
+- Observation: after conditions 05 and 07, a complete TPCC check pass returns
+  2 matches, 10 mismatches, and no timeouts. Every remaining mismatch belongs
+  to grouped/derived aggregation property selection or the join/access path
+  above such an aggregation; prepared execution itself is no longer the
+  source of the former condition 10/12 timeout.
+
+## Decision Log
+
+- Decision: compare plans before preparing formal datasets or measuring
+  throughput.
+  Rationale: throughput from a different access path does not validate a Rust
+  rewrite of Go TiDB, even if rows are correct.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: inventory SQL from pinned go-tpc and materialized Sysbench sources,
+  then validate runtime coverage; do not maintain a hand-written partial list.
+  Rationale: TPCC has branch-dependent prepared statements and Sysbench builds
+  SQL dynamically.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: normalize only plan-node IDs and internal column ordinals.
+  Rationale: task placement, operator algorithm, access object, ranges, and
+  ordering are the behavior under test and cannot be normalized away.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: capture each case through the same direct or prepared-statement
+  path used by the pinned client and compare it under identical planner inputs.
+  Transaction-control, session, and DDL statements that have no physical plan
+  remain in the inventory and need compatibility receipts, but are explicitly
+  classified as non-plan statements rather than silently omitted.
+  Rationale: text substitution alone can miss prepared-plan-cache behavior,
+  while asking EXPLAIN to model statements that have no plan creates false
+  coverage. The inventory must account for both classes without weakening the
+  physical-plan gate.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: represent client parameter types explicitly as MySQL wire types:
+  go-tpc integers use signed LONGLONG while Sysbench `INT` uses signed LONG;
+  strings, doubles, NULLs, and unsigned forms have bounded encoders.
+  Rationale: Python/client-library inference can silently change parameter
+  metadata and therefore cannot be authoritative for prepared-plan parity.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: an `incomplete` manifest is executable only with the explicit WIP
+  override; formal mode exits before plan collection and cannot emit a passing
+  report.
+  Rationale: a green partial inventory is more dangerous than a visible red
+  mismatch because it can be mistaken for workload-wide compatibility.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: implement the TPCC history fix as Go's two-stage coprocessor
+  `IndexLookUp`, not as a cost penalty, forced table scan, added index, raw KV
+  batch-get substitute, client SQL rewrite, or changed transaction boundary.
+  Rationale: the user requires physical plan and execution agreement with Go.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: preserve a correctness fallback for unsupported or dirty-transaction
+  shapes; never approximate an unsupported coprocessor descriptor.
+  Rationale: Go semantics and read-your-own-writes take priority over speed.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: enumerate the Sysbench access-object dimension explicitly: 32
+  common prepared-table variants, 16 worker-local variants, 32 prepare-data
+  INSERT families, and 16 bulk INSERT families.
+  Rationale: table and index names are protected fields, and the pinned harness
+  has different prepare-time and execute-time reachability.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: resolve rebase conflicts in favor of the new upstream
+  `hparser-integration` implementation boundary, then reapply only prototype
+  behavior that remains necessary and compatible with those APIs.
+  Rationale: the user explicitly made updated upstream behavior authoritative,
+  and preserving an obsolete local shape would defeat the rebase.
+  Date/Author: 2026-08-09 / Codex.
+- Decision: verify every physical-order claim against the path actually built.
+  A required order may be a prefix of a longer delivered common-handle order,
+  but no promise may be inferred from an unchosen index.
+  Rationale: this admits Go's legal MergeJoin path without reviving the earlier
+  promise-without-delivery row-loss hazard.
+  Date/Author: 2026-08-09 / Codex.
+
+## Outcomes & Retrospective
+
+No final outcome yet. The cluster is operational. The differential gate now
+expands to 15,248 SQL shapes and remains explicitly incomplete pending runtime
+coverage. All 63 TPCC transaction plans and 13,984 expanded Sysbench run plans
+match; TPCC checks are at 3/12 with no protocol errors. Formal datasets and
+benchmark results remain blocked on complete plan parity.
+
+## Context and Orientation
+
+The active source worktree is
+`/mnt/nvme/src/tidb-hparser-integration-rebased` on `i4i-test-4`, branch
+`codex/hparser-integration-parity`, based on upstream commit
+`854c784e7216d709d294ca08529c4e908444d012`. The original detached worktree at
+`/mnt/nvme/src/tidb-hparser-integration` and its pre-existing local changes are
+preserved untouched. The Rust workspace is `rust/`.
+
+`rust/crates/tidb-executor/src/access_path.rs` owns the current
+`IndexRangeSourceExec`. It batches handles for ordering but calls
+`KvTable::get_row_by_handle` once per row. `rust/crates/tidb-exec/src/cop_scan.rs`
+already lowers a table scan, pushed Selection, and Limit into a TiKV DAG and
+streams rows through `tidb-distsql`. `rust/crates/tidb-exec/src/dag_request.rs`
+and `rust/crates/tidb-planner/src/physical_index_scan.rs` already support
+schema-resolved `PhysicalIndexScan` DAG encoding, but that path is not wired
+into `IndexRangeSourceExec`. `rust/crates/tidb-executor/src/plan_trace.rs` owns
+the EXPLAIN tree and currently collapses the double read into one root
+`IndexRangeScan` node.
+
+The first mismatch is:
+
+    SELECT SUM(h_amount)
+    FROM history
+    WHERE h_c_w_id = 1 AND h_c_d_id = 1 AND h_c_id = 1;
+
+Go TiDB answers in about 0.03 seconds with:
+
+    StreamAgg root
+      IndexLookUp root
+        IndexRangeScan Build cop[tikv] on idx_h_c_w_id
+        Selection Probe cop[tikv]
+          TableRowIDScan cop[tikv]
+
+Rust currently times out after 5 seconds with:
+
+    HashAgg root
+      Selection root
+        IndexRangeScan root on idx_h_c_w_id
+
+The official benchmark client is in
+`/mnt/nvme/hparser-bench/tools/go-tpc-v1.0.12/go-tpc`. Its source is pinned at
+`/mnt/nvme/src/go-tpc-v1.0.12`. A read-only archive of the CSE benchmark files
+is in `/mnt/nvme/src/cse-table-group-m1-snapshot`.
+
+`rust/scripts/generate-plan-manifest.py` is the source of the generated
+`rust/scripts/tpcc-sysbench-plan-manifest.json`. `rust/scripts/plan-parity.py`
+owns source-pin validation, exact direct/prepared plan acquisition,
+normalization, comparison, and evidence rendering. It reuses the bounded
+handshake/metadata parser in `rust/scripts/mysql-prepared-client.py` but owns
+the generic typed parameter and string-plan result codec. The focused tests are
+in `rust/scripts/test-plan-parity.py`.
+
+## Plan of Work
+
+First, generate a manifest of every prepared or direct SQL template reachable
+from the five TPCC transactions, TPCC consistency checks, TPCC preparation,
+and the ten retained Sysbench workloads. Record branch-dependent variants such
+as customer-by-id versus customer-by-last-name and variable-width `IN`/VALUES
+lists as separate plan cases when they can change the physical plan. Run short
+pinned client phases and compare observed normalized SQL fingerprints with the
+manifest; a missing observed template or an unobserved manifest entry fails.
+The manifest also records protocol mode, transaction state, parameter types
+and representative/boundary values, schema version, statistics version,
+bindings, and all plan-affecting session variables. Statements without a
+physical plan are retained with an explicit non-plan classification and an
+execution-compatibility result.
+
+Second, build a plan-differential runner under `rust/scripts/`. It initializes
+the same schema and representative rows once and obtains
+`EXPLAIN FORMAT='brief'` from the direct Go TiDB endpoint on port 4100 and a
+direct Rust TiDB endpoint on port 4000. Prepared cases send
+`EXPLAIN FORMAT='brief' <original SQL with ?>` itself through COM_STMT_PREPARE,
+bind the client's parameter types and values, then collect rows from
+COM_STMT_EXECUTE. Direct cases use direct EXPLAIN. The runner normalizes only
+generated IDs/ordinals and emits Markdown plus machine-readable JSON. It exits
+nonzero on missing cases, SQL errors, or any protected-field difference. Each
+output record includes the SQL fingerprint, parameter set, environment
+fingerprint, raw plans, normalized plans, and a structural diff.
+
+Third, turn `the_double_read_issues_one_point_get_per_index_row` into the first
+failing regression: the expected behavior is one coprocessor index stream and
+batched coprocessor table-reader requests, with no per-row snapshot gets. Add a
+real-TiKV integration case that checks the emitted DAG receipts and the exact
+Go-shaped EXPLAIN tree. Wire the existing physical index scan lowering into a
+new remote index-lookup seam. The Build request scans index ranges and returns
+handles. Each handle batch becomes point record ranges for the Probe table DAG,
+which carries residual Selection and projection. Preserve index order when Go
+requires it and merge/fallback correctly when the transaction has staged index
+or table writes.
+
+Fourth, run the differential gate and fix the next mismatching plan family in
+Go-source order. Each fix receives a focused unit test, an end-to-end query
+case, and a new plan-manifest receipt. Do not group unrelated plan families in
+one edit.
+
+Finally, recreate a clean three-replica cluster for formal data. Prepare 100
+TPCC warehouses and 32 Sysbench tables with 10,000,000 rows each through
+nightly TiProxy using 16 preparation threads. Run the full plan gate before
+each workload family, then correctness checks, warm-up, measurement, post-check,
+three simultaneous Rust CPU profiles, and PD/TiProxy/TiKV health gates. Compare
+only with the frozen nightly `3 TiDB + 3 TiKV` baseline from
+`codex/table-group-m1`.
+
+## Concrete Steps
+
+Run all commands from EC2. The coding-loop validation profile is WIP:
+
+    ssh i4i-test-4
+    cd /mnt/nvme/src/tidb-hparser-integration/rust
+    cargo test --offline --locked -j12 -p tidb-executor --lib the_double_read
+    cargo test --offline --locked -j12 -p tidb-exec --test all tikv_scan_dag
+
+Use the direct differential diagnostic after each candidate binary deployment:
+
+    timeout 5 mysql -h127.0.0.1 -P4000 -uroot -Nse \
+      'SELECT SUM(h_amount) FROM history WHERE h_c_w_id=1 AND h_c_d_id=1 AND h_c_id=1' \
+      tpcc_pinned_smoke_20260809
+
+The pre-fix result is exit 124 after exactly 5 seconds. The fixed result must
+equal Go's `10.00`, finish below one second on an idle node, and print the same
+normalized physical plan as Go.
+
+Regenerate and check the workload manifest from the repository root:
+
+    python3 rust/scripts/generate-plan-manifest.py
+    python3 rust/scripts/generate-plan-manifest.py --check
+    python3 rust/scripts/test-plan-parity.py
+
+Formal plan collection deliberately fails while coverage is incomplete. WIP
+collection requires `--allow-incomplete-manifest`; current receipts are under
+`/mnt/nvme/hparser-bench/evidence/plan-parity/`.
+
+At completion use the Ready profile from the repository skill. Run Rust format,
+the affected targeted and all-target crate tests, the real-TiKV plan gate, the
+full TPCC/Sysbench plan manifest, repository-required lint, and diff checks.
+Do not run concurrent Cargo commands.
+
+## Validation and Acceptance
+
+Acceptance requires all of the following:
+
+1. The manifest contains every SQL template/shape emitted by the pinned TPCC
+   and retained Sysbench prepare/run/check phases, including every reachable
+   branch and plan-relevant variable-width form. Runtime capture finds no
+   unknown SQL, and every manifest entry is either observed or has a documented
+   source-reachability receipt.
+2. Every manifest case has identical normalized Go/Rust physical plans under
+   the protected fields defined above. There are zero allowlisted operator,
+   task-boundary, access-path, range, algorithm, or pushdown mismatches.
+3. Both sides use identical schema/data/statistics versions, bindings,
+   plan-affecting global/session variables, transaction context, protocol mode,
+   parameter types, and parameter values. Prepared workload SQL has a prepared
+   execution-plan receipt; direct EXPLAIN substitution is insufficient.
+4. Every transaction-control, session, or DDL statement without a physical
+   plan is inventoried and passes execution compatibility; none is silently
+   excluded to make coverage appear complete.
+5. The index-lookup regression proves batched coprocessor Build/Probe requests,
+   correct row/order/NULL results, no per-row point-get loop, correct
+   read-your-own-writes behavior or an explicit correctness fallback, and exact
+   Go-shaped EXPLAIN output.
+6. Standard TPCC pre/post checks pass with the official unmodified client;
+   workload logs contain zero execution failures or ignored errors.
+7. Every accepted Sysbench scenario reports zero errors/reconnects, and all
+   three stores remain `Up` with no missing/down/pending peers.
+8. Formal results use exactly 16 total client threads through nightly TiProxy,
+   one PD, three nightly TiKV, three Rust TiDB, three replicas, and no TiFlash.
+9. README evidence names source commits, binary hashes, commands, plan-parity
+   report identity, throughput, latency, prepare time, profiles, and health.
+
+## Idempotence and Recovery
+
+SQL inventory and plan comparison are read-only after their fixture schema is
+created and may be rerun. Every evidence run uses a new timestamped directory.
+Long data preparation runs as an EC2 systemd transient unit so SSH loss does
+not kill it; its unit exit status is authoritative. Candidate binaries are
+copied to `.next`, checksum-verified, and rolled one node at a time, with the
+previous SHA retained beside them. Never reset or clean the source worktree.
+
+A cancelled query that remains active is recovered by rolling only its Rust
+TiDB node after two others are confirmed healthy. Formal datasets are created
+under new data roots; debug schemas are never reused for accepted results.
+
+## Artifacts and Notes
+
+Current diagnostic evidence is under
+`/mnt/nvme/hparser-bench/evidence/pinned-go-tpc-smoke-t16-20260809T0126Z`.
+The first full candidate receipts are
+`/mnt/nvme/hparser-bench/evidence/plan-parity/wip-tpcc-run-candidate.json`,
+`wip-tpcc-check-candidate.json`, and `wip-sysbench-run-candidate.json`.
+Dynamic-shape and access-object boundary receipts are
+`wip-expanded-dimensions-boundaries.json`,
+`wip-sysbench-table-dimension-boundaries.json`, and
+`repro-point-select-table32-run{1,2}.json`.
+The latest three-node Rust binary is SHA-256 `2b793e...e5126fe`. The frozen
+nightly TPCC baseline is 41,011.5 tpmC at 32 threads; it is historical context,
+not a thread-matched ratio for the new required 16-thread candidate run.
+
+## Interfaces and Dependencies
+
+The implementation may extend the optional remote-scan capability between
+`tidb-executor` and `tidb-exec`, but the in-process storage fallback remains
+object-safe and exact. `tidb-exec` owns TiPB DAG construction and
+`tidb-distsql` transport; `tidb-executor` must not reimplement region routing
+or RPC. `tidb-planner` remains the authority for validated table/index scan
+metadata. Public interfaces need explicit docs and must not expose a partial
+or guessed descriptor.
+
+The Go TiDB source in this repository is authoritative. For every plan-family
+fix, record the exact Go planner/executor functions used as the source model in
+the regression-test comment and commit message.
+
+Plan revision note (2026-08-09): promoted exact workload-wide plan parity to a
+fail-closed gate, documented binary prepared EXPLAIN acquisition, and recorded
+the first 87-case Go/Rust differential receipts and remaining inventory gaps.

--- a/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
+++ b/rust/TPCC_SYSBENCH_PLAN_PARITY_EXEC_PLAN.md
@@ -59,32 +59,30 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
 - [x] (2026-08-09 02:51Z) Ran 87 candidate plan cases with zero collection
   errors in TPCC run and Sysbench run: TPCC run matched 14/63, TPCC checks
   matched 0/12 with two compatibility errors, and Sysbench run matched 2/12.
-- [ ] (2026-08-09 03:32Z) Complete TPCC prepare/cleanup and Sysbench
-  prepare/cleanup/bulk-batching inventory (completed: exact default TPCC DDL,
-  32-table Sysbench DDL/split/cleanup, 32 common prepared-table variants,
-  16 worker-local variants, and every 1..851 bulk width; remaining: runtime
-  coverage receipts and execution compatibility for non-plan statements).
-- [x] (2026-08-09 03:34Z) Expanded the fail-closed manifest from 92 candidate
+- [x] (2026-08-10) Completed TPCC prepare/run/check/cleanup and Sysbench
+  prepare/run/cleanup inventory, including exact default TPCC DDL, 32-table
+  Sysbench DDL/split/cleanup, 32 common prepared-table variants, 16
+  worker-local variants, every reachable bulk width, and source/runtime
+  coverage receipts for every non-plan statement.
+- [x] (2026-08-10) Expanded the fail-closed manifest from 92 candidate
   statements to 563 static cases plus 57 dynamic families, or 15,248 expanded
-  SQL shapes, while retaining `coverage_status=incomplete`.
+  SQL shapes, and promoted it to `coverage_status=complete` only after source,
+  reachability, and execution-compatibility coverage all passed.
 - [x] (2026-08-09 03:38Z) Created all 32 empty Sysbench diagnostic tables
   through a temporary localhost-only Go DDL owner, verified both Go and Rust
   see 32 tables, stopped the owner, and verified port 4200 is closed.
 - [x] (2026-08-09 03:42Z) Established a four-second deterministic point-get
   differential loop: Go emits one `Point_Get`; Rust emits
   `Projection -> Selection -> Point_Get` for the same prepared statement.
-- [x] (2026-08-09) Isolated the upstream rebase in
+- [x] (2026-08-10) Isolated the upstream rebase in
   `/mnt/nvme/src/tidb-hparser-integration-rebased` on branch
   `codex/hparser-integration-parity`, based on upstream commit
-  `8b28739bf921a34f3c3dc98035aa9dab46641d02`. The latest 27 upstream commits
-  rebased without conflict; the earlier six conflict resolutions already gave
-  upstream ownership and APIs precedence. The original dirty detached
-  worktree remains untouched.
-- [x] (2026-08-09) Restored exact parity for all 63 TPCC transaction plans and
-  all 13,984 expanded Sysbench run-plan cases. Receipts are
-  `tpcc-run-63-after-index-join.json` and
-  `sysbench-static-after-post-filter.json` under the plan-parity evidence
-  directory.
+  `951ccad0c76ce12b558662a18ee9c1613108aa11`. Upstream implementation and
+  APIs won every conflict. The original dirty detached worktree remains
+  untouched.
+- [x] (2026-08-10) Restored exact parity for all 63 TPCC transaction plans,
+  all 12 TPCC consistency-check plans, all 1,037 TPCC prepare plans, all 32
+  Sysbench prepare plans, and all 13,952 expanded Sysbench run plans.
 - [x] (2026-08-09) Matched TPCC consistency conditions 05 and 07 exactly.
   Condition 07 now proves the result set, common-handle range access on both
   leaves, MergeJoin ordering, and the cross-leaf `other cond`; the complete
@@ -104,13 +102,16 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
   The complete check receipt is `tpcc-check-after-condition02-full.json`;
   candidate SHA-256 is
   `e2856b07a5b06b36775050a42c92386bc98e8976c93ee23d0b4113b5834079e1`.
-- [ ] (2026-08-09) Match the remaining TPCC consistency plans (completed:
-  6/12 exact and 0 protocol errors; remaining: conditions 06 and 08-12).
-- [ ] Promote the generated manifest from `incomplete` to `complete` only after
-  source and runtime coverage both prove no unknown or unreachable SQL shapes.
-- [ ] Implement Go-faithful coprocessor `IndexLookUp` execution and plan text
-  for the first mismatch; keep staged-write and transaction semantics exact.
-- [ ] Iterate plan families until the complete TPCC/Sysbench manifest passes.
+- [x] (2026-08-10) Matched the remaining TPCC consistency plans: 12/12 exact,
+  zero protocol errors.
+- [x] (2026-08-10) Promoted the generated manifest to `complete` after source
+  and runtime coverage proved no unknown or unreachable SQL shapes.
+- [x] (2026-08-10) Implemented Go-faithful coprocessor `IndexLookUp` execution
+  and plan text while preserving staged-write and transaction semantics.
+- [x] (2026-08-10) Passed the formal complete-manifest physical-plan gate:
+  15,096/15,096 exact, zero mismatches and zero errors. Passed the non-plan
+  gate: 152/152 exact after excluding only endpoint identity, disposable test
+  database name, and wall-clock duration.
 - [ ] Bootstrap clean formal TPCC and Sysbench datasets and run correctness,
   prepare-time, throughput, latency, health, and CPU-profile measurements.
 - [ ] Update the branch README, run the Ready validation profile, self-review,
@@ -217,6 +218,21 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
   to grouped/derived aggregation property selection or the join/access path
   above such an aggregation; prepared execution itself is no longer the
   source of the former condition 10/12 timeout.
+- Observation: sending raw TiDB table/index split keys to PD's aggregate
+  `SplitAndScatterRegions` RPC creates undecodable region boundaries. Go TiDB
+  then rejects those boundaries with an invalid memcomparable marker and Rust
+  eventually reports `Region is unavailable`.
+  Evidence: the original PD/TiKV roots are preserved as
+  `*.corrupt-unencoded-split-20260810T0329Z`; no damaged data was reused.
+- Observation: PD's split RPC expects memcomparable-encoded region keys, just
+  like `GetRegion`. Encoding, sorting, and deduplicating every key before the
+  RPC, then polling the exact PD scatter operator to completion, made both
+  table and index split results match Go (`8`, `1`) and kept a newly booted Go
+  TiDB able to create, read, and drop data on the same cluster.
+- Observation: reloading a clustered composite primary key can expose both the
+  clustered handle and a mirrored PRIMARY `IndexInfo`. Rust `SHOW CREATE TABLE`
+  printed both definitions until the mirrored entry was suppressed. The fixed
+  TPCC and Sysbench schema SHA-256 values now exactly match Go.
 
 ## Decision Log
 
@@ -286,33 +302,32 @@ from CSE branch `codex/table-group-m1`; the baseline is not rerun.
 
 ## Outcomes & Retrospective
 
-No final outcome yet. The cluster is operational. The differential gate now
-expands to 15,248 SQL shapes and remains explicitly incomplete pending runtime
-coverage. All 63 TPCC transaction plans and 13,984 expanded Sysbench run plans
-match; TPCC checks are at 6/12 with no protocol errors. Formal datasets and
-benchmark results remain blocked on complete plan parity.
+The compatibility gate is complete but the performance outcome is not final.
+The manifest accounts for 15,248 SQL shapes: 15,096 physical plans and 152
+non-plan statements. Formal reports against Go TiDB commit
+`951ccad0c76ce12b558662a18ee9c1613108aa11` show 15,096/15,096 exact plans,
+zero mismatches, and zero errors. Fresh-cluster non-plan reports show 152/152
+exact execution results and identical TPCC/Sysbench schema hashes. Formal
+dataset preparation, correctness runs, benchmark measurements, profiles, and
+the Draft PR remain pending.
 
 ## Context and Orientation
 
 The active source worktree is
 `/mnt/nvme/src/tidb-hparser-integration-rebased` on `i4i-test-4`, branch
 `codex/hparser-integration-parity`, based on upstream commit
-`8b28739bf921a34f3c3dc98035aa9dab46641d02`. The original detached worktree at
+`951ccad0c76ce12b558662a18ee9c1613108aa11`. The original detached worktree at
 `/mnt/nvme/src/tidb-hparser-integration` and its pre-existing local changes are
 preserved untouched. The Rust workspace is `rust/`.
 
-`rust/crates/tidb-executor/src/access_path.rs` owns the current
-`IndexRangeSourceExec`. It batches handles for ordering but calls
-`KvTable::get_row_by_handle` once per row. `rust/crates/tidb-exec/src/cop_scan.rs`
-already lowers a table scan, pushed Selection, and Limit into a TiKV DAG and
-streams rows through `tidb-distsql`. `rust/crates/tidb-exec/src/dag_request.rs`
-and `rust/crates/tidb-planner/src/physical_index_scan.rs` already support
-schema-resolved `PhysicalIndexScan` DAG encoding, but that path is not wired
-into `IndexRangeSourceExec`. `rust/crates/tidb-executor/src/plan_trace.rs` owns
-the EXPLAIN tree and currently collapses the double read into one root
-`IndexRangeScan` node.
+`rust/crates/tidb-executor/src/access_path.rs` owns `IndexRangeSourceExec`.
+The initial implementation issued one `KvTable::get_row_by_handle` per index
+row. The completed path now uses the TiPB DAG and `tidb-distsql` transport in
+`rust/crates/tidb-exec`, preserves the required order and transaction fallback,
+and emits Go-faithful Build/Probe plan text through
+`rust/crates/tidb-executor/src/plan_trace.rs`.
 
-The first mismatch is:
+The first mismatch used to be:
 
     SELECT SUM(h_amount)
     FROM history
@@ -326,7 +341,7 @@ Go TiDB answers in about 0.03 seconds with:
         Selection Probe cop[tikv]
           TableRowIDScan cop[tikv]
 
-Rust currently times out after 5 seconds with:
+Before the fix, Rust timed out after 5 seconds with:
 
     HashAgg root
       Selection root
@@ -398,10 +413,10 @@ only with the frozen nightly `3 TiDB + 3 TiKV` baseline from
 
 ## Concrete Steps
 
-Run all commands from EC2. The coding-loop validation profile is WIP:
+Run all commands from EC2. The coding-loop validation profile is:
 
     ssh i4i-test-4
-    cd /mnt/nvme/src/tidb-hparser-integration/rust
+    cd /mnt/nvme/src/tidb-hparser-integration-rebased/rust
     cargo test --offline --locked -j12 -p tidb-executor --lib the_double_read
     cargo test --offline --locked -j12 -p tidb-exec --test all tikv_scan_dag
 
@@ -421,8 +436,8 @@ Regenerate and check the workload manifest from the repository root:
     python3 rust/scripts/generate-plan-manifest.py --check
     python3 rust/scripts/test-plan-parity.py
 
-Formal plan collection deliberately fails while coverage is incomplete. WIP
-collection requires `--allow-incomplete-manifest`; current receipts are under
+Formal plan collection now requires `coverage_status=complete`; the WIP
+override is not used for accepted evidence. Current receipts are under
 `/mnt/nvme/hparser-bench/evidence/plan-parity/`.
 
 At completion use the Ready profile from the repository skill. Run Rust format,
@@ -477,18 +492,25 @@ under new data roots; debug schemas are never reused for accepted results.
 
 ## Artifacts and Notes
 
-Current diagnostic evidence is under
-`/mnt/nvme/hparser-bench/evidence/pinned-go-tpc-smoke-t16-20260809T0126Z`.
-The first full candidate receipts are
-`/mnt/nvme/hparser-bench/evidence/plan-parity/wip-tpcc-run-candidate.json`,
-`wip-tpcc-check-candidate.json`, and `wip-sysbench-run-candidate.json`.
-Dynamic-shape and access-object boundary receipts are
-`wip-expanded-dimensions-boundaries.json`,
-`wip-sysbench-table-dimension-boundaries.json`, and
-`repro-point-select-table32-run{1,2}.json`.
-The latest three-node Rust binary is SHA-256 `2b793e...e5126fe`. The frozen
-nightly TPCC baseline is 41,011.5 tpmC at 32 threads; it is historical context,
-not a thread-matched ratio for the new required 16-thread candidate run.
+Current accepted plan evidence is under
+`/mnt/nvme/hparser-bench/evidence/plan-parity/`:
+
+    formal-951ccad0-335edb4-tpcc-run-v1.json          63/63
+    formal-951ccad0-335edb4-tpcc-check-v1.json        12/12
+    formal-951ccad0-335edb4-tpcc-prepare-v1.json      1,037/1,037
+    formal-951ccad0-335edb4-sysbench-prepare-v1.json  32/32
+    formal-951ccad0-335edb4-sysbench-run-v1.json      13,952/13,952
+
+The matching complete-manifest non-plan receipts are
+`formal-951ccad0-335edb4-rust-non-plan-v1.json` and
+`formal-951ccad0-go-non-plan-v1.json`, covering 152/152 statements exactly.
+The candidate Rust binary SHA-256 is
+`335edb4dfaf476ed54addcc6727878039e781dbf58433d2de189f6f80236feac`.
+The Go oracle binary SHA-256 is
+`59fbf8fc40f9d37e8737ea02ba428144cbf284b61d8e8d46811e26bb36c211b9`.
+The frozen nightly TPCC baseline is 41,011.5 tpmC at 32 threads; it is
+historical context, not a thread-matched ratio for the required 16-thread
+candidate run.
 
 ## Interfaces and Dependencies
 
@@ -507,3 +529,8 @@ the regression-test comment and commit message.
 Plan revision note (2026-08-09): promoted exact workload-wide plan parity to a
 fail-closed gate, documented binary prepared EXPLAIN acquisition, and recorded
 the first 87-case Go/Rust differential receipts and remaining inventory gaps.
+
+Plan revision note (2026-08-10): rebased onto upstream `951ccad0`, completed
+the 15,248-shape workload inventory, passed all 15,096 physical-plan and 152
+non-plan compatibility cases, recorded the PD split-key encoding incident and
+fresh-cluster recovery proof, and unblocked formal benchmarking.

--- a/rust/crates/tidb-distsql/src/cop_paging/direct_unary_query_transport.rs
+++ b/rust/crates/tidb-distsql/src/cop_paging/direct_unary_query_transport.rs
@@ -1043,9 +1043,18 @@ impl<C: DirectUnaryClient, L: RegionRecoveryLoader> DirectUnaryQueryResponse<C, 
         if replace_selector {
             let mut read_policy = self.read_policy;
             read_policy.selection_seed = self.selection_seed;
-            let mut selector = cache_operation(&self.shared_runtime, |region_cache| {
+            let selector = cache_operation(&self.shared_runtime, |region_cache| {
                 region_cache.request_selector(region, read_policy)
-            })??;
+            })?;
+            let mut selector = match selector {
+                Ok(selector) => selector,
+                Err(RegionRouteError::MissingLeader) => {
+                    let failed = self.runtime.consume_failed_attempt(attempt_id)?;
+                    self.request_selectors.remove(&logical_task_id);
+                    return self.rebuild_exhausted_region(failed, region.id);
+                }
+                Err(error) => return Err(DirectUnaryTransportError::Route(error)),
+            };
             selector.set_health_policy(ReplicaHealthPolicy {
                 try_leader: matches!(
                     read_policy.mode,
@@ -1412,9 +1421,13 @@ impl<C: DirectUnaryClient, L: RegionRecoveryLoader> DirectUnaryQueryResponse<C, 
         }
         self.record_attempt_result(logical_task_id, &selected, dispatch_duration)?;
         cache_operation(&self.shared_runtime, |region_cache| {
-            region_cache
-                .on_route_success(&selected)
-                .map_err(|error| DirectUnaryTransportError::RegionRecovery(error.to_string()))?;
+            match region_cache.on_route_success(&selected) {
+                Ok(_) => {}
+                Err(RegionRecoveryError::StaleObservation(_)) => return Ok(()),
+                Err(error) => {
+                    return Err(DirectUnaryTransportError::RegionRecovery(error.to_string()));
+                }
+            }
             region_cache
                 .promote_successful_request(&selected)
                 .map_err(|error| DirectUnaryTransportError::RegionRecovery(error.to_string()))?;
@@ -1643,7 +1656,16 @@ impl<C: DirectUnaryClient, L: RegionRecoveryLoader> DirectUnaryQueryResponse<C, 
                 .region_cache_handle()
                 .on_region_error(&region_error, observed_attempt, budget)
                 .map_err(|_| DirectUnaryTransportError::RegionCacheLifecycle)?
-                .map_err(|error| DirectUnaryTransportError::RegionRecovery(error.to_string()))?
+        };
+        let disposition = match disposition {
+            Ok(disposition) => disposition,
+            Err(RegionRecoveryError::StaleObservation(_)) => {
+                self.request_selectors.remove(&logical_task_id);
+                return self.rebuild_exhausted_region(failed, region_id);
+            }
+            Err(error) => {
+                return Err(DirectUnaryTransportError::RegionRecovery(error.to_string()));
+            }
         };
 
         match disposition {

--- a/rust/crates/tidb-distsql/src/cop_paging/lock_recovery.rs
+++ b/rust/crates/tidb-distsql/src/cop_paging/lock_recovery.rs
@@ -14,10 +14,12 @@
 
 //! DistSQL continuation for bounded optimistic lock recovery.
 
+use std::cell::RefCell;
+
 use tidb_txnkv::lock::{
     decode_lock_observation, resolve_optimistic_locks, LockRecoveryClient, TimestampSource,
 };
-use tidb_txnkv::region::RegionRecoveryLoader;
+use tidb_txnkv::region::{RegionBackoffBudget, RegionBackoffKind, RegionRecoveryLoader};
 use tidb_txnkv::SharedReadRuntime;
 
 use super::{LockedResponseAction, LockedResponseDelegate, LockedResponseObservation};
@@ -26,13 +28,17 @@ use super::{LockedResponseAction, LockedResponseDelegate, LockedResponseObservat
 #[derive(Debug)]
 pub struct OptimisticLockRecovery<S> {
     timestamp_source: S,
+    lock_backoff: RefCell<RegionBackoffBudget>,
 }
 
 impl<S> OptimisticLockRecovery<S> {
     /// Creates a bounded recovery policy without another client or cache.
     #[must_use]
-    pub const fn new(timestamp_source: S) -> Self {
-        Self { timestamp_source }
+    pub fn new(timestamp_source: S) -> Self {
+        Self {
+            timestamp_source,
+            lock_backoff: RefCell::new(RegionBackoffBudget::campaign_default()),
+        }
     }
 
     /// Returns the injected timestamp authority.
@@ -68,16 +74,28 @@ where
         )
         .map_err(|error| error.to_string())?;
         if result.is_alive() {
-            let ttl = result.ttl;
+            // Go `BackoffWithMaxSleepTxnLockFast(int(msBeforeExpired), ...)`:
+            // retry a short transaction after a millisecond-scale backoff,
+            // capped by its TTL, instead of sleeping the whole TTL while the
+            // owner is normally about to commit.
+            let wait = self
+                .lock_backoff
+                .borrow_mut()
+                .next_delay_capped(RegionBackoffKind::TxnLockFast, result.ttl)
+                .map_err(|exhausted| {
+                    format!(
+                        "optimistic lock recovery exhausted {:?} backoff budget {:?}",
+                        exhausted.kind, exhausted.max_sleep
+                    )
+                })?;
             let deadline_budget = observation.call.timeout();
-            if deadline_budget.is_zero() {
+            if wait > deadline_budget {
                 return Err("optimistic lock recovery exceeded the unary deadline".to_owned());
             }
-            let wait = ttl.min(deadline_budget);
             if observation.call.cancellation().wait_timeout(wait) {
                 return Err("optimistic lock TTL wait cancelled by caller".to_owned());
             }
-            if wait < ttl {
+            if !wait.is_zero() && observation.call.timeout().is_zero() {
                 return Err("optimistic lock recovery exceeded the unary deadline".to_owned());
             }
         }

--- a/rust/crates/tidb-distsql/tests/direct_unary_region_errors.rs
+++ b/rust/crates/tidb-distsql/tests/direct_unary_region_errors.rs
@@ -22,6 +22,114 @@
 use crate::direct_unary_client_fixture::*;
 
 #[test]
+fn successful_response_ignores_feedback_for_a_concurrently_invalidated_route() {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let loader_calls = Rc::new(RefCell::new(Vec::new()));
+    let shared = tidb_txnkv::SharedReadRuntime::new_injected(
+        ScriptedClient {
+            calls: Rc::clone(&calls),
+            responses: VecDeque::from([Ok(response(b"valid-response"))]),
+            events: Rc::new(RefCell::new(Vec::new())),
+            liveness: RefCell::new(VecDeque::new()),
+            batch_errors: RefCell::new(VecDeque::new()),
+            batch_completion_gate: None,
+        },
+        RegionCache::new(ScriptedLoader {
+            cluster_id: 9001,
+            calls: Rc::clone(&loader_calls),
+            regions: VecDeque::from([location(1, "a", "z", "tikv-1:20160")]),
+        }),
+    );
+    let cache = shared.region_cache_handle();
+    let transport = DirectUnaryQueryTransport::with_shared_runtime_batch_first(
+        shared,
+        DirectUnaryRuntimeConfig::default(),
+        tidb_txnkv::lock::FixedTimestampSource::new(1 << 18),
+    )
+    .unwrap();
+    let evidence = transport.evidence_handle();
+    let mut runtime = InjectedQueryRuntime::new(transport);
+    let mut result = select_result(&mut runtime, &transport_request(metadata("a", "z")));
+    evidence
+        .set_publication_observer(move |_| {
+            cache
+                .with_cache(|cache| assert!(cache.invalidate(RegionVerId::new(1, 1, 2))))
+                .unwrap();
+        })
+        .unwrap();
+
+    assert_eq!(
+        result.next_raw().unwrap(),
+        Some(b"valid-response".to_vec())
+    );
+    assert_eq!(result.next_raw().unwrap(), None);
+    assert_eq!(calls.borrow().len(), 1);
+    assert_eq!(loader_calls.borrow().as_slice(), [b"a".to_vec()]);
+}
+
+#[test]
+fn stale_region_error_rebuilds_ranges_from_the_current_route() {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let loader_calls = Rc::new(RefCell::new(Vec::new()));
+    let shared = tidb_txnkv::SharedReadRuntime::new_injected(
+        ScriptedClient {
+            calls: Rc::clone(&calls),
+            responses: VecDeque::from([
+                Ok(not_leader(1, None)),
+                Ok(response(b"current-route")),
+            ]),
+            events: Rc::new(RefCell::new(Vec::new())),
+            liveness: RefCell::new(VecDeque::new()),
+            batch_errors: RefCell::new(VecDeque::new()),
+            batch_completion_gate: None,
+        },
+        RegionCache::new(ScriptedLoader {
+            cluster_id: 9001,
+            calls: Rc::clone(&loader_calls),
+            regions: VecDeque::from([
+                location(1, "a", "z", "tikv-old:20160"),
+                location(1, "a", "z", "tikv-new:20160"),
+            ]),
+        }),
+    );
+    let cache = shared.region_cache_handle();
+    let transport = DirectUnaryQueryTransport::with_shared_runtime_batch_first(
+        shared,
+        DirectUnaryRuntimeConfig::default(),
+        tidb_txnkv::lock::FixedTimestampSource::new(1 << 18),
+    )
+    .unwrap();
+    let evidence = transport.evidence_handle();
+    let mut runtime = InjectedQueryRuntime::new(transport);
+    let mut result = select_result(&mut runtime, &transport_request(metadata("a", "z")));
+    let invalidated = Rc::new(Cell::new(false));
+    evidence
+        .set_publication_observer(move |_| {
+            if !invalidated.replace(true) {
+                cache
+                    .with_cache(|cache| assert!(cache.invalidate(RegionVerId::new(1, 1, 2))))
+                    .unwrap();
+            }
+        })
+        .unwrap();
+
+    assert_eq!(result.next_raw().unwrap(), Some(b"current-route".to_vec()));
+    assert_eq!(result.next_raw().unwrap(), None);
+    assert_eq!(
+        calls
+            .borrow()
+            .iter()
+            .map(|call| call.address.as_str())
+            .collect::<Vec<_>>(),
+        ["tikv-old:20160", "tikv-new:20160"]
+    );
+    assert_eq!(
+        loader_calls.borrow().as_slice(),
+        [b"a".to_vec(), b"a".to_vec()]
+    );
+}
+
+#[test]
 fn cached_leader_data_is_not_ready_falls_through_without_reload_or_backoff() {
     let calls = Rc::new(RefCell::new(Vec::new()));
     let loader_calls = Rc::new(RefCell::new(Vec::new()));

--- a/rust/crates/tidb-distsql/tests/direct_unary_retry_budget.rs
+++ b/rust/crates/tidb-distsql/tests/direct_unary_retry_budget.rs
@@ -22,6 +22,55 @@
 use crate::direct_unary_client_fixture::*;
 
 #[test]
+fn cache_invalidation_between_binding_and_dispatch_reloads_and_resends() {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let loader_calls = Rc::new(RefCell::new(Vec::new()));
+    let shared = tidb_txnkv::SharedReadRuntime::new_injected(
+        ScriptedClient {
+            calls: Rc::clone(&calls),
+            responses: VecDeque::from([Ok(response(b"reloaded"))]),
+            events: Rc::new(RefCell::new(Vec::new())),
+            liveness: RefCell::new(VecDeque::new()),
+            batch_errors: RefCell::new(VecDeque::new()),
+            batch_completion_gate: None,
+        },
+        RegionCache::new(ScriptedLoader {
+            cluster_id: 9001,
+            calls: Rc::clone(&loader_calls),
+            regions: VecDeque::from([
+                location(1, "a", "z", "tikv-old:20160"),
+                location(1, "a", "z", "tikv-new:20160"),
+            ]),
+        }),
+    );
+    let cache = shared.region_cache_handle();
+    let transport = DirectUnaryQueryTransport::with_shared_runtime(
+        shared,
+        DirectUnaryRuntimeConfig {
+            seed_read_bytes: 4096,
+            observation_time,
+            ..DirectUnaryRuntimeConfig::default()
+        },
+        tidb_txnkv::lock::FixedTimestampSource::new(1 << 18),
+    )
+    .unwrap();
+    let mut runtime = InjectedQueryRuntime::new(transport);
+    let mut result = select_result(&mut runtime, &transport_request(metadata("a", "z")));
+
+    cache
+        .with_cache(|cache| assert!(cache.invalidate(RegionVerId::new(1, 1, 2))))
+        .unwrap();
+
+    assert_eq!(result.next_raw().unwrap(), Some(b"reloaded".to_vec()));
+    assert_eq!(result.next_raw().unwrap(), None);
+    assert_eq!(
+        loader_calls.borrow().as_slice(),
+        [b"a".to_vec(), b"a".to_vec()]
+    );
+    assert_eq!(calls.borrow()[0].address, "tikv-new:20160");
+}
+
+#[test]
 fn nil_leader_sleeps_then_invalidates_reloads_and_resends() {
     let calls = Rc::new(RefCell::new(Vec::new()));
     let loader_calls = Rc::new(RefCell::new(Vec::new()));

--- a/rust/crates/tidb-distsql/tests/lock_recovery_source.rs
+++ b/rust/crates/tidb-distsql/tests/lock_recovery_source.rs
@@ -36,17 +36,19 @@ fn delegate_has_one_shared_runtime_and_only_same_task_continuation() {
 }
 
 #[test]
-fn alive_ttl_uses_exact_cancellation_wait_without_polling() {
+fn alive_ttl_uses_txn_lock_fast_backoff_without_polling() {
     let recovery = source("src/cop_paging/lock_recovery.rs");
     let alive = recovery
         .split("if result.is_alive() {")
         .nth(1)
         .expect("alive branch");
-    assert!(alive.contains("let deadline_budget = observation.call.timeout()"));
-    assert!(alive.contains("let wait = ttl.min(deadline_budget)"));
+    assert!(alive.contains("RegionBackoffKind::TxnLockFast"));
+    assert!(alive.contains("next_delay_capped"));
+    assert!(alive.contains("result.ttl"));
+    assert!(alive.contains("observation.call.timeout()"));
     assert!(alive.contains("observation.call.cancellation().wait_timeout(wait)"));
-    assert!(alive.contains("wait < ttl"));
     assert!(alive.contains("cancelled by caller"));
+    assert!(!alive.contains("ttl.min(deadline_budget)"));
     assert!(!alive.contains("thread::sleep"));
     assert!(!alive.contains("is_cancelled"));
 }

--- a/rust/crates/tidb-exec/src/cluster_table_storage.rs
+++ b/rust/crates/tidb-exec/src/cluster_table_storage.rs
@@ -56,25 +56,33 @@
 //! [`ClusterSnapshot`]: tidb_executor::cluster_storage::ClusterSnapshot
 //! [`MutationBuffer`]: tidb_executor::cluster_storage::MutationBuffer
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::multi_statement_transaction::TRANSACTION_END_TIMEOUT;
+use crate::multi_statement_transaction::{
+    LockKeysOutcome, TransactionStatementError, TRANSACTION_END_TIMEOUT,
+};
 use tidb_executor::cluster_storage::{
     ClusterSnapshot, ClusterTableStorage, MutationBuffer, SnapshotPairs,
 };
 use tidb_executor::storage::StorageError;
+use tidb_planner::read_only_scan::ReadLockWait;
 use tidb_txnkv::rpc::UnaryCallContext;
 use tidb_txnkv::transaction::{
-    OptimisticCommitOutcome, OptimisticCoordinatorError, OptimisticMutation,
-    ProductionOptimisticTransaction, RealOptimisticTransactionOpener, MAX_OPTIMISTIC_MUTATIONS,
+    CommitProtocol, LockKeepAlive, LockWaitTime, OptimisticCommitOutcome,
+    OptimisticCoordinatorError, OptimisticMutation, ProductionOptimisticTransaction,
+    ProductionPessimisticTransaction, RealOptimisticTransactionOpener, MAX_OPTIMISTIC_MUTATIONS,
     MAX_OPTIMISTIC_TRANSACTION_BYTES,
 };
 use tidb_txnkv::Key;
 
-use crate::pessimistic_lock_error::{commit_outcome_to_sql_error, LockSqlError};
+use crate::pessimistic_lock_error::{
+    commit_outcome_to_sql_error, is_retryable_statement_failure, lock_failure_to_sql_error,
+    locked_with_conflict_error, transaction_cause_to_sql_error, LockSqlError,
+};
 use crate::pinned_thread_pool::PinnedThreadPool;
 
 /// One request the transaction's own thread serves, with the channel its answer
@@ -91,6 +99,12 @@ enum TransactionRequest {
         /// batch it consumes rather than for its whole range.
         limit: Option<usize>,
         reply: Sender<Result<SnapshotPairs, StorageError>>,
+    },
+    LockKeys {
+        keys: Vec<Vec<u8>>,
+        presume_not_exists: BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+        reply: Sender<Result<WorkerLockOutcome, TransactionStatementError>>,
     },
     /// Publishes `mutations` at the transaction's original `start_ts` and ends
     /// the thread, whatever the outcome.
@@ -121,6 +135,32 @@ enum TransactionRequest {
 struct TransactionThread {
     requests: Option<Sender<TransactionRequest>>,
     start_ts: u64,
+    statement_read_ts: u64,
+}
+
+struct WorkerLockOutcome {
+    outcome: LockKeysOutcome,
+    statement_read_ts: u64,
+}
+
+/// Go client-go `KVSnapshot.Get`/`BatchGet` use a 20-second retry backoff
+/// budget (`getMaxBackoff`/`batchGetMaxBackoff`) around their short TiKV RPCs.
+const SNAPSHOT_READ_MAX_BACKOFF: Duration = Duration::from_secs(20);
+
+fn transaction_request_timeout(request: &TransactionRequest, default: Duration) -> Duration {
+    match request {
+        TransactionRequest::Get { .. } | TransactionRequest::Scan { .. } => {
+            default.max(SNAPSHOT_READ_MAX_BACKOFF)
+        }
+        TransactionRequest::LockKeys { wait, .. } => match wait {
+            ReadLockWait::Blocking => default.max(Duration::from_secs(55)),
+            ReadLockWait::NoWait => default,
+            ReadLockWait::Seconds(seconds) => {
+                default.max(Duration::from_secs(seconds.saturating_add(5)))
+            }
+        },
+        _ => default,
+    }
 }
 
 /// Which transaction a [`TransactionThread`] opens, and therefore what its
@@ -135,6 +175,26 @@ enum TransactionOpen {
     Writable,
     ReadOnly,
     ReadOnlyAtMaxTs,
+    /// A multi-statement transaction whose statements may take pessimistic
+    /// locks. It still publishes through the same two-phase coordinator.
+    Pessimistic {
+        fair_locking: bool,
+        commit_protocol: CommitProtocol,
+    },
+}
+
+enum OpenTransaction {
+    Optimistic(ProductionOptimisticTransaction),
+    Pessimistic(ProductionPessimisticTransaction),
+}
+
+impl OpenTransaction {
+    fn start_ts(&self) -> u64 {
+        match self {
+            Self::Optimistic(transaction) => transaction.start_ts(),
+            Self::Pessimistic(transaction) => transaction.start_ts(),
+        }
+    }
 }
 
 impl TransactionOpen {
@@ -181,18 +241,35 @@ impl TransactionThread {
                 name,
                 Box::new(move || {
                     let begun = match open {
-                        TransactionOpen::Writable => {
-                            opener.begin(MAX_OPTIMISTIC_MUTATIONS, MAX_OPTIMISTIC_TRANSACTION_BYTES)
+                        TransactionOpen::Writable => opener
+                            .begin(MAX_OPTIMISTIC_MUTATIONS, MAX_OPTIMISTIC_TRANSACTION_BYTES)
+                            .map(OpenTransaction::Optimistic),
+                        TransactionOpen::ReadOnly => {
+                            opener.begin_read_only().map(OpenTransaction::Optimistic)
                         }
-                        TransactionOpen::ReadOnly => opener.begin_read_only(),
-                        TransactionOpen::ReadOnlyAtMaxTs => opener.begin_read_only_at_max_ts(),
+                        TransactionOpen::ReadOnlyAtMaxTs => opener
+                            .begin_read_only_at_max_ts()
+                            .map(OpenTransaction::Optimistic),
+                        TransactionOpen::Pessimistic {
+                            fair_locking,
+                            commit_protocol,
+                        } => opener
+                            .begin_pessimistic(
+                                MAX_OPTIMISTIC_MUTATIONS,
+                                MAX_OPTIMISTIC_TRANSACTION_BYTES,
+                            )
+                            .map(|mut transaction| {
+                                transaction.set_fair_locking(fair_locking);
+                                transaction.set_commit_protocol(commit_protocol);
+                                OpenTransaction::Pessimistic(transaction)
+                            }),
                     };
                     let transaction = match begun {
                         Ok(transaction) => {
                             // A caller that stopped waiting leaves no lock
                             // behind: the transaction ends here instead.
                             if opened.send(Ok(transaction.start_ts())).is_err() {
-                                let _ = transaction.finish_without_writes();
+                                finish_open_transaction(transaction);
                                 return;
                             }
                             transaction
@@ -202,7 +279,7 @@ impl TransactionThread {
                             return;
                         }
                     };
-                    serve_transaction(transaction, &incoming, timeout);
+                    serve_transaction(transaction, &incoming, timeout, &opener);
                 }),
             )
             .map_err(OptimisticCoordinatorError::SnapshotGet)?;
@@ -217,6 +294,7 @@ impl TransactionThread {
         Ok(Self {
             requests: Some(requests),
             start_ts,
+            statement_read_ts: start_ts,
         })
     }
 
@@ -259,6 +337,45 @@ impl TransactionThread {
         }
     }
 
+    fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        presume_not_exists: &BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError> {
+        let requests = self.requests.as_ref().cloned().ok_or_else(|| {
+            TransactionStatementError::Transaction(LockSqlError {
+                code: 1105,
+                state: *b"HY000",
+                message: "the transaction is already finished".to_owned(),
+            })
+        })?;
+        let (reply, answer) = mpsc::channel();
+        requests
+            .send(TransactionRequest::LockKeys {
+                keys: keys.to_vec(),
+                presume_not_exists: presume_not_exists.clone(),
+                wait,
+                reply,
+            })
+            .map_err(|_| {
+                TransactionStatementError::Transaction(LockSqlError {
+                    code: 1105,
+                    state: *b"HY000",
+                    message: "the transaction thread is gone".to_owned(),
+                })
+            })?;
+        let answer = answer.recv().map_err(|_| {
+            TransactionStatementError::Transaction(LockSqlError {
+                code: 1105,
+                state: *b"HY000",
+                message: "the transaction thread stopped while locking keys".to_owned(),
+            })
+        })??;
+        self.statement_read_ts = answer.statement_read_ts;
+        Ok(answer.outcome)
+    }
+
     fn sender(&self) -> Result<Sender<TransactionRequest>, StorageError> {
         self.requests
             .as_ref()
@@ -293,24 +410,32 @@ fn ask<T>(
 /// Serves the transaction on its own thread until it is committed, finished, or
 /// its last handle goes away.
 fn serve_transaction(
-    mut transaction: ProductionOptimisticTransaction,
+    mut transaction: OpenTransaction,
     incoming: &Receiver<TransactionRequest>,
     timeout: Duration,
+    opener: &RealOptimisticTransactionOpener,
 ) {
+    let mut keep_alive: Option<LockKeepAlive> = None;
     while let Ok(request) = incoming.recv() {
         // Minted per request, never once for the thread. `UnaryCallContext`
         // carries an ABSOLUTE deadline, so a single context made when the
         // transaction opened would charge every later statement — and the
         // commit — for the wall-clock time the client spent holding the
         // transaction, which is not work anything did.
-        let call = UnaryCallContext::with_timeout(timeout);
+        let call = UnaryCallContext::with_timeout(transaction_request_timeout(&request, timeout));
         let call = &call;
         match request {
             TransactionRequest::Get { key, reply } => {
-                let answer = transaction
-                    .snapshot_get(&key, call)
-                    .map(|result| result.value)
-                    .map_err(classify);
+                let answer = match &mut transaction {
+                    OpenTransaction::Optimistic(transaction) => transaction
+                        .snapshot_get(&key, call)
+                        .map(|result| result.value)
+                        .map_err(classify),
+                    OpenTransaction::Pessimistic(transaction) => transaction
+                        .statement_snapshot_get(&key, call)
+                        .map(|result| result.value)
+                        .map_err(classify),
+                };
                 let _ = reply.send(answer);
             }
             TransactionRequest::Scan {
@@ -319,9 +444,73 @@ fn serve_transaction(
                 limit,
                 reply,
             } => {
-                let answer = transaction
-                    .snapshot_scan(&start, &end, limit, call)
-                    .map_err(classify);
+                let answer = match &mut transaction {
+                    OpenTransaction::Optimistic(transaction) => transaction
+                        .snapshot_scan(&start, &end, limit, call)
+                        .map_err(classify),
+                    OpenTransaction::Pessimistic(transaction) => transaction
+                        .statement_snapshot_scan(&start, &end, limit, call)
+                        .map_err(classify),
+                };
+                let _ = reply.send(answer);
+            }
+            TransactionRequest::LockKeys {
+                keys,
+                presume_not_exists,
+                wait,
+                reply,
+            } => {
+                let answer = match &mut transaction {
+                    OpenTransaction::Optimistic(_) => {
+                        Err(TransactionStatementError::Statement(LockSqlError {
+                            code: 1105,
+                            state: *b"HY000",
+                            message: "an optimistic transaction cannot take pessimistic locks"
+                                .to_owned(),
+                        }))
+                    }
+                    OpenTransaction::Pessimistic(transaction) => {
+                        let outcome = lock_pessimistic_keys_once(
+                            transaction,
+                            &keys,
+                            &presume_not_exists,
+                            wait,
+                            call,
+                        );
+                        match outcome {
+                            Ok(outcome) => {
+                                let keep_alive_result = if keep_alive.is_none() {
+                                    transaction.primary_key().map_or(Ok(()), |primary_key| {
+                                        opener
+                                            .start_lock_keep_alive(
+                                                primary_key.to_vec(),
+                                                transaction.start_ts(),
+                                            )
+                                            .map(|started| keep_alive = Some(started))
+                                            .map_err(|error| {
+                                                TransactionStatementError::Transaction(
+                                                    LockSqlError {
+                                                        code: 1105,
+                                                        state: *b"HY000",
+                                                        message: format!(
+                                                            "cannot keep the transaction's primary lock alive: {error}"
+                                                        ),
+                                                    },
+                                                )
+                                            })
+                                    })
+                                } else {
+                                    Ok(())
+                                };
+                                keep_alive_result.map(|()| WorkerLockOutcome {
+                                    outcome,
+                                    statement_read_ts: transaction.statement_read_ts(),
+                                })
+                            }
+                            Err(error) => Err(error),
+                        }
+                    }
+                };
                 let _ = reply.send(answer);
             }
             TransactionRequest::Commit { mutations, reply } => {
@@ -333,25 +522,147 @@ fn serve_transaction(
                 // backoffers on `c.store.Ctx()` with `cleanupMaxBackoff`,
                 // deliberately decoupled from the statement's context.
                 let end_call = UnaryCallContext::with_timeout(TRANSACTION_END_TIMEOUT);
-                let _ = reply.send(
-                    transaction
+                if let Some(keep_alive) = keep_alive.take() {
+                    keep_alive.close();
+                }
+                let answer = match transaction {
+                    OpenTransaction::Optimistic(transaction) => transaction
                         .commit(mutations, &end_call)
                         .map_err(|error| error.to_string()),
-                );
+                    OpenTransaction::Pessimistic(transaction) => transaction
+                        .commit(mutations, &end_call)
+                        .map_err(|error| error.to_string()),
+                };
+                let _ = reply.send(answer);
                 return;
             }
             TransactionRequest::Finish { reply } => {
-                let _ = reply.send(
-                    transaction
+                if let Some(keep_alive) = keep_alive.take() {
+                    keep_alive.close();
+                }
+                let answer = match transaction {
+                    OpenTransaction::Optimistic(transaction) => transaction
                         .finish_without_writes()
                         .map(|_| ())
                         .map_err(|error| StorageError::Backend(error.to_string())),
-                );
+                    OpenTransaction::Pessimistic(mut transaction) => {
+                        let call = UnaryCallContext::with_timeout(TRANSACTION_END_TIMEOUT);
+                        let locked = transaction.locked_keys();
+                        if let Err(error) = transaction.pessimistic_rollback(&locked, &call) {
+                            Err(StorageError::Backend(error.to_string()))
+                        } else {
+                            transaction
+                                .into_two_pc()
+                                .finish_without_writes()
+                                .map(|_| ())
+                                .map_err(|error| StorageError::Backend(error.to_string()))
+                        }
+                    }
+                };
+                let _ = reply.send(answer);
                 return;
             }
         }
     }
-    let _ = transaction.finish_without_writes();
+    finish_open_transaction(transaction);
+}
+
+fn lock_pessimistic_keys_once(
+    transaction: &mut ProductionPessimisticTransaction,
+    keys: &[Vec<u8>],
+    presume_not_exists: &BTreeSet<Vec<u8>>,
+    wait: ReadLockWait,
+    call: &UnaryCallContext,
+) -> Result<LockKeysOutcome, TransactionStatementError> {
+    if keys.is_empty() {
+        return Ok(LockKeysOutcome::Acquired);
+    }
+    let wait = match wait {
+        ReadLockWait::Blocking => LockWaitTime::session_lock_wait_timeout(),
+        ReadLockWait::NoWait => LockWaitTime::NoWait,
+        ReadLockWait::Seconds(seconds) => LockWaitTime::Timeout(Duration::from_secs(seconds)),
+    };
+    let held: BTreeSet<Vec<u8>> = transaction.locked_keys().into_iter().collect();
+    // Fair locking keeps a lock granted with a newer committed version while
+    // the caller reruns the statement at the advanced `for_update_ts`. That
+    // lock is already owned by this transaction on the retry; asking TiKV to
+    // ForceLock it again reports the same `LockedWithConflict` forever and
+    // exhausts the statement retry budget. Reacquire only keys this statement
+    // has not already inherited from an earlier attempt or statement.
+    let keys_to_lock = lock_keys_not_held(keys, &held);
+    if keys_to_lock.is_empty() {
+        return Ok(LockKeysOutcome::Acquired);
+    }
+    let presume_not_exists_to_lock = presume_not_exists
+        .iter()
+        .filter(|key| !held.contains(*key))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let retry_reason =
+        match transaction.acquire_locks(&keys_to_lock, &presume_not_exists_to_lock, wait, call) {
+            Ok(acquired) if acquired.locked_with_conflict.is_empty() => {
+                return Ok(LockKeysOutcome::Acquired);
+            }
+            Ok(acquired) => {
+                let (key, conflict_commit_ts) = acquired
+                    .locked_with_conflict
+                    .iter()
+                    .max_by_key(|(_, conflict_ts)| *conflict_ts)
+                    .expect("the non-empty branch admits a conflict");
+                locked_with_conflict_error(transaction.start_ts(), *conflict_commit_ts, key)
+            }
+            Err(failure) => {
+                let added = transaction
+                    .locked_keys()
+                    .into_iter()
+                    .filter(|key| !held.contains(key))
+                    .collect::<Vec<_>>();
+                if let Err(cause) = transaction.pessimistic_rollback(&added, call) {
+                    return Err(TransactionStatementError::Transaction(
+                        transaction_cause_to_sql_error(&cause),
+                    ));
+                }
+                if !is_retryable_statement_failure(&failure) {
+                    let error = lock_failure_to_sql_error(&failure);
+                    return Err(if failure.is_statement_scoped() {
+                        TransactionStatementError::Statement(error)
+                    } else {
+                        TransactionStatementError::Transaction(error)
+                    });
+                }
+                lock_failure_to_sql_error(&failure)
+            }
+        };
+    transaction.advance_for_update_ts().map_err(|failure| {
+        let error = lock_failure_to_sql_error(&failure);
+        if failure.is_statement_scoped() {
+            TransactionStatementError::Statement(error)
+        } else {
+            TransactionStatementError::Transaction(error)
+        }
+    })?;
+    Ok(LockKeysOutcome::Retry(retry_reason))
+}
+
+fn lock_keys_not_held(keys: &[Vec<u8>], held: &BTreeSet<Vec<u8>>) -> Vec<Vec<u8>> {
+    keys.iter()
+        .filter(|key| !held.contains(*key))
+        .cloned()
+        .collect()
+}
+
+fn finish_open_transaction(transaction: OpenTransaction) {
+    match transaction {
+        OpenTransaction::Optimistic(transaction) => {
+            let _ = transaction.finish_without_writes();
+        }
+        OpenTransaction::Pessimistic(mut transaction) => {
+            let call = UnaryCallContext::with_timeout(TRANSACTION_END_TIMEOUT);
+            let locked = transaction.locked_keys();
+            let _ = transaction.pessimistic_rollback(&locked, &call);
+            let _ = transaction.into_two_pc().finish_without_writes();
+        }
+    }
 }
 
 /// One statement's read snapshot: a real read-only transaction at one PD
@@ -415,6 +726,12 @@ impl StatementSnapshot {
         self.thread.start_ts
     }
 
+    /// The timestamp the next statement reads at.
+    #[must_use]
+    pub const fn statement_read_ts(&self) -> u64 {
+        self.thread.statement_read_ts
+    }
+
     /// Ends the statement's read transaction, leaving no locks behind.
     ///
     /// Calling it twice is a no-op: the statement is already finished.
@@ -463,6 +780,7 @@ impl ClusterSnapshot for StatementSnapshot {
 /// read.
 pub struct SessionTransaction {
     thread: TransactionThread,
+    mode: tidb_planner::txn_mode::SessionTxnMode,
 }
 
 impl fmt::Debug for SessionTransaction {
@@ -485,15 +803,60 @@ impl SessionTransaction {
         opener: Arc<RealOptimisticTransactionOpener>,
         timeout: Duration,
     ) -> Result<Self, OptimisticCoordinatorError> {
-        Ok(Self {
-            thread: TransactionThread::open(&opener, timeout, true, "cluster-session-transaction")?,
-        })
+        Self::begin_mode(
+            opener,
+            timeout,
+            tidb_planner::txn_mode::SessionTxnMode::Optimistic,
+            false,
+            CommitProtocol::two_phase_only(),
+        )
+    }
+
+    /// Opens a real multi-statement transaction in the requested TiDB mode.
+    ///
+    /// The wide SQL session uses this entry point with no configured table;
+    /// reads are addressed by raw keys and therefore work for every loaded
+    /// table in the connection's catalog.
+    pub fn begin_mode(
+        opener: Arc<RealOptimisticTransactionOpener>,
+        timeout: Duration,
+        mode: tidb_planner::txn_mode::SessionTxnMode,
+        fair_locking: bool,
+        commit_protocol: CommitProtocol,
+    ) -> Result<Self, OptimisticCoordinatorError> {
+        let thread = match mode {
+            tidb_planner::txn_mode::SessionTxnMode::Optimistic => {
+                TransactionThread::open(&opener, timeout, true, "cluster-session-transaction")?
+            }
+            tidb_planner::txn_mode::SessionTxnMode::Pessimistic => TransactionThread::open_with(
+                &opener,
+                timeout,
+                TransactionOpen::Pessimistic {
+                    fair_locking,
+                    commit_protocol,
+                },
+                "cluster-session-pessimistic-transaction",
+            )?,
+        };
+        Ok(Self { thread, mode })
+    }
+
+    /// The mode selected when the transaction opened.
+    #[must_use]
+    pub const fn mode(&self) -> tidb_planner::txn_mode::SessionTxnMode {
+        self.mode
     }
 
     /// The one timestamp every statement of this transaction reads at.
     #[must_use]
     pub const fn start_ts(&self) -> u64 {
         self.thread.start_ts
+    }
+
+    /// The timestamp the next statement reads at.
+    #[must_use]
+    pub const fn statement_read_ts(&self) -> u64 {
+        self.thread.statement_read_ts
     }
 
     /// A read handle onto this transaction, for one statement to bind.
@@ -503,8 +866,20 @@ impl SessionTransaction {
     pub fn snapshot(&self) -> Result<Box<dyn ClusterSnapshot>, StorageError> {
         Ok(Box::new(SessionSnapshot {
             requests: self.thread.sender()?,
-            start_ts: self.thread.start_ts,
+            start_ts: self.thread.statement_read_ts,
         }))
+    }
+
+    /// Attempts one raw-key pessimistic lock batch. A retry result means the
+    /// caller must restore its statement buffer image and rerun the SQL at the
+    /// transaction's advanced statement timestamp.
+    pub fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        presume_not_exists: &BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError> {
+        self.thread.lock_keys_once(keys, presume_not_exists, wait)
     }
 
     /// Publishes every staged write of the transaction at its own `start_ts`.
@@ -781,5 +1156,69 @@ mod tests {
             )),
             StorageError::Backend(_)
         ));
+    }
+
+    #[test]
+    fn a_statement_retry_does_not_relock_fairly_acquired_keys() {
+        let held = BTreeSet::from([b"already-locked".to_vec()]);
+        let requested = vec![b"already-locked".to_vec(), b"new-key".to_vec()];
+
+        assert_eq!(
+            lock_keys_not_held(&requested, &held),
+            vec![b"new-key".to_vec()]
+        );
+    }
+
+    #[test]
+    fn a_lock_request_deadline_covers_its_wait_budget() {
+        let default = Duration::from_secs(5);
+        let request = |wait| {
+            let (reply, _) = mpsc::channel();
+            TransactionRequest::LockKeys {
+                keys: vec![b"key".to_vec()],
+                presume_not_exists: BTreeSet::new(),
+                wait,
+                reply,
+            }
+        };
+
+        assert_eq!(
+            transaction_request_timeout(&request(ReadLockWait::NoWait), default),
+            default
+        );
+        assert_eq!(
+            transaction_request_timeout(&request(ReadLockWait::Blocking), default),
+            Duration::from_secs(55)
+        );
+        assert_eq!(
+            transaction_request_timeout(&request(ReadLockWait::Seconds(60)), default),
+            Duration::from_secs(65)
+        );
+    }
+
+    #[test]
+    fn a_snapshot_request_deadline_covers_client_go_backoff() {
+        let default = Duration::from_secs(5);
+        let (get_reply, _) = mpsc::channel();
+        let get = TransactionRequest::Get {
+            key: b"key".to_vec(),
+            reply: get_reply,
+        };
+        let (scan_reply, _) = mpsc::channel();
+        let scan = TransactionRequest::Scan {
+            start: b"a".to_vec(),
+            end: b"z".to_vec(),
+            limit: None,
+            reply: scan_reply,
+        };
+
+        assert_eq!(
+            transaction_request_timeout(&get, default),
+            SNAPSHOT_READ_MAX_BACKOFF
+        );
+        assert_eq!(
+            transaction_request_timeout(&scan, default),
+            SNAPSHOT_READ_MAX_BACKOFF
+        );
     }
 }

--- a/rust/crates/tidb-exec/src/cop_scan.rs
+++ b/rust/crates/tidb-exec/src/cop_scan.rs
@@ -659,12 +659,17 @@ fn partial_aggregate_to_pb(
             )],
             false,
         ),
-        PushdownPartialAggregate::GroupedStream {
+        PushdownPartialAggregate::Grouped {
             group_offsets,
             functions,
+            streamed,
             ..
         } => (
-            ExecType::TypeStreamAgg,
+            if *streamed {
+                ExecType::TypeStreamAgg
+            } else {
+                ExecType::TypeAggregation
+            },
             group_offsets
                 .iter()
                 .map(|offset| input_expr(*offset))
@@ -685,7 +690,7 @@ fn partial_aggregate_to_pb(
                     aggregate_expr(tp, input, &function.output_type)
                 })
                 .collect(),
-            true,
+            *streamed,
         ),
     };
     Executor {
@@ -1065,7 +1070,7 @@ mod tests {
         let output = FieldType::new(FieldTypeCode::LongLong);
         let group_type = FieldType::new(FieldTypeCode::Long);
         let executor = partial_aggregate_to_pb(
-            &PushdownPartialAggregate::GroupedStream {
+            &PushdownPartialAggregate::Grouped {
                 group_offsets: vec![1],
                 group_types: vec![group_type],
                 functions: vec![
@@ -1085,6 +1090,7 @@ mod tests {
                         output_type: output,
                     },
                 ],
+                streamed: true,
             },
             &[integer_column(), integer_column()],
         );
@@ -1099,6 +1105,35 @@ mod tests {
         assert_eq!(
             aggregate.agg_func[2].children[0].tp,
             Some(ExprType::Int64 as i32)
+        );
+    }
+
+    #[test]
+    fn grouped_hash_aggregate_lowers_as_non_streamed_aggregation() {
+        let output = FieldType::new(FieldTypeCode::NewDecimal);
+        let group_type = FieldType::new(FieldTypeCode::Long);
+        let executor = partial_aggregate_to_pb(
+            &PushdownPartialAggregate::Grouped {
+                group_offsets: vec![0, 1],
+                group_types: vec![group_type.clone(), group_type],
+                functions: vec![tidb_executor::remote_scan::PushdownAggregateFunction {
+                    kind: PushdownAggregateKind::Sum,
+                    input_offset: Some(2),
+                    output_type: output,
+                }],
+                streamed: false,
+            },
+            &[integer_column(), integer_column(), integer_column()],
+        );
+        assert_eq!(executor.tp, Some(ExecType::TypeAggregation as i32));
+        let aggregate = executor.aggregation.expect("aggregation field 5");
+        assert_eq!(aggregate.streamed, Some(false));
+        assert_eq!(aggregate.group_by.len(), 2);
+        assert_eq!(aggregate.agg_func.len(), 1);
+        assert_eq!(aggregate.agg_func[0].tp, Some(ExprType::Sum as i32));
+        assert_eq!(
+            aggregate.agg_func[0].children[0].val,
+            Some(encode_column_offset(2))
         );
     }
 

--- a/rust/crates/tidb-exec/src/cop_scan.rs
+++ b/rust/crates/tidb-exec/src/cop_scan.rs
@@ -74,13 +74,17 @@ use tidb_distsql::{
 };
 use tidb_executor::predicate_pushdown::ScanPredicate;
 use tidb_executor::remote_scan::{
-    PushdownRowStream, PushdownScanColumn, PushdownScanRequest, PushdownScanner,
-    PushdownScannerError, EXTRA_HANDLE_COLUMN_ID,
+    PushdownAggregateKind, PushdownPartialAggregate, PushdownRowStream, PushdownScanColumn,
+    PushdownScanRequest, PushdownScanner, PushdownScannerError, PushdownTopN,
+    EXTRA_HANDLE_COLUMN_ID,
 };
 use tidb_executor::storage::StorageError;
 use tidb_planner::physical_table_scan::PhysicalTableScanPlan;
 use tidb_planner::tikv_scan_spec::{ScanColumnInfo, TiKvTableScanSpec};
-use tidb_proto::tipb::{ExecType, Expr};
+use tidb_proto::tipb::{
+    Aggregation, ByItem, ColumnInfo as PbColumnInfo, ExecType, Executor, Expr, ExprType,
+    FieldType as PbFieldType, IndexScan, TopN as PbTopN,
+};
 use tidb_txnkv::KeyRange;
 
 use crate::dag_request::{
@@ -218,12 +222,20 @@ where
             .map(scan_column)
             .collect::<Option<Vec<_>>>()
             .ok_or_else(|| refuse("a column has no bounded coprocessor descriptor"))?;
-        let field_types: Vec<FieldType> = request
+        let mut field_types: Vec<FieldType> = request
             .columns
             .iter()
             .map(|column| column.field_type.clone())
             .collect();
-        let output_offsets: Vec<u32> = (0..columns.len() as u32).collect();
+        let output_offsets: Vec<u32> = match request.output_offsets.as_ref() {
+            Some(offsets) => {
+                if offsets.iter().any(|offset| *offset >= columns.len()) {
+                    return Err(refuse("an output offset is outside the scan columns"));
+                }
+                offsets.iter().map(|offset| *offset as u32).collect()
+            }
+            None => (0..columns.len() as u32).collect(),
+        };
 
         // Every conjunct this lowering accepts travels; the rest simply stay
         // behind, because the scan source tests all of them locally anyway.
@@ -240,6 +252,31 @@ where
                 PushdownScannerError::Backend(StorageError::Backend(error.to_string()))
             })?
         };
+        if (request.aggregate.is_some()
+            || request.output_offsets.is_some()
+            || request.topn.is_some())
+            && lowered.len() != request.predicates.len()
+        {
+            return Err(refuse(
+                "partial aggregation, post-filter projection, and TopN require every predicate in the TiKV Selection",
+            ));
+        }
+        if request.aggregate.is_some()
+            && (request.output_offsets.is_some() || request.topn.is_some())
+        {
+            return Err(refuse(
+                "partial aggregation cannot be combined with post-filter projection or TopN",
+            ));
+        }
+        if request.topn.is_some() && request.limit.is_some() {
+            return Err(refuse("TopN cannot be combined with a scan Limit"));
+        }
+        if let Some(offsets) = request.output_offsets.as_ref() {
+            field_types = offsets
+                .iter()
+                .map(|offset| request.columns[*offset].field_type.clone())
+                .collect();
+        }
 
         // The cap may only travel with a predicate that travelled WHOLE. A
         // conjunct left behind means TiKV counts its `limit` rows against a
@@ -254,6 +291,8 @@ where
         };
 
         let mut spec = TiKvTableScanSpec::new(request.table_id, columns.clone());
+        spec.primary_column_ids = request.primary_column_ids.clone();
+        spec.primary_prefix_column_ids = request.primary_prefix_column_ids.clone();
         // The merge above reads the remote rows in record-key order, which is
         // the order it merges the staged buffer against.
         spec.keep_order = true;
@@ -261,7 +300,7 @@ where
         // Go `ConstructDAGReq`: the zone comes from the SESSION VARIABLES of
         // the statement that issued this request, read fresh every time.
         let (time_zone_name, time_zone_offset_secs) = request.statement.time_zone.dag_zone();
-        let dag = construct_capped_read_only_dag_req_with_conditions(
+        let mut dag = construct_capped_read_only_dag_req_with_conditions(
             &DagRequestContext::new(
                 time_zone_name,
                 time_zone_offset_secs,
@@ -278,6 +317,36 @@ where
             &output_offsets,
         )
         .map_err(|error| PushdownScannerError::Unsupported(error.to_string()))?;
+        if let Some(index) = request.index.as_ref() {
+            dag.executors[0] = index_scan_to_pb(request.table_id, index, &columns);
+        }
+        if let Some(topn) = request.topn.as_ref() {
+            if topn.order_by.is_empty()
+                || topn.limit == 0
+                || topn
+                    .order_by
+                    .iter()
+                    .any(|item| item.offset >= columns.len())
+            {
+                return Err(refuse("TopN has no key/limit or names a missing column"));
+            }
+            dag.executors.push(topn_to_pb(topn, &columns));
+        }
+        if let Some(aggregate) = request.aggregate.as_ref() {
+            if aggregate
+                .input_offsets()
+                .into_iter()
+                .any(|offset| offset >= columns.len())
+            {
+                return Err(refuse(
+                    "partial aggregation input is outside the scan output",
+                ));
+            }
+            dag.executors
+                .push(partial_aggregate_to_pb(aggregate, &columns));
+            field_types = aggregate.output_types();
+            dag.output_offsets = (0..field_types.len() as u32).collect();
+        }
 
         let summary = dag_summary(&dag);
         let key_ranges: Vec<KeyRange> = request
@@ -285,11 +354,21 @@ where
             .iter()
             .map(|(start, end)| KeyRange::new(start.clone(), end.clone()))
             .collect();
-        let mut shapes = vec![ExecutorShape::new(ExecutorKind::TableScan)];
+        let mut shapes = vec![ExecutorShape::new(if request.index.is_some() {
+            ExecutorKind::IndexScan
+        } else {
+            ExecutorKind::TableScan
+        })];
         if !conditions.is_empty() {
             shapes.push(ExecutorShape::new(ExecutorKind::Other));
         }
         if remote_limit.is_some() {
+            shapes.push(ExecutorShape::new(ExecutorKind::Other));
+        }
+        if request.topn.is_some() {
+            shapes.push(ExecutorShape::new(ExecutorKind::Other));
+        }
+        if request.aggregate.is_some() {
             shapes.push(ExecutorShape::new(ExecutorKind::Other));
         }
         let plan = RemoteScanPlan {
@@ -297,6 +376,11 @@ where
             envelope: RequestEnvelope::new(shapes),
             key_ranges,
             snapshot_ts: request.snapshot_ts,
+            // The current task runtime intentionally owns only ordered
+            // response publication. Aggregation itself has no ordering
+            // guarantee, but requesting ordered region responses is a valid
+            // transport choice and keeps this request inside that runtime.
+            keep_order: true,
             field_types,
             warnings: request.statement.warnings.clone(),
         };
@@ -343,6 +427,15 @@ fn dag_summary(dag: &tidb_proto::tipb::DagRequest) -> String {
                     .unwrap_or_default();
                 format!("TableScan(table {table}, {columns} columns)")
             }
+            Some(tp) if tp == ExecType::TypeIndexScan as i32 => {
+                let scan = executor.idx_scan.as_ref();
+                format!(
+                    "IndexScan(table {}, index {}, {} columns)",
+                    scan.and_then(|scan| scan.table_id).unwrap_or_default(),
+                    scan.and_then(|scan| scan.index_id).unwrap_or_default(),
+                    scan.map_or(0, |scan| scan.columns.len())
+                )
+            }
             Some(tp) if tp == ExecType::TypeSelection as i32 => format!(
                 "Selection({} conditions)",
                 executor
@@ -358,6 +451,34 @@ fn dag_summary(dag: &tidb_proto::tipb::DagRequest) -> String {
                     .and_then(|limit| limit.limit)
                     .unwrap_or_default()
             ),
+            Some(tp) if tp == ExecType::TypeTopN as i32 => format!(
+                "TopN({} keys, limit {})",
+                executor
+                    .top_n
+                    .as_ref()
+                    .map_or(0, |topn| topn.order_by.len()),
+                executor
+                    .top_n
+                    .as_ref()
+                    .and_then(|topn| topn.limit)
+                    .unwrap_or_default()
+            ),
+            Some(tp)
+                if tp == ExecType::TypeAggregation as i32
+                    || tp == ExecType::TypeStreamAgg as i32 =>
+            {
+                let aggregation = executor.aggregation.as_ref();
+                format!(
+                    "{}({} group keys, {} functions)",
+                    if tp == ExecType::TypeStreamAgg as i32 {
+                        "StreamAgg"
+                    } else {
+                        "HashAgg"
+                    },
+                    aggregation.map_or(0, |agg| agg.group_by.len()),
+                    aggregation.map_or(0, |agg| agg.agg_func.len())
+                )
+            }
             other => format!("executor {other:?}"),
         })
         .collect();
@@ -379,6 +500,9 @@ struct RemoteScanPlan {
     /// handle range, and the coprocessor request carries them all.
     key_ranges: Vec<KeyRange>,
     snapshot_ts: u64,
+    /// Aggregation destroys scan key order; ordinary row scans preserve it
+    /// for the staged-buffer merge.
+    keep_order: bool,
     field_types: Vec<FieldType>,
     /// The statement's warning sink, carried onto the scan thread. It is an
     /// `Arc` handler, so a warning appended here lands in the buffer
@@ -431,7 +555,7 @@ where
     let mut builder = RequestBuilder::from_context(&DistSqlContext::new());
     builder
         .set_start_ts(plan.snapshot_ts)
-        .set_keep_order(true)
+        .set_keep_order(plan.keep_order)
         .set_non_partitioned_key_ranges(plan.key_ranges)
         .set_dag_request(plan.envelope, plan.dag.encode_to_vec());
     let request = builder
@@ -479,6 +603,247 @@ where
     }
     iter.close();
     Ok(())
+}
+
+/// Builds the bounded partial aggregate immediately above a TiKV scan.
+fn partial_aggregate_to_pb(
+    aggregate: &PushdownPartialAggregate,
+    inputs: &[ScanColumnInfo],
+) -> Executor {
+    let input_expr = |offset: usize| scan_column_expr(offset, inputs);
+    let (tp, group_by, agg_func, streamed) = match aggregate {
+        PushdownPartialAggregate::Count {
+            input_offset,
+            output_type,
+        } => (
+            ExecType::TypeStreamAgg,
+            Vec::new(),
+            vec![aggregate_expr(
+                ExprType::Count,
+                input_expr(*input_offset),
+                output_type,
+            )],
+            true,
+        ),
+        PushdownPartialAggregate::Sum {
+            input_offset,
+            output_type,
+        } => (
+            ExecType::TypeStreamAgg,
+            Vec::new(),
+            vec![aggregate_expr(
+                ExprType::Sum,
+                input_expr(*input_offset),
+                output_type,
+            )],
+            true,
+        ),
+        PushdownPartialAggregate::GroupBy { input_offset, .. } => (
+            ExecType::TypeAggregation,
+            vec![input_expr(*input_offset)],
+            Vec::new(),
+            false,
+        ),
+        PushdownPartialAggregate::GroupBySum {
+            group_offset,
+            sum_offset,
+            sum_type,
+            ..
+        } => (
+            ExecType::TypeAggregation,
+            vec![input_expr(*group_offset)],
+            vec![aggregate_expr(
+                ExprType::Sum,
+                input_expr(*sum_offset),
+                sum_type,
+            )],
+            false,
+        ),
+        PushdownPartialAggregate::GroupedStream {
+            group_offsets,
+            functions,
+            ..
+        } => (
+            ExecType::TypeStreamAgg,
+            group_offsets
+                .iter()
+                .map(|offset| input_expr(*offset))
+                .collect(),
+            functions
+                .iter()
+                .map(|function| {
+                    let input = function.input_offset.map_or_else(
+                        || constant_one_expr(&function.output_type),
+                        |offset| input_expr(offset),
+                    );
+                    let tp = match function.kind {
+                        PushdownAggregateKind::Count => ExprType::Count,
+                        PushdownAggregateKind::Sum => ExprType::Sum,
+                        PushdownAggregateKind::Min => ExprType::Min,
+                        PushdownAggregateKind::Max => ExprType::Max,
+                    };
+                    aggregate_expr(tp, input, &function.output_type)
+                })
+                .collect(),
+            true,
+        ),
+    };
+    Executor {
+        tp: Some(tp as i32),
+        tbl_scan: None,
+        idx_scan: None,
+        selection: None,
+        aggregation: Some(Aggregation {
+            group_by,
+            agg_func,
+            streamed: Some(streamed),
+        }),
+        top_n: None,
+        limit: None,
+        executor_id: Some(String::new()),
+        parent_idx: None,
+    }
+}
+
+fn topn_to_pb(topn: &PushdownTopN, inputs: &[ScanColumnInfo]) -> Executor {
+    Executor {
+        tp: Some(ExecType::TypeTopN as i32),
+        tbl_scan: None,
+        idx_scan: None,
+        selection: None,
+        aggregation: None,
+        top_n: Some(PbTopN {
+            order_by: topn
+                .order_by
+                .iter()
+                .map(|item| ByItem {
+                    expr: Some(scan_column_expr(item.offset, inputs)),
+                    desc: Some(item.desc),
+                })
+                .collect(),
+            limit: Some(topn.limit),
+        }),
+        limit: None,
+        executor_id: Some(String::new()),
+        parent_idx: None,
+    }
+}
+
+fn scan_column_expr(offset: usize, inputs: &[ScanColumnInfo]) -> Expr {
+    Expr {
+        tp: Some(ExprType::ColumnRef as i32),
+        val: Some(encode_column_offset(offset)),
+        children: Vec::new(),
+        sig: Some(tidb_proto::tipb::ScalarFuncSig::Unspecified as i32),
+        field_type: Some(scan_field_type(&inputs[offset])),
+        has_distinct: Some(false),
+    }
+}
+
+fn aggregate_expr(tp: ExprType, input: Expr, output_type: &FieldType) -> Expr {
+    Expr {
+        tp: Some(tp as i32),
+        val: None,
+        children: vec![input],
+        sig: Some(tidb_proto::tipb::ScalarFuncSig::Unspecified as i32),
+        field_type: Some(field_type_to_pb(output_type)),
+        has_distinct: Some(false),
+    }
+}
+
+fn constant_one_expr(output_type: &FieldType) -> Expr {
+    let mut encoded = Vec::with_capacity(8);
+    tidb_codec::encode_int(&mut encoded, 1);
+    Expr {
+        tp: Some(ExprType::Int64 as i32),
+        val: Some(encoded),
+        children: Vec::new(),
+        sig: Some(tidb_proto::tipb::ScalarFuncSig::Unspecified as i32),
+        field_type: Some(field_type_to_pb(output_type)),
+        has_distinct: Some(false),
+    }
+}
+
+fn encode_column_offset(offset: usize) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(8);
+    tidb_codec::encode_int(
+        &mut encoded,
+        i64::try_from(offset).expect("scan column offset fits i64"),
+    );
+    encoded
+}
+
+fn scan_field_type(column: &ScanColumnInfo) -> PbFieldType {
+    let collation = tidb_datatype::proto_to_collation(column.collation);
+    let charset = tidb_datatype::get_collation_by_name(&collation)
+        .map_or_else(|_| "binary".to_owned(), |row| row.charset_name);
+    PbFieldType {
+        tp: Some(column.tp),
+        flag: Some(u32::try_from(column.flag).unwrap_or(0)),
+        flen: Some(column.column_len),
+        decimal: Some(column.decimal),
+        collate: Some(column.collation),
+        charset: Some(charset),
+        elems: column.elems.clone(),
+        array: Some(column.array),
+    }
+}
+
+fn field_type_to_pb(field_type: &FieldType) -> PbFieldType {
+    PbFieldType {
+        tp: Some(i32::from(field_type.code().mysql_type())),
+        flag: Some(field_type.flags()),
+        flen: Some(i32::try_from(field_type.flen()).unwrap_or(-1)),
+        decimal: Some(i32::try_from(field_type.decimal()).unwrap_or(-1)),
+        collate: Some(tidb_datatype::collation_to_proto(
+            field_type.collation_name(),
+        )),
+        charset: Some(field_type.charset_name().to_owned()),
+        elems: field_type.elems().map_visible(ToString::to_string),
+        array: Some(field_type.is_array()),
+    }
+}
+
+fn index_scan_to_pb(
+    table_id: i64,
+    index: &tidb_executor::remote_scan::PushdownIndexScan,
+    columns: &[ScanColumnInfo],
+) -> Executor {
+    Executor {
+        tp: Some(ExecType::TypeIndexScan as i32),
+        tbl_scan: None,
+        idx_scan: Some(IndexScan {
+            table_id: Some(table_id),
+            index_id: Some(index.index_id),
+            columns: columns.iter().map(scan_column_info_to_pb).collect(),
+            desc: Some(false),
+            // The current gate's Sysbench key is non-unique. A future unique
+            // path must carry the exact point-range proof before setting this.
+            unique: Some(false),
+            primary_column_ids: Vec::new(),
+        }),
+        selection: None,
+        aggregation: None,
+        top_n: None,
+        limit: None,
+        executor_id: None,
+        parent_idx: None,
+    }
+}
+
+fn scan_column_info_to_pb(column: &ScanColumnInfo) -> PbColumnInfo {
+    PbColumnInfo {
+        column_id: Some(column.column_id),
+        tp: Some(column.tp),
+        collation: Some(column.collation),
+        column_len: Some(column.column_len),
+        decimal: Some(column.decimal),
+        flag: Some(column.flag),
+        elems: column.elems.clone(),
+        default_val: column.default_val.clone(),
+        pk_handle: Some(column.pk_handle),
+        array: Some(column.array),
+    }
 }
 
 /// The caller's end of one coprocessor scan.
@@ -602,7 +967,165 @@ fn scan_column(column: &PushdownScanColumn) -> Option<ScanColumnInfo> {
 #[must_use]
 pub fn requests_extra_handle(request: &PushdownScanRequest) -> bool {
     request
-        .columns
-        .get(request.handle_index)
+        .handle_index
+        .and_then(|index| request.columns.get(index))
         .is_some_and(|column| column.id == EXTRA_HANDLE_COLUMN_ID)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn integer_column() -> ScanColumnInfo {
+        ScanColumnInfo {
+            column_id: 2,
+            tp: MYSQL_TYPE_LONG,
+            collation: BINARY_COLLATION_ID,
+            column_len: 11,
+            decimal: 0,
+            flag: NOT_NULL_FLAG,
+            ..ScanColumnInfo::default()
+        }
+    }
+
+    #[test]
+    fn partial_sum_uses_pinned_tipb_stream_aggregation_fields() {
+        let mut output = FieldType::new(FieldTypeCode::NewDecimal);
+        output.set_flen(20);
+        output.set_decimal(0);
+        let executor = partial_aggregate_to_pb(
+            &PushdownPartialAggregate::Sum {
+                input_offset: 0,
+                output_type: output,
+            },
+            &[integer_column()],
+        );
+        assert_eq!(ExecType::TypeAggregation as i32, 3);
+        assert_eq!(ExecType::TypeStreamAgg as i32, 6);
+        assert_eq!(ExprType::Sum as i32, 3002);
+        assert_eq!(executor.tp, Some(6));
+        let aggregate = executor.aggregation.expect("aggregation field 5");
+        assert_eq!(aggregate.streamed, Some(true));
+        assert!(aggregate.group_by.is_empty());
+        assert_eq!(aggregate.agg_func.len(), 1);
+        assert_eq!(aggregate.agg_func[0].tp, Some(3002));
+        assert_eq!(aggregate.agg_func[0].children[0].tp, Some(201));
+        assert_eq!(
+            aggregate.agg_func[0].children[0].val,
+            Some(encode_column_offset(0))
+        );
+    }
+
+    #[test]
+    fn partial_distinct_is_group_only_hash_aggregation() {
+        let output = FieldType::new(FieldTypeCode::Long);
+        let executor = partial_aggregate_to_pb(
+            &PushdownPartialAggregate::GroupBy {
+                input_offset: 0,
+                output_type: output,
+            },
+            &[integer_column()],
+        );
+        assert_eq!(executor.tp, Some(3));
+        let aggregate = executor.aggregation.expect("aggregation field 5");
+        assert_eq!(aggregate.streamed, Some(false));
+        assert_eq!(aggregate.group_by.len(), 1);
+        assert!(aggregate.agg_func.is_empty());
+    }
+
+    #[test]
+    fn partial_grouped_sum_uses_hash_aggregation_schema_order() {
+        let group_type = FieldType::new(FieldTypeCode::Long);
+        let mut sum_type = FieldType::new(FieldTypeCode::NewDecimal);
+        sum_type.set_flen(20);
+        sum_type.set_decimal(2);
+        let executor = partial_aggregate_to_pb(
+            &PushdownPartialAggregate::GroupBySum {
+                group_offset: 0,
+                sum_offset: 1,
+                sum_type,
+                group_type,
+            },
+            &[integer_column(), integer_column()],
+        );
+        assert_eq!(executor.tp, Some(ExecType::TypeAggregation as i32));
+        let aggregate = executor.aggregation.expect("aggregation field 5");
+        assert_eq!(aggregate.streamed, Some(false));
+        assert_eq!(aggregate.group_by.len(), 1);
+        assert_eq!(aggregate.agg_func.len(), 1);
+        assert_eq!(aggregate.agg_func[0].tp, Some(ExprType::Sum as i32));
+        assert_eq!(
+            aggregate.agg_func[0].children[0].val,
+            Some(encode_column_offset(1))
+        );
+    }
+
+    #[test]
+    fn grouped_stream_aggregate_lowers_max_min_and_count_one() {
+        let output = FieldType::new(FieldTypeCode::LongLong);
+        let group_type = FieldType::new(FieldTypeCode::Long);
+        let executor = partial_aggregate_to_pb(
+            &PushdownPartialAggregate::GroupedStream {
+                group_offsets: vec![1],
+                group_types: vec![group_type],
+                functions: vec![
+                    tidb_executor::remote_scan::PushdownAggregateFunction {
+                        kind: PushdownAggregateKind::Max,
+                        input_offset: Some(0),
+                        output_type: output.clone(),
+                    },
+                    tidb_executor::remote_scan::PushdownAggregateFunction {
+                        kind: PushdownAggregateKind::Min,
+                        input_offset: Some(0),
+                        output_type: output.clone(),
+                    },
+                    tidb_executor::remote_scan::PushdownAggregateFunction {
+                        kind: PushdownAggregateKind::Count,
+                        input_offset: None,
+                        output_type: output,
+                    },
+                ],
+            },
+            &[integer_column(), integer_column()],
+        );
+        assert_eq!(executor.tp, Some(ExecType::TypeStreamAgg as i32));
+        let aggregate = executor.aggregation.expect("aggregation field 5");
+        assert_eq!(aggregate.streamed, Some(true));
+        assert_eq!(aggregate.group_by.len(), 1);
+        assert_eq!(aggregate.agg_func.len(), 3);
+        assert_eq!(aggregate.agg_func[0].tp, Some(ExprType::Max as i32));
+        assert_eq!(aggregate.agg_func[1].tp, Some(ExprType::Min as i32));
+        assert_eq!(aggregate.agg_func[2].tp, Some(ExprType::Count as i32));
+        assert_eq!(
+            aggregate.agg_func[2].children[0].tp,
+            Some(ExprType::Int64 as i32)
+        );
+    }
+
+    #[test]
+    fn topn_uses_the_pinned_column_direction_and_limit_fields() {
+        let executor = topn_to_pb(
+            &PushdownTopN {
+                order_by: vec![tidb_executor::remote_scan::PushdownTopNOrder {
+                    offset: 0,
+                    desc: true,
+                }],
+                limit: 1,
+            },
+            &[integer_column()],
+        );
+        assert_eq!(executor.tp, Some(ExecType::TypeTopN as i32));
+        let topn = executor.top_n.expect("TopN field 6");
+        assert_eq!(topn.limit, Some(1));
+        assert_eq!(topn.order_by.len(), 1);
+        assert_eq!(topn.order_by[0].desc, Some(true));
+        let encoded_offset = encode_column_offset(0);
+        assert_eq!(
+            topn.order_by[0]
+                .expr
+                .as_ref()
+                .and_then(|expr| expr.val.as_ref()),
+            Some(&encoded_offset)
+        );
+    }
 }

--- a/rust/crates/tidb-exec/src/dag_request.rs
+++ b/rust/crates/tidb-exec/src/dag_request.rs
@@ -192,6 +192,8 @@ pub fn limit_to_pb(limit: u64) -> Executor {
         tbl_scan: None,
         idx_scan: None,
         selection: None,
+        aggregation: None,
+        top_n: None,
         limit: Some(Limit { limit: Some(limit) }),
         executor_id: Some(String::new()),
         parent_idx: None,
@@ -395,6 +397,8 @@ fn selection_executor(conditions: Vec<Expr>) -> Result<Executor, DagRequestBuild
         tbl_scan: None,
         idx_scan: None,
         selection: Some(Selection { conditions }),
+        aggregation: None,
+        top_n: None,
         limit: None,
         // PhysicalSelection.ToPB always takes the address of executorID; it
         // remains empty for TiKV's list form.
@@ -468,6 +472,8 @@ fn table_scan_to_pb(spec: &TiKvTableScanSpec) -> Result<Executor, DagRequestBuil
         }),
         idx_scan: None,
         selection: None,
+        aggregation: None,
+        top_n: None,
         limit: None,
         // PhysicalTableScan.ToPB takes the address of its initially empty ID
         // even for TiKV, so field 10 is present with an empty string.
@@ -493,6 +499,8 @@ fn index_scan_to_pb(plan: &PhysicalIndexScanPlan) -> Result<Executor, DagRequest
         tbl_scan: None,
         idx_scan: Some(index_payload_to_pb(spec, plan)),
         selection: None,
+        aggregation: None,
+        top_n: None,
         limit: None,
         executor_id: None,
         parent_idx: None,

--- a/rust/crates/tidb-exec/src/multi_statement_transaction.rs
+++ b/rust/crates/tidb-exec/src/multi_statement_transaction.rs
@@ -59,7 +59,7 @@ use tidb_tablecodec::decode_table_row_to_map;
 use tidb_txnkv::rpc::UnaryCallContext;
 use tidb_txnkv::transaction::{
     CommitProtocol, LockKeepAlive, LockWaitTime, OptimisticCommitOutcome,
-    OptimisticCoordinatorError, OptimisticMutationKind, PessimisticLockFailure,
+    OptimisticCoordinatorError, OptimisticMutation, OptimisticMutationKind, PessimisticLockFailure,
     ProductionOptimisticTransaction, ProductionPessimisticTransaction,
     RealOptimisticTransactionOpener, TransactionMutationBuffer, MAX_OPTIMISTIC_MUTATIONS,
     MAX_OPTIMISTIC_TRANSACTION_BYTES,
@@ -79,6 +79,9 @@ use crate::real_tikv_dml::{
 /// `None` is a row the transaction deleted; `Some(row)` is its value in the
 /// read's own projection. A reader applies these over the snapshot's rows.
 pub type StagedRowOverlay = Vec<(i64, Option<Vec<Datum>>)>;
+
+/// Raw TiKV key/value pairs returned by a transaction snapshot scan.
+pub type RawSnapshotPairs = Vec<(Vec<u8>, Vec<u8>)>;
 
 /// How many times one locking statement re-acquires under a fresh
 /// `for_update_ts` after a write conflict.
@@ -155,6 +158,19 @@ impl std::fmt::Display for TransactionStatementError {
 
 impl std::error::Error for TransactionStatementError {}
 
+/// The result of one raw pessimistic lock attempt.
+///
+/// `Retry` means TiKV granted or rejected the lock because a newer commit was
+/// observed, advanced the transaction's `for_update_ts`, and left the caller
+/// responsible for rerunning the whole SQL statement at that timestamp.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LockKeysOutcome {
+    /// Every requested key is held by this transaction.
+    Acquired,
+    /// The statement must be recomputed from the transaction's new read view.
+    Retry(LockSqlError),
+}
+
 /// How one transaction ended.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransactionEnd {
@@ -175,19 +191,46 @@ enum OpenTransaction {
 }
 
 impl OpenTransaction {
-    /// The two-phase commit coordinator underneath, which is what serves every
-    /// snapshot read in either mode.
-    fn two_pc(&mut self) -> &mut ProductionOptimisticTransaction {
-        match self {
-            Self::Optimistic(transaction) => transaction,
-            Self::Pessimistic(transaction) => transaction.snapshot(),
-        }
-    }
-
     fn start_ts(&self) -> u64 {
         match self {
             Self::Optimistic(transaction) => transaction.start_ts(),
             Self::Pessimistic(transaction) => transaction.start_ts(),
+        }
+    }
+
+    fn statement_read_ts(&self) -> u64 {
+        match self {
+            Self::Optimistic(transaction) => transaction.start_ts(),
+            Self::Pessimistic(transaction) => transaction.statement_read_ts(),
+        }
+    }
+
+    fn snapshot_get(
+        &mut self,
+        key: &[u8],
+        call: &UnaryCallContext,
+    ) -> Result<Option<Vec<u8>>, OptimisticCoordinatorError> {
+        match self {
+            Self::Optimistic(transaction) => transaction.snapshot_get(key, call),
+            Self::Pessimistic(transaction) => transaction.statement_snapshot_get(key, call),
+        }
+        .map(|result| result.value)
+    }
+
+    fn snapshot_scan(
+        &mut self,
+        start_key: &[u8],
+        end_key: &[u8],
+        limit: Option<usize>,
+        call: &UnaryCallContext,
+    ) -> Result<RawSnapshotPairs, OptimisticCoordinatorError> {
+        match self {
+            Self::Optimistic(transaction) => {
+                transaction.snapshot_scan(start_key, end_key, limit, call)
+            }
+            Self::Pessimistic(transaction) => {
+                transaction.statement_snapshot_scan(start_key, end_key, limit, call)
+            }
         }
     }
 }
@@ -205,7 +248,7 @@ pub struct MultiStatementTransaction {
     mode: SessionTxnMode,
     /// The one table this node serves, needed to turn a clustered handle into
     /// the record key the buffer is keyed by.
-    table: ConfiguredTable,
+    table: Option<ConfiguredTable>,
     buffer: TransactionMutationBuffer,
     /// Per-statement RPC budget. Stored as a duration, never as an already
     /// minted [`UnaryCallContext`]: that type carries an absolute deadline, so
@@ -232,6 +275,36 @@ impl MultiStatementTransaction {
         fair_locking: bool,
         commit_protocol: CommitProtocol,
         table: ConfiguredTable,
+        timeout: Duration,
+    ) -> Result<Self, OptimisticCoordinatorError> {
+        Self::begin_with_table(
+            opener,
+            mode,
+            fair_locking,
+            commit_protocol,
+            Some(table),
+            timeout,
+        )
+    }
+
+    /// Opens a transaction for a wide-SQL cluster session, whose statement
+    /// executor supplies raw TiKV keys instead of one configured table.
+    pub fn begin_unconfigured(
+        opener: &RealOptimisticTransactionOpener,
+        mode: SessionTxnMode,
+        fair_locking: bool,
+        commit_protocol: CommitProtocol,
+        timeout: Duration,
+    ) -> Result<Self, OptimisticCoordinatorError> {
+        Self::begin_with_table(opener, mode, fair_locking, commit_protocol, None, timeout)
+    }
+
+    fn begin_with_table(
+        opener: &RealOptimisticTransactionOpener,
+        mode: SessionTxnMode,
+        fair_locking: bool,
+        commit_protocol: CommitProtocol,
+        table: Option<ConfiguredTable>,
         timeout: Duration,
     ) -> Result<Self, OptimisticCoordinatorError> {
         let open = match mode {
@@ -335,6 +408,41 @@ impl MultiStatementTransaction {
         self.open.start_ts()
     }
 
+    /// Timestamp the next statement reads at.
+    ///
+    /// It remains `start_ts` in optimistic mode. In pessimistic mode it is
+    /// the current `for_update_ts`, which advances when lock acquisition
+    /// discovers a newer committed version.
+    #[must_use]
+    pub fn statement_read_ts(&self) -> u64 {
+        self.open.statement_read_ts()
+    }
+
+    /// Reads one raw key at the transaction's current statement timestamp.
+    ///
+    /// The wide-SQL storage layer uses this instead of the configured-table
+    /// row overlay path. The transaction's lock and commit timestamp remain
+    /// separate from this read version in pessimistic mode.
+    pub fn snapshot_get_raw(
+        &mut self,
+        key: &[u8],
+        call: &UnaryCallContext,
+    ) -> Result<Option<Vec<u8>>, OptimisticCoordinatorError> {
+        self.open.snapshot_get(key, call)
+    }
+
+    /// Scans one raw key range at the transaction's current statement
+    /// timestamp, for the wide-SQL storage layer.
+    pub fn snapshot_scan_raw(
+        &mut self,
+        start_key: &[u8],
+        end_key: &[u8],
+        limit: Option<usize>,
+        call: &UnaryCallContext,
+    ) -> Result<RawSnapshotPairs, OptimisticCoordinatorError> {
+        self.open.snapshot_scan(start_key, end_key, limit, call)
+    }
+
     /// The mode this transaction runs in.
     #[must_use]
     pub const fn mode(&self) -> SessionTxnMode {
@@ -356,7 +464,8 @@ impl MultiStatementTransaction {
     /// the snapshot's rows.
     #[must_use]
     pub fn staged_row(&self, handle: i64) -> Option<Option<&[u8]>> {
-        let key = encode_row_key_with_handle(self.table.table_id(), &RecordHandle::Int(handle));
+        let table = self.table.as_ref()?;
+        let key = encode_row_key_with_handle(table.table_id(), &RecordHandle::Int(handle));
         let staged = self.buffer.staged(&key)?;
         match staged.kind() {
             OptimisticMutationKind::Delete => Some(None),
@@ -392,6 +501,11 @@ impl MultiStatementTransaction {
         projection: &[ResolvedProjectionColumn],
         ranges: &[SignedBigIntRange],
     ) -> Result<StagedRowOverlay, TransactionStatementError> {
+        let Some(table) = self.table.as_ref() else {
+            return Err(TransactionStatementError::refused(
+                "a configured table is required for staged row overlay",
+            ));
+        };
         let mut overlay = Vec::new();
         for staged in self.buffer.staged_entries() {
             // Only record keys carry rows; a secondary-index entry changes no
@@ -399,7 +513,7 @@ impl MultiStatementTransaction {
             let Ok((table_id, RecordHandle::Int(handle))) = decode_record_key(staged.key()) else {
                 continue;
             };
-            if table_id != self.table.table_id()
+            if table_id != table.table_id()
                 || !ranges
                     .iter()
                     .any(|range| range.start() <= handle && handle <= range.end())
@@ -496,7 +610,13 @@ impl MultiStatementTransaction {
         let keys = handles
             .iter()
             .map(|handle| {
-                encode_row_key_with_handle(self.table.table_id(), &RecordHandle::Int(*handle))
+                encode_row_key_with_handle(
+                    self.table
+                        .as_ref()
+                        .expect("handle locks require a configured table")
+                        .table_id(),
+                    &RecordHandle::Int(*handle),
+                )
             })
             .collect::<Vec<_>>();
         let wait = match wait {
@@ -584,6 +704,103 @@ impl MultiStatementTransaction {
         Ok(())
     }
 
+    /// Attempts one raw-key lock batch and advances `for_update_ts` when the
+    /// caller must rerun the whole SQL statement at the newer read timestamp.
+    ///
+    /// This is the wide-SQL counterpart of [`Self::lock_handles`]. It accepts
+    /// record and index keys because a general executor does not have one
+    /// configured table to turn handles into keys.
+    pub fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        presume_not_exists: &BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError> {
+        if keys.is_empty() {
+            return Ok(LockKeysOutcome::Acquired);
+        }
+        if !self.mode.is_pessimistic() {
+            return Err(TransactionStatementError::refused(
+                "a locking read requires a pessimistic transaction; optimistic transactions \
+                 detect conflicts at COMMIT",
+            ));
+        }
+        let wait = match wait {
+            ReadLockWait::Blocking => LockWaitTime::session_lock_wait_timeout(),
+            ReadLockWait::NoWait => LockWaitTime::NoWait,
+            ReadLockWait::Seconds(seconds) => LockWaitTime::Timeout(Duration::from_secs(seconds)),
+        };
+        let call = self.statement_call();
+        let OpenTransaction::Pessimistic(transaction) = &mut self.open else {
+            unreachable!("the pessimistic mode check above admits only a pessimistic transaction");
+        };
+        let held: BTreeSet<Vec<u8>> = transaction.locked_keys().into_iter().collect();
+        let retry_reason = match transaction.acquire_locks(keys, presume_not_exists, wait, &call) {
+            Ok(acquired) if acquired.locked_with_conflict.is_empty() => {
+                let primary_key = acquired.primary_key;
+                let start_ts = transaction.start_ts();
+                self.ensure_lock_keep_alive(primary_key, start_ts)?;
+                return Ok(LockKeysOutcome::Acquired);
+            }
+            Ok(acquired) => {
+                let (key, conflict_commit_ts) = acquired
+                    .locked_with_conflict
+                    .iter()
+                    .max_by_key(|(_, conflict_ts)| *conflict_ts)
+                    .expect("the non-empty branch above admits a conflict");
+                locked_with_conflict_error(transaction.start_ts(), *conflict_commit_ts, key)
+            }
+            Err(failure) => {
+                let added = transaction
+                    .locked_keys()
+                    .into_iter()
+                    .filter(|key| !held.contains(key))
+                    .collect::<Vec<_>>();
+                if let Err(cause) = transaction.pessimistic_rollback(&added, &call) {
+                    return Err(TransactionStatementError::Transaction(
+                        transaction_cause_to_sql_error(&cause),
+                    ));
+                }
+                if !is_retryable_statement_failure(&failure) {
+                    return Err(TransactionStatementError::from_lock_failure(&failure));
+                }
+                lock_failure_to_sql_error(&failure)
+            }
+        };
+        transaction
+            .advance_for_update_ts()
+            .map_err(|error| TransactionStatementError::from_lock_failure(&error))?;
+        let primary_key = transaction.primary_key().map(ToOwned::to_owned);
+        let start_ts = transaction.start_ts();
+        if let Some(primary_key) = primary_key {
+            self.ensure_lock_keep_alive(primary_key, start_ts)?;
+        }
+        Ok(LockKeysOutcome::Retry(retry_reason))
+    }
+
+    fn ensure_lock_keep_alive(
+        &mut self,
+        primary_key: Vec<u8>,
+        start_ts: u64,
+    ) -> Result<(), TransactionStatementError> {
+        if self.keep_alive.is_none() {
+            let keep_alive = self
+                .opener
+                .start_lock_keep_alive(primary_key, start_ts)
+                .map_err(|error| {
+                    TransactionStatementError::Transaction(LockSqlError {
+                        code: 1105,
+                        state: *b"HY000",
+                        message: format!(
+                            "cannot keep the transaction's primary lock alive: {error}"
+                        ),
+                    })
+                })?;
+            self.keep_alive = Some(keep_alive);
+        }
+        Ok(())
+    }
+
     /// Publishes every buffered mutation in one two-phase commit.
     ///
     /// A transaction that staged nothing commits trivially — there is nothing to
@@ -592,6 +809,18 @@ impl MultiStatementTransaction {
     /// transaction beat it to a key: that is the 9007 the client sees.
     pub fn commit(self) -> Result<TransactionEnd, TransactionStatementError> {
         self.finish(true)
+    }
+
+    /// Commits mutations supplied by the wide-SQL `MutationBuffer`.
+    ///
+    /// The same pessimistic coordinator and Prewrite actions are used as the
+    /// configured-table path; only the executor-owned mutation container is
+    /// different.
+    pub fn commit_mutations(
+        self,
+        mutations: Vec<OptimisticMutation>,
+    ) -> Result<TransactionEnd, TransactionStatementError> {
+        self.finish_with_mutations(true, mutations)
     }
 
     /// Discards every buffered mutation and releases every held lock.
@@ -603,12 +832,20 @@ impl MultiStatementTransaction {
     }
 
     fn finish(mut self, publish: bool) -> Result<TransactionEnd, TransactionStatementError> {
-        let call = Self::transaction_end_call();
         let mutations = if publish {
             std::mem::take(&mut self.buffer).into_mutations()
         } else {
             Vec::new()
         };
+        self.finish_with_mutations(publish, mutations)
+    }
+
+    fn finish_with_mutations(
+        mut self,
+        publish: bool,
+        mutations: Vec<OptimisticMutation>,
+    ) -> Result<TransactionEnd, TransactionStatementError> {
+        let call = Self::transaction_end_call();
         // The keep-alive thread must stop before the locks it refreshes are
         // resolved, so a heartbeat can never revive a lock the commit released.
         if let Some(keep_alive) = self.keep_alive.take() {
@@ -687,7 +924,7 @@ impl WritePlanningSnapshot for MultiStatementTransaction {
                 OptimisticMutationKind::LockOnly => unreachable!("filtered above"),
             });
         }
-        Ok(self.open.two_pc().snapshot_get(key, call)?.value)
+        Ok(self.open.snapshot_get(key, call)?)
     }
 }
 
@@ -822,20 +1059,26 @@ mod tests {
 
     #[test]
     fn a_successful_commit_is_the_only_outcome_that_answers_ok() {
-        for cause in [
-            TransactionCause::Region {
-                detail: "epoch not match".to_owned(),
-            },
-            TransactionCause::Transport {
-                detail: "connection reset".to_owned(),
-            },
+        for (cause, expected_code) in [
+            (
+                TransactionCause::Region {
+                    detail: "epoch not match".to_owned(),
+                },
+                9005,
+            ),
+            (
+                TransactionCause::Transport {
+                    detail: "connection reset".to_owned(),
+                },
+                1105,
+            ),
         ] {
             let error = classify_commit_outcome(&rolled_back(cause))
                 .expect_err("a non-commit never reports durable rows");
             assert_eq!(
                 error.sql_error().code,
-                1105,
-                "only a write conflict earns 9007"
+                expected_code,
+                "only a write conflict earns 9007; region failures retain 9005"
             );
             assert!(!error.keeps_transaction_open());
         }

--- a/rust/crates/tidb-exec/src/pessimistic_lock_error.rs
+++ b/rust/crates/tidb-exec/src/pessimistic_lock_error.rs
@@ -39,6 +39,9 @@ pub const ERR_LOCK_ACQUIRE_FAIL_AND_NO_WAIT_SET: u16 = 3572;
 /// Go `errno.ErrWriteConflict`, the statement-scoped conflict a pessimistic
 /// retry resolves.
 pub const ERR_WRITE_CONFLICT: u16 = 9007;
+/// Go `errno.ErrRegionUnavailable`, a determinate routing failure an
+/// autocommit statement may replay at a fresh timestamp.
+pub const ERR_REGION_UNAVAILABLE: u16 = 9005;
 
 /// Go `mysql.DefaultMySQLState`, used by every code absent from `state.go`.
 const DEFAULT_SQL_STATE: [u8; 5] = *b"HY000";
@@ -130,10 +133,9 @@ pub fn commit_outcome_to_sql_error(outcome: &OptimisticCommitOutcome) -> Result<
 
 /// Renders a transaction-ending cause as the error TiDB reports for it.
 ///
-/// A write conflict is the one cause with a code of its own: Go's
-/// `kv.ErrWriteConflict` (9007) is what an optimistic transaction that lost the
-/// race reports at `COMMIT`. Everything else keeps its exact diagnostic under
-/// the generic 1105 rather than being disguised as a retryable conflict.
+/// Write conflicts and determinate region failures keep the codes Go uses to
+/// decide whether an autocommit statement can be replayed. Everything else
+/// keeps its exact diagnostic under the generic 1105.
 #[must_use]
 pub fn transaction_cause_to_sql_error(cause: &TransactionCause) -> LockSqlError {
     match cause {
@@ -141,6 +143,11 @@ pub fn transaction_cause_to_sql_error(cause: &TransactionCause) -> LockSqlError 
             code: ERR_WRITE_CONFLICT,
             state: DEFAULT_SQL_STATE,
             message: format!("[kv:9007]Write conflict, {detail} [try again later]"),
+        },
+        TransactionCause::Region { .. } => LockSqlError {
+            code: ERR_REGION_UNAVAILABLE,
+            state: DEFAULT_SQL_STATE,
+            message: "[tikv:9005]Region is unavailable".to_owned(),
         },
         other => LockSqlError {
             code: 1105,
@@ -197,7 +204,7 @@ mod tests {
     use super::{
         is_retryable_statement_failure, lock_failure_to_sql_error,
         ERR_LOCK_ACQUIRE_FAIL_AND_NO_WAIT_SET, ERR_LOCK_DEADLOCK, ERR_LOCK_WAIT_TIMEOUT,
-        ERR_WRITE_CONFLICT,
+        ERR_REGION_UNAVAILABLE, ERR_WRITE_CONFLICT,
     };
     use tidb_txnkv::transaction::{
         CommittedTransaction, DeadlockDetail, OptimisticCommitOutcome,
@@ -253,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn a_write_conflict_is_the_only_cause_with_a_code_of_its_own() {
+    fn retryable_transaction_causes_keep_their_tidb_codes() {
         assert_eq!(
             transaction_cause_to_sql_error(&TransactionCause::WriteConflict {
                 detail: "d".to_owned()
@@ -261,11 +268,11 @@ mod tests {
             .code,
             ERR_WRITE_CONFLICT
         );
-        let other = transaction_cause_to_sql_error(&TransactionCause::Region {
+        let region = transaction_cause_to_sql_error(&TransactionCause::Region {
             detail: "epoch not match".to_owned(),
         });
-        assert_eq!(other.code, 1105);
-        assert!(other.message.contains("epoch not match"));
+        assert_eq!(region.code, ERR_REGION_UNAVAILABLE);
+        assert_eq!(region.message, "[tikv:9005]Region is unavailable");
     }
 
     #[test]

--- a/rust/crates/tidb-exec/src/real_tikv_read.rs
+++ b/rust/crates/tidb-exec/src/real_tikv_read.rs
@@ -776,6 +776,18 @@ impl ProductionReadProcessAuthority {
         self.opener_ref().cluster_id()
     }
 
+    /// Cloneable request handle for control-plane operations that must share
+    /// this process authority's PD worker and shutdown order.
+    #[must_use]
+    pub fn pd_client(&self) -> PdClient {
+        match &self.lifecycle.pd {
+            ProductionPdLifecycle::Running(pd) => pd.clone(),
+            ProductionPdLifecycle::Closed => {
+                panic!("production read/write authority is closed")
+            }
+        }
+    }
+
     /// Stable executor process-authority identity.
     #[must_use]
     pub const fn authority_id(&self) -> u64 {

--- a/rust/crates/tidb-executor/src/access_cost.rs
+++ b/rust/crates/tidb-executor/src/access_cost.rs
@@ -1514,6 +1514,17 @@ pub(crate) fn selectivity_of_conjuncts(
         let Some(column) = table.columns.get(offset) else {
             continue;
         };
+        // `conditionChecker` correctly refuses `IS NOT NULL` as an INDEX
+        // access condition because `(NULL,+inf]` does not narrow the scan.
+        // `cardinality.Selectivity` uses a different ranger entry point: the
+        // same interval is still a COLUMN statistics node and removes the
+        // NULL bucket. Recover that mask here instead of treating the
+        // condition as the generic 0.8 fallback.
+        let not_null_mask = conjuncts
+            .iter()
+            .enumerate()
+            .filter(|(_, conjunct)| is_not_null_on_column(conjunct, offset, resolver))
+            .fold(0_i64, |mask, (index, _)| mask | (1_i64 << index));
         // Go `getMaskAndRanges` down the `ranger.ColumnRangeType` arm: a range
         // over the COLUMN itself, so no index prefix length is in play.
         let built = crate::index_range::detach_conds_for_column(
@@ -1522,20 +1533,30 @@ pub(crate) fn selectivity_of_conjuncts(
             &resolver.time_zone(),
         );
         // `BuildColumnRange` with no access condition returns the full range
-        // and an empty mask, which the greedy cover can never select.
-        if built.access_count == 0 {
+        // and an empty mask, which the greedy cover can never select. `IS NOT
+        // NULL` is the one full range the statistics path still consumes.
+        if built.access_count == 0 && not_null_mask == 0 {
             continue;
         }
-        let ranges: Vec<ColumnRange> = built
-            .ranges
-            .iter()
-            .map(|range| ColumnRange {
-                low: range.low.first().cloned().unwrap_or(Datum::MinNotNull),
-                high: range.high.first().cloned().unwrap_or(Datum::MaxValue),
-                low_exclude: range.low_exclusive,
-                high_exclude: range.high_exclusive,
-            })
-            .collect();
+        let ranges: Vec<ColumnRange> = if built.access_count == 0 {
+            vec![ColumnRange {
+                low: Datum::MinNotNull,
+                high: Datum::MaxValue,
+                low_exclude: false,
+                high_exclude: false,
+            }]
+        } else {
+            built
+                .ranges
+                .iter()
+                .map(|range| ColumnRange {
+                    low: range.low.first().cloned().unwrap_or(Datum::MinNotNull),
+                    high: range.high.first().cloned().unwrap_or(Datum::MaxValue),
+                    low_exclude: range.low_exclusive,
+                    high_exclude: range.high_exclusive,
+                })
+                .collect()
+        };
         let is_handle = table.pk_handle_offset() == Some(offset);
         let row_count = match loaded {
             Some(stats) => {
@@ -1580,7 +1601,7 @@ pub(crate) fn selectivity_of_conjuncts(
                     StatsNodeType::Column
                 },
                 column.id,
-                covered_mask(&conjuncts, &built.residual),
+                covered_mask(&conjuncts, &built.residual) | not_null_mask,
                 1,
             )
         });
@@ -1597,6 +1618,28 @@ pub(crate) fn selectivity_of_conjuncts(
         realtime as i64,
         SelectivityDefaults::default(),
     )
+}
+
+/// Whether one statistics condition is `column IS NOT NULL` for `offset`.
+fn is_not_null_on_column(
+    conjunct: &tidb_ast::Expr,
+    offset: usize,
+    resolver: &dyn tidb_expr::rewriter::ColumnResolver,
+) -> bool {
+    let tidb_ast::Expr::Is {
+        expr,
+        target: tidb_ast::IsTarget::Null,
+        not: true,
+    } = strip_parens(conjunct)
+    else {
+        return false;
+    };
+    let tidb_ast::Expr::Column(path) = strip_parens(expr) else {
+        return false;
+    };
+    resolver
+        .resolve(path)
+        .is_some_and(|(resolved, _, _)| resolved == offset)
 }
 
 /// Go's `expression.ExtractColumnsMapFromExpressions` over the whole condition
@@ -2134,6 +2177,40 @@ mod tests {
             None,
         );
         assert!((actual - 99.0 / 10_000.0).abs() < 1e-12, "{actual}");
+    }
+
+    /// `cardinality.Selectivity` treats `IS NOT NULL` as the pseudo column
+    /// range `(NULL,+inf]`. It is not an index access condition, but it still
+    /// owns a statistics node and therefore removes one pseudo NULL bucket.
+    #[test]
+    fn pseudo_not_null_is_a_column_statistics_range() {
+        let table = KvTable::with_storage(
+            82,
+            vec![long_column("a", 1), long_column("b", 2)],
+            Box::new(MemTableStorage::new()),
+        );
+        let predicate = tidb_ast::Expr::Binary(
+            tidb_ast::BinaryOp::LogicAnd,
+            Box::new(tidb_ast::Expr::Binary(
+                tidb_ast::BinaryOp::Eq,
+                Box::new(tidb_ast::Expr::Column(vec!["a".to_owned()])),
+                Box::new(tidb_ast::Expr::Int("1".to_owned())),
+            )),
+            Box::new(tidb_ast::Expr::Is {
+                expr: Box::new(tidb_ast::Expr::Column(vec!["b".to_owned()])),
+                target: tidb_ast::IsTarget::Null,
+                not: true,
+            }),
+        );
+
+        let actual = selectivity(
+            &predicate,
+            &table,
+            &NamedColumnResolver { table: &table },
+            None,
+        );
+        let expected = 1.0 / 1_000.0 * (1.0 - 1.0 / 1_000.0);
+        assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
     }
 
     /// `t(a, b, c)` with a non-unique index on `b`, the shape

--- a/rust/crates/tidb-executor/src/access_cost.rs
+++ b/rust/crates/tidb-executor/src/access_cost.rs
@@ -131,9 +131,8 @@ use std::collections::BTreeMap;
 use tidb_chunk::codec::estimate_type_width;
 use tidb_datatype::{Datum, FieldType, FieldTypeCode};
 use tidb_planner::cardinality::pseudo::{
-    pseudo_row_count_by_index_ranges, pseudo_row_count_by_scalar_ranges, pseudo_selectivity,
-    IndexRange as PseudoIndexRange, PseudoBoundKind, PseudoColumn, PseudoFunctionKind, PseudoIndex,
-    PseudoPredicate, ScalarRange,
+    pseudo_row_count_by_index_ranges, pseudo_selectivity, IndexRange as PseudoIndexRange,
+    PseudoBoundKind, PseudoColumn, PseudoFunctionKind, PseudoIndex, PseudoPredicate, ScalarRange,
 };
 use tidb_planner::cardinality::row_count_column::RowEstimate;
 use tidb_planner::cardinality::row_count_estimator::{
@@ -144,6 +143,7 @@ use tidb_planner::cardinality::row_size::{
     get_index_avg_row_size, get_table_avg_row_size, RowSizeColumn, RowSizeColumnStats,
     RowSizeStore, RowSizeType,
 };
+use tidb_planner::cost_factors::TOLERANCE_FACTOR;
 use tidb_planner::selectivity_greedy::{
     combine_selectivity, ConditionKind, SelectivityDefaults, StatsNode, StatsNodeType,
 };
@@ -317,6 +317,21 @@ impl ScanEstimate {
     }
 }
 
+/// Go `StatsInfo::ScaleByExpectCnt`'s row-count result for a physical scan.
+///
+/// The access path retains its own (possibly fractional) estimate for path
+/// comparison. The physical TableScan/IndexScan is initialized from the
+/// table's statistics and Go deliberately refuses to scale a table of at
+/// most one estimated row any lower, avoiding an unstable division by a
+/// tiny cardinality.
+fn physical_scan_row_count(table_rows: f64, path_rows: f64) -> f64 {
+    if path_rows >= table_rows || table_rows <= 1.0 {
+        table_rows
+    } else {
+        path_rows
+    }
+}
+
 /// The `LIMIT` a candidate index path may carry into its cost, Go's
 /// `PhysicalIndexLookUpReader.PushedLimit` / `PhysicalIndexReader`'s
 /// `ExpectedCnt` property.
@@ -353,6 +368,9 @@ pub(crate) struct AccessPath {
     pub(crate) table_ranges: Option<Vec<IndexRange>>,
     /// The estimate `EXPLAIN` prints for the scan node.
     pub(crate) estimate: ScanEstimate,
+    /// Go `AccessPath.CountAfterAccess`, before the physical scan applies
+    /// `StatsInfo::ScaleByExpectCnt` to produce [`Self::estimate`].
+    pub(crate) count_after_access: f64,
     /// `plan_cost_ver2.go`'s cost of the reader this path lowers to.
     pub(crate) cost: f64,
     /// How far the estimator admits [`ScanEstimate::rows`] could be wrong, and
@@ -655,14 +673,24 @@ pub(crate) fn enumerate_paths(
     );
     // Go's `getTableCandidate`: a table path is always a single scan, and it
     // is the full range exactly when the ranger built nothing. Its access
-    // column is the handle itself, which is what lets skyline pruning see
-    // that a narrowed table path accesses a column an unrelated index does
-    // not.
+    // columns are the handle KEY PARTS actually constrained by its access
+    // conditions. A common handle `(w,d,o)` narrowed only on `w` must not
+    // claim `d` and `o`: doing so lets the table path skyline-prune an index
+    // that has the same `w` range but is materially cheaper to scan.
+    let handle_key_offsets = table.pk_handle_offset().map_or_else(
+        || table.common_handle_offsets().to_vec(),
+        |offset| vec![offset],
+    );
     let handle_access_columns: ColSet = handle
         .as_ref()
-        .and_then(|_| table.pk_handle_offset())
-        .into_iter()
-        .collect();
+        .map(|built| {
+            built
+                .access_columns
+                .iter()
+                .filter_map(|position| handle_key_offsets.get(*position).copied())
+                .collect()
+        })
+        .unwrap_or_default();
     // Go's `available`: a `USE`/`FORCE INDEX` that named an index deletes the
     // table path outright, so the cost model never gets to prefer the scan
     // (or the point get, which is the same path) over the hinted index.
@@ -674,7 +702,7 @@ pub(crate) fn enumerate_paths(
             single_scan: true,
             eq_or_in_count: handle.as_ref().map_or(0, |built| built.eq_or_in_count),
             full_range: handle_ranges.is_none(),
-            count_after_access: table_scan.estimate.rows,
+            count_after_access: table_scan.count_after_access,
             max_count_after_access: table_scan.risk.max,
             min_count_after_access: table_scan.risk.min,
             count_after_index: table_scan.risk.after_index,
@@ -697,7 +725,17 @@ pub(crate) fn enumerate_paths(
     let substitution = crate::generated_column_substitute::SubstitutionMap::collect(table);
     let substituted = where_clause.and_then(|clause| substitution.substitute_condition(clause));
     let range_clause = substituted.as_ref().or(where_clause);
+    let common_handle_primary =
+        crate::handle_range::common_handle_primary(table).map(|index| index.id);
     for index in table.plan_indexes() {
+        // Go represents a clustered common-handle PRIMARY as the table path:
+        // its ranges read `_r<common_handle>` records directly. Treating the
+        // same metadata as a secondary index creates an index lookup and one
+        // point read per row, which is both the wrong physical plan and
+        // catastrophic for broad primary-key prefixes.
+        if common_handle_primary == Some(index.id) {
+            continue;
+        }
         // Go's restricted `available` and `removeIgnoredPaths`: an index a
         // `USE`/`FORCE` did not name, or an `IGNORE` did, is not a path.
         if !hints.allows_index(index.id) {
@@ -807,7 +845,7 @@ pub(crate) fn enumerate_paths(
             single_scan: is_covering(index, table, needed_columns),
             eq_or_in_count: built.eq_or_in_count,
             full_range: false,
-            count_after_access: path.estimate.rows,
+            count_after_access: path.count_after_access,
             max_count_after_access: path.risk.max,
             min_count_after_access: path.risk.min,
             count_after_index: path.risk.after_index,
@@ -903,7 +941,7 @@ fn full_scan_candidate(
         single_scan: covering,
         eq_or_in_count: 0,
         full_range: true,
-        count_after_access: path.estimate.rows,
+        count_after_access: path.count_after_access,
         max_count_after_access: path.risk.max,
         min_count_after_access: path.risk.min,
         count_after_index: path.risk.after_index,
@@ -1005,28 +1043,29 @@ fn table_scan_path(
     // consulting the estimator at all ("Skip the expensive
     // GetRowCountByIntColumnRanges call in this case"). With one, it is the
     // estimate over the CONVERTED ranges.
-    let count_after_access = match ranges {
+    let unadjusted_count_after_access = match ranges {
         None => realtime,
         Some(ranges) => crate::handle_range::handle_range_row_count(table, ranges, stats),
     };
+    let after_filter = source_row_count(table, where_clause, resolver, stats, realtime);
+    let count_after_access =
+        adjust_count_after_access(unadjusted_count_after_access, after_filter, realtime);
     // Go costs the scan at the rows it READS and the reader's net transfer at
     // the rows that leave the cop task, which is after the pushed Selection.
     let scan_rows = count_after_access.max(MIN_NUM_ROWS);
     let scanned = scan_cost(scan_rows + penalty_rows, row_size.max(MIN_ROW_SIZE));
-    let after_filter = source_row_count(table, where_clause, resolver, stats, realtime);
     let transferred = net_cost(after_filter, row_size.max(MIN_ROW_SIZE));
     AccessPath {
         index: None,
         table_ranges: ranges.map(<[IndexRange]>::to_vec),
         estimate: ScanEstimate {
-            rows: count_after_access,
+            rows: physical_scan_row_count(realtime, count_after_access),
             pseudo: is_pseudo(stats),
         },
+        count_after_access,
         cost: (scanned + transferred) / DIST_SQL_SCAN_CONCURRENCY,
-        // Go leaves all three at zero for a table path, and
-        // `adjustCountAfterAccess` -- the only thing that could move them --
-        // is not ported here (see [`source_row_count`]). `CountAfterIndex` is
-        // documented as meaningless for a table path either way.
+        // Go's skyline comparison does not use the index-risk interval for a
+        // table path; `CountAfterIndex` is meaningless there as well.
         risk: RowRisk::default(),
     }
 }
@@ -1035,30 +1074,10 @@ fn table_scan_path(
 /// `ds.StatsInfo().RowCount`: the table's realtime count narrowed by EVERY
 /// pushed condition, estimated per column.
 ///
-/// # Why `adjustCountAfterAccess` is NOT ported on top of this
-///
-/// Go's `adjustCountAfterAccess` (`pkg/planner/core/stats.go`) raises a path's
-/// `CountAfterAccess` to `RowCount / SelectionFactor` whenever the path's own
-/// access estimate falls BELOW this number, and keeps the pre-adjustment value
-/// as `MinCountAfterAccess`. It is excluded here because THIS number is not
-/// yet Go's.
-///
-/// Under pseudo statistics Go reaches its min-based `pseudoSelectivity` only
-/// when the `HistColl` has no column and no index entry at all; otherwise it
-/// runs the full `Selectivity`, which MULTIPLIES the pseudo rates. This tier
-/// always takes the min. On `t(bucket, rare)` with 2000 rows and no analyzed
-/// histogram, `WHERE bucket = 1 AND rare = 7` gives Go `0.01` rows for the
-/// data source and this tier `10`, so a ported adjustment fires here where
-/// Go's does not: the live differential showed the chosen path's `estRows`
-/// going to `10 / 0.8 = 12.50` against Go's `0.10`, with both nodes still
-/// choosing `idx_cover`.
-///
-/// So the adjustment is held out until the pseudo selectivity it reads is
-/// Go's. Direction of the exclusion, for `compareRiskRatio`: a path's
-/// `MinCountAfterAccess` stays at the estimator's own minimum instead of the
-/// pre-adjustment estimate, which only narrows Go's second branch -- the one
-/// that needs `MinCountAfterAccess > 0` AND a lower interval. It cannot make
-/// this port prune a path Go keeps.
+/// This feeds [`adjust_count_after_access`]. It uses the same ordinary
+/// selectivity-node combination as Go, including pseudo histograms and the
+/// one-row floor, so the lower-bound adjustment compares estimates formed
+/// under the same assumptions.
 fn source_row_count(
     table: &KvTable,
     where_clause: Option<&tidb_ast::Expr>,
@@ -1069,6 +1088,19 @@ fn source_row_count(
     match where_clause {
         Some(predicate) => realtime * selectivity(predicate, table, resolver, stats),
         None => realtime,
+    }
+}
+
+/// Go `adjustCountAfterAccess`: all access paths must estimate at least the
+/// logical data source's row count (with the planner's selection-factor
+/// tolerance), even when the range estimator used a more optimistic set of
+/// assumptions. The unadjusted value remains in [`RowRisk`] for skyline
+/// comparison; this return value is the physical scan's `estRows` and cost.
+pub(crate) fn adjust_count_after_access(count: f64, source_rows: f64, realtime: f64) -> f64 {
+    if count + TOLERANCE_FACTOR < source_rows {
+        (source_rows / crate::plan_trace::SELECTIVITY_FACTOR).min(realtime)
+    } else {
+        count
     }
 }
 
@@ -1109,7 +1141,7 @@ fn index_path(
     // out of the plan that TiDB's own recording chooses.
     let estimate_ranges = prune_estimate_range(&ranges, index.column_offsets.len());
     let bounds = index_row_count(index, table, &estimate_ranges, stats, realtime);
-    let estimated = bounds.est;
+    let estimated = adjust_count_after_access(bounds.est, source_row_count, realtime);
     // Go `deriveIndexPathStats`: with index filters the post-index count is
     // the access count narrowed by them, floored at the data source's own row
     // count; with none it is the access count itself.
@@ -1183,9 +1215,10 @@ fn index_path(
         index: Some((index.id, ranges)),
         table_ranges: None,
         estimate: ScanEstimate {
-            rows: estimated,
+            rows: physical_scan_row_count(realtime, estimated),
             pseudo: is_pseudo(stats),
         },
+        count_after_access: estimated,
         cost,
         risk: RowRisk {
             min: bounds.min_est,
@@ -1199,7 +1232,9 @@ fn index_path(
 /// index, so no row lookup is needed.
 ///
 /// An integer primary key is stored in every index entry as its handle, so a
-/// path over such a table covers the handle column too.
+/// path over such a table covers the handle column too. A clustered common
+/// handle is carried in the same way and covers each of its component
+/// columns.
 ///
 /// A PREFIX key part does not count: its entry holds `'abc'` where the row
 /// holds `'abcdef'`, so answering from it is the truncation this feature
@@ -1231,7 +1266,9 @@ fn is_covering(index: &KvIndex, table: &KvTable, needed_columns: &[usize]) -> bo
             .columns
             .get(*offset)
             .map_or(-1, |column| column.field_type.flen());
-        index.covers(*offset, flen) || table.pk_handle_offset() == Some(*offset)
+        index.covers(*offset, flen)
+            || table.pk_handle_offset() == Some(*offset)
+            || table.common_handle_offsets().contains(offset)
     })
 }
 
@@ -1288,6 +1325,20 @@ fn index_row_count(
     );
     estimate.clamp(0.0, realtime.max(0.0));
     estimate
+}
+
+/// The primary-index estimate used by a common-handle table path.
+///
+/// Go's `deriveCommonHandleTablePathStats` estimates its table path through
+/// the PRIMARY index histogram even though execution scans record keys.
+pub(crate) fn index_range_row_count(
+    index: &KvIndex,
+    table: &KvTable,
+    ranges: &[IndexRange],
+    stats: Option<&TableStatistics>,
+    realtime: f64,
+) -> f64 {
+    index_row_count(index, table, ranges, stats, realtime).est
 }
 
 /// The stats-less index estimate: Go `getPseudoRowCountByIndexRanges`
@@ -1499,12 +1550,23 @@ pub(crate) fn selectivity_of_conjuncts(
                 )
                 .est
             }
+            // A pseudo handle column uses Go's signed/unsigned integer range
+            // estimator, not the ordinary scalar BETWEEN rate. The former
+            // clamps a finite handle span to its numeric width: `[1,100]`
+            // estimates 99 rows on a 10,000-row pseudo table, while a normal
+            // column estimates 250. `GetRowCountByColumnRanges` owns that
+            // `pkIsHandle` dispatch for both loaded and pseudo statistics.
             None => {
-                let scalar: Vec<ScalarRange> = ranges
-                    .iter()
-                    .map(|range| scalar_range(Some(&range.low), Some(&range.high)))
-                    .collect();
-                pseudo_row_count_by_scalar_ranges(&scalar, realtime)
+                get_row_count_by_column_ranges(
+                    None,
+                    &ranges,
+                    column.field_type.collation(),
+                    realtime as i64,
+                    0,
+                    is_handle,
+                    estimator_options(),
+                )
+                .est
             }
         };
         nodes.push(StatsNode {
@@ -1644,6 +1706,68 @@ fn dnf_selectivity(
     (selectivity != 0.0).then_some(selectivity)
 }
 
+/// Go's row-valued `IN` rewrite as the DNF estimator sees it.
+///
+/// The expression rewriter lowers
+///
+/// ```text
+/// (a, b) IN ((1, 2), (3, 4))
+/// ```
+///
+/// to `(a = 1 AND b = 2) OR (a = 3 AND b = 4)` before
+/// `cardinality.Selectivity` classifies the condition.  This AST deliberately
+/// retains the compact row-valued `IN`, so reproduce that rewrite only for
+/// estimation.  Each tuple is estimated through the ordinary CNF entry point;
+/// importantly, that applies Go's one-row floor *per tuple* before the DNF
+/// inclusion-exclusion step.  On a 10,000-row pseudo table, ten distinct
+/// common-handle prefixes therefore produce
+/// `10000 * (1 - (1 - 1/10000)^10) = 9.995501...` logical rows, which is the
+/// lower bound consumed by `adjustCountAfterAccess`.
+fn row_in_selectivity(
+    conjunct: &tidb_ast::Expr,
+    table: &KvTable,
+    resolver: &dyn tidb_expr::rewriter::ColumnResolver,
+    stats: Option<&TableStatistics>,
+) -> Option<f64> {
+    let tidb_ast::Expr::In { expr, list, not } = strip_parens(conjunct) else {
+        return None;
+    };
+    if *not {
+        return None;
+    }
+    let tidb_ast::Expr::Row(left) = strip_parens(expr) else {
+        return None;
+    };
+    if left.is_empty() || list.is_empty() {
+        return None;
+    }
+
+    let mut selectivity = 0.0_f64;
+    for candidate in list {
+        let tidb_ast::Expr::Row(right) = strip_parens(candidate) else {
+            return None;
+        };
+        if right.len() != left.len() {
+            return None;
+        }
+        let equalities: Vec<tidb_ast::Expr> = left
+            .iter()
+            .zip(right)
+            .map(|(lhs, rhs)| {
+                tidb_ast::Expr::Binary(
+                    tidb_ast::BinaryOp::Eq,
+                    Box::new(lhs.clone()),
+                    Box::new(rhs.clone()),
+                )
+            })
+            .collect();
+        let conjuncts: Vec<&tidb_ast::Expr> = equalities.iter().collect();
+        let current = selectivity_of_conjuncts(&conjuncts, table, resolver, stats);
+        selectivity = selectivity + current - selectivity * current;
+    }
+    (selectivity != 0.0).then_some(selectivity)
+}
+
 /// Which leftover bucket one uncovered condition falls in
 /// (`selectivity.go:238-304`).
 ///
@@ -1668,6 +1792,9 @@ fn condition_kind(
         }
         tidb_ast::Expr::Binary(tidb_ast::BinaryOp::LogicOr, _, _) => {
             ConditionKind::Disjunction(dnf_selectivity(conjunct, table, resolver, stats))
+        }
+        tidb_ast::Expr::In { .. } => {
+            ConditionKind::Disjunction(row_in_selectivity(conjunct, table, resolver, stats))
         }
         _ => ConditionKind::Other,
     }
@@ -1813,7 +1940,27 @@ mod tests {
     use super::*;
     use crate::kv_table::KvColumn;
     use crate::storage::MemTableStorage;
-    use tidb_expr::rewriter::NoResolver;
+    use tidb_expr::rewriter::{ColumnResolver, NoResolver};
+
+    struct NamedColumnResolver<'a> {
+        table: &'a KvTable,
+    }
+
+    impl ColumnResolver for NamedColumnResolver<'_> {
+        fn resolve(&self, path: &[String]) -> Option<(usize, FieldType, i64)> {
+            let name = path.last()?;
+            self.table
+                .columns
+                .iter()
+                .enumerate()
+                .find(|(_, column)| column.name.eq_ignore_ascii_case(name))
+                .map(|(offset, column)| (offset, column.field_type.clone(), column.id))
+        }
+
+        fn time_zone(&self) -> tidb_datatype::SessionTimeZone {
+            tidb_datatype::SessionTimeZone::utc()
+        }
+    }
 
     fn long_column(name: &str, id: i64) -> KvColumn {
         KvColumn {
@@ -1876,6 +2023,119 @@ mod tests {
         assert!(is_covering(&index(20), &table, &[0]));
     }
 
+    /// Every secondary-index entry carries the clustered common handle, so
+    /// its primary-key columns are covering even when they are not declared
+    /// as secondary-index key parts. Go relies on this for TPCC's
+    /// `idx_customer(..., c_first)` to return `c_id` as an IndexReader.
+    #[test]
+    fn a_secondary_index_covers_common_handle_columns() {
+        let mut table = KvTable::with_storage(
+            79,
+            vec![
+                long_column("w_id", 1),
+                long_column("d_id", 2),
+                long_column("c_id", 3),
+                long_column("last", 4),
+                long_column("balance", 5),
+            ],
+            Box::new(MemTableStorage::new()),
+        );
+        table.set_common_handle_offsets(vec![0, 1, 2]);
+        let secondary = KvIndex {
+            id: 2,
+            name: "idx_customer".to_owned(),
+            unique: false,
+            column_offsets: vec![0, 1, 3],
+            prefix_lengths: vec![
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH,
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH,
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH,
+            ],
+            visible: true,
+            global: false,
+        };
+
+        assert!(is_covering(&secondary, &table, &[0, 1, 2, 3]));
+        assert!(!is_covering(&secondary, &table, &[4]));
+    }
+
+    #[test]
+    fn count_after_access_uses_the_logical_row_count_lower_bound() {
+        assert_eq!(adjust_count_after_access(0.001, 1.0, 10_000.0), 1.25);
+        assert_eq!(adjust_count_after_access(2.0, 1.0, 10_000.0), 2.0);
+        assert_eq!(adjust_count_after_access(0.0, 1.0, 1.0), 1.0);
+    }
+
+    /// Go lowers row-valued IN to DNF before cardinality estimation and
+    /// applies the one-row floor independently to every tuple.  Keeping the
+    /// compact AST must not lose that floor: this is the exact logical row
+    /// count behind TPCC delivery's 12.49-row common-handle range scan.
+    #[test]
+    fn row_in_selectivity_applies_the_one_row_floor_per_tuple() {
+        let table = KvTable::with_storage(
+            80,
+            vec![
+                long_column("w_id", 1),
+                long_column("d_id", 2),
+                long_column("o_id", 3),
+            ],
+            Box::new(MemTableStorage::new()),
+        );
+        let left = tidb_ast::Expr::Row(
+            ["w_id", "d_id", "o_id"]
+                .into_iter()
+                .map(|name| tidb_ast::Expr::Column(vec![name.to_owned()]))
+                .collect(),
+        );
+        let list = (1..=10)
+            .map(|district| {
+                tidb_ast::Expr::Row(vec![
+                    tidb_ast::Expr::Int("1".to_owned()),
+                    tidb_ast::Expr::Int(district.to_string()),
+                    tidb_ast::Expr::Int("1".to_owned()),
+                ])
+            })
+            .collect();
+        let predicate = tidb_ast::Expr::In {
+            expr: Box::new(left),
+            list,
+            not: false,
+        };
+
+        let actual = selectivity(
+            &predicate,
+            &table,
+            &NamedColumnResolver { table: &table },
+            None,
+        );
+        let expected = 1.0_f64 - (1.0_f64 - 1.0_f64 / 10_000.0_f64).powi(10);
+        assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
+    }
+
+    #[test]
+    fn pseudo_integer_handle_range_uses_its_numeric_span() {
+        let mut table = KvTable::with_storage(
+            81,
+            vec![long_column("id", 1)],
+            Box::new(MemTableStorage::new()),
+        );
+        table.set_pk_handle_offset(0);
+        let predicate = tidb_ast::Expr::Between {
+            expr: Box::new(tidb_ast::Expr::Column(vec!["id".to_owned()])),
+            low: Box::new(tidb_ast::Expr::Int("1".to_owned())),
+            high: Box::new(tidb_ast::Expr::Int("100".to_owned())),
+            not: false,
+        };
+
+        let actual = selectivity(
+            &predicate,
+            &table,
+            &NamedColumnResolver { table: &table },
+            None,
+        );
+        assert!((actual - 99.0 / 10_000.0).abs() < 1e-12, "{actual}");
+    }
+
     /// `t(a, b, c)` with a non-unique index on `b`, the shape
     /// [`crate::access_path`]'s tests use.
     fn table_with_index() -> KvTable {
@@ -1913,6 +2173,16 @@ mod tests {
             low_exclusive: false,
             high_exclusive: false,
         }
+    }
+
+    /// `StatsInfo::ScaleByExpectCnt` refuses to scale a one-row table below
+    /// one. The access path still owns its fractional `CountAfterAccess`, but
+    /// the physical scan displayed by EXPLAIN owns the scaled table stats.
+    #[test]
+    fn a_physical_scan_keeps_gos_one_row_estimate_floor() {
+        assert_eq!(physical_scan_row_count(1.0, 0.025), 1.0);
+        assert_eq!(physical_scan_row_count(10_000.0, 250.0), 250.0);
+        assert_eq!(physical_scan_row_count(10_000.0, 20_000.0), 10_000.0);
     }
 
     /// Go's `keepIndex` in `skylinePruning` (`find_best_task.go:1830`):

--- a/rust/crates/tidb-executor/src/access_path.rs
+++ b/rust/crates/tidb-executor/src/access_path.rs
@@ -1374,7 +1374,7 @@ impl Executor for IndexJoinLookupExec {
             // [`IndexRangeSourceExec`].
             if let Some(row) = row {
                 let visible = visible_of(&self.table, &row);
-                if !self.row_passes_filters(&visible)? {
+                if !self.row_passes_filters(visible)? {
                     continue;
                 }
                 for (c, value) in visible.iter().enumerate() {

--- a/rust/crates/tidb-executor/src/access_path.rs
+++ b/rust/crates/tidb-executor/src/access_path.rs
@@ -56,11 +56,16 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use tidb_chunk::chunk::Chunk;
-use tidb_datatype::{Datum, FieldType, SessionTimeZone};
+use tidb_datatype::{Datum, Decimal, FieldType, SessionTimeZone};
+use tidb_expr::expression::Expression;
 use tidb_expr::schema::Schema;
+use tidb_expr::truthy_of;
 
 use crate::executor::{ExecError, Executor, ExecutorMeta};
 use crate::kv_table::{IndexRange, IndexRangeCursor, KvTable, TableHandle};
+use crate::remote_scan::{
+    PushdownAggregateKind, PushdownPartialAggregate, PushdownRowStream, PushdownStatementContext,
+};
 
 /// What a statement declares about its whole read, before its first read
 /// happens.
@@ -258,6 +263,9 @@ pub struct HandleSourceExec {
     /// a stored `TIMESTAMP` is read back into, captured where the statement's
     /// context is (`Executor` has none).
     decode_context: crate::kv_table::RowDecodeContext,
+    /// Source-row offsets this complete point plan emits, in result order.
+    /// `None` keeps the ordinary visible-row schema for residual root work.
+    output_offsets: Option<Vec<usize>>,
 }
 
 impl HandleSourceExec {
@@ -276,6 +284,7 @@ impl HandleSourceExec {
             cursor: 0,
             produced: Rc::new(Cell::new(0)),
             decode_context,
+            output_offsets: None,
         }
     }
 
@@ -294,6 +303,27 @@ impl HandleSourceExec {
             handles,
             crate::kv_table::RowDecodeContext::legacy_default(&zone),
         )
+    }
+
+    /// Builds Go's complete point plan, projecting source offsets while the
+    /// row is read instead of leaving a root Projection above the lookup.
+    #[must_use]
+    pub fn new_projected_with_context(
+        meta: ExecutorMeta,
+        table: KvTable,
+        handles: Vec<TableHandle>,
+        output_offsets: Vec<usize>,
+        decode_context: crate::kv_table::RowDecodeContext,
+    ) -> Self {
+        Self {
+            meta,
+            table,
+            handles,
+            cursor: 0,
+            produced: Rc::new(Cell::new(0)),
+            decode_context,
+            output_offsets: Some(output_offsets),
+        }
     }
 
     /// The live count of rows this source produced.
@@ -325,8 +355,18 @@ impl Executor for HandleSourceExec {
                 .get_row_by_handle_with_context(handle, &self.decode_context)
                 .map_err(|_| ExecError::unsupported("table bytes failed to decode"))?;
             if let Some(row) = row {
-                for (c, value) in visible_of(&self.table, &row).iter().enumerate() {
-                    req.append_datum(c, value);
+                let visible = visible_of(&self.table, &row);
+                if let Some(offsets) = &self.output_offsets {
+                    for (output, source) in offsets.iter().copied().enumerate() {
+                        let value = visible.get(source).ok_or_else(|| {
+                            ExecError::unsupported("point-get output column is outside the row")
+                        })?;
+                        req.append_datum(output, value);
+                    }
+                } else {
+                    for (column, value) in visible.iter().enumerate() {
+                        req.append_datum(column, value);
+                    }
                 }
                 self.produced.set(self.produced.get() + 1);
             }
@@ -472,6 +512,15 @@ pub struct IndexRangeSourceExec {
     /// The statement-class flags and session zone the row is decoded under;
     /// the zone also encodes the index probe. See [`HandleSourceExec`].
     decode_context: crate::kv_table::RowDecodeContext,
+    /// Statement flags and warning sink carried into a remote DAG request.
+    statement: PushdownStatementContext,
+    /// Planner estimate used to avoid partial aggregation for point-like work.
+    estimated_rows: Option<f64>,
+    /// Partial aggregation accepted from the root aggregation executor.
+    partial_aggregate: Option<PushdownPartialAggregate>,
+    partial_remote: Option<Box<dyn PushdownRowStream>>,
+    partial_rows: Option<std::vec::IntoIter<Vec<Datum>>>,
+    partial_done: bool,
 }
 
 /// Go's `indexWorker.batchSize` at its first batch.
@@ -498,6 +547,27 @@ impl IndexRangeSourceExec {
         ranges: Vec<IndexRange>,
         decode_context: crate::kv_table::RowDecodeContext,
     ) -> Self {
+        Self::new_with_statement(
+            meta,
+            table,
+            index_id,
+            ranges,
+            decode_context,
+            PushdownStatementContext::default(),
+        )
+    }
+
+    /// Builds an index source carrying the statement context required by a
+    /// real TiKV partial-aggregation request.
+    #[must_use]
+    pub fn new_with_statement(
+        meta: ExecutorMeta,
+        table: KvTable,
+        index_id: i64,
+        ranges: Vec<IndexRange>,
+        decode_context: crate::kv_table::RowDecodeContext,
+        statement: PushdownStatementContext,
+    ) -> Self {
         IndexRangeSourceExec {
             meta,
             table,
@@ -514,6 +584,12 @@ impl IndexRangeSourceExec {
             batch_at: 0,
             batch_size: INIT_HANDLE_BATCH,
             decode_context,
+            statement,
+            estimated_rows: None,
+            partial_aggregate: None,
+            partial_remote: None,
+            partial_rows: None,
+            partial_done: false,
         }
     }
 
@@ -620,6 +696,191 @@ impl IndexRangeSourceExec {
             );
         }
     }
+
+    /// The next index-range row surviving the pushed filter, for the local
+    /// fallback of a partial aggregate request. A remote coprocessor takes
+    /// the same request in [`Self::open`]; this path keeps in-memory storage
+    /// and tests semantically identical.
+    fn next_partial_input_row(&mut self) -> Result<Option<Vec<Datum>>, ExecError> {
+        loop {
+            let Some(handle) = self.next_lookup_handle()? else {
+                return Ok(None);
+            };
+            let row = self
+                .table
+                .get_row_by_handle_with_context(&handle, &self.decode_context)
+                .map_err(|_| ExecError::unsupported("table bytes failed to decode"))?;
+            let Some(row) = row else {
+                continue;
+            };
+            self.scanned.set(self.scanned.get() + 1);
+            let row = visible_of(&self.table, &row);
+            if let Some(filter) = self.filter.as_mut() {
+                if !filter.admits(row)? {
+                    continue;
+                }
+            }
+            self.produced.set(self.produced.get() + 1);
+            return Ok(Some(row.to_vec()));
+        }
+    }
+
+    fn local_partial_rows(
+        &mut self,
+        aggregate: &PushdownPartialAggregate,
+    ) -> Result<Vec<Vec<Datum>>, ExecError> {
+        match aggregate {
+            PushdownPartialAggregate::Count { input_offset, .. } => {
+                let mut count = 0_i64;
+                while let Some(row) = self.next_partial_input_row()? {
+                    if !matches!(row.get(*input_offset), None | Some(Datum::Null)) {
+                        count += 1;
+                    }
+                }
+                Ok(vec![vec![Datum::Int(count)]])
+            }
+            PushdownPartialAggregate::GroupedStream {
+                group_offsets,
+                group_types,
+                functions,
+            } => {
+                if group_offsets.len() != group_types.len() || group_offsets.is_empty() {
+                    return Err(ExecError::unsupported(
+                        "index partial grouped StreamAgg requires typed group keys",
+                    ));
+                }
+
+                enum PartialValue {
+                    Count(i64),
+                    Sum(Option<Decimal>),
+                    Extreme { value: Option<Datum>, is_max: bool },
+                }
+                let new_values = || {
+                    functions
+                        .iter()
+                        .map(|function| match function.kind {
+                            PushdownAggregateKind::Count => PartialValue::Count(0),
+                            PushdownAggregateKind::Sum => PartialValue::Sum(None),
+                            PushdownAggregateKind::Min => PartialValue::Extreme {
+                                value: None,
+                                is_max: false,
+                            },
+                            PushdownAggregateKind::Max => PartialValue::Extreme {
+                                value: None,
+                                is_max: true,
+                            },
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let finish = |groups: Vec<Datum>, values: Vec<PartialValue>| {
+                    values
+                        .into_iter()
+                        .map(|value| match value {
+                            PartialValue::Count(count) => Datum::Int(count),
+                            PartialValue::Sum(sum) => sum.map_or(Datum::Null, Datum::Decimal),
+                            PartialValue::Extreme { value, .. } => value.unwrap_or(Datum::Null),
+                        })
+                        .chain(groups)
+                        .collect::<Vec<_>>()
+                };
+
+                let mut rows = Vec::new();
+                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
+                while let Some(row) = self.next_partial_input_row()? {
+                    let groups = group_offsets
+                        .iter()
+                        .map(|offset| {
+                            row.get(*offset).cloned().ok_or_else(|| {
+                                ExecError::unsupported(
+                                    "index partial GROUP BY input is outside the scan row",
+                                )
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let mut key = Vec::new();
+                    for (group, field_type) in groups.iter().zip(group_types) {
+                        key.extend_from_slice(&crate::hash_agg::group_key_part(
+                            &field_type.collation(),
+                            group,
+                        ));
+                        key.push(0xff);
+                    }
+                    if current
+                        .as_ref()
+                        .is_some_and(|(current_key, _, _)| current_key != &key)
+                    {
+                        let (_, previous_groups, previous_values) =
+                            current.take().expect("current group exists");
+                        rows.push(finish(previous_groups, previous_values));
+                    }
+                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    for (function, value) in functions.iter().zip(values.iter_mut()) {
+                        let input = function
+                            .input_offset
+                            .map(|offset| {
+                                row.get(offset).cloned().ok_or_else(|| {
+                                    ExecError::unsupported(
+                                        "index partial aggregate input is outside the scan row",
+                                    )
+                                })
+                            })
+                            .transpose()?;
+                        match (value, input) {
+                            (PartialValue::Count(count), None) => *count += 1,
+                            (PartialValue::Count(_), Some(Datum::Null)) => {}
+                            (PartialValue::Count(count), Some(_)) => *count += 1,
+                            (PartialValue::Sum(_), None) | (PartialValue::Extreme { .. }, None) => {
+                                return Err(ExecError::unsupported(
+                                    "only COUNT may omit an index partial aggregate input",
+                                ));
+                            }
+                            (PartialValue::Sum(_), Some(Datum::Null))
+                            | (PartialValue::Extreme { .. }, Some(Datum::Null)) => {}
+                            (PartialValue::Sum(sum), Some(input)) => {
+                                let addend = match input {
+                                    Datum::Int(value) => Decimal::from_int(value),
+                                    Datum::UInt(value) => Decimal::from_uint(value),
+                                    Datum::Decimal(value) => value,
+                                    _ => {
+                                        return Err(ExecError::unsupported(
+                                            "index partial SUM requires integer or decimal input",
+                                        ));
+                                    }
+                                };
+                                *sum = Some(match sum.take() {
+                                    Some(current) => current.add(&addend),
+                                    None => addend,
+                                });
+                            }
+                            (PartialValue::Extreme { value, is_max }, Some(candidate)) => {
+                                let replace = value.as_ref().is_none_or(|current| {
+                                    tidb_expr::compare_datums(&candidate, current).is_ok_and(
+                                        |ordering| {
+                                            if *is_max {
+                                                ordering.is_gt()
+                                            } else {
+                                                ordering.is_lt()
+                                            }
+                                        },
+                                    )
+                                });
+                                if replace {
+                                    *value = Some(candidate);
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some((_, groups, values)) = current {
+                    rows.push(finish(groups, values));
+                }
+                Ok(rows)
+            }
+            _ => Err(ExecError::unsupported(
+                "this index partial aggregation is not supported",
+            )),
+        }
+    }
 }
 
 impl Executor for IndexRangeSourceExec {
@@ -631,12 +892,63 @@ impl Executor for IndexRangeSourceExec {
         self.batch.clear();
         self.batch_at = 0;
         self.batch_size = INIT_HANDLE_BATCH;
+        self.partial_remote = None;
+        self.partial_rows = None;
+        self.partial_done = false;
+        if let Some(aggregate) = self.partial_aggregate.as_ref() {
+            self.partial_remote = self
+                .table
+                .pushdown_index_partial_aggregate_cursor(
+                    self.index_id,
+                    &self.ranges,
+                    aggregate,
+                    self.decode_context.zone(),
+                    &self.statement,
+                )
+                .map_err(|_| ExecError::unsupported("index aggregate request failed"))?;
+        }
         Ok(())
     }
 
     fn next(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
         req.reset();
         let cap = self.meta.max_chunk_size();
+        if let Some(remote) = self.partial_remote.as_mut() {
+            while req.num_rows() < cap {
+                let Some(row) = remote.next_row().map_err(|error| {
+                    ExecError::unsupported(format!("index aggregate response failed: {error:?}"))
+                })?
+                else {
+                    self.partial_remote = None;
+                    self.partial_done = true;
+                    break;
+                };
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
+            }
+            return Ok(());
+        }
+        if let Some(aggregate) = self.partial_aggregate.clone() {
+            if self.partial_done {
+                return Ok(());
+            }
+            if self.partial_rows.is_none() {
+                self.partial_rows = Some(self.local_partial_rows(&aggregate)?.into_iter());
+            }
+            let rows = self.partial_rows.as_mut().expect("just initialized");
+            while req.num_rows() < cap {
+                let Some(row) = rows.next() else {
+                    self.partial_rows = None;
+                    self.partial_done = true;
+                    break;
+                };
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
+            }
+            return Ok(());
+        }
         while req.num_rows() < cap {
             if self.limit.is_some_and(|limit| self.produced.get() >= limit) {
                 // Early stop: the cursor is dropped, so no entry past the cap
@@ -675,6 +987,9 @@ impl Executor for IndexRangeSourceExec {
 
     fn close(&mut self) -> Result<(), ExecError> {
         self.cursor = None;
+        self.partial_remote = None;
+        self.partial_rows = None;
+        self.partial_done = false;
         Ok(())
     }
 
@@ -704,6 +1019,41 @@ impl Executor for IndexRangeSourceExec {
 }
 
 impl crate::table_access::TableAccess for IndexRangeSourceExec {
+    fn accept_scan_estimate(&mut self, rows: f64) {
+        self.estimated_rows = Some(rows);
+    }
+
+    fn accept_partial_aggregate(&mut self, aggregate: &PushdownPartialAggregate) -> bool {
+        let supported = matches!(aggregate, PushdownPartialAggregate::Count { .. })
+            || (matches!(aggregate, PushdownPartialAggregate::GroupedStream { .. })
+                && !self.can_reorder_handles);
+        if self.estimated_rows.is_none_or(|rows| rows <= 1.0)
+            || !supported
+            || self.partial_aggregate.is_some()
+            || self.limit.is_some()
+        {
+            return false;
+        }
+        let columns = aggregate
+            .output_types()
+            .into_iter()
+            .enumerate()
+            .map(|(index, field_type)| {
+                let mut column = tidb_expr::column::Column::new((index + 1) as i64, field_type);
+                column.index = index as i64;
+                column
+            })
+            .collect();
+        self.meta = ExecutorMeta::new(
+            Schema::new(columns),
+            self.meta.id(),
+            self.meta.init_cap(),
+            self.meta.max_chunk_size(),
+        );
+        self.partial_aggregate = Some(aggregate.clone());
+        true
+    }
+
     /// The ranges are walked in plan order and each one in index order, so a
     /// cap truncates the same prefix the `LimitExec` above would have kept.
     /// The driver only offers one when nothing above this source filters the
@@ -763,6 +1113,21 @@ pub enum LookupObject {
     /// Go's `TableRangeScan ... range: decided by [outer_key]`: the outer
     /// key IS the handle, so the probe is a point read.
     Handle,
+    /// Go's clustered common-handle table path. Each probe supplies the
+    /// complete primary-key tuple and addresses the record directly, without
+    /// manufacturing a secondary PRIMARY index entry.
+    CommonHandle,
+}
+
+/// One object-key component of an index-join probe.
+///
+/// Go's ranger can combine `eq(inner_col, outer_col)` with constant access
+/// conditions on earlier key columns. `Dynamic` indexes the join-key tuple
+/// supplied by `JoinExec`; `Constant` is copied into every probe.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum LookupProbePart {
+    Dynamic(usize),
+    Constant(Datum),
 }
 
 /// The inner side of an index join: the rows of one table whose join-key
@@ -783,6 +1148,9 @@ pub struct IndexJoinLookupExec {
     meta: ExecutorMeta,
     table: KvTable,
     object: LookupObject,
+    /// The complete object-key template. Empty preserves the legacy contract
+    /// where the dynamic join-key tuple already is the complete probe.
+    probe_parts: Vec<LookupProbePart>,
     /// The current outer batch's distinct probe tuples, in walk order.
     probes: Vec<Vec<Datum>>,
     /// The next probe to open a cursor over.
@@ -793,6 +1161,12 @@ pub struct IndexJoinLookupExec {
     produced: Rc<Cell<u64>>,
     /// See [`HandleSourceExec`].
     decode_context: crate::kv_table::RowDecodeContext,
+    /// Leaf-local predicates that Go places below the index join's inner
+    /// reader. They are evaluated over the same full table row this source
+    /// returns, so replacing the originally-built leaf cannot drop them.
+    filters: Vec<Expression>,
+    filter_context: Option<crate::StmtContext>,
+    filter_chunk: Chunk,
 }
 
 impl IndexJoinLookupExec {
@@ -806,15 +1180,20 @@ impl IndexJoinLookupExec {
         object: LookupObject,
         decode_context: crate::kv_table::RowDecodeContext,
     ) -> Self {
+        let filter_chunk = meta.new_chunk();
         IndexJoinLookupExec {
             meta,
             table,
             object,
+            probe_parts: Vec::new(),
             probes: Vec::new(),
             next_probe: 0,
             cursor: None,
             produced: Rc::new(Cell::new(0)),
             decode_context,
+            filters: Vec::new(),
+            filter_context: None,
+            filter_chunk,
         }
     }
 
@@ -846,6 +1225,17 @@ impl IndexJoinLookupExec {
         self.cursor = None;
     }
 
+    /// Installs the complete object-key shape built by the index ranger.
+    pub(crate) fn set_probe_parts(&mut self, probe_parts: Vec<LookupProbePart>) {
+        self.probe_parts = probe_parts;
+    }
+
+    /// Installs every predicate local to the looked-up leaf.
+    pub(crate) fn set_filters(&mut self, filters: Vec<Expression>, context: crate::StmtContext) {
+        self.filters = filters;
+        self.filter_context = Some(context);
+    }
+
     /// The live count of rows this source produced.
     #[must_use]
     pub fn produced_rows(&self) -> Rc<Cell<u64>> {
@@ -865,10 +1255,26 @@ impl IndexJoinLookupExec {
                 }
                 self.cursor = None;
             }
-            let Some(probe) = self.probes.get(self.next_probe).cloned() else {
+            let Some(dynamic_probe) = self.probes.get(self.next_probe).cloned() else {
                 return Ok(None);
             };
             self.next_probe += 1;
+            let probe = if self.probe_parts.is_empty() {
+                dynamic_probe
+            } else {
+                let Some(probe) = self
+                    .probe_parts
+                    .iter()
+                    .map(|part| match part {
+                        LookupProbePart::Dynamic(offset) => dynamic_probe.get(*offset).cloned(),
+                        LookupProbePart::Constant(value) => Some(value.clone()),
+                    })
+                    .collect::<Option<Vec<_>>>()
+                else {
+                    continue;
+                };
+                probe
+            };
             match &self.object {
                 LookupObject::Index(index_id) => {
                     // Go's `IndexRangeScan` over the range the outer row
@@ -899,8 +1305,38 @@ impl IndexJoinLookupExec {
                     };
                     return Ok(Some(handle));
                 }
+                LookupObject::CommonHandle => {
+                    let handle = self
+                        .table
+                        .common_handle_of_values(&probe, self.decode_context.zone())
+                        .map_err(|_| {
+                            ExecError::unsupported("common handle probe failed to encode")
+                        })?;
+                    return Ok(Some(handle));
+                }
             }
         }
+    }
+
+    fn row_passes_filters(&mut self, row: &[Datum]) -> Result<bool, ExecError> {
+        if self.filters.is_empty() {
+            return Ok(true);
+        }
+        let context = self
+            .filter_context
+            .as_ref()
+            .expect("a filtered lookup source has a statement context");
+        self.filter_chunk.reset();
+        for (offset, value) in row.iter().enumerate() {
+            self.filter_chunk.append_datum(offset, value);
+        }
+        let chunk_row = self.filter_chunk.get_row(0);
+        for filter in &self.filters {
+            if truthy_of(&filter.eval(context, chunk_row)?)? != Some(true) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 }
 
@@ -919,6 +1355,7 @@ impl Executor for IndexJoinLookupExec {
         self.next_probe = 0;
         self.cursor = None;
         self.produced.set(0);
+        self.filter_chunk.reset();
         Ok(())
     }
 
@@ -936,7 +1373,11 @@ impl Executor for IndexJoinLookupExec {
             // An index entry whose row is gone is not a row, as in
             // [`IndexRangeSourceExec`].
             if let Some(row) = row {
-                for (c, value) in visible_of(&self.table, &row).iter().enumerate() {
+                let visible = visible_of(&self.table, &row);
+                if !self.row_passes_filters(&visible)? {
+                    continue;
+                }
+                for (c, value) in visible.iter().enumerate() {
                     req.append_datum(c, value);
                 }
                 self.produced.set(self.produced.get() + 1);
@@ -1244,6 +1685,132 @@ mod tests {
             gets.load(Ordering::Relaxed),
             5,
             "five rows were still looked up, though the index covers them"
+        );
+    }
+
+    /// A common-handle table is stored in primary-key order. Equality on the
+    /// leading handle columns therefore leaves the remaining suffix as the
+    /// scan order, so `ORDER BY` that suffix can stop at the LIMIT. This is
+    /// the TPC-C Delivery shape: `(w_id, d_id)` is fixed and `o_id` is ordered.
+    #[test]
+    fn a_common_handle_equality_prefix_satisfies_order_and_pushes_the_limit() {
+        let store = CountingStorage::default();
+        let entries = Arc::clone(&store.entries);
+        let mut table = KvTable::with_storage(
+            79,
+            vec![column("w_id", 1), column("d_id", 2), column("o_id", 3)],
+            Box::new(store),
+        );
+        table.set_common_handle_offsets(vec![0, 1, 2]);
+        table
+            .create_index(
+                crate::kv_table::KvIndex {
+                    id: 1,
+                    name: "PRIMARY".to_owned(),
+                    unique: true,
+                    column_offsets: vec![0, 1, 2],
+                    prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+                    visible: true,
+                    global: false,
+                },
+                &tidb_expr::NoColumns,
+            )
+            .unwrap();
+        for o_id in 1..=100 {
+            table
+                .insert_row(
+                    &[Datum::Int(1), Datum::Int(1), Datum::Int(o_id)],
+                    &tidb_expr::NoColumns,
+                )
+                .unwrap();
+        }
+        let mut catalog = Catalog::default();
+        catalog.register_kv("new_order", table);
+        entries.store(0, Ordering::Relaxed);
+
+        let rows = run_select_on(
+            "SELECT o_id FROM new_order \
+             WHERE w_id = 1 AND d_id = 1 \
+             ORDER BY o_id LIMIT 1",
+            &catalog,
+            &crate::StmtContext::for_query(),
+        )
+        .unwrap();
+        assert_eq!(first_column(&rows), vec![1]);
+        assert_eq!(
+            entries.load(Ordering::Relaxed),
+            1,
+            "the ordered common-handle range must stop after its first row"
+        );
+    }
+
+    /// Row-valued `IN` over a leading common-handle prefix opens one record
+    /// range per tuple instead of scanning the relation. This is the two slow
+    /// TPC-C Delivery statements over `(w_id, d_id, o_id, line_number)`.
+    #[test]
+    fn a_common_handle_row_in_reads_only_the_named_prefixes() {
+        let store = CountingStorage::default();
+        let entries = Arc::clone(&store.entries);
+        let mut table = KvTable::with_storage(
+            80,
+            vec![
+                column("w_id", 1),
+                column("d_id", 2),
+                column("o_id", 3),
+                column("line_number", 4),
+                column("amount", 5),
+            ],
+            Box::new(store),
+        );
+        table.set_common_handle_offsets(vec![0, 1, 2, 3]);
+        table
+            .create_index(
+                crate::kv_table::KvIndex {
+                    id: 1,
+                    name: "PRIMARY".to_owned(),
+                    unique: true,
+                    column_offsets: vec![0, 1, 2, 3],
+                    prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 4],
+                    visible: true,
+                    global: false,
+                },
+                &tidb_expr::NoColumns,
+            )
+            .unwrap();
+        for d_id in 1..=2 {
+            for o_id in 1..=100 {
+                for line_number in 1..=2 {
+                    table
+                        .insert_row(
+                            &[
+                                Datum::Int(1),
+                                Datum::Int(d_id),
+                                Datum::Int(o_id),
+                                Datum::Int(line_number),
+                                Datum::Int(o_id * 10 + line_number),
+                            ],
+                            &tidb_expr::NoColumns,
+                        )
+                        .unwrap();
+                }
+            }
+        }
+        let mut catalog = Catalog::default();
+        catalog.register_kv("order_line", table);
+        entries.store(0, Ordering::Relaxed);
+
+        let rows = run_select_on(
+            "SELECT amount FROM order_line \
+             WHERE (w_id, d_id, o_id) IN ((1, 1, 42), (1, 2, 43))",
+            &catalog,
+            &crate::StmtContext::for_query(),
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 4);
+        assert_eq!(
+            entries.load(Ordering::Relaxed),
+            4,
+            "only the four records under the two named prefixes may be read"
         );
     }
 

--- a/rust/crates/tidb-executor/src/access_path.rs
+++ b/rust/crates/tidb-executor/src/access_path.rs
@@ -53,6 +53,7 @@
 //! with one it reports the truncation, as Go's does.
 
 use std::cell::Cell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use tidb_chunk::chunk::Chunk;
@@ -739,14 +740,15 @@ impl IndexRangeSourceExec {
                 }
                 Ok(vec![vec![Datum::Int(count)]])
             }
-            PushdownPartialAggregate::GroupedStream {
+            PushdownPartialAggregate::Grouped {
                 group_offsets,
                 group_types,
                 functions,
+                streamed,
             } => {
                 if group_offsets.len() != group_types.len() || group_offsets.is_empty() {
                     return Err(ExecError::unsupported(
-                        "index partial grouped StreamAgg requires typed group keys",
+                        "index partial grouped aggregation requires typed group keys",
                     ));
                 }
 
@@ -783,10 +785,7 @@ impl IndexRangeSourceExec {
                         .chain(groups)
                         .collect::<Vec<_>>()
                 };
-
-                let mut rows = Vec::new();
-                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
-                while let Some(row) = self.next_partial_input_row()? {
+                let group = |row: &[Datum]| -> Result<(Vec<u8>, Vec<Datum>), ExecError> {
                     let groups = group_offsets
                         .iter()
                         .map(|offset| {
@@ -805,15 +804,11 @@ impl IndexRangeSourceExec {
                         ));
                         key.push(0xff);
                     }
-                    if current
-                        .as_ref()
-                        .is_some_and(|(current_key, _, _)| current_key != &key)
-                    {
-                        let (_, previous_groups, previous_values) =
-                            current.take().expect("current group exists");
-                        rows.push(finish(previous_groups, previous_values));
-                    }
-                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    Ok((key, groups))
+                };
+                let update = |values: &mut [PartialValue],
+                              row: &[Datum]|
+                 -> Result<(), ExecError> {
                     for (function, value) in functions.iter().zip(values.iter_mut()) {
                         let input = function
                             .input_offset
@@ -870,6 +865,37 @@ impl IndexRangeSourceExec {
                             }
                         }
                     }
+                    Ok(())
+                };
+
+                if !streamed {
+                    let mut grouped = BTreeMap::<Vec<u8>, (Vec<Datum>, Vec<PartialValue>)>::new();
+                    while let Some(row) = self.next_partial_input_row()? {
+                        let (key, groups) = group(&row)?;
+                        let (_, values) =
+                            grouped.entry(key).or_insert_with(|| (groups, new_values()));
+                        update(values, &row)?;
+                    }
+                    return Ok(grouped
+                        .into_values()
+                        .map(|(groups, values)| finish(groups, values))
+                        .collect());
+                }
+
+                let mut rows = Vec::new();
+                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
+                while let Some(row) = self.next_partial_input_row()? {
+                    let (key, groups) = group(&row)?;
+                    if current
+                        .as_ref()
+                        .is_some_and(|(current_key, _, _)| current_key != &key)
+                    {
+                        let (_, previous_groups, previous_values) =
+                            current.take().expect("current group exists");
+                        rows.push(finish(previous_groups, previous_values));
+                    }
+                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    update(values, &row)?;
                 }
                 if let Some((_, groups, values)) = current {
                     rows.push(finish(groups, values));
@@ -1025,8 +1051,17 @@ impl crate::table_access::TableAccess for IndexRangeSourceExec {
 
     fn accept_partial_aggregate(&mut self, aggregate: &PushdownPartialAggregate) -> bool {
         let supported = matches!(aggregate, PushdownPartialAggregate::Count { .. })
-            || (matches!(aggregate, PushdownPartialAggregate::GroupedStream { .. })
-                && !self.can_reorder_handles);
+            || matches!(
+                aggregate,
+                PushdownPartialAggregate::Grouped {
+                    streamed: false,
+                    ..
+                }
+            )
+            || (matches!(
+                aggregate,
+                PushdownPartialAggregate::Grouped { streamed: true, .. }
+            ) && !self.can_reorder_handles);
         if self.estimated_rows.is_none_or(|rows| rows <= 1.0)
             || !supported
             || self.partial_aggregate.is_some()

--- a/rust/crates/tidb-executor/src/cluster_storage.rs
+++ b/rust/crates/tidb-executor/src/cluster_storage.rs
@@ -59,7 +59,7 @@
 //! * [`key_count`](TableStorage::key_count) reports the staged key count only.
 //!   TiKV has no exact count, and the seam's own doc already says so.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
@@ -146,6 +146,64 @@ pub trait ClusterSnapshot: fmt::Debug + Send {
 /// membuffer rather than a copy of it -- which a statement rollback or a
 /// savepoint returns to.
 pub type BufferImage = Vec<(Key, Option<Vec<u8>>)>;
+
+/// Raw keys actually consumed by the current statement.
+///
+/// A pessimistic locking read must lock rows after the executor has applied
+/// its predicates and limits. Tracking at the storage seam records precisely
+/// those point gets and iterator rows, while leaving ordinary statements on
+/// the zero-work disabled path.
+#[derive(Clone, Debug, Default)]
+pub struct StatementReadKeys {
+    state: Arc<Mutex<StatementReadKeyState>>,
+}
+
+#[derive(Debug, Default)]
+struct StatementReadKeyState {
+    enabled: bool,
+    keys: BTreeSet<Vec<u8>>,
+}
+
+impl StatementReadKeys {
+    /// Starts a new locking statement and discards any prior statement's keys.
+    pub fn begin(&self) {
+        let mut state = self.lock();
+        state.keys.clear();
+        state.enabled = true;
+    }
+
+    /// Ends the statement and returns its keys in encoded-key order.
+    #[must_use]
+    pub fn finish(&self) -> Vec<Vec<u8>> {
+        let mut state = self.lock();
+        state.enabled = false;
+        std::mem::take(&mut state.keys).into_iter().collect()
+    }
+
+    /// Ends a failed statement without returning its partial read set.
+    pub fn cancel(&self) {
+        let mut state = self.lock();
+        state.enabled = false;
+        state.keys.clear();
+    }
+
+    fn record(&self, key: &Key) {
+        let mut state = self.lock();
+        if state.enabled {
+            state.keys.insert(key.as_bytes().to_vec());
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.lock().enabled
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, StatementReadKeyState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+}
 
 /// The session's staged writes: Go's `kv.MemBuffer`.
 ///
@@ -332,6 +390,7 @@ impl ClusterSnapshot for SwappableSnapshot {
 pub struct ClusterTableStorage {
     buffer: MutationBuffer,
     snapshot: Arc<Mutex<dyn ClusterSnapshot>>,
+    read_keys: StatementReadKeys,
     /// Whether THIS table handle was truncated (see [`Self::check_usable`]).
     ///
     /// Deliberately a plain `bool` and not shared: the buffer and the snapshot
@@ -353,6 +412,7 @@ impl ClusterTableStorage {
         ClusterTableStorage {
             buffer,
             snapshot,
+            read_keys: StatementReadKeys::default(),
             truncated: false,
             scanner: None,
         }
@@ -374,6 +434,12 @@ impl ClusterTableStorage {
     #[must_use]
     pub fn buffer(&self) -> MutationBuffer {
         self.buffer.clone()
+    }
+
+    /// The per-statement raw-key collector shared by every table clone.
+    #[must_use]
+    pub fn read_keys(&self) -> StatementReadKeys {
+        self.read_keys.clone()
     }
 
     fn check_usable(&self) -> Result<(), StorageError> {
@@ -403,6 +469,7 @@ impl TableStorage for ClusterTableStorage {
         // buffer answers is still one `get` here, because the shape the count
         // describes is the plan's, not the transport's.
         crate::storage::note_storage_op(|ops| ops.gets += 1);
+        self.read_keys.record(key);
         match self.buffer.get(key) {
             Some(Some(value)) => Ok(value),
             Some(None) => Err(StorageError::NotFound),
@@ -437,6 +504,7 @@ impl TableStorage for ClusterTableStorage {
         let staged = self.buffer.range(start, end);
         Ok(Box::new(MergedIterator::open(
             Arc::clone(&self.snapshot),
+            self.read_keys.clone(),
             start.clone(),
             end.clone(),
             staged,
@@ -457,6 +525,9 @@ impl TableStorage for ClusterTableStorage {
         request: &PushdownScanRequest,
     ) -> Option<Result<PushdownScan, StorageError>> {
         let scanner = self.scanner.as_ref()?;
+        if self.read_keys.is_enabled() {
+            return None;
+        }
         if let Err(error) = self.check_usable() {
             return Some(Err(error));
         }
@@ -534,6 +605,7 @@ const SNAPSHOT_BATCH: usize = 256;
 #[derive(Debug)]
 struct MergedIterator {
     snapshot: Arc<Mutex<dyn ClusterSnapshot>>,
+    read_keys: StatementReadKeys,
     /// Where the next refill starts, or `None` once the snapshot half of the
     /// range is drained.
     cursor: Option<Key>,
@@ -552,6 +624,7 @@ impl MergedIterator {
     /// one snapshot batch to find it.
     fn open(
         snapshot: Arc<Mutex<dyn ClusterSnapshot>>,
+        read_keys: StatementReadKeys,
         start: Key,
         end: Key,
         staged: Vec<(Key, Option<Vec<u8>>)>,
@@ -559,6 +632,7 @@ impl MergedIterator {
         let empty = end <= start;
         let mut iterator = MergedIterator {
             snapshot,
+            read_keys,
             cursor: (!empty).then_some(start),
             end,
             batch: Vec::new(),
@@ -646,9 +720,14 @@ impl StorageIterator for MergedIterator {
     }
 
     fn key(&self) -> &Key {
-        self.current
+        let key = self
+            .current
             .as_ref()
-            .map_or(&self.empty_key, |(key, _)| key)
+            .map_or(&self.empty_key, |(key, _)| key);
+        if self.current.is_some() {
+            self.read_keys.record(key);
+        }
+        key
     }
 
     fn value(&self) -> &[u8] {

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -1829,6 +1829,37 @@ pub(super) fn run_select_traced_with_delivery(
     // valid ORDER BY on that output above the aggregate.
     let projection_elided =
         cop_projection_ready || cop_filtered_projection_ready || full_row_projection;
+    // Only EXPLAIN needs a second view of the executable expression tree.
+    // Ordinary execution moves the sole copy into ProjectionExec, so the
+    // TPCC hot path pays no clone for physical-expression rendering.
+    let projection_trace_exprs =
+        (trace.is_some() && direct_distinct_input.is_none() && !projection_elided)
+            .then(|| exprs.clone());
+    let projection_trace_columns = projection_trace_exprs.as_ref().map(|_| {
+        (0..current_scope.width())
+            .map(|offset| {
+                let path = current_scope.qualified_path(offset)?;
+                let [relation, column] = path.as_slice() else {
+                    return None;
+                };
+                let key = crate::driver::merge_decision::RelColumn {
+                    relation: relation.clone(),
+                    column: column.clone(),
+                };
+                let from = select.from.as_ref()?;
+                crate::driver::merge_decision::physical_column_trace_name(
+                    &from.left, &key, catalog, current_db,
+                )
+                .or_else(|| {
+                    from.right.as_ref().and_then(|right| {
+                        crate::driver::merge_decision::physical_column_trace_name(
+                            right, &key, catalog, current_db,
+                        )
+                    })
+                })
+            })
+            .collect::<Vec<_>>()
+    });
     let mut root: Box<dyn Executor> = if let Some(input) = direct_distinct_input.as_ref() {
         let input = if partial_distinct {
             Expression::Column(source.schema().columns[0].clone())
@@ -1872,10 +1903,21 @@ pub(super) fn run_select_traced_with_delivery(
     };
     if direct_distinct_input.is_none() && !projection_elided {
         if let Some(trace) = trace.as_deref_mut() {
-            if reader_ready {
-                trace.projection_at_rows(traced_select.fields.fields(), &qualify, logical_rows);
-            } else {
-                trace.projection(traced_select.fields.fields(), &qualify);
+            let physical = projection_trace_exprs
+                .as_deref()
+                .is_some_and(|expressions| {
+                    trace.physical_real_projection(
+                        expressions,
+                        projection_trace_columns.as_deref().unwrap_or(&[]),
+                        reader_ready.then_some(logical_rows).flatten(),
+                    )
+                });
+            if !physical {
+                if reader_ready {
+                    trace.projection_at_rows(traced_select.fields.fields(), &qualify, logical_rows);
+                } else {
+                    trace.projection(traced_select.fields.fields(), &qualify);
+                }
             }
             root = trace.meter(root);
         }

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -298,6 +298,7 @@ mod agg_select;
 mod catalog;
 mod clause_resolve;
 mod derived_agg_pruning;
+mod derived_projection_pushdown;
 mod dml;
 mod errors;
 mod from;
@@ -695,6 +696,18 @@ pub(super) fn run_select_traced_with_delivery(
         }
         None => select,
     };
+    // Go substitutes predicates through a pass-through derived projection
+    // before simplifying NULL-rejecting outer joins. The TPCC consistency
+    // checks use that chain to expose both leaf ranges and a local inner
+    // merge join; the proof-shaped rewrite refuses every other derived form.
+    let globally_counted;
+    let select = match derived_projection_pushdown::fuse_global_count(select, catalog, current_db) {
+        Some(rewritten) => {
+            globally_counted = rewritten;
+            &globally_counted
+        }
+        None => select,
+    };
     // Go's `LogicalAggregation.PruneColumns` reaching a derived table: an
     // ungrouped aggregation nobody reads a column of keeps only the `count(1)`
     // that carries its row. See `driver::derived_agg_pruning`.
@@ -783,22 +796,33 @@ pub(super) fn run_select_traced_with_delivery(
             // property that has to reach the leaf before the aggregate is
             // built, so the leaf must cost its WHERE-constrained ordered path
             // here instead of waiting for the later empty-property fast path.
-            let wanted = (access::single_kv_table(&select.from, catalog, current_db).is_none()
-                || aggregation_order.is_some())
-            .then(|| leaf_demand::LeafDemand::of_select(select));
+            let plan_at_leaf = access::single_kv_table(&select.from, catalog, current_db).is_none()
+                || aggregation_order.is_some();
+            let wanted = plan_at_leaf.then(|| leaf_demand::LeafDemand::of_select(select));
             // The estimate owner: every relation of this `FROM` with the row
             // count `derive_stats` derives for it, read off the statement,
             // the catalog and the statistics. It is built here, beside the
             // reorder that costs the same models, because both need the join
             // group as WRITTEN -- and NOT off `PlanTrace`, which exists only
             // under `EXPLAIN`. See `driver::join_search`.
-            let row_source = join_reorder::row_source(
-                join,
-                select.where_clause.as_ref(),
-                catalog,
-                current_db,
-                ctx,
-            );
+            // A plain single-KV-table SELECT is costed later by
+            // `commit_fast_path_source`, with its original WHERE intact. If
+            // RowSource consumes that predicate here while column demand is
+            // deliberately absent, the later point/range chooser sees no
+            // key condition and the statement degenerates to a full scan.
+            // A grouped stream plan is the exception above: its non-empty
+            // property has already committed leaf planning at this site.
+            let row_source = plan_at_leaf
+                .then(|| {
+                    join_reorder::row_source(
+                        join,
+                        select.where_clause.as_ref(),
+                        catalog,
+                        current_db,
+                        ctx,
+                    )
+                })
+                .flatten();
             grouped_logical_rows = row_source
                 .as_ref()
                 .and_then(|rows| rows.grouped_rows(&select.group_by));
@@ -930,10 +954,9 @@ pub(super) fn run_select_traced_with_delivery(
         .as_ref()
         .is_some_and(|order| order.is_delivered_by(&from_delivered, &scope));
     if grouped_stream_ordered {
-        if let (Some(delivered), Some(order)) = (
-            output_delivered.as_deref_mut(),
-            grouped_select_output_order(traced_select),
-        ) {
+        if let (Some(delivered), Some(order)) =
+            (output_delivered, grouped_select_output_order(traced_select))
+        {
             delivered.push(order);
         }
     }
@@ -1081,6 +1104,9 @@ pub(super) fn run_select_traced_with_delivery(
             .iter()
             .any(|item| item.expr.has_aggregate_flag());
     if is_aggregate {
+        let grouped_stream_physical_order = aggregation_order
+            .as_ref()
+            .and_then(|order| order.physical_group_offsets(&scope));
         let resolver = ScopeResolver { scope: &scope };
         return run_aggregate_select(
             select,
@@ -1094,6 +1120,7 @@ pub(super) fn run_select_traced_with_delivery(
             logical_rows,
             grouped_logical_rows,
             grouped_stream_ordered,
+            grouped_stream_physical_order,
             derived_output,
             grouped_derived_output_pruned,
             trace,

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -297,7 +297,9 @@ mod agg_build;
 mod agg_select;
 mod catalog;
 mod clause_resolve;
+mod correlated_agg_decorrelate;
 mod derived_agg_pruning;
+pub(crate) use derived_agg_pruning::has_pruned_row_count;
 mod derived_projection_pushdown;
 mod dml;
 mod errors;
@@ -658,10 +660,6 @@ pub(super) fn run_select_traced_with_delivery(
     if let Some(delivered) = output_delivered.as_deref_mut() {
         delivered.clear();
     }
-    // The statement as written, which the plan text is rendered from: the
-    // rewrites below (CTE materialization, subquery folding, window
-    // hoisting) change what is EXECUTED, not what the user asked for.
-    let traced_select = select;
     // A WITH clause's CTEs are materialized first, then the query runs against
     // a catalog that contains them.
     let with_catalog;
@@ -672,6 +670,26 @@ pub(super) fn run_select_traced_with_delivery(
         }
         None => catalog,
     };
+    // Go's DecorrelateSolver turns equality-correlated scalar aggregations
+    // into ordinary joins and aggregations. This executor has no retained
+    // logical-plan tree, so the proof-shaped equivalent rewrites the AST
+    // before every later optimizer rule and before plan tracing.
+    let decorrelated;
+    let decorrelated_aggregate;
+    let select = match correlated_agg_decorrelate::rewrite(select, catalog, current_db, ctx) {
+        Some(rewritten) => {
+            decorrelated = rewritten;
+            decorrelated_aggregate = true;
+            &decorrelated
+        }
+        None => {
+            decorrelated_aggregate = false;
+            select
+        }
+    };
+    // The plan text follows optimizer-visible rewrites. Runtime-only rewrites
+    // below (subquery folding and window hoisting) still remain invisible.
+    let traced_select = select;
     // Uncorrelated subqueries are evaluated now and folded into literals, so
     // everything below plans against ordinary expressions (Go's
     // handleScalarSubquery for the non-Apply case).
@@ -683,16 +701,41 @@ pub(super) fn run_select_traced_with_delivery(
     } else {
         select
     };
-    // Go's `tidb_opt_join_reorder_through_proj`: a derived table whose
-    // projection sits directly on a join dissolves into the statement, so the
-    // relations under it become leaves of THIS join group and the reorder can
-    // move them. Both of Go's gates and this tier's own are in
-    // `driver::through_proj`; every default session gets `None` here.
+    // Go expands a derived table's wildcard while constructing its logical
+    // Projection. Projection elimination then sees the expanded expressions,
+    // so a `SELECT * FROM (a JOIN b)` identity projection can disappear
+    // before join reorder even when through-projection reordering is OFF.
+    let expanded_derived_wildcards;
+    let select =
+        match derived_projection_pushdown::expand_derived_wildcards(select, catalog, current_db) {
+            Some(rewritten) => {
+                expanded_derived_wildcards = rewritten;
+                &expanded_derived_wildcards
+            }
+            None => select,
+        };
+    // Go's projection elimination removes bare-column projections before join
+    // reorder. Projections that still compute expressions dissolve only when
+    // `tidb_opt_join_reorder_through_proj` is enabled; both cases share the
+    // same name-preserving AST splice.
     let inlined;
     let select = match through_proj::inline(select, catalog, current_db, ctx) {
         Some(rewritten) => {
             inlined = rewritten;
             &inlined
+        }
+        None => select,
+    };
+    // Move leaf-local predicates through those derived projections before
+    // pruning their now-unread outputs. Join equalities and multi-relation
+    // predicates remain at the join that executes them.
+    let derived_predicates_pushed;
+    let select = match derived_projection_pushdown::push_local_predicates_into_derived(
+        select, catalog, current_db, ctx,
+    ) {
+        Some(rewritten) => {
+            derived_predicates_pushed = rewritten;
+            &derived_predicates_pushed
         }
         None => select,
     };
@@ -738,6 +781,12 @@ pub(super) fn run_select_traced_with_delivery(
         }
         None => select,
     };
+    // Derived-table fusion can pull a decorrelated scalar-SUM shape into a
+    // caller after this recursive call's initial rewrite returned `None`.
+    // Recognize the resulting invariant shape here so physical plan details
+    // keep using catalog table/column names throughout the pulled plan.
+    let physical_source_names =
+        decorrelated_aggregate || correlated_agg_decorrelate::is_pulled_scalar_sum(select);
 
     // Go's `buildSelect` pushes this block's `/*+ ... */` hints and its
     // deferred `popTableHints` reports the ones no `DataSource` of the block
@@ -789,14 +838,10 @@ pub(super) fn run_select_traced_with_delivery(
             // source no longer owes a group-key order; asking for it here
             // would make the eventual scan claim `keep order:true` for work
             // the executable plan does not require.
-            aggregation_order =
-                (!agg_select::aggregation_can_be_eliminated(select, catalog, current_db))
-                    .then(|| {
-                        merge_decision::aggregation_order(
-                            select, join, catalog, current_db, &offered,
-                        )
-                    })
-                    .flatten();
+            aggregation_order = (!physical_source_names
+                && !agg_select::aggregation_can_be_eliminated(select, catalog, current_db))
+            .then(|| merge_decision::aggregation_order(select, join, catalog, current_db, &offered))
+            .flatten();
             // Go's `rule_column_pruning`: what every `DataSource` below still
             // has to produce, which is the input its access-path costing
             // needs (`isCoveringIndex`). A `FROM` of ONE base table is
@@ -846,6 +891,7 @@ pub(super) fn run_select_traced_with_delivery(
                 columns: wanted.as_ref(),
                 rows: row_source.as_ref(),
                 join_hints: (!join_hints.is_empty()).then_some(&join_hints),
+                physical_source_names,
             };
             // Go's `join_reorder` rule, which runs on the logical plan
             // between predicate pushdown and physical planning. It only ever
@@ -965,9 +1011,10 @@ pub(super) fn run_select_traced_with_delivery(
         .as_ref()
         .is_some_and(|order| order.is_delivered_by(&from_delivered, &scope));
     if grouped_stream_ordered {
-        if let (Some(delivered), Some(order)) =
-            (output_delivered, grouped_select_output_order(traced_select))
-        {
+        if let (Some(delivered), Some(order)) = (
+            output_delivered.as_deref_mut(),
+            grouped_select_output_order(traced_select),
+        ) {
             delivered.push(order);
         }
     }
@@ -1133,7 +1180,7 @@ pub(super) fn run_select_traced_with_delivery(
             grouped_stream_ordered,
             grouped_stream_physical_order,
             derived_output,
-            grouped_derived_output_pruned,
+            grouped_derived_output_pruned || physical_source_names,
             trace,
         );
     }
@@ -1360,7 +1407,7 @@ pub(super) fn run_select_traced_with_delivery(
         let mut pred = rewrite_expr_resolved(&predicate, &predicate_resolver)
             .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
         refine_comparisons(&mut pred, ctx);
-        let physical_trace_predicate = grouped_derived_output_pruned.then(|| pred.clone());
+        let physical_trace_predicate = physical_source_names.then(|| pred.clone());
         source = Box::new(SelectionExec::new(
             ExecutorMeta::new(source_schema, 1, INIT_CAP, MAX_CHUNK_SIZE),
             vec![pred],
@@ -1628,6 +1675,50 @@ pub(super) fn run_select_traced_with_delivery(
         }
     }
 
+    // A plain projection preserves each input order through its bare-column
+    // outputs. Report that ACTUAL mapping to a parent join so its merge-plan
+    // verification reads the executor just built rather than a catalog
+    // promise. Clauses with their own physical ordering semantics stay
+    // fail-closed here, matching `merge_decision::order_preserving_source`.
+    let projection_sources = exprs
+        .iter()
+        .map(|expr| {
+            expr.as_column()
+                .and_then(|column| usize::try_from(column.index).ok())
+        })
+        .collect::<Vec<_>>();
+    if !select.distinct
+        && select.group_by.is_empty()
+        && select.having.is_none()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && select.windows.is_empty()
+    {
+        if let Some(delivered) = output_delivered.as_deref_mut() {
+            delivered.extend(crate::driver::merge_decision::project_delivered_orders(
+                &from_delivered,
+                &projection_sources,
+            ));
+        }
+    }
+    // Go folds an increasing bare-column subset into the child join's pruned
+    // output schema. ProjectionExec remains this executor's implementation of
+    // that pruning, but it is not a separate physical Projection in Go's
+    // plan tree.
+    let derived_column_prune = derived_output
+        && !select.distinct
+        && select.group_by.is_empty()
+        && select.having.is_none()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && select.windows.is_empty()
+        && projection_sources.iter().all(Option::is_some)
+        && projection_sources.windows(2).all(|pair| {
+            pair[0]
+                .zip(pair[1])
+                .is_some_and(|(left, right)| left < right)
+        });
+
     // Output schema: one column per field, typed by the expression's static type.
     let out_columns: Vec<Column> = exprs
         .iter()
@@ -1878,9 +1969,11 @@ pub(super) fn run_select_traced_with_delivery(
     // Only EXPLAIN needs a second view of the executable expression tree.
     // Ordinary execution moves the sole copy into ProjectionExec, so the
     // TPCC hot path pays no clone for physical-expression rendering.
-    let projection_trace_exprs =
-        (trace.is_some() && direct_distinct_input.is_none() && !projection_elided)
-            .then(|| exprs.clone());
+    let projection_trace_exprs = (trace.is_some()
+        && direct_distinct_input.is_none()
+        && !projection_elided
+        && !derived_column_prune)
+        .then(|| exprs.clone());
     let projection_trace_columns = projection_trace_exprs.as_ref().map(|_| {
         (0..current_scope.width())
             .map(|offset| {
@@ -1947,7 +2040,7 @@ pub(super) fn run_select_traced_with_delivery(
             ctx.clone(),
         ))
     };
-    if direct_distinct_input.is_none() && !projection_elided {
+    if direct_distinct_input.is_none() && !projection_elided && !derived_column_prune {
         if let Some(trace) = trace.as_deref_mut() {
             let physical = projection_trace_exprs
                 .as_deref()

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -784,8 +784,19 @@ pub(super) fn run_select_traced_with_delivery(
             // build the cross product the filter would then throw away. See
             // `driver::predicate_push_down`.
             let offered = predicate_push_down::offered_conjuncts(select.where_clause.as_ref());
+            // Go's aggregation elimination runs before physical property
+            // enforcement. Once a unique group becomes a projection, the
+            // source no longer owes a group-key order; asking for it here
+            // would make the eventual scan claim `keep order:true` for work
+            // the executable plan does not require.
             aggregation_order =
-                merge_decision::aggregation_order(select, join, catalog, current_db, &offered);
+                (!agg_select::aggregation_can_be_eliminated(select, catalog, current_db))
+                    .then(|| {
+                        merge_decision::aggregation_order(
+                            select, join, catalog, current_db, &offered,
+                        )
+                    })
+                    .flatten();
             // Go's `rule_column_pruning`: what every `DataSource` below still
             // has to produce, which is the input its access-path costing
             // needs (`isCoveringIndex`). A `FROM` of ONE base table is

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -31,7 +31,7 @@
 
 use crate::access_path::{HandleSourceExec, IndexRangeSourceExec};
 use crate::executor::{ExecError, Executor, ExecutorMeta};
-use crate::hash_agg::{AggFunc, AggKind, HashAggExec};
+use crate::hash_agg::{AggFunc, AggKind, HashAggExec, StreamAggExec};
 use crate::join::{JoinExec, JoinKind};
 use crate::kv_table::{IndexRange, KvTable, TableHandle, TableScanExec};
 use crate::limit::LimitExec;
@@ -42,6 +42,7 @@ use crate::predicate_pushdown::{
     PushedScanFilter, ScanComparison, ScanComparisonOp, ScanPredicate,
 };
 use crate::projection::ProjectionExec;
+use crate::remote_scan::{PushdownPartialAggregate, PushdownTopN, PushdownTopNOrder};
 use crate::selection::SelectionExec;
 use crate::sort::{SortByItem, SortExec};
 use crate::table_dual::TableDualExec;
@@ -483,6 +484,29 @@ pub fn run_select_meta_stmt(
     run_select_stmt(select, catalog, current_db, ctx)
 }
 
+/// Plans one parsed `SELECT` and returns only its result-column metadata.
+///
+/// The ordinary planner still builds the exact executor pipeline, including
+/// access-path selection and output type derivation, but a plan-only trace
+/// stops before the pipeline is opened or drained.
+pub fn plan_select_meta_stmt(
+    select: &tidb_ast::SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> Result<Vec<(String, FieldType)>, DriverError> {
+    let mut trace = PlanTrace::planning();
+    let (columns, _) = run_select_traced(
+        select,
+        catalog,
+        current_db,
+        ctx,
+        Some(&mut trace),
+        &tidb_planner::physical_property::PhysicalProperty::default(),
+    )?;
+    Ok(columns)
+}
+
 /// Go `restoreSchemaIfChanged`, for a scope whose leaves the join reorder
 /// moved.
 ///
@@ -508,6 +532,28 @@ fn restore_written_order(scope: &mut FromScope, written_order: &[usize]) {
     scope.star = star;
 }
 
+/// The grouped columns' positions in a SELECT's own result row. A grouped
+/// StreamAgg emits in this order; selected carriers preserve it through the
+/// final projection.
+fn grouped_select_output_order(select: &tidb_ast::SelectStmt) -> Option<Vec<usize>> {
+    select
+        .group_by
+        .iter()
+        .map(|group| {
+            let tidb_ast::Expr::Column(group_path) = &group.expr else {
+                return None;
+            };
+            select.fields.fields().iter().position(|field| {
+                matches!(field,
+                    tidb_ast::SelectField::Expr {
+                        expr: tidb_ast::Expr::Column(path),
+                        ..
+                    } if path == group_path)
+            })
+        })
+        .collect()
+}
+
 /// The name a source operator's `access object` prints: the alias the FROM
 /// clause gave the table, which is what Go prints too.
 fn source_table_name<'a>(scope: &'a FromScope, table: &'a str) -> &'a str {
@@ -515,6 +561,38 @@ fn source_table_name<'a>(scope: &'a FromScope, table: &'a str) -> &'a str {
         Some(first) => &first.name,
         None => table,
     }
+}
+
+/// Whether the select list is the source table's complete row in source
+/// order. Go eliminates this identity projection even when the columns were
+/// written explicitly (`SELECT id, k, c, pad`), while retaining a projection
+/// for a proper subset such as `SELECT c`.
+fn projects_entire_single_table_in_order(select: &tidb_ast::SelectStmt, scope: &FromScope) -> bool {
+    let [table] = scope.tables.as_slice() else {
+        return false;
+    };
+    let fields = select.fields.fields();
+    if let [SelectField::Wildcard(qualifier)] = fields {
+        return qualifier
+            .last()
+            .is_none_or(|name| table.name.eq_ignore_ascii_case(name));
+    }
+    if fields.len() != table.columns.len() {
+        return false;
+    }
+    let resolver = ScopeResolver { scope };
+    fields.iter().enumerate().all(|(expected, field)| {
+        let SelectField::Expr {
+            expr: tidb_ast::Expr::Column(path),
+            ..
+        } = field
+        else {
+            return false;
+        };
+        resolver
+            .resolve(path)
+            .is_some_and(|(offset, _, _)| offset == expected)
+    })
 }
 
 /// Runs one parsed `SELECT` against the catalog.
@@ -553,9 +631,32 @@ pub(crate) fn run_select_traced(
     catalog: &Catalog,
     current_db: &str,
     ctx: &crate::StmtContext,
-    mut trace: Option<&mut PlanTrace>,
+    trace: Option<&mut PlanTrace>,
     required: &tidb_planner::physical_property::PhysicalProperty,
 ) -> Result<SelectMeta, DriverError> {
+    run_select_traced_with_delivery(select, catalog, current_db, ctx, trace, required, None)
+}
+
+/// [`run_select_traced`] plus the order the built SELECT output actually
+/// retains. Derived-table materialization uses this receipt instead of
+/// predicting order from catalog properties after execution.
+pub(super) fn run_select_traced_with_delivery(
+    select: &tidb_ast::SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+    mut trace: Option<&mut PlanTrace>,
+    required: &tidb_planner::physical_property::PhysicalProperty,
+    mut output_delivered: Option<&mut from::Delivered>,
+) -> Result<SelectMeta, DriverError> {
+    // Only a derived-table caller asks for an output-order receipt. Go's
+    // projection elimination can then map the outer relation directly onto
+    // an aggregation's schema, while a top-level SELECT retains the visible
+    // Projection that restores function-first partial aggregate outputs.
+    let derived_output = output_delivered.is_some();
+    if let Some(delivered) = output_delivered.as_deref_mut() {
+        delivered.clear();
+    }
     // The statement as written, which the plan text is rendered from: the
     // rewrites below (CTE materialization, subquery folding, window
     // hoisting) change what is EXECUTED, not what the user asked for.
@@ -598,12 +699,18 @@ pub(crate) fn run_select_traced(
     // ungrouped aggregation nobody reads a column of keeps only the `count(1)`
     // that carries its row. See `driver::derived_agg_pruning`.
     let unaggregated;
+    let grouped_derived_output_pruned;
     let select = match derived_agg_pruning::prune(select) {
         Some(rewritten) => {
+            grouped_derived_output_pruned =
+                derived_agg_pruning::is_single_grouped_derived(&rewritten);
             unaggregated = rewritten;
             &unaggregated
         }
-        None => select,
+        None => {
+            grouped_derived_output_pruned = false;
+            select
+        }
     };
     // Go's `rule_join_elimination`: an outer join whose null-producing side
     // nobody reads and which cannot duplicate an outer row is dropped, so the
@@ -625,7 +732,18 @@ pub(crate) fn run_select_traced(
     // a `FROM`-less select names nothing and is reported too. Captured.
     crate::index_hints::report_comment_index_hints(select, catalog, current_db, ctx);
     // Resolve FROM: none -> table-dual; otherwise the (possibly joined) tables.
-    let (mut from_source, mut scope): (Option<Box<dyn Executor>>, FromScope) = match &select.from {
+    let mut join_consumed_where = false;
+    // `Some` means a join group proved how the written WHERE splits.  The
+    // inner option is its cross-leaf residue; `Some(None)` means leaf filters
+    // and join equalities consumed the whole predicate.
+    let mut join_residual_where: Option<Option<tidb_ast::Expr>> = None;
+    let mut aggregation_order = None;
+    let mut grouped_logical_rows = None;
+    let (mut from_source, mut scope, from_delivered): (
+        Option<Box<dyn Executor>>,
+        FromScope,
+        from::Delivered,
+    ) = match &select.from {
         None => {
             if let Some(trace) = trace.as_deref_mut() {
                 trace.table_dual();
@@ -636,6 +754,7 @@ pub(crate) fn run_select_traced(
                     zone: ctx.session_zone(),
                     ..FromScope::default()
                 },
+                from::Delivered::new(),
             )
         }
         Some(join) => {
@@ -652,15 +771,21 @@ pub(crate) fn run_select_traced(
             // build the cross product the filter would then throw away. See
             // `driver::predicate_push_down`.
             let offered = predicate_push_down::offered_conjuncts(select.where_clause.as_ref());
+            aggregation_order =
+                merge_decision::aggregation_order(select, join, catalog, current_db, &offered);
             // Go's `rule_column_pruning`: what every `DataSource` below still
             // has to produce, which is the input its access-path costing
             // needs (`isCoveringIndex`). A `FROM` of ONE base table is
             // deliberately excluded -- `commit_fast_path_source` below costs
             // that table's paths WITH its `WHERE`, and a second, condition-
-            // blind choice here could only be the worse of the two.
-            let wanted = access::single_kv_table(&select.from, catalog, current_db)
-                .is_none()
-                .then(|| leaf_demand::LeafDemand::of_select(select));
+            // blind choice here could only be the worse of the two. A
+            // grouping order is the exception: it is a non-empty physical
+            // property that has to reach the leaf before the aggregate is
+            // built, so the leaf must cost its WHERE-constrained ordered path
+            // here instead of waiting for the later empty-property fast path.
+            let wanted = (access::single_kv_table(&select.from, catalog, current_db).is_none()
+                || aggregation_order.is_some())
+            .then(|| leaf_demand::LeafDemand::of_select(select));
             // The estimate owner: every relation of this `FROM` with the row
             // count `derive_stats` derives for it, read off the statement,
             // the catalog and the statistics. It is built here, beside the
@@ -674,6 +799,9 @@ pub(crate) fn run_select_traced(
                 current_db,
                 ctx,
             );
+            grouped_logical_rows = row_source
+                .as_ref()
+                .and_then(|rows| rows.grouped_rows(&select.group_by));
             // Go's `SetPreferredJoinTypeAndOrder`: the statement's own join
             // hints, which decide at some sites which physical families are
             // enumerated AT ALL. See `driver::join_method_hints`.
@@ -698,7 +826,13 @@ pub(crate) fn run_select_traced(
                 ctx,
             );
             let planned = reordered.as_ref().map_or(join, |plan| &plan.join);
-            let (exec, mut scope, _) = build_join(
+            let parent_required = merge_decision::from_required_prop(
+                select, planned, required, catalog, current_db, &offered,
+            );
+            let source_required = aggregation_order
+                .as_ref()
+                .map_or(&parent_required, merge_decision::AggregationOrder::required);
+            let (exec, mut scope, delivered) = build_join(
                 planned,
                 catalog,
                 current_db,
@@ -710,10 +844,17 @@ pub(crate) fn run_select_traced(
                 // onto the `FROM` it is projected from -- read off `planned`
                 // rather than the written join, because a reorder renumbers
                 // the leaves and the offsets are the reordered ones.
-                &merge_decision::from_required_prop(
-                    select, planned, required, catalog, current_db, &offered,
-                ),
+                source_required,
             )?;
+            // Read the residue only after both leaves committed their
+            // physical paths and reported which local filters those paths
+            // actually accepted.
+            if let Some(rows) = row_source.as_ref() {
+                let residual = rows.residual_where();
+                join_consumed_where = select.where_clause.is_some() && residual.is_none();
+                join_residual_where = Some(residual);
+            }
+            join_consumed_where |= exec.consumes_where();
             // Go's `restoreSchemaIfChanged`: the reordered join's schema is
             // the new leaf order, and the statement's output must stay the
             // written one. Go wraps a `Projection`; here the scope carries
@@ -722,23 +863,123 @@ pub(crate) fn run_select_traced(
             if let Some(plan) = &reordered {
                 restore_written_order(&mut scope, &plan.written_order);
             }
-            (Some(exec), scope)
+            (Some(exec), scope, delivered)
         }
+    };
+
+    // Predicate pushdown through a join is not all-or-nothing.  Build the
+    // remaining pipeline from the exact cross-leaf residue: leaf-local
+    // conjuncts are already installed by `build_from`, and join equalities by
+    // `build_join`.  The traced statement follows the same rewrite so EXPLAIN
+    // describes the executor tree that actually runs.
+    let residual_select;
+    let residual_traced_select;
+    let (select, traced_select) = match join_residual_where {
+        Some(residual) => {
+            residual_select = {
+                let mut rewritten = select.clone();
+                rewritten.where_clause = residual.clone();
+                rewritten
+            };
+            residual_traced_select = {
+                let mut rewritten = traced_select.clone();
+                rewritten.where_clause = residual;
+                rewritten
+            };
+            (&residual_select, &residual_traced_select)
+        }
+        None => (select, traced_select),
     };
 
     // The access-path decision and the work handed down to it live in
     // `driver::access`; `index_order` is set when the committed source emits
     // rows in an index's order, which is what lets a `LIMIT` under a matching
     // `ORDER BY` stop the scan early.
-    let index_order = commit_fast_path_source(
-        select,
-        catalog,
-        current_db,
-        &scope,
-        &mut from_source,
-        trace.as_deref_mut(),
-        ctx,
-    )?;
+    // A grouped StreamAgg's non-empty property was already costed and
+    // committed by the leaf builder. Re-entering the empty-property chooser
+    // here loses both its range predicate (already marked consumed) and its
+    // required order, replacing the real `[w_id,w_id]` path with an
+    // `IndexFullScan`. Go keeps the task returned for the requested property.
+    let access_path = if aggregation_order.is_some() {
+        AccessPathCommit::default()
+    } else {
+        commit_fast_path_source(
+            select,
+            catalog,
+            current_db,
+            &scope,
+            &mut from_source,
+            trace.as_deref_mut(),
+            ctx,
+        )?
+    };
+    let AccessPathCommit {
+        index_order,
+        direct_output,
+        direct_output_offsets,
+        cop_projection_offsets,
+        filtered_cop_projection_offsets,
+        consumed_where,
+        handle_range_residual,
+        logical_rows,
+        reader_ready,
+        order_satisfied,
+    } = access_path;
+    let consumed_where = consumed_where || join_consumed_where;
+    let grouped_stream_ordered = aggregation_order
+        .as_ref()
+        .is_some_and(|order| order.is_delivered_by(&from_delivered, &scope));
+    if grouped_stream_ordered {
+        if let (Some(delivered), Some(order)) = (
+            output_delivered.as_deref_mut(),
+            grouped_select_output_order(traced_select),
+        ) {
+            delivered.push(order);
+        }
+    }
+    // Go's `TryFastPlan` makes a simple select list part of PointGetPlan or
+    // BatchPointGetPlan itself. The lookup source already emits exactly that
+    // schema, and the equality/IN predicate was fully consumed by the key,
+    // so returning it here is the real one-node executor tree Go explains --
+    // not a display-only suppression of Selection and Projection.
+    if let Some(columns) = direct_output {
+        let direct_ready = match direct_output_offsets {
+            Some(offsets) => {
+                let accepted = from_source
+                    .as_mut()
+                    .and_then(|source| source.table_access())
+                    .is_some_and(|access| access.accept_column_prune(&offsets));
+                if accepted {
+                    if let Some(trace) = trace.as_deref_mut() {
+                        trace.cop_table_projection(
+                            traced_select.fields.fields(),
+                            &Qualifier {
+                                db: current_db,
+                                scope: &scope,
+                            },
+                            logical_rows,
+                        );
+                    }
+                }
+                accepted
+            }
+            None => true,
+        };
+        if direct_ready {
+            if trace.as_deref().is_some_and(PlanTrace::is_plan_only) {
+                return Ok((columns, Vec::new()));
+            }
+            let types: Vec<FieldType> = columns
+                .iter()
+                .map(|(_, field_type)| field_type.clone())
+                .collect();
+            let source = from_source
+                .take()
+                .expect("a direct access plan installed its source");
+            let rows = drain_executor_rows(source, &types)?;
+            return Ok((columns, rows));
+        }
+    }
     // Go's `rule_partition_processor` runs after the access path is chosen
     // and BEFORE anything above the scan is built, which is exactly here: the
     // leaf is final (renamed or replaced by whichever path won) and nothing
@@ -757,13 +998,58 @@ pub(crate) fn run_select_traced(
             ));
         }
     }
+    // An exact ordered handle range still has root work to do, so it cannot
+    // take the early-return path above. When its ORDER BY reads only the
+    // simple projected columns, the scan can nevertheless emit that narrow
+    // schema from the cop task. Mutate the scope together with the real scan
+    // offer so every expression built below resolves against the executor's
+    // actual row layout.
+    let mut cop_projection_ready = false;
+    if let (Some(offsets), Some(source)) = (cop_projection_offsets, from_source.as_mut()) {
+        if source
+            .table_access()
+            .is_some_and(|access| access.accept_column_prune(&offsets))
+        {
+            scope = crate::column_prune::pruned_scope(&scope, &offsets);
+            if let Some(trace) = trace.as_deref_mut() {
+                trace.cop_table_projection(
+                    traced_select.fields.fields(),
+                    &Qualifier {
+                        db: current_db,
+                        scope: &scope,
+                    },
+                    logical_rows,
+                );
+            }
+            cop_projection_ready = true;
+        }
+    }
+    let full_row_projection = projects_entire_single_table_in_order(select, &scope);
+
     // Column pruning: over a single base-table scan the fast paths left
     // alone, narrow the scan -- and with it the scope -- to the columns the
     // statement actually reads.
+    let scope_before_prune = scope.clone();
+    let general_prune_offsets = crate::column_prune::prunable_columns(select, &scope);
     prune_scan_columns(select, &mut scope, &mut from_source);
-
-    // The column resolver for this query's scope.
-    let resolver = ScopeResolver { scope: &scope };
+    // A filtered cop projection is deliberately NOT offered as ordinary
+    // column pruning: its residual predicate still needs columns outside the
+    // final SELECT list. Translate the final projection into the wider,
+    // generally-pruned scan layout and offer it only after the scan accepts
+    // that predicate below.
+    let filtered_cop_projection_offsets = filtered_cop_projection_offsets.and_then(|offsets| {
+        let scan_offsets = match general_prune_offsets.as_ref() {
+            Some(general) if scope.width() == general.len() => general,
+            _ if scope.width() == scope_before_prune.width() => {
+                return Some(offsets);
+            }
+            _ => return None,
+        };
+        offsets
+            .into_iter()
+            .map(|offset| scan_offsets.iter().position(|kept| *kept == offset))
+            .collect()
+    });
 
     // GROUPING() reads which grouping set produced a row, so it means nothing
     // without WITH ROLLUP: Go rejects it with ErrInvalidGroupFuncUse (1111),
@@ -795,6 +1081,7 @@ pub(crate) fn run_select_traced(
             .iter()
             .any(|item| item.expr.has_aggregate_flag());
     if is_aggregate {
+        let resolver = ScopeResolver { scope: &scope };
         return run_aggregate_select(
             select,
             traced_select,
@@ -803,6 +1090,12 @@ pub(crate) fn run_select_traced(
             catalog,
             current_db,
             ctx,
+            consumed_where,
+            logical_rows,
+            grouped_logical_rows,
+            grouped_stream_ordered,
+            derived_output,
+            grouped_derived_output_pruned,
             trace,
         );
     }
@@ -810,32 +1103,29 @@ pub(crate) fn run_select_traced(
     // `SELECT DISTINCT ... ORDER BY`, for the queries that never reach the
     // aggregate pipeline. The aggregate path runs the same check itself, after
     // ONLY_FULL_GROUP_BY, which is the order Go's two builders impose.
-    only_full_group_by::check_order_by_in_distinct(select, resolver.scope, ctx)?;
+    only_full_group_by::check_order_by_in_distinct(select, &scope, ctx)?;
 
     // Source: the table rows (matrix- or TiKV-byte-backed), or one virtual row
     // from a table-dual.
-    let (mut source, source_schema): (Box<dyn Executor>, Schema) = match from_source {
-        Some(exec) => {
-            let schema = exec.schema().clone();
-            (exec, schema)
-        }
+    let mut source: Box<dyn Executor> = match from_source {
+        Some(exec) => exec,
         None => {
             let exec: Box<dyn Executor> = Box::new(TableDualExec::new(
                 ExecutorMeta::new(Schema::new(vec![]), 0, INIT_CAP, MAX_CHUNK_SIZE),
                 1,
             ));
-            let exec = match trace.as_deref_mut() {
+            match trace.as_deref_mut() {
                 Some(trace) => trace.meter(exec),
                 None => exec,
-            };
-            (exec, Schema::new(vec![]))
+            }
         }
     };
     // The plan text quotes the statement as written, against the FROM scope
     // the driver just built.
+    let filter_scope = scope.clone();
     let qualify = Qualifier {
         db: current_db,
-        scope: &scope,
+        scope: &filter_scope,
     };
 
     // Optional WHERE: a selection over the source rows. A correlated
@@ -843,11 +1133,38 @@ pub(crate) fn run_select_traced(
     // appending the column the rewritten predicate reads (Go's plan shape).
     // The scope the rows above the WHERE have: the FROM tables, plus the
     // column a correlated WHERE subquery's Apply appends.
-    let mut current_scope = scope.clone();
     // Predicate push-down: over a single base table, offer the source the
     // conjuncts it can apply itself; only the residual needs a `Selection`.
-    let executed_where =
-        negotiate_scan_filter(select, &scope, &mut source, ctx, trace.as_deref_mut());
+    let executed_where = negotiate_scan_filter(
+        select,
+        &scope,
+        &mut source,
+        ctx,
+        consumed_where,
+        trace.as_deref_mut(),
+    );
+    let cop_filtered_projection_ready = handle_range_residual.is_some()
+        && executed_where.is_none()
+        && select.limit.is_none()
+        && !select.order_by.is_empty()
+        && filtered_cop_projection_offsets
+            .as_ref()
+            .is_some_and(|offsets| {
+                source
+                    .table_access()
+                    .is_some_and(|access| access.accept_post_filter_projection(offsets))
+            });
+    if cop_filtered_projection_ready {
+        scope = crate::column_prune::pruned_scope(
+            &scope,
+            filtered_cop_projection_offsets
+                .as_deref()
+                .expect("a ready filtered projection has offsets"),
+        );
+    }
+    let resolver = ScopeResolver { scope: &scope };
+    let source_schema = source.schema().clone();
+    let mut current_scope = scope.clone();
     // LIMIT push-down: offer the source the row cap, when nothing between it
     // and the `LimitExec` can add, drop or reorder a row.
     offer_scan_limit(
@@ -860,18 +1177,60 @@ pub(crate) fn run_select_traced(
     // `keep order`: whether the source's own walk order is the answer's, which
     // is what decides whether an index lookup reorders its handle batch.
     offer_keep_order(select, index_order.as_ref(), &resolver, &mut source);
+    if order_satisfied {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.keep_order();
+        }
+    }
 
     // A `WHERE` whose conjuncts all moved into the scan still records its
     // `Selection`, over the predicate as written, and meters the filtered
     // rows the scan now emits.
-    if executed_where.is_none() && select.where_clause.is_some() {
+    if !consumed_where && executed_where.is_none() && select.where_clause.is_some() {
         if let Some(trace) = trace.as_deref_mut() {
             if let Some(written) = &traced_select.where_clause {
-                trace.selection(
-                    written,
-                    &qualify,
-                    select_stats_selectivity(select, catalog, current_db, &scope),
-                );
+                let predicate = handle_range_residual.as_ref().unwrap_or(written);
+                if handle_range_residual.is_some() {
+                    trace.residual_selection(
+                        predicate,
+                        &qualify,
+                        crate::driver::access::select_predicate_stats_selectivity(
+                            select,
+                            predicate,
+                            catalog,
+                            current_db,
+                            &filter_scope,
+                        ),
+                    );
+                } else if grouped_derived_output_pruned {
+                    let resolver = ScopeResolver {
+                        scope: &filter_scope,
+                    };
+                    let mut physical = rewrite_expr_resolved(predicate, &resolver)
+                        .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
+                    refine_comparisons(&mut physical, ctx);
+                    if !trace.physical_selection(
+                        &physical,
+                        predicate,
+                        select_stats_selectivity(select, catalog, current_db, &filter_scope),
+                    ) {
+                        trace.refuse(
+                            "a pruned derived aggregation's Selection is not printable yet",
+                        );
+                    }
+                } else {
+                    trace.selection(
+                        predicate,
+                        &qualify,
+                        select_stats_selectivity(select, catalog, current_db, &filter_scope),
+                    );
+                }
+                if cop_filtered_projection_ready
+                    && !trace
+                        .cop_selection_projection_reader(traced_select.fields.fields(), &qualify)
+                {
+                    trace.refuse("cop Selection/Projection child is not a bare table scan");
+                }
                 source = trace.meter(source);
             }
         }
@@ -963,6 +1322,7 @@ pub(crate) fn run_select_traced(
         let mut pred = rewrite_expr_resolved(&predicate, &predicate_resolver)
             .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
         refine_comparisons(&mut pred, ctx);
+        let physical_trace_predicate = grouped_derived_output_pruned.then(|| pred.clone());
         source = Box::new(SelectionExec::new(
             ExecutorMeta::new(source_schema, 1, INIT_CAP, MAX_CHUNK_SIZE),
             vec![pred],
@@ -975,13 +1335,27 @@ pub(crate) fn run_select_traced(
             // stays out of the trace rather than changing the shape EXPLAIN
             // reports.
             if let Some(written) = &traced_select.where_clause {
-                trace.selection(
-                    written,
-                    &qualify,
-                    select_stats_selectivity(select, catalog, current_db, &scope),
-                );
+                let stats = select_stats_selectivity(select, catalog, current_db, &filter_scope);
+                if let Some(predicate) = &physical_trace_predicate {
+                    if !trace.physical_selection(predicate, written, stats) {
+                        trace.refuse(
+                            "a pruned derived aggregation's Selection is not printable yet",
+                        );
+                    }
+                } else {
+                    trace.selection(written, &qualify, stats);
+                }
                 source = trace.meter(source);
             }
+        }
+    }
+
+    // A covering scan whose access ranges consumed the whole predicate is
+    // already the cop task Go places below IndexReader/TableReader. Record
+    // that boundary before root sorting and projection are added.
+    if reader_ready {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.scan_reader();
         }
     }
 
@@ -1236,6 +1610,12 @@ pub(crate) fn run_select_traced(
         .iter()
         .map(|c| c.ret_type.clone().expect("output column has a type"))
         .collect();
+    let direct_distinct_candidate = if select.distinct && exprs.len() == 1 {
+        exprs[0].as_column().map(|_| exprs[0].clone())
+    } else {
+        None
+    };
+    let mut deferred_distinct_sort: Option<Vec<SortByItem>> = None;
 
     // ORDER BY: a sort below the projection, with by-items resolved against
     // the SELECT list first and the SOURCE schema second -- Go's own
@@ -1244,7 +1624,8 @@ pub(crate) fn run_select_traced(
     //
     // Whether the `LIMIT` below was already consumed by a fused `TopN`.
     let mut fused_topn = false;
-    if !select.order_by.is_empty() {
+    let mut limit_before_projection = false;
+    if !select.order_by.is_empty() && !order_satisfied {
         let mut by_items = Vec::with_capacity(select.order_by.len());
         for item in &select.order_by {
             let resolved = substitute_output_aliases(&item.expr, &projected_fields, true)?;
@@ -1256,6 +1637,27 @@ pub(crate) fn run_select_traced(
                 expr,
                 desc: item.desc,
             });
+        }
+        let defer_sort = direct_distinct_candidate
+            .as_ref()
+            .and_then(Expression::as_column)
+            .is_some_and(|selected| {
+                by_items.iter().all(|item| {
+                    item.expr
+                        .as_column()
+                        .is_some_and(|order| order.index == selected.index)
+                })
+            });
+        if defer_sort {
+            deferred_distinct_sort = Some(
+                by_items
+                    .iter()
+                    .map(|item| SortByItem {
+                        expr: Expression::Column(out_schema.columns[0].clone()),
+                        desc: item.desc,
+                    })
+                    .collect(),
+            );
         }
         let sort_schema = source.schema().clone();
         // Go's `topn_push_down` rule fuses the `LIMIT` into the `Sort`: the
@@ -1276,12 +1678,56 @@ pub(crate) fn run_select_traced(
         } else {
             select.limit.as_ref()
         };
-        if let Some(limit) = fused_limit {
+        if defer_sort {
+            // Go places this Sort above buildDistinct's HashAgg. It is built
+            // below after the direct distinct executor exists.
+        } else if let Some(limit) = fused_limit {
             let count = eval_limit_bound(&limit.count)?;
             let offset = match &limit.offset {
                 Some(expr) => eval_limit_bound(expr)?,
                 None => 0,
             };
+            let remote_topn_ready = offset.checked_add(count).is_some_and(|cap| {
+                let order_by: Option<Vec<PushdownTopNOrder>> = by_items
+                    .iter()
+                    .map(|item| {
+                        Some(PushdownTopNOrder {
+                            offset: usize::try_from(item.expr.as_column()?.index).ok()?,
+                            desc: item.desc,
+                        })
+                    })
+                    .collect();
+                let Some(order_by) = order_by else {
+                    return false;
+                };
+                source.table_access().is_some_and(|access| {
+                    access.accept_remote_topn(&PushdownTopN {
+                        order_by,
+                        limit: cap,
+                    })
+                })
+            });
+            if remote_topn_ready {
+                let cap = offset
+                    .checked_add(count)
+                    .expect("a ready remote TopN has a bounded cap");
+                source = Box::new(TopNExec::new(
+                    ExecutorMeta::new(sort_schema.clone(), 3, INIT_CAP, MAX_CHUNK_SIZE),
+                    by_items.clone(),
+                    source,
+                    ctx.clone(),
+                    0,
+                    cap,
+                    ctx.statement_memory(),
+                ));
+                if let Some(trace) = trace.as_deref_mut() {
+                    if trace.pushed_topn_reader(&traced_select.order_by, &qualify, cap) {
+                        source = trace.meter(source);
+                    } else {
+                        trace.refuse("cop TopN child is not a table scan or pushed Selection");
+                    }
+                }
+            }
             source = Box::new(TopNExec::new(
                 ExecutorMeta::new(sort_schema, 3, INIT_CAP, MAX_CHUNK_SIZE),
                 by_items,
@@ -1311,22 +1757,134 @@ pub(crate) fn run_select_traced(
         }
     }
 
-    // Projection of the rewritten fields.
-    let mut root: Box<dyn Executor> = Box::new(ProjectionExec::new(
-        ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
-        exprs,
-        source,
-        ctx.clone(),
-    ));
-    if let Some(trace) = trace.as_deref_mut() {
-        trace.projection(traced_select.fields.fields(), &qualify);
-        root = trace.meter(root);
+    // An ORDER BY already satisfied by the clustered/index walk keeps its
+    // Limit below the select-list Projection in Go. The scan accepted the
+    // same cap above; the root Limit remains real as well, while the TiKV cap
+    // stops the ordered read at the same row.
+    if order_satisfied && !select.distinct {
+        if let Some(limit) = select.limit.as_ref() {
+            let count = eval_limit_bound(&limit.count)?;
+            let offset = match &limit.offset {
+                Some(expr) => eval_limit_bound(expr)?,
+                None => 0,
+            };
+            let cap = offset.saturating_add(count);
+            let pushed = source
+                .table_access()
+                .is_some_and(|access| access.accept_scan_limit(cap));
+            if pushed {
+                let limit_schema = source.schema().clone();
+                source = Box::new(LimitExec::new(
+                    ExecutorMeta::new(limit_schema, 4, INIT_CAP, MAX_CHUNK_SIZE),
+                    offset,
+                    count,
+                    source,
+                ));
+                if let Some(trace) = trace.as_deref_mut() {
+                    if !trace.pushed_limit_reader(offset, count) {
+                        trace.refuse("pushed ordered Limit child is not a bare table scan");
+                    }
+                    trace.limit(offset, count);
+                    source = trace.meter(source);
+                }
+                limit_before_projection = true;
+            }
+        }
+    }
+
+    // The cluster-session transaction seam collects the raw keys consumed by
+    // a locking read and issues their TiKV pessimistic lock. It is transparent
+    // to row values, so the executor chain needs no row-transforming wrapper,
+    // but the physical plan retains Go's SelectLock at this point.
+    if select.lock.is_some() {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.select_lock();
+        }
+    }
+
+    let direct_distinct_input = direct_distinct_candidate
+        .filter(|_| select.order_by.is_empty() || deferred_distinct_sort.is_some());
+
+    let partial_distinct = direct_distinct_input.as_ref().is_some_and(|input| {
+        let Some(input_offset) = input
+            .as_column()
+            .and_then(|column| usize::try_from(column.index).ok())
+        else {
+            return false;
+        };
+        let aggregate = PushdownPartialAggregate::GroupBy {
+            input_offset,
+            output_type: out_schema.columns[0]
+                .ret_type
+                .clone()
+                .expect("distinct output has a type"),
+        };
+        source
+            .table_access()
+            .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+    });
+
+    // A direct one-column DISTINCT groups the source expression itself. Go
+    // absorbs its FIRST_ROW output projection into HashAgg, and places a
+    // valid ORDER BY on that output above the aggregate.
+    let projection_elided =
+        cop_projection_ready || cop_filtered_projection_ready || full_row_projection;
+    let mut root: Box<dyn Executor> = if let Some(input) = direct_distinct_input.as_ref() {
+        let input = if partial_distinct {
+            Expression::Column(source.schema().columns[0].clone())
+        } else {
+            input.clone()
+        };
+        let aggregate = HashAggExec::new(
+            ExecutorMeta::new(out_schema.clone(), 5, INIT_CAP, MAX_CHUNK_SIZE),
+            vec![input.clone()],
+            vec![AggFunc::new(AggKind::FirstRow, Some(input.clone()))],
+            source,
+            ctx.clone(),
+            ctx.statement_memory(),
+        );
+        let mut aggregate: Box<dyn Executor> = Box::new(aggregate);
+        if let Some(trace) = trace.as_deref_mut() {
+            if partial_distinct {
+                if !trace.partial_hash_agg(traced_select.fields.fields(), &qualify) {
+                    trace.refuse("partial HashAgg child is not a bare table scan");
+                }
+            } else {
+                trace.scan_reader();
+            }
+            if partial_distinct {
+                trace.final_distinct(traced_select.fields.fields(), &qualify);
+            } else {
+                trace.distinct(traced_select.fields.fields(), &qualify);
+            }
+            aggregate = trace.meter(aggregate);
+        }
+        aggregate
+    } else if projection_elided {
+        source
+    } else {
+        Box::new(ProjectionExec::new(
+            ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
+            exprs,
+            source,
+            ctx.clone(),
+        ))
+    };
+    if direct_distinct_input.is_none() && !projection_elided {
+        if let Some(trace) = trace.as_deref_mut() {
+            if reader_ready {
+                trace.projection_at_rows(traced_select.fields.fields(), &qualify, logical_rows);
+            } else {
+                trace.projection(traced_select.fields.fields(), &qualify);
+            }
+            root = trace.meter(root);
+        }
     }
 
     // SELECT DISTINCT: Go `buildDistinct` builds an aggregation grouping by
     // every projected column, with a FIRST_ROW aggregate per column, which is
     // exactly a deduplication. It sits above the projection and below LIMIT.
-    if select.distinct {
+    if select.distinct && direct_distinct_input.is_none() {
         let all: Vec<usize> = (0..out_schema.columns.len()).collect();
         root = Box::new(distinct_over(root, &out_schema, &all, ctx));
         if let Some(trace) = trace.as_deref_mut() {
@@ -1335,10 +1893,28 @@ pub(crate) fn run_select_traced(
         }
     }
 
+    if let Some(by_items) = deferred_distinct_sort {
+        root = Box::new(SortExec::new(
+            ExecutorMeta::new(out_schema.clone(), 3, INIT_CAP, MAX_CHUNK_SIZE),
+            by_items,
+            root,
+            ctx.clone(),
+            ctx.statement_memory(),
+        ));
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.sort(&traced_select.order_by, &qualify);
+            root = trace.meter(root);
+        }
+    }
+
     // LIMIT [offset,] count: both bounds must be non-negative integer literals
     // (as in SQL; Go validates the same in the planner). A fused `TopN`
     // already applied this window.
-    if let Some(limit) = select.limit.as_ref().filter(|_| !fused_topn) {
+    if let Some(limit) = select
+        .limit
+        .as_ref()
+        .filter(|_| !fused_topn && !limit_before_projection)
+    {
         let count = eval_limit_bound(&limit.count)?;
         let offset = match &limit.offset {
             Some(expr) => eval_limit_bound(expr)?,

--- a/rust/crates/tidb-executor/src/driver.rs
+++ b/rust/crates/tidb-executor/src/driver.rs
@@ -1854,8 +1854,16 @@ pub(super) fn run_select_traced_with_delivery(
     // A direct one-column DISTINCT groups the source expression itself. Go
     // absorbs its FIRST_ROW output projection into HashAgg, and places a
     // valid ORDER BY on that output above the aggregate.
-    let projection_elided =
+    let projection_elision_candidate =
         cop_projection_ready || cop_filtered_projection_ready || full_row_projection;
+    // A correlated subquery in HAVING appends its Apply result to the source
+    // row after the identity-projection decision above was made.  The final
+    // projection is no longer an identity in that case: it has to trim the
+    // private Apply column before the row reaches the client.  Keep elision
+    // fail-closed on the physical output width so Row::GetDatumRow retains
+    // Go's one-field-type-per-chunk-column invariant.
+    let projection_elided =
+        projection_elision_candidate && source.schema().columns.len() == out_schema.columns.len();
     // Only EXPLAIN needs a second view of the executable expression tree.
     // Ordinary execution moves the sole copy into ProjectionExec, so the
     // TPCC hot path pays no clone for physical-expression rendering.

--- a/rust/crates/tidb-executor/src/driver/access.rs
+++ b/rust/crates/tidb-executor/src/driver/access.rs
@@ -23,8 +23,9 @@
 //!    otherwise the cheapest access path [`crate::access_cost`] enumerates
 //!    supplies ranges ([`choose_index_range_path`]), which may be the full
 //!    scan itself. Each fast path installs a *streaming*
-//!    source over the narrowed path, and the `WHERE` stays in the pipeline
-//!    above: these narrow the source, they never replace the filter.
+//!    source over the narrowed path. A complete Go-style point plan consumes
+//!    its exact key predicate and simple select list; a merely narrowed path
+//!    leaves the `WHERE` in the pipeline above.
 //! 2. [`prune_scan_columns`] -- the kept-column offer.
 //! 3. [`negotiate_scan_filter`] -- the pushed-conjunct offer, and the residual
 //!    `WHERE` left above.
@@ -48,20 +49,64 @@
 use super::point_get_key::point_get_value;
 use super::*;
 
+/// What the single-table access-path decision committed.
+#[derive(Default)]
+pub(crate) struct AccessPathCommit {
+    /// The order an index path establishes for the ordinary pipeline.
+    pub(crate) index_order: Option<IndexAccessOrder>,
+    /// Result metadata when a complete Go-style point plan absorbed the
+    /// simple select list and can be returned without root wrappers.
+    pub(crate) direct_output: Option<Vec<(String, FieldType)>>,
+    /// Source offsets for a range scan whose simple projection was pushed
+    /// into the coprocessor read. Point plans project in their own source and
+    /// therefore leave this `None`.
+    pub(crate) direct_output_offsets: Option<Vec<usize>>,
+    /// Source offsets for an exact range whose simple projection executes in
+    /// the cop task while a root operator (currently ORDER BY) remains above
+    /// the TableReader boundary.
+    pub(crate) cop_projection_offsets: Option<Vec<usize>>,
+    /// Source offsets for the same cop projection when a residual Selection
+    /// remains after the clustered-handle prefix. The driver installs the
+    /// Selection before it records this projection/reader boundary.
+    pub(crate) filtered_cop_projection_offsets: Option<Vec<usize>>,
+    /// Whether the chosen access ranges represent the complete WHERE rather
+    /// than a superset that still needs a residual Selection.
+    pub(crate) consumed_where: bool,
+    /// The conjuncts left after a clustered-handle range consumed its access
+    /// prefix, joined back in written order. This is the Selection Go places
+    /// above the range rather than the complete WHERE it started from.
+    pub(crate) handle_range_residual: Option<tidb_ast::Expr>,
+    /// The logical data source's estimated output rows after its complete
+    /// predicate, before physical access-path lower bounds are applied.
+    pub(crate) logical_rows: Option<f64>,
+    /// Whether a bare covering scan is ready to move below its root reader.
+    pub(crate) reader_ready: bool,
+    /// Whether the committed access order satisfies the written ORDER BY.
+    pub(crate) order_satisfied: bool,
+}
+
+#[derive(Clone)]
+struct FastPointOutput {
+    offsets: Vec<usize>,
+    columns: Vec<(String, FieldType)>,
+}
+
 /// Commits the narrowed access path a single-table `SELECT` qualifies for,
 /// replacing `from_source`, and reports the row order the committed path
-/// produces (`None` when it establishes none).
+/// produces plus any complete point plan that absorbed the select list.
 ///
 /// Go's `TryFastPlan` runs before the ordinary plan and this mirrors its
 /// order: the batch point get is tried first, then an index range when no
 /// point get applies, and finally the single point get -- which supersedes an
 /// index range already committed, and its ordering claim with it.
 ///
-/// The `WHERE` stays in the pipeline above, so an unsatisfied extra condition
-/// still filters the row out. Each fast path installs a streaming source over
-/// the narrowed path (see [`crate::access_path`]), not a `Vec` of rows it
-/// already read, so an index range over a huge table costs one chunk of
-/// memory and a pushed `LIMIT` never reads past its cap.
+/// A complete point plan consumes its exact key predicate and simple select
+/// list, as Go does. A path with work the point plan cannot own keeps that
+/// work in the ordinary pipeline, so an unsatisfied extra condition still
+/// filters the row out. Each path installs a streaming source over the
+/// narrowed path (see [`crate::access_path`]), not a `Vec` of rows it already
+/// read, so an index range over a huge table costs one chunk of memory and a
+/// pushed `LIMIT` never reads past its cap.
 pub(crate) fn commit_fast_path_source(
     select: &tidb_ast::SelectStmt,
     catalog: &Catalog,
@@ -70,15 +115,28 @@ pub(crate) fn commit_fast_path_source(
     from_source: &mut Option<Box<dyn Executor>>,
     mut trace: Option<&mut PlanTrace>,
     ctx: &crate::StmtContext,
-) -> Result<Option<IndexAccessOrder>, DriverError> {
+) -> Result<AccessPathCommit, DriverError> {
     // Go's `PlanBuilder` reads the zone off the same `sessionctx` every other
     // decision here reads; taking it from `ctx` keeps the two from being
     // separately supplied and separately wrong.
     let zone = &ctx.session_zone();
     let mut index_order: Option<IndexAccessOrder> = None;
+    let mut direct_output = None;
+    let mut direct_output_offsets = None;
+    let mut cop_projection_offsets = None;
+    let mut filtered_cop_projection_offsets = None;
+    let mut consumed_where = false;
+    let mut handle_range_residual = None;
+    let mut reader_ready = false;
     let Some(table) = single_kv_table(&select.from, catalog, current_db) else {
-        return Ok(None);
+        return Ok(AccessPathCommit::default());
     };
+    let statistics = catalog.table_statistics(table.table_id);
+    let logical_rows = Some(
+        crate::access_cost::realtime_row_count(statistics.map(AsRef::as_ref))
+            * stats_selectivity(catalog, &table, scope, select.where_clause.as_ref())
+                .unwrap_or(1.0),
+    );
     let columns = scope.column_list();
     // Go's `getPossibleAccessPaths`: the statement's own `USE`/`FORCE`/
     // `IGNORE INDEX` decide which paths exist before any of them is costed.
@@ -101,7 +159,7 @@ pub(crate) fn commit_fast_path_source(
     if let Some(where_clause) = select.where_clause.as_ref() {
         if crate::index_range::where_is_unsatisfiable(&columns, where_clause, zone) {
             install_contradiction_dual(&columns, from_source, trace.as_deref_mut());
-            return Ok(None);
+            return Ok(AccessPathCommit::default());
         }
     }
     // Go's `PartitionProcessor` prunes before any access path is costed, and
@@ -123,20 +181,12 @@ pub(crate) fn commit_fast_path_source(
     }
     // Go tries the batch point get before the single one.
     if let Some(handles) = try_batch_point_get(select, &table, &columns, zone)? {
-        let exec = HandleSourceExec::new_with_context(
-            ExecutorMeta::new(
-                Schema::new(source_schema_columns(&columns)),
-                0,
-                INIT_CAP,
-                MAX_CHUNK_SIZE,
-            ),
-            table.clone(),
-            handles.clone(),
-            crate::kv_table::RowDecodeContext::for_query(ctx),
-        );
+        let output = fast_point_output(select, scope);
+        let exec = handle_source_exec(&table, handles.clone(), &columns, output.as_ref(), ctx);
         if let Some(trace) = trace.as_deref_mut() {
             trace.batch_point_get(
                 source_table_name(scope, &table.name),
+                &table,
                 &handles,
                 &table.handle_partition_names(&handles, zone, ctx),
             );
@@ -144,6 +194,7 @@ pub(crate) fn commit_fast_path_source(
             // rather than a `Vec`'s length.
             trace.set_scan_act_rows(exec.produced_rows());
         }
+        direct_output = output.map(|output| output.columns);
         *from_source = Some(Box::new(exec));
     } else
     // An index range scan, when no point get applies: the ranges replace the
@@ -182,6 +233,19 @@ pub(crate) fn commit_fast_path_source(
                     .and_then(|source| source.table_access())
                     .is_some_and(|access| access.accept_handle_ranges(&ranges));
                 if accepted {
+                    if let Some(access) = from_source
+                        .as_mut()
+                        .and_then(|source| source.table_access())
+                    {
+                        access.accept_scan_estimate(estimate.rows);
+                    }
+                    consumed_where = handle_path_consumes_where(select, &table, zone);
+                    handle_range_residual = select.where_clause.as_ref().and_then(|predicate| {
+                        let built =
+                            crate::handle_range::build_handle_ranges(&table, predicate, zone)?;
+                        join_predicates(&built.residual)
+                    });
+                    index_order = handle_range_order(&table, &ranges);
                     if let Some(trace) = trace.as_deref_mut() {
                         // Go's `findBestTask` returns a `PhysicalTableDual`
                         // the moment a chosen path has NO ranges
@@ -192,7 +256,10 @@ pub(crate) fn commit_fast_path_source(
                         // the NULL-ended interval, leaving nothing to read.
                         if ranges.is_empty() {
                             trace.empty_range_table_dual();
-                        } else if let Some(handle) = single_point_handle(&ranges) {
+                        } else if let Some(handle) = table
+                            .pk_handle_offset()
+                            .and_then(|_| single_point_handle(&ranges))
+                        {
                             // Go's `isPointGetPath` converts a table path whose
                             // one range is a single non-null point on the
                             // integer handle to a `Point_Get`
@@ -200,7 +267,11 @@ pub(crate) fn commit_fast_path_source(
                             // when an extra conjunct stays a filter above --
                             // `c1 = 1 AND c2 > 1` reads `Point_Get`, not a
                             // `TableRangeScan` over `[1,1]`.
-                            trace.point_get(source_table_name(scope, &table.name), Some(&handle));
+                            trace.point_get(
+                                source_table_name(scope, &table.name),
+                                &table,
+                                Some(&handle),
+                            );
                         } else {
                             trace.table_range_scan(
                                 source_table_name(scope, &table.name),
@@ -209,9 +280,21 @@ pub(crate) fn commit_fast_path_source(
                             );
                         }
                     }
+                    if consumed_where && range_can_return_direct(select) {
+                        if let Some(output) = fast_point_output(select, scope) {
+                            direct_output_offsets = Some(output.offsets);
+                            direct_output = Some(output.columns);
+                        }
+                    } else if consumed_where {
+                        cop_projection_offsets = range_order_projection(select, scope);
+                    } else {
+                        filtered_cop_projection_offsets = range_order_projection(select, scope);
+                    }
                 }
             }
             Some(ChosenPath::Index(index_id, ranges, estimate, covering)) => {
+                consumed_where = index_path_consumes_where(select, &table, index_id, zone);
+                reader_ready = covering && consumed_where;
                 commit_index_range_source(
                     &table,
                     scope,
@@ -237,27 +320,347 @@ pub(crate) fn commit_fast_path_source(
     {
         // A `None` handle is a WHERE that pins a handle no row can have: the
         // plan is a point get over an empty handle list.
-        let exec = HandleSourceExec::new_with_context(
-            ExecutorMeta::new(
-                Schema::new(source_schema_columns(&columns)),
-                0,
-                INIT_CAP,
-                MAX_CHUNK_SIZE,
-            ),
-            table.clone(),
+        let output = point_get_consumes_where(select, &table, &columns, zone)
+            .then(|| fast_point_output(select, scope))
+            .flatten();
+        let exec = handle_source_exec(
+            &table,
             handle.clone().into_iter().collect(),
-            crate::kv_table::RowDecodeContext::for_query(ctx),
+            &columns,
+            output.as_ref(),
+            ctx,
         );
         if let Some(trace) = trace {
-            trace.point_get(source_table_name(scope, &table.name), handle.as_ref());
+            trace.point_get(
+                source_table_name(scope, &table.name),
+                &table,
+                handle.as_ref(),
+            );
             trace.set_scan_act_rows(exec.produced_rows());
         }
         // The index-range path above may have already committed a source; a
         // point get supersedes it, and so does its ordering claim.
         index_order = None;
+        reader_ready = false;
+        direct_output = output.map(|output| output.columns);
         *from_source = Some(Box::new(exec));
     }
-    Ok(index_order)
+    let order_satisfied = !select.order_by.is_empty()
+        && index_order
+            .as_ref()
+            .is_some_and(|order| order_is_index_order(select, order, &ScopeResolver { scope }));
+    Ok(AccessPathCommit {
+        index_order,
+        direct_output,
+        direct_output_offsets,
+        cop_projection_offsets,
+        filtered_cop_projection_offsets,
+        consumed_where,
+        handle_range_residual,
+        logical_rows,
+        reader_ready,
+        order_satisfied,
+    })
+}
+
+fn join_predicates(predicates: &[&tidb_ast::Expr]) -> Option<tidb_ast::Expr> {
+    predicates.iter().cloned().cloned().reduce(|left, right| {
+        tidb_ast::Expr::Binary(
+            tidb_ast::BinaryOp::LogicAnd,
+            Box::new(left),
+            Box::new(right),
+        )
+    })
+}
+
+/// Builds the narrowed handle source. A simple select list is part of Go's
+/// point plan itself; every other field shape keeps the ordinary all-column
+/// source so the driver can build its real Selection and Projection above it.
+fn handle_source_exec(
+    table: &KvTable,
+    handles: Vec<TableHandle>,
+    columns: &[(String, FieldType)],
+    output: Option<&FastPointOutput>,
+    ctx: &crate::StmtContext,
+) -> HandleSourceExec {
+    match output {
+        Some(output) => HandleSourceExec::new_projected_with_context(
+            ExecutorMeta::new(
+                Schema::new(source_schema_columns(&output.columns)),
+                0,
+                INIT_CAP,
+                MAX_CHUNK_SIZE,
+            ),
+            table.clone(),
+            handles,
+            output.offsets.clone(),
+            crate::kv_table::RowDecodeContext::for_query(ctx),
+        ),
+        None => HandleSourceExec::new_with_context(
+            ExecutorMeta::new(
+                Schema::new(source_schema_columns(columns)),
+                0,
+                INIT_CAP,
+                MAX_CHUNK_SIZE,
+            ),
+            table.clone(),
+            handles,
+            crate::kv_table::RowDecodeContext::for_query(ctx),
+        ),
+    }
+}
+
+/// Go `buildSchemaFromFields` for a point plan: only source columns and
+/// wildcards can be owned by the lookup. Expressions decline the complete
+/// fast plan and leave the normal projection pipeline intact.
+fn fast_point_output(select: &tidb_ast::SelectStmt, scope: &FromScope) -> Option<FastPointOutput> {
+    let resolver = ScopeResolver { scope };
+    let mut offsets = Vec::new();
+    let mut columns = Vec::new();
+    for (field_index, field) in select.fields.fields().iter().enumerate() {
+        match field {
+            SelectField::Expr {
+                expr: expr @ tidb_ast::Expr::Column(path),
+                alias,
+            } => {
+                let (offset, field_type, _) = resolver.resolve(path)?;
+                let name = alias.clone().unwrap_or_else(|| {
+                    default_field_display_name(&select.fields, field_index, expr)
+                });
+                offsets.push(offset);
+                columns.push((name, field_type));
+            }
+            SelectField::Expr { .. } => return None,
+            SelectField::Wildcard(qualifier) => {
+                if qualifier.last().is_none() {
+                    for (offset, name, field_type) in scope.star_columns() {
+                        offsets.push(offset);
+                        columns.push((name, field_type));
+                    }
+                    continue;
+                }
+                let table_name = qualifier.last()?;
+                let mut matched = false;
+                for table in scope
+                    .tables
+                    .iter()
+                    .filter(|table| table.name.eq_ignore_ascii_case(table_name))
+                {
+                    matched = true;
+                    for (local_offset, (name, field_type)) in table.columns.iter().enumerate() {
+                        offsets.push(table.offset + local_offset);
+                        columns.push((name.clone(), field_type.clone()));
+                    }
+                }
+                if !matched {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(FastPointOutput { offsets, columns })
+}
+
+/// A plain column projection over an exact range can be returned directly by
+/// the coprocessor read. Every clause that needs another root operator keeps
+/// the ordinary pipeline for that operator to be built in the right place.
+fn range_can_return_direct(select: &tidb_ast::SelectStmt) -> bool {
+    !select.distinct
+        && select.group_by.is_empty()
+        && select.having.is_none()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && !crate::window::select_has_window(select)
+}
+
+/// The ordered-range shape whose only root work is sorting the same simple
+/// columns the statement returns. The source can therefore emit exactly the
+/// projected row from the cop task, while Sort remains above TableReader.
+fn range_order_projection(select: &tidb_ast::SelectStmt, scope: &FromScope) -> Option<Vec<usize>> {
+    if select.distinct
+        || !select.group_by.is_empty()
+        || select.having.is_some()
+        || select.order_by.is_empty()
+        || select.limit.is_some()
+        || crate::window::select_has_window(select)
+    {
+        return None;
+    }
+    let output = fast_point_output(select, scope)?;
+    let resolver = ScopeResolver { scope };
+    for item in &select.order_by {
+        let tidb_ast::Expr::Column(path) = &item.expr else {
+            return None;
+        };
+        let (offset, _, _) = resolver.resolve(path)?;
+        if !output.offsets.contains(&offset) {
+            return None;
+        }
+    }
+    Some(output.offsets)
+}
+
+fn handle_path_consumes_where(
+    select: &tidb_ast::SelectStmt,
+    table: &KvTable,
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    handle_predicate_is_consumed(select.where_clause.as_ref(), table, zone)
+}
+
+fn handle_predicate_is_consumed(
+    where_clause: Option<&tidb_ast::Expr>,
+    table: &KvTable,
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    where_clause.is_some_and(|where_clause| {
+        predicate_is_exact_range(where_clause)
+            && crate::handle_range::build_handle_ranges(table, where_clause, zone)
+                .is_some_and(|built| built.access_count > 0 && built.residual.is_empty())
+    })
+}
+
+fn index_path_consumes_where(
+    select: &tidb_ast::SelectStmt,
+    table: &KvTable,
+    index_id: i64,
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    let Some(where_clause) = select.where_clause.as_ref() else {
+        return false;
+    };
+    let Some(index) = table.indexes().iter().find(|index| index.id == index_id) else {
+        return false;
+    };
+    // A prefix range is a superset even when the detacher consumed the
+    // written condition; the whole value must still be checked above it.
+    if index.has_prefix() {
+        return false;
+    }
+    let range_columns: Vec<crate::index_range::RangeColumn> = index
+        .column_offsets
+        .iter()
+        .filter_map(|offset| {
+            let column = table.columns.get(*offset)?;
+            Some(crate::index_range::RangeColumn::whole(
+                column.name.clone(),
+                column.field_type.clone(),
+            ))
+        })
+        .collect();
+    if range_columns.len() != index.column_offsets.len() {
+        return false;
+    }
+    crate::index_range::detach_cond_and_build_range_for_index(&range_columns, where_clause, zone)
+        .is_some_and(|built| {
+            predicate_is_exact_range(where_clause)
+                && built.access_count > 0
+                && built.residual.is_empty()
+        })
+}
+
+/// Whether a ranger-owned predicate describes exactly the rows in its ranges.
+///
+/// The ranger may report no residual for a lossy bound such as `LIKE 'abc%'.`
+/// That means the expression helped construct the access range, not that the
+/// range alone proves the predicate. Keep this proof deliberately closed over
+/// exact comparison shapes so every approximation retains its Selection.
+fn predicate_is_exact_range(predicate: &tidb_ast::Expr) -> bool {
+    match predicate {
+        tidb_ast::Expr::Paren(inner) => predicate_is_exact_range(inner),
+        tidb_ast::Expr::Binary(
+            tidb_ast::BinaryOp::LogicAnd | tidb_ast::BinaryOp::LogicOr,
+            left,
+            right,
+        ) => predicate_is_exact_range(left) && predicate_is_exact_range(right),
+        tidb_ast::Expr::Binary(
+            tidb_ast::BinaryOp::Eq
+            | tidb_ast::BinaryOp::NullEq
+            | tidb_ast::BinaryOp::Ge
+            | tidb_ast::BinaryOp::Gt
+            | tidb_ast::BinaryOp::Le
+            | tidb_ast::BinaryOp::Lt,
+            ..,
+        )
+        | tidb_ast::Expr::In { .. }
+        | tidb_ast::Expr::Between { .. }
+        | tidb_ast::Expr::Is {
+            target: tidb_ast::IsTarget::Null,
+            ..
+        } => true,
+        _ => false,
+    }
+}
+
+/// Whether every equality in a single-point `WHERE` is one of the key parts
+/// that produced the handle. `try_point_get` may also be used as a narrowed
+/// source when a common/unique key is pinned alongside an extra predicate;
+/// that shape must retain its Selection above the source.
+fn point_get_consumes_where(
+    select: &tidb_ast::SelectStmt,
+    table: &KvTable,
+    columns: &[(String, FieldType)],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    point_get_predicate_is_consumed(select.where_clause.as_ref(), table, columns, zone)
+}
+
+/// Whether a write's narrowed read path consumed its complete predicate.
+/// Go's update/delete fast plan has no Selection in this case; a range path
+/// or a point lookup with any extra equality must still evaluate the WHERE.
+pub(crate) fn write_read_path_consumes_predicate(
+    read_path: Option<&WriteReadPath>,
+    stmt: &PointPlanStmt<'_>,
+    table: &KvTable,
+    columns: &[(String, FieldType)],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    match read_path {
+        Some(WriteReadPath::Batch(_)) => true,
+        Some(WriteReadPath::Point(_)) => {
+            point_get_predicate_is_consumed(stmt.where_clause, table, columns, zone)
+        }
+        Some(WriteReadPath::Ranges(..)) => {
+            handle_predicate_is_consumed(stmt.where_clause, table, zone)
+        }
+        Some(WriteReadPath::IndexRanges(..)) | None => false,
+    }
+}
+
+pub(crate) fn point_get_predicate_is_consumed(
+    where_clause: Option<&tidb_ast::Expr>,
+    table: &KvTable,
+    columns: &[(String, FieldType)],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> bool {
+    let Some(where_clause) = where_clause else {
+        return false;
+    };
+    let mut pairs = Vec::new();
+    if !name_value_pairs(where_clause, &mut pairs, zone) || pairs.is_empty() {
+        return false;
+    }
+    let key_matches = |offsets: &[usize]| {
+        offsets.len() == pairs.len()
+            && offsets.iter().all(|offset| {
+                columns.get(*offset).is_some_and(|(name, _)| {
+                    pairs
+                        .iter()
+                        .any(|pair| pair.column.eq_ignore_ascii_case(name))
+                })
+            })
+    };
+    if table
+        .pk_handle_offset()
+        .is_some_and(|offset| key_matches(std::slice::from_ref(&offset)))
+        || key_matches(table.common_handle_offsets())
+    {
+        return true;
+    }
+    let matches_unique_index = table
+        .plan_indexes()
+        .any(|index| index.unique && !index.has_prefix() && key_matches(&index.column_offsets));
+    matches_unique_index
 }
 
 /// The partitions a single-table `SELECT` still reads, named as declared and
@@ -330,7 +733,7 @@ fn install_contradiction_dual(
 /// `None` for anything else: several ranges, an open bound, a NULL endpoint, or
 /// a non-integer bound. A common (multi-column) handle never reaches here,
 /// because this tier only builds handle ranges over the integer handle.
-fn single_point_handle(ranges: &[IndexRange]) -> Option<TableHandle> {
+pub(crate) fn single_point_handle(ranges: &[IndexRange]) -> Option<TableHandle> {
     let [range] = ranges else {
         return None;
     };
@@ -363,7 +766,7 @@ fn commit_index_range_source(
     index_order: &mut Option<IndexAccessOrder>,
     ctx: &crate::StmtContext,
 ) {
-    let mut exec = IndexRangeSourceExec::new_with_context(
+    let mut exec = IndexRangeSourceExec::new_with_statement(
         ExecutorMeta::new(
             Schema::new(source_schema_columns(columns)),
             0,
@@ -374,7 +777,9 @@ fn commit_index_range_source(
         index_id,
         ranges.clone(),
         crate::kv_table::RowDecodeContext::for_query(ctx),
+        crate::remote_scan::PushdownStatementContext::from_stmt(ctx),
     );
+    crate::table_access::TableAccess::accept_scan_estimate(&mut exec, estimate.rows);
     // A covering path is Go's `PhysicalIndexReader`: the index answers on its
     // own, no handle batch is ever built, and the rows leave in INDEX order.
     // This tier reads the row either way (it has no index-only reader), so the
@@ -437,6 +842,9 @@ fn commit_index_range_source(
             );
         }
         trace.set_scan_act_rows(exec.produced_rows());
+        if !covering && !trace.index_lookup(source_table_name(scope, &table.name), estimate) {
+            trace.refuse("a non-covering index path did not produce an index scan");
+        }
     }
     *from_source = Some(Box::new(exec));
 }
@@ -506,8 +914,12 @@ pub(crate) fn negotiate_scan_filter(
     scope: &FromScope,
     source: &mut Box<dyn Executor>,
     ctx: &crate::StmtContext,
+    access_consumed_where: bool,
     trace: Option<&mut PlanTrace>,
 ) -> Option<tidb_ast::Expr> {
+    if access_consumed_where {
+        return None;
+    }
     match (&select.where_clause, scope.tables.len()) {
         (Some(predicate), 1) => {
             let (pushed, residual) = split_scan_predicates(predicate, &scope_resolver(scope), ctx);
@@ -859,8 +1271,31 @@ pub(crate) fn select_stats_selectivity(
     current_db: &str,
     scope: &FromScope,
 ) -> Option<f64> {
+    select_predicate_stats_selectivity(
+        select,
+        select.where_clause.as_ref()?,
+        catalog,
+        current_db,
+        scope,
+    )
+    // A predicate spanning a join has no single DataSource statistics node.
+    // Go's `Selectivity` leaves it uncovered and charges the global
+    // `selectionFactor` once.
+    .or_else(|| (scope.tables.len() > 1).then_some(tidb_planner::cost_factors::SELECTION_FACTOR))
+}
+
+/// `cardinality.Selectivity` for one residual predicate of a single-table
+/// `SELECT`. Unlike [`select_stats_selectivity`], this deliberately does not
+/// re-price access conditions already represented by a range scan.
+pub(crate) fn select_predicate_stats_selectivity(
+    select: &tidb_ast::SelectStmt,
+    predicate: &tidb_ast::Expr,
+    catalog: &Catalog,
+    current_db: &str,
+    scope: &FromScope,
+) -> Option<f64> {
     let table = single_kv_table(&select.from, catalog, current_db)?;
-    stats_selectivity(catalog, &table, scope, select.where_clause.as_ref())
+    stats_selectivity(catalog, &table, scope, Some(predicate))
 }
 
 /// The full-scan estimate and stats-backed selectivity a single-table write's
@@ -900,6 +1335,9 @@ pub(crate) enum WriteReadPath {
     /// Go's `Point_Get`: one record, read by key. `None` is a key no row can
     /// carry, which Go also plans as a `Point_Get` that reads nothing.
     Point(Option<TableHandle>),
+    /// Go's `Batch_Point_Get`: several records read directly by their
+    /// clustered or unique handles.
+    Batch(Vec<TableHandle>),
     /// Go's `TableRangeScan`: the handle intervals the `WHERE` implies, and
     /// the estimate `EXPLAIN` prints for them.
     Ranges(Vec<IndexRange>, crate::access_cost::ScanEstimate),
@@ -955,6 +1393,9 @@ pub(crate) fn write_read_path(
         .iter()
         .map(|column| (column.name.clone(), column.field_type.clone()))
         .collect();
+    if let Some(handles) = try_batch_point_get_stmt(stmt, table, &columns, zone)? {
+        return Ok(Some(WriteReadPath::Batch(handles)));
+    }
     if let Some(handle) = try_point_get(stmt, table, &columns, zone)? {
         return Ok(Some(WriteReadPath::Point(handle)));
     }
@@ -1040,10 +1481,19 @@ fn write_handle_ranges(
         return None;
     };
     let ranges = crate::handle_range::build_handle_ranges(table, where_clause, zone)?.ranges;
-    let stats = catalog.table_statistics(table.table_id);
-    let stats = stats.as_ref().map(AsRef::as_ref);
+    let stats = catalog.table_statistics(table.table_id).map(AsRef::as_ref);
+    let realtime = crate::access_cost::realtime_row_count(stats);
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| (column.name.clone(), column.field_type.clone()))
+        .collect::<Vec<_>>();
+    let scope = PlanTrace::single_table_scope(name, None, columns);
+    let source_rows =
+        realtime * stats_selectivity(catalog, table, &scope, Some(where_clause)).unwrap_or(1.0);
+    let raw_rows = crate::handle_range::handle_range_row_count(table, &ranges, stats);
     let estimate = crate::access_cost::ScanEstimate {
-        rows: crate::handle_range::handle_range_row_count(table, &ranges, stats),
+        rows: crate::access_cost::adjust_count_after_access(raw_rows, source_rows, realtime),
         pseudo: stats.is_none_or(|stats| stats.pseudo),
     };
     Some((ranges, estimate))
@@ -1414,10 +1864,21 @@ pub(crate) fn single_kv_table(
 /// the handle and the column names it; otherwise a unique index whose only
 /// column it is.
 ///
-/// DEFERRED (documented): Go's row form, `(a, b) IN ((1, 2), (3, 4))`, which
-/// needs multi-column key lookup.
+/// The row form, `(a, b) IN ((1, 2), (3, 4))`, is a composite-key
+/// `Batch_Point_Get` when the tuples pin every column of a unique index or a
+/// clustered common handle.
 pub(crate) fn try_batch_point_get(
     select: &tidb_ast::SelectStmt,
+    table: &KvTable,
+    columns: &[(String, FieldType)],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> Result<Option<Vec<TableHandle>>, DriverError> {
+    let stmt = PointPlanStmt::of_select(select);
+    try_batch_point_get_stmt(&stmt, table, columns, zone)
+}
+
+pub(crate) fn try_batch_point_get_stmt(
+    select: &PointPlanStmt<'_>,
     table: &KvTable,
     columns: &[(String, FieldType)],
     zone: &tidb_datatype::SessionTimeZone,
@@ -1430,7 +1891,7 @@ pub(crate) fn try_batch_point_get(
     {
         return Ok(None);
     }
-    let Some(where_clause) = &select.where_clause else {
+    let Some(where_clause) = select.where_clause else {
         return Ok(None);
     };
     // The WHERE must be exactly the IN, as Go requires a PatternInExpr.
@@ -1438,6 +1899,137 @@ pub(crate) fn try_batch_point_get(
         return Ok(None);
     };
     if *not || list.is_empty() {
+        return Ok(None);
+    }
+    // The row form is Go's composite-key Batch_Point_Get. Each tuple value
+    // is converted into the indexed column's domain before the key lookup;
+    // any value that cannot round-trip exactly declines the fast path and
+    // leaves the ordinary scan to preserve the written predicate's answer.
+    if let tidb_ast::Expr::Row(left) = &**expr {
+        let mut names = Vec::with_capacity(left.len());
+        for column in left {
+            let tidb_ast::Expr::Column(path) = column else {
+                return Ok(None);
+            };
+            let Some(name) = path.last() else {
+                return Ok(None);
+            };
+            names.push(name);
+        }
+        let mut table = table.clone();
+        // A clustered composite primary key is represented by the common
+        // handle offsets, not by a KvIndex. Its encoded datum key is the
+        // record handle itself, so it can use the same direct lookup source as
+        // a unique index without manufacturing a redundant index entry.
+        let common_offsets = table.common_handle_offsets().to_vec();
+        if common_offsets.len() == names.len() {
+            let mut positions = Vec::with_capacity(common_offsets.len());
+            for offset in &common_offsets {
+                let Some((column_name, _)) = columns.get(*offset) else {
+                    positions.clear();
+                    break;
+                };
+                let Some(position) = names
+                    .iter()
+                    .position(|name| column_name.eq_ignore_ascii_case(name))
+                else {
+                    positions.clear();
+                    break;
+                };
+                positions.push(position);
+            }
+            if positions.len() == common_offsets.len() {
+                let mut handles = Vec::with_capacity(list.len());
+                for candidate in list {
+                    let tidb_ast::Expr::Row(values) = candidate else {
+                        return Ok(None);
+                    };
+                    if values.len() != left.len() {
+                        return Ok(None);
+                    }
+                    let mut key_values = Vec::with_capacity(common_offsets.len());
+                    for (offset, position) in common_offsets.iter().zip(&positions) {
+                        let Ok(Expression::Constant(constant)) = rewrite_expr_resolved(
+                            &values[*position],
+                            &tidb_expr::rewriter::ZonedNoResolver(zone.clone()),
+                        ) else {
+                            return Ok(None);
+                        };
+                        let Ok(value) = constant.eval() else {
+                            return Ok(None);
+                        };
+                        let Some(value) = point_get_value(&columns[*offset].1, &value) else {
+                            return Ok(None);
+                        };
+                        key_values.push(value);
+                    }
+                    let encoded =
+                        tidb_codec::encode_key_in_timezone(zone, &key_values).map_err(|e| {
+                            DriverError::Parse(format!("common handle encode failed: {e:?}"))
+                        })?;
+                    let handle = tidb_txnkv::CommonHandle::new(encoded).map_err(|e| {
+                        DriverError::Parse(format!("common handle build failed: {e:?}"))
+                    })?;
+                    handles.push(TableHandle::Common(handle.encoded().to_vec()));
+                }
+                return Ok(Some(handles));
+            }
+        }
+        for index in table.plan_indexes().cloned().collect::<Vec<_>>() {
+            if !index.unique || index.has_prefix() || index.column_offsets.len() != names.len() {
+                continue;
+            }
+            let mut positions = Vec::with_capacity(index.column_offsets.len());
+            for offset in &index.column_offsets {
+                let Some((column_name, _)) = columns.get(*offset) else {
+                    positions.clear();
+                    break;
+                };
+                let Some(position) = names
+                    .iter()
+                    .position(|name| column_name.eq_ignore_ascii_case(name))
+                else {
+                    positions.clear();
+                    break;
+                };
+                positions.push(position);
+            }
+            if positions.len() != index.column_offsets.len() {
+                continue;
+            }
+            let mut handles = Vec::with_capacity(list.len());
+            for candidate in list {
+                let tidb_ast::Expr::Row(values) = candidate else {
+                    return Ok(None);
+                };
+                if values.len() != left.len() {
+                    return Ok(None);
+                }
+                let mut key_values = Vec::with_capacity(index.column_offsets.len());
+                for (offset, position) in index.column_offsets.iter().zip(&positions) {
+                    let Ok(Expression::Constant(constant)) = rewrite_expr_resolved(
+                        &values[*position],
+                        &tidb_expr::rewriter::ZonedNoResolver(zone.clone()),
+                    ) else {
+                        return Ok(None);
+                    };
+                    let Ok(value) = constant.eval() else {
+                        return Ok(None);
+                    };
+                    let Some(value) = point_get_value(&columns[*offset].1, &value) else {
+                        return Ok(None);
+                    };
+                    key_values.push(value);
+                }
+                if let Some(handle) = table
+                    .lookup_unique(index.id, &key_values, zone)
+                    .map_err(|e| DriverError::Parse(format!("index lookup failed: {e:?}")))?
+                {
+                    handles.push(handle);
+                }
+            }
+            return Ok(Some(handles));
+        }
         return Ok(None);
     }
     let tidb_ast::Expr::Column(path) = &**expr else {
@@ -1639,6 +2231,8 @@ pub(crate) struct PointPlanStmt<'a> {
     /// of these; only a real `SELECT` can.
     having: Option<&'a tidb_ast::Expr>,
     group_by: &'a [tidb_ast::GroupByItem],
+    /// `DISTINCT` is present only on a real `SELECT`; writes set this false.
+    distinct: bool,
 }
 
 impl<'a> PointPlanStmt<'a> {
@@ -1650,6 +2244,7 @@ impl<'a> PointPlanStmt<'a> {
             limit: select.limit.as_ref(),
             having: select.having.as_ref(),
             group_by: &select.group_by,
+            distinct: select.distinct,
         }
     }
 
@@ -1667,6 +2262,7 @@ impl<'a> PointPlanStmt<'a> {
             limit,
             having: None,
             group_by: &[],
+            distinct: false,
         }
     }
 }
@@ -1731,6 +2327,36 @@ pub(crate) fn try_point_get(
         }
     }
 
+    // A clustered composite primary key is encoded directly as a common
+    // handle rather than materialized as a secondary `KvIndex`. When every
+    // handle column is pinned, it is the same one-row lookup as an integer
+    // point get; extra equalities remain in the filter above the source.
+    let common_offsets = table.common_handle_offsets().to_vec();
+    if !common_offsets.is_empty() {
+        let mut values = Vec::with_capacity(common_offsets.len());
+        for offset in common_offsets {
+            let Some((name, _)) = columns.get(offset) else {
+                values.clear();
+                break;
+            };
+            let Some(pair) = pairs
+                .iter()
+                .find(|pair| pair.column.eq_ignore_ascii_case(name))
+            else {
+                values.clear();
+                break;
+            };
+            values.push(pair.value.clone());
+        }
+        if values.len() == table.common_handle_offsets().len() {
+            let encoded = tidb_codec::encode_key_in_timezone(zone, &values)
+                .map_err(|e| DriverError::Parse(format!("common handle encode failed: {e:?}")))?;
+            let handle = tidb_txnkv::CommonHandle::new(encoded)
+                .map_err(|e| DriverError::Parse(format!("common handle build failed: {e:?}")))?;
+            return Ok(Some(Some(TableHandle::Common(handle.encoded().to_vec()))));
+        }
+    }
+
     // The unique-index path: every column of some unique index is pinned.
     let mut table = table.clone();
     for index in table.plan_indexes().cloned().collect::<Vec<_>>() {
@@ -1779,10 +2405,10 @@ pub(crate) fn try_point_get(
     Ok(None)
 }
 
-/// The row order a committed index access path produces, for the `ORDER BY`
-/// half of the `LIMIT` push-down rule.
+/// The row order a committed access path produces, for the `ORDER BY` half of
+/// the `LIMIT` push-down rule.
 pub(crate) struct IndexAccessOrder {
-    /// The index's columns as offsets into the source row, in index order.
+    /// The unfixed key columns as offsets into the source row, in key order.
     column_offsets: Vec<usize>,
     /// Whether one range covers the access path. Several ranges are each
     /// internally in index order but are walked one after another, and their
@@ -1823,6 +2449,34 @@ impl IndexAccessOrder {
             constant_positions,
         }
     }
+}
+
+/// The order a single clustered-handle range still provides after its equal
+/// leading columns have been fixed by the range.
+///
+/// A common handle `(w_id, d_id, o_id)` is the record key itself. The range
+/// `[1 1, 1 1]` therefore walks in `o_id` order, which is the TPC-C Delivery
+/// `ORDER BY o_id LIMIT 1` property. More than one range is declined for the
+/// same conservative reason as an index path: each range is ordered, but this
+/// layer does not promise that their concatenation is one total order.
+fn handle_range_order(table: &KvTable, ranges: &[IndexRange]) -> Option<IndexAccessOrder> {
+    let [range] = ranges else {
+        return None;
+    };
+    let handle_columns: Vec<usize> = if table.common_handle_offsets().is_empty() {
+        table.pk_handle_offset().into_iter().collect()
+    } else {
+        table.common_handle_offsets().to_vec()
+    };
+    let fixed_prefix = range
+        .low
+        .iter()
+        .zip(&range.high)
+        .take_while(|(low, high)| low == high)
+        .count()
+        .min(handle_columns.len());
+    (fixed_prefix < handle_columns.len())
+        .then(|| IndexAccessOrder::from_ranges(&handle_columns, ranges))
 }
 
 /// The row cap a `LIMIT` may push into the source, or `None` to leave all the

--- a/rust/crates/tidb-executor/src/driver/agg_build.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_build.rs
@@ -386,6 +386,56 @@ pub(crate) fn agg_kind_and_type(
     })
 }
 
+/// Go `typeInfer4Sum`: the result type and DECIMAL widening used both by the
+/// aggregate executor and by aggregation elimination's replacement cast.
+pub(super) fn sum_result_type(argument: Option<&FieldType>) -> FieldType {
+    const MAX_REAL_WIDTH: i64 = 23;
+
+    let Some(argument) = argument else {
+        let mut result = FieldType::new(FieldTypeCode::Double);
+        result.set_flen(MAX_REAL_WIDTH);
+        result.set_decimal(tidb_datatype::UNSPECIFIED_LENGTH);
+        result.add_flags(FieldTypeFlags::BINARY);
+        return result;
+    };
+    let mut result = match argument.code() {
+        FieldTypeCode::Tiny
+        | FieldTypeCode::Short
+        | FieldTypeCode::Int24
+        | FieldTypeCode::Long
+        | FieldTypeCode::LongLong
+        | FieldTypeCode::Year => {
+            let mut result = FieldType::new(FieldTypeCode::NewDecimal);
+            if argument.flen() < 0 {
+                result.set_flen(tidb_datatype::MAX_DECIMAL_WIDTH);
+            } else {
+                result.set_flen_under_limit(argument.flen() + 21);
+            }
+            result.set_decimal(0);
+            result
+        }
+        FieldTypeCode::NewDecimal => {
+            let mut result = FieldType::new(FieldTypeCode::NewDecimal);
+            result.update_flen_and_decimal_under_limit(argument, 0, 22);
+            result
+        }
+        FieldTypeCode::Double | FieldTypeCode::Float => {
+            let mut result = FieldType::new(FieldTypeCode::Double);
+            result.set_flen(MAX_REAL_WIDTH);
+            result.set_decimal(argument.decimal());
+            result
+        }
+        _ => {
+            let mut result = FieldType::new(FieldTypeCode::Double);
+            result.set_flen(MAX_REAL_WIDTH);
+            result.set_decimal(tidb_datatype::UNSPECIFIED_LENGTH);
+            result
+        }
+    };
+    result.add_flags(FieldTypeFlags::BINARY);
+    result
+}
+
 /// Go `mysql.MaxDecimalWidth`, the width `APPROX_PERCENTILE` gives a DECIMAL
 /// result.
 const MAX_DECIMAL_WIDTH: i64 = 65;

--- a/rust/crates/tidb-executor/src/driver/agg_select.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_select.rs
@@ -1705,8 +1705,21 @@ fn grouped_stream_partial_plan(
             .and_then(Expression::as_column)
             .map_or(i64::MAX, |column| column.index)
     });
-    function_states.extend(carrier_states);
-    let (state_order, sources): (Vec<_>, Vec<_>) = function_states.into_iter().unzip();
+    let ordered_states = if super::derived_agg_pruning::has_pruned_row_count(select) {
+        // LogicalAggregation.PruneColumns removed the last explicit
+        // aggregate and appended COUNT(1) after the surviving FIRST_ROW
+        // carriers. The cop task still emits its partial COUNT before the
+        // group tuple, but the root aggregation preserves that logical append
+        // order while reading each state from its physical source slot.
+        carrier_states.extend(function_states);
+        carrier_states
+    } else {
+        // Go builds written aggregate functions first, then appends the
+        // source-column FIRST_ROW carriers.
+        function_states.extend(carrier_states);
+        function_states
+    };
+    let (state_order, sources): (Vec<_>, Vec<_>) = ordered_states.into_iter().unzip();
     Some(GroupedStreamPartialPlan {
         group_offsets,
         group_types,
@@ -1714,6 +1727,119 @@ fn grouped_stream_partial_plan(
         state_order,
         sources,
     })
+}
+
+/// Installs one grouped partial aggregation and rewires the root aggregate
+/// states to consume TiKV's function-first, group-key-last output schema.
+fn accept_grouped_partial(
+    source: &mut Box<dyn Executor>,
+    state: &mut AggPipelineState,
+    group_by: &mut Vec<Expression>,
+    plan: GroupedStreamPartialPlan,
+    derived_output: bool,
+    streamed: bool,
+) -> bool {
+    let GroupedStreamPartialPlan {
+        group_offsets,
+        group_types,
+        functions,
+        state_order,
+        sources,
+    } = plan;
+    let aggregate_count = functions.len();
+    let aggregate = PushdownPartialAggregate::Grouped {
+        group_offsets,
+        group_types,
+        functions: functions.clone(),
+        streamed,
+    };
+    if !source
+        .table_access()
+        .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+    {
+        return false;
+    }
+
+    let old_funcs = std::mem::take(&mut state.agg_funcs);
+    state.agg_funcs = state_order
+        .iter()
+        .map(|index| old_funcs[*index].clone())
+        .collect();
+    if derived_output {
+        // Go's projection elimination maps a derived relation directly onto
+        // the aggregation schema. Keep the logical names/types/slots and
+        // scatter physical states into them.
+        state.grouped_stream_output_positions = Some(state_order);
+    } else {
+        // A top-level SELECT exposes the function-first aggregation schema
+        // and restores its written field order with a real Projection.
+        let old_names = std::mem::take(&mut state.names);
+        state.names = state_order
+            .iter()
+            .map(|index| old_names[*index].clone())
+            .collect();
+        let old_types = std::mem::take(&mut state.types);
+        state.types = state_order
+            .iter()
+            .map(|index| old_types[*index].clone())
+            .collect();
+        let mut old_to_new = vec![0; state_order.len()];
+        for (new, old) in state_order.iter().copied().enumerate() {
+            old_to_new[old] = new;
+        }
+        for slot in &mut state.slots {
+            if let OutputSlot::Agg(index) = slot {
+                *index = old_to_new[*index];
+            }
+        }
+        state.partial_grouped_stream_reordered =
+            !state_order.iter().copied().eq(0..state_order.len());
+    }
+
+    for (function, source_kind) in state.agg_funcs.iter_mut().zip(&sources) {
+        let source_column = match source_kind {
+            GroupedPartialSource::Function(index) => *index,
+            GroupedPartialSource::Group(index) => aggregate_count + *index,
+        };
+        let mut partial = source.schema().columns[source_column].clone();
+        partial.index = source_column as i64;
+        function.arg = Some(Expression::Column(partial));
+        if matches!(source_kind, GroupedPartialSource::Function(index)
+            if matches!(functions[*index].kind, crate::remote_scan::PushdownAggregateKind::Count))
+        {
+            function.kind = AggKind::FinalCount;
+        }
+    }
+    group_by.clear();
+    for index in aggregate_count..source.schema().columns.len() {
+        let mut group = source.schema().columns[index].clone();
+        group.index = index as i64;
+        group_by.push(Expression::Column(group));
+    }
+    true
+}
+
+/// The same decomposable function set as grouped StreamAgg, but with no
+/// ordering requirement. This is Go's cop HashAgg split.
+fn grouped_hash_partial_plan(
+    select: &tidb_ast::SelectStmt,
+    state: &AggPipelineState,
+    group_by: &[Expression],
+    has_pre_agg_applies: bool,
+    grouped_stream_ordered: bool,
+    source_has_no_residual_filter: bool,
+) -> Option<GroupedStreamPartialPlan> {
+    if grouped_stream_ordered || !select.order_by.is_empty() {
+        return None;
+    }
+    grouped_stream_partial_plan(
+        select,
+        state,
+        group_by,
+        has_pre_agg_applies,
+        true,
+        source_has_no_residual_filter,
+    )
 }
 
 /// The bounded grouped aggregate TiKV can execute as a partial HashAgg.
@@ -2187,13 +2313,12 @@ fn build_aggregation(
             true
         });
 
-    // An ordered grouped scan can run all decomposable functions at TiKV and
-    // stream the partial groups through the reader. The final root stage
-    // keeps the same grouping order; COUNT alone changes kind because it must
-    // sum per-region partial counts rather than count partial rows.
-    let partial_grouped_stream = (aggregation_elimination.is_none() && !partial_grouped_sum)
+    // An unordered scan can run the same decomposable functions in a TiKV
+    // partial HashAgg. The final root HashAgg merges the function-first
+    // partial rows.
+    let partial_grouped_hash = (aggregation_elimination.is_none() && !partial_grouped_sum)
         .then(|| {
-            grouped_stream_partial_plan(
+            grouped_hash_partial_plan(
                 select,
                 state,
                 &group_by,
@@ -2204,85 +2329,43 @@ fn build_aggregation(
         })
         .flatten()
         .is_some_and(|plan| {
-            let GroupedStreamPartialPlan {
-                group_offsets,
-                group_types,
-                functions,
-                state_order,
-                sources,
-            } = plan;
-            let aggregate_count = functions.len();
-            let aggregate = PushdownPartialAggregate::GroupedStream {
-                group_offsets,
-                group_types,
-                functions: functions.clone(),
-            };
-            if !source
-                .table_access()
-                .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
-            {
-                return false;
-            }
-
-            let old_funcs = std::mem::take(&mut state.agg_funcs);
-            state.agg_funcs = state_order
-                .iter()
-                .map(|index| old_funcs[*index].clone())
-                .collect();
-            if derived_output {
-                // Go's projection elimination maps a derived relation
-                // directly onto the aggregation schema. Keep the logical
-                // names/types/slots and scatter physical states into them.
-                state.grouped_stream_output_positions = Some(state_order);
-            } else {
-                // A top-level SELECT exposes the function-first aggregation
-                // schema and restores its written field order with a real
-                // Projection.
-                let old_names = std::mem::take(&mut state.names);
-                state.names = state_order
-                    .iter()
-                    .map(|index| old_names[*index].clone())
-                    .collect();
-                let old_types = std::mem::take(&mut state.types);
-                state.types = state_order
-                    .iter()
-                    .map(|index| old_types[*index].clone())
-                    .collect();
-                let mut old_to_new = vec![0; state_order.len()];
-                for (new, old) in state_order.iter().copied().enumerate() {
-                    old_to_new[old] = new;
-                }
-                for slot in &mut state.slots {
-                    if let OutputSlot::Agg(index) = slot {
-                        *index = old_to_new[*index];
-                    }
-                }
-                state.partial_grouped_stream_reordered =
-                    !state_order.iter().copied().eq(0..state_order.len());
-            }
-
-            for (function, source_kind) in state.agg_funcs.iter_mut().zip(&sources) {
-                let source_column = match source_kind {
-                    GroupedPartialSource::Function(index) => *index,
-                    GroupedPartialSource::Group(index) => aggregate_count + *index,
-                };
-                let mut partial = source.schema().columns[source_column].clone();
-                partial.index = source_column as i64;
-                function.arg = Some(Expression::Column(partial));
-                if matches!(source_kind, GroupedPartialSource::Function(index)
-                    if matches!(functions[*index].kind, crate::remote_scan::PushdownAggregateKind::Count))
-                {
-                    function.kind = AggKind::FinalCount;
-                }
-            }
-            group_by.clear();
-            for index in aggregate_count..source.schema().columns.len() {
-                let mut group = source.schema().columns[index].clone();
-                group.index = index as i64;
-                group_by.push(Expression::Column(group));
-            }
-            true
+            accept_grouped_partial(
+                &mut source,
+                state,
+                &mut group_by,
+                plan,
+                derived_output,
+                false,
+            )
         });
+
+    // An ordered grouped scan can run all decomposable functions at TiKV and
+    // stream the partial groups through the reader. The final root stage
+    // keeps the same grouping order; COUNT alone changes kind because it must
+    // sum per-region partial counts rather than count partial rows.
+    let partial_grouped_stream =
+        (aggregation_elimination.is_none() && !partial_grouped_sum && !partial_grouped_hash)
+            .then(|| {
+                grouped_stream_partial_plan(
+                    select,
+                    state,
+                    &group_by,
+                    has_pre_agg_applies,
+                    grouped_stream_ordered,
+                    executed_where.is_none(),
+                )
+            })
+            .flatten()
+            .is_some_and(|plan| {
+                accept_grouped_partial(
+                    &mut source,
+                    state,
+                    &mut group_by,
+                    plan,
+                    derived_output,
+                    true,
+                )
+            });
 
     // A join/derived source cannot push this package to one scan. Go still
     // injects a real Projection below the ordered root StreamAgg so the
@@ -2312,6 +2395,7 @@ fn build_aggregation(
     let grouped_stream_input_projection = if aggregation_elimination.is_none()
         && grouped_stream_ordered
         && !partial_grouped_sum
+        && !partial_grouped_hash
         && !partial_grouped_stream
         && crate::driver::access::single_kv_table(&select.from, catalog, current_db).is_none()
     {
@@ -2388,6 +2472,32 @@ fn build_aggregation(
         })
         .collect();
     let out_schema = Schema::new(out_columns);
+    let hash_agg_trace = trace
+        .is_some()
+        .then(|| {
+            state
+                .agg_funcs
+                .iter()
+                .all(|function| {
+                    matches!(
+                        &function.kind,
+                        crate::hash_agg::AggKind::FirstRow | crate::hash_agg::AggKind::Sum
+                    )
+                })
+                .then(|| {
+                    (
+                        group_by.clone(),
+                        state.agg_funcs.clone(),
+                        physical_source_column_names(
+                            traced_select,
+                            resolver.scope,
+                            catalog,
+                            current_db,
+                        ),
+                    )
+                })
+        })
+        .flatten();
 
     let root: Box<dyn Executor> = if let Some(expressions) = &aggregation_elimination {
         Box::new(ProjectionExec::new(
@@ -2524,6 +2634,11 @@ fn build_aggregation(
                     trace.refuse("partial grouped SUM child is not a bare table scan");
                 }
                 trace.final_grouped_sum_hash_agg(traced_select, &qualify);
+            } else if partial_grouped_hash {
+                if !trace.partial_grouped_hash_agg(traced_select, &qualify, grouped_logical_rows) {
+                    trace.refuse("partial grouped HashAgg child is not a supported scan");
+                }
+                trace.final_grouped_hash_agg(traced_select, &qualify);
             } else if partial_grouped_stream {
                 if !trace.partial_grouped_stream_agg(traced_select, &qualify) {
                     trace.refuse("partial grouped StreamAgg child is not a bare scan");
@@ -2544,7 +2659,18 @@ fn build_aggregation(
                     &grouped_stream_extra_first_rows,
                 );
             } else {
-                trace.hash_agg(traced_select, &qualify);
+                if let Some((group_by, functions, column_names)) = hash_agg_trace.as_ref() {
+                    trace.hash_agg_first_row_sum(
+                        traced_select,
+                        &qualify,
+                        group_by,
+                        functions,
+                        column_names,
+                        grouped_logical_rows,
+                    );
+                } else {
+                    trace.hash_agg(traced_select, &qualify, grouped_logical_rows);
+                }
             }
             trace.meter(root)
         }

--- a/rust/crates/tidb-executor/src/driver/agg_select.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_select.rs
@@ -108,6 +108,97 @@ fn agg_output_resolver(state: &AggPipelineState, ctx: &crate::StmtContext) -> Ag
     }
 }
 
+/// Whether Go's `EliminateAggregation` can replace this grouped query block
+/// with a projection over one unique source row per group.
+///
+/// This first port deliberately owns the shape needed by TPCC condition 09:
+/// one base table, plain-column group keys covering a non-null unique key,
+/// and a select list made only of carried columns and single-column `SUM`s.
+/// Every unsupported aggregate or clause fails closed and keeps the ordinary
+/// aggregation pipeline.
+pub(super) fn aggregation_can_be_eliminated(
+    select: &tidb_ast::SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+) -> bool {
+    if select.rollup
+        || select.distinct
+        || select.group_by.is_empty()
+        || select.having.is_some()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || !select.windows.is_empty()
+    {
+        return false;
+    }
+    let Some(table) = crate::driver::access::single_kv_table(&select.from, catalog, current_db)
+    else {
+        return false;
+    };
+    let column_offset = |path: &[String]| {
+        let name = path.last()?;
+        table
+            .columns
+            .iter()
+            .position(|column| column.name.eq_ignore_ascii_case(name))
+    };
+    let Some(group_offsets) = select
+        .group_by
+        .iter()
+        .map(|item| match &item.expr {
+            tidb_ast::Expr::Column(path) => column_offset(path),
+            _ => None,
+        })
+        .collect::<Option<std::collections::BTreeSet<_>>>()
+    else {
+        return false;
+    };
+    let key_is_covered =
+        |key: &[usize]| !key.is_empty() && key.iter().all(|offset| group_offsets.contains(offset));
+    let primary_is_covered = table
+        .pk_handle_offset()
+        .is_some_and(|offset| group_offsets.contains(&offset))
+        || key_is_covered(table.common_handle_offsets());
+    let unique_index_is_covered = table.plan_indexes().any(|index| {
+        index.unique
+            && index
+                .prefix_lengths
+                .iter()
+                .all(|length| *length == crate::ddl::index_prefix::UNSPECIFIED_LENGTH)
+            && key_is_covered(&index.column_offsets)
+            && index.column_offsets.iter().all(|offset| {
+                table.columns[*offset]
+                    .field_type
+                    .has_flag(FieldTypeFlags::NOT_NULL)
+            })
+    });
+    if !primary_is_covered && !unique_index_is_covered {
+        return false;
+    }
+    select.fields.fields().iter().all(|field| match field {
+        tidb_ast::SelectField::Expr {
+            expr: tidb_ast::Expr::Column(_),
+            ..
+        } => true,
+        tidb_ast::SelectField::Expr {
+            expr:
+                tidb_ast::Expr::Aggregate {
+                    name,
+                    distinct: false,
+                    args,
+                },
+            ..
+        } => {
+            name.eq_ignore_ascii_case("SUM")
+                && matches!(args.as_slice(), [tidb_ast::Expr::Column(path)]
+                if column_offset(path).is_some_and(|offset| {
+                    table.columns[offset].field_type.code() == FieldTypeCode::NewDecimal
+                }))
+        }
+        _ => false,
+    })
+}
+
 /// Runs an aggregate `SELECT` (`GROUP BY` and/or aggregate select fields)
 /// through [`HashAggExec`].
 ///
@@ -1727,6 +1818,47 @@ fn physical_source_column_names(
         .collect()
 }
 
+/// Builds the executable projection that replaces a grouped aggregation once
+/// [`aggregation_can_be_eliminated`] proved every group contains at most one
+/// source row. `FIRST_ROW(x)` becomes `x`; decimal `SUM(x)` becomes the same
+/// widened DECIMAL cast Go installs during aggregation elimination.
+fn eliminated_aggregation_projection(
+    select: &tidb_ast::SelectStmt,
+    state: &mut AggPipelineState,
+    catalog: &Catalog,
+    current_db: &str,
+    has_pre_agg_applies: bool,
+) -> Option<Vec<Expression>> {
+    if has_pre_agg_applies || !aggregation_can_be_eliminated(select, catalog, current_db) {
+        return None;
+    }
+    let mut expressions = Vec::with_capacity(state.agg_funcs.len());
+    let mut result_types = state.types.clone();
+    for (index, function) in state.agg_funcs.iter().enumerate() {
+        if function.distinct || !function.extra_args.is_empty() || !function.order_by.is_empty() {
+            return None;
+        }
+        let argument = function.arg.as_ref()?.clone();
+        match function.kind {
+            AggKind::FirstRow => expressions.push(argument),
+            AggKind::Sum if argument.static_type()?.code() == FieldTypeCode::NewDecimal => {
+                let result = super::agg_build::sum_result_type(argument.static_type());
+                result_types[index] = result.clone();
+                expressions.push(Expression::ScalarFunction(
+                    tidb_expr::scalar_function::ScalarFunction::new(
+                        tidb_ast::CiString::new("cast_decimal"),
+                        result,
+                        vec![argument],
+                    ),
+                ));
+            }
+            _ => return None,
+        }
+    }
+    state.types = result_types;
+    Some(expressions)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_aggregation(
     select: &tidb_ast::SelectStmt,
@@ -1919,6 +2051,8 @@ fn build_aggregation(
     let has_pre_agg_applies = !state.pre_agg_applies.is_empty();
     let mut source =
         build_pre_agg_applies(source, state, resolver.scope, catalog, current_db, ctx)?;
+    let aggregation_elimination =
+        eliminated_aggregation_projection(select, state, catalog, current_db, has_pre_agg_applies);
 
     // Go's physical optimizer chooses a root StreamAgg for the two Sysbench
     // range families once the range has been fully consumed by a table/index
@@ -1993,70 +2127,71 @@ fn build_aggregation(
     // changes the physical root aggregation to [SUM, FIRST_ROW(group)] and
     // remaps the select slots; stage 10 then builds the real [group, SUM]
     // projection Go has above that final aggregation.
-    let partial_grouped_sum = grouped_sum_plan(
-        select,
-        state,
-        &group_by,
-        has_pre_agg_applies,
-        scan_consumed_where,
-    )
-    .is_some_and(|plan| {
-        let aggregate = PushdownPartialAggregate::GroupBySum {
-            group_offset: plan.group_input,
-            sum_offset: plan.sum_input,
-            sum_type: plan.sum_type.clone(),
-            group_type: plan.group_type.clone(),
-        };
-        if !source
-            .table_access()
-            .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
-        {
-            return false;
-        }
-
-        let old_funcs = std::mem::take(&mut state.agg_funcs);
-        state.agg_funcs = vec![
-            old_funcs[plan.sum_func].clone(),
-            old_funcs[plan.group_func].clone(),
-        ];
-        let old_names = std::mem::take(&mut state.names);
-        state.names = vec![
-            old_names[plan.sum_func].clone(),
-            old_names[plan.group_func].clone(),
-        ];
-        let old_types = std::mem::take(&mut state.types);
-        state.types = vec![
-            old_types[plan.sum_func].clone(),
-            old_types[plan.group_func].clone(),
-        ];
-        for slot in &mut state.slots {
-            if let OutputSlot::Agg(index) = slot {
-                *index = if *index == plan.sum_func {
-                    0
-                } else {
-                    debug_assert_eq!(*index, plan.group_func);
-                    1
-                };
+    let partial_grouped_sum = aggregation_elimination.is_none()
+        && grouped_sum_plan(
+            select,
+            state,
+            &group_by,
+            has_pre_agg_applies,
+            scan_consumed_where,
+        )
+        .is_some_and(|plan| {
+            let aggregate = PushdownPartialAggregate::GroupBySum {
+                group_offset: plan.group_input,
+                sum_offset: plan.sum_input,
+                sum_type: plan.sum_type.clone(),
+                group_type: plan.group_type.clone(),
+            };
+            if !source
+                .table_access()
+                .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+            {
+                return false;
             }
-        }
 
-        let mut partial_sum = source.schema().columns[0].clone();
-        partial_sum.index = 0;
-        let mut partial_group = source.schema().columns[1].clone();
-        partial_group.index = 1;
-        state.agg_funcs[0].arg = Some(Expression::Column(partial_sum));
-        state.agg_funcs[1].arg = Some(Expression::Column(partial_group.clone()));
-        group_by.clear();
-        group_by.push(Expression::Column(partial_group));
-        state.partial_grouped_sum = true;
-        true
-    });
+            let old_funcs = std::mem::take(&mut state.agg_funcs);
+            state.agg_funcs = vec![
+                old_funcs[plan.sum_func].clone(),
+                old_funcs[plan.group_func].clone(),
+            ];
+            let old_names = std::mem::take(&mut state.names);
+            state.names = vec![
+                old_names[plan.sum_func].clone(),
+                old_names[plan.group_func].clone(),
+            ];
+            let old_types = std::mem::take(&mut state.types);
+            state.types = vec![
+                old_types[plan.sum_func].clone(),
+                old_types[plan.group_func].clone(),
+            ];
+            for slot in &mut state.slots {
+                if let OutputSlot::Agg(index) = slot {
+                    *index = if *index == plan.sum_func {
+                        0
+                    } else {
+                        debug_assert_eq!(*index, plan.group_func);
+                        1
+                    };
+                }
+            }
+
+            let mut partial_sum = source.schema().columns[0].clone();
+            partial_sum.index = 0;
+            let mut partial_group = source.schema().columns[1].clone();
+            partial_group.index = 1;
+            state.agg_funcs[0].arg = Some(Expression::Column(partial_sum));
+            state.agg_funcs[1].arg = Some(Expression::Column(partial_group.clone()));
+            group_by.clear();
+            group_by.push(Expression::Column(partial_group));
+            state.partial_grouped_sum = true;
+            true
+        });
 
     // An ordered grouped scan can run all decomposable functions at TiKV and
     // stream the partial groups through the reader. The final root stage
     // keeps the same grouping order; COUNT alone changes kind because it must
     // sum per-region partial counts rather than count partial rows.
-    let partial_grouped_stream = (!partial_grouped_sum)
+    let partial_grouped_stream = (aggregation_elimination.is_none() && !partial_grouped_sum)
         .then(|| {
             grouped_stream_partial_plan(
                 select,
@@ -2174,7 +2309,8 @@ fn build_aggregation(
             grouped_projection_expression_text(argument, &qualify, &derived_aliases)
         })
         .collect::<Vec<_>>();
-    let grouped_stream_input_projection = if grouped_stream_ordered
+    let grouped_stream_input_projection = if aggregation_elimination.is_none()
+        && grouped_stream_ordered
         && !partial_grouped_sum
         && !partial_grouped_stream
         && crate::driver::access::single_kv_table(&select.from, catalog, current_db).is_none()
@@ -2253,7 +2389,14 @@ fn build_aggregation(
         .collect();
     let out_schema = Schema::new(out_columns);
 
-    let root: Box<dyn Executor> = if select.rollup {
+    let root: Box<dyn Executor> = if let Some(expressions) = &aggregation_elimination {
+        Box::new(ProjectionExec::new(
+            ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
+            expressions.clone(),
+            source,
+            ctx.clone(),
+        ))
+    } else if select.rollup {
         run_rollup_aggregate(
             source,
             &group_by,
@@ -2336,7 +2479,20 @@ fn build_aggregation(
     };
     let root = match trace {
         Some(trace) => {
-            if let Some(stream_plan) = stream_plan {
+            if let Some(expressions) = aggregation_elimination.as_deref() {
+                if !trace.scan_reader() {
+                    trace.refuse("aggregation elimination child is not a bare scan");
+                }
+                let column_names = physical_source_column_names(
+                    traced_select,
+                    resolver.scope,
+                    catalog,
+                    current_db,
+                );
+                if !trace.aggregation_elimination_projection(expressions, &column_names) {
+                    trace.refuse("aggregation elimination projection is not printable yet");
+                }
+            } else if let Some(stream_plan) = stream_plan {
                 if partial_stream_agg {
                     if !trace.partial_stream_agg(
                         traced_select,

--- a/rust/crates/tidb-executor/src/driver/agg_select.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_select.rs
@@ -83,6 +83,18 @@ struct AggPipelineState {
     having_expr: Option<tidb_ast::Expr>,
     /// `ORDER BY` with its aggregates hoisted, as `(expr, desc)`.
     order_by_exprs: Vec<(tidb_ast::Expr, bool)>,
+    /// The physical aggregate was reordered to TiKV's partial grouped-SUM
+    /// schema and therefore needs the select-order projection above it.
+    partial_grouped_sum: bool,
+    /// Where each physical grouped-StreamAgg state writes in the logical
+    /// aggregation schema. TiKV puts aggregate functions before FIRST_ROW
+    /// group carriers; the executor writes them directly into select order so
+    /// Go's aggregation needs no restoring Projection above it.
+    grouped_stream_output_positions: Option<Vec<usize>>,
+    /// A top-level grouped partial StreamAgg retains Go's visible restoring
+    /// Projection. Derived-table projection elimination uses
+    /// [`Self::grouped_stream_output_positions`] instead.
+    partial_grouped_stream_reordered: bool,
 }
 
 /// A resolver over the aggregation's CURRENT output columns, which is what
@@ -127,6 +139,12 @@ pub(crate) fn run_aggregate_select(
     catalog: &Catalog,
     current_db: &str,
     ctx: &crate::StmtContext,
+    access_consumed_where: bool,
+    logical_rows: Option<f64>,
+    grouped_logical_rows: Option<f64>,
+    grouped_stream_ordered: bool,
+    derived_output: bool,
+    physical_source_columns: bool,
     mut trace: Option<&mut PlanTrace>,
 ) -> Result<SelectMeta, DriverError> {
     // Stage 0: ONLY_FULL_GROUP_BY. Go runs this before the GROUP BY
@@ -198,6 +216,12 @@ pub(crate) fn run_aggregate_select(
         catalog,
         current_db,
         ctx,
+        access_consumed_where,
+        logical_rows,
+        grouped_logical_rows,
+        grouped_stream_ordered,
+        derived_output,
+        physical_source_columns,
         trace.as_deref_mut(),
     )?;
 
@@ -272,8 +296,44 @@ pub(crate) fn run_aggregate_select(
     )?;
 
     // Stage 10: the select list's own columns.
+    let has_scalar_aggregate_projection = state
+        .slots
+        .iter()
+        .any(|slot| matches!(slot, OutputSlot::Expr(_)));
     let root = build_final_projection(root, select, &agg_resolver, &mut state, ctx)?;
-
+    if has_scalar_aggregate_projection {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.aggregate_projection(
+                traced_select,
+                &Qualifier {
+                    db: current_db,
+                    scope: resolver.scope,
+                },
+            );
+        }
+    }
+    if state.partial_grouped_sum {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.grouped_sum_projection(
+                traced_select,
+                &Qualifier {
+                    db: current_db,
+                    scope: resolver.scope,
+                },
+            );
+        }
+    }
+    if state.partial_grouped_stream_reordered {
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.grouped_stream_output_projection(
+                traced_select,
+                &Qualifier {
+                    db: current_db,
+                    scope: resolver.scope,
+                },
+            );
+        }
+    }
     // Stage 11: DISTINCT (for the shape stage 8b declined), then drain.
     distinct_and_drain(
         root,
@@ -1157,6 +1217,443 @@ fn carry_apply_columns(
 ///
 /// Mirrors Go's `buildSelection` + `buildAggregation` operator construction,
 /// including the `WITH ROLLUP` Expand path ([`run_rollup_aggregate`]).
+fn integer_decimal_precision(field_type: &FieldType) -> Option<i64> {
+    Some(match field_type.code() {
+        FieldTypeCode::Tiny => 3,
+        FieldTypeCode::Short => 5,
+        FieldTypeCode::Int24 => 8,
+        FieldTypeCode::Long => 10,
+        FieldTypeCode::LongLong => 20,
+        FieldTypeCode::Year => 4,
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum GlobalStreamAggPlan {
+    Count,
+    /// A global COUNT above a join/derived source. There is no bare scan to
+    /// move below a reader, but the already-formed input is one ordered group
+    /// and Go chooses its serial StreamAgg.
+    CountComplex,
+    CountDistinct,
+    IntegerSum {
+        precision: i64,
+    },
+}
+
+struct GroupedSumPlan {
+    group_func: usize,
+    sum_func: usize,
+    group_input: usize,
+    sum_input: usize,
+    group_type: FieldType,
+    sum_type: FieldType,
+}
+
+struct GroupedStreamPartialPlan {
+    group_offsets: Vec<usize>,
+    group_types: Vec<FieldType>,
+    functions: Vec<crate::remote_scan::PushdownAggregateFunction>,
+    state_order: Vec<usize>,
+    sources: Vec<GroupedPartialSource>,
+}
+
+#[derive(Clone, Copy)]
+enum GroupedPartialSource {
+    Function(usize),
+    Group(usize),
+}
+
+struct GroupedStreamInputProjectionPlan {
+    expressions: Vec<Expression>,
+    group_positions: Vec<usize>,
+    function_positions: Vec<usize>,
+    injected_for_scalar: bool,
+}
+
+/// Go `WrapCastForAggFuncs`: integer SUM consumes DECIMAL rather than folding
+/// in integer width, and that scalar cast is what triggers
+/// `InjectProjBelowAgg`.
+fn grouped_projection_argument(function: &AggFunc) -> Option<Expression> {
+    let argument = function.arg.as_ref()?.clone();
+    if !matches!(function.kind, AggKind::Sum) {
+        return Some(argument);
+    }
+    let source_type = argument.static_type()?;
+    let Some(precision) = integer_decimal_precision(source_type) else {
+        return Some(argument);
+    };
+    let source_flags = source_type.flags();
+    let mut decimal_type = FieldType::new(FieldTypeCode::NewDecimal);
+    decimal_type.set_flen(precision);
+    decimal_type.set_decimal(0);
+    decimal_type.add_flags(
+        FieldTypeFlags::BINARY
+            | (source_flags & (FieldTypeFlags::UNSIGNED | FieldTypeFlags::NOT_NULL)),
+    );
+    Some(Expression::ScalarFunction(
+        tidb_expr::scalar_function::ScalarFunction::new(
+            tidb_ast::CiString::new("cast_decimal"),
+            decimal_type,
+            vec![argument],
+        ),
+    ))
+}
+
+fn add_grouped_projection_expression(
+    expressions: &mut Vec<Expression>,
+    expression: &Expression,
+) -> Option<usize> {
+    match expression {
+        Expression::Column(_) => {}
+        Expression::ScalarFunction(function)
+            if function.func_name.lowercase() == "cast_decimal"
+                && function.args.len() == 1
+                && matches!(function.args[0], Expression::Column(_)) => {}
+        _ => return None,
+    }
+    if let Some(position) = expressions
+        .iter()
+        .position(|existing| existing.equal(expression))
+    {
+        return Some(position);
+    }
+    let position = expressions.len();
+    expressions.push(expression.clone());
+    Some(position)
+}
+
+fn grouped_projection_expression_text(
+    expression: &Expression,
+    qualify: &Qualifier<'_>,
+    derived_aliases: &[String],
+) -> Option<String> {
+    match expression {
+        Expression::Column(column) => {
+            let offset = usize::try_from(column.index).ok()?;
+            let derived = qualify.scope.tables.iter().any(|table| {
+                (table.offset..table.offset + table.columns.len()).contains(&offset)
+                    && derived_aliases
+                        .iter()
+                        .any(|alias| alias.eq_ignore_ascii_case(&table.name))
+            });
+            Some(if derived {
+                format!("Column#{offset}")
+            } else {
+                crate::driver::from::qualified_scope_column(qualify.scope, qualify.db, offset)
+            })
+        }
+        Expression::ScalarFunction(function)
+            if function.func_name.lowercase() == "cast_decimal" && function.args.len() == 1 =>
+        {
+            let argument =
+                grouped_projection_expression_text(&function.args[0], qualify, derived_aliases)?;
+            let result_type = function.ret_type.as_ref()?;
+            Some(format!(
+                "cast({argument}, decimal({},{}) BINARY)",
+                result_type.flen(),
+                result_type.decimal()
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn collect_derived_aliases(node: &tidb_ast::JoinNode, aliases: &mut Vec<String>) {
+    match node {
+        tidb_ast::JoinNode::Join(join) => {
+            collect_derived_aliases(&join.left, aliases);
+            if let Some(right) = &join.right {
+                collect_derived_aliases(right, aliases);
+            }
+        }
+        tidb_ast::JoinNode::Derived { alias, .. } => {
+            if let Some(alias) = alias {
+                aliases.push(alias.clone());
+            }
+        }
+        tidb_ast::JoinNode::Table(_) => {}
+    }
+}
+
+/// The projection below a complex grouped StreamAgg. If wrapping an aggregate
+/// argument introduced a scalar function, Go's `InjectProjBelowAgg` emits
+/// aggregate arguments first and group items after them. Otherwise the
+/// compact projection produced by column pruning keeps group keys first.
+fn grouped_stream_input_projection_plan(
+    group_by: &[Expression],
+    functions: &[AggFunc],
+) -> Option<GroupedStreamInputProjectionPlan> {
+    let mut expressions = Vec::<Expression>::new();
+    let function_arguments = functions
+        .iter()
+        .map(grouped_projection_argument)
+        .collect::<Option<Vec<_>>>()?;
+    let injected_for_scalar = function_arguments
+        .iter()
+        .any(|argument| matches!(argument, Expression::ScalarFunction(_)));
+    let (group_positions, function_positions) = if injected_for_scalar {
+        // Column pruning moves FIRST_ROW group carriers behind the real
+        // aggregate functions. They still read the group-key projection
+        // slot, but must not make that slot appear before SUM's injected
+        // cast (Go condition 04: cast(SUM arg), MAX arg, group key).
+        let mut function_positions = function_arguments
+            .iter()
+            .map(|argument| {
+                if group_by.iter().any(|group| group.equal(argument)) {
+                    Some(None)
+                } else {
+                    add_grouped_projection_expression(&mut expressions, argument).map(Some)
+                }
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let group_positions = group_by
+            .iter()
+            .map(|group| add_grouped_projection_expression(&mut expressions, group))
+            .collect::<Option<Vec<_>>>()?;
+        for (position, argument) in function_positions.iter_mut().zip(&function_arguments) {
+            if position.is_none() {
+                let group = group_by
+                    .iter()
+                    .position(|group| group.equal(argument))
+                    .expect("a deferred aggregate argument is a group carrier");
+                *position = Some(group_positions[group]);
+            }
+        }
+        let function_positions = function_positions
+            .into_iter()
+            .map(|position| position.expect("every aggregate argument has a projection slot"))
+            .collect();
+        (group_positions, function_positions)
+    } else {
+        let group_positions = group_by
+            .iter()
+            .map(|group| add_grouped_projection_expression(&mut expressions, group))
+            .collect::<Option<Vec<_>>>()?;
+        let function_positions = function_arguments
+            .iter()
+            .map(|argument| add_grouped_projection_expression(&mut expressions, argument))
+            .collect::<Option<Vec<_>>>()?;
+        (group_positions, function_positions)
+    };
+    Some(GroupedStreamInputProjectionPlan {
+        expressions,
+        group_positions,
+        function_positions,
+        injected_for_scalar,
+    })
+}
+
+/// Go's aggregation above an injected projection reads the projection's
+/// internal columns, not the source names the SQL wrote. Build the EXPLAIN
+/// payload from the same positions installed into the executor below.
+fn grouped_stream_physical_aggregate_info(
+    group_positions: &[usize],
+    function_positions: &[usize],
+    functions: &[AggFunc],
+) -> Option<String> {
+    let groups = group_positions
+        .iter()
+        .map(|position| format!("Column#{position}"))
+        .collect::<Vec<_>>();
+    let functions = functions
+        .iter()
+        .zip(function_positions)
+        .enumerate()
+        .map(|(output, (function, input))| {
+            let name = match &function.kind {
+                AggKind::Count => "count",
+                AggKind::FinalCount | AggKind::Sum => "sum",
+                AggKind::FirstRow => "firstrow",
+                AggKind::Min => "min",
+                AggKind::Max => "max",
+                AggKind::Avg => "avg",
+                _ => return None,
+            };
+            Some(format!(
+                "funcs:{name}({}Column#{input})->Column#{output}",
+                if function.distinct { "distinct " } else { "" }
+            ))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(format!(
+        "group by:{}, {}",
+        groups.join(", "),
+        functions.join(", ")
+    ))
+}
+
+/// The grouped StreamAgg split used by TPCC condition queries whose ordered
+/// table path already delivers the group keys. The accepted function set is
+/// exactly the algebra TiKV can merge losslessly at the root today.
+fn grouped_stream_partial_plan(
+    select: &tidb_ast::SelectStmt,
+    state: &AggPipelineState,
+    group_by: &[Expression],
+    has_pre_agg_applies: bool,
+    grouped_stream_ordered: bool,
+    source_has_no_residual_filter: bool,
+) -> Option<GroupedStreamPartialPlan> {
+    if !grouped_stream_ordered
+        || !source_has_no_residual_filter
+        || select.rollup
+        || select.distinct
+        || select.having.is_some()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || !state.window_calls.is_empty()
+        || has_pre_agg_applies
+        || group_by.is_empty()
+        || state.agg_funcs.is_empty()
+    {
+        return None;
+    }
+    let mut group_offsets = Vec::with_capacity(group_by.len());
+    let mut group_types = Vec::with_capacity(group_by.len());
+    for group in group_by {
+        group_offsets.push(
+            group
+                .as_column()
+                .and_then(|column| usize::try_from(column.index).ok())?,
+        );
+        group_types.push(group.static_type()?.clone());
+    }
+    let mut functions = Vec::with_capacity(state.agg_funcs.len());
+    let mut function_states = Vec::new();
+    let mut carrier_states = Vec::new();
+    for (state_index, (function, output_type)) in
+        state.agg_funcs.iter().zip(&state.types).enumerate()
+    {
+        if function.distinct || !function.extra_args.is_empty() || !function.order_by.is_empty() {
+            return None;
+        }
+        let input_offset = function
+            .arg
+            .as_ref()
+            .and_then(Expression::as_column)
+            .and_then(|column| usize::try_from(column.index).ok());
+        let kind = match function.kind {
+            AggKind::FirstRow => {
+                let group = group_offsets
+                    .iter()
+                    .position(|offset| Some(*offset) == input_offset)?;
+                carrier_states.push((state_index, GroupedPartialSource::Group(group)));
+                continue;
+            }
+            AggKind::Count => {
+                if input_offset.is_none()
+                    && !matches!(
+                        function.arg.as_ref(),
+                        Some(Expression::Constant(constant))
+                            if matches!(constant.value, Datum::Int(1) | Datum::UInt(1))
+                    )
+                {
+                    return None;
+                }
+                crate::remote_scan::PushdownAggregateKind::Count
+            }
+            AggKind::Sum if input_offset.is_some() => {
+                crate::remote_scan::PushdownAggregateKind::Sum
+            }
+            AggKind::Min if input_offset.is_some() => {
+                crate::remote_scan::PushdownAggregateKind::Min
+            }
+            AggKind::Max if input_offset.is_some() => {
+                crate::remote_scan::PushdownAggregateKind::Max
+            }
+            _ => return None,
+        };
+        functions.push(crate::remote_scan::PushdownAggregateFunction {
+            kind,
+            input_offset,
+            output_type: output_type.clone(),
+        });
+        function_states.push((
+            state_index,
+            GroupedPartialSource::Function(functions.len() - 1),
+        ));
+    }
+    if functions.is_empty() {
+        return None;
+    }
+    function_states.extend(carrier_states);
+    let (state_order, sources): (Vec<_>, Vec<_>) = function_states.into_iter().unzip();
+    Some(GroupedStreamPartialPlan {
+        group_offsets,
+        group_types,
+        functions,
+        state_order,
+        sources,
+    })
+}
+
+/// The bounded grouped aggregate TiKV can execute as a partial HashAgg.
+///
+/// Go chooses this split for TPCC delivery: one plain group-key carrier and
+/// one non-DISTINCT SUM over a scan whose complete predicate is already in
+/// its ranges.  Keep the contract structural so another statement with the
+/// same physical shape receives the same plan, while HAVING/ORDER/LIMIT and
+/// every richer aggregate remain on the ordinary root path.
+fn grouped_sum_plan(
+    select: &tidb_ast::SelectStmt,
+    state: &AggPipelineState,
+    group_by: &[Expression],
+    has_pre_agg_applies: bool,
+    scan_consumed_where: bool,
+) -> Option<GroupedSumPlan> {
+    if select.rollup
+        || select.distinct
+        || select.having.is_some()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || !state.window_calls.is_empty()
+        || has_pre_agg_applies
+        || !scan_consumed_where
+        || group_by.len() != 1
+        || state.agg_funcs.len() != 2
+        || state.slots.len() != 2
+        || select.fields.fields().len() != 2
+    {
+        return None;
+    }
+    let group_input = group_by[0]
+        .as_column()
+        .and_then(|column| usize::try_from(column.index).ok())?;
+    let mut group_func = None;
+    let mut sum_func = None;
+    for (index, func) in state.agg_funcs.iter().enumerate() {
+        if func.distinct || !func.extra_args.is_empty() || !func.order_by.is_empty() {
+            return None;
+        }
+        let input = func
+            .arg
+            .as_ref()
+            .and_then(Expression::as_column)
+            .and_then(|column| usize::try_from(column.index).ok())?;
+        match &func.kind {
+            AggKind::FirstRow if input == group_input => group_func = Some(index),
+            AggKind::Sum => sum_func = Some((index, input)),
+            _ => return None,
+        }
+    }
+    let group_func = group_func?;
+    let (sum_func, sum_input) = sum_func?;
+    if !state.slots.iter().all(
+        |slot| matches!(slot, OutputSlot::Agg(index) if *index == group_func || *index == sum_func),
+    ) {
+        return None;
+    }
+    Some(GroupedSumPlan {
+        group_func,
+        sum_func,
+        group_input,
+        sum_input,
+        group_type: state.types.get(group_func)?.clone(),
+        sum_type: state.types.get(sum_func)?.clone(),
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_aggregation(
     select: &tidb_ast::SelectStmt,
@@ -1167,6 +1664,12 @@ fn build_aggregation(
     catalog: &Catalog,
     current_db: &str,
     ctx: &crate::StmtContext,
+    access_consumed_where: bool,
+    logical_rows: Option<f64>,
+    grouped_logical_rows: Option<f64>,
+    grouped_stream_ordered: bool,
+    derived_output: bool,
+    physical_source_columns: bool,
     mut trace: Option<&mut PlanTrace>,
 ) -> Result<Box<dyn Executor>, DriverError> {
     let qualify = Qualifier {
@@ -1212,11 +1715,14 @@ fn build_aggregation(
         resolver.scope,
         &mut source,
         ctx,
+        access_consumed_where,
         trace.as_deref_mut(),
     );
+    let scan_consumed_where = select.where_clause.is_some() && executed_where.is_none();
     if let Some(predicate) = &executed_where {
-        let pred = rewrite_expr_resolved(predicate, resolver)
+        let mut pred = rewrite_expr_resolved(predicate, resolver)
             .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
+        refine_comparisons(&mut pred, ctx);
         source = Box::new(SelectionExec::new(
             ExecutorMeta::new(source_schema, 1, INIT_CAP, MAX_CHUNK_SIZE),
             vec![pred],
@@ -1228,14 +1734,28 @@ fn build_aggregation(
     // whether or not an executor survived above the scan: Go prints one
     // `Selection` for both halves, and this tier prints no `cop[tikv]` task
     // to distinguish them.
-    if select.where_clause.is_some() {
+    if !access_consumed_where && select.where_clause.is_some() {
         if let Some(trace) = trace.as_deref_mut() {
             if let Some(written) = &traced_select.where_clause {
-                trace.selection(
-                    written,
-                    &qualify,
-                    select_stats_selectivity(select, catalog, current_db, resolver.scope),
-                );
+                let stats = select_stats_selectivity(select, catalog, current_db, resolver.scope);
+                if physical_source_columns {
+                    let mut physical = rewrite_expr_resolved(
+                        select
+                            .where_clause
+                            .as_ref()
+                            .expect("a recorded Selection has a predicate"),
+                        resolver,
+                    )
+                    .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
+                    refine_comparisons(&mut physical, ctx);
+                    if !trace.physical_selection(&physical, written, stats) {
+                        trace.refuse(
+                            "a pruned derived aggregation's Selection is not printable yet",
+                        );
+                    }
+                } else {
+                    trace.selection(written, &qualify, stats);
+                }
                 source = trace.meter(source);
             }
         }
@@ -1243,9 +1763,321 @@ fn build_aggregation(
 
     // Stage 5b: the Applies for the aggregates' own arguments, between the
     // WHERE and the aggregation -- Go's `Apply` under the `HashAgg`.
-    let source = build_pre_agg_applies(source, state, resolver.scope, catalog, current_db, ctx)?;
+    let has_pre_agg_applies = !state.pre_agg_applies.is_empty();
+    let mut source =
+        build_pre_agg_applies(source, state, resolver.scope, catalog, current_db, ctx)?;
 
-    // The aggregation output schema.
+    // Go's physical optimizer chooses a root StreamAgg for the two Sysbench
+    // range families once the range has been fully consumed by a table/index
+    // scan. Keep this deliberately narrow: one direct global COUNT/SUM,
+    // without an Apply or DISTINCT, over a genuinely narrowed scan.
+    let complex_global_count = select.from.is_some()
+        && crate::driver::access::single_kv_table(&select.from, catalog, current_db).is_none()
+        && state.agg_funcs.len() == 1
+        && matches!(state.agg_funcs[0].kind, AggKind::Count)
+        && !state.agg_funcs[0].distinct;
+    let stream_plan = if !select.rollup
+        && group_by.is_empty()
+        && !has_pre_agg_applies
+        && (scan_consumed_where || complex_global_count)
+        && state.agg_funcs.len() == 1
+        && select.fields.fields().len() == 1
+    {
+        let func = &state.agg_funcs[0];
+        if !func.extra_args.is_empty() || !func.order_by.is_empty() {
+            None
+        } else {
+            match (&func.kind, func.arg.as_ref(), func.distinct) {
+                (AggKind::Count, Some(_), false) => Some(if complex_global_count {
+                    GlobalStreamAggPlan::CountComplex
+                } else {
+                    GlobalStreamAggPlan::Count
+                }),
+                (AggKind::Count, Some(_), true) => Some(GlobalStreamAggPlan::CountDistinct),
+                (AggKind::Sum, Some(argument), false) => argument
+                    .static_type()
+                    .and_then(integer_decimal_precision)
+                    .map(|precision| GlobalStreamAggPlan::IntegerSum { precision }),
+                _ => None,
+            }
+        }
+    } else {
+        None
+    };
+
+    // Go's coster splits the high-cardinality Sysbench range aggregates into
+    // a TiKV partial stage and a root final stage. The access source owns the
+    // estimate and accepts only when that same decision applies; accepting
+    // also changes its output schema to the one partial-result column.
+    let partial_stream_agg = stream_plan.is_some_and(|plan| {
+        let Some(input_offset) = state.agg_funcs[0]
+            .arg
+            .as_ref()
+            .and_then(Expression::as_column)
+            .and_then(|column| usize::try_from(column.index).ok())
+        else {
+            return false;
+        };
+        let output_type = state.types[0].clone();
+        let aggregate = match plan {
+            GlobalStreamAggPlan::Count => PushdownPartialAggregate::Count {
+                input_offset,
+                output_type,
+            },
+            GlobalStreamAggPlan::CountComplex | GlobalStreamAggPlan::CountDistinct => return false,
+            GlobalStreamAggPlan::IntegerSum { .. } => PushdownPartialAggregate::Sum {
+                input_offset,
+                output_type,
+            },
+        };
+        source
+            .table_access()
+            .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+    });
+
+    // The TPCC delivery grouped SUM is the corresponding HashAgg split. TiKV
+    // returns partial aggregate functions before group keys, so acceptance
+    // changes the physical root aggregation to [SUM, FIRST_ROW(group)] and
+    // remaps the select slots; stage 10 then builds the real [group, SUM]
+    // projection Go has above that final aggregation.
+    let partial_grouped_sum = grouped_sum_plan(
+        select,
+        state,
+        &group_by,
+        has_pre_agg_applies,
+        scan_consumed_where,
+    )
+    .is_some_and(|plan| {
+        let aggregate = PushdownPartialAggregate::GroupBySum {
+            group_offset: plan.group_input,
+            sum_offset: plan.sum_input,
+            sum_type: plan.sum_type.clone(),
+            group_type: plan.group_type.clone(),
+        };
+        if !source
+            .table_access()
+            .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+        {
+            return false;
+        }
+
+        let old_funcs = std::mem::take(&mut state.agg_funcs);
+        state.agg_funcs = vec![
+            old_funcs[plan.sum_func].clone(),
+            old_funcs[plan.group_func].clone(),
+        ];
+        let old_names = std::mem::take(&mut state.names);
+        state.names = vec![
+            old_names[plan.sum_func].clone(),
+            old_names[plan.group_func].clone(),
+        ];
+        let old_types = std::mem::take(&mut state.types);
+        state.types = vec![
+            old_types[plan.sum_func].clone(),
+            old_types[plan.group_func].clone(),
+        ];
+        for slot in &mut state.slots {
+            if let OutputSlot::Agg(index) = slot {
+                *index = if *index == plan.sum_func {
+                    0
+                } else {
+                    debug_assert_eq!(*index, plan.group_func);
+                    1
+                };
+            }
+        }
+
+        let mut partial_sum = source.schema().columns[0].clone();
+        partial_sum.index = 0;
+        let mut partial_group = source.schema().columns[1].clone();
+        partial_group.index = 1;
+        state.agg_funcs[0].arg = Some(Expression::Column(partial_sum));
+        state.agg_funcs[1].arg = Some(Expression::Column(partial_group.clone()));
+        group_by.clear();
+        group_by.push(Expression::Column(partial_group));
+        state.partial_grouped_sum = true;
+        true
+    });
+
+    // An ordered grouped scan can run all decomposable functions at TiKV and
+    // stream the partial groups through the reader. The final root stage
+    // keeps the same grouping order; COUNT alone changes kind because it must
+    // sum per-region partial counts rather than count partial rows.
+    let partial_grouped_stream = (!partial_grouped_sum)
+        .then(|| {
+            grouped_stream_partial_plan(
+                select,
+                state,
+                &group_by,
+                has_pre_agg_applies,
+                grouped_stream_ordered,
+                executed_where.is_none(),
+            )
+        })
+        .flatten()
+        .is_some_and(|plan| {
+            let GroupedStreamPartialPlan {
+                group_offsets,
+                group_types,
+                functions,
+                state_order,
+                sources,
+            } = plan;
+            let aggregate_count = functions.len();
+            let aggregate = PushdownPartialAggregate::GroupedStream {
+                group_offsets,
+                group_types,
+                functions: functions.clone(),
+            };
+            if !source
+                .table_access()
+                .is_some_and(|access| access.accept_partial_aggregate(&aggregate))
+            {
+                return false;
+            }
+
+            let old_funcs = std::mem::take(&mut state.agg_funcs);
+            state.agg_funcs = state_order
+                .iter()
+                .map(|index| old_funcs[*index].clone())
+                .collect();
+            if derived_output {
+                // Go's projection elimination maps a derived relation
+                // directly onto the aggregation schema. Keep the logical
+                // names/types/slots and scatter physical states into them.
+                state.grouped_stream_output_positions = Some(state_order);
+            } else {
+                // A top-level SELECT exposes the function-first aggregation
+                // schema and restores its written field order with a real
+                // Projection.
+                let old_names = std::mem::take(&mut state.names);
+                state.names = state_order
+                    .iter()
+                    .map(|index| old_names[*index].clone())
+                    .collect();
+                let old_types = std::mem::take(&mut state.types);
+                state.types = state_order
+                    .iter()
+                    .map(|index| old_types[*index].clone())
+                    .collect();
+                let mut old_to_new = vec![0; state_order.len()];
+                for (new, old) in state_order.iter().copied().enumerate() {
+                    old_to_new[old] = new;
+                }
+                for slot in &mut state.slots {
+                    if let OutputSlot::Agg(index) = slot {
+                        *index = old_to_new[*index];
+                    }
+                }
+                state.partial_grouped_stream_reordered =
+                    !state_order.iter().copied().eq(0..state_order.len());
+            }
+
+            for (function, source_kind) in state.agg_funcs.iter_mut().zip(&sources) {
+                let source_column = match source_kind {
+                    GroupedPartialSource::Function(index) => *index,
+                    GroupedPartialSource::Group(index) => aggregate_count + *index,
+                };
+                let mut partial = source.schema().columns[source_column].clone();
+                partial.index = source_column as i64;
+                function.arg = Some(Expression::Column(partial));
+                if matches!(source_kind, GroupedPartialSource::Function(index)
+                    if matches!(functions[*index].kind, crate::remote_scan::PushdownAggregateKind::Count))
+                {
+                    function.kind = AggKind::FinalCount;
+                }
+            }
+            group_by.clear();
+            for index in aggregate_count..source.schema().columns.len() {
+                let mut group = source.schema().columns[index].clone();
+                group.index = index as i64;
+                group_by.push(Expression::Column(group));
+            }
+            true
+        });
+
+    // A join/derived source cannot push this package to one scan. Go still
+    // injects a real Projection below the ordered root StreamAgg so the
+    // aggregate reads a compact, position-stable row. Rewriting the physical
+    // expressions to those projected columns keeps the trace and executor on
+    // the same operator boundary.
+    let mut source_slot = Some(source);
+    let mut grouped_stream_input_projection_trace: Option<(Vec<String>, bool)> = None;
+    let mut grouped_stream_physical_agg_trace = None;
+    let mut derived_aliases = Vec::new();
+    if let Some(from) = &select.from {
+        collect_derived_aliases(&from.left, &mut derived_aliases);
+        if let Some(right) = &from.right {
+            collect_derived_aliases(right, &mut derived_aliases);
+        }
+    }
+    let grouped_stream_input_projection = if grouped_stream_ordered
+        && !partial_grouped_sum
+        && !partial_grouped_stream
+        && crate::driver::access::single_kv_table(&select.from, catalog, current_db).is_none()
+    {
+        grouped_stream_input_projection_plan(&group_by, &state.agg_funcs).is_some_and(|plan| {
+            let GroupedStreamInputProjectionPlan {
+                expressions,
+                group_positions,
+                function_positions,
+                injected_for_scalar,
+            } = plan;
+            let Some(trace_expressions) = expressions
+                .iter()
+                .map(|expression| {
+                    grouped_projection_expression_text(expression, &qualify, &derived_aliases)
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                return false;
+            };
+            if injected_for_scalar {
+                grouped_stream_physical_agg_trace = grouped_stream_physical_aggregate_info(
+                    &group_positions,
+                    &function_positions,
+                    &state.agg_funcs,
+                );
+            }
+            let columns = expressions
+                .iter()
+                .enumerate()
+                .map(|(index, expression)| {
+                    let mut column = Column::new(
+                        (index + 1) as i64,
+                        expression
+                            .static_type()
+                            .expect("projection eligibility requires typed columns")
+                            .clone(),
+                    );
+                    column.index = index as i64;
+                    column
+                })
+                .collect::<Vec<_>>();
+            let projection_schema = Schema::new(columns.clone());
+            let child = source_slot.take().expect("source is installed once");
+            source_slot = Some(Box::new(ProjectionExec::new(
+                ExecutorMeta::new(projection_schema, 1, INIT_CAP, MAX_CHUNK_SIZE),
+                expressions,
+                child,
+                ctx.clone(),
+            )));
+            for (group, position) in group_by.iter_mut().zip(group_positions) {
+                *group = Expression::Column(columns[position].clone());
+            }
+            for (function, position) in state.agg_funcs.iter_mut().zip(function_positions) {
+                function.arg = Some(Expression::Column(columns[position].clone()));
+            }
+            grouped_stream_input_projection_trace = Some((trace_expressions, injected_for_scalar));
+            true
+        })
+    } else {
+        false
+    };
+    let mut source = source_slot.expect("source remains installed");
+
+    // Build the aggregation schema after a partial grouped SUM has reordered
+    // its physical outputs.
     let out_columns: Vec<Column> = state
         .types
         .iter()
@@ -1268,6 +2100,67 @@ fn build_aggregation(
             &state.grouping_specs,
             ctx,
         )?
+    } else if let Some(stream_plan) = stream_plan {
+        let mut agg_funcs = std::mem::take(&mut state.agg_funcs);
+        if partial_stream_agg {
+            let mut partial = source.schema().columns[0].clone();
+            partial.index = 0;
+            agg_funcs[0].arg = Some(Expression::Column(partial));
+            if matches!(stream_plan, GlobalStreamAggPlan::Count) {
+                agg_funcs[0].kind = AggKind::FinalCount;
+            }
+        } else if let GlobalStreamAggPlan::IntegerSum { precision } = stream_plan {
+            let argument = agg_funcs[0]
+                .arg
+                .take()
+                .expect("integer SUM eligibility requires one argument");
+            let source_flags = argument.static_type().map_or(0, FieldType::flags);
+            let mut decimal_type = FieldType::new(FieldTypeCode::NewDecimal);
+            decimal_type.set_flen(precision);
+            decimal_type.set_decimal(0);
+            decimal_type.add_flags(
+                FieldTypeFlags::BINARY
+                    | (source_flags & (FieldTypeFlags::UNSIGNED | FieldTypeFlags::NOT_NULL)),
+            );
+            let cast = Expression::ScalarFunction(tidb_expr::scalar_function::ScalarFunction::new(
+                tidb_ast::CiString::new("cast_decimal"),
+                decimal_type.clone(),
+                vec![argument],
+            ));
+            let mut projected_column = Column::new(1, decimal_type.clone());
+            projected_column.index = 0;
+            source = Box::new(ProjectionExec::new(
+                ExecutorMeta::new(
+                    Schema::new(vec![projected_column.clone()]),
+                    1,
+                    INIT_CAP,
+                    MAX_CHUNK_SIZE,
+                ),
+                vec![cast],
+                source,
+                ctx.clone(),
+            ));
+            agg_funcs[0].arg = Some(Expression::Column(projected_column));
+        }
+        Box::new(StreamAggExec::new(
+            ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
+            agg_funcs,
+            source,
+            ctx.clone(),
+        ))
+    } else if grouped_stream_ordered && !partial_grouped_sum {
+        let output_positions = state
+            .grouped_stream_output_positions
+            .take()
+            .unwrap_or_else(|| (0..state.agg_funcs.len()).collect());
+        Box::new(crate::hash_agg::GroupedStreamAggExec::new(
+            ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
+            group_by,
+            std::mem::take(&mut state.agg_funcs),
+            output_positions,
+            source,
+            ctx.clone(),
+        ))
     } else {
         Box::new(HashAggExec::new(
             ExecutorMeta::new(out_schema.clone(), 2, INIT_CAP, MAX_CHUNK_SIZE),
@@ -1280,7 +2173,59 @@ fn build_aggregation(
     };
     let root = match trace {
         Some(trace) => {
-            trace.hash_agg(traced_select, &qualify);
+            if let Some(stream_plan) = stream_plan {
+                if partial_stream_agg {
+                    if !trace.partial_stream_agg(
+                        traced_select,
+                        &qualify,
+                        matches!(stream_plan, GlobalStreamAggPlan::IntegerSum { .. }),
+                    ) {
+                        trace.refuse("partial StreamAgg child is not a bare table/index scan");
+                    }
+                } else if !matches!(
+                    stream_plan,
+                    GlobalStreamAggPlan::CountComplex | GlobalStreamAggPlan::CountDistinct
+                ) && !trace.scan_reader()
+                {
+                    trace.refuse("global StreamAgg child is not a bare table/index scan");
+                }
+                if !partial_stream_agg {
+                    if let GlobalStreamAggPlan::IntegerSum { precision } = stream_plan {
+                        trace.sum_cast_projection(traced_select, &qualify, precision);
+                    }
+                }
+                trace.stream_agg(
+                    traced_select,
+                    &qualify,
+                    partial_stream_agg
+                        || matches!(stream_plan, GlobalStreamAggPlan::IntegerSum { .. }),
+                );
+            } else if partial_grouped_sum {
+                if !trace.partial_grouped_sum(traced_select, &qualify, logical_rows) {
+                    trace.refuse("partial grouped SUM child is not a bare table scan");
+                }
+                trace.final_grouped_sum_hash_agg(traced_select, &qualify);
+            } else if partial_grouped_stream {
+                if !trace.partial_grouped_stream_agg(traced_select, &qualify) {
+                    trace.refuse("partial grouped StreamAgg child is not a bare scan");
+                }
+                trace.final_grouped_stream_agg(traced_select, &qualify);
+            } else if grouped_stream_ordered {
+                if let Some((expressions, injected_for_scalar)) =
+                    grouped_stream_input_projection_trace.as_ref()
+                {
+                    trace.grouped_stream_input_projection(expressions, *injected_for_scalar);
+                }
+                trace.grouped_stream_agg(
+                    traced_select,
+                    &qualify,
+                    grouped_stream_input_projection,
+                    grouped_logical_rows,
+                    grouped_stream_physical_agg_trace.as_deref(),
+                );
+            } else {
+                trace.hash_agg(traced_select, &qualify);
+            }
             trace.meter(root)
         }
         None => root,

--- a/rust/crates/tidb-executor/src/driver/agg_select.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_select.rs
@@ -1379,10 +1379,11 @@ fn collect_derived_aliases(node: &tidb_ast::JoinNode, aliases: &mut Vec<String>)
     }
 }
 
-/// The projection below a complex grouped StreamAgg. If wrapping an aggregate
-/// argument introduced a scalar function, Go's `InjectProjBelowAgg` emits
-/// aggregate arguments first and group items after them. Otherwise the
-/// compact projection produced by column pruning keeps group keys first.
+/// The projection below a complex grouped StreamAgg. Go's
+/// `InjectProjBelowAgg` emits real aggregate arguments first, group items
+/// next, and `FIRST_ROW` carriers last when either a scalar wrapper or an
+/// ungrouped carrier requires the projection. Otherwise the compact
+/// projection produced by column pruning keeps group keys first.
 fn grouped_stream_input_projection_plan(
     group_by: &[Expression],
     functions: &[AggFunc],
@@ -1395,32 +1396,49 @@ fn grouped_stream_input_projection_plan(
     let injected_for_scalar = function_arguments
         .iter()
         .any(|argument| matches!(argument, Expression::ScalarFunction(_)));
-    let (group_positions, function_positions) = if injected_for_scalar {
+    let has_ungrouped_carrier =
+        functions
+            .iter()
+            .zip(&function_arguments)
+            .any(|(function, argument)| {
+                matches!(function.kind, AggKind::FirstRow)
+                    && !group_by.iter().any(|group| group.equal(argument))
+            });
+    let (group_positions, function_positions) = if injected_for_scalar || has_ungrouped_carrier {
         // Column pruning moves FIRST_ROW group carriers behind the real
         // aggregate functions. They still read the group-key projection
         // slot, but must not make that slot appear before SUM's injected
-        // cast (Go condition 04: cast(SUM arg), MAX arg, group key).
-        let mut function_positions = function_arguments
-            .iter()
-            .map(|argument| {
-                if group_by.iter().any(|group| group.equal(argument)) {
-                    Some(None)
-                } else {
-                    add_grouped_projection_expression(&mut expressions, argument).map(Some)
-                }
-            })
-            .collect::<Option<Vec<_>>>()?;
+        // cast (Go condition 04: cast(SUM arg), MAX arg, group key), nor may
+        // an ungrouped carrier precede SUM (TPCC condition 08).
+        let mut function_positions = vec![None; function_arguments.len()];
+        for (position, (function, argument)) in function_positions
+            .iter_mut()
+            .zip(functions.iter().zip(&function_arguments))
+        {
+            if !matches!(function.kind, AggKind::FirstRow)
+                && !group_by.iter().any(|group| group.equal(argument))
+            {
+                *position = Some(add_grouped_projection_expression(
+                    &mut expressions,
+                    argument,
+                )?);
+            }
+        }
         let group_positions = group_by
             .iter()
             .map(|group| add_grouped_projection_expression(&mut expressions, group))
             .collect::<Option<Vec<_>>>()?;
         for (position, argument) in function_positions.iter_mut().zip(&function_arguments) {
             if position.is_none() {
-                let group = group_by
-                    .iter()
-                    .position(|group| group.equal(argument))
-                    .expect("a deferred aggregate argument is a group carrier");
-                *position = Some(group_positions[group]);
+                *position =
+                    if let Some(group) = group_by.iter().position(|group| group.equal(argument)) {
+                        Some(group_positions[group])
+                    } else {
+                        Some(add_grouped_projection_expression(
+                            &mut expressions,
+                            argument,
+                        )?)
+                    };
             }
         }
         let function_positions = function_positions
@@ -1673,6 +1691,42 @@ fn grouped_sum_plan(
     })
 }
 
+/// Source-table identities behind a derived relation's physical columns.
+/// Aggregate outputs deliberately remain `None` and therefore print as
+/// internal `Column#N` values.
+fn physical_source_column_names(
+    select: &tidb_ast::SelectStmt,
+    scope: &FromScope,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Vec<Option<String>> {
+    let Some(from) = &select.from else {
+        return vec![None; scope.width()];
+    };
+    (0..scope.width())
+        .map(|offset| {
+            let path = scope.qualified_path(offset)?;
+            let [.., relation, column] = path.as_slice() else {
+                return None;
+            };
+            let column = crate::driver::merge_decision::RelColumn {
+                relation: relation.clone(),
+                column: column.clone(),
+            };
+            crate::driver::merge_decision::physical_column_trace_name(
+                &from.left, &column, catalog, current_db,
+            )
+            .or_else(|| {
+                from.right.as_ref().and_then(|right| {
+                    crate::driver::merge_decision::physical_column_trace_name(
+                        right, &column, catalog, current_db,
+                    )
+                })
+            })
+        })
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_aggregation(
     select: &tidb_ast::SelectStmt,
@@ -1835,7 +1889,18 @@ fn build_aggregation(
                         let mut physical = rewrite_expr_resolved(predicate, resolver)
                             .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
                         refine_comparisons(&mut physical, ctx);
-                        if !trace.physical_selection(&physical, written, stats) {
+                        let column_names = physical_source_column_names(
+                            traced_select,
+                            resolver.scope,
+                            catalog,
+                            current_db,
+                        );
+                        if !trace.physical_selection_with_columns(
+                            &physical,
+                            written,
+                            stats,
+                            &column_names,
+                        ) {
                             trace.refuse(
                                 "a pruned derived aggregation's Selection is not printable yet",
                             );
@@ -2099,6 +2164,16 @@ fn build_aggregation(
             collect_derived_aliases(right, &mut derived_aliases);
         }
     }
+    let grouped_stream_extra_first_rows = state
+        .agg_funcs
+        .iter()
+        .filter(|function| matches!(function.kind, AggKind::FirstRow))
+        .filter_map(|function| function.arg.as_ref())
+        .filter(|argument| !group_by.iter().any(|group| group.equal(argument)))
+        .filter_map(|argument| {
+            grouped_projection_expression_text(argument, &qualify, &derived_aliases)
+        })
+        .collect::<Vec<_>>();
     let grouped_stream_input_projection = if grouped_stream_ordered
         && !partial_grouped_sum
         && !partial_grouped_stream
@@ -2310,6 +2385,7 @@ fn build_aggregation(
                     grouped_stream_input_projection,
                     grouped_logical_rows,
                     grouped_stream_physical_agg_trace.as_deref(),
+                    &grouped_stream_extra_first_rows,
                 );
             } else {
                 trace.hash_agg(traced_select, &qualify);

--- a/rust/crates/tidb-executor/src/driver/agg_select.rs
+++ b/rust/crates/tidb-executor/src/driver/agg_select.rs
@@ -143,6 +143,7 @@ pub(crate) fn run_aggregate_select(
     logical_rows: Option<f64>,
     grouped_logical_rows: Option<f64>,
     grouped_stream_ordered: bool,
+    grouped_stream_physical_order: Option<Vec<usize>>,
     derived_output: bool,
     physical_source_columns: bool,
     mut trace: Option<&mut PlanTrace>,
@@ -220,6 +221,7 @@ pub(crate) fn run_aggregate_select(
         logical_rows,
         grouped_logical_rows,
         grouped_stream_ordered,
+        grouped_stream_physical_order,
         derived_output,
         physical_source_columns,
         trace.as_deref_mut(),
@@ -1495,12 +1497,19 @@ fn grouped_stream_partial_plan(
     grouped_stream_ordered: bool,
     source_has_no_residual_filter: bool,
 ) -> Option<GroupedStreamPartialPlan> {
+    let order_by_matches_groups = select.order_by.is_empty()
+        || (select.order_by.len() == select.group_by.len()
+            && select
+                .order_by
+                .iter()
+                .zip(&select.group_by)
+                .all(|(order, group)| !order.desc && order.expr == group.expr));
     if !grouped_stream_ordered
         || !source_has_no_residual_filter
         || select.rollup
         || select.distinct
         || select.having.is_some()
-        || !select.order_by.is_empty()
+        || !order_by_matches_groups
         || select.limit.is_some()
         || !state.window_calls.is_empty()
         || has_pre_agg_applies
@@ -1577,6 +1586,16 @@ fn grouped_stream_partial_plan(
     if functions.is_empty() {
         return None;
     }
+    // Go orders FIRST_ROW carriers by their physical source-column offset,
+    // independently of the SELECT-list order. The final projection maps
+    // these states back to the visible derived-table columns.
+    carrier_states.sort_by_key(|(state_index, _)| {
+        state.agg_funcs[*state_index]
+            .arg
+            .as_ref()
+            .and_then(Expression::as_column)
+            .map_or(i64::MAX, |column| column.index)
+    });
     function_states.extend(carrier_states);
     let (state_order, sources): (Vec<_>, Vec<_>) = function_states.into_iter().unzip();
     Some(GroupedStreamPartialPlan {
@@ -1668,6 +1687,7 @@ fn build_aggregation(
     logical_rows: Option<f64>,
     grouped_logical_rows: Option<f64>,
     grouped_stream_ordered: bool,
+    grouped_stream_physical_order: Option<Vec<usize>>,
     derived_output: bool,
     physical_source_columns: bool,
     mut trace: Option<&mut PlanTrace>,
@@ -1688,6 +1708,77 @@ fn build_aggregation(
                 .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?,
         );
     }
+    // Go's StreamAgg property matching removes equality-fixed index prefixes
+    // and places those fixed group keys after the ordered suffix. This changes
+    // neither group identity nor visible output, but it does define the
+    // physical group tuple and the plan text.
+    let physical_group_order = grouped_stream_physical_order
+        .as_ref()
+        .and_then(|source_offsets| {
+            source_offsets
+                .iter()
+                .map(|source_offset| {
+                    group_by.iter().position(|group| {
+                        group
+                            .as_column()
+                            .and_then(|column| usize::try_from(column.index).ok())
+                            == Some(*source_offset)
+                    })
+                })
+                .collect::<Option<Vec<_>>>()
+        })
+        .filter(|order| order.len() == group_by.len())
+        .unwrap_or_else(|| (0..group_by.len()).collect());
+    let reordered_groups = !physical_group_order.iter().copied().eq(0..group_by.len());
+    if reordered_groups {
+        group_by = physical_group_order
+            .iter()
+            .map(|index| group_by[*index].clone())
+            .collect();
+    }
+    let physical_trace_select;
+    let traced_select = if reordered_groups && traced_select.group_by.len() == group_by.len() {
+        physical_trace_select = {
+            let mut rewritten = traced_select.clone();
+            rewritten.group_by = physical_group_order
+                .iter()
+                .map(|index| traced_select.group_by[*index].clone())
+                .collect();
+            let mut fields = rewritten.fields.fields().to_vec();
+            let carrier_positions = fields
+                .iter()
+                .enumerate()
+                .filter_map(|(index, field)| match field {
+                    tidb_ast::SelectField::Expr {
+                        expr: tidb_ast::Expr::Column(path),
+                        ..
+                    } if traced_select.group_by.iter().any(|group| {
+                        matches!(&group.expr, tidb_ast::Expr::Column(group_path) if group_path == path)
+                    }) => Some(index),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            let mut carriers = carrier_positions
+                .iter()
+                .map(|index| fields[*index].clone())
+                .collect::<Vec<_>>();
+            carriers.sort_by_key(|field| match field {
+                tidb_ast::SelectField::Expr {
+                    expr: tidb_ast::Expr::Column(path),
+                    ..
+                } => resolver.resolve(path).map_or(usize::MAX, |column| column.0),
+                _ => usize::MAX,
+            });
+            for (position, field) in carrier_positions.into_iter().zip(carriers) {
+                fields[position] = field;
+            }
+            rewritten.fields = fields.into();
+            rewritten
+        };
+        &physical_trace_select
+    } else {
+        traced_select
+    };
 
     // Source (+ WHERE), as in the plain path.
     let (mut source, source_schema): (Box<dyn Executor>, Schema) = match from_source {
@@ -1734,29 +1825,26 @@ fn build_aggregation(
     // whether or not an executor survived above the scan: Go prints one
     // `Selection` for both halves, and this tier prints no `cop[tikv]` task
     // to distinguish them.
-    if !access_consumed_where && select.where_clause.is_some() {
-        if let Some(trace) = trace.as_deref_mut() {
-            if let Some(written) = &traced_select.where_clause {
-                let stats = select_stats_selectivity(select, catalog, current_db, resolver.scope);
-                if physical_source_columns {
-                    let mut physical = rewrite_expr_resolved(
-                        select
-                            .where_clause
-                            .as_ref()
-                            .expect("a recorded Selection has a predicate"),
-                        resolver,
-                    )
-                    .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
-                    refine_comparisons(&mut physical, ctx);
-                    if !trace.physical_selection(&physical, written, stats) {
-                        trace.refuse(
-                            "a pruned derived aggregation's Selection is not printable yet",
-                        );
+    if !access_consumed_where {
+        if let Some(predicate) = select.where_clause.as_ref() {
+            if let Some(trace) = trace.as_deref_mut() {
+                if let Some(written) = &traced_select.where_clause {
+                    let stats =
+                        select_stats_selectivity(select, catalog, current_db, resolver.scope);
+                    if physical_source_columns {
+                        let mut physical = rewrite_expr_resolved(predicate, resolver)
+                            .map_err(|e| DriverError::Exec(ExecError::Eval(e)))?;
+                        refine_comparisons(&mut physical, ctx);
+                        if !trace.physical_selection(&physical, written, stats) {
+                            trace.refuse(
+                                "a pruned derived aggregation's Selection is not printable yet",
+                            );
+                        }
+                    } else {
+                        trace.selection(written, &qualify, stats);
                     }
-                } else {
-                    trace.selection(written, &qualify, stats);
+                    source = trace.meter(source);
                 }
-                source = trace.meter(source);
             }
         }
     }

--- a/rust/crates/tidb-executor/src/driver/correlated_agg_decorrelate.rs
+++ b/rust/crates/tidb-executor/src/driver/correlated_agg_decorrelate.rs
@@ -1,0 +1,718 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Decorrelation of equality-correlated scalar aggregations.
+//!
+//! Go's `DecorrelateSolver` has two aggregation arms.  When an outer source
+//! has a non-null unique key, the first scalar aggregation can be pulled above
+//! a left join: the unique key becomes `GROUP BY`, outer values become
+//! `FIRST_ROW`, and the scalar aggregate keeps its empty-input NULL through
+//! the left join.  Once the outer side is itself aggregated, later scalar
+//! aggregations stay below the join: their correlation keys are appended to
+//! their own grouping and the Apply becomes a left join to that grouped
+//! relation.
+//!
+//! This module transcribes those two arms over the AST because this executor
+//! does not retain a separate logical-plan tree.  Its acceptance boundary is
+//! deliberately proof-shaped:
+//!
+//! * one base-table outer source with a non-null primary/unique key;
+//! * selected outer values are bare columns;
+//! * each rewritten field is exactly one non-distinct `SUM(column)` scalar
+//!   subquery;
+//! * every correlation is a column equality, and removing those equalities
+//!   leaves no outer reference in the subquery;
+//! * the inner `FROM` contains inner joins only.
+//!
+//! Any clause outside that boundary leaves the statement byte-for-byte
+//! unchanged.  In particular, no LIMIT, HAVING, DISTINCT, window, locking,
+//! volatile expression, nullable unique key, or non-equality correlation is
+//! guessed at.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use tidb_ast::{
+    BinaryOp, Expr, GroupByItem, Join, JoinNode, JoinType, QueryStmt, SelectField, SelectStmt,
+    TableRef,
+};
+use tidb_datatype::FieldTypeFlags;
+use tidb_expr::rewriter::ColumnResolver;
+
+use super::catalog::{Catalog, TableEntry};
+use super::from::ScopeResolver;
+
+/// Rewrites every eligible derived SELECT first, then the current SELECT.
+/// Returning `None` means no node in the tree changed.
+pub(crate) fn rewrite(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> Option<SelectStmt> {
+    let mut rewritten = select.clone();
+    let mut changed = rewritten
+        .from
+        .as_mut()
+        .is_some_and(|from| rewrite_join(from, catalog, current_db, ctx));
+    if let Some(current) = rewrite_current(&rewritten, catalog, current_db, ctx) {
+        rewritten = current;
+        changed = true;
+    }
+    changed.then_some(rewritten)
+}
+
+/// Whether later optimizer rules are looking at the grouped left-join form
+/// produced by this module. Derived-table fusion may move that form into a
+/// caller after [`rewrite`] returned, so the driver recognizes the invariant
+/// shape rather than relying on a transient boolean from the first pass.
+pub(crate) fn is_pulled_scalar_sum(select: &SelectStmt) -> bool {
+    !select.group_by.is_empty()
+        && select
+            .from
+            .as_ref()
+            .is_some_and(|join| join.tp == JoinType::Left)
+        && select.fields.fields().iter().any(|field| {
+            matches!(
+                field,
+                SelectField::Expr {
+                    expr: Expr::Aggregate { name, .. },
+                    ..
+                } if name.eq_ignore_ascii_case("SUM")
+            )
+        })
+        && select.fields.fields().iter().all(|field| match field {
+            SelectField::Expr { expr, .. } => !super::subquery::expr_has_subquery(expr),
+            SelectField::Wildcard(_) => false,
+        })
+}
+
+fn rewrite_join(
+    join: &mut Join,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    let mut changed = rewrite_node(&mut join.left, catalog, current_db, ctx);
+    if let Some(right) = &mut join.right {
+        changed |= rewrite_node(right, catalog, current_db, ctx);
+    }
+    changed
+}
+
+fn rewrite_node(
+    node: &mut JoinNode,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    match node {
+        JoinNode::Derived { subquery, .. } => {
+            let QueryStmt::Select(select) = &mut **subquery else {
+                return false;
+            };
+            let Some(rewritten) = rewrite(select, catalog, current_db, ctx) else {
+                return false;
+            };
+            **select = rewritten;
+            true
+        }
+        JoinNode::Join(join) => rewrite_join(join, catalog, current_db, ctx),
+        JoinNode::Table(_) => false,
+    }
+}
+
+#[derive(Clone)]
+struct ScalarSum {
+    field_index: usize,
+    output_name: String,
+    output_alias: Option<String>,
+    sum: Expr,
+    inner: SelectStmt,
+    local_conditions: Vec<Expr>,
+    correlations: Vec<Correlation>,
+}
+
+#[derive(Clone)]
+struct Correlation {
+    inner: Vec<String>,
+    outer_offset: usize,
+}
+
+fn rewrite_current(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> Option<SelectStmt> {
+    if !plain_outer(select) {
+        return None;
+    }
+    let outer_ref = single_table_ref(select.from.as_ref()?)?;
+    let outer_scope = super::subquery::select_outer_scope(select, catalog, current_db, ctx);
+    if outer_scope.tables.len() != 1 {
+        return None;
+    }
+    let outer_resolver = ScopeResolver {
+        scope: &outer_scope,
+    };
+    let field_names = super::from::derived_field_names(select)?;
+
+    let mut output_by_offset = BTreeMap::new();
+    let mut sums = Vec::new();
+    for (field_index, field) in select.fields.fields().iter().enumerate() {
+        let SelectField::Expr { expr, alias } = field else {
+            return None;
+        };
+        if let Some(sum) = scalar_sum(
+            expr,
+            field_index,
+            &field_names[field_index],
+            alias,
+            &outer_scope,
+            catalog,
+            current_db,
+            ctx,
+        ) {
+            sums.push(sum);
+            continue;
+        }
+        if super::subquery::expr_has_subquery(expr) {
+            return None;
+        }
+        let Expr::Column(path) = expr else {
+            return None;
+        };
+        let (offset, _, _) = outer_resolver.resolve(path)?;
+        if output_by_offset
+            .insert(offset, field_names[field_index].clone())
+            .is_some()
+        {
+            return None;
+        }
+    }
+    if sums.is_empty() {
+        return None;
+    }
+
+    let table = table_entry(outer_ref, catalog, current_db)?;
+    let TableEntry::Kv(table) = table else {
+        return None;
+    };
+    let unique_key = non_null_unique_key(table)?;
+    let first = &sums[0];
+    let mut group_offsets = first
+        .correlations
+        .iter()
+        .map(|correlation| correlation.outer_offset)
+        .collect::<Vec<_>>();
+    for offset in unique_key {
+        if !group_offsets.contains(&offset) {
+            group_offsets.push(offset);
+        }
+    }
+    let outer_visible = outer_ref
+        .alias
+        .as_deref()
+        .or_else(|| outer_ref.name.last().map(String::as_str))?;
+    let outer_columns = table.visible_columns();
+    let group_by = group_offsets
+        .iter()
+        .map(|offset| GroupByItem {
+            expr: Expr::Column(vec![
+                outer_visible.to_owned(),
+                outer_columns[*offset].name.clone(),
+            ]),
+            desc: None,
+        })
+        .collect::<Vec<_>>();
+
+    // The first Apply is pulled above a left join and aggregation.
+    let mut inner_from = first.inner.from.clone()?;
+    let residual_local =
+        attach_to_inner_join(&mut inner_from, combine_and(first.local_conditions.clone()));
+    let mut outer_on = first
+        .correlations
+        .iter()
+        .map(|correlation| {
+            Expr::Binary(
+                BinaryOp::Eq,
+                Box::new(Expr::Column(vec![
+                    outer_visible.to_owned(),
+                    outer_columns[correlation.outer_offset].name.clone(),
+                ])),
+                Box::new(Expr::Column(correlation.inner.clone())),
+            )
+        })
+        .collect::<Vec<_>>();
+    if let Some(residual) = residual_local {
+        outer_on.push(residual);
+    }
+    let left = join_node(select.from.clone()?);
+    let right = join_node(inner_from);
+    let mut pulled = select.clone();
+    pulled.from = Some(Join {
+        left,
+        right: Some(right),
+        tp: JoinType::Left,
+        straight: false,
+        on: combine_and(outer_on),
+        using: Vec::new(),
+        natural: false,
+        explicit_parens: false,
+    });
+    pulled.group_by = group_by;
+    let later = sums
+        .iter()
+        .skip(1)
+        .map(|sum| sum.field_index)
+        .collect::<BTreeSet<_>>();
+    let mut pulled_fields = Vec::new();
+    for (index, field) in select.fields.fields().iter().enumerate() {
+        if later.contains(&index) {
+            continue;
+        }
+        if index == first.field_index {
+            pulled_fields.push(SelectField::Expr {
+                expr: first.sum.clone(),
+                alias: first.output_alias.clone(),
+            });
+        } else {
+            pulled_fields.push(field.clone());
+        }
+    }
+    pulled.fields = pulled_fields.into();
+
+    if sums.len() == 1 {
+        return Some(pulled);
+    }
+
+    // Later Applies see an already-aggregated outer side. Their own SUM stays
+    // below the join, grouped by the inner correlation keys.
+    let mut current = pulled;
+    let mut available = select
+        .fields
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, _)| (!later.contains(&index)).then_some(index))
+        .collect::<BTreeSet<_>>();
+    for (round, sum) in sums.iter().skip(1).enumerate() {
+        let outer_alias = format!("__decorrelated_outer_{round}");
+        let inner_alias = format!("__decorrelated_sum_{round}");
+        let mut grouped_inner = sum.inner.clone();
+        grouped_inner.where_clause = combine_and(sum.local_conditions.clone());
+        grouped_inner.group_by = sum
+            .correlations
+            .iter()
+            .map(|correlation| GroupByItem {
+                expr: Expr::Column(correlation.inner.clone()),
+                desc: None,
+            })
+            .collect();
+        let mut inner_fields = vec![SelectField::Expr {
+            expr: sum.sum.clone(),
+            alias: Some(sum.output_name.clone()),
+        }];
+        inner_fields.extend(
+            sum.correlations
+                .iter()
+                .map(|correlation| SelectField::Expr {
+                    expr: Expr::Column(correlation.inner.clone()),
+                    alias: correlation.inner.last().cloned(),
+                }),
+        );
+        grouped_inner.fields = inner_fields.into();
+
+        let on = combine_and(
+            sum.correlations
+                .iter()
+                .map(|correlation| {
+                    let outer_name = output_by_offset.get(&correlation.outer_offset)?;
+                    let inner_name = correlation.inner.last()?;
+                    Some(Expr::Binary(
+                        BinaryOp::Eq,
+                        Box::new(Expr::Column(vec![inner_alias.clone(), inner_name.clone()])),
+                        Box::new(Expr::Column(vec![outer_alias.clone(), outer_name.clone()])),
+                    ))
+                })
+                .collect::<Option<Vec<_>>>()?,
+        );
+        let from = Join {
+            left: derived_node(current, &outer_alias),
+            right: Some(derived_node(grouped_inner, &inner_alias)),
+            tp: JoinType::Left,
+            straight: false,
+            on,
+            using: Vec::new(),
+            natural: false,
+            explicit_parens: false,
+        };
+        available.insert(sum.field_index);
+        let mut fields = Vec::with_capacity(available.len());
+        for index in available.iter().copied() {
+            let from_inner = index == sum.field_index;
+            fields.push(SelectField::Expr {
+                expr: Expr::Column(vec![
+                    if from_inner {
+                        inner_alias.clone()
+                    } else {
+                        outer_alias.clone()
+                    },
+                    field_names[index].clone(),
+                ]),
+                alias: Some(field_names[index].clone()),
+            });
+        }
+        let mut pass_through = select.clone();
+        pass_through.fields = fields.into();
+        pass_through.from = Some(from);
+        pass_through.where_clause = None;
+        current = pass_through;
+    }
+    Some(current)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scalar_sum(
+    expr: &Expr,
+    field_index: usize,
+    output_name: &str,
+    output_alias: &Option<String>,
+    outer_scope: &super::from::FromScope,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> Option<ScalarSum> {
+    let Expr::Subquery(query) = expr else {
+        return None;
+    };
+    let QueryStmt::Select(inner) = &**query else {
+        return None;
+    };
+    if !plain_scalar_inner(inner) || !inner_joins_only(inner.from.as_ref()?) {
+        return None;
+    }
+    let [SelectField::Expr {
+        expr:
+            sum @ Expr::Aggregate {
+                name,
+                distinct: false,
+                args,
+            },
+        ..
+    }] = inner.fields.fields()
+    else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("SUM") || !matches!(args.as_slice(), [Expr::Column(_)]) {
+        return None;
+    }
+    let inner_scope = super::subquery::select_outer_scope(inner, catalog, current_db, ctx);
+    let inner_resolver = ScopeResolver {
+        scope: &inner_scope,
+    };
+    let outer_resolver = ScopeResolver { scope: outer_scope };
+    let mut correlations = Vec::new();
+    let mut local_conditions = Vec::new();
+    for conjunct in conjuncts(inner.where_clause.as_ref()?) {
+        if let Some((inner_path, outer_path)) =
+            correlation_equality(conjunct, &inner_resolver, &outer_resolver)
+        {
+            let (outer_offset, _, _) = outer_resolver.resolve(&outer_path)?;
+            correlations.push(Correlation {
+                inner: inner_path,
+                outer_offset,
+            });
+        } else {
+            local_conditions.push(normalize_inner_expression(
+                conjunct,
+                &inner_resolver,
+                &inner_scope,
+            )?);
+        }
+    }
+    if correlations.is_empty() {
+        return None;
+    }
+    let mut uncorrelated = (**inner).clone();
+    uncorrelated.where_clause = combine_and(local_conditions.clone());
+    let mut remaining = Vec::new();
+    super::subquery::collect_correlated_columns_query(
+        &QueryStmt::Select(Box::new(uncorrelated)),
+        outer_scope,
+        catalog,
+        current_db,
+        &mut remaining,
+        ctx,
+    );
+    if !remaining.is_empty() {
+        return None;
+    }
+    // The SUM argument itself must belong to the inner row.
+    let Expr::Aggregate { args, .. } = sum else {
+        unreachable!()
+    };
+    let [Expr::Column(argument)] = args.as_slice() else {
+        unreachable!()
+    };
+    inner_resolver.resolve(argument)?;
+    Some(ScalarSum {
+        field_index,
+        output_name: output_name.to_owned(),
+        output_alias: output_alias.clone(),
+        sum: sum.clone(),
+        inner: (**inner).clone(),
+        local_conditions,
+        correlations,
+    })
+}
+
+/// Replaces parser spelling with the resolved source spelling Go's logical
+/// expression carries after name resolution. This affects only plan text;
+/// identifier matching and runtime semantics remain case-insensitive.
+fn normalize_inner_expression(
+    expression: &Expr,
+    resolver: &ScopeResolver<'_>,
+    scope: &super::from::FromScope,
+) -> Option<Expr> {
+    struct Normalize<'a> {
+        resolver: &'a ScopeResolver<'a>,
+        scope: &'a super::from::FromScope,
+        valid: bool,
+    }
+    impl tidb_ast::Visitor for Normalize<'_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            if let Some(Expr::Column(path)) = node.downcast_mut::<Expr>() {
+                let Some((offset, _, _)) = self.resolver.resolve(path) else {
+                    self.valid = false;
+                    return false;
+                };
+                let Some(qualified) = self.scope.qualified_path(offset) else {
+                    self.valid = false;
+                    return false;
+                };
+                *path = qualified;
+            }
+            false
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut normalized = expression.clone();
+    let mut visitor = Normalize {
+        resolver,
+        scope,
+        valid: true,
+    };
+    tidb_ast::Visitable::accept(&mut normalized, &mut visitor);
+    visitor.valid.then_some(normalized)
+}
+
+fn correlation_equality(
+    expr: &Expr,
+    inner: &ScopeResolver<'_>,
+    outer: &ScopeResolver<'_>,
+) -> Option<(Vec<String>, Vec<String>)> {
+    let Expr::Binary(BinaryOp::Eq, left, right) = expr else {
+        return None;
+    };
+    let Expr::Column(left) = &**left else {
+        return None;
+    };
+    let Expr::Column(right) = &**right else {
+        return None;
+    };
+    let classify = |path: &[String]| (inner.resolve(path).is_some(), outer.resolve(path).is_some());
+    match (classify(left), classify(right)) {
+        ((true, false), (false, true)) => Some((left.clone(), right.clone())),
+        ((false, true), (true, false)) => Some((right.clone(), left.clone())),
+        _ => None,
+    }
+}
+
+fn plain_outer(select: &SelectStmt) -> bool {
+    select.with.is_none()
+        && select.hints.is_empty()
+        && !select.sql_small_result
+        && !select.sql_big_result
+        && !select.sql_buffer_result
+        && !select.sql_no_cache
+        && !select.straight_join
+        && !select.calc_found_rows
+        && !select.distinct
+        && !select.all
+        && select.values.is_empty()
+        && select.group_by.is_empty()
+        && !select.rollup
+        && select.having.is_none()
+        && select.windows.is_empty()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && select.lock.is_none()
+        && select.into_outfile.is_none()
+}
+
+fn plain_scalar_inner(select: &SelectStmt) -> bool {
+    select.with.is_none()
+        && select.hints.is_empty()
+        && !select.distinct
+        && select.values.is_empty()
+        && select.group_by.is_empty()
+        && !select.rollup
+        && select.having.is_none()
+        && select.windows.is_empty()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && select.lock.is_none()
+        && select.into_outfile.is_none()
+        && select.from.is_some()
+        && select.where_clause.is_some()
+}
+
+fn single_table_ref(join: &Join) -> Option<&TableRef> {
+    if join.right.is_some() || join.on.is_some() || !join.using.is_empty() || join.natural {
+        return None;
+    }
+    match &join.left {
+        JoinNode::Table(table) => Some(table),
+        _ => None,
+    }
+}
+
+fn table_entry<'a>(
+    table: &TableRef,
+    catalog: &'a Catalog,
+    current_db: &str,
+) -> Option<&'a TableEntry> {
+    let name = table.name.last()?;
+    let database = match table.name.as_slice() {
+        [name] if !name.is_empty() => current_db,
+        [database, _] => database,
+        _ => return None,
+    };
+    catalog.get_in(database, name)
+}
+
+fn non_null_unique_key(table: &crate::KvTable) -> Option<Vec<usize>> {
+    let key = table
+        .pk_handle_offset()
+        .map(|offset| vec![offset])
+        .or_else(|| {
+            (!table.common_handle_offsets().is_empty())
+                .then(|| table.common_handle_offsets().to_vec())
+        })
+        .or_else(|| {
+            table
+                .indexes()
+                .iter()
+                .find(|index| {
+                    index.unique
+                        && index.name.eq_ignore_ascii_case("PRIMARY")
+                        && !index.has_prefix()
+                })
+                .map(|index| index.column_offsets.clone())
+        })
+        .or_else(|| {
+            table
+                .indexes()
+                .iter()
+                .find(|index| index.unique && !index.has_prefix())
+                .map(|index| index.column_offsets.clone())
+        })?;
+    key.iter()
+        .all(|offset| {
+            table
+                .visible_columns()
+                .get(*offset)
+                .is_some_and(|column| column.field_type.has_flag(FieldTypeFlags::NOT_NULL))
+        })
+        .then_some(key)
+}
+
+fn inner_joins_only(join: &Join) -> bool {
+    if join.tp != JoinType::Cross || join.natural || !join.using.is_empty() {
+        return false;
+    }
+    node_inner_only(&join.left) && join.right.as_ref().is_none_or(node_inner_only)
+}
+
+fn node_inner_only(node: &JoinNode) -> bool {
+    match node {
+        JoinNode::Table(_) => true,
+        JoinNode::Join(join) => inner_joins_only(join),
+        JoinNode::Derived { .. } => false,
+    }
+}
+
+fn join_node(join: Join) -> JoinNode {
+    if join.right.is_none() && join.on.is_none() && join.using.is_empty() && !join.natural {
+        join.left
+    } else {
+        JoinNode::Join(Box::new(join))
+    }
+}
+
+fn derived_node(select: SelectStmt, alias: &str) -> JoinNode {
+    JoinNode::Derived {
+        subquery: tidb_ast::NodeBox::new(QueryStmt::Select(Box::new(select))),
+        alias: Some(alias.to_owned()),
+        lateral: false,
+        column_names: Vec::new(),
+    }
+}
+
+/// Places inner-local predicates on the inner join itself. A single-table
+/// inner has no join node to own them, so they remain part of the outer
+/// join's ON condition.
+fn attach_to_inner_join(join: &mut Join, conditions: Option<Expr>) -> Option<Expr> {
+    let Some(conditions) = conditions else {
+        return None;
+    };
+    if join.right.is_none() && join.on.is_none() && join.using.is_empty() && !join.natural {
+        if let JoinNode::Join(inner) = &mut join.left {
+            return attach_to_inner_join(inner, Some(conditions));
+        }
+        return Some(conditions);
+    }
+    join.on = and(join.on.take(), Some(conditions));
+    None
+}
+
+fn conjuncts(expr: &Expr) -> Vec<&Expr> {
+    let mut result = Vec::new();
+    crate::plan_trace::collect_and(expr, &mut result);
+    result
+}
+
+fn combine_and(mut conditions: Vec<Expr>) -> Option<Expr> {
+    let first = conditions.pop()?;
+    Some(conditions.into_iter().rev().fold(first, |right, left| {
+        Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right))
+    }))
+}
+
+fn and(left: Option<Expr>, right: Option<Expr>) -> Option<Expr> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(Expr::Binary(
+            BinaryOp::LogicAnd,
+            Box::new(left),
+            Box::new(right),
+        )),
+        (Some(expr), None) | (None, Some(expr)) => Some(expr),
+        (None, None) => None,
+    }
+}

--- a/rust/crates/tidb-executor/src/driver/derived_agg_pruning.rs
+++ b/rust/crates/tidb-executor/src/driver/derived_agg_pruning.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 //! Go's `LogicalAggregation.PruneColumns` (`logical_aggregation.go:113`)
-//! reaching a derived table: an UNGROUPED aggregation nobody reads a column
-//! of computes nothing at all -- only the fact that it produced its one row.
+//! reaching a derived table. An UNGROUPED aggregation nobody reads a column
+//! of computes only the fact that it produced its one row. A GROUPED
+//! aggregation also drops an unread selected group carrier while retaining
+//! the `GROUP BY` expression that determines its rows.
 //!
 //! # The Go rule, and why the answer is `count(1)`
 //!
@@ -111,8 +113,25 @@ use tidb_datatype::{FieldType, FieldTypeCode};
 
 use super::leaf_demand::LeafDemand;
 
-/// The statement with its derived table's field list reduced to `count(1)`,
-/// or `None` when no reduction is provable.
+/// Whether this statement's sole relation is a grouped derived SELECT. Used
+/// by the caller to render the post-pruning physical expressions that no
+/// longer have source-column names.
+pub(crate) fn is_single_grouped_derived(select: &SelectStmt) -> bool {
+    let Some(from) = &select.from else {
+        return false;
+    };
+    if from.right.is_some() {
+        return false;
+    }
+    matches!(
+        &from.left,
+        JoinNode::Derived { subquery, .. }
+            if matches!(&**subquery, QueryStmt::Select(inner) if !inner.group_by.is_empty())
+    )
+}
+
+/// The statement with unread derived-aggregation outputs removed, or `None`
+/// when no reduction is provable.
 pub(crate) fn prune(select: &SelectStmt) -> Option<SelectStmt> {
     let from = select.from.as_ref()?;
     if from.right.is_some() {
@@ -133,29 +152,36 @@ pub(crate) fn prune(select: &SelectStmt) -> Option<SelectStmt> {
     let QueryStmt::Select(inner) = &**subquery else {
         return None;
     };
-    if !is_prunable_ungrouped_aggregation(inner) {
-        return None;
-    }
-    // The outer statement must read no column of the derived table. Only the
-    // NAMES matter to `LeafDemand::needed`, so the type is a placeholder.
+    // Only the clauses ABOVE the derived relation decide which of its output
+    // columns survive. Walking into the subquery would charge its own source
+    // references to identically named output columns (condition 04's
+    // `o_d_id`) and incorrectly keep the FIRST_ROW carrier Go prunes.
+    let mut outer = select.clone();
+    outer.from = None;
+
+    // Only the output NAMES matter to `LeafDemand::needed`, so the type is a
+    // placeholder.
     let names = super::from::derived_field_names(inner)?;
     let columns: Vec<(String, FieldType)> = names
         .into_iter()
         .map(|name| (name, FieldType::new(FieldTypeCode::LongLong)))
         .collect();
-    if !LeafDemand::of_select(select)
-        .needed(alias, &columns)
-        .is_empty()
-    {
-        return None;
-    }
+    let needed = LeafDemand::of_select(&outer).needed(alias, &columns);
 
-    let mut pruned_inner = inner.clone();
-    pruned_inner.fields = vec![SelectField::Expr {
-        expr: count_one(),
-        alias: None,
-    }]
-    .into();
+    let pruned_inner = if is_prunable_ungrouped_aggregation(inner) {
+        if !needed.is_empty() {
+            return None;
+        }
+        let mut inner = inner.clone();
+        inner.fields = vec![SelectField::Expr {
+            expr: count_one(),
+            alias: None,
+        }]
+        .into();
+        inner
+    } else {
+        Box::new(prune_unread_group_carriers(inner, &needed)?)
+    };
     let mut rewritten = select.clone();
     rewritten.from = Some(tidb_ast::Join {
         left: JoinNode::Derived {
@@ -167,6 +193,49 @@ pub(crate) fn prune(select: &SelectStmt) -> Option<SelectStmt> {
         ..from.clone()
     });
     Some(rewritten)
+}
+
+/// Drops selected group-key columns the outer query does not read. The group
+/// item itself remains, so row cardinality and ordering are unchanged; only
+/// the `FIRST_ROW` aggregate Go synthesized to expose that key disappears.
+///
+/// This is deliberately narrower than Go's general column-pruning rule. It
+/// refuses DISTINCT and output-order-sensitive clauses and keeps every
+/// aggregate output, even an unread one. The TPCC condition-04 shape needs
+/// only the safe plain-column group carrier case.
+fn prune_unread_group_carriers(select: &SelectStmt, needed: &[usize]) -> Option<SelectStmt> {
+    if select.group_by.is_empty()
+        || select.distinct
+        || select.rollup
+        || !select.order_by.is_empty()
+        || !select.windows.is_empty()
+    {
+        return None;
+    }
+
+    let mut changed = false;
+    let mut fields = Vec::with_capacity(select.fields.fields().len());
+    for (index, field) in select.fields.fields().iter().enumerate() {
+        let is_group_carrier = match field {
+            SelectField::Expr {
+                expr: expr @ Expr::Column(_),
+                alias: _,
+            } => select.group_by.iter().any(|item| &item.expr == expr),
+            _ => false,
+        };
+        if is_group_carrier && !needed.contains(&index) {
+            changed = true;
+        } else {
+            fields.push(field.clone());
+        }
+    }
+    if !changed || fields.is_empty() {
+        return None;
+    }
+
+    let mut pruned = select.clone();
+    pruned.fields = fields.into();
+    Some(pruned)
 }
 
 /// `COUNT(1)`, the aggregate Go appends when it prunes the last one -- the

--- a/rust/crates/tidb-executor/src/driver/derived_agg_pruning.rs
+++ b/rust/crates/tidb-executor/src/driver/derived_agg_pruning.rs
@@ -59,9 +59,6 @@
 //!
 //! Refusals, each keeping the statement exactly as written:
 //!
-//! * a `FROM` that is anything but the one derived table (a join needs the
-//!   per-relation parent-column set, which the statement text does not
-//!   carry);
 //! * a derived subquery that is not a plain `SELECT`, or is `LATERAL`, or
 //!   carries an alias column list;
 //! * a subquery that is not an UNGROUPED aggregation: a `GROUP BY`,
@@ -113,6 +110,30 @@ use tidb_datatype::{FieldType, FieldTypeCode};
 
 use super::leaf_demand::LeafDemand;
 
+/// Marks the row-count aggregate Go appends after column pruning removes the
+/// last non-FIRST_ROW aggregate from a grouped derived relation. This alias
+/// exists only on the optimizer's private AST; the parent proved it does not
+/// read the replaced output column before the marker is installed.
+const PRUNED_ROW_COUNT_ALIAS: &str = "__tidb_pruned_row_count";
+
+/// Whether this grouped SELECT carries the synthetic row-count aggregate
+/// installed by [`prune_unread_grouped_outputs`]. Physical aggregation keeps
+/// this state after its FIRST_ROW carriers, matching Go's
+/// `LogicalAggregation.PruneColumns` append order.
+pub(crate) fn has_pruned_row_count(select: &SelectStmt) -> bool {
+    select.fields.fields().iter().any(|field| {
+        matches!(
+            field,
+            SelectField::Expr {
+                expr: Expr::Aggregate { name, distinct: false, args },
+                alias: Some(alias),
+            } if alias == PRUNED_ROW_COUNT_ALIAS
+                && name.eq_ignore_ascii_case("count")
+                && matches!(args.as_slice(), [Expr::Int(value)] if value == "1")
+        )
+    })
+}
+
 /// Whether this statement's sole relation is a grouped derived SELECT. Used
 /// by the caller to render the post-pruning physical expressions that no
 /// longer have source-column names.
@@ -133,77 +154,141 @@ pub(crate) fn is_single_grouped_derived(select: &SelectStmt) -> bool {
 /// The statement with unread derived-aggregation outputs removed, or `None`
 /// when no reduction is provable.
 pub(crate) fn prune(select: &SelectStmt) -> Option<SelectStmt> {
-    let from = select.from.as_ref()?;
-    if from.right.is_some() {
-        return None;
-    }
-    let JoinNode::Derived {
-        subquery,
-        alias: Some(alias),
-        lateral: false,
-        column_names,
-    } = &from.left
-    else {
-        return None;
-    };
-    if !column_names.is_empty() {
-        return None;
-    }
-    let QueryStmt::Select(inner) = &**subquery else {
-        return None;
-    };
-    // Only the clauses ABOVE the derived relation decide which of its output
-    // columns survive. Walking into the subquery would charge its own source
-    // references to identically named output columns (condition 04's
-    // `o_d_id`) and incorrectly keep the FIRST_ROW carrier Go prunes.
-    let mut outer = select.clone();
-    outer.from = None;
-
-    // Only the output NAMES matter to `LeafDemand::needed`, so the type is a
-    // placeholder.
-    let names = super::from::derived_field_names(inner)?;
-    let columns: Vec<(String, FieldType)> = names
-        .into_iter()
-        .map(|name| (name, FieldType::new(FieldTypeCode::LongLong)))
-        .collect();
-    let needed = LeafDemand::of_select(&outer).needed(alias, &columns);
-
-    let pruned_inner = if is_prunable_ungrouped_aggregation(inner) {
-        if !needed.is_empty() {
-            return None;
-        }
-        let mut inner = inner.clone();
-        inner.fields = vec![SelectField::Expr {
-            expr: count_one(),
-            alias: None,
-        }]
-        .into();
-        inner
-    } else {
-        Box::new(prune_unread_group_carriers(inner, &needed)?)
-    };
     let mut rewritten = select.clone();
-    rewritten.from = Some(tidb_ast::Join {
-        left: JoinNode::Derived {
-            subquery: tidb_ast::NodeBox::new(QueryStmt::Select(pruned_inner)),
-            alias: Some(alias.clone()),
-            lateral: false,
-            column_names: Vec::new(),
-        },
-        ..from.clone()
-    });
-    Some(rewritten)
+    prune_select(&mut rewritten).then_some(rewritten)
 }
 
-/// Drops selected group-key columns the outer query does not read. The group
-/// item itself remains, so row cardinality and ordering are unchanged; only
-/// the `FIRST_ROW` aggregate Go synthesized to expose that key disappears.
+/// Prunes one query block top-down. Its own output has already been reduced
+/// by its caller, so references in the surviving projection and join
+/// predicates are the exact demand to propagate into the block's derived
+/// children.
+fn prune_select(select: &mut SelectStmt) -> bool {
+    let demand = LeafDemand::of_select(&without_derived_inputs(select));
+    select
+        .from
+        .as_mut()
+        .is_some_and(|from| prune_join(from, &demand))
+}
+
+fn prune_join(join: &mut tidb_ast::Join, demand: &LeafDemand) -> bool {
+    let mut changed = prune_node(&mut join.left, demand);
+    if let Some(right) = &mut join.right {
+        changed |= prune_node(right, demand);
+    }
+    changed
+}
+
+fn prune_node(node: &mut JoinNode, demand: &LeafDemand) -> bool {
+    match node {
+        JoinNode::Join(join) => prune_join(join, demand),
+        JoinNode::Table(_) => false,
+        JoinNode::Derived {
+            subquery,
+            alias,
+            lateral,
+            column_names,
+        } => {
+            let QueryStmt::Select(inner) = &mut **subquery else {
+                return false;
+            };
+            let mut changed = false;
+            if let (Some(alias), false, true) =
+                (alias.as_deref(), *lateral, column_names.is_empty())
+            {
+                if let Some(names) = super::from::derived_field_names(inner) {
+                    // Only output names matter to `LeafDemand::needed`; the
+                    // type is a placeholder until the child is built.
+                    let columns = names
+                        .into_iter()
+                        .map(|name| (name, FieldType::new(FieldTypeCode::LongLong)))
+                        .collect::<Vec<_>>();
+                    let needed = demand.needed(alias, &columns);
+                    let pruned = if is_prunable_ungrouped_aggregation(inner) {
+                        needed.is_empty().then(|| {
+                            let mut pruned = (**inner).clone();
+                            pruned.fields = vec![SelectField::Expr {
+                                expr: count_one(),
+                                alias: None,
+                            }]
+                            .into();
+                            pruned
+                        })
+                    } else {
+                        prune_unread_grouped_outputs(inner, &needed)
+                            .or_else(|| prune_unread_pass_through_columns(inner, &needed))
+                    };
+                    if let Some(pruned) = pruned {
+                        **inner = pruned;
+                        changed = true;
+                    }
+                }
+            }
+            changed | prune_select(inner)
+        }
+    }
+}
+
+/// Computes one query block's parent demand without descending into the
+/// derived inputs whose output is being pruned. Join `ON`/`USING` clauses
+/// remain, as do correlated subqueries written in this block's expressions.
+fn without_derived_inputs(select: &SelectStmt) -> SelectStmt {
+    fn strip_join(join: &mut tidb_ast::Join) {
+        strip_node(&mut join.left);
+        if let Some(right) = &mut join.right {
+            strip_node(right);
+        }
+    }
+
+    fn strip_node(node: &mut JoinNode) {
+        match node {
+            JoinNode::Join(join) => strip_join(join),
+            JoinNode::Table(_) => {}
+            JoinNode::Derived { subquery, .. } => {
+                let QueryStmt::Select(inner) = &mut **subquery else {
+                    return;
+                };
+                inner.with = None;
+                inner.fields = vec![SelectField::Expr {
+                    expr: count_one(),
+                    alias: None,
+                }]
+                .into();
+                inner.values.clear();
+                inner.from = None;
+                inner.where_clause = None;
+                inner.group_by.clear();
+                inner.rollup = false;
+                inner.having = None;
+                inner.windows.clear();
+                inner.order_by.clear();
+                inner.limit = None;
+            }
+        }
+    }
+
+    let mut outer = select.clone();
+    if let Some(from) = &mut outer.from {
+        strip_join(from);
+    }
+    outer
+}
+
+/// Drops grouped outputs the outer query does not read. The group items remain,
+/// so row cardinality and ordering are unchanged; only their exposed
+/// `FIRST_ROW` carriers and side-effect-free aggregate outputs disappear.
 ///
-/// This is deliberately narrower than Go's general column-pruning rule. It
-/// refuses DISTINCT and output-order-sensitive clauses and keeps every
-/// aggregate output, even an unread one. The TPCC condition-04 shape needs
-/// only the safe plain-column group carrier case.
-fn prune_unread_group_carriers(select: &SelectStmt, needed: &[usize]) -> Option<SelectStmt> {
+/// Go builds explicit aggregate functions before the source-column
+/// `FIRST_ROW` carriers. If pruning removes the last explicit aggregate while
+/// carriers remain, `LogicalAggregation.PruneColumns` appends `COUNT(1)` to
+/// preserve the empty-input row-count distinction. TPCC condition 11 reaches
+/// exactly that state for `customer_count`, so retaining the written COUNT or
+/// moving the replacement before the carriers describes a different physical
+/// aggregation.
+///
+/// This remains narrower than Go's general rule: scalar select expressions
+/// and aggregate arguments with possible side effects are retained, and
+/// DISTINCT/output-order-sensitive shapes are refused.
+fn prune_unread_grouped_outputs(select: &SelectStmt, needed: &[usize]) -> Option<SelectStmt> {
     if select.group_by.is_empty()
         || select.distinct
         || select.rollup
@@ -214,6 +299,8 @@ fn prune_unread_group_carriers(select: &SelectStmt, needed: &[usize]) -> Option<
     }
 
     let mut changed = false;
+    let mut saw_non_first_row = false;
+    let mut kept_non_first_row = false;
     let mut fields = Vec::with_capacity(select.fields.fields().len());
     for (index, field) in select.fields.fields().iter().enumerate() {
         let is_group_carrier = match field {
@@ -223,13 +310,85 @@ fn prune_unread_group_carriers(select: &SelectStmt, needed: &[usize]) -> Option<
             } => select.group_by.iter().any(|item| &item.expr == expr),
             _ => false,
         };
-        if is_group_carrier && !needed.contains(&index) {
+        let aggregate = match field {
+            SelectField::Expr {
+                expr:
+                    Expr::Aggregate {
+                        name,
+                        distinct: _,
+                        args,
+                    },
+                ..
+            } => Some((name, args)),
+            _ => None,
+        };
+        let is_first_row =
+            aggregate.is_some_and(|(name, _)| name.eq_ignore_ascii_case("first_row"));
+        if aggregate.is_some() && !is_first_row {
+            saw_non_first_row = true;
+        }
+        let removable_aggregate =
+            aggregate.is_some_and(|(_, args)| args.iter().all(is_side_effect_free_argument));
+
+        if !needed.contains(&index) && (is_group_carrier || removable_aggregate) {
             changed = true;
         } else {
+            kept_non_first_row |= aggregate.is_some() && !is_first_row;
             fields.push(field.clone());
         }
     }
+    if saw_non_first_row && !kept_non_first_row {
+        fields.push(SelectField::Expr {
+            expr: count_one(),
+            alias: Some(PRUNED_ROW_COUNT_ALIAS.to_owned()),
+        });
+        changed = true;
+    }
     if !changed || fields.is_empty() {
+        return None;
+    }
+
+    let mut pruned = select.clone();
+    pruned.fields = fields.into();
+    Some(pruned)
+}
+
+/// Drops unread columns from a projection-only derived relation. The join
+/// and filter below it still read every column they require; only values no
+/// parent consumes stop crossing the derived-table boundary.
+fn prune_unread_pass_through_columns(select: &SelectStmt, needed: &[usize]) -> Option<SelectStmt> {
+    if select.from.is_none()
+        || select.with.is_some()
+        || !select.values.is_empty()
+        || select.distinct
+        || select.rollup
+        || !select.group_by.is_empty()
+        || select.having.is_some()
+        || !select.windows.is_empty()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || !select.fields.fields().iter().all(|field| {
+            matches!(
+                field,
+                SelectField::Expr {
+                    expr: Expr::Column(_),
+                    ..
+                }
+            )
+        })
+    {
+        return None;
+    }
+
+    let fields = select
+        .fields
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| needed.contains(index))
+        .map(|(_, field)| field.clone())
+        .collect::<Vec<_>>();
+    if fields.is_empty() || fields.len() == select.fields.fields().len() {
         return None;
     }
 
@@ -297,4 +456,63 @@ fn is_side_effect_free_argument(expr: &Expr) -> bool {
             | Expr::Null
             | Expr::Bool(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demand_crosses_pass_through_join_before_pruning_group_carrier() {
+        let statement = tidb_parser::parse(
+            r#"SELECT t.c1,t.sm,t.smh FROM (
+                 SELECT o.c_id,o.c_d_id,o.c_w_id,o.c1,o.sm,h.smh FROM (
+                   SELECT c.c_id,c.c_d_id,c.c_w_id,c.c_balance AS c1,
+                          SUM(ol.amount) AS sm
+                   FROM customer c LEFT JOIN ol
+                     ON c.c_id=ol.c_id AND c.c_d_id=ol.c_d_id
+                   GROUP BY c.c_d_id,c.c_id,c.c_w_id
+                 ) o LEFT JOIN (
+                   SELECT SUM(h.amount) AS smh,h.c_d_id,h.c_id FROM history h
+                   GROUP BY h.c_d_id,h.c_id
+                 ) h ON o.c_d_id=h.c_d_id AND o.c_id=h.c_id
+               ) t"#,
+        )
+        .unwrap();
+        let tidb_ast::Stmt::Query(query) = statement else {
+            panic!("not a query");
+        };
+        let QueryStmt::Select(select) = &*query else {
+            panic!("not a SELECT");
+        };
+
+        let pruned = prune(select).expect("the pass-through projection is reducible");
+        let JoinNode::Derived { subquery: top, .. } =
+            &pruned.from.as_ref().expect("outer FROM").left
+        else {
+            panic!("outer source is not derived");
+        };
+        let QueryStmt::Select(pass_through) = &**top else {
+            panic!("outer derived query is not a SELECT");
+        };
+        assert_eq!(
+            super::super::from::derived_field_names(pass_through).unwrap(),
+            ["c1", "sm", "smh"]
+        );
+
+        let JoinNode::Derived {
+            subquery: grouped, ..
+        } = &pass_through.from.as_ref().expect("pass-through FROM").left
+        else {
+            panic!("grouped outer source is not derived");
+        };
+        let QueryStmt::Select(grouped) = &**grouped else {
+            panic!("grouped query is not a SELECT");
+        };
+        assert_eq!(
+            super::super::from::derived_field_names(grouped).unwrap(),
+            ["c_id", "c_d_id", "c1", "sm"]
+        );
+        assert_eq!(grouped.group_by.len(), 3);
+    }
 }

--- a/rust/crates/tidb-executor/src/driver/derived_projection_pushdown.rs
+++ b/rust/crates/tidb-executor/src/driver/derived_projection_pushdown.rs
@@ -1,0 +1,466 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Predicate pushdown through a pass-through derived projection.
+//!
+//! Go builds a `LogicalProjection` for a derived table, substitutes its
+//! defining expressions into predicates above it, and then runs predicate
+//! pushdown and `simplifyOuterJoin`. The TPCC condition-06 query depends on
+//! the whole chain: a `COUNT(1)` over two bare projected columns can fuse with
+//! the inner SELECT; the substituted inequality rejects the LEFT JOIN's NULL
+//! row and makes it an inner join; its nullable left operand contributes an
+//! `IS NOT NULL` leaf filter; and a constant on the left join key reaches the
+//! grouped derived table on the right.
+//!
+//! The rewrites here are deliberately narrow and proof-oriented. Fusion is
+//! accepted only for a global `COUNT(1)` over one non-lateral derived SELECT
+//! whose projection consists entirely of bare columns and whose row count is
+//! not changed by DISTINCT, grouping, ordering, LIMIT, windows, locks, or
+//! SELECT modifiers. A filter offered to a grouped derived table is accepted
+//! only when every referenced output is itself a selected group-key column;
+//! aggregate outputs never move below the aggregation.
+
+use tidb_ast::{
+    Expr, IsTarget, Join, JoinNode, JoinType, QueryStmt, SelectField, SelectStatementKind,
+    SelectStmt, StatementPriority,
+};
+
+use super::catalog::Catalog;
+
+/// Fuses a global COUNT over a pass-through derived SELECT, then applies Go's
+/// NULL-rejecting outer-join simplification and derived not-null predicate.
+pub(crate) fn fuse_global_count(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<SelectStmt> {
+    if !plain_global_count(select) {
+        return None;
+    }
+    let from = select.from.as_ref()?;
+    if from.right.is_some() || from.on.is_some() || from.natural || !from.using.is_empty() {
+        return None;
+    }
+    let JoinNode::Derived {
+        subquery,
+        alias: Some(alias),
+        lateral: false,
+        column_names,
+    } = &from.left
+    else {
+        return None;
+    };
+    if !column_names.is_empty() {
+        return None;
+    }
+    let QueryStmt::Select(inner) = &**subquery else {
+        return None;
+    };
+    if !pass_through_select(inner) {
+        return None;
+    }
+    let definitions = pass_through_definitions(inner)?;
+    let outer_filter = substitute_outputs(select.where_clause.as_ref()?, alias, &definitions)?;
+
+    let mut fused = (**inner).clone();
+    fused.fields = select.fields.clone();
+    fused.where_clause = and(fused.where_clause.take(), Some(outer_filter.clone()));
+    let simplified = simplify_outer_join(&mut fused, catalog, current_db);
+    if simplified {
+        inject_left_not_null_filters(&mut fused, &outer_filter, catalog, current_db);
+    }
+    Some(fused)
+}
+
+/// Pushes filters attributed to a derived relation through its projection.
+/// Grouped SELECTs accept only selected bare group keys, so a predicate can
+/// never be moved from HAVING semantics into WHERE semantics by this helper.
+pub(crate) fn push_filters_into_derived(
+    subquery: &QueryStmt,
+    alias: &str,
+    column_names: &[String],
+    predicate: &Expr,
+) -> Option<QueryStmt> {
+    if !column_names.is_empty() {
+        return None;
+    }
+    let QueryStmt::Select(select) = subquery else {
+        return None;
+    };
+    if select.from.is_none()
+        || select.distinct
+        || select.rollup
+        || select.having.is_some()
+        || select.limit.is_some()
+        || !select.windows.is_empty()
+        || select.lock.is_some()
+        || select.into_outfile.is_some()
+    {
+        return None;
+    }
+    let definitions = group_key_definitions(select)?;
+    let pushed = substitute_outputs(predicate, alias, &definitions)?;
+    let mut rewritten = select.clone();
+    rewritten.where_clause = and(rewritten.where_clause.take(), Some(pushed));
+    Some(QueryStmt::Select(rewritten))
+}
+
+fn plain_global_count(select: &SelectStmt) -> bool {
+    if select.with.is_some()
+        || !select.hints.is_empty()
+        || select.sql_small_result
+        || select.sql_big_result
+        || select.sql_buffer_result
+        || select.sql_no_cache
+        || select.straight_join
+        || select.calc_found_rows
+        || select.kind != SelectStatementKind::Select
+        || select.priority != StatementPriority::None
+        || select.distinct
+        || select.all
+        || !select.values.is_empty()
+        || !select.group_by.is_empty()
+        || select.rollup
+        || select.having.is_some()
+        || !select.windows.is_empty()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || select.lock.is_some()
+        || select.into_outfile.is_some()
+        || select.where_clause.is_none()
+    {
+        return false;
+    }
+    matches!(
+        select.fields.fields(),
+        [SelectField::Expr {
+            expr: Expr::Aggregate {
+                name,
+                distinct: false,
+                args,
+            },
+            ..
+        }] if name.eq_ignore_ascii_case("count")
+            && matches!(args.as_slice(), [Expr::Int(one)] if one == "1")
+    )
+}
+
+fn pass_through_select(select: &SelectStmt) -> bool {
+    select.from.is_some()
+        && select.with.is_none()
+        && !select.distinct
+        && !select.rollup
+        && select.group_by.is_empty()
+        && select.having.is_none()
+        && select.windows.is_empty()
+        && select.order_by.is_empty()
+        && select.limit.is_none()
+        && select.lock.is_none()
+        && select.into_outfile.is_none()
+        && select.values.is_empty()
+        && select.fields.fields().iter().all(|field| {
+            matches!(
+                field,
+                SelectField::Expr {
+                    expr: Expr::Column(_),
+                    ..
+                }
+            )
+        })
+}
+
+fn pass_through_definitions(select: &SelectStmt) -> Option<Vec<(String, Expr)>> {
+    let names = super::from::derived_field_names(select)?;
+    unique_definitions(
+        names
+            .into_iter()
+            .zip(select.fields.fields())
+            .map(|(name, field)| match field {
+                SelectField::Expr {
+                    expr: expr @ Expr::Column(_),
+                    ..
+                } => Some((name, expr.clone())),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?,
+    )
+}
+
+fn group_key_definitions(select: &SelectStmt) -> Option<Vec<(String, Expr)>> {
+    let names = super::from::derived_field_names(select)?;
+    let definitions = names
+        .into_iter()
+        .zip(select.fields.fields())
+        .filter_map(|(name, field)| match field {
+            SelectField::Expr {
+                expr: expr @ Expr::Column(path),
+                ..
+            } if select.group_by.iter().any(
+                |group| matches!(&group.expr, Expr::Column(group_path) if group_path == path),
+            ) =>
+            {
+                Some((name, expr.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    unique_definitions(definitions)
+}
+
+fn unique_definitions(definitions: Vec<(String, Expr)>) -> Option<Vec<(String, Expr)>> {
+    for (index, (name, _)) in definitions.iter().enumerate() {
+        if definitions[..index]
+            .iter()
+            .any(|(earlier, _)| earlier.eq_ignore_ascii_case(name))
+        {
+            return None;
+        }
+    }
+    Some(definitions)
+}
+
+fn substitute_outputs(
+    predicate: &Expr,
+    alias: &str,
+    definitions: &[(String, Expr)],
+) -> Option<Expr> {
+    struct Rewrite<'a> {
+        alias: &'a str,
+        definitions: &'a [(String, Expr)],
+        ok: bool,
+    }
+    impl tidb_ast::Visitor for Rewrite<'_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            let Some(expr) = node.downcast_mut::<Expr>() else {
+                return false;
+            };
+            if matches!(
+                expr,
+                Expr::Subquery(_)
+                    | Expr::Exists { .. }
+                    | Expr::InSubquery { .. }
+                    | Expr::CompareSubquery { .. }
+            ) {
+                self.ok = false;
+                return true;
+            }
+            let Expr::Column(path) = expr else {
+                return false;
+            };
+            let name = match path.as_slice() {
+                [name] => name,
+                [qualifier, name] | [_, qualifier, name]
+                    if qualifier.eq_ignore_ascii_case(self.alias) =>
+                {
+                    name
+                }
+                [_, _] | [_, _, _] => {
+                    self.ok = false;
+                    return true;
+                }
+                _ => {
+                    self.ok = false;
+                    return true;
+                }
+            };
+            let Some((_, defining)) = self
+                .definitions
+                .iter()
+                .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+            else {
+                self.ok = false;
+                return true;
+            };
+            *expr = defining.clone();
+            true
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut rewritten = predicate.clone();
+    let mut visitor = Rewrite {
+        alias,
+        definitions,
+        ok: true,
+    };
+    tidb_ast::Visitable::accept(&mut rewritten, &mut visitor);
+    visitor.ok.then_some(rewritten)
+}
+
+fn simplify_outer_join(select: &mut SelectStmt, catalog: &Catalog, current_db: &str) -> bool {
+    let where_clause = match &select.where_clause {
+        Some(predicate) => predicate,
+        None => return false,
+    };
+    let join = match select.from.as_ref().and_then(top_join) {
+        Some(join) => join,
+        None => return false,
+    };
+    if !matches!(join.tp, JoinType::Left | JoinType::Right)
+        || join.natural
+        || !join.using.is_empty()
+    {
+        return false;
+    }
+    let right = match &join.right {
+        Some(right) => right,
+        None => return false,
+    };
+    let offered = super::predicate_push_down::offered_conjuncts(Some(where_clause));
+    let joined = match super::merge_decision::join_properties(
+        join,
+        catalog,
+        current_db,
+        &offered,
+        super::merge_decision::Phase::Promise,
+    ) {
+        Some(properties) => properties,
+        None => return false,
+    };
+    let left =
+        match super::merge_decision::possible_properties(&join.left, catalog, current_db, &offered)
+        {
+            Some(properties) => properties,
+            None => return false,
+        };
+    let right =
+        match super::merge_decision::possible_properties(right, catalog, current_db, &offered) {
+            Some(properties) => properties,
+            None => return false,
+        };
+    let rejects = match join.tp {
+        JoinType::Left => left.width..left.width + right.width,
+        JoinType::Right => 0..left.width,
+        JoinType::Cross => return false,
+    }
+    .any(|offset| {
+        super::funcdep::null_reject::is_null_rejected(where_clause, offset, &|path| {
+            joined.offset_of(path)
+        })
+    });
+    if !rejects {
+        return false;
+    }
+    let Some(join) = select.from.as_mut().and_then(top_join_mut) else {
+        return false;
+    };
+    join.tp = JoinType::Cross;
+    true
+}
+
+fn inject_left_not_null_filters(
+    select: &mut SelectStmt,
+    pushed_filter: &Expr,
+    catalog: &Catalog,
+    current_db: &str,
+) {
+    let Some(join) = select.from.as_ref().and_then(top_join) else {
+        return;
+    };
+    if join.tp != JoinType::Cross {
+        return;
+    }
+    let offered = super::predicate_push_down::offered_conjuncts(select.where_clause.as_ref());
+    let Some(joined) = super::merge_decision::join_properties(
+        join,
+        catalog,
+        current_db,
+        &offered,
+        super::merge_decision::Phase::Promise,
+    ) else {
+        return;
+    };
+    let Some(left) =
+        super::merge_decision::possible_properties(&join.left, catalog, current_db, &offered)
+    else {
+        return;
+    };
+    let mut paths = Vec::new();
+    collect_column_paths(pushed_filter, &mut paths);
+    for path in paths {
+        let Some(offset) = joined.offset_of(&path) else {
+            continue;
+        };
+        if offset >= left.width
+            || !super::funcdep::null_reject::is_null_rejected(pushed_filter, offset, &|path| {
+                joined.offset_of(path)
+            })
+        {
+            continue;
+        }
+        let predicate = Expr::Is {
+            expr: Box::new(Expr::Column(path)),
+            target: IsTarget::Null,
+            not: true,
+        };
+        select.where_clause = and(select.where_clause.take(), Some(predicate));
+    }
+}
+
+fn collect_column_paths(expr: &Expr, out: &mut Vec<Vec<String>>) {
+    struct Collect<'a>(&'a mut Vec<Vec<String>>);
+    impl tidb_ast::Visitor for Collect<'_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            if let Some(Expr::Column(path)) = node.downcast_ref::<Expr>() {
+                if !self.0.contains(path) {
+                    self.0.push(path.clone());
+                }
+            }
+            false
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+    let mut owned = expr.clone();
+    tidb_ast::Visitable::accept(&mut owned, &mut Collect(out));
+}
+
+fn top_join(join: &Join) -> Option<&Join> {
+    if join.right.is_none() && join.on.is_none() && join.using.is_empty() && !join.natural {
+        if let JoinNode::Join(inner) = &join.left {
+            return top_join(inner);
+        }
+    }
+    join.right.as_ref().map(|_| join)
+}
+
+fn top_join_mut(join: &mut Join) -> Option<&mut Join> {
+    if join.right.is_some() {
+        return Some(join);
+    }
+    if join.on.is_some() || !join.using.is_empty() || join.natural {
+        return None;
+    }
+    match &mut join.left {
+        JoinNode::Join(inner) => top_join_mut(inner),
+        JoinNode::Table(_) | JoinNode::Derived { .. } => None,
+    }
+}
+
+fn and(left: Option<Expr>, right: Option<Expr>) -> Option<Expr> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(Expr::Binary(
+            tidb_ast::BinaryOp::LogicAnd,
+            Box::new(left),
+            Box::new(right),
+        )),
+        (Some(expr), None) | (None, Some(expr)) => Some(expr),
+        (None, None) => None,
+    }
+}

--- a/rust/crates/tidb-executor/src/driver/derived_projection_pushdown.rs
+++ b/rust/crates/tidb-executor/src/driver/derived_projection_pushdown.rs
@@ -36,7 +36,293 @@ use tidb_ast::{
     SelectStmt, StatementPriority,
 };
 
-use super::catalog::Catalog;
+use super::catalog::{split_table_path, Catalog};
+
+/// Expands wildcards inside derived SELECTs against their already-known FROM
+/// schema. Go performs this while building the derived projection, before
+/// predicate pushdown and column pruning inspect that projection's outputs.
+///
+/// The top-level SELECT is deliberately left alone. Only nested SELECTs are
+/// rewritten, and a wildcard is expanded only when every source column can be
+/// identified without executing the query. NATURAL/USING joins and set
+/// operations therefore remain in their original form.
+pub(crate) fn expand_derived_wildcards(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<SelectStmt> {
+    let mut rewritten = select.clone();
+    let changed = rewritten
+        .from
+        .as_mut()
+        .is_some_and(|from| expand_join_derived_wildcards(from, catalog, current_db));
+    changed.then_some(rewritten)
+}
+
+/// Pushes leaf-local WHERE predicates into derived SELECTs before column
+/// pruning. This is the logical half of the same RowSource inventory the
+/// physical builder later uses: constants are propagated across inner join
+/// equalities, predicates are substituted through projections, and only the
+/// predicates proven installed in a derived child are removed from the
+/// parent WHERE. Join equalities and `other cond` predicates stay at their
+/// join so the physical builder can install them there.
+pub(crate) fn push_local_predicates_into_derived(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> Option<SelectStmt> {
+    let mut rewritten = select.clone();
+    push_select_predicates(&mut rewritten, catalog, current_db, ctx).then_some(rewritten)
+}
+
+fn expand_join_derived_wildcards(join: &mut Join, catalog: &Catalog, current_db: &str) -> bool {
+    let mut changed = expand_node_derived_wildcards(&mut join.left, catalog, current_db);
+    if let Some(right) = &mut join.right {
+        changed |= expand_node_derived_wildcards(right, catalog, current_db);
+    }
+    changed
+}
+
+fn expand_node_derived_wildcards(node: &mut JoinNode, catalog: &Catalog, current_db: &str) -> bool {
+    match node {
+        JoinNode::Table(_) => false,
+        JoinNode::Join(join) => expand_join_derived_wildcards(join, catalog, current_db),
+        JoinNode::Derived { subquery, .. } => {
+            let QueryStmt::Select(select) = &mut **subquery else {
+                return false;
+            };
+            let mut changed = select
+                .from
+                .as_mut()
+                .is_some_and(|from| expand_join_derived_wildcards(from, catalog, current_db));
+            if select
+                .fields
+                .fields()
+                .iter()
+                .any(|field| matches!(field, SelectField::Wildcard(_)))
+            {
+                if let Some(fields) = expanded_fields(select, catalog, current_db) {
+                    select.fields = fields.into();
+                    changed = true;
+                }
+            }
+            changed
+        }
+    }
+}
+
+fn expanded_fields(
+    select: &SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<Vec<SelectField>> {
+    let columns = join_output_columns(select.from.as_ref()?, catalog, current_db)?;
+    let mut expanded = Vec::new();
+    for field in select.fields.fields() {
+        let SelectField::Wildcard(path) = field else {
+            expanded.push(field.clone());
+            continue;
+        };
+        let qualifier = path.last();
+        let mut matched = false;
+        for (relation, column) in &columns {
+            if qualifier.is_some_and(|wanted| !relation.eq_ignore_ascii_case(wanted)) {
+                continue;
+            }
+            matched = true;
+            expanded.push(SelectField::Expr {
+                expr: Expr::Column(vec![relation.clone(), column.clone()]),
+                alias: None,
+            });
+        }
+        if !matched {
+            return None;
+        }
+    }
+    Some(expanded)
+}
+
+fn join_output_columns(
+    join: &Join,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<Vec<(String, String)>> {
+    if join.natural || !join.using.is_empty() {
+        return None;
+    }
+    let mut columns = node_output_columns(&join.left, catalog, current_db)?;
+    if let Some(right) = &join.right {
+        columns.extend(node_output_columns(right, catalog, current_db)?);
+    }
+    Some(columns)
+}
+
+fn node_output_columns(
+    node: &JoinNode,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<Vec<(String, String)>> {
+    match node {
+        JoinNode::Table(table) => {
+            let (database, name) = split_table_path(&table.name, current_db).ok()?;
+            let visible = table.alias.as_deref().unwrap_or(name).to_owned();
+            Some(
+                catalog
+                    .get_in(database, name)?
+                    .column_list()
+                    .into_iter()
+                    .map(|(column, _)| (visible.clone(), column))
+                    .collect(),
+            )
+        }
+        JoinNode::Join(join) => join_output_columns(join, catalog, current_db),
+        JoinNode::Derived {
+            subquery,
+            alias: Some(alias),
+            lateral: false,
+            column_names,
+        } => {
+            let QueryStmt::Select(select) = &**subquery else {
+                return None;
+            };
+            let mut names = super::from::derived_field_names(select)?;
+            if !column_names.is_empty() {
+                if column_names.len() != names.len() {
+                    return None;
+                }
+                names.clone_from(column_names);
+            }
+            Some(
+                names
+                    .into_iter()
+                    .map(|column| (alias.clone(), column))
+                    .collect(),
+            )
+        }
+        JoinNode::Derived { .. } => None,
+    }
+}
+
+fn push_select_predicates(
+    select: &mut SelectStmt,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    let rows = select.from.as_ref().and_then(|from| {
+        super::join_reorder::row_source(
+            from,
+            select.where_clause.as_ref(),
+            catalog,
+            current_db,
+            ctx,
+        )
+    });
+    let mut changed = false;
+    if let (Some(from), Some(rows)) = (&mut select.from, rows.as_ref()) {
+        let predicates_pushed = push_join_predicates(from, rows, catalog, current_db, ctx);
+        if predicates_pushed {
+            select.where_clause = rows.residual_where_after_logical_leaf_pushdown();
+            changed = true;
+        }
+    }
+    if let Some(from) = &mut select.from {
+        changed |= recurse_join_predicates(from, catalog, current_db, ctx);
+    }
+    changed
+}
+
+fn push_join_predicates(
+    join: &mut Join,
+    rows: &super::join_reorder::RowSource,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    let mut changed = push_node_predicates(&mut join.left, rows, catalog, current_db, ctx);
+    if let Some(right) = &mut join.right {
+        changed |= push_node_predicates(right, rows, catalog, current_db, ctx);
+    }
+    changed
+}
+
+fn push_node_predicates(
+    node: &mut JoinNode,
+    rows: &super::join_reorder::RowSource,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    match node {
+        JoinNode::Table(_) => false,
+        JoinNode::Join(join) => push_join_predicates(join, rows, catalog, current_db, ctx),
+        JoinNode::Derived {
+            subquery,
+            alias: Some(alias),
+            column_names,
+            lateral: false,
+        } => {
+            let QueryStmt::Select(select) = &**subquery else {
+                return false;
+            };
+            if !pass_through_select(select) {
+                // Direct grouped relations already receive their local
+                // filters from the physical RowSource walk. The early pass is
+                // needed only to cross an intervening projection before
+                // column pruning decides which projection outputs survive.
+                return false;
+            }
+            let predicate = rows.filters_for(alias).and_then(|filters| {
+                filters.iter().cloned().reduce(|left, right| {
+                    Expr::Binary(
+                        tidb_ast::BinaryOp::LogicAnd,
+                        Box::new(left),
+                        Box::new(right),
+                    )
+                })
+            });
+            let Some(rewritten) = predicate.as_ref().and_then(|predicate| {
+                push_filters_into_derived(subquery, alias, column_names, predicate)
+            }) else {
+                return false;
+            };
+            **subquery = rewritten;
+            rows.mark_leaf_filters_consumed(alias);
+            true
+        }
+        JoinNode::Derived { .. } => false,
+    }
+}
+
+fn recurse_join_predicates(
+    join: &mut Join,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    let mut changed = recurse_node_predicates(&mut join.left, catalog, current_db, ctx);
+    if let Some(right) = &mut join.right {
+        changed |= recurse_node_predicates(right, catalog, current_db, ctx);
+    }
+    changed
+}
+
+fn recurse_node_predicates(
+    node: &mut JoinNode,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+) -> bool {
+    match node {
+        JoinNode::Table(_) => false,
+        JoinNode::Join(join) => recurse_join_predicates(join, catalog, current_db, ctx),
+        JoinNode::Derived { subquery, .. } => match &mut **subquery {
+            QueryStmt::Select(select) => push_select_predicates(select, catalog, current_db, ctx),
+            QueryStmt::SetOpr(_) => false,
+        },
+    }
+}
 
 /// Fuses a global COUNT over a pass-through derived SELECT, then applies Go's
 /// NULL-rejecting outer-join simplification and derived not-null predicate.
@@ -109,10 +395,17 @@ pub(crate) fn push_filters_into_derived(
     {
         return None;
     }
-    let definitions = group_key_definitions(select)?;
+    let definitions = if select.group_by.is_empty() {
+        if !pass_through_select(select) {
+            return None;
+        }
+        pass_through_definitions(select)?
+    } else {
+        group_key_definitions(select)?
+    };
     let pushed = substitute_outputs(predicate, alias, &definitions)?;
     let mut rewritten = select.clone();
-    rewritten.where_clause = and(rewritten.where_clause.take(), Some(pushed));
+    rewritten.where_clause = and_unique(rewritten.where_clause.take(), pushed);
     Some(QueryStmt::Select(rewritten))
 }
 
@@ -402,6 +695,19 @@ fn inject_left_not_null_filters(
         {
             continue;
         }
+        let Some(column) = left.column_at(offset) else {
+            continue;
+        };
+        if super::merge_decision::physical_column_is_nullable(
+            &join.left, &column, catalog, current_db,
+        ) != Some(true)
+        {
+            // Go derives this leaf predicate only for a nullable base
+            // column. NOT NULL columns are already proven, while aggregate
+            // and computed outputs cannot be pushed through as a base-table
+            // null test.
+            continue;
+        }
         let predicate = Expr::Is {
             expr: Box::new(Expr::Column(path)),
             target: IsTarget::Null,
@@ -463,4 +769,26 @@ fn and(left: Option<Expr>, right: Option<Expr>) -> Option<Expr> {
         (Some(expr), None) | (None, Some(expr)) => Some(expr),
         (None, None) => None,
     }
+}
+
+fn and_unique(left: Option<Expr>, right: Expr) -> Option<Expr> {
+    let mut conjuncts = Vec::new();
+    if let Some(left) = &left {
+        crate::plan_trace::collect_and(left, &mut conjuncts);
+    }
+    let mut offered = Vec::new();
+    crate::plan_trace::collect_and(&right, &mut offered);
+    let mut combined = conjuncts.into_iter().cloned().collect::<Vec<_>>();
+    for conjunct in offered {
+        if !combined.contains(conjunct) {
+            combined.push(conjunct.clone());
+        }
+    }
+    combined.into_iter().reduce(|left, right| {
+        Expr::Binary(
+            tidb_ast::BinaryOp::LogicAnd,
+            Box::new(left),
+            Box::new(right),
+        )
+    })
 }

--- a/rust/crates/tidb-executor/src/driver/dml.rs
+++ b/rust/crates/tidb-executor/src/driver/dml.rs
@@ -705,7 +705,7 @@ pub(crate) fn run_insert_traced(
         }
         let conflicts = target(catalog, &database, &table_name)
             .conflicting_handles(row, &ctx.session_zone())
-            .map_err(|e| DriverError::Parse(format!("conflict lookup failed: {e:?}")))?;
+            .map_err(|e| kv_read_error("conflict lookup failed", e))?;
         if !conflicts.is_empty() {
             if insert.replace {
                 // Go `InsertValues.removeRow` (`insert_common.go`): a
@@ -719,7 +719,7 @@ pub(crate) fn run_insert_traced(
                 for handle in &conflicts {
                     let existing = target(catalog, &database, &table_name)
                         .get_row_by_handle(handle, &ctx.session_zone())
-                        .map_err(|e| DriverError::Parse(format!("row read failed: {e:?}")))?;
+                        .map_err(|e| kv_read_error("row read failed", e))?;
                     if existing.as_deref() == Some(row) {
                         inserted += 1;
                         unchanged = true;
@@ -746,7 +746,7 @@ pub(crate) fn run_insert_traced(
                     // row.
                     target(catalog, &database, &table_name)
                         .delete_row(handle, &ctx.session_zone())
-                        .map_err(|e| DriverError::Parse(format!("row delete failed: {e:?}")))?;
+                        .map_err(|e| kv_read_error("row delete failed", e))?;
                     inserted += 1;
                 }
                 if unchanged {
@@ -766,7 +766,7 @@ pub(crate) fn run_insert_traced(
             } else if insert.ignore {
                 let reported = target(catalog, &database, &table_name)
                     .duplicate_entry_error(row, &ctx.session_zone())
-                    .map_err(|e| DriverError::Parse(format!("conflict lookup failed: {e:?}")))?;
+                    .map_err(|e| kv_read_error("conflict lookup failed", e))?;
                 if let crate::kv_table::KvTableError::DuplicateEntry { value, key } = reported {
                     let warning = DriverError::DuplicateEntry { value, key }.to_mysql_error();
                     ctx.append_warning_parts(warning.code, &warning.message);
@@ -801,6 +801,9 @@ pub(crate) fn run_insert_traced(
 /// would replace the code an application branches on.
 pub(crate) fn kv_write_error(error: crate::kv_table::KvTableError) -> DriverError {
     match error {
+        crate::kv_table::KvTableError::Storage(message) if message.starts_with("Retryable(") => {
+            DriverError::Txn(crate::TxnErrorKind::RegionUnavailable)
+        }
         crate::kv_table::KvTableError::DuplicateEntry { value, key } => {
             DriverError::DuplicateEntry { value, key }
         }
@@ -826,6 +829,17 @@ pub(crate) fn kv_write_error(error: crate::kv_table::KvTableError) -> DriverErro
         // same 1467 an allocated column value would have reported.
         crate::kv_table::KvTableError::AutoIdExhausted => DriverError::AutoincReadFailed,
         other => DriverError::Parse(format!("row encode failed: {other:?}")),
+    }
+}
+
+/// Renders a table read failure while preserving the storage layer's
+/// retryable-region signal as a transaction error instead of a parse error.
+pub(crate) fn kv_read_error(operation: &str, error: crate::kv_table::KvTableError) -> DriverError {
+    match error {
+        crate::kv_table::KvTableError::Storage(message) if message.starts_with("Retryable(") => {
+            DriverError::Txn(crate::TxnErrorKind::RegionUnavailable)
+        }
+        other => DriverError::Parse(format!("{operation}: {other:?}")),
     }
 }
 
@@ -1082,7 +1096,7 @@ pub(crate) fn apply_on_duplicate(
 ) -> Result<u64, DriverError> {
     let Some(existing) = table
         .get_row_by_handle(handle, &ctx.session_zone())
-        .map_err(|e| DriverError::Parse(format!("row read failed: {e:?}")))?
+        .map_err(|e| kv_read_error("row read failed", e))?
     else {
         return Ok(0);
     };
@@ -1427,36 +1441,47 @@ pub(crate) fn run_update_traced(
     // key, otherwise the handle intervals it implies. See
     // `access::write_read_path` for the Go functions this mirrors and for why
     // neither narrowing can change which rows the statement acts on.
-    let read_path = super::access::write_read_path(
-        catalog,
-        &database,
-        &name,
-        &super::access::PointPlanStmt::of_write(
-            update.where_clause.as_ref(),
-            &update.order_by,
-            update.limit.as_ref(),
+    let point_plan = super::access::PointPlanStmt::of_write(
+        update.where_clause.as_ref(),
+        &update.order_by,
+        update.limit.as_ref(),
+    );
+    let read_path = super::access::write_read_path(catalog, &database, &name, &point_plan, &zone)?;
+    let predicate_consumed = match catalog.get_in(&database, &name) {
+        Some(TableEntry::Kv(table)) => super::access::write_read_path_consumes_predicate(
+            read_path.as_ref(),
+            &point_plan,
+            table,
+            &column_list,
+            &zone,
         ),
-        &ctx.session_zone(),
-    )?;
+        _ => false,
+    };
     if let Some(trace) = trace.as_deref_mut() {
         trace_dml_source(
             trace,
-            catalog,
-            DmlTarget {
-                table_ref,
-                database: &database,
-                name: &name,
+            DmlSourceTrace {
+                catalog,
+                target: DmlTarget {
+                    table_ref,
+                    database: &database,
+                    name: &name,
+                },
+                columns: &column_list,
+                predicate: &update.where_clause,
+                read_path: read_path.as_ref(),
+                current_db,
+                zone: &zone,
+                ctx,
+                predicate_consumed,
             },
-            &column_list,
-            &update.where_clause,
-            read_path.as_ref(),
-            current_db,
         );
         trace.write("Update", true);
         if trace.is_plan_only() {
             return Ok(0);
         }
     }
+    let predicate = if predicate_consumed { None } else { predicate };
     // Assigned by every arm that reaches the loops below (a view returns
     // before them), so a write's read plan always reports a real count.
     let scanned;
@@ -1788,36 +1813,47 @@ pub(crate) fn run_delete_traced(
     let row_limit = dml_row_limit(&delete.limit)?;
     // As in UPDATE: the key or the handle intervals the `WHERE` implies are
     // the records this write fetches.
-    let read_path = super::access::write_read_path(
-        catalog,
-        &database,
-        &name,
-        &super::access::PointPlanStmt::of_write(
-            delete.where_clause.as_ref(),
-            &delete.order_by,
-            delete.limit.as_ref(),
+    let point_plan = super::access::PointPlanStmt::of_write(
+        delete.where_clause.as_ref(),
+        &delete.order_by,
+        delete.limit.as_ref(),
+    );
+    let read_path = super::access::write_read_path(catalog, &database, &name, &point_plan, &zone)?;
+    let predicate_consumed = match catalog.get_in(&database, &name) {
+        Some(TableEntry::Kv(table)) => super::access::write_read_path_consumes_predicate(
+            read_path.as_ref(),
+            &point_plan,
+            table,
+            &column_list,
+            &zone,
         ),
-        &ctx.session_zone(),
-    )?;
+        _ => false,
+    };
     if let Some(trace) = trace.as_deref_mut() {
         trace_dml_source(
             trace,
-            catalog,
-            DmlTarget {
-                table_ref,
-                database: &database,
-                name: &name,
+            DmlSourceTrace {
+                catalog,
+                target: DmlTarget {
+                    table_ref,
+                    database: &database,
+                    name: &name,
+                },
+                columns: &column_list,
+                predicate: &delete.where_clause,
+                read_path: read_path.as_ref(),
+                current_db,
+                zone: &zone,
+                ctx,
+                predicate_consumed,
             },
-            &column_list,
-            &delete.where_clause,
-            read_path.as_ref(),
-            current_db,
         );
         trace.write("Delete", true);
         if trace.is_plan_only() {
             return Ok(0);
         }
     }
+    let predicate = if predicate_consumed { None } else { predicate };
     let scanned;
     let entry = catalog
         .get_mut_in(&database, &name)
@@ -1911,7 +1947,7 @@ pub(crate) fn run_delete_traced(
         };
         for (handle, _) in &doomed {
             kv.delete_row(handle, &zone)
-                .map_err(|e| DriverError::Parse(format!("row delete failed: {e:?}")))?;
+                .map_err(|e| kv_read_error("row delete failed", e))?;
             deleted += 1;
         }
     }
@@ -1954,6 +1990,15 @@ fn fetch_write_rows(
         Some(super::access::WriteReadPath::Ranges(ranges, _)) => kv
             .scan_rows_with_handles_in(Some(ranges), zone)
             .map_err(decode_failed),
+        Some(super::access::WriteReadPath::Batch(handles)) => {
+            let mut rows = Vec::with_capacity(handles.len());
+            for handle in handles {
+                if let Some(row) = kv.get_row_by_handle(handle, zone).map_err(decode_failed)? {
+                    rows.push((handle.clone(), row));
+                }
+            }
+            Ok(rows)
+        }
         Some(super::access::WriteReadPath::IndexRanges(index_id, ranges, _)) => {
             // The index range narrows WHICH records are fetched, in index
             // order; the row is then read by its handle, and the `WHERE` above
@@ -1983,6 +2028,21 @@ fn fetch_write_rows(
 /// `TableRangeScan`, or the full scan neither narrowed -- with a `Selection`
 /// above it for the `WHERE` (`explain`'s divergences 7 and 8).
 ///
+/// Everything required to describe the read side of one single-table write.
+struct DmlSourceTrace<'a> {
+    catalog: &'a Catalog,
+    target: DmlTarget<'a>,
+    columns: &'a [(String, FieldType)],
+    predicate: &'a Option<tidb_ast::Expr>,
+    read_path: Option<&'a super::access::WriteReadPath>,
+    current_db: &'a str,
+    zone: &'a tidb_datatype::SessionTimeZone,
+    ctx: &'a crate::StmtContext,
+    /// The point/batch key is the complete WHERE, so Go's fast write plan
+    /// has no Selection above it.
+    predicate_consumed: bool,
+}
+
 /// The table a single-table write reads, as the statement names it.
 struct DmlTarget<'a> {
     /// The `FROM`-side reference, which carries the alias `EXPLAIN` prints.
@@ -2026,15 +2086,18 @@ fn trace_write_index_scan(
     }
 }
 
-fn trace_dml_source(
-    trace: &mut PlanTrace,
-    catalog: &Catalog,
-    target: DmlTarget<'_>,
-    columns: &[(String, FieldType)],
-    where_clause: &Option<tidb_ast::Expr>,
-    read_path: Option<&super::access::WriteReadPath>,
-    current_db: &str,
-) {
+fn trace_dml_source(trace: &mut PlanTrace, source: DmlSourceTrace<'_>) {
+    let DmlSourceTrace {
+        catalog,
+        target,
+        columns,
+        predicate,
+        read_path,
+        current_db,
+        zone,
+        ctx,
+        predicate_consumed,
+    } = source;
     let DmlTarget {
         table_ref,
         database,
@@ -2047,7 +2110,7 @@ fn trace_dml_source(
         name,
         &visible,
         columns,
-        where_clause.as_ref(),
+        predicate.as_ref(),
     );
     trace.table_full_scan(&visible, estimate, false);
     // The same two rewrites the read side performs, from the same chooser: a
@@ -2057,6 +2120,9 @@ fn trace_dml_source(
     match read_path {
         Some(super::access::WriteReadPath::Ranges(ranges, range_estimate)) => {
             trace.table_range_scan(&visible, ranges, *range_estimate);
+            if predicate_consumed {
+                trace.scan_reader();
+            }
         }
         Some(super::access::WriteReadPath::IndexRanges(index_id, ranges, range_estimate)) => {
             trace_write_index_scan(
@@ -2070,12 +2136,20 @@ fn trace_dml_source(
                 *range_estimate,
             );
         }
+        Some(super::access::WriteReadPath::Batch(handles)) => {
+            if let Some(super::catalog::TableEntry::Kv(table)) = catalog.get_in(database, name) {
+                let partitions = table.handle_partition_names(handles, zone, ctx);
+                trace.batch_point_get(&visible, table, handles, &partitions);
+            }
+        }
         Some(super::access::WriteReadPath::Point(handle)) => {
-            trace.point_get(&visible, handle.as_ref());
+            if let Some(super::catalog::TableEntry::Kv(table)) = catalog.get_in(database, name) {
+                trace.point_get(&visible, table, handle.as_ref());
+            }
         }
         None => {}
     }
-    let Some(predicate) = where_clause else {
+    let Some(predicate) = predicate.as_ref().filter(|_| !predicate_consumed) else {
         return;
     };
     let scope = PlanTrace::single_table_scope(

--- a/rust/crates/tidb-executor/src/driver/errors/exec.rs
+++ b/rust/crates/tidb-executor/src/driver/errors/exec.rs
@@ -43,6 +43,8 @@ const ER_DIVISION_BY_ZERO: u16 = 1365;
 const ER_TRUNCATED_WRONG_VALUE: u16 = 1292;
 /// Go `ErrWarnAllowedPacketOverflowed`.
 const ER_WARN_ALLOWED_PACKET_OVERFLOWED: u16 = 1301;
+/// Go `expression.ErrOperandColumns`.
+const ER_OPERAND_COLUMNS: u16 = tidb_error::mysql::errcode::ErrOperandColumns;
 
 /// The MySQL error an execution failure reaches the client as.
 pub(super) fn to_mysql_error(error: ExecError) -> MysqlError {
@@ -123,6 +125,10 @@ fn eval_to_mysql_error(error: EvalError) -> MysqlError {
         // message and the SQLSTATE is derived from it like the JSON class
         // above.
         EvalError::WrongTemporalLiteral { code, message } => MysqlError::coded(code, message),
+        EvalError::OperandColumns(columns) => MysqlError::coded(
+            ER_OPERAND_COLUMNS,
+            format!("Operand should contain {columns} column(s)"),
+        ),
         // CAPTURED from TiDB: `select 9223372036854775807 + 1` is
         // `1690 / 22003 / BIGINT value is out of range in '(9223372036854775807 + 1)'`,
         // `select 1e308 * 10` the DOUBLE spelling, and a 65-digit product the

--- a/rust/crates/tidb-executor/src/driver/errors/mod.rs
+++ b/rust/crates/tidb-executor/src/driver/errors/mod.rs
@@ -100,7 +100,9 @@ impl MysqlError {
 /// MySQL `ER_PARSE_ERROR`.
 const ER_PARSE_ERROR: u16 = 1064;
 /// TiDB `ErrWriteConflict`.
-const ER_WRITE_CONFLICT: u16 = 9007;
+const ER_WRITE_CONFLICT: u16 = tidb_error::tidb::errcode::ErrWriteConflict;
+/// TiDB `ErrRegionUnavailable`.
+const ER_REGION_UNAVAILABLE: u16 = tidb_error::tidb::errcode::ErrRegionUnavailable;
 /// MySQL `ER_UNKNOWN_SYSTEM_VARIABLE`.
 const ER_UNKNOWN_SYSTEM_VARIABLE: u16 = 1193;
 /// MySQL `ER_INCORRECT_GLOBAL_LOCAL_VAR`.
@@ -134,6 +136,11 @@ impl DriverError {
                 "Write conflict, please retry the transaction".to_owned(),
             )
         }
+        DriverError::Txn(crate::TxnErrorKind::RegionUnavailable) => MysqlError::new(
+            ER_REGION_UNAVAILABLE,
+            *b"HY000",
+            tidb_error::tidb::errname::ErrRegionUnavailable.raw.to_owned(),
+        ),
         // Go: "The used SELECT statements have a different number of columns".
         DriverError::WrongNumberOfColumnsInSelect => MysqlError::new(
             1222,

--- a/rust/crates/tidb-executor/src/driver/errors/txn.rs
+++ b/rust/crates/tidb-executor/src/driver/errors/txn.rs
@@ -18,4 +18,8 @@ pub enum TxnErrorKind {
     /// The catalog moved under the transaction, so committing would discard
     /// another session's writes.
     WriteConflict,
+    /// The storage route was stale or temporarily unavailable. Go exposes
+    /// this as `ErrRegionUnavailable` (9005), which an autocommit statement
+    /// may replay after refreshing its route.
+    RegionUnavailable,
 }

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -2195,11 +2195,11 @@ pub(crate) fn build_join(
                         .expect("a committed merge keeps its logical key names"),
                 )
                 .map(|(key, (left_name, right_name))| {
-                    let left = crate::driver::merge_decision::derived_column_trace_name(
+                    let left = crate::driver::merge_decision::physical_column_trace_name(
                         &join.left, left_name, catalog, current_db,
                     )
                     .unwrap_or_else(|| qualified_scope_column(&scope, current_db, key.left));
-                    let right = crate::driver::merge_decision::derived_column_trace_name(
+                    let right = crate::driver::merge_decision::physical_column_trace_name(
                         right_node, right_name, catalog, current_db,
                     )
                     .unwrap_or_else(|| {

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -557,6 +557,10 @@ pub(crate) fn build_from(
             // offsets. Empty until an index branch fills it in; the table
             // branch's answer is read off the catalog at the end of the arm.
             let mut walked_index: Option<Vec<usize>> = None;
+            // A handle range consumes only its access conjuncts. The
+            // remainder is still executed by the scan as a cop Selection and
+            // must remain visible in the physical plan.
+            let mut access_residual_filter = None;
             let mut access_consumed_filter = false;
             // `RowSource` has already classified predicates that reference
             // only this leaf. Keep them as one local WHERE for range costing;
@@ -670,6 +674,26 @@ pub(crate) fn build_from(
                                 .table_access()
                                 .is_some_and(|access| access.accept_handle_ranges(&ranges));
                             if accepted {
+                                access_residual_filter =
+                                    leaf_where.as_ref().and_then(|predicate| {
+                                        crate::handle_range::build_handle_ranges(
+                                            kv,
+                                            predicate,
+                                            &ctx.session_zone(),
+                                        )?
+                                        .residual
+                                        .into_iter()
+                                        .cloned()
+                                        .reduce(
+                                            |left, right| {
+                                                tidb_ast::Expr::Binary(
+                                                    tidb_ast::BinaryOp::LogicAnd,
+                                                    Box::new(left),
+                                                    Box::new(right),
+                                                )
+                                            },
+                                        )
+                                    });
                                 if let Some(access) = source.table_access() {
                                     access.accept_scan_estimate(estimate.rows);
                                 }
@@ -732,7 +756,7 @@ pub(crate) fn build_from(
                 zone: ctx.session_zone(),
                 ..FromScope::default()
             };
-            if let Some(predicate) = demand.rows.and_then(|rows| {
+            let derived_trace_filter = demand.rows.and_then(|rows| {
                 rows.trace_filters_for(&visible)?
                     .iter()
                     .cloned()
@@ -743,16 +767,45 @@ pub(crate) fn build_from(
                             Box::new(right),
                         )
                     })
-            }) {
+            });
+            let has_access_residual = access_residual_filter.is_some();
+            let trace_filter = match (access_residual_filter, derived_trace_filter) {
+                (Some(left), Some(right)) if left == right => Some(left),
+                (Some(left), Some(right)) => Some(tidb_ast::Expr::Binary(
+                    tidb_ast::BinaryOp::LogicAnd,
+                    Box::new(left),
+                    Box::new(right),
+                )),
+                (Some(predicate), None) | (None, Some(predicate)) => Some(predicate),
+                (None, None) => None,
+            };
+            if let Some(predicate) = trace_filter {
                 if let Some(trace) = trace.as_deref_mut() {
-                    trace.selection(
-                        &predicate,
-                        &crate::plan_trace::Qualifier {
-                            db: current_db,
-                            scope: &scope,
-                        },
-                        Some(1.0),
-                    );
+                    let selectivity = match entry {
+                        TableEntry::Kv(table)
+                            if catalog.table_statistics(table.table_id).is_some() =>
+                        {
+                            crate::driver::access::stats_selectivity(
+                                catalog,
+                                table,
+                                &scope,
+                                Some(&predicate),
+                            )
+                        }
+                        TableEntry::Kv(_) => None,
+                        TableEntry::Mem(_) | TableEntry::View(_) | TableEntry::Sequence(_) => {
+                            Some(1.0)
+                        }
+                    };
+                    let qualify = crate::plan_trace::Qualifier {
+                        db: current_db,
+                        scope: &scope,
+                    };
+                    if has_access_residual {
+                        trace.residual_selection(&predicate, &qualify, selectivity);
+                    } else {
+                        trace.selection(&predicate, &qualify, selectivity);
+                    }
                 }
             }
             // What this leaf DELIVERS -- read off the branch that RAN, which
@@ -810,8 +863,31 @@ pub(crate) fn build_from(
             // of delivering it. Go's `PhysicalProjection.exhaustPhysicalPlans`
             // maps the property through the select list; see
             // `merge_decision::from_required_prop`.
+            let leaf_filter = alias.as_deref().and_then(|visible| {
+                demand.rows.and_then(|rows| {
+                    rows.filters_for(visible)?
+                        .iter()
+                        .cloned()
+                        .reduce(|left, right| {
+                            tidb_ast::Expr::Binary(
+                                tidb_ast::BinaryOp::LogicAnd,
+                                Box::new(left),
+                                Box::new(right),
+                            )
+                        })
+                })
+            });
+            let rewritten_subquery = alias.as_deref().and_then(|visible| {
+                super::derived_projection_pushdown::push_filters_into_derived(
+                    subquery,
+                    visible,
+                    column_names,
+                    leaf_filter.as_ref()?,
+                )
+            });
+            let planned_subquery = rewritten_subquery.as_ref().unwrap_or(subquery);
             let (exec, mut scope, actual_delivered) = build_derived_source(
-                subquery,
+                planned_subquery,
                 alias.as_deref(),
                 catalog,
                 current_db,
@@ -819,6 +895,11 @@ pub(crate) fn build_from(
                 trace,
                 required,
             )?;
+            if rewritten_subquery.is_some() {
+                if let (Some(rows), Some(visible)) = (demand.rows, alias.as_deref()) {
+                    rows.mark_leaf_filters_consumed(visible);
+                }
+            }
             rename_derived_columns(&mut scope.tables[0].columns, column_names)?;
             // A derived table is MATERIALIZED here -- `build_derived_source`
             // drains its subquery into a `MemTableSourceExec`, which replays
@@ -1896,6 +1977,36 @@ pub(crate) fn build_join(
     // `equal:[...]`/`other cond:` and the hash table's own keys are one
     // decision rather than two that can drift.
     let split = crate::hash_join::split_equi(&conditions, left_width);
+    let physical_conditions = {
+        let mut flattened = Vec::new();
+        for condition in &conditions {
+            collect_physical_join_conjuncts(condition, &mut flattened);
+        }
+        let columns = (0..scope.width())
+            .map(|offset| {
+                let path = scope.qualified_path(offset)?;
+                let [.., relation, column] = path.as_slice() else {
+                    return None;
+                };
+                let column = crate::driver::merge_decision::RelColumn {
+                    relation: relation.clone(),
+                    column: column.clone(),
+                };
+                crate::driver::merge_decision::physical_column_trace_name(
+                    if offset < left_width {
+                        &join.left
+                    } else {
+                        right_node
+                    },
+                    &column,
+                    catalog,
+                    current_db,
+                )
+            })
+            .collect::<Vec<_>>();
+        (flattened.len() == split.equal_mask.len() && columns.iter().any(Option::is_none))
+            .then_some((flattened, columns))
+    };
     // Go's stats-less build side: the inner (non-preserved) child, which is
     // the left one only for a RIGHT join. See `join.rs`'s module doc.
     let build_is_left = kind == JoinKind::Right;
@@ -2186,6 +2297,7 @@ pub(crate) fn build_join(
             .as_ref()
             .map_or(build_is_left, |decision| !decision.lookup_is_left),
         index_lookup: index_text,
+        physical_conditions,
         merge_keys: merged.as_ref().map(|plan| {
             plan.keys
                 .iter()
@@ -2297,6 +2409,18 @@ pub(crate) fn build_join(
     // [`FromScope::qualified_star_is_output_only`].
     scope.qualified_star_is_output_only = join.tp == tidb_ast::JoinType::Cross && join.on.is_some();
     Ok((meter(exec, trace), scope, delivered))
+}
+
+fn collect_physical_join_conjuncts(expression: &Expression, out: &mut Vec<Expression>) {
+    if let Expression::ScalarFunction(function) = expression {
+        if function.func_name.lowercase() == "and" {
+            for argument in &function.args {
+                collect_physical_join_conjuncts(argument, out);
+            }
+            return;
+        }
+    }
+    out.push(expression.clone());
 }
 
 /// `kv` with any `PARTITION (p, ...)` restriction on the reference applied,

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -2071,13 +2071,11 @@ pub(crate) fn build_join(
                 .any(|equi| equi.left == key.left && equi.right == key.right)
         })
     });
-    if let Some(plan) = merged.clone() {
-        join_exec.set_merge_plan(plan);
-    }
     // The index strategy: one side read once per outer key rather than whole.
-    // It is asked only where the merge decision declined, and it refuses a
-    // coalesced join for the same reason the merge one is dropped there --
-    // that scope addresses columns by row offset, not by name.
+    // The search may choose it over an available merge plan for a one-row
+    // outer side. It refuses a coalesced join for the same reason the merge
+    // one is dropped there -- that scope addresses columns by row offset, not
+    // by name.
     //
     // WHICH strategy this site may use is asked of Go's own enumeration --
     // `exhaustPhysicalPlans4LogicalJoin` under the property this join was
@@ -2110,7 +2108,15 @@ pub(crate) fn build_join(
             rows: demand.rows,
         })
     };
-    let index_join = (!coalescing && chosen == crate::driver::join_search::Chosen::Index)
+    let estimated_join_rows = crate::driver::join_search::estimated_rows(join, demand.rows);
+    let index_chosen = matches!(
+        chosen,
+        crate::driver::join_search::Chosen::Index
+            | crate::driver::join_search::Chosen::IndexForSingleOuterRow
+    );
+    let single_outer_row_choice =
+        chosen == crate::driver::join_search::Chosen::IndexForSingleOuterRow;
+    let index_join = (!coalescing && index_chosen)
         .then(|| {
             let (left_side, right_side) = crate::driver::index_join_decision::join_sides(
                 join,
@@ -2126,12 +2132,33 @@ pub(crate) fn build_join(
                 &split.keys,
                 &left_side,
                 &right_side,
-                merged.is_some(),
+                merged.is_some() && !single_outer_row_choice,
                 demand.rows,
                 ctx,
             )
         })
         .flatten();
+    let index_join = index_join.filter(|decision| {
+        if !single_outer_row_choice {
+            return true;
+        }
+        let crate::access_path::LookupObject::Index(id) = &decision.object else {
+            return false;
+        };
+        decision
+            .table
+            .indexes()
+            .iter()
+            .find(|index| index.id == *id)
+            .is_some_and(|index| !index.name.eq_ignore_ascii_case("PRIMARY"))
+    });
+    // Commit exactly one strategy to the executor. A chosen index candidate
+    // replaces the merge candidate; if its structural decision fails closed,
+    // retain the already validated merge plan as the fallback.
+    let merged = if index_join.is_some() { None } else { merged };
+    if let Some(plan) = merged.clone() {
+        join_exec.set_merge_plan(plan);
+    }
     let index_text = index_join.as_ref().map(|decision| {
         let mut source = crate::access_path::IndexJoinLookupExec::new_with_context(
             ExecutorMeta::new(
@@ -2178,6 +2205,17 @@ pub(crate) fn build_join(
             crate::access_path::LookupObject::Handle
             | crate::access_path::LookupObject::CommonHandle => false,
         };
+        let needed_columns = demand.columns.map_or_else(
+            || (0..decision.columns.len()).collect::<Vec<_>>(),
+            |columns| columns.needed(&decision.visible, &decision.columns),
+        );
+        let index_lookup = match &decision.object {
+            crate::access_path::LookupObject::Index(id) => {
+                !crate::access_cost::index_is_covering(&decision.table, *id, &needed_columns)
+            }
+            crate::access_path::LookupObject::Handle
+            | crate::access_path::LookupObject::CommonHandle => false,
+        };
         let unique = match &decision.object {
             crate::access_path::LookupObject::Index(id) => decision
                 .table
@@ -2213,6 +2251,15 @@ pub(crate) fn build_join(
                 format!("table:{}", decision.visible)
             }
         };
+        let (estimated_outer_rows, estimated_probe_rows_one) =
+            estimated_join_rows.map_or((None, None), |rows| {
+                let outer = if decision.lookup_is_left {
+                    rows.right
+                } else {
+                    rows.left
+                };
+                (Some(outer), (outer > 0.0).then_some(rows.joined / outer))
+            });
         join_exec.set_index_lookup_plan(crate::join::IndexLookupPlan {
             lookup_is_left: decision.lookup_is_left,
             probe_keys: decision.probe_keys.clone(),
@@ -2221,7 +2268,13 @@ pub(crate) fn build_join(
         join_exec.set_consumes_where(decision.consumes_where);
         (
             crate::plan_trace::IndexJoinText {
-                reader: if index { "IndexReader" } else { "TableReader" },
+                reader: if index_lookup {
+                    "IndexLookUp"
+                } else if index {
+                    "IndexReader"
+                } else {
+                    "TableReader"
+                },
                 keys,
                 lookup_is_left: decision.lookup_is_left,
                 unique,
@@ -2245,11 +2298,15 @@ pub(crate) fn build_join(
                         &right_types
                     },
                 ),
+                estimated_outer_rows,
+                estimated_probe_rows_one,
+                estimated_join_rows: estimated_join_rows.map(|rows| rows.joined),
             },
             decision.lookup_is_left,
             access,
             decision.range_info.clone(),
             index,
+            index_lookup,
         )
     });
     // The plan row and the executor are one decision: if the recorder cannot
@@ -2257,7 +2314,7 @@ pub(crate) fn build_join(
     // refused rather than printed with a whole-table read under an index
     // join. The EXECUTOR is unaffected -- it still answers correctly.
     let index_text = match (index_text, trace.as_deref_mut()) {
-        (Some((text, lookup_is_left, access, range_info, index)), Some(trace)) => {
+        (Some((text, lookup_is_left, access, range_info, index, index_lookup)), Some(trace)) => {
             let decision = index_join
                 .as_ref()
                 .expect("printable index text has an index decision");
@@ -2273,9 +2330,14 @@ pub(crate) fn build_join(
             if trace
                 .index_join_inner_scan(
                     lookup_is_left,
-                    access,
-                    &range_info,
-                    index,
+                    crate::plan_trace::IndexJoinInnerPathText {
+                        access,
+                        range_info: &range_info,
+                        index,
+                        index_lookup,
+                        visible: &decision.visible,
+                        estimated_rows: estimated_join_rows.map(|rows| rows.joined),
+                    },
                     &filters,
                     decision.filter_selectivity,
                 )

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -557,17 +557,33 @@ pub(crate) fn build_from(
             // offsets. Empty until an index branch fills it in; the table
             // branch's answer is read off the catalog at the end of the arm.
             let mut walked_index: Option<Vec<usize>> = None;
-            let exec: Box<dyn Executor> = match entry {
+            let mut access_consumed_filter = false;
+            // `RowSource` has already classified predicates that reference
+            // only this leaf. Keep them as one local WHERE for range costing;
+            // the written predicates still remain above the join.
+            let leaf_where = demand.rows.and_then(|rows| {
+                rows.filters_for(&visible)?
+                    .iter()
+                    .cloned()
+                    .reduce(|left, right| {
+                        tidb_ast::Expr::Binary(
+                            tidb_ast::BinaryOp::LogicAnd,
+                            Box::new(left),
+                            Box::new(right),
+                        )
+                    })
+            });
+            let mut exec: Box<dyn Executor> = match entry {
                 TableEntry::Mem(mem) => Box::new(MemTableSourceExec::new(
                     ExecutorMeta::new(schema, 0, INIT_CAP, MAX_CHUNK_SIZE),
                     mem.rows.clone(),
                 )),
                 // Go's `findBestTask` costs an access path for EVERY
                 // `DataSource` of the tree, this leaf included, and answers
-                // its parent with the cheapest. `leaf_index_path` is that
-                // costing. It is offered no condition, so the only path it
-                // can return is a WHOLE covering index -- the same rows the
-                // scan below reads, through a narrower structure.
+                // its parent with the cheapest. The local predicates are
+                // offered to the same chooser, so a bounded table/index path
+                // can replace the full scan without removing the filter from
+                // the join's upper pipeline.
                 //
                 // `keep_order` no longer DELETES that costing. It narrows it:
                 // Go's `findBestTask` under a NON-EMPTY property enumerates
@@ -597,22 +613,84 @@ pub(crate) fn build_from(
                             &visible,
                             &columns,
                             wanted,
+                            leaf_where.as_ref(),
                             &hints,
                             catalog,
                             &ctx.session_zone(),
                             wanted_order.as_deref(),
                         )
                     }) {
-                        Some(path) => {
+                        Some(crate::driver::leaf_access::LeafAccessPath::Point {
+                            handle,
+                            order,
+                        }) => {
+                            walked_index = Some(order);
+                            access_consumed_filter =
+                                crate::driver::access::point_get_predicate_is_consumed(
+                                    leaf_where.as_ref(),
+                                    kv,
+                                    &columns,
+                                    &ctx.session_zone(),
+                                );
+                            let handles = handle.iter().cloned().collect::<Vec<_>>();
+                            let source = HandleSourceExec::new_with_context(
+                                ExecutorMeta::new(schema, 0, INIT_CAP, MAX_CHUNK_SIZE),
+                                kv.clone(),
+                                handles,
+                                crate::kv_table::RowDecodeContext::for_query(ctx),
+                            );
+                            if let Some(trace) = trace.as_deref_mut() {
+                                trace.point_get(&visible, kv, handle.as_ref());
+                            }
+                            Box::new(source)
+                        }
+                        Some(crate::driver::leaf_access::LeafAccessPath::Index(path)) => {
                             walked_index = Some(path.order().to_vec());
-                            crate::driver::leaf_access::leaf_index_source(
+                            let source = crate::driver::leaf_access::leaf_index_source(
                                 kv,
                                 &visible,
                                 &columns,
                                 path,
                                 trace.as_deref_mut(),
                                 ctx,
-                            )
+                            );
+                            source
+                        }
+                        Some(crate::driver::leaf_access::LeafAccessPath::HandleRange {
+                            ranges,
+                            estimate,
+                        }) => {
+                            let mut source = TableScanExec::new_with_context(
+                                ExecutorMeta::new(schema, 0, INIT_CAP, MAX_CHUNK_SIZE),
+                                restricted_to_partitions(kv, &table_ref.partitions, name)?,
+                                crate::kv_table::RowDecodeContext::for_query(ctx),
+                                crate::remote_scan::PushdownStatementContext::from_stmt(ctx),
+                            );
+                            let accepted = source
+                                .table_access()
+                                .is_some_and(|access| access.accept_handle_ranges(&ranges));
+                            if accepted {
+                                if let Some(access) = source.table_access() {
+                                    access.accept_scan_estimate(estimate.rows);
+                                }
+                                if let Some(trace) = trace.as_deref_mut() {
+                                    if ranges.is_empty() {
+                                        trace.empty_range_table_dual();
+                                    } else if let Some(handle) =
+                                        kv.pk_handle_offset().and_then(|_| {
+                                            crate::driver::access::single_point_handle(&ranges)
+                                        })
+                                    {
+                                        trace.point_get(&visible, kv, Some(&handle));
+                                    } else {
+                                        trace.table_range_scan(&visible, &ranges, estimate);
+                                        if keep_order {
+                                            trace.keep_order();
+                                        }
+                                    }
+                                }
+                            }
+                            Box::new(source)
                         }
                         None => Box::new(TableScanExec::new_with_context(
                             ExecutorMeta::new(schema, 0, INIT_CAP, MAX_CHUNK_SIZE),
@@ -630,9 +708,20 @@ pub(crate) fn build_from(
                     unreachable!("views and sequences take the branches above")
                 }
             };
+            // Record predicate consumption only from the physical path that
+            // was actually built. A point path consumes its exact key; a
+            // streaming source may accept the complete pushed filter. Any
+            // declined residue remains in the Selection above the join.
+            let scan_consumed_filter =
+                offer_leaf_filter(exec.as_mut(), leaf_where.as_ref(), &visible, &columns, ctx);
+            if leaf_where.is_some() && (access_consumed_filter || scan_consumed_filter) {
+                if let Some(rows) = demand.rows {
+                    rows.mark_leaf_filters_consumed(&visible);
+                }
+            }
             let scope = FromScope {
                 tables: vec![FromTable {
-                    name: visible,
+                    name: visible.clone(),
                     // An alias replaces the whole path, so `db.t.col` no
                     // longer names the table once it is aliased.
                     database: table_ref.alias.is_none().then(|| database.to_owned()),
@@ -643,6 +732,29 @@ pub(crate) fn build_from(
                 zone: ctx.session_zone(),
                 ..FromScope::default()
             };
+            if let Some(predicate) = demand.rows.and_then(|rows| {
+                rows.trace_filters_for(&visible)?
+                    .iter()
+                    .cloned()
+                    .reduce(|left, right| {
+                        tidb_ast::Expr::Binary(
+                            tidb_ast::BinaryOp::LogicAnd,
+                            Box::new(left),
+                            Box::new(right),
+                        )
+                    })
+            }) {
+                if let Some(trace) = trace.as_deref_mut() {
+                    trace.selection(
+                        &predicate,
+                        &crate::plan_trace::Qualifier {
+                            db: current_db,
+                            scope: &scope,
+                        },
+                        Some(1.0),
+                    );
+                }
+            }
             // What this leaf DELIVERS -- read off the branch that RAN, which
             // is the verify half of `merge_decision`'s promise/verify
             // contract.
@@ -698,7 +810,7 @@ pub(crate) fn build_from(
             // of delivering it. Go's `PhysicalProjection.exhaustPhysicalPlans`
             // maps the property through the select list; see
             // `merge_decision::from_required_prop`.
-            let (exec, mut scope) = build_derived_source(
+            let (exec, mut scope, actual_delivered) = build_derived_source(
                 subquery,
                 alias.as_deref(),
                 catalog,
@@ -716,17 +828,47 @@ pub(crate) fn build_from(
             // LOWER bound on the inner build (see its doc): the inner join
             // forms its candidates from the PROMISE and verifies them the same
             // way this one does, so it can only deliver more.
-            let delivered = crate::driver::merge_decision::delivered_properties(
-                node,
-                catalog,
-                current_db,
-                demand.offered,
-            )
-            .map(|properties| properties.orders)
-            .unwrap_or_default();
+            let delivered = if actual_delivered.is_empty() {
+                crate::driver::merge_decision::delivered_properties(
+                    node,
+                    catalog,
+                    current_db,
+                    demand.offered,
+                )
+                .map(|properties| properties.orders)
+                .unwrap_or_default()
+            } else {
+                actual_delivered
+            };
             Ok((exec, scope, delivered))
         }
     }
+}
+
+/// Offers a join leaf's local predicates to the storage source. Returns true
+/// only when that source accepted the complete predicate.
+fn offer_leaf_filter(
+    source: &mut dyn Executor,
+    where_clause: Option<&tidb_ast::Expr>,
+    visible: &str,
+    columns: &[(String, FieldType)],
+    ctx: &crate::StmtContext,
+) -> bool {
+    let Some(where_clause) = where_clause else {
+        return false;
+    };
+    let resolver = TableResolver {
+        table_name: visible,
+        columns,
+        zone: ctx.session_zone(),
+    };
+    let (pushed, residual) =
+        crate::driver::access::split_scan_predicates(where_clause, &resolver, ctx);
+    !pushed.is_empty()
+        && residual.is_none()
+        && source
+            .table_access()
+            .is_some_and(|access| access.accept_scan_filter(&pushed, ctx))
 }
 
 /// Runs a derived table's subquery and presents its rows as a `FROM` source.
@@ -757,9 +899,18 @@ pub(crate) fn build_derived_source(
     ctx: &crate::StmtContext,
     trace: Option<&mut PlanTrace>,
     required: &tidb_planner::physical_property::PhysicalProperty,
-) -> Result<(Box<dyn Executor>, FromScope), DriverError> {
-    let (alias, columns, rows) =
-        derived_source_relation(subquery, alias, catalog, current_db, ctx, trace, required)?;
+) -> Result<(Box<dyn Executor>, FromScope, Delivered), DriverError> {
+    let mut delivered = Delivered::new();
+    let (alias, columns, rows) = derived_source_relation_with_delivery(
+        subquery,
+        alias,
+        catalog,
+        current_db,
+        ctx,
+        trace,
+        required,
+        Some(&mut delivered),
+    )?;
     let schema_columns: Vec<Column> = columns
         .iter()
         .enumerate()
@@ -785,7 +936,7 @@ pub(crate) fn build_derived_source(
         zone: ctx.session_zone(),
         ..FromScope::default()
     };
-    Ok((exec, scope))
+    Ok((exec, scope, delivered))
 }
 
 /// A derived table's MATERIALIZED relation: the alias it answers to, its
@@ -809,6 +960,22 @@ pub(crate) fn derived_source_relation<'a>(
     trace: Option<&mut PlanTrace>,
     required: &tidb_planner::physical_property::PhysicalProperty,
 ) -> Result<DerivedSourceRelation<'a>, DriverError> {
+    derived_source_relation_with_delivery(
+        subquery, alias, catalog, current_db, ctx, trace, required, None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn derived_source_relation_with_delivery<'a>(
+    subquery: &QueryStmt,
+    alias: Option<&'a str>,
+    catalog: &Catalog,
+    current_db: &str,
+    ctx: &crate::StmtContext,
+    trace: Option<&mut PlanTrace>,
+    required: &tidb_planner::physical_property::PhysicalProperty,
+    delivered: Option<&mut Delivered>,
+) -> Result<DerivedSourceRelation<'a>, DriverError> {
     // Captured from Go: an alias-less derived table is ErrDerivedMustHaveAlias
     // in a plain SELECT and in a view body alike.
     let alias = alias.filter(|alias| !alias.is_empty());
@@ -816,9 +983,9 @@ pub(crate) fn derived_source_relation<'a>(
         return Err(DriverError::DerivedMustHaveAlias);
     };
     let (columns, rows) = match subquery {
-        QueryStmt::Select(select) => {
-            run_select_traced(select, catalog, current_db, ctx, trace, required)?
-        }
+        QueryStmt::Select(select) => super::run_select_traced_with_delivery(
+            select, catalog, current_db, ctx, trace, required, delivered,
+        )?,
         QueryStmt::SetOpr(set_opr) => {
             // A set operation has no traced builder: `run_set_opr_stmt` runs
             // its arms and concatenates them without recording an operator, so
@@ -1439,14 +1606,15 @@ pub(crate) fn build_join(
         .map(|(left, right)| (left.orders.clone(), right.orders.clone()));
     let (left_required, right_required) = match &merge {
         // `tryToGetChildReqProp`: each child is required to produce ITS OWN
-        // join keys' order, in the direction the parent asked for.
+        // join keys' order, including any index prefix fixed by an equality
+        // predicate, in the direction the parent asked for.
         Some(decision) => (
             crate::driver::merge_decision::child_required_prop(
-                decision.plan.keys.iter().map(|key| key.left),
+                decision.left_required.iter().copied(),
                 decision.plan.desc,
             ),
             crate::driver::merge_decision::child_required_prop(
-                decision.plan.keys.iter().map(|key| key.right),
+                decision.right_required.iter().copied(),
                 decision.plan.desc,
             ),
         ),
@@ -1545,11 +1713,19 @@ pub(crate) fn build_join(
     // identity `build_from` reported its delivery in; the pruning below
     // renumbers the joined row and happens after this.
     let merge = merge.filter(|decision| {
-        let left_keys: Vec<usize> = decision.plan.keys.iter().map(|key| key.left).collect();
-        let right_keys: Vec<usize> = decision.plan.keys.iter().map(|key| key.right).collect();
-        crate::driver::merge_decision::delivers(&left_delivered, &left_keys)
-            && crate::driver::merge_decision::delivers(&right_delivered, &right_keys)
+        crate::driver::merge_decision::delivers(&left_delivered, &decision.left_required)
+            && crate::driver::merge_decision::delivers(&right_delivered, &decision.right_required)
     });
+    // Keep the complete child orders by NAME before the decision is consumed
+    // while re-resolving its executor keys. They include any fixed leading
+    // index columns and become this join's truthful delivery receipt below.
+    let merge_required_names = merge.as_ref().map(|decision| {
+        (
+            decision.left_required_names.clone(),
+            decision.right_required_names.clone(),
+        )
+    });
+    let merge_trace_names = merge.as_ref().map(|decision| decision.names.clone());
 
     // The joined scope: the right tables' columns follow the left's.
     let mut left_width = left_scope.width();
@@ -1636,11 +1812,9 @@ pub(crate) fn build_join(
     // widths below are read back off the narrowed scope rather than assumed.
     // A coalesced join is exempt: its scope addresses columns by row offset
     // in `star`/`coalesced`, which renumbering would invalidate.
-    // Whether the joined row was RENUMBERED below. A pruned join is the top
-    // of its `FROM` plan (only the outermost one is offered a `prune`), so it
-    // has no parent to report a delivery to -- and the offsets its children
-    // reported are no longer the offsets of its row.
-    let mut pruned = false;
+    // The join may be renumbered below. Its committed merge plan is resolved
+    // again against the narrowed scope, so the delivery report later uses
+    // those final offsets rather than the children's pre-prune offsets.
     if let Some(select) = prune.filter(|_| !coalescing) {
         if let Some((left_columns, right_columns)) = crate::column_prune::prune_join_sides(
             select,
@@ -1649,7 +1823,6 @@ pub(crate) fn build_join(
             &mut left_exec,
             &mut right_exec,
         ) {
-            pruned = true;
             left_width = left_columns.len();
             scope.tables[0].columns = left_columns;
             scope.tables[0].offset = 0;
@@ -1799,22 +1972,33 @@ pub(crate) fn build_join(
     // `exhaustPhysicalPlans4LogicalJoin` under the property this join was
     // required to produce -- and not of the structural rule underneath. See
     // `driver::join_search`.
-    let chosen = crate::driver::join_search::choose(&crate::driver::join_search::SearchInput {
-        join,
-        join_type: match kind {
-            JoinKind::Inner => tidb_planner::find_best_task::LogicalJoinType::Inner,
-            JoinKind::Left => tidb_planner::find_best_task::LogicalJoinType::LeftOuter,
-            JoinKind::Right => tidb_planner::find_best_task::LogicalJoinType::RightOuter,
-        },
-        keys: &split.keys,
-        left_width,
-        width: scope.width(),
-        orders: search_orders
-            .as_ref()
-            .map(|(left, right)| (left.as_slice(), right.as_slice())),
-        required,
-        rows: demand.rows,
+    let (hint_left, hint_right) = crate::driver::join_method_hints::side_aliases(join);
+    let forced_index_name = demand.join_hints.and_then(|hints| {
+        hints.forced_index_join_name(
+            (hint_left.as_deref(), hint_right.as_deref()),
+            required.is_sort_item_empty(),
+        )
     });
+    let chosen = if forced_index_name.is_some() {
+        crate::driver::join_search::Chosen::Index
+    } else {
+        crate::driver::join_search::choose(&crate::driver::join_search::SearchInput {
+            join,
+            join_type: match kind {
+                JoinKind::Inner => tidb_planner::find_best_task::LogicalJoinType::Inner,
+                JoinKind::Left => tidb_planner::find_best_task::LogicalJoinType::LeftOuter,
+                JoinKind::Right => tidb_planner::find_best_task::LogicalJoinType::RightOuter,
+            },
+            keys: &split.keys,
+            left_width,
+            width: scope.width(),
+            orders: search_orders
+                .as_ref()
+                .map(|(left, right)| (left.as_slice(), right.as_slice())),
+            required,
+            rows: demand.rows,
+        })
+    };
     let index_join = (!coalescing && chosen == crate::driver::join_search::Chosen::Index)
         .then(|| {
             let (left_side, right_side) = crate::driver::index_join_decision::join_sides(
@@ -1826,17 +2010,19 @@ pub(crate) fn build_join(
                 &left_types,
                 &right_types,
             );
-            crate::driver::index_join_decision::index_join_decision(
+            crate::driver::index_join_decision::index_join_decision_with_context(
                 kind,
                 &split.keys,
                 &left_side,
                 &right_side,
                 merged.is_some(),
+                demand.rows,
+                ctx,
             )
         })
         .flatten();
     let index_text = index_join.as_ref().map(|decision| {
-        let source = crate::access_path::IndexJoinLookupExec::new_with_context(
+        let mut source = crate::access_path::IndexJoinLookupExec::new_with_context(
             ExecutorMeta::new(
                 Schema::new(
                     decision
@@ -1858,6 +2044,8 @@ pub(crate) fn build_join(
             decision.object.clone(),
             crate::kv_table::RowDecodeContext::for_query(ctx),
         );
+        source.set_probe_parts(decision.probe_parts.clone());
+        source.set_filters(decision.filter_exprs.clone(), ctx.clone());
         let keys: Vec<(String, String)> = decision
             .probe_keys
             .iter()
@@ -1876,7 +2064,18 @@ pub(crate) fn build_join(
             .collect();
         let index = match &decision.object {
             crate::access_path::LookupObject::Index(_) => true,
-            crate::access_path::LookupObject::Handle => false,
+            crate::access_path::LookupObject::Handle
+            | crate::access_path::LookupObject::CommonHandle => false,
+        };
+        let unique = match &decision.object {
+            crate::access_path::LookupObject::Index(id) => decision
+                .table
+                .indexes()
+                .iter()
+                .find(|index| index.id == *id)
+                .is_some_and(|index| index.unique),
+            crate::access_path::LookupObject::Handle
+            | crate::access_path::LookupObject::CommonHandle => true,
         };
         let access = match &decision.object {
             crate::access_path::LookupObject::Index(id) => {
@@ -1899,17 +2098,23 @@ pub(crate) fn build_join(
                 )
             }
             crate::access_path::LookupObject::Handle => format!("table:{}", decision.visible),
+            crate::access_path::LookupObject::CommonHandle => {
+                format!("table:{}", decision.visible)
+            }
         };
         join_exec.set_index_lookup_plan(crate::join::IndexLookupPlan {
             lookup_is_left: decision.lookup_is_left,
             probe_keys: decision.probe_keys.clone(),
             source,
         });
+        join_exec.set_consumes_where(decision.consumes_where);
         (
             crate::plan_trace::IndexJoinText {
                 reader: if index { "IndexReader" } else { "TableReader" },
                 keys,
                 lookup_is_left: decision.lookup_is_left,
+                unique,
+                forced_name: forced_index_name,
                 // `getAvgRowSize(.., Schema().Columns)` for each side. Go
                 // reaches its `HistColl` branch when the child is a
                 // `DataSource`; this tier has no `HistColl` at a join's child
@@ -1942,8 +2147,27 @@ pub(crate) fn build_join(
     // join. The EXECUTOR is unaffected -- it still answers correctly.
     let index_text = match (index_text, trace.as_deref_mut()) {
         (Some((text, lookup_is_left, access, range_info, index)), Some(trace)) => {
+            let decision = index_join
+                .as_ref()
+                .expect("printable index text has an index decision");
+            let qualify = crate::plan_trace::Qualifier {
+                db: current_db,
+                scope: &scope,
+            };
+            let filters: Vec<String> = decision
+                .filters
+                .iter()
+                .map(|filter| qualify.expr(filter))
+                .collect();
             if trace
-                .index_join_inner_scan(lookup_is_left, access, &range_info, index)
+                .index_join_inner_scan(
+                    lookup_is_left,
+                    access,
+                    &range_info,
+                    index,
+                    &filters,
+                    decision.filter_selectivity,
+                )
                 .is_ok()
             {
                 Some(text)
@@ -1958,16 +2182,30 @@ pub(crate) fn build_join(
     let exec: Box<dyn Executor> = Box::new(join_exec);
     let strategy = crate::plan_trace::JoinStrategy {
         equal_mask: split.equal_mask.clone(),
-        build_is_left,
+        build_is_left: index_join
+            .as_ref()
+            .map_or(build_is_left, |decision| !decision.lookup_is_left),
         index_lookup: index_text,
         merge_keys: merged.as_ref().map(|plan| {
             plan.keys
                 .iter()
-                .map(|key| {
-                    (
-                        qualified_scope_column(&scope, current_db, key.left),
-                        qualified_scope_column(&scope, current_db, left_width + key.right),
+                .zip(
+                    merge_trace_names
+                        .as_ref()
+                        .expect("a committed merge keeps its logical key names"),
+                )
+                .map(|(key, (left_name, right_name))| {
+                    let left = crate::driver::merge_decision::derived_column_trace_name(
+                        &join.left, left_name, catalog, current_db,
                     )
+                    .unwrap_or_else(|| qualified_scope_column(&scope, current_db, key.left));
+                    let right = crate::driver::merge_decision::derived_column_trace_name(
+                        right_node, right_name, catalog, current_db,
+                    )
+                    .unwrap_or_else(|| {
+                        qualified_scope_column(&scope, current_db, left_width + key.right)
+                    });
+                    (left, right)
                 })
                 .collect()
         }),
@@ -1987,14 +2225,26 @@ pub(crate) fn build_join(
     //
     // Either way the side an outer join NULL-EXTENDS is dropped, which is
     // `union_orders`' whole job.
-    let delivered = if pruned {
-        Delivered::new()
-    } else if let Some(plan) = &merged {
-        crate::driver::merge_decision::union_orders(
-            join.tp,
-            vec![plan.keys.iter().map(|key| key.left).collect()],
-            vec![plan.keys.iter().map(|key| key.right + left_width).collect()],
-        )
+    let merged_orders = merged.as_ref().and_then(|_| {
+        let (left_names, right_names) = merge_required_names.as_ref()?;
+        let left: Option<Vec<usize>> = left_names
+            .iter()
+            .map(|name| {
+                let offset = scope_offset_of(&scope, name)?;
+                (offset < left_width).then_some(offset)
+            })
+            .collect();
+        let right: Option<Vec<usize>> = right_names
+            .iter()
+            .map(|name| {
+                let offset = scope_offset_of(&scope, name)?;
+                (offset >= left_width).then_some(offset)
+            })
+            .collect();
+        Some((left?, right?))
+    });
+    let delivered = if let Some((left, right)) = merged_orders {
+        crate::driver::merge_decision::union_orders(join.tp, vec![left], vec![right])
     } else if let Some(decision) = &index_join {
         let outer = if decision.lookup_is_left {
             right_delivered
@@ -2030,11 +2280,16 @@ pub(crate) fn build_join(
             // The recorder prints the `ON` as written, and a coalesced join
             // has none -- its equalities are synthesized here.
             trace.refuse("NATURAL and USING joins are not printed yet");
-        } else if trace
-            .join(join, &scope, current_db, &pushed, &strategy)
-            .is_err()
-        {
-            trace.refuse("this join's plan is not supported yet");
+        } else {
+            if merged.is_some() {
+                trace.join_scan_readers();
+            }
+            if trace
+                .join(join, &scope, current_db, &pushed, &strategy)
+                .is_err()
+            {
+                trace.refuse("this join's plan is not supported yet");
+            }
         }
     }
     // Set, never merged: this is a property of the node at the TOP of the

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -1217,12 +1217,12 @@ pub(crate) fn build_lateral_join(
         tidb_ast::JoinType::Left => {
             return Err(DriverError::InvalidLateralJoin(
                 "LEFT JOIN is not supported with LATERAL",
-            ))
+            ));
         }
         tidb_ast::JoinType::Right => {
             return Err(DriverError::InvalidLateralJoin(
                 "RIGHT JOIN is not supported with LATERAL",
-            ))
+            ));
         }
         // Comma syntax (which the parser spells `CrossJoin`) and an explicit
         // INNER JOIN are the shapes Go plans.
@@ -1775,6 +1775,22 @@ pub(crate) fn build_join(
         demand,
         &right_required,
     )?;
+    // Predicate pushdown has now received an acceptance receipt from each
+    // concrete leaf source. Remove a leaf-local ON conjunct from the physical
+    // join only when that source accepted the exact predicate; equalities and
+    // outer-join preserved-side conditions remain untouched.
+    let pushed_join;
+    let join = match demand.rows {
+        Some(rows) => {
+            pushed_join = {
+                let mut join = join.clone();
+                join.on = rows.residual_on(join.on.as_ref());
+                join
+            };
+            &pushed_join
+        }
+        None => join,
+    };
 
     // VERIFY -- the second half of the promise/verify contract (see
     // `merge_decision`'s module doc). `merge` was formed from the PROMISE:
@@ -2004,8 +2020,9 @@ pub(crate) fn build_join(
                 )
             })
             .collect::<Vec<_>>();
-        (flattened.len() == split.equal_mask.len() && columns.iter().any(Option::is_none))
-            .then_some((flattened, columns))
+        (flattened.len() == split.equal_mask.len()
+            && (demand.physical_source_names || columns.iter().any(Option::is_none)))
+        .then_some((flattened, columns))
     };
     // Go's stats-less build side: the inner (non-preserved) child, which is
     // the left one only for a RIGHT join. See `join.rs`'s module doc.
@@ -2037,6 +2054,14 @@ pub(crate) fn build_join(
         ctx.clone(),
         ctx.statement_memory(),
     );
+    // When every stable WHERE conjunct belongs to this inner join, the join
+    // executor now evaluates the complete predicate (equal keys and `other
+    // cond` alike). Report that receipt so the equivalent Selection above it
+    // is removed. A partial push remains fail-closed and keeps the Selection.
+    let pushed_consumes_where = !demand.offered.is_empty()
+        && pushed.len() == demand.offered.len()
+        && join.tp == tidb_ast::JoinType::Cross;
+    join_exec.set_consumes_where(pushed_consumes_where);
     // The key offsets the decision computed are pre-pruning; the scope is
     // post-pruning. Re-resolving the key NAMES against it is what keeps the
     // executor's merge keys and the columns it actually holds one answer.
@@ -2360,6 +2385,17 @@ pub(crate) fn build_join(
                 };
                 (Some(outer), Some(probe_rows_one))
             });
+        // A unique lookup reads at most one pre-filter row for each outer
+        // key. Go prices the dynamic range at the outer row count and the
+        // cop Selection above it at that count times the residual filter
+        // selectivity. The full logical join estimator cannot recover this
+        // access-path fact: scaling the inner table's rows and join-key NDV
+        // together cancels the residual filter from its equality estimate.
+        let estimated_lookup_rows = if unique {
+            estimated_outer_rows.map(|rows| rows * decision.filter_selectivity)
+        } else {
+            estimated_join_rows.map(|rows| rows.joined)
+        };
         let (outer_not_null, inner_not_null) = comparison_not_null.iter().copied().fold(
             (Vec::new(), Vec::new()),
             |mut offsets, offset| {
@@ -2385,7 +2421,7 @@ pub(crate) fn build_join(
             outer_not_null: outer_not_null.clone(),
             inner_not_null: inner_not_null.clone(),
         });
-        join_exec.set_consumes_where(decision.consumes_where);
+        join_exec.set_consumes_where(pushed_consumes_where || decision.consumes_where);
         (
             crate::plan_trace::IndexJoinText {
                 reader: if decision.aggregation.is_some() && !inner_not_null.is_empty() {
@@ -2432,6 +2468,7 @@ pub(crate) fn build_join(
             decision.range_info.clone(),
             index,
             index_lookup,
+            estimated_lookup_rows,
             outer_not_null,
             inner_not_null,
         )
@@ -2449,6 +2486,7 @@ pub(crate) fn build_join(
                 range_info,
                 index,
                 index_lookup,
+                estimated_lookup_rows,
                 outer_not_null,
                 inner_not_null,
             )),
@@ -2475,7 +2513,8 @@ pub(crate) fn build_join(
                         index,
                         index_lookup,
                         visible: &decision.visible,
-                        estimated_rows: estimated_join_rows.map(|rows| rows.joined),
+                        estimated_rows: estimated_lookup_rows,
+                        unique: text.unique,
                         grouped_derived: decision.aggregation.is_some(),
                         aggregation_info: decision.aggregation_info.as_deref(),
                         outer_not_null: &outer_not_null,
@@ -2496,6 +2535,19 @@ pub(crate) fn build_join(
         (None, _) => None,
     };
     let exec: Box<dyn Executor> = Box::new(join_exec);
+    let build_is_left = if merged.is_none() && index_join.is_none() {
+        estimated_join_rows.map_or(build_is_left, |rows| {
+            if rows.left < rows.right {
+                true
+            } else if rows.right < rows.left {
+                false
+            } else {
+                build_is_left
+            }
+        })
+    } else {
+        build_is_left
+    };
     let strategy = crate::plan_trace::JoinStrategy {
         equal_mask: split.equal_mask.clone(),
         build_is_left: index_join
@@ -2503,6 +2555,7 @@ pub(crate) fn build_join(
             .map_or(build_is_left, |decision| !decision.lookup_is_left),
         index_lookup: index_text,
         physical_conditions,
+        estimated_join_rows: estimated_join_rows.map(|rows| rows.joined),
         merge_keys: merged.as_ref().map(|plan| {
             plan.keys
                 .iter()
@@ -2598,7 +2651,7 @@ pub(crate) fn build_join(
             // has none -- its equalities are synthesized here.
             trace.refuse("NATURAL and USING joins are not printed yet");
         } else {
-            if merged.is_some() {
+            if index_join.is_none() {
                 trace.join_scan_readers();
             }
             if trace

--- a/rust/crates/tidb-executor/src/driver/from.rs
+++ b/rust/crates/tidb-executor/src/driver/from.rs
@@ -2015,6 +2015,19 @@ pub(crate) fn build_join(
     // executors know.
     let left_types = left_exec.ret_field_types().to_vec();
     let right_types = right_exec.ret_field_types().to_vec();
+    let mut comparison_not_null = Vec::new();
+    for condition in &conditions {
+        collect_comparison_not_null_columns(condition, &mut comparison_not_null);
+    }
+    comparison_not_null.sort_unstable();
+    comparison_not_null.dedup();
+    comparison_not_null.retain(|offset| {
+        left_types
+            .iter()
+            .chain(&right_types)
+            .nth(*offset)
+            .is_some_and(|field_type| !field_type.has_flag(tidb_datatype::FieldTypeFlags::NOT_NULL))
+    });
     let mut join_exec = JoinExec::new(
         meta,
         kind,
@@ -2116,7 +2129,20 @@ pub(crate) fn build_join(
     );
     let single_outer_row_choice =
         chosen == crate::driver::join_search::Chosen::IndexForSingleOuterRow;
-    let index_join = (!coalescing && index_chosen)
+    // Go's empty-property search also picks an index join on cost when a
+    // grouped derived inner has a constant on the dynamically probed key:
+    // at most one distinct outer key can return rows.  This is a strict
+    // dominance-sized subset of the unresolved full candidate-tree costing
+    // problem: admit it only when the outer and joined estimates are no
+    // larger than the materialized inner aggregate.  Every other
+    // HashAlsoEnumerated site remains fail-closed.
+    let grouped_cost_candidate = matches!(
+        chosen,
+        crate::driver::join_search::Chosen::Refused(
+            crate::driver::join_search::Refusal::HashAlsoEnumerated
+        )
+    );
+    let index_join = (!coalescing && (index_chosen || grouped_cost_candidate))
         .then(|| {
             let (left_side, right_side) = crate::driver::index_join_decision::join_sides(
                 join,
@@ -2137,6 +2163,25 @@ pub(crate) fn build_join(
                 ctx,
             )
         })
+        .flatten();
+    let grouped_cost_choice = index_join.as_ref().is_some_and(|decision| {
+        if !grouped_cost_candidate
+            || decision.aggregation.is_none()
+            || !decision.constant_constrained_probe
+        {
+            return false;
+        }
+        estimated_join_rows.is_some_and(|rows| {
+            let (outer, inner) = if decision.lookup_is_left {
+                (rows.right, rows.left)
+            } else {
+                (rows.left, rows.right)
+            };
+            outer <= inner && rows.joined <= inner
+        })
+    });
+    let index_join = (index_chosen || grouped_cost_choice)
+        .then_some(index_join)
         .flatten();
     let index_join = index_join.filter(|decision| {
         if !single_outer_row_choice {
@@ -2184,6 +2229,30 @@ pub(crate) fn build_join(
         );
         source.set_probe_parts(decision.probe_parts.clone());
         source.set_filters(decision.filter_exprs.clone(), ctx.clone());
+        let physical_name = |offset: usize| {
+            let fallback = qualified_scope_column(&scope, current_db, offset);
+            let Some(path) = scope.qualified_path(offset) else {
+                return fallback;
+            };
+            let [.., relation, column] = path.as_slice() else {
+                return fallback;
+            };
+            let column = crate::driver::merge_decision::RelColumn {
+                relation: relation.clone(),
+                column: column.clone(),
+            };
+            crate::driver::merge_decision::physical_column_trace_name(
+                if offset < left_width {
+                    &join.left
+                } else {
+                    right_node
+                },
+                &column,
+                catalog,
+                current_db,
+            )
+            .unwrap_or(fallback)
+        };
         let keys: Vec<(String, String)> = decision
             .probe_keys
             .iter()
@@ -2194,21 +2263,35 @@ pub(crate) fn build_join(
                 } else {
                     (key.left, left_width + key.right)
                 };
-                (
-                    qualified_scope_column(&scope, current_db, outer),
-                    qualified_scope_column(&scope, current_db, inner),
-                )
+                (physical_name(outer), physical_name(inner))
             })
             .collect();
+        let equal_conditions = split
+            .keys
+            .iter()
+            .map(|key| {
+                format!(
+                    "eq({}, {})",
+                    physical_name(key.left),
+                    physical_name(left_width + key.right)
+                )
+            })
+            .collect::<Vec<_>>();
         let index = match &decision.object {
             crate::access_path::LookupObject::Index(_) => true,
             crate::access_path::LookupObject::Handle
             | crate::access_path::LookupObject::CommonHandle => false,
         };
-        let needed_columns = demand.columns.map_or_else(
+        let mut needed_columns = demand.columns.map_or_else(
             || (0..decision.columns.len()).collect::<Vec<_>>(),
             |columns| columns.needed(&decision.visible, &decision.columns),
         );
+        if let Some(aggregation) = &decision.aggregation {
+            needed_columns.extend(aggregation.group_offsets.iter().copied());
+            needed_columns.push(aggregation.sum_offset);
+            needed_columns.sort_unstable();
+            needed_columns.dedup();
+        }
         let index_lookup = match &decision.object {
             crate::access_path::LookupObject::Index(id) => {
                 !crate::access_cost::index_is_covering(&decision.table, *id, &needed_columns)
@@ -2258,17 +2341,58 @@ pub(crate) fn build_join(
                 } else {
                     rows.left
                 };
-                (Some(outer), (outer > 0.0).then_some(rows.joined / outer))
+                let inner = if decision.lookup_is_left {
+                    rows.left
+                } else {
+                    rows.right
+                };
+                // A rebuilt grouped inner is costed for the complete group
+                // result of ONE dynamic range.  Its join output may be much
+                // smaller after equality matching, so dividing joined rows
+                // by outer rows underprices the IndexJoin hash table and can
+                // select `IndexJoin` where Go selects `IndexHashJoin`.
+                let probe_rows_one = if decision.aggregation.is_some() {
+                    inner
+                } else if outer > 0.0 {
+                    rows.joined / outer
+                } else {
+                    0.0
+                };
+                (Some(outer), Some(probe_rows_one))
             });
+        let (outer_not_null, inner_not_null) = comparison_not_null.iter().copied().fold(
+            (Vec::new(), Vec::new()),
+            |mut offsets, offset| {
+                if decision.lookup_is_left {
+                    if offset < left_width {
+                        offsets.1.push(offset);
+                    } else {
+                        offsets.0.push(offset - left_width);
+                    }
+                } else if offset < left_width {
+                    offsets.0.push(offset);
+                } else {
+                    offsets.1.push(offset - left_width);
+                }
+                offsets
+            },
+        );
         join_exec.set_index_lookup_plan(crate::join::IndexLookupPlan {
             lookup_is_left: decision.lookup_is_left,
             probe_keys: decision.probe_keys.clone(),
             source,
+            aggregation: decision.aggregation.clone(),
+            outer_not_null: outer_not_null.clone(),
+            inner_not_null: inner_not_null.clone(),
         });
         join_exec.set_consumes_where(decision.consumes_where);
         (
             crate::plan_trace::IndexJoinText {
-                reader: if index_lookup {
+                reader: if decision.aggregation.is_some() && !inner_not_null.is_empty() {
+                    "Selection"
+                } else if decision.aggregation.is_some() {
+                    "HashAgg"
+                } else if index_lookup {
                     "IndexLookUp"
                 } else if index {
                     "IndexReader"
@@ -2276,6 +2400,7 @@ pub(crate) fn build_join(
                     "TableReader"
                 },
                 keys,
+                equal_conditions,
                 lookup_is_left: decision.lookup_is_left,
                 unique,
                 forced_name: forced_index_name,
@@ -2307,6 +2432,8 @@ pub(crate) fn build_join(
             decision.range_info.clone(),
             index,
             index_lookup,
+            outer_not_null,
+            inner_not_null,
         )
     });
     // The plan row and the executor are one decision: if the recorder cannot
@@ -2314,7 +2441,19 @@ pub(crate) fn build_join(
     // refused rather than printed with a whole-table read under an index
     // join. The EXECUTOR is unaffected -- it still answers correctly.
     let index_text = match (index_text, trace.as_deref_mut()) {
-        (Some((text, lookup_is_left, access, range_info, index, index_lookup)), Some(trace)) => {
+        (
+            Some((
+                text,
+                lookup_is_left,
+                access,
+                range_info,
+                index,
+                index_lookup,
+                outer_not_null,
+                inner_not_null,
+            )),
+            Some(trace),
+        ) => {
             let decision = index_join
                 .as_ref()
                 .expect("printable index text has an index decision");
@@ -2337,6 +2476,10 @@ pub(crate) fn build_join(
                         index_lookup,
                         visible: &decision.visible,
                         estimated_rows: estimated_join_rows.map(|rows| rows.joined),
+                        grouped_derived: decision.aggregation.is_some(),
+                        aggregation_info: decision.aggregation_info.as_deref(),
+                        outer_not_null: &outer_not_null,
+                        inner_not_null: &inner_not_null,
                     },
                     &filters,
                     decision.filter_selectivity,
@@ -2483,6 +2626,30 @@ fn collect_physical_join_conjuncts(expression: &Expression, out: &mut Vec<Expres
         }
     }
     out.push(expression.clone());
+}
+
+/// Direct column arguments a NULL-propagating comparison proves non-NULL.
+/// `NullEQ` is deliberately absent: it is true for two NULL operands.
+fn collect_comparison_not_null_columns(expression: &Expression, out: &mut Vec<usize>) {
+    let Expression::ScalarFunction(function) = expression else {
+        return;
+    };
+    let name = function.func_name.lowercase();
+    if name == "and" {
+        for argument in &function.args {
+            collect_comparison_not_null_columns(argument, out);
+        }
+        return;
+    }
+    if !matches!(name, "eq" | "ne" | "lt" | "le" | "gt" | "ge") {
+        return;
+    }
+    out.extend(function.args.iter().filter_map(|argument| {
+        let Expression::Column(column) = argument else {
+            return None;
+        };
+        usize::try_from(column.index).ok()
+    }));
 }
 
 /// `kv` with any `PARTITION (p, ...)` restriction on the reference applied,

--- a/rust/crates/tidb-executor/src/driver/index_join_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/index_join_decision.rs
@@ -411,7 +411,9 @@
 //! protocol between `build_join` and its children), not another estimator and
 //! not a bigger cost model.
 
-use tidb_datatype::FieldType;
+use tidb_datatype::{Datum, FieldType};
+use tidb_expr::expression::Expression;
+use tidb_expr::rewriter::rewrite_expr_resolved;
 
 use crate::driver::from::FromScope;
 use crate::driver::{Catalog, TableEntry};
@@ -430,6 +432,9 @@ pub(crate) struct IndexJoinDecision {
     /// Offsets into the join's equality keys that decide the probe range, in
     /// the object's own key-column order.
     pub(crate) probe_keys: Vec<usize>,
+    /// The complete object key assembled from dynamic join keys and static
+    /// access conditions.
+    pub(crate) probe_parts: Vec<crate::access_path::LookupProbePart>,
     /// The table the probes read.
     pub(crate) table: KvTable,
     /// The object the probes read: an index, or the clustered handle.
@@ -442,6 +447,16 @@ pub(crate) struct IndexJoinDecision {
     /// The `EXPLAIN` text of what decided the range: Go's
     /// `indexJoinPathRangeInfo` / `indexJoinIntPKRangeInfo`.
     pub(crate) range_info: String,
+    /// Every predicate local to the looked-up leaf, in statement form for
+    /// EXPLAIN and rewritten form for execution.
+    pub(crate) filters: Vec<tidb_ast::Expr>,
+    pub(crate) filter_exprs: Vec<Expression>,
+    /// Selectivity of the filter residue not already represented by a static
+    /// object-key part.
+    pub(crate) filter_selectivity: f64,
+    /// Whether those leaf filters plus the join equalities cover the complete
+    /// written WHERE.
+    pub(crate) consumes_where: bool,
 }
 
 /// One join side reduced to what the decision reads about it.
@@ -476,12 +491,35 @@ pub(crate) struct JoinSide<'a> {
 /// `keys` are the join's equality conjuncts as
 /// [`crate::hash_join::split_equi`] produced them: `left` is an offset in the
 /// LEFT child's row and `right` an offset in the RIGHT child's.
+#[cfg(test)]
 pub(crate) fn index_join_decision(
     kind: crate::join::JoinKind,
     keys: &[EquiKey],
     left: &JoinSide<'_>,
     right: &JoinSide<'_>,
     merge_chosen: bool,
+) -> Option<IndexJoinDecision> {
+    index_join_decision_with_context(
+        kind,
+        keys,
+        left,
+        right,
+        merge_chosen,
+        None,
+        &crate::StmtContext::for_query(),
+    )
+}
+
+/// The production decision with the statement's derived leaf predicates and
+/// evaluation context.
+pub(crate) fn index_join_decision_with_context(
+    kind: crate::join::JoinKind,
+    keys: &[EquiKey],
+    left: &JoinSide<'_>,
+    right: &JoinSide<'_>,
+    merge_chosen: bool,
+    rows: Option<&crate::driver::join_reorder::RowSource>,
+    ctx: &crate::StmtContext,
 ) -> Option<IndexJoinDecision> {
     if keys.is_empty() || merge_chosen {
         return None;
@@ -501,7 +539,7 @@ pub(crate) fn index_join_decision(
         let Some(table) = inner.table else {
             continue;
         };
-        if let Some(decision) = decide_over(table, lookup_is_left, keys, inner, outer) {
+        if let Some(decision) = decide_over(table, lookup_is_left, keys, inner, outer, rows, ctx) {
             return Some(decision);
         }
     }
@@ -515,6 +553,8 @@ fn decide_over(
     keys: &[EquiKey],
     inner: &JoinSide<'_>,
     outer: &JoinSide<'_>,
+    rows: Option<&crate::driver::join_reorder::RowSource>,
+    ctx: &crate::StmtContext,
 ) -> Option<IndexJoinDecision> {
     // A partitioned table's probe would have to name the partition the key
     // falls in; Go refuses `keepOrder` there and prunes per probe, neither of
@@ -541,6 +581,54 @@ fn decide_over(
                 && probe_compatible(&inner.types[inner_at(key)], &outer.types[outer_at(key)])
         })
     };
+    let filters = rows
+        .and_then(|rows| rows.filters_for(&inner.visible))
+        .unwrap_or_default()
+        .to_vec();
+    let filter_exprs = rewrite_inner_filters(inner, &columns, &filters, ctx)?;
+    let constants = static_equalities(&columns, &filters, ctx);
+    let consumes_where = rows
+        .is_some_and(crate::driver::join_reorder::RowSource::all_where_is_leaf_or_join_equality);
+
+    // Builds the object's complete leading key from dynamic equality columns
+    // and leaf-local constants. At least one part must be dynamic -- a wholly
+    // static key is a point get, not an index join.
+    let probe_for = |offsets: &[usize]| {
+        let mut probe_keys = Vec::new();
+        let mut probe_parts = Vec::new();
+        let mut dynamic_info = Vec::new();
+        let mut static_info = Vec::new();
+        let mut static_columns = Vec::new();
+        for offset in offsets {
+            if let Some(key) = key_of_column(*offset) {
+                let dynamic = probe_keys.len();
+                probe_keys.push(key);
+                probe_parts.push(crate::access_path::LookupProbePart::Dynamic(dynamic));
+                dynamic_info.push(format!(
+                    "eq({}, {})",
+                    inner_column_name(inner, *offset),
+                    outer.names[outer_at(&keys[key])]
+                ));
+            } else if let Some(value) = constants.get(*offset).and_then(Clone::clone) {
+                probe_parts.push(crate::access_path::LookupProbePart::Constant(value.clone()));
+                static_columns.push(*offset);
+                static_info.push(format!(
+                    "eq({}, {})",
+                    inner_column_name(inner, *offset),
+                    datum_text(&value)
+                ));
+            } else {
+                break;
+            }
+        }
+        (!probe_keys.is_empty()).then_some((
+            probe_keys,
+            probe_parts,
+            dynamic_info,
+            static_info,
+            static_columns,
+        ))
+    };
 
     // The clustered integer handle first, as Go does
     // (`buildDataSource2TableScanByIndexJoinProp` is "no worse than" the
@@ -551,71 +639,226 @@ fn decide_over(
             return Some(IndexJoinDecision {
                 lookup_is_left,
                 probe_keys: vec![key],
+                probe_parts: vec![crate::access_path::LookupProbePart::Dynamic(0)],
                 table: table.clone(),
                 object: crate::access_path::LookupObject::Handle,
+                filter_selectivity: residual_filter_selectivity(
+                    &filters,
+                    &[],
+                    &columns,
+                    &ctx.session_zone(),
+                ),
                 columns,
                 visible: inner.visible.clone(),
                 // Go `indexJoinIntPKRangeInfo`: the OUTER keys, bare.
                 range_info: format!("[{}]", outer.names[outer_at(&keys[key])]),
+                filters,
+                filter_exprs,
+                consumes_where,
             });
+        }
+    }
+
+    // A clustered composite primary key is a table path, not a secondary
+    // PRIMARY index. Constants may pin any leading parts while join keys fill
+    // the rest; the resulting complete tuple addresses the record directly.
+    if !table.common_handle_offsets().is_empty() {
+        if let Some((probe_keys, probe_parts, dynamic, static_parts, static_columns)) =
+            probe_for(table.common_handle_offsets())
+        {
+            if probe_parts.len() == table.common_handle_offsets().len() {
+                let range_info = format!(
+                    "[{}]",
+                    dynamic
+                        .into_iter()
+                        .chain(static_parts)
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                );
+                return Some(IndexJoinDecision {
+                    lookup_is_left,
+                    probe_keys,
+                    probe_parts,
+                    table: table.clone(),
+                    object: crate::access_path::LookupObject::CommonHandle,
+                    filter_selectivity: residual_filter_selectivity(
+                        &filters,
+                        &static_columns,
+                        &columns,
+                        &ctx.session_zone(),
+                    ),
+                    columns,
+                    visible: inner.visible.clone(),
+                    range_info,
+                    filters,
+                    filter_exprs,
+                    consumes_where,
+                });
+            }
         }
     }
 
     // Otherwise the longest LEADING run of an index's columns that are all
     // join keys -- Go's `indexJoinPathTmpInit` walk, which stops at the first
     // index column no inner key covers.
-    let mut best: Option<(i64, Vec<usize>)> = None;
+    let mut best: Option<(
+        i64,
+        Vec<usize>,
+        Vec<crate::access_path::LookupProbePart>,
+        Vec<String>,
+        Vec<String>,
+        Vec<usize>,
+    )> = None;
     for index in table.indexes() {
         if !index.visible || index.has_prefix() {
             continue;
         }
-        let mut probe_keys = Vec::new();
-        for offset in &index.column_offsets {
-            let Some(key) = key_of_column(*offset) else {
-                break;
-            };
-            probe_keys.push(key);
-        }
-        if probe_keys.is_empty() {
+        let Some((probe_keys, probe_parts, dynamic, static_parts, static_columns)) =
+            probe_for(&index.column_offsets)
+        else {
             continue;
-        }
+        };
         if best
             .as_ref()
-            .is_none_or(|(_, best)| best.len() < probe_keys.len())
+            .is_none_or(|(_, best, ..)| best.len() < probe_keys.len())
         {
-            best = Some((index.id, probe_keys));
+            best = Some((
+                index.id,
+                probe_keys,
+                probe_parts,
+                dynamic,
+                static_parts,
+                static_columns,
+            ));
         }
     }
-    let (index_id, probe_keys) = best?;
-    let index = table.indexes().iter().find(|i| i.id == index_id)?;
+    let (index_id, probe_keys, probe_parts, dynamic, static_parts, static_columns) = best?;
     // Go `indexJoinPathRangeInfo`: `eq(<index column>, <outer key>)` per
     // covered index column, in index order. The index column is Go's
     // `OrigName`, which an alias does not rename -- see [`JoinSide::origin`].
     let range_info = format!(
         "[{}]",
-        probe_keys
-            .iter()
-            .enumerate()
-            .map(|(at, key)| {
-                let column = index.column_offsets[at];
-                format!(
-                    "eq({}, {})",
-                    inner_column_name(inner, column),
-                    outer.names[outer_at(&keys[*key])]
-                )
-            })
+        dynamic
+            .into_iter()
+            .chain(static_parts)
             .collect::<Vec<_>>()
             .join(" ")
     );
     Some(IndexJoinDecision {
         lookup_is_left,
         probe_keys,
+        probe_parts,
         table: table.clone(),
         object: crate::access_path::LookupObject::Index(index_id),
+        filter_selectivity: residual_filter_selectivity(
+            &filters,
+            &static_columns,
+            &columns,
+            &ctx.session_zone(),
+        ),
         columns,
         visible: inner.visible.clone(),
         range_info,
+        filters,
+        filter_exprs,
+        consumes_where,
     })
+}
+
+/// Rewrites leaf-local predicates against the full table row the lookup
+/// source returns. `RowSource` has already classified them as belonging to
+/// this leaf; a rewrite failure therefore means the physical and logical
+/// scopes disagree, and the index strategy is refused.
+fn rewrite_inner_filters(
+    inner: &JoinSide<'_>,
+    columns: &[(String, FieldType)],
+    filters: &[tidb_ast::Expr],
+    ctx: &crate::StmtContext,
+) -> Option<Vec<Expression>> {
+    let database = inner
+        .origin
+        .as_deref()
+        .and_then(|origin| origin.rsplit_once('.'))
+        .map(|(database, _)| database.to_owned());
+    let mut scope = crate::plan_trace::PlanTrace::single_table_scope(
+        &inner.visible,
+        database,
+        columns.to_vec(),
+    );
+    scope.zone = ctx.session_zone();
+    let resolver = crate::driver::from::ScopeResolver { scope: &scope };
+    filters
+        .iter()
+        .map(|filter| rewrite_expr_resolved(filter, &resolver).ok())
+        .collect()
+}
+
+/// Constant equalities available to the looked-up table, in table-column
+/// order and already converted into each column's storage domain.
+fn static_equalities(
+    columns: &[(String, FieldType)],
+    filters: &[tidb_ast::Expr],
+    ctx: &crate::StmtContext,
+) -> Vec<Option<Datum>> {
+    let mut values = vec![None; columns.len()];
+    for filter in filters {
+        let mut pairs = Vec::new();
+        if !crate::driver::access::name_value_pairs(filter, &mut pairs, &ctx.session_zone())
+            || pairs.len() != 1
+            || !crate::driver::access::convert_pairs_to_column_domain(&mut pairs, columns)
+        {
+            continue;
+        }
+        let pair = &pairs[0];
+        if let Some(offset) = columns
+            .iter()
+            .position(|(name, _)| name.eq_ignore_ascii_case(pair.column()))
+        {
+            values[offset] = Some(pair.value().clone());
+        }
+    }
+    values
+}
+
+/// Pseudo selectivity of the inner filters not already represented by static
+/// key parts. Go leaves the static equality visible in the cop Selection but
+/// prices it in the range only once.
+fn residual_filter_selectivity(
+    filters: &[tidb_ast::Expr],
+    static_columns: &[usize],
+    columns: &[(String, FieldType)],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> f64 {
+    let residual: Vec<&tidb_ast::Expr> = filters
+        .iter()
+        .filter(|filter| {
+            let mut pairs = Vec::new();
+            if !crate::driver::access::name_value_pairs(filter, &mut pairs, zone)
+                || pairs.len() != 1
+            {
+                return true;
+            }
+            !static_columns.iter().any(|offset| {
+                columns
+                    .get(*offset)
+                    .is_some_and(|(name, _)| pairs[0].column().eq_ignore_ascii_case(name))
+            })
+        })
+        .collect();
+    if residual.is_empty() {
+        1.0
+    } else {
+        crate::plan_trace::pseudo_selectivity_of_conjuncts(&residual)
+    }
+}
+
+fn datum_text(value: &Datum) -> String {
+    match value {
+        Datum::Int(value) => value.to_string(),
+        Datum::UInt(value) => value.to_string(),
+        Datum::Bytes(value) => format!("\"{}\"", String::from_utf8_lossy(value)),
+        other => other.sql_string().unwrap_or_else(|_| format!("{other:?}")),
+    }
 }
 
 /// One looked-up column as `EXPLAIN` prints it INSIDE a range, which is Go's

--- a/rust/crates/tidb-executor/src/driver/index_join_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/index_join_decision.rs
@@ -701,14 +701,15 @@ fn decide_over(
     // Otherwise the longest LEADING run of an index's columns that are all
     // join keys -- Go's `indexJoinPathTmpInit` walk, which stops at the first
     // index column no inner key covers.
-    let mut best: Option<(
+    type IndexCandidate = (
         i64,
         Vec<usize>,
         Vec<crate::access_path::LookupProbePart>,
         Vec<String>,
         Vec<String>,
         Vec<usize>,
-    )> = None;
+    );
+    let mut best: Option<IndexCandidate> = None;
     for index in table.indexes() {
         if !index.visible || index.has_prefix() {
             continue;

--- a/rust/crates/tidb-executor/src/driver/index_join_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/index_join_decision.rs
@@ -454,6 +454,15 @@ pub(crate) struct IndexJoinDecision {
     /// Selectivity of the filter residue not already represented by a static
     /// object-key part.
     pub(crate) filter_selectivity: f64,
+    /// A grouped derived table retained above the re-seeded base-table
+    /// reader. Bare table lookup sides leave this absent.
+    pub(crate) aggregation: Option<crate::join::IndexLookupAggregation>,
+    /// Go's physical HashAgg payload for that retained aggregation.
+    pub(crate) aggregation_info: Option<String>,
+    /// Whether a local equality constrains a dynamically probed object-key
+    /// column. For a grouped lookup this means at most one distinct outer key
+    /// can produce base rows; every other probe is empty.
+    pub(crate) constant_constrained_probe: bool,
     /// Whether those leaf filters plus the join equalities cover the complete
     /// written WHERE.
     pub(crate) consumes_where: bool,
@@ -480,6 +489,18 @@ pub(crate) struct JoinSide<'a> {
     /// `<db>.t1.b` in the same row's `range: decided by [...]`. Qualifying the
     /// range's inner column off the scope would print the alias in both.
     pub(crate) origin: Option<String>,
+    /// The base table name printed by the lookup reader.  This differs from
+    /// `visible` when the join side is a derived table alias.
+    pub(crate) source_visible: String,
+    /// For each side output, the base-table column it carries. Computed
+    /// aggregate outputs have no source offset.
+    pub(crate) output_to_source: Vec<Option<usize>>,
+    /// Predicates written inside a grouped derived table, evaluated by the
+    /// re-seeded base-table reader before aggregation.
+    pub(crate) source_filters: Vec<tidb_ast::Expr>,
+    /// The executable grouped derived-table transformation, if any.
+    pub(crate) aggregation: Option<crate::join::IndexLookupAggregation>,
+    pub(crate) aggregation_info: Option<String>,
 }
 
 /// The looked-up side of `join`, or `None` when neither side qualifies.
@@ -567,9 +588,12 @@ fn decide_over(
         .iter()
         .map(|column| (column.name.clone(), column.field_type.clone()))
         .collect();
-    // A side column pruning narrowed no longer has the table's own offsets,
-    // and the probe would read the wrong column.
-    if inner.types.len() != columns.len() {
+    // Every output must have a declared mapping.  A bare side maps the whole
+    // table identity; a grouped derived side maps carried group columns and
+    // leaves its computed SUM unmapped.
+    if inner.output_to_source.len() != inner.types.len()
+        || (inner.aggregation.is_none() && inner.types.len() != columns.len())
+    {
         return None;
     }
     let inner_at = |key: &EquiKey| if lookup_is_left { key.left } else { key.right };
@@ -577,14 +601,35 @@ fn decide_over(
     // Which of this side's columns a key probes, and with which key.
     let key_of_column = |column: usize| -> Option<usize> {
         keys.iter().position(|key| {
-            inner_at(key) == column
+            inner
+                .output_to_source
+                .get(inner_at(key))
+                .is_some_and(|offset| *offset == Some(column))
                 && probe_compatible(&inner.types[inner_at(key)], &outer.types[outer_at(key)])
         })
     };
-    let filters = rows
+    let outer_filters = rows
         .and_then(|rows| rows.filters_for(&inner.visible))
         .unwrap_or_default()
         .to_vec();
+    let outer_filters = if inner.aggregation.is_some() {
+        outer_filters
+            .iter()
+            .map(|filter| rewrite_derived_filter_to_source(filter, inner, &columns))
+            .collect::<Option<Vec<_>>>()?
+    } else {
+        outer_filters
+    };
+    let mut filters = inner
+        .source_filters
+        .iter()
+        .cloned()
+        .chain(outer_filters)
+        .collect::<Vec<_>>();
+    for filter in &mut filters {
+        normalize_source_filter(filter, &inner.source_visible, &columns)?;
+    }
+    filters.dedup();
     let filter_exprs = rewrite_inner_filters(inner, &columns, &filters, ctx)?;
     let constants = static_equalities(&columns, &filters, ctx);
     let consumes_where = rows
@@ -648,8 +693,11 @@ fn decide_over(
                     &columns,
                     &ctx.session_zone(),
                 ),
+                aggregation: inner.aggregation.clone(),
+                aggregation_info: inner.aggregation_info.clone(),
+                constant_constrained_probe: constants[pk].is_some(),
                 columns,
-                visible: inner.visible.clone(),
+                visible: inner.source_visible.clone(),
                 // Go `indexJoinIntPKRangeInfo`: the OUTER keys, bare.
                 range_info: format!("[{}]", outer.names[outer_at(&keys[key])]),
                 filters,
@@ -675,6 +723,14 @@ fn decide_over(
                         .collect::<Vec<_>>()
                         .join(" ")
                 );
+                let constant_constrained_probe = table
+                    .common_handle_offsets()
+                    .iter()
+                    .zip(&probe_parts)
+                    .any(|(offset, part)| {
+                        matches!(part, crate::access_path::LookupProbePart::Dynamic(_))
+                            && constants[*offset].is_some()
+                    });
                 return Some(IndexJoinDecision {
                     lookup_is_left,
                     probe_keys,
@@ -687,8 +743,11 @@ fn decide_over(
                         &columns,
                         &ctx.session_zone(),
                     ),
+                    aggregation: inner.aggregation.clone(),
+                    aggregation_info: inner.aggregation_info.clone(),
+                    constant_constrained_probe,
                     columns,
-                    visible: inner.visible.clone(),
+                    visible: inner.source_visible.clone(),
                     range_info,
                     filters,
                     filter_exprs,
@@ -734,6 +793,17 @@ fn decide_over(
         }
     }
     let (index_id, probe_keys, probe_parts, dynamic, static_parts, static_columns) = best?;
+    let constant_constrained_probe = table
+        .indexes()
+        .iter()
+        .find(|index| index.id == index_id)?
+        .column_offsets
+        .iter()
+        .zip(&probe_parts)
+        .any(|(offset, part)| {
+            matches!(part, crate::access_path::LookupProbePart::Dynamic(_))
+                && constants[*offset].is_some()
+        });
     // Go `indexJoinPathRangeInfo`: `eq(<index column>, <outer key>)` per
     // covered index column, in index order. The index column is Go's
     // `OrigName`, which an alias does not rename -- see [`JoinSide::origin`].
@@ -757,13 +827,126 @@ fn decide_over(
             &columns,
             &ctx.session_zone(),
         ),
+        aggregation: inner.aggregation.clone(),
+        aggregation_info: inner.aggregation_info.clone(),
+        constant_constrained_probe,
         columns,
-        visible: inner.visible.clone(),
+        visible: inner.source_visible.clone(),
         range_info,
         filters,
         filter_exprs,
         consumes_where,
     })
+}
+
+/// Pushes a predicate on carried derived outputs down to the base row the
+/// lookup source returns. A reference to a computed aggregate output refuses
+/// the index strategy; applying it before aggregation would be wrong.
+fn rewrite_derived_filter_to_source(
+    filter: &tidb_ast::Expr,
+    inner: &JoinSide<'_>,
+    columns: &[(String, FieldType)],
+) -> Option<tidb_ast::Expr> {
+    struct Rewriter<'a, 'b> {
+        inner: &'a JoinSide<'b>,
+        columns: &'a [(String, FieldType)],
+        failed: bool,
+    }
+    impl tidb_ast::Visitor for Rewriter<'_, '_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            let Some(expr) = node.downcast_mut::<tidb_ast::Expr>() else {
+                return false;
+            };
+            match expr {
+                tidb_ast::Expr::Subquery(_) | tidb_ast::Expr::Exists { .. } => {
+                    self.failed = true;
+                    true
+                }
+                tidb_ast::Expr::Column(path) => {
+                    let Some(name) = path.last() else {
+                        self.failed = true;
+                        return true;
+                    };
+                    let output = self.inner.names.iter().position(|candidate| {
+                        candidate
+                            .rsplit('.')
+                            .next()
+                            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(name))
+                    });
+                    let Some(source) = output
+                        .and_then(|output| self.inner.output_to_source.get(output))
+                        .copied()
+                        .flatten()
+                    else {
+                        self.failed = true;
+                        return true;
+                    };
+                    *path = vec![
+                        self.inner.source_visible.clone(),
+                        self.columns[source].0.clone(),
+                    ];
+                    true
+                }
+                _ => false,
+            }
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut rewritten = filter.clone();
+    let mut rewriter = Rewriter {
+        inner,
+        columns,
+        failed: false,
+    };
+    tidb_ast::Visitable::accept(&mut rewritten, &mut rewriter);
+    (!rewriter.failed).then_some(rewritten)
+}
+
+/// Gives every base-column reference one spelling so a predicate copied out
+/// of a derived table and the same predicate inferred above it deduplicate.
+fn normalize_source_filter(
+    filter: &mut tidb_ast::Expr,
+    visible: &str,
+    columns: &[(String, FieldType)],
+) -> Option<()> {
+    struct Rewriter<'a> {
+        visible: &'a str,
+        columns: &'a [(String, FieldType)],
+        failed: bool,
+    }
+    impl tidb_ast::Visitor for Rewriter<'_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            let Some(tidb_ast::Expr::Column(path)) = node.downcast_mut::<tidb_ast::Expr>() else {
+                return false;
+            };
+            let Some(column) = path.last().and_then(|name| {
+                self.columns
+                    .iter()
+                    .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+            }) else {
+                self.failed = true;
+                return true;
+            };
+            *path = vec![self.visible.to_owned(), column.0.clone()];
+            true
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut rewriter = Rewriter {
+        visible,
+        columns,
+        failed: false,
+    };
+    tidb_ast::Visitable::accept(filter, &mut rewriter);
+    (!rewriter.failed).then_some(())
 }
 
 /// Rewrites leaf-local predicates against the full table row the lookup
@@ -782,7 +965,7 @@ fn rewrite_inner_filters(
         .and_then(|origin| origin.rsplit_once('.'))
         .map(|(database, _)| database.to_owned());
     let mut scope = crate::plan_trace::PlanTrace::single_table_scope(
-        &inner.visible,
+        &inner.source_visible,
         database,
         columns.to_vec(),
     );
@@ -936,6 +1119,11 @@ pub(crate) fn join_sides<'a>(
             types: Vec::new(),
             names: Vec::new(),
             origin: None,
+            source_visible: String::new(),
+            output_to_source: Vec::new(),
+            source_filters: Vec::new(),
+            aggregation: None,
+            aggregation_info: None,
         },
     };
     (left, right)
@@ -951,7 +1139,7 @@ fn side_of<'a>(
     to: usize,
 ) -> JoinSide<'a> {
     let computed = computed_columns(node, to - from);
-    let names: Vec<String> = (from..to)
+    let mut names: Vec<String> = (from..to)
         .map(|offset| {
             if computed.get(offset - from).copied().unwrap_or(false) {
                 UNNAMED_COLUMN.to_owned()
@@ -960,17 +1148,242 @@ fn side_of<'a>(
             }
         })
         .collect();
-    let read = single_table_of(node, catalog, current_db);
-    let visible = read
+    let relation_visible = relation_visible_name(node);
+    let derived = grouped_decimal_sum_of(node, catalog, current_db);
+    let read = derived
+        .as_ref()
+        .map(|derived| {
+            (
+                derived.table,
+                derived.source_visible.clone(),
+                derived.origin.clone(),
+            )
+        })
+        .or_else(|| single_table_of(node, catalog, current_db));
+    let visible = relation_visible.or_else(|| {
+        read.as_ref()
+            .map(|(_, source_visible, _)| source_visible.clone())
+    });
+    let origin = read.as_ref().map(|(_, _, origin)| origin.clone());
+    let source_visible = read
         .as_ref()
         .map_or_else(String::new, |(_, visible, _)| visible.clone());
-    let origin = read.as_ref().map(|(_, _, origin)| origin.clone());
+    let output_to_source = derived.as_ref().map_or_else(
+        || (0..types.len()).map(Some).collect(),
+        |derived| derived.output_to_source.clone(),
+    );
+    if let Some(derived) = &derived {
+        for (output, source) in output_to_source.iter().copied().enumerate() {
+            if let Some(source) = source {
+                names[output] = format!(
+                    "{}.{}",
+                    derived.origin,
+                    derived.table.visible_columns()[source].name
+                );
+            }
+        }
+    }
     JoinSide {
         table: read.map(|(kv, ..)| kv),
-        visible,
+        visible: visible.unwrap_or_default(),
         types: types.to_vec(),
         names,
         origin,
+        source_visible,
+        output_to_source,
+        source_filters: derived
+            .as_ref()
+            .map_or_else(Vec::new, |derived| derived.filters.clone()),
+        aggregation: derived.as_ref().map(|derived| derived.aggregation.clone()),
+        aggregation_info: derived
+            .as_ref()
+            .map(|derived| derived.aggregation_info.clone()),
+    }
+}
+
+fn relation_visible_name(node: &tidb_ast::JoinNode) -> Option<String> {
+    match node {
+        tidb_ast::JoinNode::Table(table) => {
+            table.alias.clone().or_else(|| table.name.last().cloned())
+        }
+        tidb_ast::JoinNode::Derived { alias, .. } => alias.clone(),
+        tidb_ast::JoinNode::Join(join)
+            if join.right.is_none()
+                && join.on.is_none()
+                && join.using.is_empty()
+                && !join.natural =>
+        {
+            relation_visible_name(&join.left)
+        }
+        tidb_ast::JoinNode::Join(_) => None,
+    }
+}
+
+struct GroupedDecimalSumLookup<'a> {
+    table: &'a KvTable,
+    source_visible: String,
+    origin: String,
+    output_to_source: Vec<Option<usize>>,
+    filters: Vec<tidb_ast::Expr>,
+    aggregation: crate::join::IndexLookupAggregation,
+    aggregation_info: String,
+}
+
+/// A grouped derived side Go can rebuild over a re-seeded index reader.
+///
+/// This is intentionally the smallest truthful rule: one base table, plain
+/// non-null integer group keys, carried group columns, and exactly one
+/// decimal `SUM`.  Unsupported clauses or expressions keep the ordinary
+/// materialized hash join.
+fn grouped_decimal_sum_of<'a>(
+    node: &tidb_ast::JoinNode,
+    catalog: &'a Catalog,
+    current_db: &str,
+) -> Option<GroupedDecimalSumLookup<'a>> {
+    let tidb_ast::JoinNode::Derived {
+        subquery,
+        lateral: false,
+        column_names,
+        ..
+    } = node
+    else {
+        return None;
+    };
+    if !column_names.is_empty() {
+        return None;
+    }
+    let tidb_ast::QueryStmt::Select(select) = &**subquery else {
+        return None;
+    };
+    if select.with.is_some()
+        || !select.values.is_empty()
+        || select.distinct
+        || select.rollup
+        || select.group_by.is_empty()
+        || select.having.is_some()
+        || !select.order_by.is_empty()
+        || select.limit.is_some()
+        || !select.windows.is_empty()
+    {
+        return None;
+    }
+    let from = select.from.as_ref()?;
+    if from.right.is_some() || from.on.is_some() || !from.using.is_empty() || from.natural {
+        return None;
+    }
+    let (table, source_visible, origin) = single_table_of(&from.left, catalog, current_db)?;
+    let column_offset = |path: &[String]| {
+        let name = path.last()?;
+        table
+            .visible_columns()
+            .iter()
+            .position(|column| column.name.eq_ignore_ascii_case(name))
+    };
+    let group_offsets = select
+        .group_by
+        .iter()
+        .map(|item| match &item.expr {
+            tidb_ast::Expr::Column(path) => column_offset(path),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if group_offsets.iter().any(|offset| {
+        let field_type = &table.visible_columns()[*offset].field_type;
+        !field_type.code().is_type_integer()
+            || !field_type.has_flag(tidb_datatype::FieldTypeFlags::NOT_NULL)
+    }) {
+        return None;
+    }
+    let group_set = group_offsets
+        .iter()
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut sum_offset = None;
+    let mut output_to_source = Vec::with_capacity(select.fields.fields().len());
+    let mut outputs = Vec::with_capacity(select.fields.fields().len());
+    for field in select.fields.fields() {
+        match field {
+            tidb_ast::SelectField::Expr {
+                expr: tidb_ast::Expr::Column(path),
+                ..
+            } => {
+                let offset = column_offset(path)?;
+                if !group_set.contains(&offset) {
+                    return None;
+                }
+                output_to_source.push(Some(offset));
+                outputs.push(crate::join::IndexLookupAggregateOutput::Column(offset));
+            }
+            tidb_ast::SelectField::Expr {
+                expr:
+                    tidb_ast::Expr::Aggregate {
+                        name,
+                        distinct: false,
+                        args,
+                    },
+                ..
+            } if name.eq_ignore_ascii_case("SUM") => {
+                let [tidb_ast::Expr::Column(path)] = args.as_slice() else {
+                    return None;
+                };
+                let offset = column_offset(path)?;
+                if table.visible_columns()[offset].field_type.code()
+                    != tidb_datatype::FieldTypeCode::NewDecimal
+                    || sum_offset.replace(offset).is_some()
+                {
+                    return None;
+                }
+                output_to_source.push(None);
+                outputs.push(crate::join::IndexLookupAggregateOutput::DecimalSum);
+            }
+            _ => return None,
+        }
+    }
+    let sum_offset = sum_offset?;
+    let physical_name =
+        |offset: usize| format!("{origin}.{}", table.visible_columns()[offset].name);
+    let groups = group_offsets
+        .iter()
+        .map(|offset| physical_name(*offset))
+        .collect::<Vec<_>>();
+    let mut functions = vec![format!(
+        "funcs:sum({})->Column#0",
+        physical_name(sum_offset)
+    )];
+    functions.extend(outputs.iter().filter_map(|output| match output {
+        crate::join::IndexLookupAggregateOutput::Column(offset) => {
+            let name = physical_name(*offset);
+            Some(format!("funcs:firstrow({name})->{name}"))
+        }
+        crate::join::IndexLookupAggregateOutput::DecimalSum => None,
+    }));
+    let aggregation_info = format!("group by:{}, {}", groups.join(", "), functions.join(", "));
+    let mut filters = Vec::new();
+    if let Some(predicate) = &select.where_clause {
+        ast_conjuncts(predicate, &mut filters);
+    }
+    Some(GroupedDecimalSumLookup {
+        table,
+        source_visible,
+        origin,
+        output_to_source,
+        filters,
+        aggregation: crate::join::IndexLookupAggregation {
+            group_offsets,
+            sum_offset,
+            outputs,
+        },
+        aggregation_info,
+    })
+}
+
+fn ast_conjuncts(expr: &tidb_ast::Expr, out: &mut Vec<tidb_ast::Expr>) {
+    match expr {
+        tidb_ast::Expr::Binary(tidb_ast::BinaryOp::LogicAnd, left, right) => {
+            ast_conjuncts(left, out);
+            ast_conjuncts(right, out);
+        }
+        expr => out.push(expr.clone()),
     }
 }
 

--- a/rust/crates/tidb-executor/src/driver/join_method_hints.rs
+++ b/rust/crates/tidb-executor/src/driver/join_method_hints.rs
@@ -105,9 +105,12 @@ pub(crate) struct JoinMethodHints {
     /// `HASH_JOIN` / `TIDB_HJ` -- Go `PlanHints.HashJoin`.
     hash: Vec<String>,
     /// `INL_JOIN` / `TIDB_INLJ` / `INL_HASH_JOIN` / `INL_MERGE_JOIN` -- Go
-    /// `PlanHints.IndexJoin`'s three table lists, which
-    /// `hasForceIndexJoinFamilyHint` reads as one.
+    /// `PlanHints.IndexJoin`'s ordinary lookup-join table list.
     index: Vec<String>,
+    /// Go `PlanHints.IndexHashJoin`.
+    index_hash: Vec<String>,
+    /// Go `PlanHints.IndexMergeJoin`.
+    index_merge: Vec<String>,
 }
 
 impl JoinMethodHints {
@@ -128,7 +131,9 @@ impl JoinMethodHints {
                 "merge_join" | "tidb_smj" => &mut hints.merge,
                 "no_merge_join" => &mut hints.no_merge,
                 "hash_join" | "tidb_hj" => &mut hints.hash,
-                "inl_join" | "tidb_inlj" | "inl_hash_join" | "inl_merge_join" => &mut hints.index,
+                "inl_join" | "tidb_inlj" => &mut hints.index,
+                "inl_hash_join" => &mut hints.index_hash,
+                "inl_merge_join" => &mut hints.index_merge,
                 _ => continue,
             };
             list.extend(tables);
@@ -143,6 +148,8 @@ impl JoinMethodHints {
             && self.no_merge.is_empty()
             && self.hash.is_empty()
             && self.index.is_empty()
+            && self.index_hash.is_empty()
+            && self.index_merge.is_empty()
     }
 
     /// Go's `MatchTableName`: does `list` name either side's alias.
@@ -198,7 +205,54 @@ impl JoinMethodHints {
         // `handleForceIndexJoinHints` returning `forced, true`. See the
         // module doc's NAMED RESIDUE for why this does not first check that an
         // index join is available.
-        !Self::matches(&self.index, sides)
+        !self.matches_index_family(sides)
+    }
+
+    /// Whether Go's forced index-join arm owns this site.
+    ///
+    /// `MERGE_JOIN` and a viable empty-property `HASH_JOIN` are tested before
+    /// `handleForceIndexJoinHints` in the same preference walk, so they keep
+    /// their precedence when hints conflict. Structural index eligibility is
+    /// still checked by `index_join_decision`; this method only narrows the
+    /// candidate family.
+    #[cfg(test)]
+    pub(crate) fn forces_index_join(
+        &self,
+        sides: (Option<&str>, Option<&str>),
+        prop_is_empty: bool,
+    ) -> bool {
+        !Self::matches(&self.merge, sides)
+            && !(prop_is_empty && Self::matches(&self.hash, sides))
+            && self.matches_index_family(sides)
+    }
+
+    /// The exact executor name forced by the matching index-family hint.
+    /// Keeping the three lists separate is observable: Go does not cost an
+    /// `INL_JOIN` into `IndexHashJoin`, nor vice versa.
+    pub(crate) fn forced_index_join_name(
+        &self,
+        sides: (Option<&str>, Option<&str>),
+        prop_is_empty: bool,
+    ) -> Option<&'static str> {
+        if Self::matches(&self.merge, sides) || (prop_is_empty && Self::matches(&self.hash, sides))
+        {
+            return None;
+        }
+        if Self::matches(&self.index, sides) {
+            Some("IndexJoin")
+        } else if Self::matches(&self.index_hash, sides) {
+            Some("IndexHashJoin")
+        } else if Self::matches(&self.index_merge, sides) {
+            Some("IndexMergeJoin")
+        } else {
+            None
+        }
+    }
+
+    fn matches_index_family(&self, sides: (Option<&str>, Option<&str>)) -> bool {
+        Self::matches(&self.index, sides)
+            || Self::matches(&self.index_hash, sides)
+            || Self::matches(&self.index_merge, sides)
     }
 }
 
@@ -296,7 +350,30 @@ mod tests {
     fn an_index_join_hint_drops_the_merge() {
         let hints = hints_of("select /*+ TIDB_INLJ(t2) */ * from t t1 join t t2 on t1.a = t2.a");
         assert!(!hints.merge_join_allowed((Some("t1"), Some("t2")), true));
+        assert!(hints.forces_index_join((Some("t1"), Some("t2")), true));
+        assert_eq!(
+            hints.forced_index_join_name((Some("t1"), Some("t2")), true),
+            Some("IndexJoin")
+        );
         assert!(hints.merge_join_allowed((Some("t1"), Some("t3")), true));
+        assert!(!hints.forces_index_join((Some("t1"), Some("t3")), true));
+    }
+
+    #[test]
+    fn each_index_hint_keeps_its_executor_name() {
+        for (hint, expected) in [
+            ("INL_JOIN(t2)", "IndexJoin"),
+            ("INL_HASH_JOIN(t2)", "IndexHashJoin"),
+            ("INL_MERGE_JOIN(t2)", "IndexMergeJoin"),
+        ] {
+            let hints = hints_of(&format!(
+                "select /*+ {hint} */ * from t t1 join t t2 on t1.a = t2.a"
+            ));
+            assert_eq!(
+                hints.forced_index_join_name((Some("t1"), Some("t2")), true),
+                Some(expected)
+            );
+        }
     }
 
     /// The merge hint is read FIRST, so it wins over every other -- including

--- a/rust/crates/tidb-executor/src/driver/join_reorder.rs
+++ b/rust/crates/tidb-executor/src/driver/join_reorder.rs
@@ -234,7 +234,7 @@
 //! `DataSource`s exist, what selectivity was pushed into each, and which
 //! column is which. See [`Rel`] and [`emit`].
 
-use std::collections::BTreeSet;
+use std::{cell::RefCell, collections::BTreeSet};
 
 use tidb_ast::{BinaryOp, Expr, Join, JoinNode, JoinType, QueryStmt, SelectField};
 use tidb_datatype::FieldType;
@@ -271,6 +271,9 @@ pub(crate) struct Reordered {
     /// already uses (`FromScope::star`).
     pub(crate) written_order: Vec<usize>,
 }
+
+type LeafColumn = (usize, usize);
+type JoinEdge = (LeafColumn, LeafColumn);
 
 /// One leaf of the join group: a relation the reorder moves but never opens.
 struct Leaf<'a> {
@@ -313,6 +316,9 @@ struct DerivedRel<'a> {
     visible: String,
     /// One entry per output column: its defining expression.
     exprs: Vec<&'a Expr>,
+    /// The aggregation's group expressions, or `None` for a plain projection.
+    /// `Some([])` is a global aggregation.
+    group_by: Option<Vec<&'a Expr>>,
     /// The output columns' names, for a conjunct written against them.
     names: Vec<String>,
     /// The output columns' ids.
@@ -320,7 +326,7 @@ struct DerivedRel<'a> {
     /// The subquery's own `FROM` leaves.
     inner: Vec<Leaf<'a>>,
     /// The subquery's own equi edges, as `(leaf, column)` pairs into `inner`.
-    inner_edges: Vec<((usize, usize), (usize, usize))>,
+    inner_edges: Vec<JoinEdge>,
     /// The subquery's own single-leaf conjuncts, per inner leaf.
     inner_filters: Vec<Vec<Expr>>,
 }
@@ -951,11 +957,10 @@ fn leaf_of<'a>(
             let QueryStmt::Select(select) = &**subquery else {
                 return None;
             };
-            // Only a plain projection over a join is a relation whose row
-            // count this module can derive; anything that changes the count on
-            // its own way up is a decline.
-            if !select.group_by.is_empty()
-                || select.having.is_some()
+            // LIMIT, DISTINCT and the remaining clauses change the relation
+            // through logical nodes this row source still does not model. A
+            // grouped/global aggregation is modelled explicitly below.
+            if select.having.is_some()
                 || select.distinct
                 || select.limit.is_some()
                 || select.with.is_some()
@@ -966,17 +971,18 @@ fn leaf_of<'a>(
             }
             let names = crate::driver::from::derived_field_names(select)?;
             let mut exprs = Vec::new();
+            let mut has_aggregate = false;
             for field in select.fields.fields() {
                 match field {
                     SelectField::Expr { expr, .. } => {
-                        if expr.has_aggregate_flag() {
-                            return None;
-                        }
+                        has_aggregate |= expr.has_aggregate_flag();
                         exprs.push(expr);
                     }
                     SelectField::Wildcard { .. } => return None,
                 }
             }
+            let group_by = (!select.group_by.is_empty() || has_aggregate)
+                .then(|| select.group_by.iter().map(|item| &item.expr).collect());
             let from = select.from.as_ref()?;
             let mut inner = Vec::new();
             let mut inner_on = Vec::new();
@@ -1021,6 +1027,7 @@ fn leaf_of<'a>(
                 rel: Rel::Derived(DerivedRel {
                     visible: alias.to_owned(),
                     exprs,
+                    group_by,
                     names,
                     ids: column_ids,
                     inner,
@@ -1078,21 +1085,36 @@ fn emit(rel: &Rel<'_>, demand: &Demand) -> Option<LogicalNode> {
                 push_filter(derived, filter, &mut inner)?;
             }
             let child = emit_tree(derived, &inner)?;
-            Some(LogicalNode::Projection {
-                child: Box::new(child),
-                exprs: (0..derived.exprs.len())
-                    .map(|output| ProjectionExpr {
-                        output: derived.ids[output],
-                        inputs: column_paths(derived.exprs[output])
-                            .iter()
-                            .filter_map(|path| {
-                                let (leaf, column) = resolve(path, &derived.inner)?;
-                                column_id(&derived.inner[leaf].rel, column)
-                            })
-                            .collect(),
-                    })
-                    .collect(),
-            })
+            if let Some(group_by) = &derived.group_by {
+                let mut group_columns = Vec::new();
+                for expression in group_by {
+                    for path in column_paths(expression) {
+                        let (leaf, column) = resolve(&path, &derived.inner)?;
+                        group_columns.push(column_id(&derived.inner[leaf].rel, column)?);
+                    }
+                }
+                Some(LogicalNode::Aggregation {
+                    child: Box::new(child),
+                    group_by: group_columns,
+                    columns: derived.ids.clone(),
+                })
+            } else {
+                Some(LogicalNode::Projection {
+                    child: Box::new(child),
+                    exprs: (0..derived.exprs.len())
+                        .map(|output| ProjectionExpr {
+                            output: derived.ids[output],
+                            inputs: column_paths(derived.exprs[output])
+                                .iter()
+                                .filter_map(|path| {
+                                    let (leaf, column) = resolve(path, &derived.inner)?;
+                                    column_id(&derived.inner[leaf].rel, column)
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+            }
         }
     }
 }
@@ -1854,16 +1876,57 @@ fn rebuild_node(plan: &Plan, leaves: &[Leaf<'_>], edges: &[Edge<'_>]) -> Option<
 pub(crate) struct RowSource {
     leaves: Vec<RowLeaf>,
     /// `(leaf, column)` pairs, as [`Edge`] holds them.
-    edges: Vec<((usize, usize), (usize, usize))>,
+    edges: Vec<JoinEdge>,
     context: DeriveStatsContext,
+    /// Whether every written predicate belongs to one leaf or is an equality
+    /// edge between two leaves. An index join that installs every leaf's
+    /// filter can consume this wider class even when a leaf is not a point
+    /// get.
+    where_is_leaf_or_join_equality: bool,
+    /// Outer-join leaf predicates are still useful to access-path planning,
+    /// but this source's inner-join cardinality formula must not price an
+    /// outer join. `rows_of_join` declines while the filter inventory remains
+    /// available.
+    join_rows_valid: bool,
+    /// The written WHERE inventory, classified against this join group.
+    where_parts: Vec<WherePart>,
+    /// Leaves whose complete local predicate was accepted by their actual
+    /// physical source. The builder records this only after it commits a
+    /// point/range/index/table access path, so residual selection placement
+    /// cannot drift from the executor that was built.
+    consumed_filter_leaves: RefCell<BTreeSet<usize>>,
+}
+
+struct WherePart {
+    expr: Expr,
+    class: WhereClass,
+}
+
+enum WhereClass {
+    /// Executed by an inner join equality.
+    Edge,
+    /// Eligible for one leaf, provided that leaf's committed path accepts it.
+    Single(usize),
+    /// Executed as an inner join's `other cond`.
+    JoinOther,
+    /// Must remain above the join.
+    Residual,
 }
 
 /// One relation of the group: how it is named, what it models, and the
 /// [`ColumnId`] of each of its output columns.
 struct RowLeaf {
     visible: String,
+    /// Output column names, for resolving a GROUP BY above this FROM.
+    columns: Vec<String>,
     model: LogicalNode,
     ids: Vec<ColumnId>,
+    /// The predicates that reference only this relation. The physical
+    /// builder reuses these for leaf access-path narrowing; the original
+    /// predicates remain above the join for semantic equivalence.
+    filters: Vec<Expr>,
+    /// DNF-derived predicates Go records as a cop Selection above this leaf.
+    trace_filters: Vec<Expr>,
 }
 
 /// Builds the [`RowSource`] of one `FROM`, or `None` for a group whose shape
@@ -1886,8 +1949,12 @@ pub(crate) fn row_source(
     // `max(equality estimate, preserved side)` and is not derivable from the
     // leaf set alone. So this source keeps declining an outer-join group,
     // which is the answer it gave before [`reorder`] started accepting one.
+    // Collect through outer joins so their preserved-side WHERE predicates
+    // and ON-derived constants can still narrow both leaf reads. This does
+    // not authorize reordering: `join_rows_valid` below keeps the inner-only
+    // strategy coster away from these rows.
     let scope = Scope {
-        outer_join_reorder: false,
+        outer_join_reorder: true,
     };
     if !collect(
         join,
@@ -1900,24 +1967,74 @@ pub(crate) fn row_source(
     ) {
         return None;
     }
-    let mut conjuncts: Vec<(&Expr, Option<Outer>)> = on_conds
-        .iter()
-        .map(|cond| (cond.expr, cond.outer))
-        .collect();
+    let join_rows_valid = on_conds.iter().all(|condition| condition.outer.is_none());
+    let mut where_conjuncts = Vec::new();
     if let Some(where_clause) = where_clause {
-        let mut flat = Vec::new();
-        crate::plan_trace::collect_and(where_clause, &mut flat);
-        conjuncts.extend(flat.into_iter().map(|expr| (expr, None)));
+        crate::plan_trace::collect_and(where_clause, &mut where_conjuncts);
     }
     let mut edges = Vec::new();
     let mut filters: Vec<Vec<Expr>> = vec![Vec::new(); leaves.len()];
-    for (conjunct, outer) in &conjuncts {
-        match classify(conjunct, &leaves, *outer)? {
+    let mut trace_filters: Vec<Vec<Expr>> = vec![Vec::new(); leaves.len()];
+    let extended: BTreeSet<usize> = on_conds
+        .iter()
+        .filter_map(|condition| condition.outer.map(|outer| outer.extended))
+        .collect();
+    // An outer join's ON predicate may be pushed only into its
+    // null-supplying side. Pushing a preserved-side condition would delete a
+    // row that the join must instead retain and NULL-extend.
+    for condition in &on_conds {
+        match classify(condition.expr, &leaves, condition.outer)? {
             Classified::Edge(edge) => edges.push((edge.left, edge.right)),
-            Classified::Single(leaf) => filters[leaf].push((*conjunct).clone()),
+            Classified::Single(leaf)
+                if condition.outer.is_none_or(|outer| leaf == outer.extended) =>
+            {
+                filters[leaf].push(condition.expr.clone());
+            }
+            Classified::Single(_) => {}
             Classified::Other(_) | Classified::Foreign => {}
         }
     }
+    let mut where_parts = Vec::with_capacity(where_conjuncts.len());
+    for conjunct in where_conjuncts {
+        let class = match classify(conjunct, &leaves, None)? {
+            Classified::Edge(edge) if join_rows_valid => {
+                edges.push((edge.left, edge.right));
+                WhereClass::Edge
+            }
+            Classified::Single(leaf) if !extended.contains(&leaf) => {
+                filters[leaf].push(conjunct.clone());
+                WhereClass::Single(leaf)
+            }
+            Classified::Other(_) => {
+                for leaf in 0..leaves.len() {
+                    if extended.contains(&leaf) {
+                        continue;
+                    }
+                    if let Some(derived) = project_dnf_to_leaf(conjunct, leaf, &leaves) {
+                        filters[leaf].push(derived.clone());
+                        trace_filters[leaf].push(derived);
+                    }
+                }
+                if join_rows_valid {
+                    WhereClass::JoinOther
+                } else {
+                    WhereClass::Residual
+                }
+            }
+            Classified::Edge(_) | Classified::Single(_) | Classified::Foreign => {
+                WhereClass::Residual
+            }
+        };
+        where_parts.push(WherePart {
+            expr: conjunct.clone(),
+            class,
+        });
+    }
+    propagate_leaf_constants(&leaves, &edges, &mut filters);
+    let where_is_leaf_or_join_equality = !where_parts.is_empty()
+        && where_parts
+            .iter()
+            .all(|part| matches!(part.class, WhereClass::Edge | WhereClass::Single(_)));
     let mut demands: Vec<Demand> = (0..leaves.len()).map(|_| Demand::default()).collect();
     for (left, right) in &edges {
         demands[left.0].not_null.insert(left.1);
@@ -1929,13 +2046,17 @@ pub(crate) fn row_source(
     let rows: Option<Vec<RowLeaf>> = leaves
         .iter()
         .zip(&demands)
-        .map(|(leaf, demand)| {
+        .enumerate()
+        .map(|(at, (leaf, demand))| {
             Some(RowLeaf {
                 visible: leaf.visible.clone(),
+                columns: leaf.columns.clone(),
                 model: emit(&leaf.rel, demand)?,
                 ids: (0..leaf.columns.len())
                     .map(|column| column_id(&leaf.rel, column))
                     .collect::<Option<Vec<_>>>()?,
+                filters: demand.filters.clone(),
+                trace_filters: trace_filters[at].clone(),
             })
         })
         .collect();
@@ -1943,13 +2064,215 @@ pub(crate) fn row_source(
         leaves: rows?,
         edges,
         context: DeriveStatsContext::with_join_reorder_threshold(ctx.join_reorder_threshold()),
+        where_is_leaf_or_join_equality,
+        join_rows_valid,
+        where_parts,
+        consumed_filter_leaves: RefCell::new(BTreeSet::new()),
     })
 }
 
+/// Go's DNF predicate pushdown: for `(a1 AND b1) OR (a2 AND b2)`, each leaf
+/// may evaluate the necessary weakening `a1 OR a2` / `b1 OR b2`. Every OR
+/// branch must contribute a predicate for the target leaf; otherwise the
+/// weakening is `TRUE` and no Selection is useful.
+fn project_dnf_to_leaf(expr: &Expr, target: usize, leaves: &[Leaf<'_>]) -> Option<Expr> {
+    fn collect_or<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+        match expr {
+            Expr::Paren(inner) => collect_or(inner, out),
+            Expr::Binary(BinaryOp::LogicOr, left, right) => {
+                collect_or(left, out);
+                collect_or(right, out);
+            }
+            other => out.push(other),
+        }
+    }
+
+    let mut branches = Vec::new();
+    collect_or(expr, &mut branches);
+    if branches.len() < 2 {
+        return None;
+    }
+    branches
+        .into_iter()
+        .map(|branch| {
+            let mut conjuncts = Vec::new();
+            crate::plan_trace::collect_and(branch, &mut conjuncts);
+            conjuncts
+                .into_iter()
+                .filter(|conjunct| {
+                    matches!(classify(conjunct, leaves, None), Some(Classified::Single(leaf)) if leaf == target)
+                })
+                .cloned()
+                .reduce(|left, right| {
+                    Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right))
+                })
+        })
+        .collect::<Option<Vec<_>>>()?
+        .into_iter()
+        .reduce(|left, right| Expr::Binary(BinaryOp::LogicOr, Box::new(left), Box::new(right)))
+}
+
+/// Copies a constant equality through the inner-join equality graph. This is
+/// the narrow constant-propagation rule needed for composite leading keys:
+/// `warehouse.w_id = 1` plus `customer.c_w_id = warehouse.w_id` gives the
+/// customer leaf a local `c_w_id = 1` range. Only base-table columns with the
+/// same integer domain are propagated; refusing other types is fail-closed.
+fn propagate_leaf_constants(leaves: &[Leaf<'_>], edges: &[JoinEdge], filters: &mut [Vec<Expr>]) {
+    let mut constants = Vec::new();
+    for predicates in filters.iter() {
+        for predicate in predicates {
+            let Some((column, value)) = local_constant_equality(predicate, leaves) else {
+                continue;
+            };
+            constants.push((column, value));
+        }
+    }
+    for (source, value) in constants {
+        let mut reachable = vec![source];
+        let mut seen = BTreeSet::from([source]);
+        let mut cursor = 0;
+        while let Some(column) = reachable.get(cursor).copied() {
+            cursor += 1;
+            for (left, right) in edges {
+                let next = if *left == column {
+                    *right
+                } else if *right == column {
+                    *left
+                } else {
+                    continue;
+                };
+                if seen.insert(next) {
+                    reachable.push(next);
+                }
+            }
+        }
+        for target in reachable.into_iter().filter(|target| *target != source) {
+            if !same_integer_domain(leaves, source, target) {
+                continue;
+            }
+            let Some(path) = leaf_column_path(leaves, target) else {
+                continue;
+            };
+            filters[target.0].push(tidb_ast::Expr::Binary(
+                tidb_ast::BinaryOp::Eq,
+                Box::new(tidb_ast::Expr::Column(path)),
+                Box::new(value.clone()),
+            ));
+        }
+    }
+}
+
+/// The `(leaf, column)` and constant expression of a local equality.
+fn local_constant_equality(
+    predicate: &Expr,
+    leaves: &[Leaf<'_>],
+) -> Option<((usize, usize), Expr)> {
+    let Expr::Binary(BinaryOp::Eq, lhs, rhs) = predicate else {
+        return None;
+    };
+    let (column, value) = match (strip(lhs), strip(rhs)) {
+        (Expr::Column(path), other) if propagatable_constant(other) => (path, other),
+        (other, Expr::Column(path)) if propagatable_constant(other) => (path, other),
+        _ => return None,
+    };
+    Some((resolve(column, leaves)?, value.clone()))
+}
+
+fn propagatable_constant(expr: &Expr) -> bool {
+    match expr {
+        Expr::Paren(inner) => propagatable_constant(inner),
+        Expr::Unary(tidb_ast::UnaryOp::Minus | tidb_ast::UnaryOp::Plus, inner) => {
+            propagatable_constant(inner)
+        }
+        Expr::Int(_)
+        | Expr::Decimal(_)
+        | Expr::Float(_)
+        | Expr::Hex(_)
+        | Expr::Bit(_)
+        | Expr::String(_)
+        | Expr::RawString(_)
+        | Expr::CharsetString { .. }
+        | Expr::Bool(_) => true,
+        _ => false,
+    }
+}
+
+fn leaf_column_path(leaves: &[Leaf<'_>], (leaf, column): (usize, usize)) -> Option<Vec<String>> {
+    Some(vec![
+        leaves.get(leaf)?.visible.clone(),
+        leaves.get(leaf)?.columns.get(column)?.clone(),
+    ])
+}
+
+fn same_integer_domain(leaves: &[Leaf<'_>], left: (usize, usize), right: (usize, usize)) -> bool {
+    let column_type = |(leaf, column): (usize, usize)| match &leaves.get(leaf)?.rel {
+        Rel::Table(table) => table.columns.get(column).map(|(_, field_type)| field_type),
+        Rel::Derived(_) => None,
+    };
+    let (Some(left), Some(right)) = (column_type(left), column_type(right)) else {
+        return false;
+    };
+    left.code().is_type_integer()
+        && right.code().is_type_integer()
+        && left.is_unsigned() == right.is_unsigned()
+}
+
 impl RowSource {
+    /// Whether installing every leaf-local filter and every join equality
+    /// accounts for the complete written `WHERE`.
+    pub(crate) const fn all_where_is_leaf_or_join_equality(&self) -> bool {
+        self.where_is_leaf_or_join_equality
+    }
+
+    /// Records that the committed access path for `visible` accepted every
+    /// leaf-local predicate offered to it.
+    pub(crate) fn mark_leaf_filters_consumed(&self, visible: &str) {
+        if let Some((leaf, _)) = self
+            .leaves
+            .iter()
+            .enumerate()
+            .find(|(_, leaf)| leaf.visible.eq_ignore_ascii_case(visible))
+        {
+            self.consumed_filter_leaves.borrow_mut().insert(leaf);
+        }
+    }
+
+    /// The part of the written `WHERE` that the committed leaf paths and
+    /// inner-join equalities did not consume.
+    pub(crate) fn residual_where(&self) -> Option<Expr> {
+        let consumed = self.consumed_filter_leaves.borrow();
+        self.where_parts
+            .iter()
+            .filter_map(|part| match part.class {
+                WhereClass::Edge | WhereClass::JoinOther => None,
+                WhereClass::Single(leaf) if consumed.contains(&leaf) => None,
+                WhereClass::Single(_) | WhereClass::Residual => Some(part.expr.clone()),
+            })
+            .reduce(|left, right| Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right)))
+    }
+
+    /// The predicates that can be evaluated using only the named leaf.
+    pub(crate) fn filters_for(&self, visible: &str) -> Option<&[Expr]> {
+        self.leaves
+            .iter()
+            .find(|leaf| leaf.visible.eq_ignore_ascii_case(visible))
+            .map(|leaf| leaf.filters.as_slice())
+    }
+
+    /// DNF-derived predicates that are physically evaluated at this leaf.
+    pub(crate) fn trace_filters_for(&self, visible: &str) -> Option<&[Expr]> {
+        self.leaves
+            .iter()
+            .find(|leaf| leaf.visible.eq_ignore_ascii_case(visible))
+            .map(|leaf| leaf.trace_filters.as_slice())
+    }
+
     /// The rows of a joined pair, and of each side, in one walk: the three
     /// counts a join-strategy comparison reads.
     pub(crate) fn rows_of_join(&self, left: &[String], right: &[String]) -> Option<JoinRows> {
+        if !self.join_rows_valid {
+            return None;
+        }
         let (left_rows, left_model, left_at) = self.model_of(left)?;
         let (right_rows, right_model, right_at) = self.model_of(right)?;
         let (left_keys, right_keys) = self.keys_between(&left_at, &right_at)?;
@@ -1965,6 +2288,66 @@ impl RowSource {
             right: right_rows,
             joined: derive_stats(&model, &self.context).stats.row_count,
         })
+    }
+
+    /// Go's `LogicalAggregation.DeriveStats` row count for a GROUP BY above
+    /// this complete FROM tree. This is the group-key NDV after leaf filters
+    /// and join-key NDV clamping, so it distinguishes TPCC condition 01's
+    /// one-row join from condition 04's eight district groups without a
+    /// trace-only heuristic.
+    pub(crate) fn grouped_rows(&self, group_by: &[tidb_ast::GroupByItem]) -> Option<f64> {
+        if !self.join_rows_valid || group_by.is_empty() {
+            return None;
+        }
+        let names: Vec<String> = self
+            .leaves
+            .iter()
+            .map(|leaf| leaf.visible.clone())
+            .collect();
+        let (_, child, _) = self.model_of(&names)?;
+        let mut group_columns = Vec::new();
+        for item in group_by {
+            for path in column_paths(&item.expr) {
+                let (leaf, column) = self.resolve_output_path(&path)?;
+                group_columns.push(*self.leaves.get(leaf)?.ids.get(column)?);
+            }
+        }
+        let model = LogicalNode::Aggregation {
+            child: Box::new(child),
+            group_by: group_columns,
+            // Only RowCount is read. Go assigns that same NDV to every
+            // output, so an empty synthetic schema loses no input here.
+            columns: Vec::new(),
+        };
+        Some(derive_stats(&model, &self.context).stats.row_count)
+    }
+
+    /// Resolves a column path against this row-count inventory with the same
+    /// ambiguity rule as the logical leaf walk.
+    fn resolve_output_path(&self, path: &[String]) -> Option<(usize, usize)> {
+        let (qualifier, name) = match path {
+            [name] => (None, name),
+            [table, name] | [_, table, name] => (Some(table), name),
+            _ => return None,
+        };
+        let mut found = None;
+        for (leaf, relation) in self.leaves.iter().enumerate() {
+            if qualifier.is_some_and(|table| !table.eq_ignore_ascii_case(&relation.visible)) {
+                continue;
+            }
+            let Some(column) = relation
+                .columns
+                .iter()
+                .position(|column| column.eq_ignore_ascii_case(name))
+            else {
+                continue;
+            };
+            if found.is_some() {
+                return None;
+            }
+            found = Some((leaf, column));
+        }
+        found
     }
 
     /// The model of one side, its row count, and which leaves it holds.

--- a/rust/crates/tidb-executor/src/driver/join_reorder.rs
+++ b/rust/crates/tidb-executor/src/driver/join_reorder.rs
@@ -374,6 +374,7 @@ pub(crate) fn reorder(
     let threshold = ctx.join_reorder_threshold();
     let scope = Scope {
         outer_join_reorder: ctx.outer_join_reorder(),
+        allow_ordered_derived: false,
     };
     let mut ids = Ids::default();
     let mut leaves = Vec::new();
@@ -784,6 +785,10 @@ struct Outer {
 /// that the extended side be a single relation.
 struct Scope {
     outer_join_reorder: bool,
+    /// Row estimation may look through an ORDER BY because it does not
+    /// change cardinality. Logical join reordering keeps declining that
+    /// shape until it can prove the requested physical order survives.
+    allow_ordered_derived: bool,
 }
 
 /// Go's `extractJoinGroupImpl`, narrowed: walks the join spine, pushing every
@@ -840,7 +845,7 @@ fn collect<'a>(
                 return false;
             }
             let at = leaves.len();
-            match leaf_of(right, catalog, current_db, ids) {
+            match leaf_of(right, catalog, current_db, scope, ids) {
                 Some(leaf) => leaves.push(leaf),
                 None => return false,
             }
@@ -848,7 +853,7 @@ fn collect<'a>(
         }
         Some(_) => {
             let at = leaves.len();
-            match leaf_of(&join.left, catalog, current_db, ids) {
+            match leaf_of(&join.left, catalog, current_db, scope, ids) {
                 Some(leaf) => leaves.push(leaf),
                 None => return false,
             }
@@ -889,7 +894,7 @@ fn push_node<'a>(
     if let JoinNode::Join(inner) = node {
         return collect(inner, catalog, current_db, scope, ids, leaves, on_conds);
     }
-    match leaf_of(node, catalog, current_db, ids) {
+    match leaf_of(node, catalog, current_db, scope, ids) {
         Some(leaf) => {
             leaves.push(leaf);
             true
@@ -903,6 +908,7 @@ fn leaf_of<'a>(
     node: &'a JoinNode,
     catalog: &'a Catalog,
     current_db: &str,
+    scope: &Scope,
     ids: &mut Ids,
 ) -> Option<Leaf<'a>> {
     match node {
@@ -964,7 +970,7 @@ fn leaf_of<'a>(
                 || select.distinct
                 || select.limit.is_some()
                 || select.with.is_some()
-                || !select.order_by.is_empty()
+                || (!scope.allow_ordered_derived && !select.order_by.is_empty())
                 || !select.windows.is_empty()
             {
                 return None;
@@ -992,6 +998,7 @@ fn leaf_of<'a>(
             // into the subquery; this module leaves that relation atomic.
             let inner_scope = Scope {
                 outer_join_reorder: false,
+                allow_ordered_derived: scope.allow_ordered_derived,
             };
             if !collect(
                 from,
@@ -1955,6 +1962,7 @@ pub(crate) fn row_source(
     // strategy coster away from these rows.
     let scope = Scope {
         outer_join_reorder: true,
+        allow_ordered_derived: true,
     };
     if !collect(
         join,
@@ -2115,8 +2123,9 @@ fn project_dnf_to_leaf(expr: &Expr, target: usize, leaves: &[Leaf<'_>]) -> Optio
 /// Copies a constant equality through the inner-join equality graph. This is
 /// the narrow constant-propagation rule needed for composite leading keys:
 /// `warehouse.w_id = 1` plus `customer.c_w_id = warehouse.w_id` gives the
-/// customer leaf a local `c_w_id = 1` range. Only base-table columns with the
-/// same integer domain are propagated; refusing other types is fail-closed.
+/// customer leaf a local `c_w_id = 1` range. Only columns with the same
+/// integer domain are propagated; a derived output qualifies only when it is
+/// a bare pass-through column whose source type can be followed recursively.
 fn propagate_leaf_constants(leaves: &[Leaf<'_>], edges: &[JoinEdge], filters: &mut [Vec<Expr>]) {
     let mut constants = Vec::new();
     for predicates in filters.iter() {
@@ -2205,9 +2214,10 @@ fn leaf_column_path(leaves: &[Leaf<'_>], (leaf, column): (usize, usize)) -> Opti
 }
 
 fn same_integer_domain(leaves: &[Leaf<'_>], left: (usize, usize), right: (usize, usize)) -> bool {
-    let column_type = |(leaf, column): (usize, usize)| match &leaves.get(leaf)?.rel {
-        Rel::Table(table) => table.columns.get(column).map(|(_, field_type)| field_type),
-        Rel::Derived(_) => None,
+    let column_type = |(leaf, column): (usize, usize)| {
+        leaves
+            .get(leaf)
+            .and_then(|leaf| relation_column_type(&leaf.rel, column))
     };
     let (Some(left), Some(right)) = (column_type(left), column_type(right)) else {
         return false;
@@ -2215,6 +2225,19 @@ fn same_integer_domain(leaves: &[Leaf<'_>], left: (usize, usize), right: (usize,
     left.code().is_type_integer()
         && right.code().is_type_integer()
         && left.is_unsigned() == right.is_unsigned()
+}
+
+fn relation_column_type<'a>(rel: &'a Rel<'a>, column: usize) -> Option<&'a FieldType> {
+    match rel {
+        Rel::Table(table) => table.columns.get(column).map(|(_, field_type)| field_type),
+        Rel::Derived(derived) => {
+            let Expr::Column(path) = strip(derived.exprs.get(column)?) else {
+                return None;
+            };
+            let (leaf, column) = resolve(path, &derived.inner)?;
+            relation_column_type(&derived.inner.get(leaf)?.rel, column)
+        }
+    }
 }
 
 impl RowSource {

--- a/rust/crates/tidb-executor/src/driver/join_reorder.rs
+++ b/rust/crates/tidb-executor/src/driver/join_reorder.rs
@@ -503,6 +503,20 @@ pub(crate) fn reorder(
         .map(|cond| cond.expr)
         .collect();
 
+    // Go runs constant propagation before join reorder.  The cost model must
+    // therefore see the same transitive leaf predicates as the physical
+    // access-path builder: `customer.c_w_id = 1` plus
+    // `customer.c_w_id = order_new_order.no_w_id` narrows both sides before
+    // the greedy solver compares their cumulative costs.  Outer-join edges
+    // are deliberately excluded because a constant cannot cross a
+    // null-producing boundary in both directions.
+    let inner_edges: Vec<JoinEdge> = edges
+        .iter()
+        .filter(|edge| edge.outer.is_none())
+        .map(|edge| (edge.left, edge.right))
+        .collect();
+    propagate_leaf_constants(&leaves, &inner_edges, &mut filters);
+
     // Go's `not(isnull(key))`, derived by `LogicalJoin.PredicatePushDown` for
     // every equi key. An OUTER join derives it for the NULL-EXTENDED side
     // alone -- `DeriveOtherConditions(p, ..., false, true)` under
@@ -1056,7 +1070,7 @@ fn leaf_of<'a>(
 fn emit(rel: &Rel<'_>, demand: &Demand) -> Option<LogicalNode> {
     match rel {
         Rel::Table(table) => {
-            let mut selectivity = table_selectivity(table, &demand.filters);
+            let mut selectivity = table_selectivity(table, &demand.filters, &demand.not_null);
             for column in &demand.not_null {
                 if table.nullable.get(*column).copied().unwrap_or(true) {
                     selectivity *= NOT_NULL_RATE;
@@ -1091,6 +1105,12 @@ fn emit(rel: &Rel<'_>, demand: &Demand) -> Option<LogicalNode> {
             for filter in &demand.filters {
                 push_filter(derived, filter, &mut inner)?;
             }
+            // A parent predicate may have entered this derived relation
+            // through one pass-through output.  Continue Go's equality
+            // propagation across the derived query's own inner-join graph so
+            // every narrowed base relation contributes the right reorder
+            // cost.
+            propagate_demand_constants(&derived.inner, &derived.inner_edges, &mut inner);
             let child = emit_tree(derived, &inner)?;
             if let Some(group_by) = &derived.group_by {
                 let mut group_columns = Vec::new();
@@ -1127,7 +1147,11 @@ fn emit(rel: &Rel<'_>, demand: &Demand) -> Option<LogicalNode> {
 }
 
 /// `cardinality.Selectivity` over the conjuncts pushed into one base table.
-fn table_selectivity(table: &TableRel<'_>, filters: &[Expr]) -> f64 {
+fn table_selectivity(
+    table: &TableRel<'_>,
+    filters: &[Expr],
+    derived_not_null: &BTreeSet<usize>,
+) -> f64 {
     if filters.is_empty() {
         return 1.0;
     }
@@ -1135,6 +1159,12 @@ fn table_selectivity(table: &TableRel<'_>, filters: &[Expr]) -> f64 {
     // to be reduced to its bare column name before it will resolve.
     let bare: Vec<Expr> = filters
         .iter()
+        // The row inventory keeps derived join-key `IS NOT NULL` predicates
+        // in `filters` so the physical leaf can execute and print them, and
+        // also in `Demand::not_null` so the stats model can apply Go's
+        // 0.999 pseudo NULL-bucket rate. Exclude the duplicate copy here;
+        // the loop in `emit` accounts for it exactly once.
+        .filter(|filter| !is_derived_not_null_filter(filter, table, derived_not_null))
         .filter_map(|filter| {
             rewrite_paths(filter, &|path| {
                 Some(vec![path.last().cloned().unwrap_or_default()])
@@ -1145,6 +1175,32 @@ fn table_selectivity(table: &TableRel<'_>, filters: &[Expr]) -> f64 {
     let resolver = crate::driver::from::scope_resolver(&scope);
     let conjuncts: Vec<&Expr> = bare.iter().collect();
     crate::access_cost::selectivity_of_conjuncts(&conjuncts, table.table, &resolver, table.stats)
+}
+
+fn is_derived_not_null_filter(
+    filter: &Expr,
+    table: &TableRel<'_>,
+    derived_not_null: &BTreeSet<usize>,
+) -> bool {
+    let Expr::Is {
+        expr,
+        target: tidb_ast::IsTarget::Null,
+        not: true,
+    } = strip(filter)
+    else {
+        return false;
+    };
+    let Expr::Column(path) = strip(expr) else {
+        return false;
+    };
+    let Some(name) = path.last() else {
+        return false;
+    };
+    table
+        .columns
+        .iter()
+        .position(|(column, _)| column.eq_ignore_ascii_case(name))
+        .is_some_and(|offset| derived_not_null.contains(&offset))
 }
 
 /// Pushes one output column's demand through a projection.
@@ -1882,6 +1938,8 @@ fn rebuild_node(plan: &Plan, leaves: &[Leaf<'_>], edges: &[Edge<'_>]) -> Option<
 /// only the tree over them moves.
 pub(crate) struct RowSource {
     leaves: Vec<RowLeaf>,
+    /// The immutable written topology, including outer-join preservation.
+    plan: RowPlan,
     /// `(leaf, column)` pairs, as [`Edge`] holds them.
     edges: Vec<JoinEdge>,
     context: DeriveStatsContext,
@@ -1890,11 +1948,6 @@ pub(crate) struct RowSource {
     /// filter can consume this wider class even when a leaf is not a point
     /// get.
     where_is_leaf_or_join_equality: bool,
-    /// Outer-join leaf predicates are still useful to access-path planning,
-    /// but this source's inner-join cardinality formula must not price an
-    /// outer join. `rows_of_join` declines while the filter inventory remains
-    /// available.
-    join_rows_valid: bool,
     /// The written WHERE inventory, classified against this join group.
     where_parts: Vec<WherePart>,
     /// Leaves whose complete local predicate was accepted by their actual
@@ -1936,6 +1989,161 @@ struct RowLeaf {
     trace_filters: Vec<Expr>,
 }
 
+/// The half-open leaf range an outer join null-extends in the row inventory.
+///
+/// Logical join reordering deliberately accepts only a one-leaf extended
+/// side, because moving a multi-relation unit would require Go's complete
+/// outer-bind machinery. Row estimation and predicate routing never move the
+/// tree, so they can safely retain the whole written subtree as this range.
+#[derive(Clone, Copy)]
+struct RowOuter {
+    start: usize,
+    end: usize,
+}
+
+impl RowOuter {
+    fn contains(self, leaf: usize) -> bool {
+        (self.start..self.end).contains(&leaf)
+    }
+}
+
+/// One written `ON` conjunct and the complete side it may null-extend.
+struct RowOnCond<'a> {
+    expr: &'a Expr,
+    outer: Option<RowOuter>,
+}
+
+/// The written join topology retained by the row-count inventory.
+///
+/// The ordinary reorder solver owns a different plan tree because it may
+/// move all-inner leaves. This one is immutable and exists only so cardinality
+/// derivation can preserve which side an outer join keeps.
+#[derive(Clone)]
+enum RowPlan {
+    Leaf(usize),
+    Join {
+        left: Box<RowPlan>,
+        right: Box<RowPlan>,
+        kind: JoinKind,
+    },
+}
+
+fn row_plan(join: &Join, leaves: &[Leaf<'_>]) -> Option<RowPlan> {
+    if join.right.is_none() && join.on.is_none() && join.using.is_empty() && !join.natural {
+        return row_plan_node(&join.left, leaves);
+    }
+    let left = row_plan_node(&join.left, leaves)?;
+    let right = row_plan_node(join.right.as_ref()?, leaves)?;
+    let kind = match join.tp {
+        JoinType::Cross => JoinKind::Inner,
+        JoinType::Left => JoinKind::LeftOuter,
+        JoinType::Right => JoinKind::RightOuter,
+    };
+    Some(RowPlan::Join {
+        left: Box::new(left),
+        right: Box::new(right),
+        kind,
+    })
+}
+
+fn row_plan_node(node: &JoinNode, leaves: &[Leaf<'_>]) -> Option<RowPlan> {
+    if let JoinNode::Join(join) = node {
+        return row_plan(join, leaves);
+    }
+    let visible = match node {
+        JoinNode::Table(table) => table
+            .alias
+            .as_deref()
+            .or_else(|| table.name.last().map(String::as_str))?,
+        JoinNode::Derived {
+            alias: Some(alias), ..
+        } => alias,
+        JoinNode::Derived { alias: None, .. } | JoinNode::Join(_) => return None,
+    };
+    leaves
+        .iter()
+        .position(|leaf| leaf.visible.eq_ignore_ascii_case(visible))
+        .map(RowPlan::Leaf)
+}
+
+/// Collects the written relation tree for [`row_source`] without reordering
+/// it. Unlike [`collect`], this accepts a multi-relation null-producing side:
+/// that extra freedom is valid here because this walk only routes safe leaf
+/// predicates and derives statistics; it never rebuilds the join tree.
+fn collect_rows<'a>(
+    join: &'a Join,
+    catalog: &'a Catalog,
+    current_db: &str,
+    ids: &mut Ids,
+    leaves: &mut Vec<Leaf<'a>>,
+    on_conds: &mut Vec<RowOnCond<'a>>,
+) -> bool {
+    if join.right.is_none() && join.on.is_none() && join.using.is_empty() && !join.natural {
+        return push_row_node(&join.left, catalog, current_db, ids, leaves, on_conds);
+    }
+    if join.straight || join.natural || !join.using.is_empty() {
+        return false;
+    }
+    let Some(right) = &join.right else {
+        return false;
+    };
+    if join.tp != JoinType::Cross && join.on.is_none() {
+        return false;
+    }
+
+    let left_start = leaves.len();
+    if !push_row_node(&join.left, catalog, current_db, ids, leaves, on_conds) {
+        return false;
+    }
+    let left_end = leaves.len();
+    let right_start = left_end;
+    if !push_row_node(right, catalog, current_db, ids, leaves, on_conds) {
+        return false;
+    }
+    let right_end = leaves.len();
+    let outer = match join.tp {
+        JoinType::Cross => None,
+        JoinType::Left => Some(RowOuter {
+            start: right_start,
+            end: right_end,
+        }),
+        JoinType::Right => Some(RowOuter {
+            start: left_start,
+            end: left_end,
+        }),
+    };
+    if let Some(on) = &join.on {
+        let mut conjuncts = Vec::new();
+        crate::plan_trace::collect_and(on, &mut conjuncts);
+        on_conds.extend(conjuncts.into_iter().map(|expr| RowOnCond { expr, outer }));
+    }
+    true
+}
+
+fn push_row_node<'a>(
+    node: &'a JoinNode,
+    catalog: &'a Catalog,
+    current_db: &str,
+    ids: &mut Ids,
+    leaves: &mut Vec<Leaf<'a>>,
+    on_conds: &mut Vec<RowOnCond<'a>>,
+) -> bool {
+    if let JoinNode::Join(join) = node {
+        return collect_rows(join, catalog, current_db, ids, leaves, on_conds);
+    }
+    let scope = Scope {
+        outer_join_reorder: false,
+        allow_ordered_derived: true,
+    };
+    match leaf_of(node, catalog, current_db, &scope, ids) {
+        Some(leaf) => {
+            leaves.push(leaf);
+            true
+        }
+        None => false,
+    }
+}
+
 /// Builds the [`RowSource`] of one `FROM`, or `None` for a group whose shape
 /// [`emit`] cannot model.
 ///
@@ -1951,31 +2159,20 @@ pub(crate) fn row_source(
     let mut ids = Ids::default();
     let mut leaves = Vec::new();
     let mut on_conds = Vec::new();
-    // The row counts here feed a JOIN-STRATEGY comparison, whose
-    // [`LogicalNode::Join`] is built inner-only; an outer join's own count is
-    // `max(equality estimate, preserved side)` and is not derivable from the
-    // leaf set alone. So this source keeps declining an outer-join group,
-    // which is the answer it gave before [`reorder`] started accepting one.
-    // Collect through outer joins so their preserved-side WHERE predicates
-    // and ON-derived constants can still narrow both leaf reads. This does
-    // not authorize reordering: `join_rows_valid` below keeps the inner-only
-    // strategy coster away from these rows.
-    let scope = Scope {
-        outer_join_reorder: true,
-        allow_ordered_derived: true,
-    };
-    if !collect(
+    // This inventory never rebuilds the join tree. Its dedicated collector
+    // can therefore look through a multi-relation null-producing side while
+    // the logical reorder above keeps its stricter one-leaf boundary.
+    if !collect_rows(
         join,
         catalog,
         current_db,
-        &scope,
         &mut ids,
         &mut leaves,
         &mut on_conds,
     ) {
         return None;
     }
-    let join_rows_valid = on_conds.iter().all(|condition| condition.outer.is_none());
+    let has_outer_join = on_conds.iter().any(|condition| condition.outer.is_some());
     let mut where_conjuncts = Vec::new();
     if let Some(where_clause) = where_clause {
         crate::plan_trace::collect_and(where_clause, &mut where_conjuncts);
@@ -1983,18 +2180,31 @@ pub(crate) fn row_source(
     let mut edges = Vec::new();
     let mut filters: Vec<Vec<Expr>> = vec![Vec::new(); leaves.len()];
     let mut trace_filters: Vec<Vec<Expr>> = vec![Vec::new(); leaves.len()];
+    let mut not_null: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); leaves.len()];
     let extended: BTreeSet<usize> = on_conds
         .iter()
-        .filter_map(|condition| condition.outer.map(|outer| outer.extended))
+        .flat_map(|condition| {
+            condition
+                .outer
+                .into_iter()
+                .flat_map(|outer| outer.start..outer.end)
+        })
         .collect();
     // An outer join's ON predicate may be pushed only into its
     // null-supplying side. Pushing a preserved-side condition would delete a
     // row that the join must instead retain and NULL-extend.
     for condition in &on_conds {
-        match classify(condition.expr, &leaves, condition.outer)? {
-            Classified::Edge(edge) => edges.push((edge.left, edge.right)),
+        match classify(condition.expr, &leaves, None)? {
+            Classified::Edge(edge) => {
+                for side in [edge.left, edge.right] {
+                    if condition.outer.is_none_or(|outer| outer.contains(side.0)) {
+                        not_null[side.0].insert(side.1);
+                    }
+                }
+                edges.push((edge.left, edge.right));
+            }
             Classified::Single(leaf)
-                if condition.outer.is_none_or(|outer| leaf == outer.extended) =>
+                if condition.outer.is_none_or(|outer| outer.contains(leaf)) =>
             {
                 filters[leaf].push(condition.expr.clone());
             }
@@ -2005,7 +2215,9 @@ pub(crate) fn row_source(
     let mut where_parts = Vec::with_capacity(where_conjuncts.len());
     for conjunct in where_conjuncts {
         let class = match classify(conjunct, &leaves, None)? {
-            Classified::Edge(edge) if join_rows_valid => {
+            Classified::Edge(edge) if !has_outer_join => {
+                not_null[edge.left.0].insert(edge.left.1);
+                not_null[edge.right.0].insert(edge.right.1);
                 edges.push((edge.left, edge.right));
                 WhereClass::Edge
             }
@@ -2023,7 +2235,7 @@ pub(crate) fn row_source(
                         trace_filters[leaf].push(derived);
                     }
                 }
-                if join_rows_valid {
+                if !has_outer_join {
                     WhereClass::JoinOther
                 } else {
                     WhereClass::Residual
@@ -2038,19 +2250,41 @@ pub(crate) fn row_source(
             class,
         });
     }
+    // `LogicalJoin.PredicatePushDown` derives `not(isnull(key))` for both
+    // sides of an inner equality and only the null-producing side of an
+    // outer equality. Make that derived condition part of the same leaf
+    // predicate inventory the physical source must explicitly accept.
+    for (leaf, columns) in not_null.iter().enumerate() {
+        let Rel::Table(table) = &leaves[leaf].rel else {
+            continue;
+        };
+        for column in columns {
+            if !table.nullable.get(*column).copied().unwrap_or(true) {
+                continue;
+            }
+            filters[leaf].push(Expr::Is {
+                expr: Box::new(Expr::Column(vec![
+                    leaves[leaf].visible.clone(),
+                    leaves[leaf].columns[*column].clone(),
+                ])),
+                target: tidb_ast::IsTarget::Null,
+                not: true,
+            });
+        }
+    }
     propagate_leaf_constants(&leaves, &edges, &mut filters);
     let where_is_leaf_or_join_equality = !where_parts.is_empty()
         && where_parts
             .iter()
             .all(|part| matches!(part.class, WhereClass::Edge | WhereClass::Single(_)));
     let mut demands: Vec<Demand> = (0..leaves.len()).map(|_| Demand::default()).collect();
-    for (left, right) in &edges {
-        demands[left.0].not_null.insert(left.1);
-        demands[right.0].not_null.insert(right.1);
+    for (demand, columns) in demands.iter_mut().zip(&not_null) {
+        demand.not_null.extend(columns.iter().copied());
     }
     for (demand, filters) in demands.iter_mut().zip(filters) {
         demand.filters = filters;
     }
+    let plan = row_plan(join, &leaves)?;
     let rows: Option<Vec<RowLeaf>> = leaves
         .iter()
         .zip(&demands)
@@ -2070,10 +2304,10 @@ pub(crate) fn row_source(
         .collect();
     Some(RowSource {
         leaves: rows?,
+        plan,
         edges,
         context: DeriveStatsContext::with_join_reorder_threshold(ctx.join_reorder_threshold()),
         where_is_leaf_or_join_equality,
-        join_rows_valid,
         where_parts,
         consumed_filter_leaves: RefCell::new(BTreeSet::new()),
     })
@@ -2171,6 +2405,17 @@ fn propagate_leaf_constants(leaves: &[Leaf<'_>], edges: &[JoinEdge], filters: &m
     }
 }
 
+fn propagate_demand_constants(leaves: &[Leaf<'_>], edges: &[JoinEdge], demands: &mut [Demand]) {
+    let mut filters: Vec<Vec<Expr>> = demands
+        .iter_mut()
+        .map(|demand| std::mem::take(&mut demand.filters))
+        .collect();
+    propagate_leaf_constants(leaves, edges, &mut filters);
+    for (demand, filters) in demands.iter_mut().zip(filters) {
+        demand.filters = filters;
+    }
+}
+
 /// The `(leaf, column)` and constant expression of a local equality.
 fn local_constant_equality(
     predicate: &Expr,
@@ -2240,6 +2485,61 @@ fn relation_column_type<'a>(rel: &'a Rel<'a>, column: usize) -> Option<&'a Field
     }
 }
 
+impl RowPlan {
+    fn leaf_set(&self) -> BTreeSet<usize> {
+        match self {
+            RowPlan::Leaf(leaf) => [*leaf].into_iter().collect(),
+            RowPlan::Join { left, right, .. } => {
+                let mut leaves = left.leaf_set();
+                leaves.extend(right.leaf_set());
+                leaves
+            }
+        }
+    }
+
+    fn kind_for_split(
+        &self,
+        wanted_left: &BTreeSet<usize>,
+        wanted_right: &BTreeSet<usize>,
+    ) -> Option<JoinKind> {
+        let RowPlan::Join { left, right, kind } = self else {
+            return None;
+        };
+        let left_set = left.leaf_set();
+        let right_set = right.leaf_set();
+        if &left_set == wanted_left && &right_set == wanted_right {
+            return Some(*kind);
+        }
+        if &left_set == wanted_right && &right_set == wanted_left {
+            return Some(match kind {
+                JoinKind::Inner => JoinKind::Inner,
+                JoinKind::LeftOuter => JoinKind::RightOuter,
+                JoinKind::RightOuter => JoinKind::LeftOuter,
+            });
+        }
+        left.kind_for_split(wanted_left, wanted_right)
+            .or_else(|| right.kind_for_split(wanted_left, wanted_right))
+    }
+
+    fn model(&self, source: &RowSource) -> Option<LogicalNode> {
+        match self {
+            RowPlan::Leaf(leaf) => Some(source.leaves.get(*leaf)?.model.clone()),
+            RowPlan::Join { left, right, kind } => {
+                let left_set = left.leaf_set().into_iter().collect::<Vec<_>>();
+                let right_set = right.leaf_set().into_iter().collect::<Vec<_>>();
+                let (left_keys, right_keys) = source.keys_between(&left_set, &right_set)?;
+                Some(LogicalNode::Join {
+                    left: Box::new(left.model(source)?),
+                    right: Box::new(right.model(source)?),
+                    left_keys,
+                    right_keys,
+                    kind: *kind,
+                })
+            }
+        }
+    }
+}
+
 impl RowSource {
     /// Whether installing every leaf-local filter and every join equality
     /// accounts for the complete written `WHERE`.
@@ -2274,6 +2574,57 @@ impl RowSource {
             .reduce(|left, right| Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right)))
     }
 
+    /// The written WHERE that remains after derived-table leaf predicates
+    /// have been substituted into their child SELECTs during logical
+    /// rewriting. Unlike [`Self::residual_where`], join equalities and
+    /// multi-relation `other cond` predicates remain here: no physical join
+    /// has been built yet to execute them.
+    pub(crate) fn residual_where_after_logical_leaf_pushdown(&self) -> Option<Expr> {
+        let consumed = self.consumed_filter_leaves.borrow();
+        self.where_parts
+            .iter()
+            .filter_map(|part| match part.class {
+                WhereClass::Single(leaf) if consumed.contains(&leaf) => None,
+                WhereClass::Edge
+                | WhereClass::Single(_)
+                | WhereClass::JoinOther
+                | WhereClass::Residual => Some(part.expr.clone()),
+            })
+            .reduce(|left, right| Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right)))
+    }
+
+    /// The part of one join node's written `ON` that its committed leaf
+    /// sources did not consume.
+    ///
+    /// A predicate is removed only when it belongs to exactly one leaf, was
+    /// present in that leaf's safe filter inventory, and that exact source
+    /// accepted its complete inventory. Join equalities and preserved-side
+    /// outer-join predicates therefore always remain at the join.
+    pub(crate) fn residual_on(&self, on: Option<&Expr>) -> Option<Expr> {
+        let on = on?;
+        let consumed = self.consumed_filter_leaves.borrow();
+        let mut conjuncts = Vec::new();
+        crate::plan_trace::collect_and(on, &mut conjuncts);
+        conjuncts
+            .into_iter()
+            .filter(|conjunct| {
+                let owners = column_paths(conjunct)
+                    .iter()
+                    .map(|path| self.resolve_output_path(path).map(|(leaf, _)| leaf))
+                    .collect::<Option<BTreeSet<_>>>();
+                let Some(owners) = owners else {
+                    return true;
+                };
+                if owners.len() != 1 {
+                    return true;
+                }
+                let leaf = *owners.first().expect("one predicate owner");
+                !consumed.contains(&leaf) || !self.leaves[leaf].filters.contains(*conjunct)
+            })
+            .cloned()
+            .reduce(|left, right| Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right)))
+    }
+
     /// The predicates that can be evaluated using only the named leaf.
     pub(crate) fn filters_for(&self, visible: &str) -> Option<&[Expr]> {
         self.leaves
@@ -2293,23 +2644,46 @@ impl RowSource {
     /// The rows of a joined pair, and of each side, in one walk: the three
     /// counts a join-strategy comparison reads.
     pub(crate) fn rows_of_join(&self, left: &[String], right: &[String]) -> Option<JoinRows> {
-        if !self.join_rows_valid {
-            return None;
-        }
         let (left_rows, left_model, left_at) = self.model_of(left)?;
         let (right_rows, right_model, right_at) = self.model_of(right)?;
         let (left_keys, right_keys) = self.keys_between(&left_at, &right_at)?;
+        let left_set = left_at.iter().copied().collect::<BTreeSet<_>>();
+        let right_set = right_at.iter().copied().collect::<BTreeSet<_>>();
+        let kind = self.plan.kind_for_split(&left_set, &right_set)?;
+        let outer_rows = (kind != JoinKind::Inner && !left_keys.is_empty()).then(|| {
+            let grouped_rows = |child: &LogicalNode, keys: &[ColumnId]| {
+                derive_stats(
+                    &LogicalNode::Aggregation {
+                        child: Box::new(child.clone()),
+                        group_by: keys.to_vec(),
+                        columns: Vec::new(),
+                    },
+                    &self.context,
+                )
+                .stats
+                .row_count
+            };
+            let left_ndv = grouped_rows(&left_model, &left_keys);
+            let right_ndv = grouped_rows(&right_model, &right_keys);
+            let equality_rows = left_rows * right_rows / left_ndv.max(right_ndv).max(1.0);
+            match kind {
+                JoinKind::Inner => equality_rows,
+                JoinKind::LeftOuter => equality_rows.max(left_rows),
+                JoinKind::RightOuter => equality_rows.max(right_rows),
+            }
+        });
         let model = LogicalNode::Join {
             left: Box::new(left_model),
             right: Box::new(right_model),
             left_keys,
             right_keys,
-            kind: JoinKind::Inner,
+            kind,
         };
         Some(JoinRows {
             left: left_rows,
             right: right_rows,
-            joined: derive_stats(&model, &self.context).stats.row_count,
+            joined: outer_rows
+                .unwrap_or_else(|| derive_stats(&model, &self.context).stats.row_count),
         })
     }
 
@@ -2319,15 +2693,10 @@ impl RowSource {
     /// one-row join from condition 04's eight district groups without a
     /// trace-only heuristic.
     pub(crate) fn grouped_rows(&self, group_by: &[tidb_ast::GroupByItem]) -> Option<f64> {
-        if !self.join_rows_valid || group_by.is_empty() {
+        if group_by.is_empty() {
             return None;
         }
-        let names: Vec<String> = self
-            .leaves
-            .iter()
-            .map(|leaf| leaf.visible.clone())
-            .collect();
-        let (_, child, _) = self.model_of(&names)?;
+        let child = self.plan.model(self)?;
         let mut group_columns = Vec::new();
         for item in group_by {
             for path in column_paths(&item.expr) {
@@ -2377,7 +2746,11 @@ impl RowSource {
     fn model_of(&self, names: &[String]) -> Option<(f64, LogicalNode, Vec<usize>)> {
         let at: Option<Vec<usize>> = names
             .iter()
-            .map(|name| self.leaves.iter().position(|leaf| leaf.visible == *name))
+            .map(|name| {
+                self.leaves
+                    .iter()
+                    .position(|leaf| leaf.visible.eq_ignore_ascii_case(name))
+            })
             .collect();
         let at = at?;
         let (&first, rest) = at.split_first()?;

--- a/rust/crates/tidb-executor/src/driver/join_search.rs
+++ b/rust/crates/tidb-executor/src/driver/join_search.rs
@@ -41,6 +41,10 @@
 //! left, and no cost can change which family wins:
 //!
 //! * INDEX BY ELIMINATION -- taken here.
+//! * INDEX FOR A SINGLE OUTER ROW -- taken when the estimate says one outer
+//!   row probes strictly fewer rows than reading the inner side whole. This is
+//!   the one cost choice the available row source can settle without pricing
+//!   a candidate tree.
 //! * anything else -- REFUSED here, and refused fail-closed. Choosing between
 //!   two families is `findBestTask`'s costing layer, which needs a priced
 //!   `Candidate` tree per side ([`tidb_planner::candidate_cost`]); this tier
@@ -73,9 +77,12 @@ use crate::hash_join::EquiKey;
 /// What the enumeration leaves standing at one join site.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Chosen {
-    /// Only index-join candidates were enumerated: the choice by elimination,
-    /// which no cost can overturn.
+    /// Index joins are the only enumerated candidates.
     Index,
+    /// A one-row outer side can probe a strict subset of the inner side. The
+    /// caller still verifies that the physical object is a non-primary
+    /// secondary index before committing this cost-shaped choice.
+    IndexForSingleOuterRow,
     /// Refused, and why. See [`Refusal`].
     Refused(Refusal),
 }
@@ -221,15 +228,31 @@ fn decide(input: &SearchInput<'_>, record: &mut Record) -> Chosen {
     let mut index = false;
     let mut hash = false;
     let mut merge = false;
+    let mut single_outer_row_dominates = false;
     for candidate in &candidates {
         match candidate.strategy {
-            JoinStrategy::Index { .. } => index = true,
+            JoinStrategy::Index { outer_idx, .. } => {
+                index = true;
+                let (outer_rows, inner_rows) = if outer_idx == 0 {
+                    (counts.left, counts.right)
+                } else {
+                    (counts.right, counts.left)
+                };
+                // With exactly one driver row, the index alternative performs
+                // one lookup. When that lookup is expected to return fewer
+                // rows than the inner side contains, it avoids a strict
+                // subset of the whole-side read required by hash and merge.
+                // This is deliberately the only cost-shaped comparison made
+                // without a complete candidate tree.
+                single_outer_row_dominates |= outer_rows == 1.0 && counts.joined < inner_rows;
+            }
             JoinStrategy::Hash(_) => hash = true,
             JoinStrategy::Merge { .. } => merge = true,
         }
     }
     match (index, hash, merge) {
         (true, false, false) => Chosen::Index,
+        (true, _, _) if single_outer_row_dominates => Chosen::IndexForSingleOuterRow,
         (true, true, _) => Chosen::Refused(Refusal::HashAlsoEnumerated),
         (true, false, true) => Chosen::Refused(Refusal::MergeAlsoEnumerated),
         (false, ..) => Chosen::Refused(Refusal::NoIndexCandidate),
@@ -277,6 +300,19 @@ fn side_names(join: &Join) -> Option<(Vec<String>, Vec<String>)> {
     leaf_names(&join.left, &mut left)?;
     leaf_names(join.right.as_ref()?, &mut right)?;
     (!left.is_empty() && !right.is_empty()).then_some((left, right))
+}
+
+/// Returns the statement-owned estimates for one join in left/right order.
+///
+/// This is the same answer [`choose`] records and lets the committed index
+/// strategy carry its outer/probe cardinalities into the physical-plan cost
+/// comparison without consulting EXPLAIN-only state.
+pub(crate) fn estimated_rows(
+    join: &Join,
+    rows: Option<&RowSource>,
+) -> Option<crate::driver::join_reorder::JoinRows> {
+    let (left, right) = side_names(join)?;
+    rows?.rows_of_join(&left, &right)
 }
 
 /// Every relation a `FROM` subtree exposes, in row order.

--- a/rust/crates/tidb-executor/src/driver/leaf_access.rs
+++ b/rust/crates/tidb-executor/src/driver/leaf_access.rs
@@ -30,9 +30,11 @@
 //! The second question is the one this module grew for: WHICH ORDER the walk
 //! produces. A leaf whose parent requires an order is handed Go's non-empty
 //! `prop` here, and reports back only what the branch that RAN delivers --
-//! the verify half of the contract in [`super::merge_decision`].
+//! the verify half of the contract in [`super::merge_decision`]. The same
+//! chooser also receives predicates that reference only this leaf, so a
+//! clustered-handle or index range can be selected before the join runs.
 
-use super::access::{index_key_part_name, source_schema_columns};
+use super::access::{index_key_part_name, source_schema_columns, PointPlanStmt};
 use super::*;
 
 /// The covering index a LEAF of a multi-table `FROM` reads instead of its
@@ -133,11 +135,12 @@ pub(crate) fn leaf_index_path(
     visible: &str,
     columns: &[(String, FieldType)],
     demand: &crate::driver::leaf_demand::LeafDemand,
+    where_clause: Option<&tidb_ast::Expr>,
     hints: &crate::index_hints::AvailablePaths,
     catalog: &Catalog,
     zone: &tidb_datatype::SessionTimeZone,
     wanted: Option<&[usize]>,
-) -> Option<LeafIndexPath> {
+) -> Option<LeafAccessPath> {
     // A partitioned leaf would need the pruning this call site has no
     // conditions to run, and Go's `hasPartitionScan` penalty with it.
     if table.partition().is_some() {
@@ -153,10 +156,25 @@ pub(crate) fn leaf_index_path(
     };
     let stats = catalog.table_statistics(table.table_id);
     let stats = stats.as_ref().map(AsRef::as_ref);
+    // Go's TryFastPlan runs before ordinary path costing. A join leaf can use
+    // the same direct lookup when its local predicates pin a handle or a
+    // complete unique/common key; a one-row source satisfies any requested
+    // order trivially.
+    if hints.allows_table() {
+        if let Some(where_clause) = where_clause {
+            let stmt = PointPlanStmt::of_write(Some(where_clause), &[], None);
+            if let Ok(Some(handle)) = super::access::try_point_get(&stmt, table, columns, zone) {
+                return Some(LeafAccessPath::Point {
+                    handle,
+                    order: wanted.map(|order| order.to_vec()).unwrap_or_default(),
+                });
+            }
+        }
+    }
     let mut paths = crate::access_cost::enumerate_paths(
         table,
         columns,
-        None,
+        where_clause,
         &needed,
         &resolver,
         None,
@@ -197,18 +215,16 @@ pub(crate) fn leaf_index_path(
             // which is how an ordered index that is dearer than the ordered
             // table read still loses -- `best.index?` below then reads the
             // table path as "keep the whole-table scan already installed".
-            None => leaf_handle_order(table, columns) == wanted,
+            None => leaf_handle_order(table, columns).starts_with(wanted),
         });
     }
     let best = crate::access_cost::choose_access_path(paths, stats, false)?;
-    let (index_id, ranges) = best.index?;
-    // Stated as a guard rather than assumed: with no `WHERE` to detach, the
-    // enumeration has nothing to narrow an index with, so anything other than
-    // the whole index would mean this call site is reading a path it did not
-    // ask for.
-    if ranges.len() != 1 || !ranges[0].is_full() {
-        return None;
-    }
+    let Some((index_id, ranges)) = best.index else {
+        return best.table_ranges.map(|ranges| LeafAccessPath::HandleRange {
+            ranges,
+            estimate: best.estimate,
+        });
+    };
     // The order the BUILT source will deliver, which is the index walk's own
     // only when this path was chosen to satisfy a property: without that, the
     // source reorders its lookup batches by handle and answers in neither
@@ -222,13 +238,35 @@ pub(crate) fn leaf_index_path(
             .unwrap_or_default(),
         None => Vec::new(),
     };
-    Some(LeafIndexPath {
+    Some(LeafAccessPath::Index(LeafIndexPath {
         index_id,
         ranges,
         estimate: best.estimate,
         order,
         keep_order: wanted.is_some(),
-    })
+    }))
+}
+
+/// The narrowed path a join leaf committed to, or the full-table path when no
+/// candidate beat it. A table range keeps the already-built `TableScanExec`;
+/// an index range replaces it with the streaming index source.
+pub(crate) enum LeafAccessPath {
+    /// A direct point lookup over a complete handle or unique key.
+    Point {
+        /// The handle, or `None` for a guaranteed miss.
+        handle: Option<TableHandle>,
+        /// The requested order, which a one-row source satisfies.
+        order: Vec<usize>,
+    },
+    /// A clustered-handle range over the existing table scan.
+    HandleRange {
+        /// The ranges to offer to the table source.
+        ranges: Vec<IndexRange>,
+        /// The estimate printed for the narrowed scan.
+        estimate: crate::access_cost::ScanEstimate,
+    },
+    /// A secondary-index range source.
+    Index(LeafIndexPath),
 }
 
 /// The order a WHOLE-TABLE walk of `table` delivers, in the leaf's own row
@@ -331,6 +369,27 @@ pub(crate) fn leaf_index_source(
         order: _,
         keep_order,
     } = path;
+    let mut trace = trace;
+    if let Some(trace) = trace.as_deref_mut() {
+        let index = table
+            .indexes()
+            .iter()
+            .find(|index| index.id == index_id)
+            .expect("the chosen path names an index of this table");
+        let index_columns: Vec<String> = index
+            .column_offsets
+            .iter()
+            .map(|offset| index_key_part_name(table, *offset))
+            .collect();
+        let index_columns: Vec<&str> = index_columns.iter().map(String::as_str).collect();
+        if ranges.is_empty() {
+            trace.empty_range_table_dual();
+        } else if ranges.len() == 1 && ranges[0].is_full() {
+            trace.index_full_scan(visible, &index.name, &index_columns, estimate, keep_order);
+        } else {
+            trace.index_range_scan(visible, &index.name, &index_columns, &ranges, estimate);
+        }
+    }
     let mut exec = IndexRangeSourceExec::new_with_context(
         ExecutorMeta::new(
             Schema::new(source_schema_columns(columns)),
@@ -343,6 +402,7 @@ pub(crate) fn leaf_index_source(
         ranges,
         crate::kv_table::RowDecodeContext::for_query(ctx),
     );
+    crate::table_access::TableAccess::accept_scan_estimate(&mut exec, estimate.rows);
     if keep_order {
         // Go's `keep order:true` index read: `canReorderHandles` is false, so
         // the lookup batches are sorted BACK into index order and the rows
@@ -364,18 +424,6 @@ pub(crate) fn leaf_index_source(
         exec.answer_in_index_order();
     }
     if let Some(trace) = trace {
-        let index = table
-            .indexes()
-            .iter()
-            .find(|index| index.id == index_id)
-            .expect("the chosen path names an index of this table");
-        let index_columns: Vec<String> = index
-            .column_offsets
-            .iter()
-            .map(|offset| index_key_part_name(table, *offset))
-            .collect();
-        let index_columns: Vec<&str> = index_columns.iter().map(String::as_str).collect();
-        trace.index_full_scan(visible, &index.name, &index_columns, estimate, keep_order);
         trace.set_scan_act_rows(exec.produced_rows());
     }
     Box::new(exec)

--- a/rust/crates/tidb-executor/src/driver/leaf_access.rs
+++ b/rust/crates/tidb-executor/src/driver/leaf_access.rs
@@ -388,6 +388,9 @@ pub(crate) fn leaf_index_source(
             trace.index_full_scan(visible, &index.name, &index_columns, estimate, keep_order);
         } else {
             trace.index_range_scan(visible, &index.name, &index_columns, &ranges, estimate);
+            if keep_order {
+                trace.keep_order();
+            }
         }
     }
     let mut exec = IndexRangeSourceExec::new_with_context(

--- a/rust/crates/tidb-executor/src/driver/leaf_demand.rs
+++ b/rust/crates/tidb-executor/src/driver/leaf_demand.rs
@@ -114,6 +114,9 @@ pub(crate) struct FromDemand<'a> {
     /// site reads it before it decides a merge join; see
     /// [`crate::driver::join_method_hints`].
     pub(crate) join_hints: Option<&'a crate::driver::join_method_hints::JoinMethodHints>,
+    /// Render optimizer-created joins with the base-column identities Go
+    /// preserves after projection elimination, rather than with AST aliases.
+    pub(crate) physical_source_names: bool,
 }
 
 impl FromDemand<'_> {
@@ -124,6 +127,7 @@ impl FromDemand<'_> {
             columns: None,
             rows: None,
             join_hints: None,
+            physical_source_names: false,
         }
     }
 }

--- a/rust/crates/tidb-executor/src/driver/merge_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/merge_decision.rs
@@ -104,6 +104,7 @@ use super::catalog::split_table_path;
 use super::catalog::{Catalog, TableEntry};
 use super::predicate_push_down::{offered_conjuncts, Offered};
 use crate::merge_join_plan::{MergeJoinKey, MergeJoinPlan};
+use std::collections::BTreeSet;
 use tidb_ast::{Expr, Join, JoinNode, JoinType, QueryStmt, SelectField, SelectStmt};
 
 /// One relation a `FROM` subtree exposes under a name, and where its columns
@@ -239,6 +240,16 @@ pub(crate) struct MergeDecision {
     pub(crate) plan: MergeJoinPlan,
     /// The same keys as `(left, right)` relation-qualified names.
     pub(crate) names: Vec<(RelColumn, RelColumn)>,
+    /// The complete order the left child must build, including any leading
+    /// columns fixed by equality predicates.
+    pub(crate) left_required: Vec<usize>,
+    /// The complete order the right child must build, including any leading
+    /// columns fixed by equality predicates.
+    pub(crate) right_required: Vec<usize>,
+    /// [`Self::left_required`] named so it survives column pruning.
+    pub(crate) left_required_names: Vec<RelColumn>,
+    /// [`Self::right_required`] named so it survives column pruning.
+    pub(crate) right_required_names: Vec<RelColumn>,
 }
 
 /// WHICH of the two questions a properties walk is answering.
@@ -411,6 +422,144 @@ pub(crate) fn delivers(delivered: &[Vec<usize>], wanted: &[usize]) -> bool {
     delivered.iter().any(|order| order.starts_with(wanted))
 }
 
+/// The child order a grouped StreamAgg needs, including leading key columns
+/// fixed by equality predicates.
+///
+/// Go's access-path `EqCondCount` removes fixed leading index parts when it
+/// matches a physical property. This representation keeps those parts in the
+/// scan request -- the record/index walk really delivers them -- and records
+/// that the Selection below the aggregate fixes them, so the remaining suffix
+/// is ordered by the written group items.
+pub(crate) struct AggregationOrder {
+    required: tidb_planner::physical_property::PhysicalProperty,
+    required_columns: Vec<RelColumn>,
+}
+
+impl AggregationOrder {
+    /// The physical property to request from the `FROM` subtree.
+    #[must_use]
+    pub(crate) const fn required(&self) -> &tidb_planner::physical_property::PhysicalProperty {
+        &self.required
+    }
+
+    /// Whether the committed executor, rather than merely a catalog promise,
+    /// delivered the order this grouped aggregation relies on.
+    #[must_use]
+    pub(crate) fn is_delivered_by(
+        &self,
+        delivered: &[Vec<usize>],
+        scope: &super::FromScope,
+    ) -> bool {
+        let required_offsets = self
+            .required_columns
+            .iter()
+            .map(|required| {
+                scope
+                    .tables
+                    .iter()
+                    .find(|table| table.name.eq_ignore_ascii_case(&required.relation))
+                    .and_then(|table| {
+                        table
+                            .columns
+                            .iter()
+                            .position(|(column, _)| column.eq_ignore_ascii_case(&required.column))
+                            .map(|offset| table.offset + offset)
+                    })
+            })
+            .collect::<Option<Vec<_>>>();
+        required_offsets.is_some_and(|required| delivers(delivered, &required))
+    }
+}
+
+/// Finds Go's grouped-StreamAgg child property for this query block.
+pub(crate) fn aggregation_order(
+    select: &SelectStmt,
+    from: &Join,
+    catalog: &Catalog,
+    current_db: &str,
+    offered: Offered<'_>,
+) -> Option<AggregationOrder> {
+    if select.rollup || select.group_by.is_empty() {
+        return None;
+    }
+    let source = join_properties(from, catalog, current_db, offered, Phase::Promise)?;
+    let group_offsets: Vec<usize> = select
+        .group_by
+        .iter()
+        .map(|item| match &item.expr {
+            Expr::Column(path) => source.offset_of(path),
+            _ => None,
+        })
+        .collect::<Option<_>>()?;
+    let mut fixed = BTreeSet::new();
+    let mut conjuncts = Vec::new();
+    if let Some(predicate) = &select.where_clause {
+        crate::plan_trace::collect_and(predicate, &mut conjuncts);
+    }
+    for conjunct in conjuncts {
+        let Expr::Binary(tidb_ast::BinaryOp::Eq, left, right) = conjunct else {
+            continue;
+        };
+        let fixed_path = match (
+            strip_aggregation_parens(left),
+            strip_aggregation_parens(right),
+        ) {
+            (Expr::Column(path), value) if aggregation_constant(value) => Some(path),
+            (value, Expr::Column(path)) if aggregation_constant(value) => Some(path),
+            _ => None,
+        };
+        if let Some(offset) = fixed_path.and_then(|path| source.offset_of(path)) {
+            fixed.insert(offset);
+        }
+    }
+
+    for order in &source.orders {
+        let fixed_prefix = order
+            .iter()
+            .take_while(|offset| fixed.contains(offset))
+            .count();
+        if !order[fixed_prefix..].starts_with(&group_offsets) {
+            continue;
+        }
+        let required_offsets = order[..fixed_prefix + group_offsets.len()].to_vec();
+        let required_columns = required_offsets
+            .iter()
+            .map(|offset| source.column_at(*offset))
+            .collect::<Option<Vec<_>>>()?;
+        return Some(AggregationOrder {
+            required: child_required_prop(required_offsets.iter().copied(), false),
+            required_columns,
+        });
+    }
+    None
+}
+
+fn strip_aggregation_parens(mut expr: &Expr) -> &Expr {
+    while let Expr::Paren(inner) = expr {
+        expr = inner;
+    }
+    expr
+}
+
+fn aggregation_constant(expr: &Expr) -> bool {
+    match expr {
+        Expr::Paren(inner) => aggregation_constant(inner),
+        Expr::Unary(tidb_ast::UnaryOp::Minus | tidb_ast::UnaryOp::Plus, inner) => {
+            aggregation_constant(inner)
+        }
+        Expr::Int(_)
+        | Expr::Decimal(_)
+        | Expr::Float(_)
+        | Expr::Hex(_)
+        | Expr::Bit(_)
+        | Expr::String(_)
+        | Expr::RawString(_)
+        | Expr::CharsetString { .. }
+        | Expr::Bool(_) => true,
+        _ => false,
+    }
+}
+
 /// [`possible_properties`] for a join node: the two sides' relations
 /// concatenated, and the order the join's OWN chosen plan produces.
 pub(crate) fn join_properties(
@@ -517,6 +666,9 @@ fn derived_properties(
     let QueryStmt::Select(select) = subquery else {
         return None;
     };
+    if !select.group_by.is_empty() {
+        return grouped_derived_properties(select, alias, column_names, phase);
+    }
     // A derived table's own `WHERE` is the one offered INSIDE it, which is
     // what `run_select_stmt` hands its `FROM`.
     let inner_offered = offered_conjuncts(select.where_clause.as_ref());
@@ -562,6 +714,141 @@ fn derived_properties(
         columns,
         project_orders(&inner.orders, &sources),
     ))
+}
+
+/// Go `LogicalAggregation.PreparePossibleProperties` projected into a
+/// derived table's output. A grouped StreamAgg can promise the selected group
+/// keys in written order; delivery is reported by the actual materialized
+/// SELECT build, so this function never guesses it in the delivered phase.
+fn grouped_derived_properties(
+    select: &SelectStmt,
+    alias: &str,
+    column_names: &[String],
+    phase: Phase,
+) -> Option<SideProperties> {
+    if phase == Phase::Delivered
+        || select.rollup
+        || select.distinct
+        || select.having.is_some()
+        || select.limit.is_some()
+        || !select.windows.is_empty()
+    {
+        return None;
+    }
+    let group_paths = select
+        .group_by
+        .iter()
+        .map(|item| match &item.expr {
+            Expr::Column(path) => Some(path),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if !select.order_by.is_empty()
+        && (select.order_by.len() != group_paths.len()
+            || select
+                .order_by
+                .iter()
+                .zip(&group_paths)
+                .any(|(item, group)| {
+                    item.desc || !matches!(&item.expr, Expr::Column(path) if path == *group)
+                }))
+    {
+        return None;
+    }
+
+    let mut columns = Vec::with_capacity(select.fields.fields().len());
+    for field in select.fields.fields() {
+        let SelectField::Expr {
+            expr,
+            alias: field_alias,
+        } = field
+        else {
+            return None;
+        };
+        columns.push(match expr {
+            Expr::Column(path) => field_alias
+                .clone()
+                .unwrap_or_else(|| path.last().cloned().unwrap_or_default()),
+            _ => field_alias.clone()?,
+        });
+    }
+    if !column_names.is_empty() {
+        if column_names.len() != columns.len() {
+            return None;
+        }
+        columns = column_names.to_vec();
+    }
+    let order = group_paths
+        .iter()
+        .map(|group| {
+            select.fields.fields().iter().position(|field| {
+                matches!(field, SelectField::Expr { expr: Expr::Column(path), .. } if path == *group)
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(SideProperties::single(
+        alias.to_owned(),
+        columns,
+        vec![order],
+    ))
+}
+
+/// The source-column name behind a bare-column derived output. Projection
+/// elimination keeps this lineage in Go's physical join keys even though the
+/// executor resolves the key through the derived alias. Returning `None`
+/// leaves callers on the ordinary final-scope name.
+pub(crate) fn derived_column_trace_name(
+    node: &JoinNode,
+    column: &RelColumn,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<String> {
+    let JoinNode::Derived {
+        subquery,
+        alias: Some(alias),
+        lateral: false,
+        column_names,
+    } = node
+    else {
+        return None;
+    };
+    if !alias.eq_ignore_ascii_case(&column.relation) {
+        return None;
+    }
+    let QueryStmt::Select(select) = &**subquery else {
+        return None;
+    };
+    let mut output_names = super::from::derived_field_names(select)?;
+    if !column_names.is_empty() {
+        if column_names.len() != output_names.len() {
+            return None;
+        }
+        output_names = column_names.to_vec();
+    }
+    let output = output_names
+        .iter()
+        .position(|name| name.eq_ignore_ascii_case(&column.column))?;
+    let SelectField::Expr {
+        expr: Expr::Column(path),
+        ..
+    } = select.fields.fields().get(output)?
+    else {
+        return None;
+    };
+    let from = select.from.as_ref()?;
+    let source = join_properties(
+        from,
+        catalog,
+        current_db,
+        &offered_conjuncts(select.where_clause.as_ref()),
+        Phase::Promise,
+    )?;
+    let origin = source.column_at(source.offset_of(path)?)?;
+    let database = match path.as_slice() {
+        [database, _, _] => database.as_str(),
+        _ => current_db,
+    };
+    Some(format!("{database}.{}.{}", origin.relation, origin.column))
 }
 
 /// Each of `orders` rewritten through a projection, where `sources[i]` is the
@@ -681,6 +968,28 @@ pub(crate) fn decide(
             .collect();
         conjuncts.extend(repeated);
     }
+    let mut left_fixed = BTreeSet::new();
+    let mut right_fixed = BTreeSet::new();
+    for conjunct in &conjuncts {
+        let Expr::Binary(tidb_ast::BinaryOp::Eq, lhs, rhs) = conjunct else {
+            continue;
+        };
+        let fixed_path = match (strip_aggregation_parens(lhs), strip_aggregation_parens(rhs)) {
+            (Expr::Column(path), value) if aggregation_constant(value) => Some(path),
+            (value, Expr::Column(path)) if aggregation_constant(value) => Some(path),
+            _ => None,
+        };
+        let Some(path) = fixed_path else {
+            continue;
+        };
+        if let Some(offset) = left.offset_of(path) {
+            left_fixed.insert(offset);
+        }
+        if let Some(offset) = right.offset_of(path) {
+            right_fixed.insert(offset);
+        }
+    }
+
     let mut keys = Vec::new();
     for conjunct in conjuncts {
         let Expr::Binary(tidb_ast::BinaryOp::Eq, lhs, rhs) = conjunct else {
@@ -702,12 +1011,27 @@ pub(crate) fn decide(
             keys.push(MergeJoinKey { left: l, right: r });
         }
     }
+    // A fixed column that is itself a join key remains part of the merge
+    // order. Only constant columns BEFORE the first join key are neutral: in
+    // `d_w_id=w_id AND w_id=1`, both key columns are fixed but Go still
+    // merges on `d_w_id=w_id`; trimming them would erase the join key and
+    // incorrectly fall back to an index/hash join.
+    for key in &keys {
+        left_fixed.remove(&key.left);
+        right_fixed.remove(&key.right);
+    }
+    let left_effective = trim_fixed_prefixes(&left.orders, &left_fixed);
+    let right_effective = trim_fixed_prefixes(&right.orders, &right_fixed);
     let plan = crate::merge_join_plan::get_merge_join(
         &keys,
-        &left.orders,
-        &right.orders,
+        &left_effective,
+        &right_effective,
         required.all_same_order().1,
     )?;
+    let left_keys: Vec<usize> = plan.keys.iter().map(|key| key.left).collect();
+    let right_keys: Vec<usize> = plan.keys.iter().map(|key| key.right).collect();
+    let left_required = required_order(&left.orders, &left_fixed, &left_keys)?;
+    let right_required = required_order(&right.orders, &right_fixed, &right_keys)?;
     let names = plan
         .keys
         .iter()
@@ -718,7 +1042,57 @@ pub(crate) fn decide(
             ))
         })
         .collect::<Option<Vec<_>>>()?;
-    Some(MergeDecision { plan, names })
+    let left_required_names = left_required
+        .iter()
+        .map(|offset| left.column_at(*offset))
+        .collect::<Option<Vec<_>>>()?;
+    let right_required_names = right_required
+        .iter()
+        .map(|offset| right.column_at(*offset))
+        .collect::<Option<Vec<_>>>()?;
+    Some(MergeDecision {
+        plan,
+        names,
+        left_required,
+        right_required,
+        left_required_names,
+        right_required_names,
+    })
+}
+
+/// Removes only the leading columns whose equality predicates make them
+/// constant for every row. The remaining suffix is the order a merge join
+/// can compare; the original prefix is restored in [`required_order`] so the
+/// child still chooses the access path and range that provide it.
+fn trim_fixed_prefixes(orders: &[Vec<usize>], fixed: &BTreeSet<usize>) -> Vec<Vec<usize>> {
+    orders
+        .iter()
+        .filter_map(|order| {
+            let prefix = order
+                .iter()
+                .take_while(|offset| fixed.contains(offset))
+                .count();
+            (prefix < order.len()).then(|| order[prefix..].to_vec())
+        })
+        .collect()
+}
+
+/// Finds the original child order whose fixed-prefix-trimmed suffix starts
+/// with `keys`, and returns the whole prefix the child must actually build.
+fn required_order(
+    orders: &[Vec<usize>],
+    fixed: &BTreeSet<usize>,
+    keys: &[usize],
+) -> Option<Vec<usize>> {
+    orders.iter().find_map(|order| {
+        let fixed_prefix = order
+            .iter()
+            .take_while(|offset| fixed.contains(offset))
+            .count();
+        order[fixed_prefix..]
+            .starts_with(keys)
+            .then(|| order[..fixed_prefix + keys.len()].to_vec())
+    })
 }
 
 /// The merge join this join node commits to, read straight off the catalog
@@ -977,5 +1351,20 @@ mod tests {
             Some("t2".to_owned())
         );
         assert!(props.column_at(2).is_none());
+    }
+
+    /// A leading index column fixed by `column = constant` no longer blocks
+    /// a merge on the following key, but the child is still required to build
+    /// the complete `(fixed, key)` order so its access path remains truthful.
+    #[test]
+    fn a_fixed_index_prefix_is_trimmed_for_matching_and_restored_for_building() {
+        let fixed = BTreeSet::from([0]);
+        let orders = vec![vec![0, 1, 2], vec![3]];
+        assert_eq!(
+            trim_fixed_prefixes(&orders, &fixed),
+            vec![vec![1, 2], vec![3]]
+        );
+        assert_eq!(required_order(&orders, &fixed, &[1]), Some(vec![0, 1]));
+        assert_eq!(required_order(&orders, &fixed, &[2]), None);
     }
 }

--- a/rust/crates/tidb-executor/src/driver/merge_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/merge_decision.rs
@@ -193,7 +193,7 @@ impl SideProperties {
     }
 
     /// The relation-qualified name of the column at `offset`.
-    fn column_at(&self, offset: usize) -> Option<RelColumn> {
+    pub(crate) fn column_at(&self, offset: usize) -> Option<RelColumn> {
         for relation in &self.relations {
             if offset >= relation.offset && offset - relation.offset < relation.columns.len() {
                 return Some(RelColumn {
@@ -851,19 +851,63 @@ pub(crate) fn physical_column_trace_name(
     catalog: &Catalog,
     current_db: &str,
 ) -> Option<String> {
+    let origin = physical_column_origin(node, column, catalog, current_db, true)?;
+    Some(format!(
+        "{}.{}.{}",
+        origin.database, origin.table, origin.column
+    ))
+}
+
+/// Whether the base column behind a projection-only output may be NULL.
+/// Aggregate/computed outputs have no single base origin and return `None`.
+pub(crate) fn physical_column_is_nullable(
+    node: &JoinNode,
+    column: &RelColumn,
+    catalog: &Catalog,
+    current_db: &str,
+) -> Option<bool> {
+    physical_column_origin(node, column, catalog, current_db, false).map(|origin| origin.nullable)
+}
+
+struct PhysicalColumnOrigin {
+    database: String,
+    table: String,
+    column: String,
+    nullable: bool,
+}
+
+fn physical_column_origin(
+    node: &JoinNode,
+    column: &RelColumn,
+    catalog: &Catalog,
+    current_db: &str,
+    cross_aggregation: bool,
+) -> Option<PhysicalColumnOrigin> {
     if let JoinNode::Table(table_ref) = node {
         let (database, name) = split_table_path(&table_ref.name, current_db).ok()?;
         let visible = table_ref.alias.as_deref().unwrap_or(name);
-        return visible
-            .eq_ignore_ascii_case(&column.relation)
-            .then(|| format!("{database}.{name}.{}", column.column));
+        if !visible.eq_ignore_ascii_case(&column.relation) {
+            return None;
+        }
+        let entry = catalog.get_in(database, name)?;
+        let (physical_name, field_type) = entry
+            .column_list()
+            .into_iter()
+            .find(|(candidate, _)| candidate.eq_ignore_ascii_case(&column.column))?;
+        return Some(PhysicalColumnOrigin {
+            database: database.to_owned(),
+            table: name.to_owned(),
+            column: physical_name,
+            nullable: !field_type.has_flag(tidb_datatype::FieldTypeFlags::NOT_NULL),
+        });
     }
     if let JoinNode::Join(join) = node {
-        return physical_column_trace_name(&join.left, column, catalog, current_db).or_else(|| {
-            join.right
-                .as_ref()
-                .and_then(|right| physical_column_trace_name(right, column, catalog, current_db))
-        });
+        return physical_column_origin(&join.left, column, catalog, current_db, cross_aggregation)
+            .or_else(|| {
+                join.right.as_ref().and_then(|right| {
+                    physical_column_origin(right, column, catalog, current_db, cross_aggregation)
+                })
+            });
     }
     let JoinNode::Derived {
         subquery,
@@ -880,6 +924,9 @@ pub(crate) fn physical_column_trace_name(
     let QueryStmt::Select(select) = &**subquery else {
         return None;
     };
+    if !cross_aggregation && !select.group_by.is_empty() {
+        return None;
+    }
     let mut output_names = super::from::derived_field_names(select)?;
     if !column_names.is_empty() {
         if column_names.len() != output_names.len() {
@@ -906,11 +953,13 @@ pub(crate) fn physical_column_trace_name(
         Phase::Promise,
     )?;
     let origin = source.column_at(source.offset_of(path)?)?;
-    let database = match path.as_slice() {
-        [database, _, _] => database.as_str(),
-        _ => current_db,
-    };
-    Some(format!("{database}.{}.{}", origin.relation, origin.column))
+    physical_column_origin(&from.left, &origin, catalog, current_db, cross_aggregation).or_else(
+        || {
+            from.right.as_ref().and_then(|right| {
+                physical_column_origin(right, &origin, catalog, current_db, cross_aggregation)
+            })
+        },
+    )
 }
 
 /// Each of `orders` rewritten through a projection, where `sources[i]` is the
@@ -950,6 +999,16 @@ fn project_orders(orders: &[Vec<usize>], sources: &[Option<usize>]) -> Vec<Vec<u
             (!projected.is_empty()).then_some(projected)
         })
         .collect()
+}
+
+/// Maps orders the built input actually delivered through a projection's
+/// output-to-input column mapping. This is the physical verification sibling
+/// of [`project_orders`]'s logical-property use in [`derived_properties`].
+pub(crate) fn project_delivered_orders(
+    orders: &[Vec<usize>],
+    sources: &[Option<usize>],
+) -> Vec<Vec<usize>> {
+    project_orders(orders, sources)
 }
 
 /// The `FROM` of a `SELECT` that carries its source's row order through

--- a/rust/crates/tidb-executor/src/driver/merge_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/merge_decision.rs
@@ -793,16 +793,30 @@ fn grouped_derived_properties(
     ))
 }
 
-/// The source-column name behind a bare-column derived output. Projection
-/// elimination keeps this lineage in Go's physical join keys even though the
-/// executor resolves the key through the derived alias. Returning `None`
-/// leaves callers on the ordinary final-scope name.
-pub(crate) fn derived_column_trace_name(
+/// The source-column name behind a physical join key. Go's projection
+/// elimination keeps the original table identity in `MergeJoin` key text,
+/// even when SQL name resolution used a base-table or derived-table alias.
+/// Returning `None` leaves callers on the ordinary final-scope name.
+pub(crate) fn physical_column_trace_name(
     node: &JoinNode,
     column: &RelColumn,
     catalog: &Catalog,
     current_db: &str,
 ) -> Option<String> {
+    if let JoinNode::Table(table_ref) = node {
+        let (database, name) = split_table_path(&table_ref.name, current_db).ok()?;
+        let visible = table_ref.alias.as_deref().unwrap_or(name);
+        return visible
+            .eq_ignore_ascii_case(&column.relation)
+            .then(|| format!("{database}.{name}.{}", column.column));
+    }
+    if let JoinNode::Join(join) = node {
+        return physical_column_trace_name(&join.left, column, catalog, current_db).or_else(|| {
+            join.right
+                .as_ref()
+                .and_then(|right| physical_column_trace_name(right, column, catalog, current_db))
+        });
+    }
     let JoinNode::Derived {
         subquery,
         alias: Some(alias),

--- a/rust/crates/tidb-executor/src/driver/merge_decision.rs
+++ b/rust/crates/tidb-executor/src/driver/merge_decision.rs
@@ -433,6 +433,7 @@ pub(crate) fn delivers(delivered: &[Vec<usize>], wanted: &[usize]) -> bool {
 pub(crate) struct AggregationOrder {
     required: tidb_planner::physical_property::PhysicalProperty,
     required_columns: Vec<RelColumn>,
+    physical_group_columns: Vec<RelColumn>,
 }
 
 impl AggregationOrder {
@@ -468,6 +469,28 @@ impl AggregationOrder {
             })
             .collect::<Option<Vec<_>>>();
         required_offsets.is_some_and(|required| delivers(delivered, &required))
+    }
+
+    /// Group-key offsets in the physical StreamAgg tuple: ordered non-fixed
+    /// keys first, then equality-fixed keys. The returned offsets use the
+    /// committed (possibly pruned) source scope.
+    pub(crate) fn physical_group_offsets(&self, scope: &super::FromScope) -> Option<Vec<usize>> {
+        self.physical_group_columns
+            .iter()
+            .map(|required| {
+                scope
+                    .tables
+                    .iter()
+                    .find(|table| table.name.eq_ignore_ascii_case(&required.relation))
+                    .and_then(|table| {
+                        table
+                            .columns
+                            .iter()
+                            .position(|(column, _)| column.eq_ignore_ascii_case(&required.column))
+                            .map(|offset| table.offset + offset)
+                    })
+            })
+            .collect()
     }
 }
 
@@ -518,17 +541,42 @@ pub(crate) fn aggregation_order(
             .iter()
             .take_while(|offset| fixed.contains(offset))
             .count();
-        if !order[fixed_prefix..].starts_with(&group_offsets) {
+        // A fixed group key contributes no ordering demand of its own. Go's
+        // `EqCondCount` removes it while matching the property, even when the
+        // same column is also written in GROUP BY. Counting it a second time
+        // would ask `(w,d,o,n)` of an index that already delivers the needed
+        // `(w,d,o)` order for `WHERE w=1 GROUP BY w,d,o`.
+        let ordered_group_offsets: Vec<usize> = group_offsets
+            .iter()
+            .copied()
+            .filter(|offset| !fixed.contains(offset))
+            .collect();
+        if !order[fixed_prefix..].starts_with(&ordered_group_offsets) {
             continue;
         }
-        let required_offsets = order[..fixed_prefix + group_offsets.len()].to_vec();
+        let required_offsets = order[..fixed_prefix + ordered_group_offsets.len()].to_vec();
         let required_columns = required_offsets
+            .iter()
+            .map(|offset| source.column_at(*offset))
+            .collect::<Option<Vec<_>>>()?;
+        let physical_group_offsets = ordered_group_offsets
+            .iter()
+            .copied()
+            .chain(
+                group_offsets
+                    .iter()
+                    .copied()
+                    .filter(|offset| fixed.contains(offset)),
+            )
+            .collect::<Vec<_>>();
+        let physical_group_columns = physical_group_offsets
             .iter()
             .map(|offset| source.column_at(*offset))
             .collect::<Option<Vec<_>>>()?;
         return Some(AggregationOrder {
             required: child_required_prop(required_offsets.iter().copied(), false),
             required_columns,
+            physical_group_columns,
         });
     }
     None

--- a/rust/crates/tidb-executor/src/driver/multi_dml.rs
+++ b/rust/crates/tidb-executor/src/driver/multi_dml.rs
@@ -811,7 +811,7 @@ pub(crate) fn run_multi_delete(
             }
             (TableEntry::Kv(kv), RowId::Kv(handle)) => {
                 kv.delete_row(handle, &ctx.session_zone())
-                    .map_err(|e| DriverError::Parse(format!("row delete failed: {e:?}")))?
+                    .map_err(|e| super::dml::kv_read_error("row delete failed", e))?
             }
             _ => {
                 return Err(DriverError::unsupported(

--- a/rust/crates/tidb-executor/src/driver/params.rs
+++ b/rust/crates/tidb-executor/src/driver/params.rs
@@ -65,173 +65,27 @@ pub fn parameter_count(sql: &str, sql_mode: tidb_parser::SqlMode) -> Result<usiz
 
 /// Walks a statement's expressions, applying `visit` to every marker.
 fn walk_statement_markers(stmt: &mut Stmt, visit: &mut dyn FnMut(&mut tidb_ast::Expr)) {
-    let walk_expr = walk_expr_markers;
-    match stmt {
-        Stmt::Query(query) => walk_query_markers(query, visit),
-        Stmt::Dml(dml) => match &mut **dml {
-            tidb_ast::DmlStmt::Insert(insert) => {
-                for row in &mut insert.rows {
-                    for value in row {
-                        walk_expr(value, visit);
-                    }
-                }
-                for assignment in &mut insert.on_duplicate {
-                    walk_expr(&mut assignment.value, visit);
-                }
-                if let Some(source) = &mut insert.source {
-                    walk_query_markers(source, visit);
-                }
-            }
-            tidb_ast::DmlStmt::Update(update) => {
-                for assignment in &mut update.assignments {
-                    walk_expr(&mut assignment.value, visit);
-                }
-                if let Some(where_clause) = &mut update.where_clause {
-                    walk_expr(where_clause, visit);
-                }
-            }
-            tidb_ast::DmlStmt::Delete(delete) => {
-                if let Some(where_clause) = &mut delete.where_clause {
-                    walk_expr(where_clause, visit);
-                }
-            }
-            _ => {}
-        },
-        // `PREPARE ps FROM 'set @z = ?'` is a prepared statement like any
-        // other (captured: `EXECUTE ps USING @one` then `SELECT @z` is 1), so
-        // its assigned values carry markers too.
-        Stmt::Session(session) => {
-            if let tidb_ast::SessionStmt::SetUserVar(set) = &mut **session {
-                for assignment in &mut set.assignments {
-                    walk_expr(&mut assignment.value, visit);
-                }
-            }
-        }
-        _ => {}
+    struct MarkerVisitor<'a> {
+        visit: &'a mut dyn FnMut(&mut tidb_ast::Expr),
     }
-}
 
-/// The markers inside one query, including its set-operation terms.
-fn walk_query_markers(query: &mut tidb_ast::QueryStmt, visit: &mut dyn FnMut(&mut tidb_ast::Expr)) {
-    match query {
-        tidb_ast::QueryStmt::Select(select) => walk_select_markers(select, visit),
-        tidb_ast::QueryStmt::SetOpr(set_opr) => walk_set_opr_markers(set_opr, visit),
-    }
-}
+    impl tidb_ast::Visitor for MarkerVisitor<'_> {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            let Some(expr @ tidb_ast::Expr::ParamMarker { .. }) =
+                node.downcast_mut::<tidb_ast::Expr>()
+            else {
+                return false;
+            };
+            (self.visit)(expr);
+            true
+        }
 
-/// The markers inside one set operation and, recursively, its nested terms.
-fn walk_set_opr_markers(
-    set_opr: &mut tidb_ast::SetOprStmt,
-    visit: &mut dyn FnMut(&mut tidb_ast::Expr),
-) {
-    for term in &mut set_opr.terms {
-        match &mut term.body {
-            tidb_ast::SetOprTermBody::Select(select) => walk_select_markers(select, visit),
-            tidb_ast::SetOprTermBody::Nested(nested) => walk_set_opr_markers(nested, visit),
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
         }
     }
-}
 
-/// The markers inside one `SELECT`.
-fn walk_select_markers(
-    select: &mut tidb_ast::SelectStmt,
-    visit: &mut dyn FnMut(&mut tidb_ast::Expr),
-) {
-    for field in select.fields.fields_mut() {
-        if let tidb_ast::SelectField::Expr { expr, .. } = field {
-            walk_expr_markers(expr, visit);
-        }
-    }
-    if let Some(where_clause) = &mut select.where_clause {
-        walk_expr_markers(where_clause, visit);
-    }
-    if let Some(having) = &mut select.having {
-        walk_expr_markers(having, visit);
-    }
-    for item in &mut select.order_by {
-        walk_expr_markers(&mut item.expr, visit);
-    }
-    for item in &mut select.group_by {
-        walk_expr_markers(&mut item.expr, visit);
-    }
-    if let Some(limit) = &mut select.limit {
-        walk_expr_markers(&mut limit.count, visit);
-        if let Some(offset) = &mut limit.offset {
-            walk_expr_markers(offset, visit);
-        }
-    }
-}
-
-/// The markers inside one expression tree.
-fn walk_expr_markers(expr: &mut tidb_ast::Expr, visit: &mut dyn FnMut(&mut tidb_ast::Expr)) {
-    use tidb_ast::Expr;
-    if matches!(expr, Expr::ParamMarker { .. }) {
-        visit(expr);
-        return;
-    }
-    match expr {
-        Expr::Paren(inner) | Expr::Unary(_, inner) => walk_expr_markers(inner, visit),
-        Expr::Binary(_, left, right) => {
-            walk_expr_markers(left, visit);
-            walk_expr_markers(right, visit);
-        }
-        Expr::Func { args, .. } => {
-            for arg in args {
-                walk_expr_markers(arg, visit);
-            }
-        }
-        Expr::In { expr, list, .. } => {
-            walk_expr_markers(expr, visit);
-            for item in list {
-                walk_expr_markers(item, visit);
-            }
-        }
-        Expr::Between {
-            expr, low, high, ..
-        } => {
-            walk_expr_markers(expr, visit);
-            walk_expr_markers(low, visit);
-            walk_expr_markers(high, visit);
-        }
-        Expr::Like { expr, pattern, .. } => {
-            walk_expr_markers(expr, visit);
-            walk_expr_markers(pattern, visit);
-        }
-        Expr::Is { expr, .. } => walk_expr_markers(expr, visit),
-        Expr::Case {
-            value,
-            when_clauses,
-            else_clause,
-        } => {
-            if let Some(value) = value {
-                walk_expr_markers(value, visit);
-            }
-            for (condition, result) in when_clauses {
-                walk_expr_markers(condition, visit);
-                walk_expr_markers(result, visit);
-            }
-            if let Some(else_clause) = else_clause {
-                walk_expr_markers(else_clause, visit);
-            }
-        }
-        Expr::Cast(cast) => walk_expr_markers(&mut cast.expr, visit),
-        // A subquery is a query, so its own clauses carry markers: captured,
-        // `select a from t where a in (select a from t where b = ?)` binds one
-        // parameter. Without these arms such a marker is simply not counted,
-        // and the count check then rejects the statement -- a silent refusal
-        // of a shape TiDB accepts.
-        Expr::Subquery(query) => walk_query_markers(query, visit),
-        Expr::Exists { subquery, .. } => walk_query_markers(subquery, visit),
-        Expr::InSubquery { expr, subquery, .. } => {
-            walk_expr_markers(expr, visit);
-            walk_query_markers(subquery, visit);
-        }
-        Expr::CompareSubquery { left, subquery, .. } => {
-            walk_expr_markers(left, visit);
-            walk_query_markers(subquery, visit);
-        }
-        _ => {}
-    }
+    tidb_ast::Visitable::accept(stmt, &mut MarkerVisitor { visit });
 }
 
 /// Replaces each marker with its value, in the parser's own left-to-right
@@ -267,4 +121,47 @@ fn bind_statement_markers(
 /// Counts the markers without changing them.
 fn count_statement_markers(stmt: &mut Stmt, counted: &mut usize) {
     walk_statement_markers(stmt, &mut |_| *counted += 1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bind_parameters, parameter_count};
+    use tidb_datatype::Datum;
+
+    #[test]
+    fn markers_in_derived_tables_and_join_conditions_are_counted_and_bound() {
+        let sql = "SELECT COUNT(*) FROM (SELECT o.o_id FROM orders o \
+                   LEFT JOIN order_line ol ON ol.ol_o_id = ? \
+                   WHERE o.o_w_id = ?) AS t WHERE t.o_id > 0";
+        let mode = tidb_parser::SqlMode::default();
+
+        assert_eq!(parameter_count(sql, mode).unwrap(), 2);
+        let bound = bind_parameters(sql, &[Datum::Int(7), Datum::Int(3)], mode).unwrap();
+        assert_eq!(parameter_count(&bound, mode).unwrap(), 0);
+
+        assert!(bound.contains("`ol`.`ol_o_id`=7"), "{bound}");
+        assert!(bound.contains("`o`.`o_w_id`=3"), "{bound}");
+    }
+
+    #[test]
+    fn markers_inside_row_in_are_bound_in_order() {
+        let sql = "SELECT o_d_id FROM orders WHERE (o_w_id, o_d_id, o_id) IN ((?,?,?),(?,?,?))";
+        let mode = tidb_parser::SqlMode::default();
+        let bound = bind_parameters(
+            sql,
+            &[
+                Datum::Int(1),
+                Datum::Int(2),
+                Datum::Int(3),
+                Datum::Int(4),
+                Datum::Int(5),
+                Datum::Int(6),
+            ],
+            mode,
+        )
+        .unwrap();
+        assert_eq!(parameter_count(&bound, mode).unwrap(), 0);
+        assert!(bound.contains("ROW(1,2,3)"), "{bound}");
+        assert!(bound.contains("ROW(4,5,6)"), "{bound}");
+    }
 }

--- a/rust/crates/tidb-executor/src/driver/predicate_push_down.rs
+++ b/rust/crates/tidb-executor/src/driver/predicate_push_down.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! WHERE equi-conditions carried down into the inner join that can use them.
+//! WHERE conditions carried down into the inner join that can use them.
 //!
 //! Mirrors the part of Go's `pkg/planner/core/rule_predicate_push_down.go`
 //! that `LogicalJoin.PredicatePushDown` performs for an inner join: a
@@ -39,29 +39,23 @@
 //!
 //! # Why the row set cannot move
 //!
-//! A pushed conjunct is not REMOVED from `WHERE`. It is COPIED into the inner
-//! join's condition list, where -- for an inner join, the only kind this
-//! touches -- a condition is a filter over the same pairs the `WHERE` above
-//! would have filtered. So the output is `WHERE(J(a,b))` before and
-//! `WHERE(J_c(a,b))` after with `J_c ⊆ J`, and every pair `J_c` drops is a
-//! pair `WHERE` dropped anyway. Redundancy is the proof: no reasoning about
-//! null-extension or about condition placement is needed, which is exactly
-//! the reasoning an outer join would require -- and outer joins are refused
-//! here rather than reasoned about.
+//! A pushed conjunct becomes an inner-join condition at the lowest node whose
+//! two children together supply its columns. The join-group inventory may
+//! then remove the redundant root predicate after the committed physical
+//! paths prove that every other conjunct is accounted for; without that
+//! proof it stays in `WHERE` as a second, equivalent check. Outer joins are
+//! refused here because moving a predicate across null-extension needs a
+//! different proof.
 //!
-//! Only a bare `col = col` between two columns is eligible. That is the whole
-//! of what turns a nested loop into a hash join
-//! ([`crate::hash_join::split_equi`] indexes nothing else), and it is
-//! trivially free of the two hazards a general predicate carries when it is
-//! evaluated twice: a subquery (whose cost and, for `EXISTS` over a mutating
-//! source, whose answer are not idempotent) and a mutable-effects or
-//! non-deterministic expression, which Go screens for by name
-//! (`expression.IsMutableEffectsExpr`, `CheckNonDeterministic`).
+//! A bare `col = col` becomes an equality key; every other eligible
+//! cross-child predicate becomes the join's `other cond`. Subqueries,
+//! variables, assignments, schema-qualified calls and mutable or
+//! non-deterministic builtins are refused, matching the safety gates Go puts
+//! around predicate movement.
 
-use tidb_ast::{BinaryOp, Expr};
+use tidb_ast::Expr;
 
 use super::from::{FromScope, ScopeResolver};
-use tidb_expr::rewriter::ColumnResolver;
 
 /// The `WHERE` conjuncts an enclosing `SELECT` offers to the joins below it.
 ///
@@ -76,29 +70,57 @@ pub(crate) fn offered_conjuncts(where_clause: Option<&Expr>) -> Vec<&Expr> {
     };
     let mut conjuncts = Vec::new();
     crate::plan_trace::collect_and(expr, &mut conjuncts);
-    conjuncts.retain(|c| column_equality(c).is_some());
+    conjuncts.retain(|conjunct| condition_is_stable(conjunct));
     conjuncts
 }
 
-/// The two column paths of a bare `col = col`, or `None` for anything else.
-fn column_equality(expr: &Expr) -> Option<(&[String], &[String])> {
-    match expr {
-        Expr::Binary(BinaryOp::Eq, lhs, rhs) => match (&**lhs, &**rhs) {
-            (Expr::Column(left), Expr::Column(right)) => Some((left, right)),
-            _ => None,
-        },
-        _ => None,
+/// Whether moving this condition can neither duplicate side effects nor
+/// observe a different volatile value at a lower join node.
+fn condition_is_stable(expr: &Expr) -> bool {
+    struct Check {
+        stable: bool,
     }
+
+    impl tidb_ast::Visitor for Check {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            let Some(expr) = node.downcast_ref::<Expr>() else {
+                return false;
+            };
+            match expr {
+                Expr::UserVar(_)
+                | Expr::SysVar { .. }
+                | Expr::Assign { .. }
+                | Expr::GenericFuncCall { .. } => self.stable = false,
+                Expr::Func { name, .. } => {
+                    let name = name.to_ascii_lowercase();
+                    if super::through_proj::is_mutable_effects(&name)
+                        || super::through_proj::is_unfoldable(&name)
+                    {
+                        self.stable = false;
+                    }
+                }
+                _ => {}
+            }
+            false
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut check = Check { stable: true };
+    let mut owned = expr.clone();
+    tidb_ast::Visitable::accept(&mut owned, &mut check);
+    check.stable
 }
 
 /// The offered conjuncts this join is the lowest node able to evaluate.
 ///
-/// "Lowest" needs no search: a conjunct whose two columns land on OPPOSITE
-/// sides of `left_width` is one neither child could have evaluated alone, and
-/// a conjunct whose columns land on the same side was already offered to that
-/// child's own join node (or belongs to a single table, which is a scan-level
-/// filter this does not attempt). Testing the sides is therefore the whole
-/// placement rule.
+/// "Lowest" needs no search: a conjunct that reads at least one column on
+/// EACH side of `left_width` is one neither child could have evaluated alone.
+/// A conjunct whose columns all land on one side was already offered to that
+/// child's own join node (or belongs to one table, which is scan-level work).
 pub(crate) fn spanning_conjuncts<'a>(
     offered: Offered<'a>,
     scope: &FromScope,
@@ -108,17 +130,15 @@ pub(crate) fn spanning_conjuncts<'a>(
     offered
         .iter()
         .filter(|conjunct| {
-            let Some((left, right)) = column_equality(conjunct) else {
-                return false;
-            };
-            // An unresolvable column is one this scope does not own -- an
-            // outer-query correlation above all -- and is left where it is.
-            let (Some((left_offset, _, _)), Some((right_offset, _, _))) =
-                (resolver.resolve(left), resolver.resolve(right))
+            // This is column pruning's exhaustive expression walk. It refuses
+            // subqueries, parameter markers and any shape whose references it
+            // cannot prove belong to this scope.
+            let Some(offsets) = crate::column_prune::expr_column_offsets(conjunct, &resolver)
             else {
                 return false;
             };
-            (left_offset < left_width) != (right_offset < left_width)
+            offsets.iter().any(|offset| *offset < left_width)
+                && offsets.iter().any(|offset| *offset >= left_width)
         })
         .copied()
         .collect()

--- a/rust/crates/tidb-executor/src/driver/subquery.rs
+++ b/rust/crates/tidb-executor/src/driver/subquery.rs
@@ -40,7 +40,9 @@ use super::*;
 /// bound to a stand-in value, which reaches the same field type without
 /// depending on any outer row -- and it must, because the appended column's
 /// width is fixed before the first inner run (a `SUM` is a 40-byte decimal,
-/// not an 8-byte integer).
+/// not an 8-byte integer). The plan-only entry point is essential: type
+/// inference must never drain the inner executor merely to inspect its output
+/// schema.
 ///
 /// The stand-in is [`probe_datum`] of the outer column's own type, NOT a bare
 /// NULL, for the reason `build_lateral_join` already states for the `LATERAL`
@@ -71,9 +73,9 @@ pub(crate) fn subquery_result_type(
         })
         .collect();
     let typed = bind_subquery_columns(&correlated.select, &probes).ok()?;
-    run_select_stmt(&typed, catalog, current_db, ctx)
+    plan_select_meta_stmt(&typed, catalog, current_db, ctx)
         .ok()
-        .and_then(|(columns, _)| columns.first().map(|(_, ft)| ft.clone()))
+        .and_then(|columns| columns.first().map(|(_, ft)| ft.clone()))
 }
 
 /// A short description of a driver error, for the executor-level error the

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -776,6 +776,220 @@ fn tpcc_condition_nine_rebuilds_grouped_history_over_index_lookup() {
     );
 }
 
+/// TPCC condition 11 pushes its outer predicates through two levels of
+/// pass-through derived projections. Go pins all three grouped leaves to the
+/// requested warehouse, places the aggregate comparison on the inner join,
+/// and preserves the grouped index orders through two merge joins.
+#[test]
+fn tpcc_condition_eleven_pushes_filters_through_nested_derived_joins() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE customer (c_id INT NOT NULL, c_d_id INT NOT NULL, c_w_id INT NOT NULL, \
+         c_first VARCHAR(16), c_middle CHAR(2), c_last VARCHAR(16), \
+         c_street_1 VARCHAR(20), c_street_2 VARCHAR(20), c_city VARCHAR(20), c_state CHAR(2), \
+         c_zip CHAR(9), c_phone CHAR(16), c_since DATETIME, c_credit CHAR(2), \
+         c_credit_lim DECIMAL(12,2), c_discount DECIMAL(4,4), c_balance DECIMAL(12,2), \
+         c_ytd_payment DECIMAL(12,2), c_payment_cnt INT, c_delivery_cnt INT, \
+         c_data VARCHAR(500), \
+         PRIMARY KEY(c_w_id,c_d_id,c_id), \
+         KEY idx_customer(c_w_id,c_d_id,c_last,c_first))",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, \
+         o_c_id INT, o_entry_d DATETIME, o_carrier_id INT, o_ol_cnt INT, o_all_local INT, \
+         PRIMARY KEY(o_w_id,o_d_id,o_id), \
+         KEY idx_order(o_w_id,o_d_id,o_c_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE new_order (no_o_id INT NOT NULL, no_d_id INT NOT NULL, \
+         no_w_id INT NOT NULL, PRIMARY KEY(no_w_id,no_d_id,no_o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+
+    for (table_name, indexes) in [
+        (
+            "customer",
+            vec![
+                ("PRIMARY", true, vec![2, 1, 0]),
+                ("idx_customer", false, vec![2, 1, 5, 3]),
+            ],
+        ),
+        (
+            "orders",
+            vec![
+                ("PRIMARY", true, vec![2, 1, 0]),
+                ("idx_order", false, vec![2, 1, 3, 0]),
+            ],
+        ),
+        ("new_order", vec![("PRIMARY", true, vec![2, 1, 0])]),
+    ] {
+        let TableEntry::Kv(table) = catalog.get_mut_in("test", table_name).unwrap() else {
+            panic!("{table_name} is not a KV table");
+        };
+        for (position, (name, unique, column_offsets)) in indexes.into_iter().enumerate() {
+            table.add_index(crate::kv_table::KvIndex {
+                id: (position + 1) as i64,
+                name: name.to_owned(),
+                unique,
+                prefix_lengths: vec![
+                    crate::ddl::index_prefix::UNSPECIFIED_LENGTH;
+                    column_offsets.len()
+                ],
+                column_offsets,
+                visible: true,
+                global: false,
+            });
+        }
+    }
+
+    // Keep one matching group and one filtered warehouse so predicate
+    // placement is observable in both the answer and the physical plan.
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO customer(c_id,c_d_id,c_w_id,c_first,c_last) VALUES \
+         (1,1,1,'A','A'),(2,1,1,'B','B'),(1,1,2,'C','C')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO orders(o_id,o_d_id,o_w_id,o_c_id) VALUES \
+         (1,1,1,1),(2,1,1,2),(1,1,2,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO new_order VALUES (1,1,1),(1,1,2)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT count(*) FROM \
+        (SELECT * FROM \
+          (SELECT o_w_id, o_d_id, count(*) order_count FROM orders \
+           GROUP BY o_w_id, o_d_id) orders \
+          JOIN \
+          (SELECT no_w_id, no_d_id, count(*) new_order_count FROM new_order \
+           GROUP BY no_w_id, no_d_id) new_order \
+          ON orders.o_w_id = new_order.no_w_id \
+             AND orders.o_d_id = new_order.no_d_id) order_new_order \
+        JOIN \
+        (SELECT c_w_id, c_d_id, count(*) customer_count FROM customer \
+         GROUP BY c_w_id, c_d_id) customer \
+        ON order_new_order.no_w_id = customer.c_w_id \
+           AND order_new_order.no_d_id = customer.c_d_id \
+        WHERE c_w_id = 1 AND order_count - 2100 != new_order_count";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(1)]]
+    );
+
+    let statement = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &statement else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, plan) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: &[Datum], column: usize| match &row[column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    let operators = plan.iter().map(|row| cell(row, 0)).collect::<Vec<_>>();
+    let details = plan.iter().map(|row| cell(row, 4)).collect::<Vec<_>>();
+    let access = plan.iter().map(|row| cell(row, 3)).collect::<Vec<_>>();
+
+    assert_eq!(
+        operators
+            .iter()
+            .filter(|operator| operator.contains("MergeJoin"))
+            .count(),
+        2,
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    let merge_details = operators
+        .iter()
+        .zip(&details)
+        .filter_map(|(operator, detail)| operator.contains("MergeJoin").then_some(detail))
+        .collect::<Vec<_>>();
+    assert_eq!(merge_details.len(), 2, "{operators:#?}\n{details:#?}");
+    assert!(
+        merge_details[0].contains("left key:test.new_order.no_w_id, test.new_order.no_d_id")
+            && merge_details[0]
+                .contains("right key:test.customer.c_w_id, test.customer.c_d_id"),
+        "top join must keep Go TiDB's order_new_order-to-customer orientation:\n{operators:#?}\n{details:#?}"
+    );
+    assert!(
+        merge_details[1].contains("left key:test.orders.o_w_id, test.orders.o_d_id")
+            && merge_details[1]
+                .contains("right key:test.new_order.no_w_id, test.new_order.no_d_id"),
+        "nested join must keep Go TiDB's orders-to-new_order orientation:\n{operators:#?}\n{details:#?}"
+    );
+    assert!(
+        operators.iter().all(|operator| {
+            !operator.contains("HashJoin")
+                && !operator.contains("Selection")
+                && !operator.contains("Projection")
+                && !operator.contains("FullScan")
+        }),
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    assert_eq!(
+        operators
+            .iter()
+            .filter(|operator| operator.contains("RangeScan"))
+            .count(),
+        3,
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    assert!(
+        details.iter().any(|detail| {
+            detail.contains("other cond:ne(minus(") && detail.contains(", 2100)")
+        }),
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    assert!(
+        access
+            .iter()
+            .any(|object| object.contains("customer") && object.contains("idx_customer")),
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    assert!(
+        access
+            .iter()
+            .any(|object| object.contains("orders") && object.contains("idx_order")),
+        "{operators:#?}\n{details:#?}\n{access:#?}"
+    );
+    let customer_aggregation = details
+        .iter()
+        .find(|detail| detail.starts_with("group by:test.customer.c_d_id"))
+        .expect("customer grouped StreamAgg");
+    let customer_district = customer_aggregation
+        .find("funcs:firstrow(test.customer.c_d_id)->test.customer.c_d_id")
+        .expect("customer district carrier");
+    let customer_warehouse = customer_aggregation
+        .find("funcs:firstrow(test.customer.c_w_id)->test.customer.c_w_id")
+        .expect("customer warehouse carrier");
+    let synthetic_count = customer_aggregation
+        .find("funcs:count(Column#")
+        .expect("synthetic customer row count");
+    assert!(
+        customer_district < customer_warehouse && customer_warehouse < synthetic_count,
+        "Go appends the synthetic COUNT after surviving FIRST_ROW carriers: {customer_aggregation}"
+    );
+}
+
 #[test]
 fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
     use crate::explain::{explain_select_stmt, ExplainFormat};

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -489,6 +489,110 @@ fn tpcc_condition_six_simplifies_and_pushes_through_derived_tables() {
     assert!(cell(8, 4).contains("keep order:true"), "{}", cell(8, 4));
 }
 
+/// TPCC condition 08: the fixed warehouse row is the ordered outer side of
+/// an IndexHashJoin into history's secondary index. The grouped SUM carries
+/// `w_ytd` through FIRST_ROW because the derived table's outer predicate
+/// compares that value with the aggregate result.
+#[test]
+fn tpcc_condition_eight_uses_index_join_and_carries_warehouse_ytd() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE warehouse (w_id INT PRIMARY KEY, w_ytd DECIMAL(12,2) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE history (h_w_id INT NOT NULL, h_amount DECIMAL(6,2) NOT NULL, \
+            KEY idx_h_w_id(h_w_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO warehouse VALUES (1,10.00),(2,20.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO history VALUES (1,3.00),(1,4.00),(2,20.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT count(*) cn FROM \
+        (SELECT w_id,w_ytd,SUM(h_amount) sm FROM history,warehouse \
+         WHERE h_w_id=w_id and w_id=1 GROUP BY w_id) t1 WHERE w_ytd<>sm";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(1)]],
+    );
+
+    crate::driver::join_search::ANSWERS.with(|answers| answers.borrow_mut().clear());
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let answers = crate::driver::join_search::ANSWERS.with(|answers| answers.borrow().clone());
+    assert_eq!(answers.len(), 1, "{answers:#?}");
+    assert_eq!(
+        answers[0].chosen,
+        crate::driver::join_search::Chosen::IndexForSingleOuterRow,
+        "{answers:#?}"
+    );
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "StreamAgg",
+            "└─Selection",
+            "  └─StreamAgg",
+            "    └─Projection",
+            "      └─IndexHashJoin",
+            "        ├─Point_Get(Build)",
+            "        └─IndexLookUp(Probe)",
+            "          ├─Selection(Build)",
+            "          │ └─IndexRangeScan",
+            "          └─TableRowIDScan(Probe)",
+        ],
+        "{rows:#?}",
+    );
+    assert_eq!(
+        cell(1, 4),
+        "ne(test.warehouse.w_ytd, Column#1)",
+        "{rows:#?}"
+    );
+    for row in [3, 4, 6, 7, 9] {
+        assert_eq!(cell(row, 1), "1.25", "{rows:#?}");
+    }
+    assert_eq!(cell(8, 1), "1250.00", "{rows:#?}");
+    assert_eq!(
+        cell(3, 4),
+        "test.history.h_amount, test.warehouse.w_id, test.warehouse.w_ytd"
+    );
+    assert!(cell(2, 4).contains("funcs:sum(test.history.h_amount)->Column#"));
+    assert!(
+        cell(2, 4).contains("funcs:firstrow(test.warehouse.w_ytd)->test.warehouse.w_ytd"),
+        "{}",
+        cell(2, 4)
+    );
+    assert!(cell(4, 4).contains("outer key:test.warehouse.w_id"));
+    assert!(cell(4, 4).contains("inner key:test.history.h_w_id"));
+    assert!(cell(5, 3).contains("table:warehouse"));
+    assert!(cell(8, 4).contains("range: decided by"));
+}
+
 #[test]
 fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
     use crate::explain::{explain_select_stmt, ExplainFormat};

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -593,6 +593,78 @@ fn tpcc_condition_eight_uses_index_join_and_carries_warehouse_ytd() {
     assert!(cell(8, 4).contains("range: decided by"));
 }
 
+/// TPCC condition 09 starts with a grouped district relation whose two group
+/// keys are the complete clustered primary key. Every group therefore holds
+/// at most one row, so Go eliminates the aggregation and widens the nullable
+/// DECIMAL `SUM` argument with a real projection cast.
+#[test]
+fn tpcc_condition_nine_eliminates_the_unique_district_aggregation() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE district (d_id INT NOT NULL, d_w_id INT NOT NULL, \
+            d_ytd DECIMAL(12,2), PRIMARY KEY (d_w_id,d_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(district) = catalog.get_mut_in("test", "district").unwrap() else {
+        panic!("district is not a KV table");
+    };
+    district.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 2],
+        column_offsets: vec![1, 0],
+        visible: true,
+        global: false,
+    });
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO district VALUES (1,1,10.25),(2,1,NULL),(1,2,20.50)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT d_id,d_w_id,SUM(d_ytd) s1 FROM district \
+        WHERE d_w_id=1 GROUP BY d_id,d_w_id";
+    let (columns, rows) = crate::run_select_meta_on(sql, &catalog, &ctx).unwrap();
+    assert_eq!(rows.len(), 2, "{rows:#?}");
+    assert!(rows.iter().any(|row| matches!(row[2], Datum::Null)));
+    assert_eq!(columns[2].1.code(), FieldTypeCode::NewDecimal);
+    assert_eq!(columns[2].1.flen(), 34);
+    assert_eq!(columns[2].1.decimal(), 2);
+
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, plan) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &plan[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..plan.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec!["Projection", "└─TableReader", "  └─TableRangeScan"],
+        "{plan:#?}",
+    );
+    assert_eq!(
+        cell(0, 4),
+        "test.district.d_id, test.district.d_w_id, \
+         cast(test.district.d_ytd, decimal(34,2) BINARY)->Column#2"
+    );
+    assert_eq!(cell(1, 4), "data:TableRangeScan");
+    assert!(cell(2, 4).contains("range:[1,1]"), "{}", cell(2, 4));
+    assert!(cell(2, 4).contains("keep order:false"), "{}", cell(2, 4));
+}
+
 #[test]
 fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
     use crate::explain::{explain_select_stmt, ExplainFormat};

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -347,6 +347,148 @@ fn tpcc_condition_four_streams_across_a_grouped_derived_table() {
     assert!(cell(4, 4).contains("right key:test.order_line.ol_d_id"));
 }
 
+/// TPCC condition 06: the predicate above a pass-through derived projection
+/// rejects the LEFT JOIN's NULL row, so Go simplifies it to an inner merge
+/// join. The fixed warehouse key then reaches both common-handle scans, while
+/// the nullable left comparison operand becomes a coprocessor IS NOT NULL
+/// filter.
+#[test]
+fn tpcc_condition_six_simplifies_and_pushes_through_derived_tables() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, \
+            o_ol_cnt INT, PRIMARY KEY (o_w_id,o_d_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(orders) = catalog.get_mut_in("test", "orders").unwrap() else {
+        panic!("orders is not a KV table");
+    };
+    orders.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+        column_offsets: vec![2, 1, 0],
+        visible: true,
+        global: false,
+    });
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (ol_o_id INT NOT NULL, ol_d_id INT NOT NULL, \
+            ol_w_id INT NOT NULL, ol_number INT NOT NULL, \
+            PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(order_line) = catalog.get_mut_in("test", "order_line").unwrap() else {
+        panic!("order_line is not a KV table");
+    };
+    order_line.add_index(crate::kv_table::KvIndex {
+        id: 2,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 4],
+        column_offsets: vec![2, 1, 0, 3],
+        visible: true,
+        global: false,
+    });
+
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO orders VALUES (1,1,1,2),(2,1,1,2),(3,2,1,NULL),(4,1,2,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO order_line VALUES \
+            (1,1,1,1),(1,1,1,2),(2,1,1,1),(3,2,1,1),(4,1,2,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT COUNT(*) FROM \
+        (SELECT o_ol_cnt, order_line_count FROM orders LEFT JOIN \
+          (SELECT ol_w_id, ol_d_id, ol_o_id, count(*) order_line_count \
+           FROM order_line GROUP BY ol_w_id, ol_d_id, ol_o_id \
+           ORDER BY ol_w_id, ol_d_id, ol_o_id) AS order_line \
+         ON orders.o_w_id=order_line.ol_w_id \
+         AND orders.o_d_id=order_line.ol_d_id \
+         AND orders.o_id=order_line.ol_o_id \
+         WHERE orders.o_w_id=1) AS T \
+        WHERE T.o_ol_cnt != T.order_line_count";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(1)]],
+    );
+
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "StreamAgg",
+            "└─MergeJoin",
+            "  ├─StreamAgg(Build)",
+            "  │ └─TableReader",
+            "  │   └─StreamAgg",
+            "  │     └─TableRangeScan",
+            "  └─TableReader(Probe)",
+            "    └─Selection",
+            "      └─TableRangeScan",
+        ],
+    );
+    assert_eq!(cell(1, 1), "9.99", "selection estimate={}", cell(7, 1));
+    assert!(cell(1, 4).contains("inner join"), "{}", cell(1, 4));
+    assert!(cell(1, 4).contains("other cond:ne("), "{}", cell(1, 4));
+    assert!(cell(1, 4).contains(", Column#"), "{}", cell(1, 4));
+    assert!(
+        cell(2, 4).starts_with(
+            "group by:test.order_line.ol_d_id, test.order_line.ol_o_id, \
+             test.order_line.ol_w_id, funcs:count(Column#"
+        ),
+        "{}",
+        cell(2, 4)
+    );
+    assert!(
+        cell(2, 4).contains(
+            "funcs:firstrow(test.order_line.ol_o_id)->test.order_line.ol_o_id, \
+             funcs:firstrow(test.order_line.ol_d_id)->test.order_line.ol_d_id, \
+             funcs:firstrow(test.order_line.ol_w_id)->test.order_line.ol_w_id"
+        ),
+        "{}",
+        cell(2, 4)
+    );
+    assert!(
+        cell(4, 4).starts_with(
+            "group by:test.order_line.ol_d_id, test.order_line.ol_o_id, \
+             test.order_line.ol_w_id, funcs:count(1)->Column#"
+        ),
+        "{}",
+        cell(4, 4)
+    );
+    assert!(cell(5, 4).contains("range:[1,1]"), "{}", cell(5, 4));
+    assert!(cell(5, 4).contains("keep order:true"), "{}", cell(5, 4));
+    assert!(cell(7, 4).contains("not(isnull("), "{}", cell(7, 4));
+    assert_eq!(cell(7, 1), "9.99");
+    assert!(cell(8, 4).contains("range:[1,1]"), "{}", cell(8, 4));
+    assert!(cell(8, 4).contains("keep order:true"), "{}", cell(8, 4));
+}
+
 #[test]
 fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
     use crate::explain::{explain_select_stmt, ExplainFormat};

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -6,6 +6,557 @@
 
 use super::*;
 
+/// TPCC condition 01: join pruning renumbers the merge-key column, but the
+/// committed MergeJoin still delivers that named order to the grouped
+/// StreamAgg. Go projects the three aggregate inputs between the join and the
+/// aggregation.
+#[test]
+fn tpcc_grouped_merge_join_keeps_order_through_pruning() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE district (d_id INT NOT NULL, d_w_id INT NOT NULL, d_ytd DECIMAL(12,2) NOT NULL, \
+            PRIMARY KEY (d_w_id,d_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(district) = catalog.get_mut_in("test", "district").unwrap() else {
+        panic!("district is not a KV table");
+    };
+    district.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 2],
+        column_offsets: vec![1, 0],
+        visible: true,
+        global: false,
+    });
+    crate::run_create_table_on(
+        "CREATE TABLE warehouse (w_id INT PRIMARY KEY, w_ytd DECIMAL(12,2) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO district VALUES (1,1,10),(2,1,20),(1,2,40)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO warehouse VALUES (1,5),(2,7)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT SUM(d_ytd)-MAX(w_ytd) diff FROM district, warehouse \
+        WHERE d_w_id=w_id AND w_id=1 GROUP BY d_w_id";
+    let result = run_select_on(sql, &catalog, &ctx).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].len(), 1);
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "Projection",
+            "└─StreamAgg",
+            "  └─Projection",
+            "    └─MergeJoin",
+            "      ├─TableReader(Build)",
+            "      │ └─TableRangeScan",
+            "      └─Point_Get(Probe)",
+        ],
+    );
+    assert!(cell(1, 4).contains("group by:test.district.d_w_id"));
+    assert!(cell(2, 4).contains("test.district.d_ytd"));
+}
+
+/// TPCC condition 03: a constant fixes the leading common-handle column, so
+/// the remaining `(district, order)` record order supplies the grouped stream
+/// directly. Go pushes the partial StreamAgg below a TableReader and keeps
+/// only the scalar arithmetic in the root Projection.
+#[test]
+fn tpcc_grouped_common_handle_uses_partial_and_final_stream_agg() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE new_order (\
+            no_o_id INT NOT NULL, no_d_id INT NOT NULL, no_w_id INT NOT NULL,\
+            PRIMARY KEY (no_w_id,no_d_id,no_o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(table) = catalog.get_mut_in("test", "new_order").unwrap() else {
+        panic!("new_order is not a KV table");
+    };
+    table.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+        column_offsets: vec![2, 1, 0],
+        visible: true,
+        global: false,
+    });
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO new_order VALUES (1,1,1),(2,1,1),(5,2,1),(7,2,1),(9,1,2)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT MAX(no_o_id)-MIN(no_o_id)+1-COUNT(*) diff \
+        FROM new_order WHERE no_w_id=1 GROUP BY no_d_id";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(0)], vec![Datum::Int(1)]],
+    );
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "Projection",
+            "└─StreamAgg",
+            "  └─TableReader",
+            "    └─StreamAgg",
+            "      └─TableRangeScan",
+        ],
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "root", "root", "cop[tikv]", "cop[tikv]"],
+    );
+    assert!(cell(0, 4).starts_with("minus(plus(minus(Column#"));
+    assert!(cell(1, 4).contains("group by:test.new_order.no_d_id"));
+    assert!(cell(3, 4).contains("funcs:max(test.new_order.no_o_id)->Column#"));
+    assert!(cell(4, 4).contains("range:[1,1], keep order:true"));
+}
+
+/// A selected group key is a root FIRST_ROW carrier, not an extra TiKV
+/// function. The partial schema is `[count, group]`; the final projection
+/// restores the written `[group, count]` order.
+#[test]
+fn grouped_partial_count_carries_the_group_key() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (ol_o_id INT NOT NULL, ol_d_id INT NOT NULL, \
+            ol_w_id INT NOT NULL, ol_number INT NOT NULL, \
+            PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(table) = catalog.get_mut_in("test", "order_line").unwrap() else {
+        panic!("order_line is not a KV table");
+    };
+    table.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 4],
+        column_offsets: vec![2, 1, 0, 3],
+        visible: true,
+        global: false,
+    });
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO order_line VALUES (1,1,1,1),(1,1,1,2),(2,2,1,1),(1,1,2,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT ol_d_id, COUNT(*) cn FROM order_line \
+        WHERE ol_w_id=1 GROUP BY ol_d_id";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![
+            vec![Datum::Int(1), Datum::Int(2)],
+            vec![Datum::Int(2), Datum::Int(1)],
+        ],
+    );
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "Projection",
+            "└─StreamAgg",
+            "  └─TableReader",
+            "    └─StreamAgg",
+            "      └─TableRangeScan",
+        ],
+    );
+    assert!(cell(0, 4).starts_with("test.order_line.ol_d_id, Column#"));
+    assert!(cell(1, 4).contains("funcs:count(Column#"));
+    assert!(cell(1, 4).contains("funcs:firstrow(test.order_line.ol_d_id)"));
+    assert!(!cell(3, 4).contains("firstrow"));
+}
+
+/// TPCC condition 04: the selected group key order survives materializing the
+/// inner aggregate and lets both the join and the aggregate above it stream.
+#[test]
+fn tpcc_condition_four_streams_across_a_grouped_derived_table() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, \
+            o_ol_cnt INT NOT NULL, PRIMARY KEY (o_w_id,o_d_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(orders) = catalog.get_mut_in("test", "orders").unwrap() else {
+        panic!("orders is not a KV table");
+    };
+    orders.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+        column_offsets: vec![2, 1, 0],
+        visible: true,
+        global: false,
+    });
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (ol_o_id INT NOT NULL, ol_d_id INT NOT NULL, \
+            ol_w_id INT NOT NULL, ol_number INT NOT NULL, \
+            PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(order_line) = catalog.get_mut_in("test", "order_line").unwrap() else {
+        panic!("order_line is not a KV table");
+    };
+    order_line.add_index(crate::kv_table::KvIndex {
+        id: 2,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 4],
+        column_offsets: vec![2, 1, 0, 3],
+        visible: true,
+        global: false,
+    });
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO orders VALUES (1,1,1,2),(2,2,1,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO order_line VALUES (1,1,1,1),(1,1,1,2),(2,2,1,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT COUNT(*) FROM (SELECT o_d_id, SUM(o_ol_cnt) sm1, MAX(cn) cn \
+        FROM orders, (SELECT ol_d_id, COUNT(*) cn FROM order_line \
+        WHERE ol_w_id=1 GROUP BY ol_d_id) ol WHERE o_w_id=1 AND ol_d_id=o_d_id \
+        GROUP BY o_d_id) t1 WHERE sm1<>cn";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(0)]],
+    );
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "StreamAgg",
+            "└─Selection",
+            "  └─StreamAgg",
+            "    └─Projection",
+            "      └─MergeJoin",
+            "        ├─StreamAgg(Build)",
+            "        │ └─TableReader",
+            "        │   └─StreamAgg",
+            "        │     └─TableRangeScan",
+            "        └─TableReader(Probe)",
+            "          └─TableRangeScan",
+        ],
+    );
+    assert!(
+        cell(3, 4).starts_with("cast(test.orders.o_ol_cnt, decimal(10,0) BINARY)"),
+        "{}",
+        cell(3, 4)
+    );
+    assert!(cell(3, 4).ends_with("test.orders.o_d_id->Column#2"));
+    assert_eq!(
+        cell(1, 4),
+        "ne(Column#0, cast(Column#1, decimal(20,0) BINARY))"
+    );
+    assert_eq!(
+        cell(2, 4),
+        "group by:Column#2, funcs:sum(Column#0)->Column#0, funcs:max(Column#1)->Column#1"
+    );
+    assert!(!cell(2, 4).contains("firstrow"));
+    assert!(cell(4, 4).contains("right key:test.order_line.ol_d_id"));
+}
+
+#[test]
+fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, \
+            o_c_id INT, o_entry_d DATETIME, o_carrier_id INT, o_ol_cnt INT, o_all_local INT, \
+            PRIMARY KEY (o_w_id,o_d_id,o_id), \
+            KEY idx_order (o_w_id,o_d_id,o_c_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(orders) = catalog.get_mut_in("test", "orders").unwrap() else {
+        panic!("orders is not a KV table");
+    };
+    orders.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+        column_offsets: vec![2, 1, 0],
+        visible: true,
+        global: false,
+    });
+    orders.add_index(crate::kv_table::KvIndex {
+        id: 2,
+        name: "idx_order".to_owned(),
+        unique: false,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 4],
+        column_offsets: vec![2, 1, 3, 0],
+        visible: true,
+        global: false,
+    });
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO orders VALUES \
+            (1,1,1,10,NULL,NULL,1,1),(2,1,1,20,NULL,NULL,1,1),\
+            (3,2,1,30,NULL,NULL,1,1),(4,1,2,40,NULL,NULL,1,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT o_d_id, MAX(o_id) mo FROM orders WHERE o_w_id=1 GROUP BY o_d_id";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![
+            vec![Datum::Int(1), Datum::Int(2)],
+            vec![Datum::Int(2), Datum::Int(3)],
+        ]
+    );
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    let plan = (0..rows.len())
+        .map(|row| (cell(row, 0), cell(row, 3), cell(row, 4)))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plan.iter()
+            .map(|(operator, _, _)| operator.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "Projection",
+            "└─StreamAgg",
+            "  └─IndexReader",
+            "    └─StreamAgg",
+            "      └─IndexRangeScan",
+        ]
+    );
+    assert!(
+        plan.iter().any(|(operator, access, info)| {
+            operator.contains("IndexRangeScan")
+                && access.contains("idx_order")
+                && info.contains("range:[1,1]")
+        }),
+        "{plan:#?}"
+    );
+}
+
+/// Go splits a pseudo-statistics Sysbench SUM range into partial/final
+/// StreamAgg stages. The partial result is already DECIMAL, so the root cast
+/// projection used by the one-row plan is absent.
+#[test]
+fn global_integer_sum_uses_gos_stream_agg_and_cast_projection() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE sum_range (id INT PRIMARY KEY, k INT NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO sum_range VALUES (1, 10), (2, 20)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT SUM(k) FROM sum_range WHERE id BETWEEN 1 AND 100";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "StreamAgg",
+            "└─TableReader",
+            "  └─StreamAgg",
+            "    └─TableRangeScan"
+        ]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "root", "cop[tikv]", "cop[tikv]"]
+    );
+    assert!(cell(0, 4).starts_with("funcs:sum(Column#"));
+    assert!(cell(2, 4).contains("funcs:sum(test.sum_range.k)->Column#"));
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Decimal(tidb_datatype::Decimal::from_int(30))]]
+    );
+}
+
+/// Go keeps Sysbench's random-range COUNT on the covering secondary index and
+/// places a partial StreamAgg over that scan below the IndexReader.
+#[test]
+fn global_count_over_index_ranges_uses_gos_stream_agg_and_index_reader() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE count_ranges (id INT PRIMARY KEY, k INT NOT NULL, KEY k_1(k))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO count_ranges VALUES (1, 1), (2, 15), (3, 20)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = concat!(
+        "SELECT COUNT(k) FROM count_ranges WHERE ",
+        "(k BETWEEN 1 AND 6) OR (k BETWEEN 2 AND 7) OR ",
+        "(k BETWEEN 3 AND 8) OR (k BETWEEN 4 AND 9) OR ",
+        "(k BETWEEN 5 AND 10) OR (k BETWEEN 6 AND 11) OR ",
+        "(k BETWEEN 7 AND 12) OR (k BETWEEN 8 AND 13) OR ",
+        "(k BETWEEN 9 AND 14) OR (k BETWEEN 10 AND 15)"
+    );
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "StreamAgg",
+            "└─IndexReader",
+            "  └─StreamAgg",
+            "    └─IndexRangeScan"
+        ]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "root", "cop[tikv]", "cop[tikv]"]
+    );
+    assert!(cell(0, 4).starts_with("funcs:count(Column#"));
+    assert_eq!(cell(1, 4), "index:StreamAgg");
+    assert!(cell(2, 4).starts_with("funcs:count(test.count_ranges.k)->Column#"));
+    assert!(cell(3, 3).contains("index:k_1(k)"));
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(2)]]
+    );
+}
+
 #[test]
 fn aggregate_selects() {
     let catalog = test_catalog();
@@ -328,6 +879,62 @@ fn select_distinct() {
             vec![Datum::Decimal(tidb_datatype::Decimal::from_int(9))],
         ]
     );
+}
+
+/// A pseudo-statistics Sysbench DISTINCT range is physically `Sort -> final
+/// HashAgg -> Reader -> partial HashAgg -> cop Scan`; the identity FIRST_ROW
+/// output projection is absorbed by the final aggregate.
+#[test]
+fn distinct_range_orders_gos_hash_agg_over_reader_tree() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE distinct_range (id INT PRIMARY KEY, c CHAR(4))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO distinct_range VALUES (1, 'b'), (2, 'a'), (3, 'b')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    let sql = "SELECT DISTINCT c FROM distinct_range WHERE id BETWEEN 1 AND 100 ORDER BY c";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "Sort",
+            "└─HashAgg",
+            "  └─TableReader",
+            "    └─HashAgg",
+            "      └─TableRangeScan"
+        ]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "root", "root", "cop[tikv]", "cop[tikv]"]
+    );
+    let values = run_select_on(sql, &catalog, &ctx)
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].sql_string().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec!["a", "b"]);
 }
 
 /// `BIT_AND`/`BIT_OR`/`BIT_XOR` return BIGINT **UNSIGNED**.

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -665,6 +665,117 @@ fn tpcc_condition_nine_eliminates_the_unique_district_aggregation() {
     assert!(cell(2, 4).contains("keep order:false"), "{}", cell(2, 4));
 }
 
+/// The other half of TPCC condition 09 is a grouped `history` derived table.
+/// Go retains that aggregation while rebuilding its indexed base-table read
+/// for each district probe.  The lookup path must therefore aggregate the
+/// fetched base rows before matching the derived outputs, including NULL SUM
+/// behavior, rather than joining raw history rows.
+#[test]
+fn tpcc_condition_nine_rebuilds_grouped_history_over_index_lookup() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE district (d_id INT NOT NULL, d_w_id INT NOT NULL, \
+            d_ytd DECIMAL(12,2), PRIMARY KEY (d_w_id,d_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(district) = catalog.get_mut_in("test", "district").unwrap() else {
+        panic!("district is not a KV table");
+    };
+    district.add_index(crate::kv_table::KvIndex {
+        id: 1,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 2],
+        column_offsets: vec![1, 0],
+        visible: true,
+        global: false,
+    });
+    crate::run_create_table_on(
+        "CREATE TABLE history (h_d_id INT NOT NULL, h_w_id INT NOT NULL, \
+            h_amount DECIMAL(6,2), KEY idx_h_w_id(h_w_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO district VALUES (1,1,10.00),(2,1,20.00),(1,2,30.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO history VALUES \
+            (1,1,4.00),(1,1,6.00),(1,1,NULL),(2,1,8.00),(1,2,30.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT COUNT(*) FROM \
+        (SELECT d_id,d_w_id,SUM(d_ytd) s1 FROM district \
+         GROUP BY d_id,d_w_id) d, \
+        (SELECT h_d_id,h_w_id,SUM(h_amount) s2 FROM history \
+         WHERE h_w_id=1 GROUP BY h_d_id,h_w_id) h \
+        WHERE h_d_id=d_id AND d_w_id=h_w_id AND d_w_id=1 AND s1<>s2";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(1)]],
+    );
+
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, plan) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &plan[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    let operators = plan
+        .iter()
+        .map(|row| match &row[0] {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            other => format!("{other:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        operators,
+        vec![
+            "StreamAgg",
+            "└─IndexHashJoin",
+            "  ├─Projection(Build)",
+            "  │ └─TableReader",
+            "  │   └─Selection",
+            "  │     └─TableRangeScan",
+            "  └─Selection(Probe)",
+            "    └─HashAgg",
+            "      └─IndexLookUp",
+            "        ├─Selection(Build)",
+            "        │ └─IndexRangeScan",
+            "        └─TableRowIDScan(Probe)",
+        ],
+        "{plan:#?}",
+    );
+    assert_eq!(
+        cell(4, 4),
+        "not(isnull(cast(test.district.d_ytd, decimal(34,2) BINARY)))"
+    );
+    let answers = crate::driver::join_search::ANSWERS.with(|answers| answers.borrow().clone());
+    assert!(
+        operators
+            .iter()
+            .any(|operator| operator.contains("IndexHashJoin")),
+        "{plan:#?}\n{answers:#?}",
+    );
+}
+
 #[test]
 fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
     use crate::explain::{explain_select_stmt, ExplainFormat};

--- a/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/aggregates.rs
@@ -432,8 +432,101 @@ fn tpcc_condition_two_orders_group_uses_the_covering_index_range() {
             operator.contains("IndexRangeScan")
                 && access.contains("idx_order")
                 && info.contains("range:[1,1]")
+                && info.contains("keep order:true")
         }),
         "{plan:#?}"
+    );
+
+    crate::run_create_table_on(
+        "CREATE TABLE district (d_id INT NOT NULL, d_w_id INT NOT NULL, \
+            d_next_o_id INT NOT NULL, PRIMARY KEY (d_w_id,d_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(district) = catalog.get_mut_in("test", "district").unwrap() else {
+        panic!("district is not a KV table");
+    };
+    district.add_index(crate::kv_table::KvIndex {
+        id: 3,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 2],
+        column_offsets: vec![1, 0],
+        visible: true,
+        global: false,
+    });
+    crate::run_create_table_on(
+        "CREATE TABLE new_order (no_o_id INT NOT NULL, no_d_id INT NOT NULL, \
+            no_w_id INT NOT NULL, PRIMARY KEY (no_w_id,no_d_id,no_o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let TableEntry::Kv(new_order) = catalog.get_mut_in("test", "new_order").unwrap() else {
+        panic!("new_order is not a KV table");
+    };
+    new_order.add_index(crate::kv_table::KvIndex {
+        id: 4,
+        name: "PRIMARY".to_owned(),
+        unique: true,
+        prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 3],
+        column_offsets: vec![2, 1, 0],
+        visible: true,
+        global: false,
+    });
+    run_insert_on(
+        "INSERT INTO district VALUES (1,1,5),(2,1,6),(1,2,10)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO new_order VALUES (2,1,1),(3,2,1),(9,1,2)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let condition = "SELECT POWER((d_next_o_id-1-mo),2) + \
+        POWER((d_next_o_id-1-mno),2) diff FROM district dis, \
+        (SELECT o_d_id,MAX(o_id) mo FROM orders WHERE o_w_id=1 GROUP BY o_d_id) q, \
+        (SELECT no_d_id,MAX(no_o_id) mno FROM new_order WHERE no_w_id=1 \
+        GROUP BY no_d_id) no WHERE d_w_id=1 AND q.o_d_id=dis.d_id \
+        AND no.no_d_id=dis.d_id";
+    assert_eq!(
+        run_select_on(condition, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Real(8.0)], vec![Datum::Real(8.0)]],
+    );
+    let stmt = tidb_parser::parse(condition).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(cell(0, 1), "10.00");
+    assert!(
+        cell(0, 4)
+            .starts_with("plus(power(cast(minus(minus(test.district.d_next_o_id, 1), Column#"),
+        "{}",
+        cell(0, 4)
+    );
+    assert!(cell(0, 4).ends_with(")->Column#0"), "{}", cell(0, 4));
+    assert_eq!(cell(1, 1), "10.00");
+    assert!(
+        cell(1, 4).contains("left key:test.district.d_id"),
+        "{}",
+        cell(1, 4)
+    );
+    assert!(
+        cell(6, 4).contains("left key:test.district.d_id"),
+        "{}",
+        cell(6, 4)
     );
 }
 

--- a/rust/crates/tidb-executor/src/driver/tests/dml.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/dml.rs
@@ -7,6 +7,106 @@
 
 use super::*;
 
+#[test]
+fn retryable_storage_errors_keep_their_transaction_identity() {
+    let retryable = || {
+        crate::kv_table::KvTableError::Storage(
+            "Retryable(\"region response no longer matches observed route\")".to_owned(),
+        )
+    };
+
+    for error in [
+        kv_read_error("row read failed", retryable()),
+        kv_write_error(retryable()),
+    ] {
+        let DriverError::Txn(TxnErrorKind::RegionUnavailable) = error else {
+            panic!("retryable storage failure lost its transaction identity")
+        };
+    }
+
+    let ordinary = kv_read_error(
+        "row read failed",
+        crate::kv_table::KvTableError::Storage("Backend(\"disk error\")".to_owned()),
+    );
+    assert!(matches!(ordinary, DriverError::Parse(_)));
+}
+
+/// go-tpc's delivery transaction deletes several `new_order` rows with one
+/// row-valued `IN` predicate. The SQL remains one DELETE and must report the
+/// number of matching composite keys exactly as Go TiDB does.
+#[test]
+fn delete_accepts_tpcc_three_column_row_in() {
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE new_order (\
+         no_w_id INT, no_d_id INT, no_o_id INT, \
+         PRIMARY KEY (no_w_id, no_d_id, no_o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO new_order VALUES \
+         (1, 1, 100), (1, 1, 101), (1, 2, 100), (2, 1, 100)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let stmt = tidb_parser::parse(
+        "DELETE FROM new_order WHERE (no_w_id, no_d_id, no_o_id) IN ((1, 1, 100), (2, 1, 100))",
+    )
+    .unwrap();
+    let Stmt::Dml(dml) = &stmt else {
+        panic!("not a DML statement");
+    };
+    let tidb_ast::DmlStmt::Delete(delete) = &**dml else {
+        panic!("not a DELETE");
+    };
+    let (_, plan_rows) = crate::explain::explain_delete_stmt(
+        delete,
+        &mut catalog,
+        "test",
+        &ctx,
+        crate::explain::ExplainFormat::Row,
+    )
+    .unwrap();
+    let plan_text: String = plan_rows
+        .iter()
+        .flat_map(|row| row.iter())
+        .filter_map(|datum| match datum {
+            Datum::Bytes(bytes) => Some(String::from_utf8_lossy(bytes).into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(plan_text.contains("Batch_Point_Get"), "plan={plan_text}");
+    assert_eq!(
+        run_delete_on(
+            "DELETE FROM new_order \
+             WHERE (no_w_id, no_d_id, no_o_id) \
+             IN ((1, 1, 100), (2, 1, 100))",
+            &mut catalog,
+            &ctx,
+        )
+        .unwrap(),
+        2,
+    );
+    assert_eq!(
+        run_select_on(
+            "SELECT no_w_id, no_d_id, no_o_id FROM new_order \
+             ORDER BY no_w_id, no_d_id, no_o_id",
+            &catalog,
+            &ctx,
+        )
+        .unwrap(),
+        vec![
+            vec![Datum::Int(1), Datum::Int(1), Datum::Int(101)],
+            vec![Datum::Int(1), Datum::Int(2), Datum::Int(100)],
+        ],
+    );
+}
+
 /// Go plans an `UPDATE`/`DELETE`'s read from the same cost chooser a `SELECT`
 /// reaches, so a `WHERE` on a secondary index reads through that index rather
 /// than scanning the whole table. `EXPLAIN` prints the `IndexRangeScan`, and

--- a/rust/crates/tidb-executor/src/driver/tests/index_ranges.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/index_ranges.rs
@@ -8,6 +8,54 @@
 
 use super::*;
 
+/// A secondary-index range that must return non-index columns is Go's
+/// two-child IndexLookUp, not an IndexReader with a root identity projection.
+#[test]
+fn non_covering_random_points_use_index_lookup_without_identity_projection() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE lookup_shape (id INT PRIMARY KEY, k INT NOT NULL, c CHAR(4), pad CHAR(4), KEY k_1(k))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO lookup_shape VALUES (1, 1, 'a', 'x'), (2, 2, 'b', 'y')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    let sql = "SELECT id, k, c, pad FROM lookup_shape WHERE k IN (1, 2)";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "IndexLookUp",
+            "├─IndexRangeScan(Build)",
+            "└─TableRowIDScan(Probe)"
+        ]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "cop[tikv]", "cop[tikv]"]
+    );
+    assert_eq!(run_select_on(sql, &catalog, &ctx).unwrap().len(), 2);
+}
+
 /// A composite-index range spans several datums per bound, an IN list
 /// produces several ranges, and an OR unions them. The answers must be
 /// the same rows a full scan would return -- a range that reads too few

--- a/rust/crates/tidb-executor/src/driver/tests/join_reorder.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/join_reorder.rs
@@ -105,6 +105,9 @@ const THREE_WAY: &str = "SELECT t1.a, dt.key_a FROM t1, t5, \
 ///
 /// `t5` at the top and `t1` under the second join is the reorder; every leaf
 /// keeping order is the merge that only becomes possible once it happens.
+/// The trace also exposes each proven root/cop reader boundary. The join
+/// equalities are consumed by the join operators, so there is no residual
+/// root `Selection` above this tree.
 #[test]
 fn the_dp_builds_the_tree_tidb_records() {
     let catalog = tables();
@@ -112,16 +115,19 @@ fn the_dp_builds_the_tree_tidb_records() {
     assert_eq!(
         reordered,
         vec![
-            "Projection_10",
-            "└─Selection_9",
-            "  └─MergeJoin_8",
-            "    ├─TableFullScan_1(Build)",
-            "    └─MergeJoin_7(Probe)",
-            "      ├─Projection_5(Build)",
-            "      │ └─MergeJoin_4",
-            "      │   ├─TableFullScan_2(Build)",
-            "      │   └─TableFullScan_3(Probe)",
-            "      └─TableFullScan_6(Probe)",
+            "Projection_13",
+            "└─MergeJoin_12",
+            "  ├─TableReader_2(Build)",
+            "  │ └─TableFullScan_1",
+            "  └─MergeJoin_11(Probe)",
+            "    ├─Projection_8(Build)",
+            "    │ └─MergeJoin_7",
+            "    │   ├─TableReader_4(Build)",
+            "    │   │ └─TableFullScan_3",
+            "    │   └─TableReader_6(Probe)",
+            "    │     └─TableFullScan_5",
+            "    └─TableReader_10(Probe)",
+            "      └─TableFullScan_9",
         ],
         "the reordered plan is not TiDB's",
     );

--- a/rust/crates/tidb-executor/src/driver/tests/joins.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/joins.rs
@@ -669,6 +669,12 @@ fn tpcc_stock_level_bounds_both_join_leaves() {
         plan.iter().any(|line| line.contains("IndexJoin")),
         "TIDB_INLJ must force the viable clustered-handle lookup, got {plan:?}"
     );
+    assert!(
+        plan.iter().any(|line| {
+            line.contains("TableReader") && line.contains("(Probe)") && line.contains(r"\t0.42\t")
+        }),
+        "the unique stock probe must apply its residual quantity selectivity, got {plan:?}"
+    );
 
     for table in ["order_line", "stock"] {
         assert!(

--- a/rust/crates/tidb-executor/src/driver/tests/joins.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/joins.rs
@@ -215,6 +215,203 @@ fn joins() {
     );
 }
 
+#[test]
+fn tpcc_check_five_keeps_only_the_cross_leaf_residual() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, o_c_id INT, o_entry_d DATETIME, o_carrier_id INT, o_ol_cnt INT, o_all_local INT, PRIMARY KEY (o_w_id,o_d_id,o_id), KEY idx_order(o_w_id,o_d_id,o_c_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE new_order (no_o_id INT NOT NULL, no_d_id INT NOT NULL, no_w_id INT NOT NULL, PRIMARY KEY (no_w_id,no_d_id,no_o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    let sql = "SELECT count(*) FROM orders LEFT JOIN new_order ON no_w_id=o_w_id AND o_d_id=no_d_id AND o_id=no_o_id WHERE o_w_id=1 AND ((o_carrier_id IS NULL and no_o_id IS NULL) OR (o_carrier_id IS NOT NULL and no_o_id IS NOT NULL))";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not query")
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not select")
+    };
+    let (_, rows) = explain_select_stmt(
+        select,
+        &catalog,
+        "test",
+        &crate::StmtContext::for_query(),
+        ExplainFormat::Row,
+    )
+    .unwrap();
+    let plan = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|datum| match datum {
+                    Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+                    other => format!("{other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\t")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        plan.iter().any(|line| line.contains("MergeJoin")),
+        "{plan:?}"
+    );
+    assert_eq!(
+        plan.iter()
+            .filter(|line| line
+                .split('\t')
+                .next()
+                .is_some_and(|id| id.contains("TableReader")))
+            .count(),
+        2,
+        "both ordered scans are TiKV tasks behind root readers: {plan:?}",
+    );
+    assert!(
+        plan.iter().any(|line| {
+            line.contains("or(and(isnull(test.orders.o_carrier_id)")
+                && !line.contains("eq(test.orders.o_w_id, 1)")
+        }),
+        "the root Selection retains only the cross-leaf residue: {plan:?}",
+    );
+    assert!(
+        plan.iter().any(|line| {
+            line.contains(
+                "or(isnull(test.orders.o_carrier_id), not(isnull(test.orders.o_carrier_id)))",
+            )
+        }),
+        "Go's DNF weakening is evaluated at the preserved orders leaf: {plan:?}",
+    );
+}
+
+#[test]
+fn tpcc_check_seven_propagates_the_warehouse_range_to_both_leaves() {
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_id INT NOT NULL, o_d_id INT NOT NULL, o_w_id INT NOT NULL, o_carrier_id INT, PRIMARY KEY (o_w_id,o_d_id,o_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (ol_o_id INT NOT NULL, ol_d_id INT NOT NULL, ol_w_id INT NOT NULL, ol_number INT NOT NULL, ol_delivery_d DATETIME, PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number))",
+        &mut catalog,
+    )
+    .unwrap();
+    // The cluster catalog carries a clustered PRIMARY as both the common
+    // handle and a plan access path. The in-memory DDL catalog stores only
+    // the former, so mirror the metadata the parity fixture exposes.
+    for (table_name, column_offsets) in
+        [("orders", vec![2, 1, 0]), ("order_line", vec![2, 1, 0, 3])]
+    {
+        let TableEntry::Kv(table) = catalog.get_mut_in("test", table_name).unwrap() else {
+            panic!("{table_name} is not a KV table");
+        };
+        table.add_index(crate::kv_table::KvIndex {
+            id: 1,
+            name: "PRIMARY".to_owned(),
+            unique: true,
+            prefix_lengths: vec![
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH;
+                column_offsets.len()
+            ],
+            column_offsets,
+            visible: true,
+            global: false,
+        });
+    }
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO orders VALUES (1,1,1,7),(2,1,1,NULL)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO order_line VALUES \
+            (1,1,1,1,NULL),(1,1,1,2,'2026-01-01 00:00:00'),\
+            (2,1,1,1,'2026-01-01 00:00:00'),(2,1,1,2,NULL)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    let sql = "SELECT count(*) FROM orders, order_line WHERE o_id=ol_o_id AND o_d_id=ol_d_id AND ol_w_id=o_w_id AND o_w_id=1 AND ((ol_delivery_d IS NULL and o_carrier_id IS NOT NULL) or (o_carrier_id IS NULL and ol_delivery_d IS NOT NULL))";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not query")
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not select")
+    };
+    let rows = crate::driver::join_reorder::row_source(
+        select.from.as_ref().expect("FROM"),
+        select.where_clause.as_ref(),
+        &catalog,
+        "test",
+        &crate::StmtContext::for_query(),
+    )
+    .expect("the TPCC join group is modelled");
+    let order_line = rows.filters_for("order_line").expect("order_line leaf");
+    assert!(
+        order_line.iter().any(|filter| {
+            let restored = filter.restore();
+            restored.contains("`order_line`.`ol_w_id`=1") || restored.contains("`ol_w_id`=1")
+        }),
+        "o_w_id=1 must propagate through the equality edge: {order_line:?}",
+    );
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(2)]],
+        "the cross-leaf disjunction must be evaluated exactly once by the join",
+    );
+
+    let (_, rows) = crate::explain::explain_select_stmt(
+        select,
+        &catalog,
+        "test",
+        &ctx,
+        crate::explain::ExplainFormat::Brief,
+    )
+    .unwrap();
+    let plan: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|datum| match datum {
+                    Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+                    other => format!("{other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\t")
+        })
+        .collect();
+    assert!(
+        plan.iter().any(|line| {
+            line.contains("MergeJoin")
+                && line.contains("other cond:or(and(isnull(test.order_line.ol_delivery_d)")
+        }),
+        "the cross-leaf disjunction must be reported as the merge join's other condition: {plan:?}",
+    );
+    for table in ["orders", "order_line"] {
+        assert!(
+            plan.iter().any(|line| {
+                line.contains("TableRangeScan") && line.contains(&format!("table:{table}"))
+            }),
+            "the propagated warehouse key must bound {table}'s common-handle scan: {plan:?}",
+        );
+        assert!(
+            !plan.iter().any(|line| {
+                line.contains("TableFullScan") && line.contains(&format!("table:{table}"))
+            }),
+            "the bounded {table} leaf must not fall back to a full scan: {plan:?}",
+        );
+    }
+}
+
 /// Every leaf of a join is costed, and a leaf whose parents read only the
 /// columns an index covers reads that index instead of the table -- Go's
 /// `findBestTask` recursing into each `DataSource` below a `LogicalJoin`.
@@ -305,6 +502,294 @@ fn a_join_leaf_reads_a_covering_index_without_moving_a_row() {
             vec![Datum::Int(3)],
         ]
     );
+}
+
+/// A predicate that references only one inner-join leaf can narrow that leaf
+/// before the join runs. The original WHERE remains above the join, so this
+/// checks both the access-path shape and the result-preservation contract.
+#[test]
+fn a_join_leaf_uses_a_single_table_constant_for_access() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE lp (id INT PRIMARY KEY, value INT)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE rp (id INT PRIMARY KEY, value INT)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO lp VALUES (1, 10), (2, 20), (3, 30)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO rp VALUES (7, 20), (8, 20), (9, 30)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT lp.id, rp.id FROM lp JOIN rp ON lp.value = rp.value WHERE lp.id = 2";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Row).unwrap();
+    let plan: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|datum| match datum {
+                    Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+                    other => format!("{other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\\t")
+        })
+        .collect();
+
+    assert!(
+        plan.iter()
+            .any(|line| line.contains("Point_Get") && line.contains("table:lp")),
+        "the lp leaf should use its constant primary-key predicate, got {plan:?}"
+    );
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![
+            vec![Datum::Int(2), Datum::Int(7)],
+            vec![Datum::Int(2), Datum::Int(8)],
+        ]
+    );
+}
+
+/// TPCC StockLevel must bound both clustered-primary-key leaves before the
+/// join. Scanning either complete table turns this low-frequency transaction
+/// into a worker-consuming minute-long query at benchmark scale.
+#[test]
+fn tpcc_stock_level_bounds_both_join_leaves() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (\
+            ol_o_id INT NOT NULL, ol_d_id INT NOT NULL, ol_w_id INT NOT NULL, \
+            ol_number INT NOT NULL, ol_i_id INT NOT NULL, \
+            PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number) CLUSTERED)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE stock (\
+            s_i_id INT NOT NULL, s_w_id INT NOT NULL, s_quantity INT, \
+            PRIMARY KEY (s_w_id, s_i_id) CLUSTERED)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO order_line VALUES \
+            (3627, 7, 1, 1, 100), (3630, 7, 1, 1, 101), \
+            (3647, 7, 1, 1, 102), (3630, 8, 1, 1, 101)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO stock VALUES \
+            (100, 1, 10), (101, 1, 20), (102, 1, 5), (100, 2, 5)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    // The cluster catalog exposes TiDB's clustered common-handle PRIMARY as a
+    // table access path. The in-memory DDL catalog stores only the handle, so
+    // mirror the loaded metadata shape explicitly after loading rows. There
+    // are deliberately no separate PRIMARY index entries to fall back to.
+    for (table_name, column_offsets) in [("order_line", vec![2, 1, 0, 3]), ("stock", vec![1, 0])] {
+        let TableEntry::Kv(table) = catalog.get_mut_in("test", table_name).unwrap() else {
+            panic!("{table_name} is not a KV table");
+        };
+        table.add_index(crate::kv_table::KvIndex {
+            id: 1,
+            name: "PRIMARY".to_owned(),
+            unique: true,
+            prefix_lengths: vec![
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH;
+                column_offsets.len()
+            ],
+            column_offsets,
+            visible: true,
+            global: false,
+        });
+    }
+    let sql = "SELECT /*+ TIDB_INLJ(`order_line`, `stock`)*/ \
+        COUNT(DISTINCT (`s_i_id`)) AS `stock_count` \
+        FROM (`order_line`) JOIN `stock` \
+        WHERE `ol_w_id`=1 AND `ol_d_id`=7 \
+        AND `ol_o_id`<3647 AND `ol_o_id`>=3647-20 \
+        AND `s_w_id`=1 AND `s_i_id`=`ol_i_id` AND `s_quantity`<18";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Row).unwrap();
+    let plan: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|datum| match datum {
+                    Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+                    other => format!("{other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\\t")
+        })
+        .collect();
+
+    assert!(
+        plan.iter().any(|line| line.contains("StreamAgg")),
+        "COUNT(DISTINCT) over the forced lookup join must stream, got {plan:?}"
+    );
+    assert!(
+        plan.iter().any(|line| line.contains("IndexJoin")),
+        "TIDB_INLJ must force the viable clustered-handle lookup, got {plan:?}"
+    );
+
+    for table in ["order_line", "stock"] {
+        assert!(
+            plan.iter().any(|line| {
+                line.contains("TableRangeScan") && line.contains(&format!("table:{table}"))
+            }),
+            "the {table} common handle must be read as a bounded table path, got {plan:?}"
+        );
+        assert!(
+            !plan.iter().any(|line| {
+                (line.contains("FullScan") || line.contains("IndexRangeScan"))
+                    && line.contains(&format!("table:{table}"))
+            }),
+            "the {table} leaf must neither scan the complete table nor double-read PRIMARY, got {plan:?}"
+        );
+    }
+    let (result, ops) =
+        crate::storage::capture_storage_ops(|| run_select_on(sql, &catalog, &ctx).unwrap());
+    assert_eq!(result, vec![vec![Datum::Int(1)]]);
+    assert_eq!(ops.scans, 2);
+    assert_eq!(
+        ops.gets, 2,
+        "the two distinct outer item keys must become common-handle point probes"
+    );
+}
+
+/// The TPCC NewOrder customer/warehouse lookup: a constant on warehouse's
+/// join key propagates to the customer's clustered composite primary key, so
+/// both leaves are direct lookups rather than full scans.
+#[test]
+fn tpcc_customer_warehouse_join_uses_two_point_gets() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE customer (\
+            c_id INT NOT NULL, c_d_id INT NOT NULL, c_w_id INT NOT NULL, \
+            c_discount INT, c_last VARCHAR(16), c_credit VARCHAR(2), \
+            PRIMARY KEY (c_w_id, c_d_id, c_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE warehouse (w_id INT PRIMARY KEY, w_tax INT)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO customer VALUES (629, 6, 1, 5, 'Smith', 'GC')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on("INSERT INTO warehouse VALUES (1, 7)", &mut catalog, &ctx).unwrap();
+
+    let sql = "SELECT c_discount, c_last, c_credit, w_tax \
+        FROM customer, warehouse \
+        WHERE w_id = 1 AND c_w_id = w_id AND c_d_id = 6 AND c_id = 629";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Row).unwrap();
+    let plan: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|datum| match datum {
+                    Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+                    other => format!("{other:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\\t")
+        })
+        .collect();
+    for table in ["customer", "warehouse"] {
+        assert!(
+            plan.iter().any(|line| {
+                line.contains("Point_Get") && line.contains(&format!("table:{table}"))
+            }),
+            "the {table} leaf should be a direct lookup, got {plan:?}"
+        );
+    }
+    assert!(
+        !plan.iter().any(|line| line.contains("Selection")),
+        "the point keys and join equality consume the complete WHERE, got {plan:?}"
+    );
+    assert!(
+        plan.iter().any(|line| {
+            (line.contains("MergeJoin") || line.contains("HashJoin"))
+                && line.split("\\t").nth(1) == Some("1.00")
+        }),
+        "two one-row point leaves produce a one-row join estimate, got {plan:?}"
+    );
+    assert_eq!(run_select_on(sql, &catalog, &ctx).unwrap().len(), 1);
+
+    let residual_sql = format!("{sql} AND c_credit = 'BC'");
+    let stmt = tidb_parser::parse(&residual_sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Row).unwrap();
+    assert!(
+        rows.iter().any(|row| match &row[0] {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).contains("Selection"),
+            _ => false,
+        }),
+        "a non-key residual predicate must remain above the point join"
+    );
+    assert!(run_select_on(&residual_sql, &catalog, &ctx)
+        .unwrap()
+        .is_empty());
 }
 
 /// THE ROW-DROP PIN: a parent merge join over a child join that HASHES.

--- a/rust/crates/tidb-executor/src/driver/tests/point_get.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/point_get.rs
@@ -363,6 +363,60 @@ fn batch_point_get() {
     );
 }
 
+/// Go's `tryWhereIn2BatchPointGet` also accepts a row-valued `IN` when the
+/// tuples pin every column of a composite primary/unique key.
+#[test]
+fn batch_point_get_accepts_row_in_on_a_composite_key() {
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE c (a INT, b INT, v INT, PRIMARY KEY (a, b))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO c VALUES (1, 1, 11), (1, 2, 12), (2, 1, 21)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    let Some(TableEntry::Kv(table)) = catalog.get_table_for_test("c") else {
+        panic!("expected a kv table");
+    };
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| (column.name.clone(), column.field_type.clone()))
+        .collect::<Vec<_>>();
+    let stmt = tidb_parser::parse("SELECT v FROM c WHERE (a, b) IN ((1, 2), (2, 1))").unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    assert!(
+        try_batch_point_get(
+            select,
+            table,
+            &columns,
+            &tidb_datatype::SessionTimeZone::utc()
+        )
+        .unwrap()
+        .is_some(),
+        "a composite row IN should use Batch_Point_Get"
+    );
+    assert_eq!(
+        run_select_on(
+            "SELECT v FROM c WHERE (a, b) IN ((1, 2), (2, 1))",
+            &catalog,
+            &ctx
+        )
+        .unwrap(),
+        vec![vec![Datum::Int(12)], vec![Datum::Int(21)]],
+    );
+}
+
 /// The answers above would be right from a scan too, so this asserts the
 /// DECISION: which shapes Go's batch point get claims.
 #[test]
@@ -501,6 +555,268 @@ fn a_point_plan_keys_by_the_constant_in_the_columns_domain() {
     assert_eq!(
         rows("SELECT id FROM uq WHERE u = 1.5"),
         Vec::<Vec<Datum>>::new()
+    );
+}
+
+/// Go `TryFastPlan` replaces the complete query plan when one primary-key
+/// equality identifies the row and every selected field is a source column.
+/// The `PointGetPlan` itself owns the output schema, so no residual
+/// `Selection` or `Projection` remains.
+#[test]
+fn fast_point_get_replaces_selection_and_projection_like_go() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE fast_point (id INT PRIMARY KEY, c CHAR(8) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO fast_point VALUES (1, 'one')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let stmt = tidb_parser::parse("SELECT c FROM fast_point WHERE id = 1").unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |datum: &Datum| match datum {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    let plan: Vec<String> = rows
+        .iter()
+        .map(|row| row.iter().map(cell).collect::<Vec<_>>().join("\t"))
+        .collect();
+
+    assert_eq!(
+        plan,
+        vec!["Point_Get\t1.00\troot\ttable:fast_point\thandle:1"]
+    );
+    assert_eq!(
+        run_select_on("SELECT c FROM fast_point WHERE id = 1", &catalog, &ctx).unwrap(),
+        vec![vec![Datum::new_string("one")]]
+    );
+}
+
+/// Go's point UPDATE/DELETE plans consume the primary-key predicate exactly
+/// as the SELECT fast plan does. An additional equality remains a real
+/// Selection and must still be evaluated before the write.
+#[test]
+fn fast_point_writes_remove_only_the_consumed_selection_like_go() {
+    use crate::explain::{explain_delete_stmt, explain_update_stmt, ExplainFormat};
+
+    fn explain_write(sql: &str, catalog: &mut Catalog, ctx: &crate::StmtContext) -> Vec<String> {
+        let stmt = tidb_parser::parse(sql).unwrap();
+        let Stmt::Dml(dml) = &stmt else {
+            panic!("not DML");
+        };
+        let (_, rows) = match &**dml {
+            tidb_ast::DmlStmt::Update(update) => {
+                explain_update_stmt(update, catalog, "test", ctx, ExplainFormat::Brief).unwrap()
+            }
+            tidb_ast::DmlStmt::Delete(delete) => {
+                explain_delete_stmt(delete, catalog, "test", ctx, ExplainFormat::Brief).unwrap()
+            }
+            _ => panic!("not an UPDATE or DELETE"),
+        };
+        let cell = |datum: &Datum| match datum {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            other => format!("{other:?}"),
+        };
+        rows.iter()
+            .map(|row| row.iter().map(cell).collect::<Vec<_>>().join("\t"))
+            .collect()
+    }
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE fast_write (id INT PRIMARY KEY, c CHAR(8) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO fast_write VALUES (1, 'one')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    assert_eq!(
+        explain_write(
+            "UPDATE fast_write SET c = 'two' WHERE id = 1",
+            &mut catalog,
+            &ctx,
+        ),
+        vec![
+            "Update\tN/A\troot\t\tN/A",
+            "└─Point_Get\t1.00\troot\ttable:fast_write\thandle:1",
+        ]
+    );
+    let guarded = explain_write(
+        "UPDATE fast_write SET c = 'bad' WHERE id = 1 AND c = 'missing'",
+        &mut catalog,
+        &ctx,
+    );
+    assert!(guarded.iter().any(|row| row.contains("Selection")));
+    assert_eq!(
+        run_update_on(
+            "UPDATE fast_write SET c = 'bad' WHERE id = 1 AND c = 'missing'",
+            &mut catalog,
+            &ctx,
+        )
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        run_update_on(
+            "UPDATE fast_write SET c = 'two' WHERE id = 1",
+            &mut catalog,
+            &ctx,
+        )
+        .unwrap(),
+        1
+    );
+    assert_eq!(
+        run_select_on("SELECT c FROM fast_write WHERE id = 1", &catalog, &ctx).unwrap(),
+        vec![vec![Datum::new_string("two")]]
+    );
+
+    assert_eq!(
+        explain_write("DELETE FROM fast_write WHERE id = 1", &mut catalog, &ctx,),
+        vec![
+            "Delete\tN/A\troot\t\tN/A",
+            "└─Point_Get\t1.00\troot\ttable:fast_write\thandle:1",
+        ]
+    );
+    assert_eq!(
+        run_delete_on("DELETE FROM fast_write WHERE id = 1", &mut catalog, &ctx,).unwrap(),
+        1
+    );
+    assert!(
+        run_select_on("SELECT c FROM fast_write WHERE id = 1", &catalog, &ctx)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A handle range that represents the complete predicate is an access
+/// condition, not a residual Selection. Go pushes a simple column projection
+/// into TiKV and returns it through a TableReader.
+#[test]
+fn exact_handle_range_uses_the_go_cop_projection_tree() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE fast_range (id INT PRIMARY KEY, c CHAR(8) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO fast_range VALUES (1, 'one'), (2, 'two')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let stmt = tidb_parser::parse("SELECT c FROM fast_range WHERE id BETWEEN 1 AND 100").unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec!["TableReader", "└─Projection", "  └─TableRangeScan"]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "cop[tikv]", "cop[tikv]"]
+    );
+    assert_eq!(
+        run_select_on(
+            "SELECT c FROM fast_range WHERE id BETWEEN 1 AND 100",
+            &catalog,
+            &ctx,
+        )
+        .unwrap(),
+        vec![
+            vec![Datum::new_string("one")],
+            vec![Datum::new_string("two")]
+        ]
+    );
+}
+
+/// An ORDER BY stays in the root task, while the exact handle range still
+/// pushes its simple projection into TiKV. This is the Sysbench
+/// `oltp_common.lua` simple ordered-range shape.
+#[test]
+fn ordered_handle_range_keeps_the_go_cop_projection_below_sort() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE ordered_range (id INT PRIMARY KEY, c CHAR(8) NOT NULL)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO ordered_range VALUES (1, 'z'), (2, 'a')",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT c FROM ordered_range WHERE id BETWEEN 1 AND 100 ORDER BY c";
+    let stmt = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &stmt else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, rows) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let cell = |row: usize, column: usize| match &rows[row][column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 0)).collect::<Vec<_>>(),
+        vec![
+            "Sort",
+            "└─TableReader",
+            "  └─Projection",
+            "    └─TableRangeScan"
+        ]
+    );
+    assert_eq!(
+        (0..rows.len()).map(|row| cell(row, 2)).collect::<Vec<_>>(),
+        vec!["root", "root", "cop[tikv]", "cop[tikv]"]
+    );
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::new_string("a")], vec![Datum::new_string("z")]]
     );
 }
 

--- a/rust/crates/tidb-executor/src/driver/tests/select_clauses.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/select_clauses.rs
@@ -37,6 +37,62 @@ fn select_with_where() {
     );
 }
 
+/// Row-valued `IN` is the predicate shape go-tpc uses to lock stock rows.
+/// Go lowers each tuple equality column by column, preserving SQL's
+/// three-valued NULL behavior, then joins the candidates with `OR`.
+#[test]
+fn row_in_matches_go_tuple_and_null_semantics() {
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE stock (id INT PRIMARY KEY, w_id INT, i_id INT)",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO stock VALUES \
+         (1, 1, 1), (2, 2, 2), (3, 1, 3), (4, 1, NULL), \
+         (5, 2, NULL), (6, NULL, 2), (7, NULL, NULL), (8, 3, NULL)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    assert_eq!(
+        run_select_on(
+            "SELECT id FROM stock \
+             WHERE (w_id, i_id) IN ((1, 1), (2, 2)) \
+             ORDER BY id FOR UPDATE",
+            &catalog,
+            &ctx,
+        )
+        .unwrap(),
+        vec![vec![Datum::Int(1)], vec![Datum::Int(2)]],
+    );
+    assert_eq!(
+        run_select_on(
+            "SELECT id FROM stock \
+             WHERE (w_id, i_id) NOT IN ((1, 1), (2, 2)) \
+             ORDER BY id",
+            &catalog,
+            &ctx,
+        )
+        .unwrap(),
+        vec![vec![Datum::Int(3)], vec![Datum::Int(8)]],
+    );
+}
+
+#[test]
+fn row_in_rejects_a_different_column_count_like_go() {
+    let error = run_select("SELECT (1, 2) IN ((1, 2, 3))")
+        .unwrap_err()
+        .to_mysql_error();
+    assert_eq!(
+        (error.code, error.state, error.message.as_str()),
+        (1241, *b"21000", "Operand should contain 2 column(s)",),
+    );
+}
+
 #[test]
 fn limit_and_order_by_wire_up() {
     // LIMIT truncates / zeroes the single row.

--- a/rust/crates/tidb-executor/src/driver/tests/subqueries.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/subqueries.rs
@@ -41,6 +41,249 @@ fn explaining_a_correlated_scalar_type_reads_no_storage() {
     assert_eq!(operations, crate::storage::StorageOps::default());
 }
 
+/// Go decorrelates a scalar SUM over equality-correlated keys by pulling the
+/// aggregation above a left join. TPCC condition 12 depends on both halves:
+/// an unmatched customer still produces one outer row with a NULL SUM, while
+/// EXPLAIN contains the real HashAgg/Join pipeline rather than an opaque
+/// per-row scalar-subquery projection.
+#[test]
+fn tpcc_conditions_ten_and_twelve_decorrelate_scalar_sums() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on(
+        "CREATE TABLE customer (c_w_id INT NOT NULL, c_d_id INT NOT NULL, \
+         c_id INT NOT NULL, c_balance DECIMAL(12,2), c_ytd_payment DECIMAL(12,2), \
+         PRIMARY KEY(c_w_id,c_d_id,c_id) CLUSTERED)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE orders (o_w_id INT NOT NULL, o_d_id INT NOT NULL, \
+         o_id INT NOT NULL, o_c_id INT, PRIMARY KEY(o_w_id,o_d_id,o_id) CLUSTERED)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE order_line (ol_w_id INT NOT NULL, ol_d_id INT NOT NULL, \
+         ol_o_id INT NOT NULL, ol_number INT NOT NULL, ol_amount DECIMAL(6,2), \
+         ol_delivery_d BIGINT, PRIMARY KEY(ol_w_id,ol_d_id,ol_o_id,ol_number) CLUSTERED)",
+        &mut catalog,
+    )
+    .unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE history (h_c_id INT, h_c_d_id INT, h_c_w_id INT, \
+         h_amount DECIMAL(6,2), INDEX idx_h_c_w_id(h_c_w_id))",
+        &mut catalog,
+    )
+    .unwrap();
+    // Cluster-loaded metadata exposes the common-handle PRIMARY as a table
+    // access path. The in-memory DDL catalog stores only the handle, so add
+    // the corresponding planner index explicitly, as the join tests do.
+    for (table_name, column_offsets) in [
+        ("customer", vec![0, 1, 2]),
+        ("orders", vec![0, 1, 2]),
+        ("order_line", vec![0, 1, 2, 3]),
+    ] {
+        let TableEntry::Kv(table) = catalog.get_mut_in("test", table_name).unwrap() else {
+            panic!("{table_name} is not a KV table");
+        };
+        table.add_index(crate::kv_table::KvIndex {
+            id: 1,
+            name: "PRIMARY".to_owned(),
+            unique: true,
+            prefix_lengths: vec![
+                crate::ddl::index_prefix::UNSPECIFIED_LENGTH;
+                column_offsets.len()
+            ],
+            column_offsets,
+            visible: true,
+            global: false,
+        });
+    }
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on(
+        "INSERT INTO customer VALUES \
+         (1,1,1,5.00,5.00),(1,1,2,0.00,0.00),(1,1,3,7.00,1.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO orders VALUES (1,1,11,1),(1,1,12,2)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO order_line VALUES \
+         (1,1,11,1,10.00,1),(1,1,11,2,100.00,NULL),(1,1,12,1,5.00,1)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+    run_insert_on(
+        "INSERT INTO history VALUES (1,1,1,5.00),(2,1,1,5.00),(3,1,1,1.00)",
+        &mut catalog,
+        &ctx,
+    )
+    .unwrap();
+
+    let sql = "SELECT count(*) FROM (SELECT c.c_id,c.c_d_id,c.c_balance c1, \
+        c_ytd_payment,(SELECT sum(ol_amount) FROM orders,order_line \
+        WHERE ol_w_id=o_w_id AND ol_d_id=o_d_id AND ol_o_id=o_id \
+        AND ol_delivery_d IS NOT NULL AND o_w_id=1 AND o_d_id=c.c_d_id \
+        AND o_c_id=c.c_id) sm FROM customer c WHERE c.c_w_id=1) t1 \
+        WHERE c1+c_ytd_payment<>sm";
+    assert_eq!(
+        run_select_on(sql, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(1)]]
+    );
+
+    let statement = tidb_parser::parse(sql).unwrap();
+    let Stmt::Query(query) = &statement else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, plan) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let operators = plan
+        .iter()
+        .map(|row| match &row[0] {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            other => format!("{other:?}"),
+        })
+        .collect::<Vec<_>>();
+    let details = plan
+        .iter()
+        .map(|row| match &row[4] {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            other => format!("{other:?}"),
+        })
+        .collect::<Vec<_>>();
+    let estimates = plan
+        .iter()
+        .map(|row| match &row[1] {
+            Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            other => format!("{other:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        operators
+            .iter()
+            .any(|operator| operator.contains("HashAgg")),
+        "{plan:#?}"
+    );
+    assert!(
+        operators
+            .iter()
+            .any(|operator| operator.contains("HashJoin")),
+        "{plan:#?}"
+    );
+    assert!(
+        operators
+            .iter()
+            .all(|operator| !operator.contains("Projection")),
+        "{plan:#?}"
+    );
+    assert_eq!(
+        operators
+            .iter()
+            .filter(|operator| operator.contains("TableRangeScan"))
+            .count(),
+        3,
+        "{plan:#?}"
+    );
+    assert_eq!(
+        operators
+            .iter()
+            .filter(|operator| operator.contains("Selection"))
+            .count(),
+        3,
+        "{plan:#?}"
+    );
+    assert!(
+        details.iter().all(|detail| !detail.contains("other cond")),
+        "{plan:#?}"
+    );
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("test.customer.c_balance")),
+        "{plan:#?}"
+    );
+    assert!(
+        details.iter().all(|detail| !detail.contains("test.c.")),
+        "{plan:#?}"
+    );
+    assert!(
+        details.iter().any(|detail| {
+            detail.contains(
+                "equal:[eq(test.customer.c_d_id, test.orders.o_d_id) \
+                 eq(test.customer.c_id, test.orders.o_c_id)]",
+            )
+        }),
+        "{plan:#?}"
+    );
+    assert_eq!(
+        details
+            .iter()
+            .filter(|detail| detail.contains("range:[1,1], keep order:false"))
+            .count(),
+        1,
+        "{plan:#?}"
+    );
+    assert_eq!(&estimates[1..4], ["6.40", "8.00", "15.61"], "{plan:#?}");
+
+    let condition_ten = "SELECT count(*) FROM (\
+        SELECT c.c_id,c.c_d_id,c.c_w_id,c.c_balance c1,\
+        (SELECT sum(ol_amount) FROM orders,order_line \
+         WHERE ol_w_id=o_w_id AND ol_d_id=o_d_id AND ol_o_id=o_id \
+         AND ol_delivery_d IS NOT NULL AND o_w_id=1 AND o_d_id=c.c_d_id \
+         AND o_c_id=c.c_id) sm,\
+        (SELECT sum(h_amount) FROM history WHERE h_c_w_id=1 \
+         AND h_c_d_id=c.c_d_id AND h_c_id=c.c_id) smh \
+        FROM customer c WHERE c.c_w_id=1) t WHERE c1<>sm-smh";
+    assert_eq!(
+        run_select_on(condition_ten, &catalog, &ctx).unwrap(),
+        vec![vec![Datum::Int(0)]]
+    );
+    let statement = tidb_parser::parse(condition_ten).unwrap();
+    let Stmt::Query(query) = &statement else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (_, plan) =
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief).unwrap();
+    let text = |row: &[Datum], column: usize| match &row[column] {
+        Datum::Bytes(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        other => format!("{other:?}"),
+    };
+    assert!(text(&plan[1], 0).contains("HashJoin"), "{plan:#?}");
+    assert_ne!(text(&plan[1], 1), "N/A", "{plan:#?}");
+    assert!(
+        plan.iter().any(|row| text(row, 0).contains("IndexLookUp")),
+        "{plan:#?}"
+    );
+    assert!(
+        plan.iter().any(|row| {
+            text(row, 0).contains("HashAgg")
+                && text(row, 2) == "cop[tikv]"
+                && text(row, 4).contains("sum(test.history.h_amount)")
+        }),
+        "{plan:#?}"
+    );
+    assert!(
+        plan.iter()
+            .all(|row| { !text(row, 4).contains("funcs:firstrow(test.customer.c_w_id)") }),
+        "{plan:#?}"
+    );
+}
+
 /// Uncorrelated subqueries are evaluated and folded into literals, the way
 /// Go's handleScalarSubquery does for the non-Apply case.
 #[test]

--- a/rust/crates/tidb-executor/src/driver/tests/subqueries.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/subqueries.rs
@@ -7,6 +7,40 @@
 
 use super::*;
 
+/// EXPLAIN infers a correlated scalar subquery's output type from its plan.
+/// It must not execute the inner query merely to discover that type: on TPCC
+/// condition 10 that planning-time scan alone exceeds the protocol timeout.
+#[test]
+fn explaining_a_correlated_scalar_type_reads_no_storage() {
+    use crate::explain::{explain_select_stmt, ExplainFormat};
+
+    let mut catalog = Catalog::default();
+    crate::run_create_table_on("CREATE TABLE outer_t (k BIGINT)", &mut catalog).unwrap();
+    crate::run_create_table_on(
+        "CREATE TABLE inner_t (k BIGINT, v DECIMAL(6,2))",
+        &mut catalog,
+    )
+    .unwrap();
+    let ctx = crate::StmtContext::for_query();
+    run_insert_on("INSERT INTO inner_t VALUES (1, 2.50)", &mut catalog, &ctx).unwrap();
+
+    let statement = tidb_parser::parse(
+        "SELECT (SELECT SUM(v) FROM inner_t WHERE inner_t.k=outer_t.k) FROM outer_t",
+    )
+    .unwrap();
+    let Stmt::Query(query) = &statement else {
+        panic!("not a query");
+    };
+    let QueryStmt::Select(select) = &**query else {
+        panic!("not a SELECT");
+    };
+    let (explained, operations) = crate::storage::capture_storage_ops(|| {
+        explain_select_stmt(select, &catalog, "test", &ctx, ExplainFormat::Brief)
+    });
+    explained.unwrap();
+    assert_eq!(operations, crate::storage::StorageOps::default());
+}
+
 /// Uncorrelated subqueries are evaluated and folded into literals, the way
 /// Go's handleScalarSubquery does for the non-Apply case.
 #[test]

--- a/rust/crates/tidb-executor/src/driver/tests/through_proj.rs
+++ b/rust/crates/tidb-executor/src/driver/tests/through_proj.rs
@@ -308,20 +308,25 @@ fn an_expression_join_key_gets_an_injected_column() {
     // closed: `plan_trace::index_join_operator` costs the two kinds with the
     // one term that differs between them and keeps the cheaper, which at this
     // site is Go's own answer (its measurement is quoted in that function).
-    // Every node of this tree is now the recorded one.
+    // The join families and leaf order are now the recorded ones. The trace
+    // also exposes every reader boundary it can prove; it deliberately keeps
+    // the scan below the injected Projection bare instead of claiming a
+    // pushdown boundary through that expression.
     assert_eq!(
         dissolved,
         vec![
-            "Projection_10".to_owned(),
-            "└─Selection_9".to_owned(),
-            "  └─MergeJoin_8".to_owned(),
-            "    ├─TableFullScan_1(Build)".to_owned(),
-            "    └─MergeJoin_7(Probe)".to_owned(),
-            "      ├─TableFullScan_2(Build)".to_owned(),
-            "      └─IndexHashJoin_6(Probe)".to_owned(),
-            "        ├─Projection_4(Build)".to_owned(),
-            "        │ └─TableFullScan_3".to_owned(),
-            "        └─IndexRangeScan_5(Probe)".to_owned(),
+            "Projection_12".to_owned(),
+            "└─MergeJoin_11".to_owned(),
+            "  ├─TableReader_2(Build)".to_owned(),
+            "  │ └─TableFullScan_1".to_owned(),
+            "  └─MergeJoin_10(Probe)".to_owned(),
+            "    ├─TableReader_4(Build)".to_owned(),
+            "    │ └─TableFullScan_3".to_owned(),
+            "    └─IndexHashJoin_9(Probe)".to_owned(),
+            "      ├─Projection_6(Build)".to_owned(),
+            "      │ └─TableFullScan_5".to_owned(),
+            "      └─IndexReader_8(Probe)".to_owned(),
+            "        └─IndexRangeScan_7".to_owned(),
         ],
     );
 }

--- a/rust/crates/tidb-executor/src/driver/through_proj.rs
+++ b/rust/crates/tidb-executor/src/driver/through_proj.rs
@@ -1117,7 +1117,7 @@ fn shape_of(expr: &Expr) -> ProjectionInlineExpr {
 }
 
 /// Go `unFoldableFunctions` (`pkg/expression/function_traits.go:48`).
-fn is_unfoldable(name: &str) -> bool {
+pub(super) fn is_unfoldable(name: &str) -> bool {
     matches!(
         name,
         "sysdate"
@@ -1142,7 +1142,7 @@ fn is_unfoldable(name: &str) -> bool {
 }
 
 /// Go `mutableEffectsFunctions` (`pkg/expression/function_traits.go:224`).
-fn is_mutable_effects(name: &str) -> bool {
+pub(super) fn is_mutable_effects(name: &str) -> bool {
     matches!(
         name,
         "now"

--- a/rust/crates/tidb-executor/src/driver/through_proj.rs
+++ b/rust/crates/tidb-executor/src/driver/through_proj.rs
@@ -54,9 +54,13 @@
 //!
 //! # When it runs
 //!
-//! Only when `@@tidb_opt_join_reorder_through_proj` is ON, which is Go's own
-//! and only gate (`extractJoinGroupImpl`, `rule_join_reorder.go:80`). It is
-//! OFF by default, so a stock session never dissolves anything.
+//! Go has two distinct paths. `ProjectionEliminator`, which runs before join
+//! reorder, unconditionally removes a projection whose expressions are all
+//! bare columns. A projection that still computes an expression survives that
+//! pass and is dissolved by `extractJoinGroupImpl` only when
+//! `@@tidb_opt_join_reorder_through_proj` is ON. The same distinction is kept
+//! here: identity/pass-through projections are eliminated in a stock session;
+//! computed projections retain the session-variable gate.
 //!
 //! This module briefly carried a second gate of its own -- a POSITIVE
 //! `@@tidb_opt_join_reorder_threshold` -- because dissolving a projection is
@@ -82,8 +86,8 @@
 //! Three declines are this rewrite's own, each because a NAME-keyed restore
 //! cannot express what a `UniqueID`-keyed one can:
 //!
-//! * an unqualified `*` in the select list, whose expansion order and column
-//!   names would have to be reconstructed from the dissolved scope;
+//! * an unqualified `*` that the caller could not expand from the catalog
+//!   before this pass, whose output order would otherwise be unknown;
 //! * a derived table with two output columns of the same name, which no
 //!   qualified reference can tell apart;
 //! * a splice that would put two relations with the same visible name in one
@@ -139,6 +143,14 @@ struct Dissolved {
 /// Everything the splice accumulated while walking the `FROM` tree.
 #[derive(Default)]
 struct Splice {
+    /// Whether `@@tidb_opt_join_reorder_through_proj` permits computed
+    /// projections to dissolve.  Bare-column projections are handled by
+    /// Go's earlier `ProjectionEliminator` and do not need this opt-in.
+    allow_general_projection: bool,
+    /// Whether any dissolved projection computed an expression rather than
+    /// merely forwarding a child column. Only this case can create a
+    /// non-column join key that needs Go's `injectExpr` equivalent.
+    computed_projection_dissolved: bool,
     dissolved: Vec<Dissolved>,
     /// `WHERE` conjuncts lifted out of a dissolved subquery. Go reaches these
     /// through the `Selection` the subquery's own predicate pushdown left
@@ -204,17 +216,15 @@ fn split_path(path: &[String]) -> Option<(Option<&String>, &String)> {
 /// `restoreSchemaIfChanged`, over one `SELECT`.
 ///
 /// Returns the rewritten statement when at least one derived table dissolved,
-/// and `None` when the statement is left exactly as written -- which is every
-/// statement a stock session runs, since the gate is off by default.
+/// and `None` when the statement is left exactly as written. Bare-column
+/// projections may dissolve at the default settings; computed projections
+/// require `@@tidb_opt_join_reorder_through_proj=ON`.
 pub(crate) fn inline(
     select: &SelectStmt,
     catalog: &Catalog,
     current_db: &str,
     ctx: &crate::StmtContext,
 ) -> Option<SelectStmt> {
-    if !ctx.join_reorder_through_proj() {
-        return None;
-    }
     // A `leading` hint PINS the join order: Go builds the named prefix into
     // `s.leadingJoinGroup` and `constructConnectedJoinTree` joins it first
     // (`rule_join_reorder_greedy.go:56-76`), so it dissolves the projection
@@ -232,7 +242,10 @@ pub(crate) fn inline(
         return None;
     }
     let from = select.from.as_ref()?;
-    let mut splice = Splice::default();
+    let mut splice = Splice {
+        allow_general_projection: ctx.join_reorder_through_proj(),
+        ..Splice::default()
+    };
     let rewritten_from = splice_join(from, catalog, current_db, &mut splice)?;
     if splice.dissolved.is_empty() {
         return None;
@@ -321,9 +334,17 @@ pub(crate) fn inline(
         })
         .collect::<Option<Vec<_>>>()?;
 
-    // Every equality must read `col = col` before this leaves; Go's
-    // `injectExpr` is what puts the ones that do not back into that form.
-    inject_expressions(rewritten, catalog, current_db)
+    if splice.computed_projection_dissolved {
+        // A computed output may now appear inside a join equality. Go's
+        // `injectExpr` materializes it back into a column on its owning side.
+        inject_expressions(rewritten, catalog, current_db)
+    } else {
+        // Projection elimination only substituted columns for columns, so it
+        // cannot have created a key that needs materialization. In
+        // particular, do not route unrelated `column = constant` filters
+        // through the injection path.
+        Some(rewritten)
+    }
 }
 
 /// Go's `baseSingleGroupJoinOrderSolver.injectExpr` (`rule_join_reorder.go:793`),
@@ -909,7 +930,10 @@ fn dissolve(
     // `Projection -> Join -> Projection -> Join` dissolves bottom-up and this
     // projection's own expressions are rewritten against base relations --
     // Go's bottom-up `colExprMap` propagation (`rule_join_reorder.go:52`).
-    let mut inner = Splice::default();
+    let mut inner = Splice {
+        allow_general_projection: splice.allow_general_projection,
+        ..Splice::default()
+    };
     let spliced_from = splice_join(from, catalog, current_db, &mut inner)?;
     for (index, name) in inner.visible.iter().enumerate() {
         if inner.visible[index + 1..]
@@ -979,6 +1003,16 @@ fn dissolve(
         });
         fields.push((name, expr));
     }
+    // `ProjectionEliminator` runs before join reorder and removes a logical
+    // projection whenever every expression is a single column.  That rule is
+    // unconditional; `tidb_opt_join_reorder_through_proj` gates only the
+    // later inlining of projections that still compute expressions.
+    let projection_eliminable = fields
+        .iter()
+        .all(|(_, expr)| matches!(strip(expr), Expr::Column(_)));
+    if !projection_eliminable && !splice.allow_general_projection {
+        return None;
+    }
     // `canInlineProjectionBasic`, over the shapes Go's own gate is written
     // against.
     let shape = ProjectionInlineShape::new(
@@ -1004,6 +1038,8 @@ fn dissolve(
         lifted.push(substitute(where_clause, &inner)?);
     }
 
+    splice.computed_projection_dissolved |=
+        inner.computed_projection_dissolved || !projection_eliminable;
     splice.dissolved.extend(inner.dissolved);
     splice.dissolved.push(Dissolved {
         alias: alias.to_owned(),

--- a/rust/crates/tidb-executor/src/executor.rs
+++ b/rust/crates/tidb-executor/src/executor.rs
@@ -139,6 +139,18 @@ pub trait Executor {
         None
     }
 
+    /// Whether this operator tree already enforces every conjunct of the
+    /// statement's `WHERE` clause.
+    ///
+    /// This is a physical-plan fact, not a semantic shortcut: the default is
+    /// deliberately false, and only an operator that has installed all leaf
+    /// filters and join equalities may opt in. The driver uses it to avoid
+    /// rebuilding a redundant root `Selection` after a join strategy is
+    /// committed.
+    fn consumes_where(&self) -> bool {
+        false
+    }
+
     /// Go `aggExecutorTreeInputEmpty` (`pkg/executor/join/hash_join_v1.go`):
     /// whether this already-executed operator tree is an aggregation that saw
     /// NO input row, and therefore owes its single output row entirely to the

--- a/rust/crates/tidb-executor/src/explain.rs
+++ b/rust/crates/tidb-executor/src/explain.rs
@@ -449,6 +449,7 @@ struct IdNode {
     est_rows: Option<f64>,
     access: String,
     info: String,
+    task: &'static str,
     left_side_child: Option<usize>,
     info_tail: String,
     label: &'static str,
@@ -472,6 +473,7 @@ fn assign_ids(node: PlanNode, counter: &mut usize) -> IdNode {
         est_rows: node.est_rows,
         access: node.access,
         info: node.info,
+        task: node.task,
         left_side_child: node.left_side_child,
         info_tail: node.info_tail,
         label: node.label,
@@ -558,8 +560,7 @@ fn flatten(
     out.push(vec![
         text(&draw_id(node, &prefix, is_root, is_last, format)),
         text(&est_text(node.est_rows)),
-        // Divergence 1: every operator here runs in the TiDB process.
-        text("root"),
+        text(node.task),
         text(&node.access),
         text(&info_text(node, format)),
     ]);
@@ -588,7 +589,7 @@ fn flatten_analyze(
         text(&draw_id(node, &prefix, is_root, is_last, format)),
         text(&est_text(node.est_rows)),
         text(&act),
-        text("root"),
+        text(node.task),
         text(&node.access),
         text("N/A"),
         text(&info_text(node, format)),

--- a/rust/crates/tidb-executor/src/handle_range.rs
+++ b/rust/crates/tidb-executor/src/handle_range.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The range of a table's CLUSTERED INTEGER HANDLE that a `WHERE` implies:
-//! what turns Go's `TableFullScan` into its `TableRangeScan`.
+//! The range of a table's CLUSTERED HANDLE that a `WHERE` implies: what
+//! turns Go's `TableFullScan` into its `TableRangeScan`.
 //!
 //! Mirrors Go `pkg/planner/core/stats.go`'s `deriveTablePathStats`, which is
 //! three steps this module keeps in the same order:
@@ -77,7 +77,7 @@
 use crate::access_cost::realtime_row_count;
 use crate::access_cost::TableStatistics;
 use crate::index_range::IndexRanges;
-use crate::kv_table::{IndexRange, KvTable};
+use crate::kv_table::{IndexRange, KvIndex, KvTable};
 use tidb_datatype::{Datum, FieldTypeCode};
 use tidb_distsql::{signed_handle_ranges_to_kv_ranges, SignedHandleRange};
 use tidb_planner::cardinality::row_count_estimator::{
@@ -85,15 +85,14 @@ use tidb_planner::cardinality::row_count_estimator::{
 };
 use tidb_txnkv::Key;
 
-/// The ranges a `WHERE` implies over `table`'s clustered integer handle, or
-/// `None` when this tier builds none.
+/// The ranges a `WHERE` implies over `table`'s clustered handle, or `None`
+/// when this tier builds none.
 ///
 /// `None` is Go's full range, and the caller reads the whole table for it.
 /// The refusals are:
 ///
-/// * a table with no integer primary-key handle -- a `_tidb_rowid` table has
-///   no handle a `WHERE` can name, and a common (clustered non-integer)
-///   handle is a multi-column key whose ranges this tier does not encode;
+/// * a table with no primary-key handle -- a `_tidb_rowid` table has no
+///   handle a `WHERE` can name;
 /// * an UNSIGNED handle. The record key encodes a handle with the SIGNED
 ///   integer codec, so an unsigned value above `i64::MAX` encodes as a
 ///   negative key and a range over it is not the interval its bounds read
@@ -106,6 +105,9 @@ pub(crate) fn build_handle_ranges<'a>(
     where_clause: &'a tidb_ast::Expr,
     zone: &tidb_datatype::SessionTimeZone,
 ) -> Option<IndexRanges<'a>> {
+    if !table.common_handle_offsets().is_empty() {
+        return build_common_handle_ranges(table, where_clause, zone);
+    }
     let column = handle_column(table)?;
     let mut built = crate::index_range::detach_cond_and_build_range_for_index(
         // The clustered handle stores the whole column: a row identifier has
@@ -139,6 +141,43 @@ pub(crate) fn build_handle_ranges<'a>(
         .ranges
         .retain(|range| range.high.first() != Some(&Datum::Null));
     Some(built)
+}
+
+/// The PRIMARY index whose columns are the common row handle.
+///
+/// TiDB exposes this metadata as an index for range building and statistics,
+/// but physically reads its ranges from the table's `_r<common_handle>`
+/// record keys. It is therefore a table path, not a secondary-index path.
+pub(crate) fn common_handle_primary(table: &KvTable) -> Option<&KvIndex> {
+    table.plan_indexes().find(|index| {
+        index.name.eq_ignore_ascii_case("PRIMARY")
+            && index.column_offsets == table.common_handle_offsets()
+    })
+}
+
+fn build_common_handle_ranges<'a>(
+    table: &KvTable,
+    where_clause: &'a tidb_ast::Expr,
+    zone: &tidb_datatype::SessionTimeZone,
+) -> Option<IndexRanges<'a>> {
+    let index = common_handle_primary(table)?;
+    let columns: Vec<crate::index_range::RangeColumn> = index
+        .column_offsets
+        .iter()
+        .enumerate()
+        .filter_map(|(position, offset)| {
+            let column = table.columns.get(*offset)?;
+            Some(crate::index_range::RangeColumn {
+                name: column.name.clone(),
+                field_type: column.field_type.clone(),
+                prefix_len: index.prefix_length(position),
+            })
+        })
+        .collect();
+    if columns.len() != index.column_offsets.len() {
+        return None;
+    }
+    crate::index_range::detach_cond_and_build_range_for_index(&columns, where_clause, zone)
 }
 
 /// The primary-key column that IS the row handle, when the table has one and
@@ -213,6 +252,9 @@ pub(crate) fn handle_range_row_count(
     stats: Option<&TableStatistics>,
 ) -> f64 {
     let realtime = realtime_row_count(stats);
+    if let Some(index) = common_handle_primary(table) {
+        return crate::access_cost::index_range_row_count(index, table, ranges, stats, realtime);
+    }
     let Some(column) = handle_column(table) else {
         return realtime;
     };
@@ -240,7 +282,14 @@ pub(crate) fn handle_range_row_count(
 /// `None` means a bound this tier cannot encode, and the caller falls back to
 /// the whole record range -- reading a superset is always correct, because
 /// the `WHERE` above the source filters every row it returns.
-pub(crate) fn record_key_ranges(table: &KvTable, ranges: &[IndexRange]) -> Option<Vec<(Key, Key)>> {
+pub(crate) fn record_key_ranges(
+    table: &KvTable,
+    ranges: &[IndexRange],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> Result<Option<Vec<(Key, Key)>>, tidb_codec::CodecError> {
+    if common_handle_primary(table).is_some() {
+        return common_handle_record_key_ranges(table, ranges, zone).map(Some);
+    }
     let ids = table.record_physical_ids();
     let mut handle_ranges = Vec::with_capacity(ranges.len());
     for range in ranges {
@@ -259,5 +308,37 @@ pub(crate) fn record_key_ranges(table: &KvTable, ranges: &[IndexRange]) -> Optio
             key_ranges.push((encoded.start_key, encoded.end_key));
         }
     }
-    Some(key_ranges)
+    Ok(Some(key_ranges))
+}
+
+/// Go `CommonHandleRangesToKVRanges`: the ranger's encoded tuple bounds
+/// prefixed by each physical table's record namespace.
+fn common_handle_record_key_ranges(
+    table: &KvTable,
+    ranges: &[IndexRange],
+    zone: &tidb_datatype::SessionTimeZone,
+) -> Result<Vec<(Key, Key)>, tidb_codec::CodecError> {
+    let ids = table.record_physical_ids();
+    let mut key_ranges = Vec::with_capacity(ranges.len() * ids.len());
+    for id in ids {
+        for range in ranges {
+            let low = tidb_codec::encode_key_in_timezone(zone, &range.low)?;
+            let low = if range.low_exclusive {
+                Key::from_bytes(low).prefix_next().into_bytes()
+            } else {
+                low
+            };
+            let high = tidb_codec::encode_key_in_timezone(zone, &range.high)?;
+            let high = if range.high_exclusive {
+                high
+            } else {
+                Key::from_bytes(high).prefix_next().into_bytes()
+            };
+            key_ranges.push((
+                Key::from_bytes(tidb_codec::encode_row_key(id, &low)),
+                Key::from_bytes(tidb_codec::encode_row_key(id, &high)),
+            ));
+        }
+    }
+    Ok(key_ranges)
 }

--- a/rust/crates/tidb-executor/src/hash_agg.rs
+++ b/rust/crates/tidb-executor/src/hash_agg.rs
@@ -116,6 +116,9 @@ impl Selectable for DatumSelection<'_> {
 pub enum AggKind {
     /// `COUNT(expr)` / `COUNT(*)` (no argument).
     Count,
+    /// Root final stage for a pushed partial `COUNT`: add the per-region
+    /// counts instead of counting the number of partial rows.
+    FinalCount,
     /// `SUM(expr)`.
     Sum,
     /// `FIRST_ROW(expr)`: the first row's value (the planner's group-column
@@ -252,6 +255,7 @@ impl AggFunc {
 /// One group's partial results, in agg-func order.
 enum Partial {
     Count(i64),
+    FinalCount(i64),
     /// `None` until the first non-NULL input (an empty sum is NULL). Go
     /// sums an integer or decimal argument exactly, in the decimal domain --
     /// `SUM` over a BIGINT column is a DECIMAL in MySQL.
@@ -553,6 +557,7 @@ impl Partial {
     fn new(kind: &AggKind) -> Partial {
         match kind {
             AggKind::Count => Partial::Count(0),
+            AggKind::FinalCount => Partial::FinalCount(0),
             // The sum's domain is chosen lazily from the first non-NULL input.
             AggKind::Sum => Partial::SumDecimal(None),
             AggKind::GroupConcat { separator } => Partial::GroupConcat {
@@ -672,6 +677,17 @@ impl Partial {
             (Partial::Count(n), None) => *n += 1,
             (Partial::Count(_), Some(Datum::Null)) => {}
             (Partial::Count(n), Some(_)) => *n += 1,
+            (Partial::FinalCount(_), None | Some(Datum::Null)) => {}
+            (Partial::FinalCount(total), Some(Datum::Int(value))) => *total += value,
+            (Partial::FinalCount(total), Some(Datum::UInt(value))) => {
+                *total += i64::try_from(value)
+                    .map_err(|_| ExecError::unsupported("partial COUNT exceeds i64"))?;
+            }
+            (Partial::FinalCount(_), Some(_)) => {
+                return Err(ExecError::unsupported(
+                    "final COUNT requires integer partial results",
+                ))
+            }
             (Partial::SumDecimal(_) | Partial::SumReal(_), None) => {
                 return Err(ExecError::unsupported("SUM requires an argument"))
             }
@@ -866,7 +882,7 @@ impl Partial {
         div_precision_increment: u32,
     ) -> Result<Datum, ExecError> {
         Ok(match self {
-            Partial::Count(n) => Datum::Int(*n),
+            Partial::Count(n) | Partial::FinalCount(n) => Datum::Int(*n),
             // An empty group is SQL NULL, not the empty document `[]`/`{}`.
             Partial::JsonArrayAgg(entries, _) if entries.is_empty() => Datum::Null,
             Partial::JsonArrayAgg(entries, _) => encode_json(BinaryJSONValue::Array(
@@ -1059,6 +1075,348 @@ pub(crate) fn aggregate_rows(
     partial.finish(&[], div_precision_increment)
 }
 
+/// Finishes one aggregate state, including GROUP_CONCAT's statement warning
+/// and byte limit. Both hash and stream aggregation use this exact path so a
+/// physical algorithm choice cannot change an aggregate's value semantics.
+fn finish_agg_value<C: Columns>(
+    state: &mut AggState,
+    func: &AggFunc,
+    ctx: &C,
+    truncated: &mut bool,
+) -> Result<Datum, ExecError> {
+    let mut value = state
+        .partial
+        .finish(&func.order_by, ctx.div_precision_increment())?;
+    if let Datum::Bytes(joined) = &mut value {
+        if matches!(func.kind, AggKind::GroupConcat { .. }) {
+            let max_len = group_concat_max_len(ctx);
+            if max_len > 0 && joined.len() as u64 > max_len {
+                joined.truncate(max_len as usize);
+                if !*truncated {
+                    *truncated = true;
+                    let text = group_concat_arg_text(func);
+                    ctx.append_warning(1260, &format!("Some rows were cut by GROUPCONCAT({text})"));
+                }
+            }
+        }
+    }
+    Ok(value)
+}
+
+/// Go `StreamAggExec` for a global aggregate (an empty group-by list).
+///
+/// A global aggregate is already one ordered group, so no hash table or row
+/// materialization is needed: each child row is folded into the one vector of
+/// partial results and that vector emits exactly once, including for empty
+/// input. The driver selects this executor only for Go plan shapes that choose
+/// StreamAgg; grouped input continues through [`HashAggExec`].
+pub struct StreamAggExec<C: Columns> {
+    meta: ExecutorMeta,
+    agg_funcs: Vec<AggFunc>,
+    child: Box<dyn Executor>,
+    ctx: C,
+    child_chunk: Chunk,
+    states: Vec<AggState>,
+    truncated: Vec<bool>,
+    emitted: bool,
+    child_returned_empty: bool,
+}
+
+impl<C: Columns> StreamAggExec<C> {
+    /// Builds a one-group streaming aggregation over `child`.
+    #[must_use]
+    pub fn new(
+        meta: ExecutorMeta,
+        agg_funcs: Vec<AggFunc>,
+        child: Box<dyn Executor>,
+        ctx: C,
+    ) -> Self {
+        let child_chunk = child.new_chunk();
+        let states = agg_funcs.iter().map(AggState::new).collect();
+        let truncated = vec![false; agg_funcs.len()];
+        Self {
+            meta,
+            agg_funcs,
+            child,
+            ctx,
+            child_chunk,
+            states,
+            truncated,
+            emitted: false,
+            child_returned_empty: true,
+        }
+    }
+
+    fn update_row(
+        agg_funcs: &[AggFunc],
+        ctx: &C,
+        states: &mut [AggState],
+        row: tidb_chunk::row::Row<'_>,
+    ) -> Result<(), ExecError> {
+        for index in 0..agg_funcs.len() {
+            let func = &agg_funcs[index];
+            let mut extra_values = Vec::new();
+            let value = eval_agg_input(func, ctx, row, &mut extra_values)?;
+            let mut sort_key = Vec::with_capacity(func.order_by.len());
+            for (expr, _) in &func.order_by {
+                sort_key.push(expr.eval(ctx, row)?);
+            }
+            states[index].update(value, &extra_values, sort_key)?;
+        }
+        Ok(())
+    }
+}
+
+impl<C: Columns> Executor for StreamAggExec<C> {
+    fn agg_tree_input_empty(&self) -> bool {
+        self.child_returned_empty
+    }
+
+    fn open(&mut self) -> Result<(), ExecError> {
+        self.child.open()?;
+        self.child_chunk.reset();
+        self.states = self.agg_funcs.iter().map(AggState::new).collect();
+        self.truncated.fill(false);
+        self.emitted = false;
+        self.child_returned_empty = true;
+        Ok(())
+    }
+
+    fn next(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
+        req.reset();
+        if self.emitted {
+            return Ok(());
+        }
+        loop {
+            self.child.next(&mut self.child_chunk)?;
+            let rows = self.child_chunk.num_rows();
+            if rows == 0 {
+                break;
+            }
+            self.child_returned_empty = false;
+            for row_index in 0..rows {
+                Self::update_row(
+                    &self.agg_funcs,
+                    &self.ctx,
+                    &mut self.states,
+                    self.child_chunk.get_row(row_index),
+                )?;
+            }
+            self.child_chunk.reset();
+        }
+        if self.agg_funcs.is_empty() {
+            req.set_num_virtual_rows(1);
+        } else {
+            for index in 0..self.agg_funcs.len() {
+                let value = finish_agg_value(
+                    &mut self.states[index],
+                    &self.agg_funcs[index],
+                    &self.ctx,
+                    &mut self.truncated[index],
+                )?;
+                req.append_datum(index, &value);
+            }
+        }
+        self.emitted = true;
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), ExecError> {
+        self.states.clear();
+        self.child.close()
+    }
+
+    fn schema(&self) -> &Schema {
+        self.meta.schema()
+    }
+
+    fn ret_field_types(&self) -> &[FieldType] {
+        self.meta.ret_field_types()
+    }
+
+    fn init_cap(&self) -> usize {
+        self.meta.init_cap()
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        self.meta.max_chunk_size()
+    }
+
+    fn new_chunk(&self) -> Chunk {
+        self.meta.new_chunk()
+    }
+}
+
+/// Go `StreamAggExec` for input already ordered by every `GROUP BY` item.
+///
+/// Unlike [`HashAggExec`], this operator holds one group at a time. A change
+/// in the encoded group key finishes the current aggregate states before the
+/// first row of the next group is folded. The driver constructs it only after
+/// the child reports the required physical order, so equal keys are contiguous
+/// and a completed group can never reappear later in the stream.
+pub struct GroupedStreamAggExec<C: Columns> {
+    meta: ExecutorMeta,
+    group_by: Vec<Expression>,
+    agg_funcs: Vec<AggFunc>,
+    /// Output column for each aggregate state. This separates TiKV's
+    /// function-first physical state order from the aggregation schema order
+    /// Go exposes without an extra Projection.
+    output_positions: Vec<usize>,
+    child: Box<dyn Executor>,
+    ctx: C,
+    child_chunk: Chunk,
+    child_at: usize,
+    states: Vec<AggState>,
+    truncated: Vec<bool>,
+    current_key: Option<Vec<u8>>,
+    child_done: bool,
+    child_returned_empty: bool,
+}
+
+impl<C: Columns> GroupedStreamAggExec<C> {
+    /// Builds a grouped streaming aggregation over an already ordered child.
+    #[must_use]
+    pub fn new(
+        meta: ExecutorMeta,
+        group_by: Vec<Expression>,
+        agg_funcs: Vec<AggFunc>,
+        output_positions: Vec<usize>,
+        child: Box<dyn Executor>,
+        ctx: C,
+    ) -> Self {
+        debug_assert!(!group_by.is_empty());
+        debug_assert_eq!(agg_funcs.len(), output_positions.len());
+        debug_assert!(output_positions
+            .iter()
+            .copied()
+            .all(|position| position < agg_funcs.len()));
+        debug_assert!((0..agg_funcs.len()).all(|position| output_positions.contains(&position)));
+        let child_chunk = child.new_chunk();
+        let states = agg_funcs.iter().map(AggState::new).collect();
+        let truncated = vec![false; agg_funcs.len()];
+        Self {
+            meta,
+            group_by,
+            agg_funcs,
+            output_positions,
+            child,
+            ctx,
+            child_chunk,
+            child_at: 0,
+            states,
+            truncated,
+            current_key: None,
+            child_done: false,
+            child_returned_empty: true,
+        }
+    }
+
+    fn group_key(&self, row: tidb_chunk::row::Row<'_>) -> Result<Vec<u8>, ExecError> {
+        let mut key = Vec::new();
+        for expr in &self.group_by {
+            let datum = expr.eval(&self.ctx, row)?;
+            key.extend_from_slice(&group_key_part(&expr_collation(expr), &datum));
+            key.push(0xff);
+        }
+        Ok(key)
+    }
+
+    fn emit_current(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
+        for index in 0..self.states.len() {
+            let value = finish_agg_value(
+                &mut self.states[index],
+                &self.agg_funcs[index],
+                &self.ctx,
+                &mut self.truncated[index],
+            )?;
+            req.append_datum(self.output_positions[index], &value);
+        }
+        Ok(())
+    }
+}
+
+impl<C: Columns> Executor for GroupedStreamAggExec<C> {
+    fn agg_tree_input_empty(&self) -> bool {
+        self.child_returned_empty
+    }
+
+    fn open(&mut self) -> Result<(), ExecError> {
+        self.child.open()?;
+        self.child_chunk.reset();
+        self.child_at = 0;
+        self.states = self.agg_funcs.iter().map(AggState::new).collect();
+        self.truncated.fill(false);
+        self.current_key = None;
+        self.child_done = false;
+        self.child_returned_empty = true;
+        Ok(())
+    }
+
+    fn next(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
+        req.reset();
+        let cap = self.meta.max_chunk_size();
+        while req.num_rows() < cap {
+            if self.child_done {
+                if self.current_key.take().is_some() {
+                    self.emit_current(req)?;
+                }
+                break;
+            }
+            if self.child_at >= self.child_chunk.num_rows() {
+                self.child_chunk.reset();
+                self.child.next(&mut self.child_chunk)?;
+                self.child_at = 0;
+                if self.child_chunk.num_rows() == 0 {
+                    self.child_done = true;
+                    continue;
+                }
+            }
+
+            let key = self.group_key(self.child_chunk.get_row(self.child_at))?;
+            if self
+                .current_key
+                .as_ref()
+                .is_some_and(|current| current != &key)
+            {
+                self.emit_current(req)?;
+                self.states = self.agg_funcs.iter().map(AggState::new).collect();
+            }
+            self.current_key = Some(key);
+            let row = self.child_chunk.get_row(self.child_at);
+            StreamAggExec::<C>::update_row(&self.agg_funcs, &self.ctx, &mut self.states, row)?;
+            self.child_at += 1;
+            self.child_returned_empty = false;
+        }
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), ExecError> {
+        self.states.clear();
+        self.current_key = None;
+        self.child.close()
+    }
+
+    fn schema(&self) -> &Schema {
+        self.meta.schema()
+    }
+
+    fn ret_field_types(&self) -> &[FieldType] {
+        self.meta.ret_field_types()
+    }
+
+    fn init_cap(&self) -> usize {
+        self.meta.init_cap()
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        self.meta.max_chunk_size()
+    }
+
+    fn new_chunk(&self) -> Chunk {
+        self.meta.new_chunk()
+    }
+}
+
 /// Go `HashAggExec` (serial `unparallelExec`): hash aggregation over the
 /// child's rows, in ROUNDS when the statement's memory quota forces a spill.
 ///
@@ -1246,40 +1604,14 @@ impl<C: Columns> HashAggExec<C> {
     }
 
     /// Appends group `idx`'s final values to `req`.
-    fn emit_group(
-        &mut self,
-        idx: usize,
-        req: &mut Chunk,
-        max_len: u64,
-        div_precision_increment: u32,
-    ) -> Result<(), ExecError> {
+    fn emit_group(&mut self, idx: usize, req: &mut Chunk) -> Result<(), ExecError> {
         for c in 0..self.ordered[idx].len() {
-            let order_by = self
-                .agg_funcs
-                .get(c)
-                .map_or(&[][..], |func| func.order_by.as_slice());
-            let mut value = self.ordered[idx][c]
-                .partial
-                .finish(order_by, div_precision_increment)?;
-            if let (Some(func), Datum::Bytes(joined)) = (self.agg_funcs.get(c), &mut value) {
-                if matches!(func.kind, AggKind::GroupConcat { .. })
-                    && max_len > 0
-                    && joined.len() as u64 > max_len
-                {
-                    // Go `bytes.Buffer.Truncate(int(e.maxLen))`: a BYTE cut, so
-                    // it lands mid-character or mid-separator (captured:
-                    // max_len 4 over 'ccc','bbb' -> `ccc,`).
-                    joined.truncate(max_len as usize);
-                    if !self.truncated[c] {
-                        self.truncated[c] = true;
-                        let text = group_concat_arg_text(func);
-                        self.ctx.append_warning(
-                            1260,
-                            &format!("Some rows were cut by GROUPCONCAT({text})"),
-                        );
-                    }
-                }
-            }
+            let value = finish_agg_value(
+                &mut self.ordered[idx][c],
+                &self.agg_funcs[c],
+                &self.ctx,
+                &mut self.truncated[c],
+            )?;
             req.append_datum(c, &value);
         }
         Ok(())
@@ -1340,8 +1672,6 @@ impl<C: Columns> Executor for HashAggExec<C> {
     /// full, and when they run out, run the next round.
     fn next(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
         req.reset();
-        let max_len = group_concat_max_len(&self.ctx);
-        let div_precision_increment = self.ctx.div_precision_increment();
         let batch = self.meta.max_chunk_size();
         loop {
             if self.prepared {
@@ -1351,7 +1681,7 @@ impl<C: Columns> Executor for HashAggExec<C> {
                         // group with no aggregate columns is still a row.
                         req.set_num_virtual_rows(req.num_rows() + 1);
                     }
-                    self.emit_group(self.cursor, req, max_len, div_precision_increment)?;
+                    self.emit_group(self.cursor, req)?;
                     self.cursor += 1;
                     if req.num_rows() >= batch {
                         return Ok(());

--- a/rust/crates/tidb-executor/src/index_hints.rs
+++ b/rust/crates/tidb-executor/src/index_hints.rs
@@ -449,20 +449,23 @@ enum HintedPath {
 }
 
 /// Go `getPathByIndexName`: an index of the table by name, or the table path
-/// when the name is `PRIMARY` and the primary key is the handle.
+/// when the name is `PRIMARY` and the primary key is the integer or common
+/// handle.
 ///
 /// Index names are case-insensitive, and an INVISIBLE index is not a path at
 /// all -- it is absent from `publicPaths`, which is why naming one is 1176
 /// rather than a plan that quietly reads it.
 fn resolve_index_name(table: &KvTable, name: &str) -> Option<HintedPath> {
+    if name.eq_ignore_ascii_case("primary")
+        && (table.pk_handle_offset().is_some() || !table.common_handle_offsets().is_empty())
+    {
+        return Some(HintedPath::Table);
+    }
     if let Some(index) = table
         .plan_indexes()
         .find(|index| index.name.eq_ignore_ascii_case(name))
     {
         return Some(HintedPath::Index(index.id));
-    }
-    if name.eq_ignore_ascii_case("primary") && table.pk_handle_offset().is_some() {
-        return Some(HintedPath::Table);
     }
     None
 }

--- a/rust/crates/tidb-executor/src/index_range.rs
+++ b/rust/crates/tidb-executor/src/index_range.rs
@@ -1330,6 +1330,103 @@ pub(crate) fn detach_conds_for_column<'a>(
     }
 }
 
+/// Builds the ranges for a row-valued `IN` over the leading index columns.
+///
+/// Go's ranger lowers `(a, b) IN ((1, 2), (3, 4))` to
+/// `(a = 1 AND b = 2) OR (a = 3 AND b = 4)` before detaching ranges. Reusing
+/// [`build_dnf_ranges`] for that normalized shape keeps endpoint conversion,
+/// prefix-index cutting, duplicate unioning and range validation in the one
+/// existing algebra instead of growing a second tuple-range implementation.
+///
+/// The normalized expression is temporary, so its residual references must
+/// not escape this function. The whole row-IN is an access condition and the
+/// caller already retains the written predicate above the scan, so only the
+/// owned range and column metadata is returned.
+fn build_row_in_ranges<'a>(
+    index_columns: &[RangeColumn],
+    condition: &Expr,
+    zone: &tidb_datatype::SessionTimeZone,
+) -> Option<IndexRanges<'a>> {
+    let Expr::In {
+        expr,
+        list,
+        not: false,
+    } = condition
+    else {
+        return None;
+    };
+    let Expr::Row(left) = &**expr else {
+        return None;
+    };
+    if left.is_empty()
+        || left.len() > index_columns.len()
+        || !left
+            .iter()
+            .zip(index_columns)
+            .all(|(expr, column)| is_column(expr, &column.name))
+    {
+        return None;
+    }
+
+    let mut branches = Vec::with_capacity(list.len());
+    for candidate in list {
+        let Expr::Row(right) = candidate else {
+            return None;
+        };
+        if right.len() != left.len() {
+            return None;
+        }
+        let mut equalities = Vec::with_capacity(left.len());
+        let mut contains_null = false;
+        for (column, value) in left.iter().zip(right) {
+            let datum = constant_value(value, zone)?;
+            if datum == Datum::Null {
+                contains_null = true;
+                break;
+            }
+            equalities.push(Expr::Binary(
+                BinaryOp::Eq,
+                Box::new(column.clone()),
+                Box::new(value.clone()),
+            ));
+        }
+        // An ordinary row equality containing NULL can never be TRUE in a
+        // WHERE predicate, so this tuple contributes no range.
+        if contains_null {
+            continue;
+        }
+        let branch = equalities
+            .into_iter()
+            .reduce(|left, right| Expr::Binary(BinaryOp::LogicAnd, Box::new(left), Box::new(right)))
+            .expect("a row-valued IN has at least one column");
+        branches.push(branch);
+    }
+
+    if branches.is_empty() {
+        return Some(IndexRanges {
+            ranges: Vec::new(),
+            access_count: 1,
+            column_count: left.len(),
+            access_columns: (0..left.len()).collect(),
+            eq_or_in_count: left.len(),
+            residual: Vec::new(),
+        });
+    }
+    let dnf = branches
+        .into_iter()
+        .reduce(|left, right| Expr::Binary(BinaryOp::LogicOr, Box::new(left), Box::new(right)))
+        .expect("the empty branch set returned above");
+    let built = build_dnf_ranges(index_columns, &dnf, zone)?;
+    Some(IndexRanges {
+        ranges: built.ranges,
+        access_count: 1,
+        column_count: built.column_count,
+        access_columns: built.access_columns,
+        eq_or_in_count: built.eq_or_in_count,
+        residual: Vec::new(),
+    })
+}
+
 /// Go `DetachCondAndBuildRangeForIndex`: the index ranges a `WHERE` implies
 /// over one index's columns.
 ///
@@ -1344,6 +1441,11 @@ pub(crate) fn detach_cond_and_build_range_for_index<'a>(
     let mut conjuncts = Vec::new();
     collect_conjuncts(where_clause, &mut conjuncts);
 
+    if let [condition] = conjuncts.as_slice() {
+        if let Some(built) = build_row_in_ranges(index_columns, condition, zone) {
+            return Some(built);
+        }
+    }
     // A lone top-level OR is the DNF case. Go also detaches an OR that is one
     // conjunct among several (`extractBestCNFItemRanges`); that selection is
     // deferred, so a mixed AND/OR reaches the CNF walk, where the OR simply
@@ -1587,6 +1689,16 @@ mod tests {
             "a = 1 and b in (2, 3) and c = 4",
             "[1 2 4,1 2 4], [1 3 4,1 3 4]",
         ),
+        (
+            &["a", "b", "c", "d"],
+            "(a, b, c) in ((1, 1, 10), (1, 2, 20))",
+            "[1 1 10,1 1 10], [1 2 20,1 2 20]",
+        ),
+        (
+            &["a", "b", "c", "d"],
+            "(a, b, c) in ((1, 1, null), (1, 2, 20))",
+            "[1 2 20,1 2 20]",
+        ),
         // DNF / OR
         (&["a"], "a = 1 or a = 2", "[1,2]"),
         (&["a"], "a < 1 or a > 10", "[-inf,1), (10,+inf]"),
@@ -1647,6 +1759,10 @@ mod tests {
         assert_eq!(derive(&["a", "b"], "a = 1 or b = 2"), "<no range>");
         // Conditions that span the whole index bound nothing, so they stay
         // filters rather than turning a full scan into a full range scan.
+        assert_eq!(
+            derive(&["a", "b", "c"], "(a, b, c) not in ((1, 2, 3))"),
+            "<no range>"
+        );
         assert_eq!(derive(&["a"], "a is not null"), "<no range>");
         assert_eq!(derive(&["s"], "s like '%abc'"), "<no range>");
         assert_eq!(derive(&["s"], "s like '%'"), "<no range>");

--- a/rust/crates/tidb-executor/src/join.rs
+++ b/rust/crates/tidb-executor/src/join.rs
@@ -357,6 +357,110 @@ impl MergeInnerGroup {
 /// pins -- so reading the default is a smaller claim, not a wrong answer.
 pub(crate) const INDEX_JOIN_BATCH_SIZE: usize = 25000;
 
+/// One output of an aggregation rebuilt below an index join's lookup side.
+///
+/// Go rebuilds the complete inner physical task for every outer batch.  Most
+/// inner tasks in this port are a bare table reader, but a grouped derived
+/// table can retain its aggregation above that reader.  These are the two
+/// output shapes needed by the first such port: a carried grouping column and
+/// one exact decimal `SUM`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum IndexLookupAggregateOutput {
+    Column(usize),
+    DecimalSum,
+}
+
+/// The executable aggregation retained above an index join's re-seeded table
+/// reader.
+///
+/// This deliberately accepts only non-null integer group columns and one
+/// decimal input.  The planner proves those type requirements before it can
+/// construct the value, so execution can use the same datum hash code and
+/// exact `Decimal::add` fold as the ordinary hash aggregation without
+/// inventing coercions at this lower boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct IndexLookupAggregation {
+    pub(crate) group_offsets: Vec<usize>,
+    pub(crate) sum_offset: usize,
+    pub(crate) outputs: Vec<IndexLookupAggregateOutput>,
+}
+
+impl IndexLookupAggregation {
+    fn apply(&self, rows: Vec<Vec<Datum>>) -> Result<Vec<Vec<Datum>>, ExecError> {
+        struct Group {
+            first: Vec<Datum>,
+            sum: Option<Decimal>,
+        }
+
+        let mut positions = std::collections::HashMap::<Vec<u8>, usize>::new();
+        let mut groups = Vec::<Group>::new();
+        for row in rows {
+            let mut key = Vec::new();
+            for offset in &self.group_offsets {
+                let value = row.get(*offset).ok_or_else(|| {
+                    ExecError::unsupported("an index lookup aggregation group offset is absent")
+                })?;
+                key.extend_from_slice(&tidb_codec::hash_code(value));
+                key.push(0xff);
+            }
+            let position = match positions.get(&key).copied() {
+                Some(position) => position,
+                None => {
+                    let position = groups.len();
+                    positions.insert(key, position);
+                    groups.push(Group {
+                        first: row.clone(),
+                        sum: None,
+                    });
+                    position
+                }
+            };
+            match row.get(self.sum_offset) {
+                Some(Datum::Null) => {}
+                Some(Datum::Decimal(value)) => {
+                    let group = &mut groups[position];
+                    group.sum = Some(match group.sum.take() {
+                        Some(sum) => sum.add(value),
+                        None => value.clone(),
+                    });
+                }
+                Some(_) => {
+                    return Err(ExecError::unsupported(
+                        "an index lookup decimal SUM received a non-decimal value",
+                    ))
+                }
+                None => {
+                    return Err(ExecError::unsupported(
+                        "an index lookup aggregation SUM offset is absent",
+                    ))
+                }
+            }
+        }
+
+        groups
+            .into_iter()
+            .map(|group| {
+                self.outputs
+                    .iter()
+                    .map(|output| match output {
+                        IndexLookupAggregateOutput::Column(offset) => {
+                            group.first.get(*offset).cloned().ok_or_else(|| {
+                                ExecError::unsupported(
+                                    "an index lookup aggregation output offset is absent",
+                                )
+                            })
+                        }
+                        IndexLookupAggregateOutput::DecimalSum => Ok(group
+                            .sum
+                            .as_ref()
+                            .map_or(Datum::Null, |sum| Datum::Decimal(sum.clone()))),
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+}
+
 /// The index-join strategy: which child is LOOKED UP once per distinct outer
 /// key, and over which object.
 ///
@@ -382,6 +486,14 @@ pub(crate) struct IndexLookupPlan {
     pub(crate) probe_keys: Vec<usize>,
     /// The re-seedable inner source.
     pub(crate) source: crate::access_path::IndexJoinLookupExec,
+    /// An aggregation retained by a grouped derived lookup side.  A bare
+    /// table lookup has no transformation.
+    pub(crate) aggregation: Option<IndexLookupAggregation>,
+    /// Outer-child columns a null-rejecting join predicate proves non-NULL.
+    pub(crate) outer_not_null: Vec<usize>,
+    /// Lookup-result columns the same predicate proves non-NULL, evaluated
+    /// after a retained derived aggregation.
+    pub(crate) inner_not_null: Vec<usize>,
 }
 
 /// The index strategy's live state: one outer batch and the inner rows its
@@ -838,7 +950,16 @@ impl<C: Columns> JoinExec<C> {
         let state = index_state.as_mut().expect("fill_index_batch installed it");
 
         // 1. The outer batch, up to `batch_size` rows.
+        let retained = state
+            .outer
+            .iter()
+            .chain(&state.inner)
+            .map(|row| row_bytes(row))
+            .sum::<i64>();
+        tracker.consume(-retained);
         state.outer.clear();
+        state.inner.clear();
+        state.matched.clear();
         state.cursor = 0;
         let mut bytes = 0i64;
         while state.outer.len() < state.batch_size {
@@ -855,6 +976,9 @@ impl<C: Columns> JoinExec<C> {
             }
             let row = datum_row(&state.outer_chunk, state.outer_row, &outer_types);
             state.outer_row += 1;
+            if !row_non_null_at(&row, &plan.outer_not_null)? {
+                continue;
+            }
             bytes += row_bytes(&row);
             state.outer.push(row);
         }
@@ -916,8 +1040,6 @@ impl<C: Columns> JoinExec<C> {
         // 3. The inner rows those probes reach.
         plan.source.set_probes(probes);
         let inner_types: Vec<FieldType> = plan.source.ret_field_types().to_vec();
-        state.inner.clear();
-        state.matched.clear();
         let mut chunk = plan.source.new_chunk();
         loop {
             plan.source.next(&mut chunk)?;
@@ -932,6 +1054,27 @@ impl<C: Columns> JoinExec<C> {
                 state.inner.push(row);
             }
             tracker.consume(bytes);
+            memory.check()?;
+        }
+        if let Some(aggregation) = &plan.aggregation {
+            let raw_bytes = state.inner.iter().map(|row| row_bytes(row)).sum::<i64>();
+            let aggregated = aggregation.apply(std::mem::take(&mut state.inner))?;
+            let aggregated_bytes = aggregated.iter().map(|row| row_bytes(row)).sum::<i64>();
+            tracker.consume(aggregated_bytes - raw_bytes);
+            state.inner = aggregated;
+            memory.check()?;
+        }
+        if !plan.inner_not_null.is_empty() {
+            let before = state.inner.iter().map(|row| row_bytes(row)).sum::<i64>();
+            let mut retained = Vec::with_capacity(state.inner.len());
+            for row in std::mem::take(&mut state.inner) {
+                if row_non_null_at(&row, &plan.inner_not_null)? {
+                    retained.push(row);
+                }
+            }
+            let after = retained.iter().map(|row| row_bytes(row)).sum::<i64>();
+            tracker.consume(after - before);
+            state.inner = retained;
             memory.check()?;
         }
 
@@ -1640,6 +1783,18 @@ impl<C: Columns> JoinExec<C> {
 
 /// What one materialized row costs: the `Vec` header plus each datum's own
 /// estimate, which is Go `Datum.MemUsage` summed the same way.
+fn row_non_null_at(row: &[Datum], offsets: &[usize]) -> Result<bool, ExecError> {
+    for offset in offsets {
+        let value = row.get(*offset).ok_or_else(|| {
+            ExecError::unsupported("an index join null-rejection offset is absent")
+        })?;
+        if matches!(value, Datum::Null) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 pub(crate) fn row_bytes(row: &[Datum]) -> i64 {
     let mut bytes = i64::try_from(size_of::<Vec<Datum>>()).unwrap_or(i64::MAX);
     for datum in row {

--- a/rust/crates/tidb-executor/src/join.rs
+++ b/rust/crates/tidb-executor/src/join.rs
@@ -471,6 +471,9 @@ pub struct JoinExec<C: Columns> {
     index_lookup: Option<IndexLookupPlan>,
     /// The index strategy's live state; absent until the first `next()`.
     index_state: Option<IndexLookupState>,
+    /// True only when the committed join strategy installed every leaf-local
+    /// filter and every inter-leaf equality from the written `WHERE`.
+    consumes_where: bool,
     /// How many times the `ON` clause has been evaluated. This is the cost
     /// the hash table exists to remove, so it is the number a scaling test
     /// asserts on directly instead of timing the machine.
@@ -528,6 +531,7 @@ impl<C: Columns> JoinExec<C> {
             merge_state: None,
             index_lookup: None,
             index_state: None,
+            consumes_where: false,
             condition_evals: Cell::new(0),
             memory,
             tracker,
@@ -729,6 +733,11 @@ impl<C: Columns> JoinExec<C> {
     /// the probed object's key columns ARE the join's own equality columns.
     pub(crate) fn set_index_lookup_plan(&mut self, plan: IndexLookupPlan) {
         self.index_lookup = Some(plan);
+    }
+
+    /// Records that this committed join tree enforces the complete `WHERE`.
+    pub(crate) fn set_consumes_where(&mut self, consumes_where: bool) {
+        self.consumes_where = consumes_where;
     }
 
     /// Whether this join looks its inner side up per outer batch.
@@ -1774,6 +1783,10 @@ impl<C: Columns> Executor for JoinExec<C> {
 
     fn new_chunk(&self) -> Chunk {
         self.meta.new_chunk()
+    }
+
+    fn consumes_where(&self) -> bool {
+        self.consumes_where
     }
 }
 

--- a/rust/crates/tidb-executor/src/join.rs
+++ b/rust/crates/tidb-executor/src/join.rs
@@ -161,7 +161,7 @@ use std::sync::Arc;
 use tidb_chunk::chunk::Chunk;
 use tidb_chunk::list::RowPtr;
 use tidb_chunk::row_container::RowContainer;
-use tidb_datatype::{Datum, FieldType};
+use tidb_datatype::{Datum, Decimal, FieldType};
 use tidb_expr::expression::Expression;
 use tidb_expr::schema::Schema;
 use tidb_expr::Columns;

--- a/rust/crates/tidb-executor/src/kv_table.rs
+++ b/rust/crates/tidb-executor/src/kv_table.rs
@@ -979,6 +979,31 @@ impl KvTable {
         &self.common_handle_offsets
     }
 
+    /// Encodes one complete clustered composite primary-key tuple as its
+    /// record handle.
+    ///
+    /// Index-join probes use this path because part of the tuple may come
+    /// from constants and the remainder from an outer row; routing the tuple
+    /// through the table's collation mode and `CommonHandle` padding keeps it
+    /// byte-identical to the handle created by an INSERT.
+    pub(crate) fn common_handle_of_values(
+        &self,
+        values: &[Datum],
+        zone: &SessionTimeZone,
+    ) -> Result<TableHandle, KvTableError> {
+        if self.common_handle_offsets.len() != values.len() {
+            return Err(KvTableError::Encode(
+                "a common handle probe does not cover every key column".to_owned(),
+            ));
+        }
+        let encoded = tidb_codec::Encoder::new(self.use_new_collation)
+            .encode_key_in_timezone(zone, values)
+            .map_err(|e| KvTableError::Encode(format!("{e:?}")))?;
+        let padded = tidb_txnkv::CommonHandle::new(encoded)
+            .map_err(|e| KvTableError::Encode(format!("{e:?}")))?;
+        Ok(TableHandle::Common(padded.encoded().to_vec()))
+    }
+
     /// Go `TableInfo.PKIsHandle` for one column: whether this offset IS the
     /// integer primary key that serves as the row handle, and so is
     /// addressable without an index of its own.
@@ -1088,20 +1113,7 @@ impl KvTable {
                 .iter()
                 .map(|offset| row.get(*offset).cloned().unwrap_or(Datum::Null))
                 .collect();
-            let encoded = tidb_codec::Encoder::new(self.use_new_collation)
-                .encode_key_in_timezone(zone, &values)
-                .map_err(|e| KvTableError::Encode(format!("{e:?}")))?;
-            // Go `kv.NewCommonHandle` pads a short encoding out to nine bytes,
-            // and so does the record-key codec this handle is about to be
-            // written through -- so a handle that skips the padding is one the
-            // READ side (which recovers it from the record key) never produces.
-            // Padding here, at the one place a row's handle is born, is what
-            // makes the write's index entries and the delete's index entries
-            // the same keys. A DECIMAL primary key is the short case: `5`
-            // encodes to four bytes.
-            let padded = tidb_txnkv::CommonHandle::new(encoded)
-                .map_err(|e| KvTableError::Encode(format!("{e:?}")))?;
-            return Ok(TableHandle::Common(padded.encoded().to_vec()));
+            return self.common_handle_of_values(&values, zone);
         }
         match self.pk_handle_offset {
             Some(offset) => match row.get(offset) {

--- a/rust/crates/tidb-executor/src/kv_table/table_scan.rs
+++ b/rust/crates/tidb-executor/src/kv_table/table_scan.rs
@@ -265,6 +265,7 @@ impl KvTable {
     /// this cursor cannot compare is a shape it must not claim to serve. So is
     /// a scan whose handle ranges cover no record at all, which a coprocessor
     /// request cannot express.
+    #[allow(clippy::too_many_arguments)]
     pub fn pushdown_row_cursor_with_context(
         &mut self,
         keep: &[usize],

--- a/rust/crates/tidb-executor/src/kv_table/table_scan.rs
+++ b/rust/crates/tidb-executor/src/kv_table/table_scan.rs
@@ -1455,7 +1455,7 @@ impl TableScanExec {
                         _ => {
                             return Err(ExecError::unsupported(
                                 "partial SUM requires an integer or decimal input",
-                            ))
+                            ));
                         }
                     };
                     sum = Some(match sum.take() {
@@ -1522,7 +1522,7 @@ impl TableScanExec {
                         _ => {
                             return Err(ExecError::unsupported(
                                 "partial SUM requires an integer or decimal input",
-                            ))
+                            ));
                         }
                     };
                     let key = crate::hash_agg::group_key_part(&group_type.collation(), &group);
@@ -1539,14 +1539,15 @@ impl TableScanExec {
                     .map(|(group, sum)| vec![sum.map_or(Datum::Null, Datum::Decimal), group])
                     .collect())
             }
-            PushdownPartialAggregate::GroupedStream {
+            PushdownPartialAggregate::Grouped {
                 group_offsets,
                 group_types,
                 functions,
+                streamed,
             } => {
                 if group_offsets.len() != group_types.len() || group_offsets.is_empty() {
                     return Err(ExecError::unsupported(
-                        "partial grouped StreamAgg requires typed group keys",
+                        "partial grouped aggregation requires typed group keys",
                     ));
                 }
 
@@ -1584,16 +1585,7 @@ impl TableScanExec {
                         .chain(groups)
                         .collect::<Vec<_>>()
                 };
-
-                let mut rows = Vec::new();
-                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
-                while let Some(row) = self.next_source_row()? {
-                    self.scanned.set(self.scanned.get() + 1);
-                    if let Some(filter) = self.filter.as_mut() {
-                        if !filter.admits(&row)? {
-                            continue;
-                        }
-                    }
+                let group = |row: &[Datum]| -> Result<(Vec<u8>, Vec<Datum>), ExecError> {
                     let groups = group_offsets
                         .iter()
                         .map(|offset| {
@@ -1612,15 +1604,11 @@ impl TableScanExec {
                         ));
                         key.push(0xff);
                     }
-                    if current
-                        .as_ref()
-                        .is_some_and(|(current_key, _, _)| current_key != &key)
-                    {
-                        let (_, previous_groups, previous_values) =
-                            current.take().expect("current group exists");
-                        rows.push(finish(previous_groups, previous_values));
-                    }
-                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    Ok((key, groups))
+                };
+                let update = |values: &mut [PartialValue],
+                              row: &[Datum]|
+                 -> Result<(), ExecError> {
                     for (function, value) in functions.iter().zip(values.iter_mut()) {
                         let input = function
                             .input_offset
@@ -1634,9 +1622,7 @@ impl TableScanExec {
                             .transpose()?;
                         match (value, input) {
                             (PartialValue::Count(count), None) => *count += 1,
-                            (PartialValue::Count(count), Some(Datum::Null)) => {
-                                let _ = count;
-                            }
+                            (PartialValue::Count(_), Some(Datum::Null)) => {}
                             (PartialValue::Count(count), Some(_)) => *count += 1,
                             (PartialValue::Sum(_), None) | (PartialValue::Extreme { .. }, None) => {
                                 return Err(ExecError::unsupported(
@@ -1653,7 +1639,7 @@ impl TableScanExec {
                                     _ => {
                                         return Err(ExecError::unsupported(
                                             "partial SUM requires an integer or decimal input",
-                                        ))
+                                        ));
                                     }
                                 };
                                 *sum = Some(match sum.take() {
@@ -1679,6 +1665,49 @@ impl TableScanExec {
                             }
                         }
                     }
+                    Ok(())
+                };
+
+                if !streamed {
+                    let mut grouped = BTreeMap::<Vec<u8>, (Vec<Datum>, Vec<PartialValue>)>::new();
+                    while let Some(row) = self.next_source_row()? {
+                        self.scanned.set(self.scanned.get() + 1);
+                        if let Some(filter) = self.filter.as_mut() {
+                            if !filter.admits(&row)? {
+                                continue;
+                            }
+                        }
+                        let (key, groups) = group(&row)?;
+                        let (_, values) =
+                            grouped.entry(key).or_insert_with(|| (groups, new_values()));
+                        update(values, &row)?;
+                    }
+                    return Ok(grouped
+                        .into_values()
+                        .map(|(groups, values)| finish(groups, values))
+                        .collect());
+                }
+
+                let mut rows = Vec::new();
+                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    let (key, groups) = group(&row)?;
+                    if current
+                        .as_ref()
+                        .is_some_and(|(current_key, _, _)| current_key != &key)
+                    {
+                        let (_, previous_groups, previous_values) =
+                            current.take().expect("current group exists");
+                        rows.push(finish(previous_groups, previous_values));
+                    }
+                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    update(values, &row)?;
                 }
                 if let Some((_, groups, values)) = current {
                     rows.push(finish(groups, values));

--- a/rust/crates/tidb-executor/src/kv_table/table_scan.rs
+++ b/rust/crates/tidb-executor/src/kv_table/table_scan.rs
@@ -34,18 +34,19 @@ use super::{
 use crate::executor::{ExecError, Executor, ExecutorMeta};
 use crate::predicate_pushdown::ScanPredicate;
 use crate::remote_scan::{
-    PushdownRowStream, PushdownScanColumn, PushdownScanRequest, PushdownStatementContext,
+    PushdownAggregateKind, PushdownIndexScan, PushdownPartialAggregate, PushdownRowStream,
+    PushdownScanColumn, PushdownScanRequest, PushdownStatementContext, PushdownTopN,
     EXTRA_HANDLE_COLUMN_ID,
 };
 use crate::storage::StorageIterator;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use tidb_chunk::chunk::Chunk;
 use tidb_codec::table_key::{
     encode_index_seek_key, encode_row_key_with_handle, get_table_handle_key_range, RecordHandle,
     RECORD_ROW_KEY_LEN,
 };
 use tidb_codec::Encoder;
-use tidb_datatype::{Datum, FieldType, SessionTimeZone};
+use tidb_datatype::{Datum, Decimal, FieldType, SessionTimeZone};
 use tidb_expr::schema::Schema;
 use tidb_tablecodec::decode_table_row_to_map;
 use tidb_txnkv::Key;
@@ -114,7 +115,7 @@ impl KvTable {
             .iter()
             .enumerate()
             .filter(|(offset, _)| kept.as_ref().is_none_or(|kept| kept.contains(offset)))
-            .map(|(_, c)| (c.id, c.field_type.clone()))
+            .map(|(_, column)| (column.id, column.field_type.clone()))
             .collect();
         note_decoded_column_ids(column_types.keys().copied());
         RowDecoder {
@@ -164,7 +165,7 @@ impl KvTable {
     ) -> Result<RowCursor, KvTableError> {
         let decoder = self.row_decoder_projected(keep, context);
         let mut iterators = Vec::new();
-        for (low, upper) in self.record_key_ranges(handle_ranges) {
+        for (low, upper) in self.record_key_ranges(handle_ranges, context.zone())? {
             iterators.push(
                 self.store
                     .iter(Some(&low), Some(&upper))
@@ -199,10 +200,30 @@ impl KvTable {
     /// in ([`KvTable::record_key_range`]). With them it is the intervals
     /// [`crate::handle_range::record_key_ranges`] encodes, which is what
     /// makes a `TableRangeScan` read less than the table.
-    fn record_key_ranges(&self, handle_ranges: Option<&[IndexRange]>) -> Vec<(Key, Key)> {
-        handle_ranges
-            .and_then(|ranges| crate::handle_range::record_key_ranges(self, ranges))
-            .unwrap_or_else(|| self.record_key_range())
+    fn record_key_ranges(
+        &self,
+        handle_ranges: Option<&[IndexRange]>,
+        zone: &SessionTimeZone,
+    ) -> Result<Vec<(Key, Key)>, KvTableError> {
+        let full_common_handle = [IndexRange {
+            low: vec![Datum::MinNotNull],
+            high: vec![Datum::MaxValue],
+            low_exclusive: false,
+            high_exclusive: false,
+        }];
+        let handle_ranges = if handle_ranges.is_none()
+            && crate::handle_range::common_handle_primary(self).is_some()
+        {
+            Some(full_common_handle.as_slice())
+        } else {
+            handle_ranges
+        };
+        let encoded = match handle_ranges {
+            Some(ranges) => crate::handle_range::record_key_ranges(self, ranges, zone)
+                .map_err(|error| KvTableError::Encode(format!("{error:?}")))?,
+            None => None,
+        };
+        Ok(encoded.unwrap_or_else(|| self.record_key_range()))
     }
 
     /// The record ranges this table's rows live in, as the storage seam's
@@ -248,12 +269,16 @@ impl KvTable {
         &mut self,
         keep: &[usize],
         predicates: &[ScanPredicate],
+        output_offsets: Option<&[usize]>,
+        topn: Option<&PushdownTopN>,
         limit: Option<u64>,
         handle_ranges: Option<&[IndexRange]>,
         context: &RowDecodeContext,
         statement: &PushdownStatementContext,
     ) -> Result<Option<RemoteRowCursor>, KvTableError> {
-        if !self.common_handle_offsets.is_empty() {
+        let common_handle = !self.common_handle_offsets.is_empty();
+        let common_primary = crate::handle_range::common_handle_primary(self);
+        if common_handle && (self.has_dirty_content() || common_primary.is_none()) {
             return Ok(None);
         }
         // A pushdown request names ONE physical table id. A partitioned table
@@ -262,7 +287,7 @@ impl KvTable {
         if self.partition.is_some() {
             return Ok(None);
         }
-        let ranges = self.record_key_ranges(handle_ranges);
+        let ranges = self.record_key_ranges(handle_ranges, context.zone())?;
         // No range at all is a read of NOTHING -- `id > 100 AND id < 100`, or a
         // bound that is NULL -- and a coprocessor request has no way to say
         // that: its `Ranges` list is what the transport turns into region
@@ -285,37 +310,69 @@ impl KvTable {
                 }
             })
             .collect();
-        // The merge needs every remote row's handle. A projected integer
-        // primary key already carries it; otherwise the row handle is no
-        // column of the table (`_tidb_rowid`), so one is appended and dropped
-        // again before the row is emitted.
-        let handle_index = match self
-            .pk_handle_offset
-            .and_then(|offset| keep.iter().position(|kept| *kept == offset))
-        {
-            Some(index) => index,
-            None => {
-                columns.push(match self.pk_handle_offset {
-                    Some(offset) => PushdownScanColumn {
-                        id: self.columns[offset].id,
-                        field_type: self.columns[offset].field_type.clone(),
-                        is_handle: true,
-                    },
-                    None => PushdownScanColumn {
-                        id: EXTRA_HANDLE_COLUMN_ID,
-                        field_type: FieldType::new(tidb_datatype::FieldTypeCode::LongLong),
-                        is_handle: true,
-                    },
-                });
-                columns.len() - 1
-            }
+        // An integer-handle merge needs every remote row's handle. A projected
+        // primary key already carries it; otherwise `_tidb_rowid` is appended
+        // and dropped before emission. A clean common-handle scan has no
+        // client-side merge, so it appends no synthetic handle.
+        let handle_index = if common_handle {
+            None
+        } else {
+            Some(
+                match self
+                    .pk_handle_offset
+                    .and_then(|offset| keep.iter().position(|kept| *kept == offset))
+                {
+                    Some(index) => index,
+                    None => {
+                        columns.push(match self.pk_handle_offset {
+                            Some(offset) => PushdownScanColumn {
+                                id: self.columns[offset].id,
+                                field_type: self.columns[offset].field_type.clone(),
+                                is_handle: true,
+                            },
+                            None => PushdownScanColumn {
+                                id: EXTRA_HANDLE_COLUMN_ID,
+                                field_type: FieldType::new(tidb_datatype::FieldTypeCode::LongLong),
+                                is_handle: true,
+                            },
+                        });
+                        columns.len() - 1
+                    }
+                },
+            )
         };
+        let primary_column_ids: Vec<i64> = common_primary
+            .into_iter()
+            .flat_map(|index| index.column_offsets.iter())
+            .filter_map(|offset| self.columns.get(*offset))
+            .map(|column| column.id)
+            .collect();
+        let primary_prefix_column_ids: Vec<i64> = common_primary
+            .into_iter()
+            .flat_map(|index| {
+                index
+                    .column_offsets
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(position, offset)| {
+                        let column = self.columns.get(*offset)?;
+                        let prefix = index.prefix_length(position);
+                        (prefix > 0 && column.field_type.flen() > prefix).then_some(column.id)
+                    })
+            })
+            .collect();
         let request = PushdownScanRequest {
             table_id: self.table_id,
+            index: None,
             columns,
             handle_index,
+            primary_column_ids,
+            primary_prefix_column_ids,
             predicates: predicates.to_vec(),
+            output_offsets: output_offsets.map(<[usize]>::to_vec),
+            topn: topn.cloned(),
             limit,
+            aggregate: None,
             // The storage that owns the snapshot fills this in; the table has
             // no timestamp of its own.
             snapshot_ts: 0,
@@ -325,7 +382,11 @@ impl KvTable {
         let Some(scan) = self.store.open_remote_scan(&request) else {
             return Ok(None);
         };
-        let scan = scan.map_err(|e| KvTableError::Storage(format!("{e:?}")))?;
+        let mut scan = scan.map_err(|e| KvTableError::Storage(format!("{e:?}")))?;
+        if common_handle && !scan.staged.is_empty() {
+            scan.stream.close();
+            return Ok(None);
+        }
         // One request reached a region. Counted here rather than at the
         // storage seam so a backend that REFUSED the shape (and returned an
         // `Unsupported` the caller turned into a byte-level cursor) is not
@@ -345,7 +406,7 @@ impl KvTable {
             staged: staged.into_iter(),
             pending_staged: None,
             pending_remote: None,
-            width: keep.len(),
+            width: output_offsets.map_or(keep.len(), <[usize]>::len),
             handle_index,
             table_id: self.table_id,
             noted_rows: 0,
@@ -366,11 +427,194 @@ impl KvTable {
         self.pushdown_row_cursor_with_context(
             keep,
             predicates,
+            None,
+            None,
             limit,
             handle_ranges,
             &RowDecodeContext::legacy_default(zone),
             statement,
         )
+    }
+
+    /// Opens a coprocessor partial aggregation over this table, or returns
+    /// `None` so the executor computes the same partial result locally.
+    ///
+    /// An aggregate result cannot be merged with staged rows. A dirty table
+    /// therefore refuses before sending a request, and a backend-reported
+    /// staged buffer closes the request and falls back as a second guard.
+    #[allow(clippy::too_many_arguments)]
+    pub fn pushdown_partial_aggregate_cursor(
+        &mut self,
+        keep: &[usize],
+        predicates: &[ScanPredicate],
+        handle_ranges: Option<&[IndexRange]>,
+        aggregate: &PushdownPartialAggregate,
+        zone: &SessionTimeZone,
+        statement: &PushdownStatementContext,
+    ) -> Result<Option<Box<dyn PushdownRowStream>>, KvTableError> {
+        if self.has_dirty_content() || self.partition.is_some() {
+            return Ok(None);
+        }
+        let ranges = self.record_key_ranges(handle_ranges, zone)?;
+        if ranges.is_empty() {
+            return Ok(None);
+        }
+        let columns = keep
+            .iter()
+            .map(|offset| {
+                let column = &self.columns[*offset];
+                PushdownScanColumn {
+                    id: column.id,
+                    field_type: column.field_type.clone(),
+                    is_handle: self.pk_handle_offset == Some(*offset),
+                }
+            })
+            .collect();
+        let common_primary = crate::handle_range::common_handle_primary(self);
+        let primary_column_ids = common_primary
+            .into_iter()
+            .flat_map(|index| index.column_offsets.iter())
+            .filter_map(|offset| self.columns.get(*offset))
+            .map(|column| column.id)
+            .collect();
+        let primary_prefix_column_ids = common_primary
+            .into_iter()
+            .flat_map(|index| {
+                index
+                    .column_offsets
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(position, offset)| {
+                        let column = self.columns.get(*offset)?;
+                        let prefix = index.prefix_length(position);
+                        (prefix > 0 && column.field_type.flen() > prefix).then_some(column.id)
+                    })
+            })
+            .collect();
+        let request = PushdownScanRequest {
+            table_id: self.table_id,
+            index: None,
+            columns,
+            handle_index: None,
+            primary_column_ids,
+            primary_prefix_column_ids,
+            predicates: predicates.to_vec(),
+            output_offsets: None,
+            topn: None,
+            limit: None,
+            aggregate: Some(aggregate.clone()),
+            snapshot_ts: 0,
+            ranges,
+            statement: statement.clone(),
+        };
+        let Some(scan) = self.store.open_remote_scan(&request) else {
+            return Ok(None);
+        };
+        let mut scan = scan.map_err(|error| KvTableError::Storage(format!("{error:?}")))?;
+        if !scan.staged.is_empty() {
+            scan.stream.close();
+            return Ok(None);
+        }
+        crate::storage::note_storage_op(|ops| ops.cop_scans += 1);
+        Ok(Some(scan.stream))
+    }
+
+    /// Index-scan counterpart of [`Self::pushdown_partial_aggregate_cursor`].
+    /// The bounded path is the covering `COUNT(k)` shape used by Sysbench:
+    /// the aggregate input must be the index's leading key column.
+    pub fn pushdown_index_partial_aggregate_cursor(
+        &mut self,
+        index_id: i64,
+        ranges: &[IndexRange],
+        aggregate: &PushdownPartialAggregate,
+        zone: &SessionTimeZone,
+        statement: &PushdownStatementContext,
+    ) -> Result<Option<Box<dyn PushdownRowStream>>, KvTableError> {
+        if self.has_dirty_content() || self.partition.is_some() {
+            return Ok(None);
+        }
+        let Some(index) = self.indexes.iter().find(|index| index.id == index_id) else {
+            return Ok(None);
+        };
+        if index.column_offsets.is_empty()
+            || !matches!(aggregate, PushdownPartialAggregate::Count { .. })
+        {
+            return Ok(None);
+        }
+        let columns: Vec<PushdownScanColumn> = index
+            .column_offsets
+            .iter()
+            .filter_map(|offset| self.columns.get(*offset))
+            .map(|column| PushdownScanColumn {
+                id: column.id,
+                field_type: column.field_type.clone(),
+                is_handle: false,
+            })
+            .collect();
+        if columns.len() != index.column_offsets.len() {
+            return Ok(None);
+        }
+        let encode = |values: &[Datum]| -> Result<Vec<u8>, KvTableError> {
+            tidb_codec::encode_key_in_timezone(zone, values)
+                .map_err(|error| KvTableError::Encode(format!("{error:?}")))
+        };
+        let mut key_ranges = Vec::with_capacity(ranges.len());
+        for range in ranges {
+            let mut low = Key::from_bytes(encode_index_seek_key(
+                self.table_id,
+                index_id,
+                &encode(&range.low)?,
+            ));
+            if range.low_exclusive {
+                low = low.prefix_next();
+            }
+            let mut high = Key::from_bytes(encode_index_seek_key(
+                self.table_id,
+                index_id,
+                &encode(&range.high)?,
+            ));
+            if !range.high_exclusive {
+                high = high.prefix_next();
+            }
+            key_ranges.push((low, high));
+        }
+        if key_ranges.is_empty() {
+            return Ok(None);
+        }
+        let mut remote_aggregate = aggregate.clone();
+        if let PushdownPartialAggregate::Count { input_offset, .. } = &mut remote_aggregate {
+            *input_offset = 0;
+        }
+        let request = PushdownScanRequest {
+            table_id: self.table_id,
+            index: Some(PushdownIndexScan {
+                index_id,
+                declared_unique: index.unique,
+                index_column_count: index.column_offsets.len(),
+            }),
+            columns,
+            handle_index: None,
+            primary_column_ids: Vec::new(),
+            primary_prefix_column_ids: Vec::new(),
+            predicates: Vec::new(),
+            output_offsets: None,
+            topn: None,
+            limit: None,
+            aggregate: Some(remote_aggregate),
+            snapshot_ts: 0,
+            ranges: key_ranges,
+            statement: statement.clone(),
+        };
+        let Some(scan) = self.store.open_remote_scan(&request) else {
+            return Ok(None);
+        };
+        let mut scan = scan.map_err(|error| KvTableError::Storage(format!("{error:?}")))?;
+        if !scan.staged.is_empty() {
+            scan.stream.close();
+            return Ok(None);
+        }
+        crate::storage::note_storage_op(|ops| ops.cop_scans += 1);
+        Ok(Some(scan.stream))
     }
 
     /// Scans the table's record-key range in key order, decoding each value.
@@ -823,7 +1067,11 @@ type KeyedRow = (Vec<u8>, Vec<Datum>);
 type StagedRow = (Vec<u8>, Option<Vec<Datum>>);
 
 /// A forward cursor over a table's record range served by the backend's
-/// coprocessor, with the session's staged writes merged back in.
+/// coprocessor.
+///
+/// Integer-handle scans merge the session's staged writes back in. A
+/// common-handle scan reaches this cursor only while the table is clean, so
+/// it consumes the remote stream directly.
 ///
 /// # Why the merge is here and not at the backend
 ///
@@ -846,8 +1094,9 @@ pub struct RemoteRowCursor {
     /// Number of projected columns, which the remote row may exceed by the
     /// appended handle column.
     width: usize,
-    /// Where the handle sits in a remote row.
-    handle_index: usize,
+    /// Where the integer handle sits in a row to be merged. `None` is a
+    /// clean common-handle stream consumed without a staged overlay.
+    handle_index: Option<usize>,
     table_id: i64,
     /// How much of [`PushdownRowStream::rows_returned`] has already been
     /// reported to the storage probe, so each row is counted once. See
@@ -892,7 +1141,10 @@ impl RemoteRowCursor {
         let Some(mut row) = next else {
             return Ok(None);
         };
-        let handle = match row.get(self.handle_index) {
+        let handle_index = self
+            .handle_index
+            .expect("only an integer-handle merge asks for keyed remote rows");
+        let handle = match row.get(handle_index) {
             Some(Datum::Int(value)) => *value,
             Some(Datum::UInt(value)) => *value as i64,
             other => {
@@ -914,17 +1166,29 @@ impl RemoteRowCursor {
         self.pending_staged.clone()
     }
 
-    /// The next row of the merged stream in record-key order, or `None` when
-    /// both sides are exhausted.
-    pub fn next_row(&mut self) -> Result<Option<(TableHandle, Vec<Datum>)>, KvTableError> {
+    /// The next projected row, either directly from a clean common-handle
+    /// stream or from the integer-handle snapshot/staged merge.
+    pub fn next_row(&mut self) -> Result<Option<Vec<Datum>>, KvTableError> {
+        if self.handle_index.is_none() {
+            debug_assert!(self.staged.len() == 0);
+            let next = self
+                .stream
+                .next_row()
+                .map_err(|error| KvTableError::Storage(format!("{error:?}")))?;
+            self.note_wire_rows();
+            return Ok(next.map(|mut row| {
+                row.truncate(self.width);
+                row
+            }));
+        }
         loop {
             let remote = self.next_remote()?;
             let staged = self.next_staged();
             match (remote, staged) {
                 (None, None) => return Ok(None),
-                (Some((key, row)), None) => {
+                (Some((_, row)), None) => {
                     self.pending_remote = None;
-                    return Ok(Some((TableHandle::Int(decode_int_handle(&key)?), row)));
+                    return Ok(Some(row));
                 }
                 (remote, Some((staged_key, staged_row))) => {
                     // A staged write of the same key is the transaction's own
@@ -933,8 +1197,8 @@ impl RemoteRowCursor {
                     if let Some((remote_key, _)) = &remote {
                         match remote_key.as_slice().cmp(staged_key.as_slice()) {
                             std::cmp::Ordering::Less => {
-                                let (key, row) = self.pending_remote.take().expect("just peeked");
-                                return Ok(Some((TableHandle::Int(decode_int_handle(&key)?), row)));
+                                let (_, row) = self.pending_remote.take().expect("just peeked");
+                                return Ok(Some(row));
                             }
                             std::cmp::Ordering::Equal => self.pending_remote = None,
                             std::cmp::Ordering::Greater => {}
@@ -942,10 +1206,7 @@ impl RemoteRowCursor {
                     }
                     self.pending_staged = None;
                     if let Some(row) = staged_row {
-                        return Ok(Some((
-                            TableHandle::Int(decode_int_handle(&staged_key)?),
-                            row,
-                        )));
+                        return Ok(Some(row));
                     }
                 }
             }
@@ -1006,11 +1267,30 @@ pub struct TableScanExec {
     cursor: Option<RowCursor>,
     /// The open coprocessor-served cursor, when the backend has one.
     remote: Option<RemoteRowCursor>,
+    /// A TiKV partial-aggregation row stream. It is separate from `remote`
+    /// because aggregate rows have no record handle and no staged merge.
+    partial_remote: Option<Box<dyn PushdownRowStream>>,
+    /// Locally computed partial rows when the backend refuses aggregation.
+    partial_rows: Option<std::vec::IntoIter<Vec<Datum>>>,
+    /// Whether the local partial result has already been fully emitted.
+    partial_done: bool,
+    /// The partial aggregation this source accepted from the planner.
+    partial_aggregate: Option<PushdownPartialAggregate>,
+    /// Access-path cardinality selected by the optimizer. Go chooses the
+    /// partial/final split only above the one-row floor for these workloads.
+    estimated_rows: Option<f64>,
     /// Conjuncts this scan took over from the `Selection` above it.
     filter: Option<crate::predicate_pushdown::ScanFilterProbe>,
     /// The same conjuncts as a description, for a backend that can evaluate
     /// them at the region. They are applied locally regardless.
     pushed: Vec<ScanPredicate>,
+    /// Final offsets into the wider scan row, applied only after `filter`.
+    /// A remote cursor already returns this projection; the local path
+    /// applies it after evaluating the same filter against the wider row.
+    post_filter_projection: Option<Vec<usize>>,
+    /// A TopN the remote backend may execute after its complete Selection.
+    /// The driver retains a local partial TopN as the semantic fallback.
+    remote_topn: Option<PushdownTopN>,
     /// The table-column offsets this scan emits, in output order. Every
     /// column of the table until the driver prunes it.
     keep: Vec<usize>,
@@ -1059,8 +1339,15 @@ impl TableScanExec {
             table,
             cursor: None,
             remote: None,
+            partial_remote: None,
+            partial_rows: None,
+            partial_done: false,
+            partial_aggregate: None,
+            estimated_rows: None,
             filter: None,
             pushed: Vec::new(),
+            post_filter_projection: None,
+            remote_topn: None,
             keep,
             scanned: std::rc::Rc::new(std::cell::Cell::new(0)),
             limit: None,
@@ -1109,16 +1396,293 @@ impl TableScanExec {
     fn next_source_row(&mut self) -> Result<Option<Vec<Datum>>, ExecError> {
         let next = match (self.remote.as_mut(), self.cursor.as_mut()) {
             (Some(remote), _) => remote.next_row(),
-            (None, Some(cursor)) => cursor.next_row(),
+            (None, Some(cursor)) => cursor
+                .next_row()
+                .map(|row| row.map(|(_, projected)| projected)),
             (None, None) => return Ok(None),
         }
         .map_err(|_| ExecError::unsupported("table bytes failed to decode"))?;
         match next {
-            Some((_, row)) => Ok(Some(row)),
+            Some(row) => Ok(Some(row)),
             None => {
                 self.remote = None;
                 self.cursor = None;
                 Ok(None)
+            }
+        }
+    }
+
+    fn build_local_partial_rows(
+        &mut self,
+        aggregate: &PushdownPartialAggregate,
+    ) -> Result<Vec<Vec<Datum>>, ExecError> {
+        match aggregate {
+            PushdownPartialAggregate::Count { input_offset, .. } => {
+                let mut count = 0_i64;
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    if !matches!(row.get(*input_offset), None | Some(Datum::Null)) {
+                        count += 1;
+                    }
+                }
+                Ok(vec![vec![Datum::Int(count)]])
+            }
+            PushdownPartialAggregate::Sum { input_offset, .. } => {
+                let mut sum: Option<Decimal> = None;
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    let Some(value) = row.get(*input_offset) else {
+                        return Err(ExecError::unsupported(
+                            "partial SUM input is outside the scan row",
+                        ));
+                    };
+                    let addend = match value {
+                        Datum::Null => continue,
+                        Datum::Int(value) => Decimal::from_int(*value),
+                        Datum::UInt(value) => Decimal::from_uint(*value),
+                        Datum::Decimal(value) => value.clone(),
+                        _ => {
+                            return Err(ExecError::unsupported(
+                                "partial SUM requires an integer or decimal input",
+                            ))
+                        }
+                    };
+                    sum = Some(match sum.take() {
+                        Some(current) => current.add(&addend),
+                        None => addend,
+                    });
+                }
+                Ok(vec![vec![sum.map_or(Datum::Null, Datum::Decimal)]])
+            }
+            PushdownPartialAggregate::GroupBy {
+                input_offset,
+                output_type,
+            } => {
+                let mut seen = HashSet::new();
+                let mut rows = Vec::new();
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    let Some(value) = row.get(*input_offset).cloned() else {
+                        return Err(ExecError::unsupported(
+                            "partial GROUP BY input is outside the scan row",
+                        ));
+                    };
+                    let key = crate::hash_agg::group_key_part(&output_type.collation(), &value);
+                    if seen.insert(key) {
+                        rows.push(vec![value]);
+                    }
+                }
+                Ok(rows)
+            }
+            PushdownPartialAggregate::GroupBySum {
+                group_offset,
+                sum_offset,
+                sum_type: _,
+                group_type,
+            } => {
+                let mut groups: BTreeMap<Vec<u8>, (Datum, Option<Decimal>)> = BTreeMap::new();
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    let Some(group) = row.get(*group_offset).cloned() else {
+                        return Err(ExecError::unsupported(
+                            "partial GROUP BY input is outside the scan row",
+                        ));
+                    };
+                    let Some(value) = row.get(*sum_offset) else {
+                        return Err(ExecError::unsupported(
+                            "partial SUM input is outside the scan row",
+                        ));
+                    };
+                    let addend = match value {
+                        Datum::Null => None,
+                        Datum::Int(value) => Some(Decimal::from_int(*value)),
+                        Datum::UInt(value) => Some(Decimal::from_uint(*value)),
+                        Datum::Decimal(value) => Some(value.clone()),
+                        _ => {
+                            return Err(ExecError::unsupported(
+                                "partial SUM requires an integer or decimal input",
+                            ))
+                        }
+                    };
+                    let key = crate::hash_agg::group_key_part(&group_type.collation(), &group);
+                    let (_, sum) = groups.entry(key).or_insert((group, None));
+                    if let Some(addend) = addend {
+                        *sum = Some(match sum.take() {
+                            Some(current) => current.add(&addend),
+                            None => addend,
+                        });
+                    }
+                }
+                Ok(groups
+                    .into_values()
+                    .map(|(group, sum)| vec![sum.map_or(Datum::Null, Datum::Decimal), group])
+                    .collect())
+            }
+            PushdownPartialAggregate::GroupedStream {
+                group_offsets,
+                group_types,
+                functions,
+            } => {
+                if group_offsets.len() != group_types.len() || group_offsets.is_empty() {
+                    return Err(ExecError::unsupported(
+                        "partial grouped StreamAgg requires typed group keys",
+                    ));
+                }
+
+                enum PartialValue {
+                    Count(i64),
+                    Sum(Option<Decimal>),
+                    Extreme { value: Option<Datum>, is_max: bool },
+                }
+
+                let new_values = || {
+                    functions
+                        .iter()
+                        .map(|function| match function.kind {
+                            PushdownAggregateKind::Count => PartialValue::Count(0),
+                            PushdownAggregateKind::Sum => PartialValue::Sum(None),
+                            PushdownAggregateKind::Min => PartialValue::Extreme {
+                                value: None,
+                                is_max: false,
+                            },
+                            PushdownAggregateKind::Max => PartialValue::Extreme {
+                                value: None,
+                                is_max: true,
+                            },
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let finish = |groups: Vec<Datum>, values: Vec<PartialValue>| {
+                    values
+                        .into_iter()
+                        .map(|value| match value {
+                            PartialValue::Count(count) => Datum::Int(count),
+                            PartialValue::Sum(sum) => sum.map_or(Datum::Null, Datum::Decimal),
+                            PartialValue::Extreme { value, .. } => value.unwrap_or(Datum::Null),
+                        })
+                        .chain(groups)
+                        .collect::<Vec<_>>()
+                };
+
+                let mut rows = Vec::new();
+                let mut current: Option<(Vec<u8>, Vec<Datum>, Vec<PartialValue>)> = None;
+                while let Some(row) = self.next_source_row()? {
+                    self.scanned.set(self.scanned.get() + 1);
+                    if let Some(filter) = self.filter.as_mut() {
+                        if !filter.admits(&row)? {
+                            continue;
+                        }
+                    }
+                    let groups = group_offsets
+                        .iter()
+                        .map(|offset| {
+                            row.get(*offset).cloned().ok_or_else(|| {
+                                ExecError::unsupported(
+                                    "partial GROUP BY input is outside the scan row",
+                                )
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let mut key = Vec::new();
+                    for (group, field_type) in groups.iter().zip(group_types) {
+                        key.extend_from_slice(&crate::hash_agg::group_key_part(
+                            &field_type.collation(),
+                            group,
+                        ));
+                        key.push(0xff);
+                    }
+                    if current
+                        .as_ref()
+                        .is_some_and(|(current_key, _, _)| current_key != &key)
+                    {
+                        let (_, previous_groups, previous_values) =
+                            current.take().expect("current group exists");
+                        rows.push(finish(previous_groups, previous_values));
+                    }
+                    let (_, _, values) = current.get_or_insert_with(|| (key, groups, new_values()));
+                    for (function, value) in functions.iter().zip(values.iter_mut()) {
+                        let input = function
+                            .input_offset
+                            .map(|offset| {
+                                row.get(offset).cloned().ok_or_else(|| {
+                                    ExecError::unsupported(
+                                        "partial aggregate input is outside the scan row",
+                                    )
+                                })
+                            })
+                            .transpose()?;
+                        match (value, input) {
+                            (PartialValue::Count(count), None) => *count += 1,
+                            (PartialValue::Count(count), Some(Datum::Null)) => {
+                                let _ = count;
+                            }
+                            (PartialValue::Count(count), Some(_)) => *count += 1,
+                            (PartialValue::Sum(_), None) | (PartialValue::Extreme { .. }, None) => {
+                                return Err(ExecError::unsupported(
+                                    "only COUNT may omit a partial aggregate input",
+                                ));
+                            }
+                            (PartialValue::Sum(_), Some(Datum::Null))
+                            | (PartialValue::Extreme { .. }, Some(Datum::Null)) => {}
+                            (PartialValue::Sum(sum), Some(input)) => {
+                                let addend = match input {
+                                    Datum::Int(value) => Decimal::from_int(value),
+                                    Datum::UInt(value) => Decimal::from_uint(value),
+                                    Datum::Decimal(value) => value,
+                                    _ => {
+                                        return Err(ExecError::unsupported(
+                                            "partial SUM requires an integer or decimal input",
+                                        ))
+                                    }
+                                };
+                                *sum = Some(match sum.take() {
+                                    Some(current) => current.add(&addend),
+                                    None => addend,
+                                });
+                            }
+                            (PartialValue::Extreme { value, is_max }, Some(candidate)) => {
+                                let replace = value.as_ref().is_none_or(|current| {
+                                    tidb_expr::compare_datums(&candidate, current).is_ok_and(
+                                        |ordering| {
+                                            if *is_max {
+                                                ordering.is_gt()
+                                            } else {
+                                                ordering.is_lt()
+                                            }
+                                        },
+                                    )
+                                });
+                                if replace {
+                                    *value = Some(candidate);
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some((_, groups, values)) = current {
+                    rows.push(finish(groups, values));
+                }
+                Ok(rows)
             }
         }
     }
@@ -1129,6 +1693,26 @@ impl Executor for TableScanExec {
         self.scanned.set(0);
         self.emitted = 0;
         self.cursor = None;
+        self.partial_remote = None;
+        self.partial_rows = None;
+        self.partial_done = false;
+        if let Some(aggregate) = self.partial_aggregate.clone() {
+            self.partial_remote = self
+                .table
+                .pushdown_partial_aggregate_cursor(
+                    &self.keep.clone(),
+                    &self.pushed,
+                    self.handle_ranges.as_deref(),
+                    &aggregate,
+                    self.decode_context.zone(),
+                    &self.statement,
+                )
+                .map_err(|_| ExecError::unsupported("table bytes failed to decode"))?;
+            if self.partial_remote.is_some() {
+                self.remote = None;
+                return Ok(());
+            }
+        }
         // A backend with a coprocessor evaluates the predicate, the cap and
         // the projection at the region, so only the surviving rows cross the
         // network. Nothing about the answer depends on it succeeding: the
@@ -1140,6 +1724,8 @@ impl Executor for TableScanExec {
             .pushdown_row_cursor_with_context(
                 &self.keep.clone(),
                 &self.pushed,
+                self.post_filter_projection.as_deref(),
+                self.remote_topn.as_ref(),
                 self.limit,
                 self.handle_ranges.as_deref(),
                 &self.decode_context,
@@ -1174,6 +1760,42 @@ impl Executor for TableScanExec {
     fn next(&mut self, req: &mut Chunk) -> Result<(), ExecError> {
         req.reset();
         let cap = self.meta.max_chunk_size();
+        if let Some(remote) = self.partial_remote.as_mut() {
+            while req.num_rows() < cap {
+                let Some(row) = remote.next_row().map_err(|error| {
+                    ExecError::unsupported(format!("partial aggregate response failed: {error:?}"))
+                })?
+                else {
+                    self.partial_remote = None;
+                    self.partial_done = true;
+                    break;
+                };
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
+            }
+            return Ok(());
+        }
+        if let Some(aggregate) = self.partial_aggregate.clone() {
+            if self.partial_done {
+                return Ok(());
+            }
+            if self.partial_rows.is_none() {
+                self.partial_rows = Some(self.build_local_partial_rows(&aggregate)?.into_iter());
+            }
+            let rows = self.partial_rows.as_mut().expect("just initialized");
+            while req.num_rows() < cap {
+                let Some(row) = rows.next() else {
+                    self.partial_rows = None;
+                    self.partial_done = true;
+                    break;
+                };
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
+            }
+            return Ok(());
+        }
         while req.num_rows() < cap {
             if self.limit.is_some_and(|limit| self.emitted >= limit) {
                 // Early stop: the cursor is dropped, so nothing past the
@@ -1185,17 +1807,35 @@ impl Executor for TableScanExec {
                 self.remote = None;
                 return Ok(());
             }
+            let remote_projected = self.remote.is_some() && self.post_filter_projection.is_some();
             let Some(row) = self.next_source_row()? else {
                 return Ok(());
             };
             self.scanned.set(self.scanned.get() + 1);
-            if let Some(filter) = self.filter.as_mut() {
-                if !filter.admits(&row)? {
-                    continue;
+            if !remote_projected {
+                if let Some(filter) = self.filter.as_mut() {
+                    if !filter.admits(&row)? {
+                        continue;
+                    }
                 }
             }
-            for (c, value) in row.iter().enumerate() {
-                req.append_datum(c, value);
+            if remote_projected {
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
+            } else if let Some(projection) = &self.post_filter_projection {
+                for (column, offset) in projection.iter().enumerate() {
+                    let Some(value) = row.get(*offset) else {
+                        return Err(ExecError::unsupported(
+                            "post-filter projection is outside the scan row",
+                        ));
+                    };
+                    req.append_datum(column, value);
+                }
+            } else {
+                for (column, value) in row.iter().enumerate() {
+                    req.append_datum(column, value);
+                }
             }
             self.emitted += 1;
         }
@@ -1205,6 +1845,9 @@ impl Executor for TableScanExec {
     fn close(&mut self) -> Result<(), ExecError> {
         self.cursor = None;
         self.remote = None;
+        self.partial_remote = None;
+        self.partial_rows = None;
+        self.partial_done = false;
         Ok(())
     }
 
@@ -1234,6 +1877,41 @@ impl Executor for TableScanExec {
 }
 
 impl crate::table_access::TableAccess for TableScanExec {
+    fn accept_scan_estimate(&mut self, rows: f64) {
+        self.estimated_rows = Some(rows);
+    }
+
+    fn accept_partial_aggregate(&mut self, aggregate: &PushdownPartialAggregate) -> bool {
+        if self.estimated_rows.is_none_or(|rows| rows <= 1.0)
+            || aggregate
+                .input_offsets()
+                .into_iter()
+                .any(|offset| offset >= self.keep.len())
+            || self.limit.is_some()
+            || self.partial_aggregate.is_some()
+        {
+            return false;
+        }
+        let columns = aggregate
+            .output_types()
+            .into_iter()
+            .enumerate()
+            .map(|(offset, field_type)| {
+                let mut column = tidb_expr::column::Column::new((offset + 1) as i64, field_type);
+                column.index = offset as i64;
+                column
+            })
+            .collect();
+        self.meta = ExecutorMeta::new(
+            Schema::new(columns),
+            self.meta.id(),
+            self.meta.init_cap(),
+            self.meta.max_chunk_size(),
+        );
+        self.partial_aggregate = Some(aggregate.clone());
+        true
+    }
+
     /// `scan_rows` reads the storage seam's merged stream -- the statement
     /// snapshot with the session's staged mutation buffer already merged in
     /// (`ClusterTableStorage`) -- and every row of it is tested here, whether
@@ -1254,6 +1932,58 @@ impl crate::table_access::TableAccess for TableScanExec {
             ctx.clone(),
             self.meta.new_chunk(),
         ));
+        true
+    }
+
+    fn accept_post_filter_projection(&mut self, keep: &[usize]) -> bool {
+        // The only current consumer is a clean clustered common-handle range.
+        // An integer-handle remote scan needs its handle column after the
+        // projection in order to merge staged rows, so it must keep using the
+        // unchanged wider-row contract until that handle is modelled as a
+        // separate transport field.
+        if self.filter.is_none()
+            || self.table.common_handle_offsets.is_empty()
+            || self.partial_aggregate.is_some()
+            || keep.is_empty()
+            || keep.iter().any(|offset| *offset >= self.keep.len())
+        {
+            return false;
+        }
+        let columns: Vec<tidb_expr::column::Column> = keep
+            .iter()
+            .enumerate()
+            .map(|(index, offset)| {
+                let mut column = self.meta.schema().columns[*offset].clone();
+                column.index = index as i64;
+                column.id = index as i64 + 1;
+                column
+            })
+            .collect();
+        self.meta = ExecutorMeta::new(
+            Schema::new(columns),
+            self.meta.id(),
+            self.meta.init_cap(),
+            self.meta.max_chunk_size(),
+        );
+        self.post_filter_projection = Some(keep.to_vec());
+        true
+    }
+
+    fn accept_remote_topn(&mut self, topn: &PushdownTopN) -> bool {
+        if topn.order_by.is_empty()
+            || topn.limit == 0
+            || topn
+                .order_by
+                .iter()
+                .any(|item| item.offset >= self.keep.len())
+            || self.partial_aggregate.is_some()
+            || self.post_filter_projection.is_some()
+            || self.limit.is_some()
+            || self.remote_topn.is_some()
+        {
+            return false;
+        }
+        self.remote_topn = Some(topn.clone());
         true
     }
 
@@ -1304,10 +2034,7 @@ impl crate::table_access::TableAccess for TableScanExec {
         if self.filter.is_some() || keep.is_empty() {
             return false;
         }
-        if !keep.windows(2).all(|pair| pair[0] < pair[1]) {
-            return false;
-        }
-        if keep.last().is_some_and(|last| *last >= self.keep.len()) {
+        if keep.iter().any(|offset| *offset >= self.keep.len()) {
             return false;
         }
         let columns: Vec<tidb_expr::column::Column> = keep

--- a/rust/crates/tidb-executor/src/lib.rs
+++ b/rust/crates/tidb-executor/src/lib.rs
@@ -119,11 +119,11 @@ pub use ddl_sequence::{
 };
 pub use driver::infoschema_meta;
 pub use driver::{
-    bind_parameters, parameter_count, run_delete_in, run_delete_on, run_insert_in, run_insert_on,
-    run_insert_reporting, run_select, run_select_meta_in, run_select_meta_on, run_select_meta_stmt,
-    run_select_on, run_set_opr_stmt, run_update_in, run_update_on, Catalog, DriverError, MemTable,
-    MysqlError, SchemaErrorKind, SelectMeta, TableEntry, TxnErrorKind, VarErrorKind, ViewDef,
-    DEFAULT_DATABASE,
+    bind_parameters, parameter_count, plan_select_meta_stmt, run_delete_in, run_delete_on,
+    run_insert_in, run_insert_on, run_insert_reporting, run_select, run_select_meta_in,
+    run_select_meta_on, run_select_meta_stmt, run_select_on, run_set_opr_stmt, run_update_in,
+    run_update_on, Catalog, DriverError, MemTable, MysqlError, SchemaErrorKind, SelectMeta,
+    TableEntry, TxnErrorKind, VarErrorKind, ViewDef, DEFAULT_DATABASE,
 };
 pub use executor::{ExecError, Executor, ExecutorMeta};
 pub use explain::{
@@ -131,7 +131,7 @@ pub use explain::{
     explain_analyze_update_stmt, explain_delete_stmt, explain_insert_stmt, explain_select_stmt,
     explain_update_stmt, ExplainFormat,
 };
-pub use hash_agg::{AggFunc, AggKind, HashAggExec};
+pub use hash_agg::{AggFunc, AggKind, GroupedStreamAggExec, HashAggExec, StreamAggExec};
 pub use join::{JoinExec, JoinKind};
 pub use kv_table::{
     FkAction, IndexRange, KvColumn, KvForeignKey, KvIndex, KvTable, RowDecodeContext, TableCharset,

--- a/rust/crates/tidb-executor/src/lib.rs
+++ b/rust/crates/tidb-executor/src/lib.rs
@@ -92,6 +92,7 @@ pub mod sequence;
 mod skyline;
 pub mod sort;
 pub mod sort_partition;
+pub mod split_region;
 pub mod statement_pushdown;
 mod stmt_context;
 pub mod storage;
@@ -144,6 +145,7 @@ pub use predicate_pushdown::{PushedScanFilter, ScanComparison, ScanComparisonOp,
 pub use projection::ProjectionExec;
 pub use selection::SelectionExec;
 pub use sort::{SortByItem, SortExec};
+pub use split_region::SplitRegionPlan;
 pub use stmt_context::{
     RetryAutoIds, SequenceSnapshot, StatementClass, StmtContext, MAX_WARNING_COUNT,
 };

--- a/rust/crates/tidb-executor/src/merge_join_plan.rs
+++ b/rust/crates/tidb-executor/src/merge_join_plan.rs
@@ -142,7 +142,9 @@ fn index_orders(table: &KvTable) -> Vec<Vec<usize>> {
 }
 
 /// The orders a whole-table scan of `table` ACTUALLY walks in -- the record
-/// key's own order, which for an integer handle is that column's order.
+/// key's own order. For an integer handle that is the one handle column; for
+/// a clustered common handle it is the complete primary-key tuple in encoded
+/// datum order.
 ///
 /// This is deliberately a DIFFERENT function from [`provided_orders`] even
 /// though the two agree today, and the difference is the whole point.
@@ -162,6 +164,13 @@ fn index_orders(table: &KvTable) -> Vec<Vec<usize>> {
 /// catch that if the verify side reads the BUILD, so the build side gets its
 /// own name here rather than sharing the promise's.
 pub(crate) fn table_scan_order(table: &KvTable) -> Vec<Vec<usize>> {
+    if !table.common_handle_offsets().is_empty() {
+        // A common handle is the mem-comparable key encoding of these datums
+        // in exactly this order. Unlike a prefix secondary index, every
+        // clustered-primary part is stored in full, so the record walk really
+        // delivers the whole tuple order it promises.
+        return vec![table.common_handle_offsets().to_vec()];
+    }
     let Some(offset) = table.pk_handle_offset() else {
         return Vec::new();
     };

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -1087,13 +1087,16 @@ impl PlanTrace {
         let estimate = Est::Scale(DISTINCT_FACTOR).apply(scan.est_rows);
         scan.task = "cop[tikv]";
         let act_rows = scan.act_rows.clone();
-        let key_ndv_ratio = scan.key_ndv_ratio;
         let mut partial = PlanNode::new(
             "StreamAgg",
             estimate,
             String::new(),
             grouped_aggregate_info(select, qualify, false, false),
         );
+        // The complete group tuple is unique in the aggregate output, so its
+        // NDV is the aggregate row count rather than the source column's
+        // pseudo 0.8 ratio. A merge join on all group keys uses this value.
+        partial.key_ndv_ratio = Some(1.0);
         partial.task = "cop[tikv]";
         partial.act_rows = act_rows.clone();
         partial.children.push(scan);
@@ -1108,7 +1111,7 @@ impl PlanTrace {
                 "index:StreamAgg".to_owned()
             },
         );
-        reader_node.key_ndv_ratio = key_ndv_ratio;
+        reader_node.key_ndv_ratio = Some(1.0);
         reader_node.act_rows = act_rows;
         reader_node.children.push(partial);
         self.stack.push(reader_node);
@@ -1195,37 +1198,54 @@ impl PlanTrace {
         let at = if lookup_is_left { depth - 2 } else { depth - 1 };
         let outer_at = if lookup_is_left { depth - 1 } else { depth - 2 };
         let outer_rows = self.stack[outer_at].est_rows;
-        let node = &mut self.stack[at];
-        // The decision only ever names a bare base table, so its child
-        // subtree is the single scan node `build_from` pushed for it. Anything
-        // else means the two disagree, and renaming it would print a range
-        // over an operator that reads none.
-        if !matches!(
-            node.name,
-            "TableFullScan" | "IndexFullScan" | "TableRangeScan" | "IndexRangeScan"
-        ) || !node.children.is_empty()
-        {
-            return Err(());
+        fn is_scan(node: &PlanNode) -> bool {
+            matches!(
+                node.name,
+                "TableFullScan" | "IndexFullScan" | "TableRangeScan" | "IndexRangeScan"
+            ) && node.children.is_empty()
         }
+
+        let node = &mut self.stack[at];
+        // A residual predicate may already have put the base scan under a cop
+        // Selection. That is still the same inner data source; any deeper or
+        // different subtree would make the dynamic range untruthful.
+        let had_selection = node.name == "Selection";
+        let scan = if is_scan(node) {
+            node
+        } else if node.name == "Selection" && node.children.len() == 1 && is_scan(&node.children[0])
+        {
+            &mut node.children[0]
+        } else {
+            return Err(());
+        };
         // `stats:pseudo` is a property of the TABLE, not of the path, so it
         // survives the rename -- and the replay compares it.
-        let pseudo = if node.info.contains("stats:pseudo") {
+        let pseudo = if scan.info.contains("stats:pseudo") {
             ", stats:pseudo"
         } else {
             ""
         };
-        node.name = if index {
+        scan.name = if index {
             "IndexRangeScan"
         } else {
             "TableRangeScan"
         };
-        node.access = access;
-        node.info = format!("range: decided by {range_info}, keep order:false{pseudo}");
+        scan.access = access;
+        scan.info = format!("range: decided by {range_info}, keep order:false{pseudo}");
 
         // One dynamic range is opened per outer row. Go derives the table
         // scan's cardinality from that probe population, not from the inner
         // table's earlier constant-only access path.
-        node.est_rows = outer_rows.or(node.est_rows);
+        scan.est_rows = outer_rows.or(scan.est_rows);
+        if had_selection {
+            let node = &mut self.stack[at];
+            node.est_rows = outer_rows
+                .or(node.est_rows)
+                .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0));
+            if !filters.is_empty() {
+                node.info = filters.join(", ");
+            }
+        }
 
         // Rebuild the two physical reader boundaries now that the strategy is
         // committed. Both leaves were built before the join family was known,
@@ -1237,7 +1257,7 @@ impl PlanTrace {
         } else {
             &mut right
         };
-        if !filters.is_empty() {
+        if !filters.is_empty() && inner.name != "Selection" {
             let estimate = inner
                 .est_rows
                 .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0));
@@ -2006,6 +2026,7 @@ impl PlanTrace {
             build_is_left,
             merge_keys,
             index_lookup,
+            physical_conditions,
         } = strategy;
         let build_is_left = *build_is_left;
         let qualify = Qualifier {
@@ -2035,8 +2056,17 @@ impl PlanTrace {
         }
         let mut equal = Vec::new();
         let mut other = Vec::new();
-        for (conjunct, is_equal) in conjuncts.iter().zip(equal_mask.iter()) {
-            let rendered = qualify.expr(conjunct);
+        for (index, (conjunct, is_equal)) in conjuncts.iter().zip(equal_mask.iter()).enumerate() {
+            let rendered = if *is_equal {
+                qualify.expr(conjunct)
+            } else {
+                physical_conditions
+                    .as_ref()
+                    .and_then(|(conditions, columns)| {
+                        physical_expression_text_with_columns(conditions.get(index)?, columns)
+                    })
+                    .unwrap_or_else(|| qualify.expr(conjunct))
+            };
             if *is_equal {
                 equal.push(rendered);
             } else {
@@ -2661,8 +2691,13 @@ pub(crate) fn pseudo_selectivity(predicate: &tidb_ast::Expr) -> f64 {
 /// `cardinality.Selectivity` takes `[]expression.Expression` for the same
 /// reason.
 pub(crate) fn pseudo_selectivity_of_conjuncts(conjuncts: &[&tidb_ast::Expr]) -> f64 {
-    let mut factor = SELECTIVITY_FACTOR;
+    let mut factor: Option<f64> = None;
+    let mut has_unclassified = false;
     for conjunct in conjuncts {
+        if complementary_null_predicates(conjunct) {
+            factor = Some(factor.map_or(1.0, |current| current.min(1.0)));
+            continue;
+        }
         let rate = match conjunct {
             tidb_ast::Expr::Binary(op, _, _) => match op {
                 tidb_ast::BinaryOp::Eq | tidb_ast::BinaryOp::NullEq => 1.0 / PSEUDO_EQUAL_RATE,
@@ -2670,14 +2705,67 @@ pub(crate) fn pseudo_selectivity_of_conjuncts(conjuncts: &[&tidb_ast::Expr]) -> 
                 | tidb_ast::BinaryOp::Gt
                 | tidb_ast::BinaryOp::Le
                 | tidb_ast::BinaryOp::Lt => 1.0 / PSEUDO_LESS_RATE,
-                _ => continue,
+                _ => {
+                    has_unclassified = true;
+                    continue;
+                }
             },
             tidb_ast::Expr::In { .. } => 1.0 / PSEUDO_EQUAL_RATE,
-            _ => continue,
+            tidb_ast::Expr::Is {
+                target: tidb_ast::IsTarget::Null,
+                not,
+                ..
+            } => {
+                if *not {
+                    1.0 - 1.0 / PSEUDO_EQUAL_RATE
+                } else {
+                    1.0 / PSEUDO_EQUAL_RATE
+                }
+            }
+            _ => {
+                has_unclassified = true;
+                continue;
+            }
         };
-        factor = factor.min(rate);
+        factor = Some(factor.map_or(rate, |current| current.min(rate)));
     }
-    factor
+    match (factor, has_unclassified) {
+        (Some(factor), true) => factor.min(SELECTIVITY_FACTOR),
+        (Some(factor), false) => factor,
+        (None, _) => SELECTIVITY_FACTOR,
+    }
+}
+
+fn complementary_null_predicates(predicate: &tidb_ast::Expr) -> bool {
+    let tidb_ast::Expr::Binary(tidb_ast::BinaryOp::LogicOr, left, right) = strip_paren(predicate)
+    else {
+        return false;
+    };
+    let (Some((left, left_not)), Some((right, right_not))) =
+        (null_predicate(left), null_predicate(right))
+    else {
+        return false;
+    };
+    left == right && left_not != right_not
+}
+
+fn null_predicate(predicate: &tidb_ast::Expr) -> Option<(&tidb_ast::Expr, bool)> {
+    let tidb_ast::Expr::Is {
+        expr,
+        target: tidb_ast::IsTarget::Null,
+        not,
+    } = strip_paren(predicate)
+    else {
+        return None;
+    };
+    Some((strip_paren(expr), *not))
+}
+
+fn strip_paren(mut expression: &tidb_ast::Expr) -> &tidb_ast::Expr {
+    while let tidb_ast::Expr::Paren(inner) = expression {
+        expression = inner;
+    }
+    expression
 }
 
 /// Go `cardinality.EstimateFullJoinRowCount` over the two subtrees a
@@ -2793,6 +2881,11 @@ pub(crate) struct JoinStrategy {
     /// and the `(outer key, inner key)` column names. `None` for every other
     /// strategy.
     pub(crate) index_lookup: Option<IndexJoinText>,
+    /// The executor's flattened conditions and the physical origin of each
+    /// joined-row column. Present only when a derived aggregate output has
+    /// no source-column name, so non-equality conditions print the internal
+    /// `Column#N` the executor evaluates instead of inventing an alias name.
+    pub(crate) physical_conditions: Option<(Vec<Expression>, Vec<Option<String>>)>,
 }
 
 /// What an index join's plan row says beyond its join kind.
@@ -3043,6 +3136,28 @@ fn binary_func_name(op: tidb_ast::BinaryOp) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn complementary_null_predicates_are_a_tautology() {
+        let column = tidb_ast::Expr::Column(vec!["c".to_owned()]);
+        let is_null = tidb_ast::Expr::Is {
+            expr: Box::new(column.clone()),
+            target: tidb_ast::IsTarget::Null,
+            not: false,
+        };
+        let is_not_null = tidb_ast::Expr::Is {
+            expr: Box::new(column),
+            target: tidb_ast::IsTarget::Null,
+            not: true,
+        };
+        let predicate = tidb_ast::Expr::Binary(
+            tidb_ast::BinaryOp::LogicOr,
+            Box::new(is_null),
+            Box::new(is_not_null),
+        );
+
+        assert_eq!(pseudo_selectivity(&predicate), 1.0);
+    }
 
     fn index_join_text(outer_row_size: f64, inner_row_size: f64) -> IndexJoinText {
         IndexJoinText {

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -91,6 +91,11 @@ pub(crate) struct PlanNode {
     /// The `operator info` cell, up to the point a join splices its
     /// `, left side:<child>` in.
     pub(crate) info: String,
+    /// Physical expressions produced by a projection, in output order. Most
+    /// nodes leave this empty; join null-rejection pushdown uses it to place
+    /// the derived predicate below the projection without parsing EXPLAIN
+    /// text back into expressions.
+    pub(crate) projection_outputs: Vec<String>,
     /// The execution boundary Go reports for this operator.
     pub(crate) task: &'static str,
     /// A join's `, left side:` insertion point: the index in `children` of
@@ -141,6 +146,7 @@ impl PlanNode {
             est_rows,
             access,
             info,
+            projection_outputs: Vec::new(),
             task: "root",
             left_side_child: None,
             info_tail: String::new(),
@@ -1196,6 +1202,10 @@ impl PlanTrace {
             index_lookup,
             visible,
             estimated_rows,
+            grouped_derived,
+            aggregation_info,
+            outer_not_null,
+            inner_not_null,
         } = path;
         let depth = self.stack.len();
         if depth < 2 {
@@ -1209,6 +1219,144 @@ impl PlanTrace {
                 node.name,
                 "TableFullScan" | "IndexFullScan" | "TableRangeScan" | "IndexRangeScan"
             ) && node.children.is_empty()
+        }
+
+        if grouped_derived {
+            if !outer_not_null.is_empty() {
+                let outer = &mut self.stack[outer_at];
+                if outer.name != "Projection"
+                    || outer.children.len() != 1
+                    || outer_not_null
+                        .iter()
+                        .any(|offset| *offset >= outer.projection_outputs.len())
+                {
+                    return Err(());
+                }
+                let predicates = outer_not_null
+                    .iter()
+                    .map(|offset| format!("not(isnull({}))", outer.projection_outputs[*offset]))
+                    .collect::<Vec<_>>();
+                outer.est_rows = estimated_rows.or(outer.est_rows);
+                let reader = &mut outer.children[0];
+                if reader.name != "TableReader" || reader.children.len() != 1 {
+                    return Err(());
+                }
+                reader.est_rows = estimated_rows.or(reader.est_rows);
+                reader.info = "data:Selection".to_owned();
+                let scan = &mut reader.children[0];
+                if !is_scan(scan) {
+                    return Err(());
+                }
+                let mut selection = PlanNode::new(
+                    "Selection",
+                    estimated_rows,
+                    String::new(),
+                    predicates.join(", "),
+                );
+                selection.task = "cop[tikv]";
+                selection.act_rows = scan.act_rows.clone();
+                selection.key_ndv_ratio = scan.key_ndv_ratio;
+                scan.task = "cop[tikv]";
+                selection.children.push(std::mem::replace(
+                    scan,
+                    PlanNode::new("TableDual", Some(0.0), String::new(), String::new()),
+                ));
+                *scan = selection;
+            }
+            let node = &mut self.stack[at];
+            // Go rebuilds this complete inner task for every outer batch:
+            // HashAgg -> IndexLookUp -> (cop Selection -> dynamic range,
+            // table row read).  The executable decision carries the same
+            // aggregation, so retaining this tree is plan reporting of the
+            // operator that actually runs rather than a trace-only rewrite.
+            if node.name != "HashAgg" || node.children.len() != 1 {
+                return Err(());
+            }
+            node.info = aggregation_info.ok_or(())?.to_owned();
+            node.est_rows = estimated_rows.or(node.est_rows);
+            let lookup = &mut node.children[0];
+            if lookup.name != "IndexLookUp" || lookup.children.len() != 2 || !index_lookup {
+                return Err(());
+            }
+            lookup.est_rows = estimated_rows.or(lookup.est_rows);
+            let scan_holder = &mut lookup.children[0];
+            let (scan, had_selection) = if is_scan(scan_holder) {
+                (&mut *scan_holder, false)
+            } else if scan_holder.name == "Selection"
+                && scan_holder.children.len() == 1
+                && is_scan(&scan_holder.children[0])
+            {
+                (&mut scan_holder.children[0], true)
+            } else {
+                return Err(());
+            };
+            let pseudo = if scan.info.contains("stats:pseudo") {
+                ", stats:pseudo"
+            } else {
+                ""
+            };
+            scan.name = if index {
+                "IndexRangeScan"
+            } else {
+                "TableRangeScan"
+            };
+            scan.access = access;
+            scan.info = format!("range: decided by {range_info}, keep order:false{pseudo}");
+            scan.est_rows = estimated_rows
+                .map(|rows| {
+                    if filter_selectivity > 0.0 {
+                        rows / filter_selectivity.clamp(0.0, 1.0)
+                    } else {
+                        rows
+                    }
+                })
+                .or(outer_rows)
+                .or(scan.est_rows);
+            if had_selection {
+                scan_holder.est_rows = estimated_rows.or(scan_holder.est_rows);
+                if !filters.is_empty() {
+                    scan_holder.info = filters.join(", ");
+                }
+            } else if !filters.is_empty() {
+                let mut selection = PlanNode::new(
+                    "Selection",
+                    estimated_rows,
+                    String::new(),
+                    filters.join(", "),
+                );
+                selection.task = "cop[tikv]";
+                selection.act_rows = scan_holder.act_rows.clone();
+                selection.key_ndv_ratio = scan_holder.key_ndv_ratio;
+                selection.label = scan_holder.label;
+                scan_holder.label = "";
+                scan_holder.task = "cop[tikv]";
+                selection.children.push(std::mem::replace(
+                    scan_holder,
+                    PlanNode::new("TableDual", Some(0.0), String::new(), String::new()),
+                ));
+                *scan_holder = selection;
+            }
+            lookup.children[1].est_rows = estimated_rows.or(lookup.children[1].est_rows);
+            if !inner_not_null.is_empty() {
+                let mut selection = PlanNode::new(
+                    "Selection",
+                    estimated_rows,
+                    String::new(),
+                    inner_not_null
+                        .iter()
+                        .map(|offset| format!("not(isnull(Column#{offset}))"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+                selection.act_rows = node.act_rows.clone();
+                selection.key_ndv_ratio = node.key_ndv_ratio;
+                selection.children.push(std::mem::replace(
+                    node,
+                    PlanNode::new("TableDual", Some(0.0), String::new(), String::new()),
+                ));
+                *node = selection;
+            }
+            return Ok(());
         }
 
         let node = &mut self.stack[at];
@@ -1954,23 +2102,28 @@ impl PlanTrace {
         expressions: &[Expression],
         column_names: &[Option<String>],
     ) -> bool {
-        let Some(info) = expressions
+        let Some(projected) = expressions
             .iter()
-            .enumerate()
-            .map(|(index, expression)| {
-                let text = physical_expression_text_with_columns(expression, column_names)?;
-                Some(if matches!(expression, Expression::Column(_)) {
-                    text
-                } else {
-                    format!("{text}->Column#{index}")
-                })
-            })
+            .map(|expression| physical_expression_text_with_columns(expression, column_names))
             .collect::<Option<Vec<_>>>()
-            .map(|parts| parts.join(", "))
         else {
             return false;
         };
-        self.wrap("Projection", Est::Inherit, info);
+        let outputs = projected
+            .iter()
+            .enumerate()
+            .map(|(index, text)| {
+                if matches!(expressions[index], Expression::Column(_)) {
+                    text.clone()
+                } else {
+                    format!("{text}->Column#{index}")
+                }
+            })
+            .collect::<Vec<_>>();
+        self.wrap("Projection", Est::Inherit, outputs.join(", "));
+        if let Some(projection) = self.stack.last_mut() {
+            projection.projection_outputs = projected;
+        }
         true
     }
 
@@ -2244,16 +2397,9 @@ impl PlanTrace {
                     .collect::<Vec<_>>()
                     .join(", "),
             );
-            if !text.keys.is_empty() {
+            if !text.equal_conditions.is_empty() {
                 tail.push_str(", equal cond:");
-                tail.push_str(
-                    &text
-                        .keys
-                        .iter()
-                        .map(|(outer, inner)| format!("eq({outer}, {inner})"))
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                );
+                tail.push_str(&text.equal_conditions.join(", "));
             }
         } else {
             if !equal.is_empty() {
@@ -2343,6 +2489,7 @@ impl PlanTrace {
             est_rows,
             access: String::new(),
             info,
+            projection_outputs: Vec::new(),
             task: "root",
             // `explainJoinLeftSide` names the LEFT child's operator, and only
             // for an OUTER join. The name carries its own id in `format='row'`,
@@ -3013,6 +3160,10 @@ pub(crate) struct IndexJoinText {
     /// The outer and inner key column names, already qualified, in probe
     /// order.
     pub(crate) keys: Vec<(String, String)>,
+    /// Every equality retained by the join, in written order and under the
+    /// base columns Go's `OrigName` prints. The dynamic access key above is a
+    /// subset; Go still repeats it in `equal cond:`.
+    pub(crate) equal_conditions: Vec<String>,
     /// Whether the LOOKED-UP (inner) side is the join's left child. The two
     /// sides are not interchangeable in the cost below: the hash table is
     /// built over the outer side for `IndexHashJoin` and over the inner one
@@ -3051,6 +3202,16 @@ pub(crate) struct IndexJoinInnerPathText<'a> {
     pub(crate) visible: &'a str,
     /// The statement-owned post-filter inner estimate for a one-row driver.
     pub(crate) estimated_rows: Option<f64>,
+    /// Whether the lookup reader remains below a grouped derived table.
+    pub(crate) grouped_derived: bool,
+    /// Go's physical HashAgg payload for a retained grouped derived table.
+    pub(crate) aggregation_info: Option<&'a str>,
+    /// Outer output columns rejected when NULL by a comparison above the
+    /// logical join. The physical plan pushes these predicates below the
+    /// eliminated outer aggregation projection.
+    pub(crate) outer_not_null: &'a [usize],
+    /// Grouped inner output columns rejected when NULL after aggregation.
+    pub(crate) inner_not_null: &'a [usize],
 }
 
 /// Unsays `keep order:true` on every leaf under `node` that a join above it
@@ -3299,6 +3460,7 @@ mod tests {
         IndexJoinText {
             reader: "IndexReader",
             keys: vec![("a".to_owned(), "b".to_owned())],
+            equal_conditions: vec!["eq(a, b)".to_owned()],
             lookup_is_left: false,
             unique: false,
             forced_name: None,

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -1185,12 +1185,18 @@ impl PlanTrace {
     pub(crate) fn index_join_inner_scan(
         &mut self,
         lookup_is_left: bool,
-        access: String,
-        range_info: &str,
-        index: bool,
+        path: IndexJoinInnerPathText<'_>,
         filters: &[String],
         filter_selectivity: f64,
     ) -> Result<(), ()> {
+        let IndexJoinInnerPathText {
+            access,
+            range_info,
+            index,
+            index_lookup,
+            visible,
+            estimated_rows,
+        } = path;
         let depth = self.stack.len();
         if depth < 2 {
             return Err(());
@@ -1233,15 +1239,28 @@ impl PlanTrace {
         scan.access = access;
         scan.info = format!("range: decided by {range_info}, keep order:false{pseudo}");
 
-        // One dynamic range is opened per outer row. Go derives the table
-        // scan's cardinality from that probe population, not from the inner
-        // table's earlier constant-only access path.
-        scan.est_rows = outer_rows.or(scan.est_rows);
+        // One dynamic range is opened per outer row. When the statement's
+        // estimator owns this simple join, its joined-row count is the exact
+        // post-filter inner estimate for a one-row driver. Recover the access
+        // estimate by removing the residual selectivity; otherwise preserve
+        // the older trace-owned outer-row fallback.
+        scan.est_rows = estimated_rows
+            .map(|rows| {
+                if filter_selectivity > 0.0 {
+                    rows / filter_selectivity.clamp(0.0, 1.0)
+                } else {
+                    rows
+                }
+            })
+            .or(outer_rows)
+            .or(scan.est_rows);
         if had_selection {
             let node = &mut self.stack[at];
-            node.est_rows = outer_rows
-                .or(node.est_rows)
-                .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0));
+            node.est_rows = estimated_rows.or_else(|| {
+                outer_rows
+                    .or(node.est_rows)
+                    .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0))
+            });
             if !filters.is_empty() {
                 node.info = filters.join(", ");
             }
@@ -1258,9 +1277,11 @@ impl PlanTrace {
             &mut right
         };
         if !filters.is_empty() && inner.name != "Selection" {
-            let estimate = inner
-                .est_rows
-                .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0));
+            let estimate = estimated_rows.or_else(|| {
+                inner
+                    .est_rows
+                    .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0))
+            });
             let mut selection =
                 PlanNode::new("Selection", estimate, String::new(), filters.join(", "));
             selection.task = "cop[tikv]";
@@ -1274,14 +1295,12 @@ impl PlanTrace {
             *inner = selection;
         }
 
-        fn reader(mut child: PlanNode, forced_index: Option<bool>) -> PlanNode {
-            let reader = forced_index.map_or_else(
-                || match child.name {
-                    "IndexFullScan" | "IndexRangeScan" => "IndexReader",
-                    _ => "TableReader",
-                },
-                |index| if index { "IndexReader" } else { "TableReader" },
-            );
+        fn reader(
+            mut child: PlanNode,
+            forced_index: Option<bool>,
+            index_lookup: bool,
+            visible: &str,
+        ) -> PlanNode {
             fn mark_cop(node: &mut PlanNode) {
                 node.task = "cop[tikv]";
                 for child in &mut node.children {
@@ -1289,6 +1308,46 @@ impl PlanTrace {
                 }
             }
             mark_cop(&mut child);
+            if index_lookup {
+                let estimate = child.est_rows;
+                let act_rows = child.act_rows.clone();
+                let key_ndv_ratio = child.key_ndv_ratio;
+                let pseudo = child.info.contains("stats:pseudo")
+                    || child
+                        .children
+                        .iter()
+                        .any(|node| node.info.contains("stats:pseudo"));
+                child.label = "(Build)";
+
+                let mut table_scan = PlanNode::new(
+                    "TableRowIDScan",
+                    estimate,
+                    format!("table:{visible}"),
+                    format!(
+                        "keep order:false{}",
+                        if pseudo { ", stats:pseudo" } else { "" }
+                    ),
+                );
+                table_scan.task = "cop[tikv]";
+                table_scan.label = "(Probe)";
+                table_scan.act_rows = act_rows.clone();
+                table_scan.key_ndv_ratio = key_ndv_ratio;
+
+                let mut lookup =
+                    PlanNode::new("IndexLookUp", estimate, String::new(), String::new());
+                lookup.act_rows = act_rows;
+                lookup.key_ndv_ratio = key_ndv_ratio;
+                lookup.children.push(child);
+                lookup.children.push(table_scan);
+                return lookup;
+            }
+            let reader = forced_index.map_or_else(
+                || match child.name {
+                    "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+                    _ => "TableReader",
+                },
+                |index| if index { "IndexReader" } else { "TableReader" },
+            );
             let estimate = child.est_rows;
             let act_rows = child.act_rows.clone();
             let key_ndv_ratio = child.key_ndv_ratio;
@@ -1305,20 +1364,20 @@ impl PlanTrace {
         }
 
         if lookup_is_left {
-            left = reader(left, Some(index));
+            left = reader(left, Some(index), index_lookup, visible);
             if matches!(
                 right.name,
                 "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
             ) {
-                right = reader(right, None);
+                right = reader(right, None, false, visible);
             }
         } else {
-            right = reader(right, Some(index));
+            right = reader(right, Some(index), index_lookup, visible);
             if matches!(
                 left.name,
                 "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
             ) {
-                left = reader(left, None);
+                left = reader(left, None, false, visible);
             }
         }
         self.stack.push(left);
@@ -1409,7 +1468,19 @@ impl PlanTrace {
         written: &tidb_ast::Expr,
         stats_selectivity: Option<f64>,
     ) -> bool {
-        let Some(info) = physical_expression_text(predicate) else {
+        self.physical_selection_with_columns(predicate, written, stats_selectivity, &[])
+    }
+
+    /// [`Self::physical_selection`] with source-table names for the physical
+    /// columns that projection elimination can still trace to a base table.
+    pub(crate) fn physical_selection_with_columns(
+        &mut self,
+        predicate: &Expression,
+        written: &tidb_ast::Expr,
+        stats_selectivity: Option<f64>,
+        column_names: &[Option<String>],
+    ) -> bool {
+        let Some(info) = physical_expression_text_with_columns(predicate, column_names) else {
             return false;
         };
         let est = if self.consumed {
@@ -1481,7 +1552,21 @@ impl PlanTrace {
         input_projection: bool,
         logical_rows: Option<f64>,
         physical_info: Option<&str>,
+        extra_first_rows: &[String],
     ) {
+        let mut info = physical_info.map_or_else(
+            || grouped_aggregate_info(select, qualify, false, true),
+            str::to_owned,
+        );
+        // A carrier introduced for an enclosing predicate is absent from the
+        // derived SELECT's written field list, but it is a real aggregate
+        // state and must remain visible in the physical plan. An explicitly
+        // supplied physical payload already enumerates every state.
+        if physical_info.is_none() {
+            for carrier in extra_first_rows {
+                info.push_str(&format!(", funcs:firstrow({carrier})->{carrier}"));
+            }
+        }
         self.wrap(
             "StreamAgg",
             logical_rows.map_or_else(
@@ -1494,10 +1579,7 @@ impl PlanTrace {
                 },
                 Est::Fixed,
             ),
-            physical_info.map_or_else(
-                || grouped_aggregate_info(select, qualify, false, true),
-                str::to_owned,
-            ),
+            info,
         );
     }
 
@@ -2164,13 +2246,17 @@ impl PlanTrace {
         right.label = if build_is_left { "(Probe)" } else { "(Build)" };
         let est_rows = index_lookup
             .as_ref()
-            .filter(|text| text.unique)
             .and_then(|text| {
-                if text.lookup_is_left {
-                    right.est_rows
-                } else {
-                    left.est_rows
-                }
+                text.estimated_join_rows.or_else(|| {
+                    if !text.unique {
+                        return None;
+                    }
+                    if text.lookup_is_left {
+                        right.est_rows
+                    } else {
+                        left.est_rows
+                    }
+                })
             })
             .or_else(|| full_join_row_count(&left, &right, equal.len(), merge_keys.as_deref()));
         let named_key_ndvs = merge_keys.as_deref().map_or_else(Vec::new, |keys| {
@@ -2323,10 +2409,6 @@ fn field_list(fields: &[tidb_ast::SelectField], qualify: &Qualifier<'_>) -> Stri
 /// projection elimination. Unsupported nodes are refused by the caller; a
 /// fallback to AST text would describe a different expression than the one
 /// the Selection executor evaluates.
-fn physical_expression_text(expression: &Expression) -> Option<String> {
-    physical_expression_text_with_columns(expression, &[])
-}
-
 fn physical_expression_text_with_columns(
     expression: &Expression,
     column_names: &[Option<String>],
@@ -2896,7 +2978,8 @@ pub(crate) struct JoinStrategy {
 /// the scan itself -- so it is named from the probed object rather than read
 /// off a child that does not exist here.
 pub(crate) struct IndexJoinText {
-    /// `IndexReader` for an index probe, `TableReader` for a handle probe.
+    /// `IndexReader` for a covering index probe, `IndexLookUp` for a double
+    /// read, and `TableReader` for a handle probe.
     pub(crate) reader: &'static str,
     /// The outer and inner key column names, already qualified, in probe
     /// order.
@@ -2917,6 +3000,28 @@ pub(crate) struct IndexJoinText {
     /// plan row carries only their text.
     pub(crate) outer_row_size: f64,
     pub(crate) inner_row_size: f64,
+    /// Statement-owned estimates used to choose `IndexJoin` versus
+    /// `IndexHashJoin`. They are independent of whether EXPLAIN is active.
+    pub(crate) estimated_outer_rows: Option<f64>,
+    pub(crate) estimated_probe_rows_one: Option<f64>,
+    /// The statement-owned equality-join output estimate.
+    pub(crate) estimated_join_rows: Option<f64>,
+}
+
+/// The physical inner access path an index join commits to its plan trace.
+pub(crate) struct IndexJoinInnerPathText<'a> {
+    /// The table or index object printed on the dynamic range scan.
+    pub(crate) access: String,
+    /// Go's `range: decided by` payload.
+    pub(crate) range_info: &'a str,
+    /// Whether the dynamic range reads a secondary index.
+    pub(crate) index: bool,
+    /// Whether that secondary-index access needs a table double read.
+    pub(crate) index_lookup: bool,
+    /// The looked-up table's visible name.
+    pub(crate) visible: &'a str,
+    /// The statement-owned post-filter inner estimate for a one-row driver.
+    pub(crate) estimated_rows: Option<f64>,
 }
 
 /// Unsays `keep order:true` on every leaf under `node` that a join above it
@@ -2993,6 +3098,8 @@ fn index_join_operator(
 ) -> &'static str {
     use tidb_planner::plan_cost_ver2::{hash_build_cost, Ver2Factors};
     use tidb_planner::task_type::TaskType;
+    let outer = text.estimated_outer_rows.or(outer);
+    let inner_rows_one = text.estimated_probe_rows_one.or(inner_rows_one);
     let (Some(build_rows), Some(probe_rows_one)) = (outer, inner_rows_one) else {
         // No estimate on one of the two sides: Go always has one, and this
         // tier's fallback is the candidate Go enumerates first.
@@ -3168,6 +3275,9 @@ mod tests {
             forced_name: None,
             outer_row_size,
             inner_row_size,
+            estimated_outer_rows: None,
+            estimated_probe_rows_one: None,
+            estimated_join_rows: None,
         }
     }
 

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -1945,6 +1945,35 @@ impl PlanTrace {
         true
     }
 
+    /// The executable projection left after Go eliminates a grouped
+    /// aggregation whose group keys cover a unique key. Carried columns keep
+    /// their source names; rewritten aggregate scalars name their new output
+    /// columns explicitly.
+    pub(crate) fn aggregation_elimination_projection(
+        &mut self,
+        expressions: &[Expression],
+        column_names: &[Option<String>],
+    ) -> bool {
+        let Some(info) = expressions
+            .iter()
+            .enumerate()
+            .map(|(index, expression)| {
+                let text = physical_expression_text_with_columns(expression, column_names)?;
+                Some(if matches!(expression, Expression::Column(_)) {
+                    text
+                } else {
+                    format!("{text}->Column#{index}")
+                })
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(|parts| parts.join(", "))
+        else {
+            return false;
+        };
+        self.wrap("Projection", Est::Inherit, info);
+        true
+    }
+
     /// Records a simple projection executed by the TiKV request and the
     /// TableReader boundary that returns it to the root task. The source has
     /// already accepted the matching kept-column list, so these nodes

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -48,6 +48,7 @@ use std::rc::Rc;
 
 use tidb_chunk::chunk::Chunk;
 use tidb_datatype::{Datum, FieldType};
+use tidb_expr::expression::Expression;
 use tidb_expr::schema::Schema;
 
 use crate::access_cost::ScanEstimate;
@@ -63,7 +64,7 @@ fn pseudo_suffix(estimate: ScanEstimate) -> &'static str {
     }
 }
 use crate::executor::{ExecError, Executor};
-use crate::kv_table::TableHandle;
+use crate::kv_table::{KvTable, TableHandle};
 
 /// Go `statistics.PseudoRowCount` (`pkg/statistics/table.go`): the row count
 /// assumed for a table with no analyzed statistics.
@@ -90,6 +91,8 @@ pub(crate) struct PlanNode {
     /// The `operator info` cell, up to the point a join splices its
     /// `, left side:<child>` in.
     pub(crate) info: String,
+    /// The execution boundary Go reports for this operator.
+    pub(crate) task: &'static str,
     /// A join's `, left side:` insertion point: the index in `children` of
     /// the operator that is this join's LEFT input. `None` for every node
     /// that does not print one (Go omits it for an inner join).
@@ -129,6 +132,7 @@ impl PlanNode {
             est_rows,
             access,
             info,
+            task: "root",
             left_side_child: None,
             info_tail: String::new(),
             label: "",
@@ -159,6 +163,9 @@ pub(crate) enum Est {
     Fixed(f64),
     /// The child's estimate times a selectivity/NDV factor.
     Scale(f64),
+    /// The child's estimate times a factor, with Go's one-row physical-plan
+    /// floor (`StatsInfo.ScaleByExpectCnt`).
+    ScaleFloorOne(f64),
     /// The child's estimate, capped (`LIMIT`).
     CapAt(f64),
 }
@@ -169,6 +176,7 @@ impl Est {
             Est::Inherit => child,
             Est::Fixed(value) => Some(value),
             Est::Scale(factor) => child.map(|rows| rows * factor),
+            Est::ScaleFloorOne(factor) => child.map(|rows| (rows * factor).max(1.0)),
             Est::CapAt(cap) => child.map(|rows| rows.min(cap)),
         }
     }
@@ -372,7 +380,9 @@ impl PlanTrace {
         // came from somewhere else entirely, and Go's `LogicalLimit` clamps
         // each NDV to the new row count rather than scaling it.
         node.key_ndv_ratio = match est {
-            Est::Inherit | Est::Scale(_) => child.as_ref().and_then(|c| c.key_ndv_ratio),
+            Est::Inherit | Est::Scale(_) | Est::ScaleFloorOne(_) => {
+                child.as_ref().and_then(|c| c.key_ndv_ratio)
+            }
             Est::Fixed(_) | Est::CapAt(_) => None,
         };
         node.children.extend(child);
@@ -587,35 +597,55 @@ impl PlanTrace {
     pub(crate) fn batch_point_get(
         &mut self,
         visible: &str,
+        table: &KvTable,
         handles: &[TableHandle],
         partitions: &[String],
     ) {
-        let printed: Vec<String> = handles.iter().map(handle_text).collect();
+        let (access, info) = if let Some(access) = common_handle_access(visible, table, partitions)
+        {
+            (access, "keep order:false, desc:false".to_owned())
+        } else {
+            let printed: Vec<String> = handles.iter().map(handle_text).collect();
+            (
+                format!("table:{visible}{}", partition_object(partitions)),
+                format!(
+                    "handle:[{}], keep order:false, desc:false",
+                    printed.join(" ")
+                ),
+            )
+        };
         self.replace_top(PlanNode::new(
             "Batch_Point_Get",
             Some(handles.len() as f64),
-            format!("table:{visible}{}", partition_object(partitions)),
-            format!(
-                "handle:[{}], keep order:false, desc:false",
-                printed.join(" ")
-            ),
+            access,
+            info,
         ));
         self.consumed = true;
     }
 
     /// Go's `Point_Get` fast path. `None` is a handle no row can carry --
     /// Go still plans a `Point_Get` and reads nothing.
-    pub(crate) fn point_get(&mut self, visible: &str, handle: Option<&TableHandle>) {
-        let printed = match handle {
-            Some(handle) => handle_text(handle),
-            None => "NULL".to_owned(),
+    pub(crate) fn point_get(
+        &mut self,
+        visible: &str,
+        table: &KvTable,
+        handle: Option<&TableHandle>,
+    ) {
+        let (access, info) = match common_handle_access(visible, table, &[]) {
+            Some(access) => (access, String::new()),
+            None => {
+                let printed = match handle {
+                    Some(handle) => handle_text(handle),
+                    None => "NULL".to_owned(),
+                };
+                (format!("table:{visible}"), format!("handle:{printed}"))
+            }
         };
-        self.replace_top(PlanNode::new(
-            "Point_Get",
-            Some(1.0),
-            format!("table:{visible}"),
-            format!("handle:{printed}"),
-        ));
+        let mut point = PlanNode::new("Point_Get", Some(1.0), access, info);
+        // A one-row relation has NDV one for every join key it can expose, so
+        // an equi-join of two point gets has Go's exact one-row estimate.
+        point.key_ndv_ratio = Some(1.0);
+        self.replace_top(point);
         self.consumed = true;
     }
 
@@ -688,6 +718,445 @@ impl PlanTrace {
         self.consumed = true;
     }
 
+    /// Exposes the two stages already performed by a non-covering
+    /// [`crate::access_path::IndexRangeSourceExec`]: build a handle batch from
+    /// the secondary index, then probe the table rows by those handles.
+    pub(crate) fn index_lookup(&mut self, visible: &str, estimate: ScanEstimate) -> bool {
+        let Some(mut index_scan) = self.stack.pop() else {
+            return false;
+        };
+        if !matches!(index_scan.name, "IndexFullScan" | "IndexRangeScan")
+            || !index_scan.children.is_empty()
+        {
+            self.stack.push(index_scan);
+            return false;
+        }
+        index_scan.task = "cop[tikv]";
+        index_scan.label = "(Build)";
+        let rows = index_scan.est_rows;
+        let act_rows = index_scan.act_rows.clone();
+        let key_ndv_ratio = index_scan.key_ndv_ratio;
+
+        let mut table_scan = PlanNode::new(
+            "TableRowIDScan",
+            rows,
+            format!("table:{visible}"),
+            format!("keep order:false{}", pseudo_suffix(estimate)),
+        );
+        table_scan.task = "cop[tikv]";
+        table_scan.label = "(Probe)";
+        table_scan.act_rows = act_rows.clone();
+        table_scan.key_ndv_ratio = key_ndv_ratio;
+
+        let mut lookup = PlanNode::new("IndexLookUp", rows, String::new(), String::new());
+        lookup.act_rows = act_rows;
+        lookup.key_ndv_ratio = key_ndv_ratio;
+        lookup.children.push(index_scan);
+        lookup.children.push(table_scan);
+        self.stack.push(lookup);
+        true
+    }
+
+    /// Moves a physical table/index scan below the root reader boundary.
+    ///
+    /// The executor already performs a TiKV-backed scan; this method records
+    /// the same root/cop task split that Go's physical plan assigns to that
+    /// request. It deliberately accepts only a bare scan so EXPLAIN cannot
+    /// claim a pushdown through an operator the executor still runs at root.
+    pub(crate) fn scan_reader(&mut self) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        let reader = match scan.name {
+            "TableFullScan" | "TableRangeScan" => "TableReader",
+            "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+            _ => {
+                self.stack.push(scan);
+                return false;
+            }
+        };
+        let scan_name = scan.name;
+        scan.task = "cop[tikv]";
+        let estimate = scan.est_rows;
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let act_rows = scan.act_rows.clone();
+        let info = if reader == "TableReader" {
+            format!("data:{scan_name}")
+        } else {
+            format!("index:{scan_name}")
+        };
+        let mut reader_node = PlanNode::new(reader, estimate, String::new(), info);
+        reader_node.key_ndv_ratio = key_ndv_ratio;
+        reader_node.act_rows = act_rows;
+        reader_node.children.push(scan);
+        self.stack.push(reader_node);
+        true
+    }
+
+    /// Places the two scan children of a merge join behind their root reader
+    /// boundaries.  Leaf predicate pushdown can leave either a bare scan or a
+    /// cop `Selection` over one; both are TiKV tasks in the physical plan,
+    /// while the merge itself remains a root executor.
+    pub(crate) fn join_scan_readers(&mut self) {
+        fn reader(mut child: PlanNode) -> PlanNode {
+            let scan_name = if matches!(
+                child.name,
+                "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
+            ) {
+                Some(child.name)
+            } else if child.name == "Selection"
+                && child.children.len() == 1
+                && matches!(
+                    child.children[0].name,
+                    "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
+                )
+            {
+                Some(child.children[0].name)
+            } else {
+                None
+            };
+            let Some(scan_name) = scan_name else {
+                return child;
+            };
+            fn mark_cop(node: &mut PlanNode) {
+                node.task = "cop[tikv]";
+                for child in &mut node.children {
+                    mark_cop(child);
+                }
+            }
+            mark_cop(&mut child);
+            let reader = if matches!(scan_name, "IndexFullScan" | "IndexRangeScan") {
+                "IndexReader"
+            } else {
+                "TableReader"
+            };
+            let estimate = child.est_rows;
+            let act_rows = child.act_rows.clone();
+            let key_ndv_ratio = child.key_ndv_ratio;
+            let mut root = PlanNode::new(
+                reader,
+                estimate,
+                String::new(),
+                if reader == "IndexReader" {
+                    format!("index:{}", child.name)
+                } else {
+                    format!("data:{}", child.name)
+                },
+            );
+            root.act_rows = act_rows;
+            root.key_ndv_ratio = key_ndv_ratio;
+            root.children.push(child);
+            root
+        }
+
+        if self.stack.len() < 2 {
+            return;
+        }
+        let right = reader(self.stack.pop().expect("two join children"));
+        let left = reader(self.stack.pop().expect("two join children"));
+        self.stack.push(left);
+        self.stack.push(right);
+    }
+
+    /// Marks the committed scan as preserving the access order requested by
+    /// the physical property. The executor accepted the same offer before
+    /// this is called, so the annotation describes real row order.
+    pub(crate) fn keep_order(&mut self) -> bool {
+        let Some(scan) = self.stack.last_mut() else {
+            return false;
+        };
+        if !matches!(
+            scan.name,
+            "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
+        ) || !scan.info.contains("keep order:false")
+        {
+            return false;
+        }
+        scan.info = scan.info.replacen("keep order:false", "keep order:true", 1);
+        true
+    }
+
+    /// Moves a bare scan and a global partial StreamAgg into the TiKV task,
+    /// leaving the root reader above it. This is the physical split Go picks
+    /// for high-estimate Sysbench `COUNT`/`SUM` ranges.
+    pub(crate) fn partial_stream_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        sum: bool,
+    ) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        let reader = match scan.name {
+            "TableFullScan" | "TableRangeScan" => "TableReader",
+            "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+            _ => {
+                self.stack.push(scan);
+                return false;
+            }
+        };
+        let argument = select.fields.fields().iter().find_map(|field| match field {
+            tidb_ast::SelectField::Expr {
+                expr: tidb_ast::Expr::Aggregate { args, .. },
+                ..
+            } => args.first(),
+            _ => None,
+        });
+        let Some(argument) = argument else {
+            self.stack.push(scan);
+            return false;
+        };
+        scan.task = "cop[tikv]";
+        let act_rows = scan.act_rows.clone();
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "StreamAgg",
+            Some(1.0),
+            String::new(),
+            format!(
+                "funcs:{}({})->Column#0",
+                if sum { "sum" } else { "count" },
+                qualify.expr(argument)
+            ),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(scan);
+
+        let mut reader_node = PlanNode::new(
+            reader,
+            Some(1.0),
+            String::new(),
+            if reader == "TableReader" {
+                "data:StreamAgg".to_owned()
+            } else {
+                "index:StreamAgg".to_owned()
+            },
+        );
+        reader_node.key_ndv_ratio = key_ndv_ratio;
+        reader_node.act_rows = act_rows;
+        reader_node.children.push(partial);
+        self.stack.push(reader_node);
+        true
+    }
+
+    /// Moves a one-column grouping stage below the reader. The root HashAgg
+    /// still deduplicates keys that different regions emitted.
+    pub(crate) fn partial_hash_agg(
+        &mut self,
+        fields: &[tidb_ast::SelectField],
+        qualify: &Qualifier<'_>,
+    ) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        let reader = match scan.name {
+            "TableFullScan" | "TableRangeScan" => "TableReader",
+            "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+            _ => {
+                self.stack.push(scan);
+                return false;
+            }
+        };
+        let estimate = Est::ScaleFloorOne(DISTINCT_FACTOR).apply(scan.est_rows);
+        let projected = field_list(fields, qualify);
+        scan.task = "cop[tikv]";
+        let act_rows = scan.act_rows.clone();
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "HashAgg",
+            estimate,
+            String::new(),
+            format!("group by:{projected},"),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(scan);
+
+        let mut reader_node = PlanNode::new(
+            reader,
+            estimate,
+            String::new(),
+            if reader == "TableReader" {
+                "data:HashAgg".to_owned()
+            } else {
+                "index:HashAgg".to_owned()
+            },
+        );
+        reader_node.key_ndv_ratio = key_ndv_ratio;
+        reader_node.act_rows = act_rows;
+        reader_node.children.push(partial);
+        self.stack.push(reader_node);
+        true
+    }
+
+    /// Moves a one-key, one-SUM partial HashAgg below the table reader.  The
+    /// estimate is derived from the logical DataSource rows rather than the
+    /// access scan's lower-bound-adjusted rows, matching Go's aggregation
+    /// statistics pipeline.
+    pub(crate) fn partial_grouped_sum(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        logical_rows: Option<f64>,
+    ) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        if !matches!(scan.name, "TableFullScan" | "TableRangeScan") {
+            self.stack.push(scan);
+            return false;
+        }
+        let Some(group) = select.group_by.first() else {
+            self.stack.push(scan);
+            return false;
+        };
+        let Some(sum_argument) = select.fields.fields().iter().find_map(|field| match field {
+            tidb_ast::SelectField::Expr {
+                expr: tidb_ast::Expr::Aggregate { name, args, .. },
+                ..
+            } if name.eq_ignore_ascii_case("SUM") => args.first(),
+            _ => None,
+        }) else {
+            self.stack.push(scan);
+            return false;
+        };
+
+        let estimate = logical_rows
+            .map(|rows| (rows * DISTINCT_FACTOR).max(1.0))
+            .or_else(|| Est::ScaleFloorOne(DISTINCT_FACTOR).apply(scan.est_rows));
+        let group = qualify.expr(&group.expr);
+        let sum_argument = qualify.expr(sum_argument);
+        scan.task = "cop[tikv]";
+        let act_rows = scan.act_rows.clone();
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "HashAgg",
+            estimate,
+            String::new(),
+            format!("group by:{group}, funcs:sum({sum_argument})->Column#0"),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(scan);
+
+        let mut reader = PlanNode::new(
+            "TableReader",
+            estimate,
+            String::new(),
+            "data:HashAgg".to_owned(),
+        );
+        reader.key_ndv_ratio = key_ndv_ratio;
+        reader.act_rows = act_rows;
+        reader.children.push(partial);
+        self.stack.push(reader);
+        true
+    }
+
+    /// Moves an ordered grouped partial StreamAgg below its reader. The
+    /// executor negotiated the same partial package with the scan before this
+    /// trace mutation, so the root/cop boundary describes work TiKV actually
+    /// performs.
+    pub(crate) fn partial_grouped_stream_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        let reader = match scan.name {
+            "TableFullScan" | "TableRangeScan" => "TableReader",
+            "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+            _ => {
+                self.stack.push(scan);
+                return false;
+            }
+        };
+        let estimate = Est::Scale(DISTINCT_FACTOR).apply(scan.est_rows);
+        scan.task = "cop[tikv]";
+        let act_rows = scan.act_rows.clone();
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "StreamAgg",
+            estimate,
+            String::new(),
+            grouped_aggregate_info(select, qualify, false, false),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(scan);
+
+        let mut reader_node = PlanNode::new(
+            reader,
+            estimate,
+            String::new(),
+            if reader == "TableReader" {
+                "data:StreamAgg".to_owned()
+            } else {
+                "index:StreamAgg".to_owned()
+            },
+        );
+        reader_node.key_ndv_ratio = key_ndv_ratio;
+        reader_node.act_rows = act_rows;
+        reader_node.children.push(partial);
+        self.stack.push(reader_node);
+        true
+    }
+
+    /// Root merger for [`Self::partial_grouped_stream_agg`]. Go keeps the
+    /// original function names in EXPLAIN even though final-mode COUNT adds
+    /// the partial count columns internally.
+    pub(crate) fn final_grouped_stream_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        self.wrap(
+            "StreamAgg",
+            Est::Inherit,
+            grouped_aggregate_info(select, qualify, true, true),
+        );
+    }
+
+    /// The root final stage for [`Self::partial_grouped_sum`].
+    pub(crate) fn final_grouped_sum_hash_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        let Some(group) = select.group_by.first() else {
+            self.refuse("grouped SUM final stage has no group key");
+            return;
+        };
+        let group = qualify.expr(&group.expr);
+        self.wrap(
+            "HashAgg",
+            Est::Inherit,
+            format!(
+                "group by:{group}, funcs:sum(Column#0)->Column#1, funcs:firstrow({group})->{group}"
+            ),
+        );
+    }
+
+    /// The select-order projection above a grouped SUM final stage.
+    pub(crate) fn grouped_sum_projection(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        let Some(group) = select.group_by.first() else {
+            self.refuse("grouped SUM projection has no group key");
+            return;
+        };
+        self.wrap(
+            "Projection",
+            Est::Inherit,
+            format!("{}, Column#1", qualify.expr(&group.expr)),
+        );
+    }
+
     /// Rewrites the inner side's scan node into the range read an index join
     /// decided per outer key: Go's `IndexRangeScan`/`TableRangeScan` with
     /// `range: decided by [...]` instead of a literal interval.
@@ -706,12 +1175,16 @@ impl PlanTrace {
         access: String,
         range_info: &str,
         index: bool,
+        filters: &[String],
+        filter_selectivity: f64,
     ) -> Result<(), ()> {
         let depth = self.stack.len();
         if depth < 2 {
             return Err(());
         }
         let at = if lookup_is_left { depth - 2 } else { depth - 1 };
+        let outer_at = if lookup_is_left { depth - 1 } else { depth - 2 };
+        let outer_rows = self.stack[outer_at].est_rows;
         let node = &mut self.stack[at];
         // The decision only ever names a bare base table, so its child
         // subtree is the single scan node `build_from` pushed for it. Anything
@@ -738,6 +1211,88 @@ impl PlanTrace {
         };
         node.access = access;
         node.info = format!("range: decided by {range_info}, keep order:false{pseudo}");
+
+        // One dynamic range is opened per outer row. Go derives the table
+        // scan's cardinality from that probe population, not from the inner
+        // table's earlier constant-only access path.
+        node.est_rows = outer_rows.or(node.est_rows);
+
+        // Rebuild the two physical reader boundaries now that the strategy is
+        // committed. Both leaves were built before the join family was known,
+        // so they still sit on the stack as bare scans at this point.
+        let mut right = self.stack.pop().ok_or(())?;
+        let mut left = self.stack.pop().ok_or(())?;
+        let inner = if lookup_is_left {
+            &mut left
+        } else {
+            &mut right
+        };
+        if !filters.is_empty() {
+            let estimate = inner
+                .est_rows
+                .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0));
+            let mut selection =
+                PlanNode::new("Selection", estimate, String::new(), filters.join(", "));
+            selection.task = "cop[tikv]";
+            selection.act_rows = inner.act_rows.clone();
+            selection.key_ndv_ratio = inner.key_ndv_ratio;
+            inner.task = "cop[tikv]";
+            selection.children.push(std::mem::replace(
+                inner,
+                PlanNode::new("TableDual", Some(0.0), String::new(), String::new()),
+            ));
+            *inner = selection;
+        }
+
+        fn reader(mut child: PlanNode, forced_index: Option<bool>) -> PlanNode {
+            let reader = forced_index.map_or_else(
+                || match child.name {
+                    "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+                    _ => "TableReader",
+                },
+                |index| if index { "IndexReader" } else { "TableReader" },
+            );
+            fn mark_cop(node: &mut PlanNode) {
+                node.task = "cop[tikv]";
+                for child in &mut node.children {
+                    mark_cop(child);
+                }
+            }
+            mark_cop(&mut child);
+            let estimate = child.est_rows;
+            let act_rows = child.act_rows.clone();
+            let key_ndv_ratio = child.key_ndv_ratio;
+            let info = if reader == "IndexReader" {
+                format!("index:{}", child.name)
+            } else {
+                format!("data:{}", child.name)
+            };
+            let mut reader_node = PlanNode::new(reader, estimate, String::new(), info);
+            reader_node.act_rows = act_rows;
+            reader_node.key_ndv_ratio = key_ndv_ratio;
+            reader_node.children.push(child);
+            reader_node
+        }
+
+        if lookup_is_left {
+            left = reader(left, Some(index));
+            if matches!(
+                right.name,
+                "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
+            ) {
+                right = reader(right, None);
+            }
+        } else {
+            right = reader(right, Some(index));
+            if matches!(
+                left.name,
+                "TableFullScan" | "TableRangeScan" | "IndexFullScan" | "IndexRangeScan"
+            ) {
+                left = reader(left, None);
+            }
+        }
+        self.stack.push(left);
+        self.stack.push(right);
         Ok(())
     }
 
@@ -814,6 +1369,44 @@ impl PlanTrace {
         self.wrap("Selection", est, qualify.expr(predicate));
     }
 
+    /// A Selection whose child projection has eliminated source names. The
+    /// executable expression already contains both the internal column
+    /// offsets and comparison casts Go prints, so EXPLAIN renders that same
+    /// expression instead of reconstructing the written predicate.
+    pub(crate) fn physical_selection(
+        &mut self,
+        predicate: &Expression,
+        written: &tidb_ast::Expr,
+        stats_selectivity: Option<f64>,
+    ) -> bool {
+        let Some(info) = physical_expression_text(predicate) else {
+            return false;
+        };
+        let est = if self.consumed {
+            Est::Inherit
+        } else {
+            Est::Scale(stats_selectivity.unwrap_or_else(|| pseudo_selectivity(written)))
+        };
+        self.wrap("Selection", est, info);
+        true
+    }
+
+    /// A residual `Selection` above an access range. The range estimate has
+    /// priced only its access conditions, so this predicate must reduce that
+    /// estimate once, with Go's one-row physical-plan floor.
+    pub(crate) fn residual_selection(
+        &mut self,
+        predicate: &tidb_ast::Expr,
+        qualify: &Qualifier<'_>,
+        stats_selectivity: Option<f64>,
+    ) {
+        self.wrap(
+            "Selection",
+            Est::ScaleFloorOne(stats_selectivity.unwrap_or_else(|| pseudo_selectivity(predicate))),
+            qualify.expr(predicate),
+        );
+    }
+
     /// The one-phase aggregate this tier builds for `GROUP BY` / an
     /// aggregate select field.
     pub(crate) fn hash_agg(&mut self, select: &tidb_ast::SelectStmt, qualify: &Qualifier<'_>) {
@@ -847,6 +1440,191 @@ impl PlanTrace {
             Est::Scale(DISTINCT_FACTOR)
         };
         self.wrap("HashAgg", est, info);
+    }
+
+    /// A one-phase grouped StreamAgg whose child already delivers the written
+    /// group-key order.
+    pub(crate) fn grouped_stream_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        input_projection: bool,
+        logical_rows: Option<f64>,
+        physical_info: Option<&str>,
+    ) {
+        self.wrap(
+            "StreamAgg",
+            logical_rows.map_or_else(
+                || {
+                    if input_projection {
+                        Est::Inherit
+                    } else {
+                        Est::Scale(DISTINCT_FACTOR)
+                    }
+                },
+                Est::Fixed,
+            ),
+            physical_info.map_or_else(
+                || grouped_aggregate_info(select, qualify, false, true),
+                str::to_owned,
+            ),
+        );
+    }
+
+    /// Restores the written select-field order above a top-level physical
+    /// grouped StreamAgg whose aggregate results precede its FIRST_ROW group
+    /// carriers. A derived table can eliminate this projection and map its
+    /// relation directly onto the same aggregation schema.
+    pub(crate) fn grouped_stream_output_projection(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        let mut next_aggregate = 0;
+        let fields = select
+            .fields
+            .fields()
+            .iter()
+            .filter_map(|field| match field {
+                tidb_ast::SelectField::Expr {
+                    expr: tidb_ast::Expr::Aggregate { .. },
+                    ..
+                } => {
+                    let column = format!("Column#{next_aggregate}");
+                    next_aggregate += 1;
+                    Some(column)
+                }
+                tidb_ast::SelectField::Expr { expr, .. } => Some(qualify.expr(expr)),
+                tidb_ast::SelectField::Wildcard(_) => None,
+            })
+            .collect::<Vec<_>>();
+        self.wrap("Projection", Est::Inherit, fields.join(", "));
+    }
+
+    /// The compact projection Go injects between a complex ordered source and
+    /// its grouped StreamAgg: group keys first, then unique aggregate inputs.
+    pub(crate) fn grouped_stream_input_projection(
+        &mut self,
+        expressions: &[String],
+        injected_for_scalar: bool,
+    ) {
+        let info = if injected_for_scalar {
+            expressions
+                .iter()
+                .enumerate()
+                .map(|(index, expression)| format!("{expression}->Column#{index}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        } else {
+            expressions.join(", ")
+        };
+        self.wrap("Projection", Est::Inherit, info);
+    }
+
+    /// The root projection that evaluates scalar expressions over aggregate
+    /// result columns. Go lowers each aggregate call to a `Column#N` first;
+    /// only the remaining arithmetic/cast/function expression lives here.
+    pub(crate) fn aggregate_projection(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        let mut next_aggregate = 0;
+        let fields = select
+            .fields
+            .fields()
+            .iter()
+            .filter_map(|field| match field {
+                tidb_ast::SelectField::Expr { expr, .. }
+                    if !matches!(expr, tidb_ast::Expr::Aggregate { .. }) =>
+                {
+                    Some(post_aggregate_expr(expr, qualify, &mut next_aggregate))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if !fields.is_empty() {
+            self.wrap("Projection", Est::Inherit, fields.join(", "));
+        }
+    }
+
+    /// The root projection Go inserts before an integer `SUM`, converting the
+    /// integer argument to the exact DECIMAL input domain consumed by SUM.
+    pub(crate) fn sum_cast_projection(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        precision: i64,
+    ) {
+        let argument = select.fields.fields().iter().find_map(|field| match field {
+            tidb_ast::SelectField::Expr {
+                expr: tidb_ast::Expr::Aggregate { name, args, .. },
+                ..
+            } if name.eq_ignore_ascii_case("SUM") => args.first(),
+            _ => None,
+        });
+        let Some(argument) = argument else {
+            self.refuse("integer SUM projection has no source argument");
+            return;
+        };
+        self.wrap(
+            "Projection",
+            Est::Inherit,
+            format!(
+                "cast({}, decimal({precision},0) BINARY)->Column#0",
+                qualify.expr(argument)
+            ),
+        );
+    }
+
+    /// A global root StreamAgg over the single aggregate selected by the
+    /// Sysbench range plans. `projected` names the cast projection's output;
+    /// COUNT reads its source column directly.
+    pub(crate) fn stream_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        projected: bool,
+    ) {
+        let aggregate = select.fields.fields().iter().find_map(|field| match field {
+            tidb_ast::SelectField::Expr {
+                expr:
+                    tidb_ast::Expr::Aggregate {
+                        name,
+                        distinct,
+                        args,
+                    },
+                ..
+            } => Some((name, *distinct, args.first())),
+            _ => None,
+        });
+        let Some((name, distinct, argument)) = aggregate else {
+            self.refuse("stream aggregation has no aggregate expression");
+            return;
+        };
+        let input = if projected {
+            "Column#0".to_owned()
+        } else {
+            fn without_parens(mut expr: &tidb_ast::Expr) -> &tidb_ast::Expr {
+                while let tidb_ast::Expr::Paren(inner) = expr {
+                    expr = inner;
+                }
+                expr
+            }
+            argument.map_or_else(
+                || "1".to_owned(),
+                |argument| qualify.expr(without_parens(argument)),
+            )
+        };
+        self.wrap(
+            "StreamAgg",
+            Est::Fixed(1.0),
+            format!(
+                "funcs:{}({}{input})->Column#0",
+                name.to_ascii_lowercase(),
+                if distinct { "distinct " } else { "" },
+            ),
+        );
     }
 
     /// Go `util.ExplainByItems`: the by-item list a `Sort` or a `TopN` prints.
@@ -893,16 +1671,268 @@ impl PlanTrace {
         );
     }
 
+    /// Pushes an already-accepted ordered scan cap into TiKV and leaves the
+    /// corresponding reader boundary above it. The root Limit is recorded
+    /// separately by [`Self::limit`], exactly as Go keeps both stages.
+    pub(crate) fn pushed_limit_reader(&mut self, offset: u64, count: u64) -> bool {
+        let Some(mut scan) = self.stack.pop() else {
+            return false;
+        };
+        if !matches!(scan.name, "TableFullScan" | "TableRangeScan") {
+            self.stack.push(scan);
+            return false;
+        }
+        scan.task = "cop[tikv]";
+        let estimate = Est::CapAt(count as f64).apply(scan.est_rows);
+        let act_rows = scan.act_rows.clone();
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "Limit",
+            estimate,
+            String::new(),
+            format!("offset:{offset}, count:{count}"),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(scan);
+
+        let mut reader = PlanNode::new(
+            "TableReader",
+            estimate,
+            String::new(),
+            "data:Limit".to_owned(),
+        );
+        reader.key_ndv_ratio = key_ndv_ratio;
+        reader.act_rows = act_rows;
+        reader.children.push(partial);
+        self.stack.push(reader);
+        true
+    }
+
+    /// Places a bounded sort after an optional pushed Selection in TiKV and
+    /// returns its rows through a TableReader. The root TopN remains above
+    /// this reader and applies the SQL offset/count again, as in Go TiDB.
+    pub(crate) fn pushed_topn_reader(
+        &mut self,
+        order_by: &[tidb_ast::OrderItem],
+        qualify: &Qualifier<'_>,
+        count: u64,
+    ) -> bool {
+        let Some(mut input) = self.stack.pop() else {
+            return false;
+        };
+        let valid = if matches!(input.name, "TableFullScan" | "TableRangeScan") {
+            input.task = "cop[tikv]";
+            true
+        } else if input.name == "Selection" && input.children.len() == 1 {
+            let scan = &mut input.children[0];
+            if matches!(scan.name, "TableFullScan" | "TableRangeScan") {
+                scan.task = "cop[tikv]";
+                input.task = "cop[tikv]";
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !valid {
+            self.stack.push(input);
+            return false;
+        }
+        let estimate = Est::CapAt(count as f64).apply(input.est_rows);
+        let act_rows = input.act_rows.clone();
+        let key_ndv_ratio = input.key_ndv_ratio;
+        let mut partial = PlanNode::new(
+            "TopN",
+            estimate,
+            String::new(),
+            format!(
+                "{}, offset:0, count:{count}",
+                Self::by_items_text(order_by, qualify)
+            ),
+        );
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.children.push(input);
+
+        let mut reader = PlanNode::new(
+            "TableReader",
+            estimate,
+            String::new(),
+            "data:TopN".to_owned(),
+        );
+        reader.key_ndv_ratio = key_ndv_ratio;
+        reader.act_rows = act_rows;
+        reader.children.push(partial);
+        self.stack.push(reader);
+        true
+    }
+
+    /// Go's locking-read marker. Cluster sessions collect the raw keys read
+    /// by the executor and issue the matching pessimistic lock after the
+    /// statement attempt, so this wrapper records that real transaction seam.
+    pub(crate) fn select_lock(&mut self) {
+        self.wrap("SelectLock", Est::Inherit, "for update 0".to_owned());
+    }
+
     /// The projection the driver always builds (divergence 3).
     pub(crate) fn projection(&mut self, fields: &[tidb_ast::SelectField], qualify: &Qualifier<'_>) {
-        self.wrap("Projection", Est::Inherit, field_list(fields, qualify));
+        self.projection_at_rows(fields, qualify, None);
+    }
+
+    /// A projection whose logical data-source estimate differs from the
+    /// physical scan estimate raised by `adjustCountAfterAccess`.
+    pub(crate) fn projection_at_rows(
+        &mut self,
+        fields: &[tidb_ast::SelectField],
+        qualify: &Qualifier<'_>,
+        rows: Option<f64>,
+    ) {
+        self.wrap(
+            "Projection",
+            rows.map_or(Est::Inherit, Est::Fixed),
+            field_list(fields, qualify),
+        );
+    }
+
+    /// Records a simple projection executed by the TiKV request and the
+    /// TableReader boundary that returns it to the root task. The source has
+    /// already accepted the matching kept-column list, so these nodes
+    /// describe the pushed execution rather than changing EXPLAIN alone.
+    pub(crate) fn cop_table_projection(
+        &mut self,
+        fields: &[tidb_ast::SelectField],
+        qualify: &Qualifier<'_>,
+        logical_rows: Option<f64>,
+    ) {
+        let Some(mut scan) = self.stack.pop() else {
+            return;
+        };
+        scan.task = "cop[tikv]";
+        let estimate = logical_rows.or(scan.est_rows);
+        let key_ndv_ratio = scan.key_ndv_ratio;
+        let act_rows = scan.act_rows.clone();
+
+        let mut projection = PlanNode::new(
+            "Projection",
+            estimate,
+            String::new(),
+            field_list(fields, qualify),
+        );
+        projection.task = "cop[tikv]";
+        projection.key_ndv_ratio = key_ndv_ratio;
+        projection.act_rows = act_rows.clone();
+        projection.children.push(scan);
+
+        let mut reader = PlanNode::new(
+            "TableReader",
+            estimate,
+            String::new(),
+            "data:Projection".to_owned(),
+        );
+        reader.key_ndv_ratio = key_ndv_ratio;
+        reader.act_rows = act_rows;
+        reader.children.push(projection);
+        self.stack.push(reader);
+    }
+
+    /// Places an access-path residual Selection and the scan's accepted
+    /// column projection in the TiKV task, then returns them through a table
+    /// reader. The executor has already pushed the same residual into the
+    /// scan and pruned its output schema before this method is called.
+    pub(crate) fn cop_selection_projection_reader(
+        &mut self,
+        fields: &[tidb_ast::SelectField],
+        qualify: &Qualifier<'_>,
+    ) -> bool {
+        let Some(mut selection) = self.stack.pop() else {
+            return false;
+        };
+        if selection.name != "Selection" || selection.children.len() != 1 {
+            self.stack.push(selection);
+            return false;
+        }
+        let mut scan = selection.children.pop().expect("one Selection child");
+        if !matches!(scan.name, "TableFullScan" | "TableRangeScan") {
+            selection.children.push(scan);
+            self.stack.push(selection);
+            return false;
+        }
+        scan.task = "cop[tikv]";
+        selection.task = "cop[tikv]";
+        selection.children.push(scan);
+        let estimate = selection.est_rows;
+        let act_rows = selection.act_rows.clone();
+        let key_ndv_ratio = selection.key_ndv_ratio;
+
+        let mut projection = PlanNode::new(
+            "Projection",
+            estimate,
+            String::new(),
+            field_list(fields, qualify),
+        );
+        projection.task = "cop[tikv]";
+        projection.key_ndv_ratio = key_ndv_ratio;
+        projection.act_rows = act_rows.clone();
+        projection.children.push(selection);
+
+        let mut reader = PlanNode::new(
+            "TableReader",
+            estimate,
+            String::new(),
+            "data:Projection".to_owned(),
+        );
+        reader.key_ndv_ratio = key_ndv_ratio;
+        reader.act_rows = act_rows;
+        reader.children.push(projection);
+        self.stack.push(reader);
+        true
     }
 
     /// `SELECT DISTINCT`: Go's `buildDistinct` is an aggregation grouping by
     /// every projected column, so it carries the same NDV assumption.
     pub(crate) fn distinct(&mut self, fields: &[tidb_ast::SelectField], qualify: &Qualifier<'_>) {
-        let info = format!("group by:{}, funcs:firstrow", field_list(fields, qualify));
-        self.wrap("HashAgg", Est::Scale(DISTINCT_FACTOR), info);
+        let projected = field_list(fields, qualify);
+        let funcs = fields
+            .iter()
+            .filter_map(|field| match field {
+                tidb_ast::SelectField::Expr { expr, .. } => {
+                    let text = qualify.expr(expr);
+                    Some(format!("firstrow({text})->{text}"))
+                }
+                tidb_ast::SelectField::Wildcard(_) => None,
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let info = format!("group by:{projected}, funcs:{funcs}");
+        self.wrap("HashAgg", Est::ScaleFloorOne(DISTINCT_FACTOR), info);
+    }
+
+    /// The final distinct stage over already-grouped partial keys. Its row
+    /// estimate is the partial NDV, not that NDV multiplied a second time.
+    pub(crate) fn final_distinct(
+        &mut self,
+        fields: &[tidb_ast::SelectField],
+        qualify: &Qualifier<'_>,
+    ) {
+        let projected = field_list(fields, qualify);
+        let funcs = fields
+            .iter()
+            .filter_map(|field| match field {
+                tidb_ast::SelectField::Expr { expr, .. } => {
+                    let text = qualify.expr(expr);
+                    Some(format!("firstrow({text})->{text}"))
+                }
+                tidb_ast::SelectField::Wildcard(_) => None,
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.wrap(
+            "HashAgg",
+            Est::Inherit,
+            format!("group by:{projected}, funcs:{funcs}"),
+        );
     }
 
     /// `LIMIT [offset,] count`, which caps the child's estimate as Go's does.
@@ -983,11 +2013,9 @@ impl PlanTrace {
         if let Some(keys) = &merge_keys {
             // `left key:%s, right key:%s` over `ExplainColumnList`, which
             // prints the LEFT child's keys and then the RIGHT child's, each
-            // comma-separated -- not pairwise. The residual `ON` conjuncts
-            // this tier still evaluates are NOT printed as `other cond:`,
-            // because Go moved the USED equal conditions out of that list and
-            // this tier keeps them (see `crate::join`); printing them would
-            // report conditions Go's plan does not carry.
+            // comma-separated -- not pairwise. Equal conditions used as merge
+            // keys are represented by those lists; a non-equality condition
+            // remains visible below as `other cond:`.
             tail.push_str(", left key:");
             tail.push_str(
                 &keys
@@ -1006,9 +2034,8 @@ impl PlanTrace {
             );
         } else if let Some(text) = &index_lookup {
             // Go `PhysicalIndexJoin.explainInfo`: the reader, then the two
-            // key lists, then the equal conditions spelled in full. The
-            // residual `ON` conjuncts this tier still evaluates are not
-            // printed, for the same reason the merge arm does not print them.
+            // key lists, then the equal conditions spelled in full. A
+            // non-equality condition remains visible below as `other cond:`.
             tail.push_str(", inner:");
             tail.push_str(text.reader);
             tail.push_str(", outer key:");
@@ -1029,9 +2056,16 @@ impl PlanTrace {
                     .collect::<Vec<_>>()
                     .join(", "),
             );
-            if !equal.is_empty() {
+            if !text.keys.is_empty() {
                 tail.push_str(", equal cond:");
-                tail.push_str(&equal.join(", "));
+                tail.push_str(
+                    &text
+                        .keys
+                        .iter()
+                        .map(|(outer, inner)| format!("eq({outer}, {inner})"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
             }
         } else {
             if !equal.is_empty() {
@@ -1039,10 +2073,10 @@ impl PlanTrace {
                 tail.push_str(&equal.join(" "));
                 tail.push(']');
             }
-            if !other.is_empty() {
-                tail.push_str(", other cond:");
-                tail.push_str(&other.join(", "));
-            }
+        }
+        if !other.is_empty() {
+            tail.push_str(", other cond:");
+            tail.push_str(&other.join(", "));
         }
         let (Some(mut right), Some(mut left)) = (self.stack.pop(), self.stack.pop()) else {
             return Err(());
@@ -1051,7 +2085,17 @@ impl PlanTrace {
         // (`flat_plan.go`'s `BuildSide`/`ProbeSide`).
         left.label = if build_is_left { "(Build)" } else { "(Probe)" };
         right.label = if build_is_left { "(Probe)" } else { "(Build)" };
-        let est_rows = full_join_row_count(&left, &right, equal.len());
+        let est_rows = index_lookup
+            .as_ref()
+            .filter(|text| text.unique)
+            .and_then(|text| {
+                if text.lookup_is_left {
+                    right.est_rows
+                } else {
+                    left.est_rows
+                }
+            })
+            .or_else(|| full_join_row_count(&left, &right, equal.len()));
         // Which index-join executor this site's row names, decided by the one
         // cost term that differs between them (`index_join_operator`).
         //
@@ -1069,7 +2113,9 @@ impl PlanTrace {
             let probe_rows_one = est_rows
                 .zip(build_rows)
                 .map(|(equal_cond_out, rows)| equal_cond_out / rows);
-            index_join_operator(build_rows, probe_rows_one, text, equal.len())
+            text.forced_name.unwrap_or_else(|| {
+                index_join_operator(build_rows, probe_rows_one, text, equal.len())
+            })
         });
         let children = if build_is_left {
             vec![left, right]
@@ -1094,6 +2140,7 @@ impl PlanTrace {
             est_rows,
             access: String::new(),
             info,
+            task: "root",
             // `explainJoinLeftSide` names the LEFT child's operator, and only
             // for an OUTER join. The name carries its own id in `format='row'`,
             // which is not assigned yet, so the renderer splices it in.
@@ -1124,7 +2171,10 @@ impl PlanTrace {
         // Of the two errors this is the smaller -- for
         // `t1.a = t2.a and t1.b > 5` it prints 12500.00 against TiDB's
         // 4162.50, where charging the equality twice would print 4.16.
-        self.consumed |= !pushed.is_empty();
+        // A join is a new predicate boundary. Access conditions consumed by
+        // either child must not suppress selectivity of a different residual
+        // predicate above the joined rows.
+        self.consumed = !pushed.is_empty();
         Ok(())
     }
 
@@ -1180,6 +2230,137 @@ fn field_list(fields: &[tidb_ast::SelectField], qualify: &Qualifier<'_>) -> Stri
     rendered.join(", ")
 }
 
+/// The physical-expression subset currently needed after derived aggregate
+/// projection elimination. Unsupported nodes are refused by the caller; a
+/// fallback to AST text would describe a different expression than the one
+/// the Selection executor evaluates.
+fn physical_expression_text(expression: &Expression) -> Option<String> {
+    match expression {
+        Expression::Column(column) => Some(format!("Column#{}", column.index)),
+        Expression::ScalarFunction(function) => {
+            let arguments = function
+                .args
+                .iter()
+                .map(physical_expression_text)
+                .collect::<Option<Vec<_>>>()?;
+            if function.func_name.lowercase() == "cast_decimal" {
+                if arguments.len() != 1 {
+                    return None;
+                }
+                let result_type = function.ret_type.as_ref()?;
+                Some(format!(
+                    "cast({}, decimal({},{}) BINARY)",
+                    arguments[0],
+                    result_type.flen(),
+                    result_type.decimal()
+                ))
+            } else {
+                Some(format!(
+                    "{}({})",
+                    function.func_name.lowercase(),
+                    arguments.join(", ")
+                ))
+            }
+        }
+        Expression::Constant(_) | Expression::CorrelatedColumn(_) => None,
+    }
+}
+
+fn aggregate_exprs(expr: &tidb_ast::Expr) -> Vec<tidb_ast::Expr> {
+    struct Collect(Vec<tidb_ast::Expr>);
+    impl tidb_ast::Visitor for Collect {
+        fn enter(&mut self, node: &mut dyn std::any::Any) -> bool {
+            if let Some(expr @ tidb_ast::Expr::Aggregate { .. }) =
+                node.downcast_ref::<tidb_ast::Expr>()
+            {
+                self.0.push(expr.clone());
+            }
+            false
+        }
+
+        fn leave(&mut self, _node: &mut dyn std::any::Any) -> bool {
+            true
+        }
+    }
+
+    let mut collect = Collect(Vec::new());
+    let mut owned = expr.clone();
+    tidb_ast::Visitable::accept(&mut owned, &mut collect);
+    collect.0
+}
+
+fn grouped_aggregate_info(
+    select: &tidb_ast::SelectStmt,
+    qualify: &Qualifier<'_>,
+    partial_inputs: bool,
+    include_first_row: bool,
+) -> String {
+    let groups = select
+        .group_by
+        .iter()
+        .map(|item| qualify.expr(&item.expr))
+        .collect::<Vec<_>>();
+    let mut functions = Vec::new();
+    let mut aggregate_index = 0;
+    for field in select.fields.fields() {
+        let tidb_ast::SelectField::Expr { expr, .. } = field else {
+            continue;
+        };
+        for aggregate in aggregate_exprs(expr) {
+            let tidb_ast::Expr::Aggregate {
+                name,
+                distinct,
+                args,
+            } = aggregate
+            else {
+                unreachable!("aggregate_exprs returns only aggregates");
+            };
+            let input = if partial_inputs {
+                format!("Column#{aggregate_index}")
+            } else {
+                args.first()
+                    .map_or_else(|| "1".to_owned(), |arg| qualify.expr(arg))
+            };
+            let name = name.to_ascii_lowercase();
+            functions.push(format!(
+                "funcs:{name}({}{input})->Column#{aggregate_index}",
+                if distinct { "distinct " } else { "" },
+            ));
+            aggregate_index += 1;
+        }
+    }
+    if include_first_row {
+        for field in select.fields.fields() {
+            let tidb_ast::SelectField::Expr { expr, .. } = field else {
+                continue;
+            };
+            if let tidb_ast::Expr::Column(path) = expr {
+                let text = qualify.expr(expr);
+                if select.group_by.iter().any(
+                    |item| matches!(&item.expr, tidb_ast::Expr::Column(group) if group == path),
+                ) {
+                    functions.push(format!("funcs:firstrow({text})->{text}"));
+                }
+            }
+        }
+    }
+    format!("group by:{}, {}", groups.join(", "), functions.join(", "))
+}
+
+fn post_aggregate_expr(
+    expr: &tidb_ast::Expr,
+    qualify: &Qualifier<'_>,
+    next_aggregate: &mut usize,
+) -> String {
+    let mut rendered = qualify.expr(expr);
+    for aggregate in aggregate_exprs(expr) {
+        let aggregate_text = qualify.expr(&aggregate);
+        rendered = rendered.replacen(&aggregate_text, &format!("Column#{}", *next_aggregate), 1);
+        *next_aggregate += 1;
+    }
+    format!("{rendered}->Column#{}", *next_aggregate)
+}
+
 /// Counts the rows its child really produced, without touching them.
 ///
 /// This is how `EXPLAIN ANALYZE`'s `actRows` is measured: the trace wraps
@@ -1232,6 +2413,10 @@ impl Executor for CountExec {
         self.child.table_access()
     }
 
+    fn consumes_where(&self) -> bool {
+        self.child.consumes_where()
+    }
+
     /// The same reason, for the same reason: Go's `aggExecutorTreeInputEmpty`
     /// walks THROUGH a single-child operator, and a meter is exactly that.
     fn agg_tree_input_empty(&self) -> bool {
@@ -1246,6 +2431,30 @@ fn handle_text(handle: &TableHandle) -> String {
         // datums, which needs the handle codec this printer does not carry.
         TableHandle::Common(_) => "<common handle>".to_owned(),
     }
+}
+
+/// Go identifies a common-handle point access by its clustered primary
+/// index. The encoded handle bytes are deliberately absent from operator
+/// info; unlike integer handles, Go does not render them there.
+fn common_handle_access(visible: &str, table: &KvTable, partitions: &[String]) -> Option<String> {
+    let offsets = table.common_handle_offsets();
+    if offsets.is_empty() {
+        return None;
+    }
+    let columns = offsets
+        .iter()
+        .map(|offset| {
+            table
+                .columns
+                .get(*offset)
+                .map(|column| column.name.as_str())
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(format!(
+        "table:{visible}{}, clustered index:PRIMARY({})",
+        partition_object(partitions),
+        columns.join(", ")
+    ))
 }
 
 /// Go's range notation: a square bracket includes the bound, a parenthesis
@@ -1474,6 +2683,11 @@ pub(crate) struct IndexJoinText {
     /// built over the outer side for `IndexHashJoin` and over the inner one
     /// for `IndexJoin`.
     pub(crate) lookup_is_left: bool,
+    /// Whether one complete probe tuple can return at most one inner row.
+    pub(crate) unique: bool,
+    /// The exact index-family executor a statement hint forced, or `None`
+    /// when Go's coster chooses between the lookup variants.
+    pub(crate) forced_name: Option<&'static str>,
     /// `getAvgRowSize(build.StatsInfo(), build.Schema().Columns)` for the
     /// OUTER side, and the same for the INNER one. Computed where the two
     /// sides' column types are known (`driver::from::build_join`), because a
@@ -1582,6 +2796,10 @@ fn index_join_operator(
 }
 
 pub(crate) fn collect_and<'a>(expr: &'a tidb_ast::Expr, out: &mut Vec<&'a tidb_ast::Expr>) {
+    if let tidb_ast::Expr::Paren(inner) = expr {
+        collect_and(inner, out);
+        return;
+    }
     if let tidb_ast::Expr::Binary(tidb_ast::BinaryOp::LogicAnd, lhs, rhs) = expr {
         collect_and(lhs, out);
         collect_and(rhs, out);
@@ -1601,6 +2819,7 @@ pub(crate) struct Qualifier<'a> {
 impl Qualifier<'_> {
     pub(crate) fn expr(&self, expr: &tidb_ast::Expr) -> String {
         match expr {
+            tidb_ast::Expr::Paren(inner) => self.expr(inner),
             tidb_ast::Expr::Column(path) => self.column(path),
             tidb_ast::Expr::Int(text) => text.clone(),
             tidb_ast::Expr::Decimal(text) => text.clone(),
@@ -1612,6 +2831,22 @@ impl Qualifier<'_> {
                 // rather than mislabelled with an invented function name.
                 None => expr.restore(),
             },
+            tidb_ast::Expr::Unary(
+                tidb_ast::UnaryOp::Not | tidb_ast::UnaryOp::NotKeyword,
+                inner,
+            ) => format!("not({})", self.expr(inner)),
+            tidb_ast::Expr::Is {
+                expr,
+                target: tidb_ast::IsTarget::Null,
+                not,
+            } => {
+                let is_null = format!("isnull({})", self.expr(expr));
+                if *not {
+                    format!("not({is_null})")
+                } else {
+                    is_null
+                }
+            }
             tidb_ast::Expr::Aggregate {
                 name,
                 distinct,
@@ -1684,6 +2919,8 @@ mod tests {
             reader: "IndexReader",
             keys: vec![("a".to_owned(), "b".to_owned())],
             lookup_is_left: false,
+            unique: false,
+            forced_name: None,
             outer_row_size,
             inner_row_size,
         }

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -123,6 +123,15 @@ pub(crate) struct PlanNode {
     /// does not scale with the row count. A join over such a side prints
     /// `N/A` rather than a number derived from the wrong NDV.
     pub(crate) key_ndv_ratio: Option<f64>,
+    /// NDVs retained under their physical source-column names after a join.
+    ///
+    /// Go's `LogicalJoin.DeriveStats` copies each child's column NDV into the
+    /// joined schema without scaling it to the join row count. The one-ratio
+    /// summary above therefore cannot survive a join, but a parent join may
+    /// still need the NDV of the exact column it uses. Keeping only committed
+    /// merge keys is sufficient for that parent and avoids pretending every
+    /// output column has one common ratio.
+    pub(crate) named_key_ndvs: Vec<(String, f64)>,
 }
 
 impl PlanNode {
@@ -139,6 +148,7 @@ impl PlanNode {
             children: Vec::new(),
             act_rows: None,
             key_ndv_ratio: None,
+            named_key_ndvs: Vec::new(),
         }
     }
 
@@ -1796,6 +1806,43 @@ impl PlanTrace {
         );
     }
 
+    /// Records the executable projection after Go's implicit real-argument
+    /// casts have been built into it. Base-table columns retain their source
+    /// names while derived aggregate outputs stay internal `Column#N` values,
+    /// matching projection elimination in Go.
+    ///
+    /// The gate is intentionally narrow: until another build-time cast family
+    /// needs physical rendering, ordinary projections keep the established
+    /// AST printer. This prevents a trace-only rewrite from changing plans
+    /// whose executor tree has no such physical node.
+    pub(crate) fn physical_real_projection(
+        &mut self,
+        expressions: &[Expression],
+        column_names: &[Option<String>],
+        rows: Option<f64>,
+    ) -> bool {
+        if !expressions
+            .iter()
+            .any(|expression| expression_has_function(expression, "cast_double"))
+        {
+            return false;
+        }
+        let Some(info) = expressions
+            .iter()
+            .enumerate()
+            .map(|(index, expression)| {
+                physical_expression_text_with_columns(expression, column_names)
+                    .map(|text| format!("{text}->Column#{index}"))
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(|parts| parts.join(", "))
+        else {
+            return false;
+        };
+        self.wrap("Projection", rows.map_or(Est::Inherit, Est::Fixed), info);
+        true
+    }
+
     /// Records a simple projection executed by the TiKV request and the
     /// TableReader boundary that returns it to the root task. The source has
     /// already accepted the matching kept-column list, so these nodes
@@ -2095,7 +2142,18 @@ impl PlanTrace {
                     left.est_rows
                 }
             })
-            .or_else(|| full_join_row_count(&left, &right, equal.len()));
+            .or_else(|| full_join_row_count(&left, &right, equal.len(), merge_keys.as_deref()));
+        let named_key_ndvs = merge_keys.as_deref().map_or_else(Vec::new, |keys| {
+            keys.iter()
+                .flat_map(|(left_name, right_name)| {
+                    [
+                        node_key_ndv(&left, left_name).map(|ndv| (left_name.clone(), ndv)),
+                        node_key_ndv(&right, right_name).map(|ndv| (right_name.clone(), ndv)),
+                    ]
+                })
+                .flatten()
+                .collect()
+        });
         // Which index-join executor this site's row names, decided by the one
         // cost term that differs between them (`index_join_operator`).
         //
@@ -2154,6 +2212,7 @@ impl PlanTrace {
             // children's maps rather than scaling either one, so the single
             // ratio this trace carries does not survive a join.
             key_ndv_ratio: None,
+            named_key_ndvs,
         });
         // The same rule an access path follows when its range consumed a
         // condition: the join has now PRICED the `WHERE` conjuncts pushed
@@ -2235,13 +2294,24 @@ fn field_list(fields: &[tidb_ast::SelectField], qualify: &Qualifier<'_>) -> Stri
 /// fallback to AST text would describe a different expression than the one
 /// the Selection executor evaluates.
 fn physical_expression_text(expression: &Expression) -> Option<String> {
+    physical_expression_text_with_columns(expression, &[])
+}
+
+fn physical_expression_text_with_columns(
+    expression: &Expression,
+    column_names: &[Option<String>],
+) -> Option<String> {
     match expression {
-        Expression::Column(column) => Some(format!("Column#{}", column.index)),
+        Expression::Column(column) => usize::try_from(column.index)
+            .ok()
+            .and_then(|index| column_names.get(index))
+            .and_then(|name| name.clone())
+            .or_else(|| Some(format!("Column#{}", column.index))),
         Expression::ScalarFunction(function) => {
             let arguments = function
                 .args
                 .iter()
-                .map(physical_expression_text)
+                .map(|argument| physical_expression_text_with_columns(argument, column_names))
                 .collect::<Option<Vec<_>>>()?;
             if function.func_name.lowercase() == "cast_decimal" {
                 if arguments.len() != 1 {
@@ -2254,6 +2324,11 @@ fn physical_expression_text(expression: &Expression) -> Option<String> {
                     result_type.flen(),
                     result_type.decimal()
                 ))
+            } else if function.func_name.lowercase() == "cast_double" {
+                if arguments.len() != 1 {
+                    return None;
+                }
+                Some(format!("cast({}, double BINARY)", arguments[0]))
             } else {
                 Some(format!(
                     "{}({})",
@@ -2262,8 +2337,22 @@ fn physical_expression_text(expression: &Expression) -> Option<String> {
                 ))
             }
         }
+        Expression::Constant(constant) if constant.param_marker.is_none() => {
+            Some(datum_go_text(&constant.value, false))
+        }
         Expression::Constant(_) | Expression::CorrelatedColumn(_) => None,
     }
+}
+
+fn expression_has_function(expression: &Expression, name: &str) -> bool {
+    let Expression::ScalarFunction(function) = expression else {
+        return false;
+    };
+    function.func_name.lowercase() == name
+        || function
+            .args
+            .iter()
+            .any(|argument| expression_has_function(argument, name))
 }
 
 fn aggregate_exprs(expr: &tidb_ast::Expr) -> Vec<tidb_ast::Expr> {
@@ -2614,20 +2703,61 @@ pub(crate) fn pseudo_selectivity_of_conjuncts(conjuncts: &[&tidb_ast::Expr]) -> 
 /// this tier's are 10000, and it prints 12487.50 where this prints 12500.00.
 /// The gap is that missing rewrite, not this arithmetic -- a CARTESIAN join,
 /// which gets no such rewrite, matches TiDB exactly.
-fn full_join_row_count(left: &PlanNode, right: &PlanNode, equal_count: usize) -> Option<f64> {
+fn node_key_ndv(node: &PlanNode, name: &str) -> Option<f64> {
+    node.named_key_ndvs
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+        .map(|(_, ndv)| *ndv)
+        .or_else(|| {
+            node.key_ndv_ratio
+                .zip(node.est_rows)
+                .map(|(ratio, rows)| rows * ratio)
+        })
+}
+
+fn full_join_row_count(
+    left: &PlanNode,
+    right: &PlanNode,
+    equal_count: usize,
+    merge_keys: Option<&[(String, String)]>,
+) -> Option<f64> {
     use tidb_planner::cardinality::join::{
         estimate_full_join_row_count, FullJoinRowCountInput, JoinKeyEstimate,
     };
     let (left_rows, right_rows) = (left.est_rows?, right.est_rows?);
-    let key = |node: &PlanNode| {
-        node.key_ndv_ratio
-            .zip(node.est_rows)
-            .map(|(ratio, rows)| JoinKeyEstimate::new(rows * ratio, 1, equal_count))
+    let key = |node: &PlanNode, left_side: bool| {
+        let named = merge_keys.and_then(|keys| {
+            if keys.len() != equal_count {
+                return None;
+            }
+            keys.iter()
+                .map(|(left_name, right_name)| {
+                    node.named_key_ndvs
+                        .iter()
+                        .find(|(candidate, _)| {
+                            candidate.eq_ignore_ascii_case(if left_side {
+                                left_name
+                            } else {
+                                right_name
+                            })
+                        })
+                        .map(|(_, ndv)| *ndv)
+                })
+                .collect::<Option<Vec<_>>>()
+                .and_then(|ndvs| ndvs.into_iter().reduce(f64::max))
+        });
+        named
+            .or_else(|| {
+                node.key_ndv_ratio
+                    .zip(node.est_rows)
+                    .map(|(ratio, rows)| rows * ratio)
+            })
+            .map(|ndv| JoinKeyEstimate::new(ndv, 1, equal_count))
     };
     let (left_keys, right_keys) = if equal_count == 0 {
         (JoinKeyEstimate::empty(), JoinKeyEstimate::empty())
     } else {
-        (key(left)?, key(right)?)
+        (key(left, true)?, key(right, false)?)
     };
     Some(estimate_full_join_row_count(&FullJoinRowCountInput {
         left_row_count: left_rows,

--- a/rust/crates/tidb-executor/src/plan_trace.rs
+++ b/rust/crates/tidb-executor/src/plan_trace.rs
@@ -1124,6 +1124,82 @@ impl PlanTrace {
         true
     }
 
+    /// Moves an unordered grouped partial HashAgg below its reader. A
+    /// non-covering index keeps the index build scan beside a HashAgg over
+    /// the table probe, exactly where TiKV evaluates the accepted remote
+    /// aggregation request.
+    pub(crate) fn partial_grouped_hash_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        grouped_rows: Option<f64>,
+    ) -> bool {
+        let Some(mut source) = self.stack.pop() else {
+            return false;
+        };
+        let estimate =
+            grouped_rows.or_else(|| Est::ScaleFloorOne(DISTINCT_FACTOR).apply(source.est_rows));
+        let info = grouped_aggregate_info(select, qualify, false, false);
+
+        if source.name == "IndexLookUp" && source.children.len() == 2 {
+            let table_scan = &mut source.children[1];
+            if table_scan.name != "TableRowIDScan" || !table_scan.children.is_empty() {
+                self.stack.push(source);
+                return false;
+            }
+            let label = table_scan.label;
+            table_scan.label = "";
+            table_scan.task = "cop[tikv]";
+            let act_rows = table_scan.act_rows.clone();
+            let mut partial = PlanNode::new("HashAgg", estimate, String::new(), info);
+            partial.task = "cop[tikv]";
+            partial.label = label;
+            partial.act_rows = act_rows;
+            partial.key_ndv_ratio = Some(1.0);
+            partial.children.push(std::mem::replace(
+                table_scan,
+                PlanNode::new("TableDual", Some(0.0), String::new(), String::new()),
+            ));
+            *table_scan = partial;
+            source.est_rows = estimate;
+            source.key_ndv_ratio = Some(1.0);
+            self.stack.push(source);
+            return true;
+        }
+
+        let reader = match source.name {
+            "TableFullScan" | "TableRangeScan" => "TableReader",
+            "IndexFullScan" | "IndexRangeScan" => "IndexReader",
+            _ => {
+                self.stack.push(source);
+                return false;
+            }
+        };
+        source.task = "cop[tikv]";
+        let act_rows = source.act_rows.clone();
+        let mut partial = PlanNode::new("HashAgg", estimate, String::new(), info);
+        partial.task = "cop[tikv]";
+        partial.act_rows = act_rows.clone();
+        partial.key_ndv_ratio = Some(1.0);
+        partial.children.push(source);
+
+        let mut reader_node = PlanNode::new(
+            reader,
+            estimate,
+            String::new(),
+            if reader == "TableReader" {
+                "data:HashAgg".to_owned()
+            } else {
+                "index:HashAgg".to_owned()
+            },
+        );
+        reader_node.act_rows = act_rows;
+        reader_node.key_ndv_ratio = Some(1.0);
+        reader_node.children.push(partial);
+        self.stack.push(reader_node);
+        true
+    }
+
     /// Root merger for [`Self::partial_grouped_stream_agg`]. Go keeps the
     /// original function names in EXPLAIN even though final-mode COUNT adds
     /// the partial count columns internally.
@@ -1134,6 +1210,21 @@ impl PlanTrace {
     ) {
         self.wrap(
             "StreamAgg",
+            Est::Inherit,
+            grouped_aggregate_info(select, qualify, true, true),
+        );
+    }
+
+    /// Root merger for [`Self::partial_grouped_hash_agg`]. Aggregate
+    /// functions read TiKV's partial result columns, while group-key
+    /// FIRST_ROW carriers retain their physical catalog names.
+    pub(crate) fn final_grouped_hash_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+    ) {
+        self.wrap(
+            "HashAgg",
             Est::Inherit,
             grouped_aggregate_info(select, qualify, true, true),
         );
@@ -1202,6 +1293,7 @@ impl PlanTrace {
             index_lookup,
             visible,
             estimated_rows,
+            unique,
             grouped_derived,
             aggregation_info,
             outer_not_null,
@@ -1214,6 +1306,13 @@ impl PlanTrace {
         let at = if lookup_is_left { depth - 2 } else { depth - 1 };
         let outer_at = if lookup_is_left { depth - 1 } else { depth - 2 };
         let outer_rows = self.stack[outer_at].est_rows;
+        let estimated_rows = if unique {
+            outer_rows
+                .map(|rows| rows * filter_selectivity.clamp(0.0, 1.0))
+                .or(estimated_rows)
+        } else {
+            estimated_rows
+        };
         fn is_scan(node: &PlanNode) -> bool {
             matches!(
                 node.name,
@@ -1336,7 +1435,23 @@ impl PlanTrace {
                 ));
                 *scan_holder = selection;
             }
-            lookup.children[1].est_rows = estimated_rows.or(lookup.children[1].est_rows);
+            // The child was first planned as an independent derived table,
+            // where a non-covering index scan may accept a cop partial
+            // HashAgg. An index join does not execute that source: it replaces
+            // it with a re-seeded lookup and rebuilds this grouped aggregation
+            // above the lookup for every outer batch. Drop the superseded
+            // partial stage so the trace describes that executable tree.
+            let table_read = &mut lookup.children[1];
+            if table_read.name == "HashAgg"
+                && table_read.children.len() == 1
+                && table_read.children[0].name == "TableRowIDScan"
+            {
+                let label = table_read.label;
+                let mut scan = table_read.children.pop().expect("one table lookup child");
+                scan.label = label;
+                *table_read = scan;
+            }
+            table_read.est_rows = estimated_rows.or(table_read.est_rows);
             if !inner_not_null.is_empty() {
                 let mut selection = PlanNode::new(
                     "Selection",
@@ -1658,7 +1773,12 @@ impl PlanTrace {
 
     /// The one-phase aggregate this tier builds for `GROUP BY` / an
     /// aggregate select field.
-    pub(crate) fn hash_agg(&mut self, select: &tidb_ast::SelectStmt, qualify: &Qualifier<'_>) {
+    pub(crate) fn hash_agg(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        logical_rows: Option<f64>,
+    ) {
         let mut info = String::new();
         if !select.group_by.is_empty() {
             info.push_str("group by:");
@@ -1685,10 +1805,66 @@ impl PlanTrace {
         let est = if select.group_by.is_empty() {
             // A whole-table aggregate collapses to one row.
             Est::Fixed(1.0)
+        } else if let Some(rows) = logical_rows {
+            Est::Fixed(rows)
         } else {
             Est::Scale(DISTINCT_FACTOR)
         };
         self.wrap("HashAgg", est, info);
+    }
+
+    /// A grouped hash aggregate whose executor states are the decorrelator's
+    /// `FIRST_ROW` carriers and scalar `SUM`s. Rendering the physical states
+    /// preserves Go's base-column identities after projection elimination.
+    pub(crate) fn hash_agg_first_row_sum(
+        &mut self,
+        select: &tidb_ast::SelectStmt,
+        qualify: &Qualifier<'_>,
+        group_by: &[Expression],
+        functions: &[crate::hash_agg::AggFunc],
+        column_names: &[Option<String>],
+        logical_rows: Option<f64>,
+    ) {
+        let groups = group_by
+            .iter()
+            .map(|expression| physical_expression_text_with_columns(expression, column_names))
+            .collect::<Option<Vec<_>>>();
+        let rendered = functions
+            .iter()
+            .enumerate()
+            .map(|(index, function)| {
+                let argument =
+                    physical_expression_text_with_columns(function.arg.as_ref()?, column_names)?;
+                match &function.kind {
+                    crate::hash_agg::AggKind::FirstRow => {
+                        Some(format!("funcs:firstrow({argument})->{argument}"))
+                    }
+                    crate::hash_agg::AggKind::Sum => {
+                        Some(format!("funcs:sum({argument})->Column#{index}"))
+                    }
+                    _ => None,
+                }
+            })
+            .collect::<Option<Vec<_>>>();
+        let (Some(groups), Some(rendered)) = (groups, rendered) else {
+            self.hash_agg(select, qualify, logical_rows);
+            return;
+        };
+        let info = format!("group by:{}, {}", groups.join(", "), rendered.join(", "));
+        self.wrap(
+            "HashAgg",
+            logical_rows.map_or(Est::Scale(DISTINCT_FACTOR), Est::Fixed),
+            info,
+        );
+        if let Some(aggregate) = self.stack.last_mut() {
+            // This decorrelator is admitted only when GROUP BY contains the
+            // outer table's complete non-null unique key. Later scalar SUMs
+            // join on that key (with any omitted member equality-fixed by a
+            // leaf predicate), so the grouped output has one row per join
+            // key. Publish the same unique-key NDV Go derives for the parent
+            // join instead of losing it at the fixed-cardinality boundary.
+            aggregate.key_ndv_ratio = Some(1.0);
+        }
     }
 
     /// A one-phase grouped StreamAgg whose child already delivers the written
@@ -2291,6 +2467,7 @@ impl PlanTrace {
             merge_keys,
             index_lookup,
             physical_conditions,
+            estimated_join_rows,
         } = strategy;
         let build_is_left = *build_is_left;
         let qualify = Qualifier {
@@ -2321,16 +2498,12 @@ impl PlanTrace {
         let mut equal = Vec::new();
         let mut other = Vec::new();
         for (index, (conjunct, is_equal)) in conjuncts.iter().zip(equal_mask.iter()).enumerate() {
-            let rendered = if *is_equal {
-                qualify.expr(conjunct)
-            } else {
-                physical_conditions
-                    .as_ref()
-                    .and_then(|(conditions, columns)| {
-                        physical_expression_text_with_columns(conditions.get(index)?, columns)
-                    })
-                    .unwrap_or_else(|| qualify.expr(conjunct))
-            };
+            let rendered = physical_conditions
+                .as_ref()
+                .and_then(|(conditions, columns)| {
+                    physical_expression_text_with_columns(conditions.get(index)?, columns)
+                })
+                .unwrap_or_else(|| qualify.expr(conjunct));
             if *is_equal {
                 equal.push(rendered);
             } else {
@@ -2433,6 +2606,7 @@ impl PlanTrace {
                     }
                 })
             })
+            .or(*estimated_join_rows)
             .or_else(|| full_join_row_count(&left, &right, equal.len(), merge_keys.as_deref()));
         let named_key_ndvs = merge_keys.as_deref().map_or_else(Vec::new, |keys| {
             keys.iter()
@@ -2677,7 +2851,7 @@ fn grouped_aggregate_info(
         .iter()
         .map(|item| qualify.expr(&item.expr))
         .collect::<Vec<_>>();
-    let mut functions = Vec::new();
+    let mut aggregate_functions = Vec::new();
     let mut aggregate_index = 0;
     for field in select.fields.fields() {
         let tidb_ast::SelectField::Expr { expr, .. } = field else {
@@ -2699,13 +2873,14 @@ fn grouped_aggregate_info(
                     .map_or_else(|| "1".to_owned(), |arg| qualify.expr(arg))
             };
             let name = name.to_ascii_lowercase();
-            functions.push(format!(
+            aggregate_functions.push(format!(
                 "funcs:{name}({}{input})->Column#{aggregate_index}",
                 if distinct { "distinct " } else { "" },
             ));
             aggregate_index += 1;
         }
     }
+    let mut first_row_functions = Vec::new();
     if include_first_row {
         for field in select.fields.fields() {
             let tidb_ast::SelectField::Expr { expr, .. } = field else {
@@ -2716,11 +2891,22 @@ fn grouped_aggregate_info(
                 if select.group_by.iter().any(
                     |item| matches!(&item.expr, tidb_ast::Expr::Column(group) if group == path),
                 ) {
-                    functions.push(format!("funcs:firstrow({text})->{text}"));
+                    first_row_functions.push(format!("funcs:firstrow({text})->{text}"));
                 }
             }
         }
     }
+    let functions = if include_first_row && crate::driver::has_pruned_row_count(select) {
+        // Go appended this COUNT(1) only after column pruning removed the
+        // last written aggregate. It therefore follows the surviving
+        // FIRST_ROW carriers instead of taking the ordinary aggregate-first
+        // position.
+        first_row_functions.extend(aggregate_functions);
+        first_row_functions
+    } else {
+        aggregate_functions.extend(first_row_functions);
+        aggregate_functions
+    };
     format!("group by:{}, {}", groups.join(", "), functions.join(", "))
 }
 
@@ -3144,6 +3330,9 @@ pub(crate) struct JoinStrategy {
     /// no source-column name, so non-equality conditions print the internal
     /// `Column#N` the executor evaluates instead of inventing an alias name.
     pub(crate) physical_conditions: Option<(Vec<Expression>, Vec<Option<String>>)>,
+    /// The statement-owned `LogicalJoin.DeriveStats` result. Outer joins use
+    /// it to retain the preserved-side floor that a flat trace cannot infer.
+    pub(crate) estimated_join_rows: Option<f64>,
 }
 
 /// What an index join's plan row says beyond its join kind.
@@ -3202,6 +3391,10 @@ pub(crate) struct IndexJoinInnerPathText<'a> {
     pub(crate) visible: &'a str,
     /// The statement-owned post-filter inner estimate for a one-row driver.
     pub(crate) estimated_rows: Option<f64>,
+    /// Whether every dynamic key probes at most one source row. In that case
+    /// the physical outer task, not the whole-table join model, owns the
+    /// dynamic range's cardinality.
+    pub(crate) unique: bool,
     /// Whether the lookup reader remains below a grouped derived table.
     pub(crate) grouped_derived: bool,
     /// Go's physical HashAgg payload for a retained grouped derived table.
@@ -3391,19 +3584,61 @@ impl Qualifier<'_> {
     /// `db.table.column`, resolving an unqualified name against the scope --
     /// the qualification Go's explain always prints in full.
     fn column(&self, path: &[String]) -> String {
+        fn physical_column<'a>(table: &'a FromTable, name: &str) -> Option<&'a str> {
+            table
+                .columns
+                .iter()
+                .find(|(column, _)| column.eq_ignore_ascii_case(name))
+                .map(|(column, _)| column.as_str())
+        }
         match path {
             [name] => {
                 let owner = self
                     .scope
                     .tables
                     .iter()
-                    .find(|t| t.columns.iter().any(|(c, _)| c.eq_ignore_ascii_case(name)));
+                    .find(|table| physical_column(table, name).is_some());
                 match owner {
-                    Some(table) => format!("{}.{}.{}", self.db, table.name, name),
+                    Some(table) => format!(
+                        "{}.{}.{}",
+                        self.db,
+                        table.name,
+                        physical_column(table, name).expect("owner has the column")
+                    ),
                     None => name.clone(),
                 }
             }
-            [table, name] => format!("{}.{table}.{name}", self.db),
+            [table_name, name] => self
+                .scope
+                .tables
+                .iter()
+                .find(|table| table.name.eq_ignore_ascii_case(table_name))
+                .and_then(|table| {
+                    physical_column(table, name)
+                        .map(|column| format!("{}.{}.{column}", self.db, table.name))
+                })
+                .unwrap_or_else(|| format!("{}.{table_name}.{name}", self.db)),
+            [database, table_name, name] => self
+                .scope
+                .tables
+                .iter()
+                .find(|table| {
+                    table.name.eq_ignore_ascii_case(table_name)
+                        && table
+                            .database
+                            .as_ref()
+                            .is_some_and(|physical| physical.eq_ignore_ascii_case(database))
+                })
+                .and_then(|table| {
+                    physical_column(table, name).map(|column| {
+                        format!(
+                            "{}.{}.{column}",
+                            table.database.as_deref().expect("matched database"),
+                            table.name
+                        )
+                    })
+                })
+                .unwrap_or_else(|| path.join(".")),
             _ => path.join("."),
         }
     }
@@ -3433,6 +3668,42 @@ fn binary_func_name(op: tidb_ast::BinaryOp) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn qualifier_prints_catalog_identifier_spelling() {
+        let scope = PlanTrace::single_table_scope(
+            "history",
+            Some("tpcc".to_owned()),
+            vec![(
+                "h_c_id".to_owned(),
+                FieldType::new(tidb_datatype::FieldTypeCode::Long),
+            )],
+        );
+        let qualify = Qualifier {
+            db: "tpcc",
+            scope: &scope,
+        };
+
+        assert_eq!(
+            qualify.expr(&tidb_ast::Expr::Column(vec!["H_C_ID".to_owned()])),
+            "tpcc.history.h_c_id"
+        );
+        assert_eq!(
+            qualify.expr(&tidb_ast::Expr::Column(vec![
+                "HISTORY".to_owned(),
+                "H_C_ID".to_owned(),
+            ])),
+            "tpcc.history.h_c_id"
+        );
+        assert_eq!(
+            qualify.expr(&tidb_ast::Expr::Column(vec![
+                "TPCC".to_owned(),
+                "HISTORY".to_owned(),
+                "H_C_ID".to_owned(),
+            ])),
+            "tpcc.history.h_c_id"
+        );
+    }
 
     #[test]
     fn complementary_null_predicates_are_a_tautology() {

--- a/rust/crates/tidb-executor/src/remote_scan.rs
+++ b/rust/crates/tidb-executor/src/remote_scan.rs
@@ -149,15 +149,17 @@ pub enum PushdownPartialAggregate {
         /// The group-key column returned by TiKV.
         group_type: FieldType,
     },
-    /// A grouped partial StreamAgg. TiKV returns aggregate results first and
-    /// group keys last, matching its aggregation-schema contract.
-    GroupedStream {
+    /// A grouped partial aggregation. TiKV returns aggregate results first
+    /// and group keys last, matching its aggregation-schema contract.
+    Grouped {
         /// Group-key offsets in [`PushdownScanRequest::columns`].
         group_offsets: Vec<usize>,
         /// Group-key result types, index-parallel with `group_offsets`.
         group_types: Vec<FieldType>,
         /// Aggregate functions, in physical output order.
         functions: Vec<PushdownAggregateFunction>,
+        /// `true` for StreamAgg over ordered input, `false` for HashAgg.
+        streamed: bool,
     },
 }
 
@@ -170,7 +172,7 @@ impl PushdownPartialAggregate {
             | Self::Sum { input_offset, .. }
             | Self::GroupBy { input_offset, .. } => *input_offset,
             Self::GroupBySum { group_offset, .. } => *group_offset,
-            Self::GroupedStream {
+            Self::Grouped {
                 group_offsets,
                 functions,
                 ..
@@ -195,7 +197,7 @@ impl PushdownPartialAggregate {
                 group_type,
                 ..
             } => vec![sum_type.clone(), group_type.clone()],
-            Self::GroupedStream {
+            Self::Grouped {
                 group_types,
                 functions,
                 ..
@@ -219,7 +221,7 @@ impl PushdownPartialAggregate {
                 sum_offset,
                 ..
             } => vec![*group_offset, *sum_offset],
-            Self::GroupedStream {
+            Self::Grouped {
                 group_offsets,
                 functions,
                 ..

--- a/rust/crates/tidb-executor/src/remote_scan.rs
+++ b/rust/crates/tidb-executor/src/remote_scan.rs
@@ -84,24 +84,223 @@ pub struct PushdownScanColumn {
 /// handle a table without an integer primary key carries.
 pub const EXTRA_HANDLE_COLUMN_ID: i64 = -1;
 
+/// One function in a grouped partial aggregation pushed below a reader.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PushdownAggregateKind {
+    /// `COUNT(expr)`; a missing input offset means Go's `COUNT(1)` lowering
+    /// of `COUNT(*)`.
+    Count,
+    /// `SUM(expr)`.
+    Sum,
+    /// `MIN(expr)`.
+    Min,
+    /// `MAX(expr)`.
+    Max,
+}
+
+/// A pushed aggregate function and the scan column it reads.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PushdownAggregateFunction {
+    /// The aggregate function implemented by TiKV.
+    pub kind: PushdownAggregateKind,
+    /// Offset in [`PushdownScanRequest::columns`], or `None` for `COUNT(1)`.
+    pub input_offset: Option<usize>,
+    /// The partial result column returned by TiKV.
+    pub output_type: FieldType,
+}
+
+/// One aggregation the base scan may execute inside TiKV before rows cross
+/// the network. This deliberately covers only the partial stages required by
+/// the pinned TPCC/Sysbench plan gate.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PushdownPartialAggregate {
+    /// A partial `COUNT(column)`; the root stage sums the per-region counts.
+    Count {
+        /// Offset in [`PushdownScanRequest::columns`].
+        input_offset: usize,
+        /// The partial count column returned by TiKV.
+        output_type: FieldType,
+    },
+    /// A partial `SUM(column)`; the root stage sums the per-region sums.
+    Sum {
+        /// Offset in [`PushdownScanRequest::columns`].
+        input_offset: usize,
+        /// The partial sum column returned by TiKV.
+        output_type: FieldType,
+    },
+    /// A partial hash aggregation with one group key and no aggregate
+    /// functions, used by one-column `SELECT DISTINCT`.
+    GroupBy {
+        /// Offset in [`PushdownScanRequest::columns`].
+        input_offset: usize,
+        /// The group-key column returned by TiKV.
+        output_type: FieldType,
+    },
+    /// A partial hash aggregation with one group key and one `SUM` function.
+    /// The partial row is returned in TiKV's aggregation-schema order:
+    /// aggregate result first, then the group key.
+    GroupBySum {
+        /// Offset of the group key in [`PushdownScanRequest::columns`].
+        group_offset: usize,
+        /// Offset of the summed column in [`PushdownScanRequest::columns`].
+        sum_offset: usize,
+        /// The partial sum column returned by TiKV.
+        sum_type: FieldType,
+        /// The group-key column returned by TiKV.
+        group_type: FieldType,
+    },
+    /// A grouped partial StreamAgg. TiKV returns aggregate results first and
+    /// group keys last, matching its aggregation-schema contract.
+    GroupedStream {
+        /// Group-key offsets in [`PushdownScanRequest::columns`].
+        group_offsets: Vec<usize>,
+        /// Group-key result types, index-parallel with `group_offsets`.
+        group_types: Vec<FieldType>,
+        /// Aggregate functions, in physical output order.
+        functions: Vec<PushdownAggregateFunction>,
+    },
+}
+
+impl PushdownPartialAggregate {
+    /// The aggregate input's scan-column offset.
+    #[must_use]
+    pub fn input_offset(&self) -> usize {
+        match self {
+            Self::Count { input_offset, .. }
+            | Self::Sum { input_offset, .. }
+            | Self::GroupBy { input_offset, .. } => *input_offset,
+            Self::GroupBySum { group_offset, .. } => *group_offset,
+            Self::GroupedStream {
+                group_offsets,
+                functions,
+                ..
+            } => group_offsets
+                .first()
+                .copied()
+                .or_else(|| functions.iter().find_map(|function| function.input_offset))
+                .unwrap_or(0),
+        }
+    }
+
+    /// The columns the partial stage returns, in TiKV aggregation-schema
+    /// order (aggregate functions followed by group keys).
+    #[must_use]
+    pub fn output_types(&self) -> Vec<FieldType> {
+        match self {
+            Self::Count { output_type, .. }
+            | Self::Sum { output_type, .. }
+            | Self::GroupBy { output_type, .. } => vec![output_type.clone()],
+            Self::GroupBySum {
+                sum_type,
+                group_type,
+                ..
+            } => vec![sum_type.clone(), group_type.clone()],
+            Self::GroupedStream {
+                group_types,
+                functions,
+                ..
+            } => functions
+                .iter()
+                .map(|function| function.output_type.clone())
+                .chain(group_types.iter().cloned())
+                .collect(),
+        }
+    }
+
+    /// Every scan-column offset read by the partial stage.
+    #[must_use]
+    pub fn input_offsets(&self) -> Vec<usize> {
+        match self {
+            Self::Count { input_offset, .. }
+            | Self::Sum { input_offset, .. }
+            | Self::GroupBy { input_offset, .. } => vec![*input_offset],
+            Self::GroupBySum {
+                group_offset,
+                sum_offset,
+                ..
+            } => vec![*group_offset, *sum_offset],
+            Self::GroupedStream {
+                group_offsets,
+                functions,
+                ..
+            } => group_offsets
+                .iter()
+                .copied()
+                .chain(
+                    functions
+                        .iter()
+                        .filter_map(|function| function.input_offset),
+                )
+                .collect(),
+        }
+    }
+}
+
+/// Index-scan identity for a partial aggregation request. `None` on
+/// [`PushdownScanRequest`] means the existing table-scan path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PushdownIndexScan {
+    /// Stable schema index id.
+    pub index_id: i64,
+    /// Whether the schema declares the index unique.
+    pub declared_unique: bool,
+    /// Number of indexed key columns.
+    pub index_column_count: usize,
+}
+
+/// One column order in a coprocessor TopN.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PushdownTopNOrder {
+    /// Offset in [`PushdownScanRequest::columns`].
+    pub offset: usize,
+    /// Whether larger values sort first.
+    pub desc: bool,
+}
+
+/// A bounded sort executed after the scan's complete Selection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PushdownTopN {
+    /// Ordered comparison keys, in SQL by-item order.
+    pub order_by: Vec<PushdownTopNOrder>,
+    /// Rows retained from offset zero. The root TopN applies the SQL offset.
+    pub limit: u64,
+}
+
 /// One base-table scan a backend may serve remotely.
 #[derive(Clone, Debug)]
 pub struct PushdownScanRequest {
     /// The table whose record range is scanned.
     pub table_id: i64,
+    /// An index source for this request; `None` means a table scan.
+    pub index: Option<PushdownIndexScan>,
     /// The columns to return, in output order.
     pub columns: Vec<PushdownScanColumn>,
-    /// Which of `columns` carries the row handle. The caller needs a handle
-    /// for every remote row to merge the staged overlay by key; when the
-    /// projection already contains the table's integer primary key this
-    /// points at it, and otherwise the handle column was appended last and
-    /// the caller drops it again before the row is emitted.
-    pub handle_index: usize,
+    /// Which of `columns` carries the integer row handle used to merge a
+    /// staged overlay. `None` is a common-handle scan with no staged writes,
+    /// where the caller consumes the remote rows directly.
+    pub handle_index: Option<usize>,
+    /// Stable column IDs forming a common row handle, in handle order.
+    pub primary_column_ids: Vec<i64>,
+    /// Common-handle columns stored as prefixes rather than whole values.
+    pub primary_prefix_column_ids: Vec<i64>,
     /// The conjuncts the caller would like evaluated remotely. Best-effort:
     /// see the module doc.
     pub predicates: Vec<ScanPredicate>,
+    /// Final output offsets into `columns`, after every predicate has been
+    /// evaluated. `None` returns every requested scan column.
+    ///
+    /// A backend must refuse this shape unless it can lower every predicate:
+    /// once the narrower row crosses the wire, the caller no longer has the
+    /// columns needed to repeat a residual filter locally.
+    pub output_offsets: Option<Vec<usize>>,
+    /// A bounded sort after the complete remote Selection. Best-effort; the
+    /// caller retains an equivalent local TopN when the backend refuses it.
+    pub topn: Option<PushdownTopN>,
     /// A row cap the backend may stop at. Best-effort: see the module doc.
     pub limit: Option<u64>,
+    /// A partial aggregation above the scan/Selection. When present, every
+    /// predicate must be lowered and no staged write may be merged locally.
+    pub aggregate: Option<PushdownPartialAggregate>,
     /// The timestamp the remote scan must read at: the statement's own
     /// snapshot, filled in by the storage that owns it.
     pub snapshot_ts: u64,
@@ -253,7 +452,7 @@ mod tests {
         ClusterSnapshot, ClusterTableStorage, MutationBuffer, SnapshotPairs,
     };
     use crate::driver::{run_select_on, Catalog};
-    use crate::kv_table::{KvColumn, KvTable, TableHandle};
+    use crate::kv_table::{KvColumn, KvIndex, KvTable, TableHandle};
     use crate::predicate_pushdown::{ScanComparisonOp, ScanPredicate};
     use crate::storage::{capture_storage_ops, MemTableStorage, TableStorage};
 
@@ -363,10 +562,25 @@ mod tests {
             if let Some(offset) = self.pk_handle_offset {
                 table.set_pk_handle_offset(offset);
             }
+            if !request.primary_column_ids.is_empty() {
+                let offsets = request
+                    .primary_column_ids
+                    .iter()
+                    .map(|id| {
+                        self.columns
+                            .iter()
+                            .position(|column| column.id == *id)
+                            .expect("a primary column belongs to the table")
+                    })
+                    .collect();
+                table.set_common_handle_offsets(offsets);
+            }
             // Every requested column that is one of the table's own; the
             // appended handle column is not, and is filled from the key.
-            let appended_handle =
-                request.columns[request.handle_index].id == EXTRA_HANDLE_COLUMN_ID;
+            let appended_handle = request
+                .handle_index
+                .and_then(|index| request.columns.get(index))
+                .is_some_and(|column| column.id == EXTRA_HANDLE_COLUMN_ID);
             let projected = if appended_handle {
                 &request.columns[..request.columns.len() - 1]
             } else {
@@ -554,6 +768,22 @@ mod tests {
         fixture_with(Some(0))
     }
 
+    /// A cluster fixture with (a, b) as the clustered common handle.
+    fn common_handle_fixture() -> Fixture {
+        let mut fixture = fixture_with(None);
+        fixture.table.set_common_handle_offsets(vec![0, 1]);
+        fixture.table.add_index(KvIndex {
+            id: 1,
+            name: "PRIMARY".to_owned(),
+            unique: true,
+            column_offsets: vec![0, 1],
+            prefix_lengths: vec![crate::ddl::index_prefix::UNSPECIFIED_LENGTH; 2],
+            visible: true,
+            global: false,
+        });
+        fixture
+    }
+
     fn fixture_with(pk_handle_offset: Option<usize>) -> Fixture {
         let snapshot = Arc::new(Mutex::new(MockSnapshot::default()));
         let handle: Arc<Mutex<dyn ClusterSnapshot>> = Arc::clone(&snapshot) as _;
@@ -585,6 +815,38 @@ mod tests {
             scanned,
             scanner,
         }
+    }
+
+    #[test]
+    fn a_clean_common_handle_range_uses_the_coprocessor() {
+        let mut fixture = common_handle_fixture();
+        for row in [[1, 10], [1, 20], [2, 30]] {
+            fixture
+                .table
+                .insert_row(
+                    &[Datum::Int(row[0]), Datum::Int(row[1])],
+                    &tidb_expr::NoColumns,
+                )
+                .unwrap();
+        }
+        commit(&fixture.buffer, &fixture.snapshot);
+        fixture.table.clear_dirty_content();
+
+        let catalog = catalog_of(fixture.table);
+        let ctx = crate::StmtContext::for_query();
+        let (rows, ops) = capture_storage_ops(|| {
+            run_select_on("SELECT a, b FROM t WHERE a = 1 ORDER BY b", &catalog, &ctx).unwrap()
+        });
+        assert_eq!(
+            rows,
+            vec![
+                vec![Datum::Int(1), Datum::Int(10)],
+                vec![Datum::Int(1), Datum::Int(20)]
+            ]
+        );
+        assert_eq!(ops.cop_scans, 1);
+        assert_eq!(ops.cop_rows, 2);
+        assert_eq!(ops.gets, 0);
     }
 
     fn catalog_of(table: KvTable) -> Catalog {

--- a/rust/crates/tidb-executor/src/sort.rs
+++ b/rust/crates/tidb-executor/src/sort.rs
@@ -56,6 +56,7 @@ use crate::sort_partition::{spill_action, SortPartition, SPILL_CHUNK_SIZE};
 
 /// Go `planner/util.ByItems`: one `ORDER BY` item -- the key expression and
 /// its direction.
+#[derive(Clone)]
 pub struct SortByItem {
     /// Go `ByItems.Expr`.
     pub expr: Expression,

--- a/rust/crates/tidb-executor/src/split_region.rs
+++ b/rust/crates/tidb-executor/src/split_region.rs
@@ -1,0 +1,306 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Split-key planning for `SPLIT TABLE` and `SPLIT TABLE ... INDEX`.
+//!
+//! Go boundary: `pkg/util/regionsplit/split_handle.go` and
+//! `pkg/util/split.go`. This first executable slice intentionally admits the
+//! two exact forms used by Sysbench prepare: an integer clustered handle and
+//! a single-column, non-unique integer secondary index, both with `BETWEEN`.
+//! Every other shape fails closed instead of claiming a region layout it did
+//! not create.
+
+use tidb_ast::{Expr, SplitOption, SplitRegionStmt};
+use tidb_codec::table_key::{
+    encode_non_unique_index_key, encode_record_key, encode_table_index_prefix,
+    gen_table_record_prefix, RecordHandle,
+};
+use tidb_datatype::Datum;
+
+use crate::{Catalog, DriverError, SchemaErrorKind, TableEntry};
+
+const MIN_REGION_STEP_VALUE: i64 = 1000;
+const MAX_SPLIT_REGION_NUM: i64 = 1000;
+
+/// Physical split request resolved against the session's current catalog.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SplitRegionPlan {
+    /// Go `TableInfo.ID`, also used as PD's scatter group.
+    pub table_id: i64,
+    /// Raw TiKV keys at which regions must be split.
+    pub split_keys: Vec<Vec<u8>>,
+}
+
+/// Resolves one parsed split statement and generates Go-compatible raw keys.
+pub fn prepare_split_region(
+    statement: &SplitRegionStmt,
+    current_database: &str,
+    catalog: &Catalog,
+) -> Result<SplitRegionPlan, DriverError> {
+    if statement.partition_syntax || !statement.partitions.is_empty() {
+        return Err(DriverError::unsupported(
+            "partitioned SPLIT TABLE is not supported yet",
+        ));
+    }
+    let (database, table_name) = resolve_table_name(&statement.table, current_database)?;
+    let table = match catalog.table_in(database, table_name) {
+        Some(TableEntry::Kv(table)) => table,
+        Some(_) => {
+            return Err(DriverError::unsupported(
+                "SPLIT TABLE needs a storage-backed base table",
+            ))
+        }
+        None => {
+            return Err(DriverError::Schema(SchemaErrorKind::UnknownTable(format!(
+                "{database}.{table_name}"
+            ))))
+        }
+    };
+    if table.partition().is_some() {
+        return Err(DriverError::unsupported(
+            "partitioned SPLIT TABLE is not supported yet",
+        ));
+    }
+
+    let (lower, upper, regions) = between_integer_bounds(&statement.option)?;
+    let split_keys = match statement.index.as_deref() {
+        Some(index_name) => {
+            let index = table
+                .indexes()
+                .iter()
+                .find(|candidate| candidate.name.eq_ignore_ascii_case(index_name))
+                .ok_or_else(|| DriverError::UnknownIndex(index_name.to_owned()))?;
+            if index.unique || index.column_offsets.len() != 1 || index.has_prefix() {
+                return Err(DriverError::unsupported(
+                    "SPLIT INDEX currently requires one non-unique, non-prefix integer column",
+                ));
+            }
+            split_index_keys(
+                table.table_id,
+                table.indexes().first().map(|first| first.id),
+                index.id,
+                lower,
+                upper,
+                regions,
+            )?
+        }
+        None => {
+            if table.pk_handle_offset().is_none() {
+                return Err(DriverError::unsupported(
+                    "SPLIT TABLE currently requires an integer clustered primary key",
+                ));
+            }
+            split_table_keys(
+                table.table_id,
+                !table.indexes().is_empty(),
+                lower,
+                upper,
+                regions,
+            )?
+        }
+    };
+    Ok(SplitRegionPlan {
+        table_id: table.table_id,
+        split_keys,
+    })
+}
+
+fn resolve_table_name<'a>(
+    path: &'a [String],
+    current_database: &'a str,
+) -> Result<(&'a str, &'a str), DriverError> {
+    match path {
+        [table] => {
+            if current_database.is_empty() {
+                Err(DriverError::unsupported("no database selected"))
+            } else {
+                Ok((current_database, table))
+            }
+        }
+        [database, table] => Ok((database, table)),
+        _ => Err(DriverError::unsupported("invalid SPLIT TABLE name")),
+    }
+}
+
+fn between_integer_bounds(option: &SplitOption) -> Result<(i64, i64, usize), DriverError> {
+    let SplitOption::Between {
+        lower,
+        upper,
+        regions,
+    } = option
+    else {
+        return Err(DriverError::unsupported(
+            "SPLIT TABLE BY is not supported yet",
+        ));
+    };
+    if !(1..=MAX_SPLIT_REGION_NUM).contains(regions) {
+        return Err(DriverError::unsupported(format!(
+            "split region count must be between 1 and {MAX_SPLIT_REGION_NUM}"
+        )));
+    }
+    let [lower] = lower.as_slice() else {
+        return Err(DriverError::unsupported(
+            "SPLIT TABLE currently requires one integer lower bound",
+        ));
+    };
+    let [upper] = upper.as_slice() else {
+        return Err(DriverError::unsupported(
+            "SPLIT TABLE currently requires one integer upper bound",
+        ));
+    };
+    let lower = integer_literal(lower)?;
+    let upper = integer_literal(upper)?;
+    if upper <= lower {
+        return Err(DriverError::unsupported(format!(
+            "lower value {lower} should be less than upper value {upper}"
+        )));
+    }
+    Ok((lower, upper, *regions as usize))
+}
+
+fn integer_literal(expression: &Expr) -> Result<i64, DriverError> {
+    match expression {
+        Expr::Int(value) => value.parse::<i64>().map_err(|_| {
+            DriverError::unsupported(format!("split bound {value} is outside signed BIGINT"))
+        }),
+        _ => Err(DriverError::unsupported(
+            "SPLIT TABLE currently requires literal integer bounds",
+        )),
+    }
+}
+
+fn split_table_keys(
+    table_id: i64,
+    contains_index: bool,
+    lower: i64,
+    upper: i64,
+    regions: usize,
+) -> Result<Vec<Vec<u8>>, DriverError> {
+    let step =
+        (upper.wrapping_sub(lower) as u64) / u64::try_from(regions).expect("positive region count");
+    if step < MIN_REGION_STEP_VALUE as u64 {
+        return Err(DriverError::unsupported(format!(
+            "the region size is too small, expected at least {MIN_REGION_STEP_VALUE}, but got {step}"
+        )));
+    }
+    let record_prefix = gen_table_record_prefix(table_id);
+    let mut keys = Vec::with_capacity(regions);
+    if contains_index {
+        // Go splits the index keyspace away from the record keyspace first.
+        keys.push(record_prefix.clone());
+    }
+    let mut handle = lower;
+    for _ in 1..regions {
+        handle = handle.wrapping_add(step as i64);
+        keys.push(encode_record_key(
+            &record_prefix,
+            &RecordHandle::Int(handle),
+        ));
+    }
+    Ok(keys)
+}
+
+fn split_index_keys(
+    table_id: i64,
+    first_index_id: Option<i64>,
+    index_id: i64,
+    lower: i64,
+    upper: i64,
+    regions: usize,
+) -> Result<Vec<Vec<u8>>, DriverError> {
+    let mut keys = Vec::with_capacity(regions + 1);
+    if first_index_id.is_some_and(|first| first != index_id) {
+        keys.push(encode_table_index_prefix(table_id, index_id));
+    }
+    // Go always isolates the index's end boundary.
+    keys.push(encode_table_index_prefix(table_id, index_id + 1));
+    let lower_key = encode_non_unique_index_key(table_id, index_id, &[Datum::Int(lower)], i64::MIN)
+        .map_err(|error| DriverError::unsupported(error.to_string()))?;
+    let upper_key = encode_non_unique_index_key(table_id, index_id, &[Datum::Int(upper)], i64::MIN)
+        .map_err(|error| DriverError::unsupported(error.to_string()))?;
+    if lower_key >= upper_key {
+        return Err(DriverError::unsupported(format!(
+            "lower value {lower} should be less than upper value {upper}"
+        )));
+    }
+    get_values_list(&lower_key, &upper_key, regions, &mut keys);
+    Ok(keys)
+}
+
+/// Port of Go `util.GetValuesList` over memcomparable byte strings.
+fn get_values_list(lower: &[u8], upper: &[u8], regions: usize, output: &mut Vec<Vec<u8>>) {
+    let common = lower
+        .iter()
+        .zip(upper)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let step = (uint64_prefix(&upper[common..], 0xff) - uint64_prefix(&lower[common..], 0))
+        / regions as u64;
+    let mut value = uint64_prefix(&lower[common..], 0);
+    for _ in 1..regions {
+        value = value.wrapping_add(step);
+        let mut key = Vec::with_capacity(common + 8);
+        key.extend_from_slice(&lower[..common]);
+        key.extend_from_slice(&value.to_be_bytes());
+        output.push(key);
+    }
+}
+
+fn uint64_prefix(bytes: &[u8], pad: u8) -> u64 {
+    let mut buffer = [pad; 8];
+    let copied = bytes.len().min(8);
+    buffer[..copied].copy_from_slice(&bytes[..copied]);
+    u64::from_be_bytes(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_values_list, split_table_keys};
+    use tidb_codec::table_key::{encode_record_key, gen_table_record_prefix, RecordHandle};
+
+    #[test]
+    fn byte_interpolation_matches_go_get_values_list() {
+        let mut lower = vec![1, 2, 1];
+        lower.extend_from_slice(&[0; 7]);
+        let mut upper = vec![1, 2, 101];
+        upper.extend_from_slice(&[0; 7]);
+        let mut values = Vec::new();
+        get_values_list(&lower, &upper, 10, &mut values);
+        assert_eq!(values.len(), 9);
+        assert_eq!(values[0], vec![1, 2, 11, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(values[8], vec![1, 2, 91, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn integer_table_split_includes_index_boundary_and_seven_handles() {
+        let table_id = 42;
+        let keys = split_table_keys(table_id, true, 0, 10_000_001, 8).unwrap();
+        assert_eq!(keys.len(), 8);
+        assert_eq!(keys[0], gen_table_record_prefix(table_id));
+        assert_eq!(
+            keys[1],
+            encode_record_key(
+                &gen_table_record_prefix(table_id),
+                &RecordHandle::Int(1_250_000),
+            )
+        );
+        assert_eq!(
+            keys[7],
+            encode_record_key(
+                &gen_table_record_prefix(table_id),
+                &RecordHandle::Int(8_750_000),
+            )
+        );
+    }
+}

--- a/rust/crates/tidb-executor/src/table_access.rs
+++ b/rust/crates/tidb-executor/src/table_access.rs
@@ -81,6 +81,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::predicate_pushdown::PushedScanFilter;
+use crate::remote_scan::{PushdownPartialAggregate, PushdownTopN};
 use crate::StmtContext;
 
 /// A base-table source that can take over work from the operators above it.
@@ -89,6 +90,21 @@ use crate::StmtContext;
 /// particular the staged-row rule that applies to all of them -- are the
 /// module doc above.
 pub trait TableAccess {
+    /// Records the physical scan estimate selected by the access-path coster.
+    /// It changes no rows and exists so later operator negotiation can make
+    /// the same partial/final aggregation choice as the optimizer.
+    fn accept_scan_estimate(&mut self, rows: f64) {
+        let _ = rows;
+    }
+
+    /// Offers the scan a real TiKV partial aggregation. Returning `true`
+    /// changes the source schema to the one partial-result column and promises
+    /// that a local fallback computes exactly the same partial rows.
+    fn accept_partial_aggregate(&mut self, aggregate: &PushdownPartialAggregate) -> bool {
+        let _ = aggregate;
+        false
+    }
+
     /// Offers `filter` to this source, as Go's predicate push-down offers a
     /// conjunct to the node below it.
     ///
@@ -101,6 +117,26 @@ pub trait TableAccess {
     /// See [`crate::predicate_pushdown`] for the split rule and the reasoning.
     fn accept_scan_filter(&mut self, filter: &PushedScanFilter, ctx: &StmtContext) -> bool {
         let _ = (filter, ctx);
+        false
+    }
+
+    /// Offers a projection that must run only after an already accepted scan
+    /// filter. `keep` indexes the scan row the filter sees, in final output
+    /// order.
+    ///
+    /// Returning `true` promises two equivalent paths: a local scan filters
+    /// the wider row before projecting it, while a remote scan returns the
+    /// narrow row only when every predicate was evaluated in the coprocessor.
+    /// The source schema must immediately describe the projected row.
+    fn accept_post_filter_projection(&mut self, keep: &[usize]) -> bool {
+        let _ = keep;
+        false
+    }
+
+    /// Offers a coprocessor TopN hint. The caller keeps an equivalent local
+    /// TopN, so refusal changes only where rows are reduced, never the answer.
+    fn accept_remote_topn(&mut self, topn: &PushdownTopN) -> bool {
+        let _ = topn;
         false
     }
 
@@ -170,8 +206,9 @@ pub trait TableAccess {
     }
 
     /// Offers this source the chance to emit only the columns at `keep`
-    /// (offsets into its current output row, ascending and unique), as Go's
-    /// column pruning narrows a `DataSource`'s schema.
+    /// (offsets into its current output row, in the requested output order),
+    /// as Go's column pruning or cop projection narrows a `DataSource`'s
+    /// schema.
     ///
     /// Returning `true` is a promise the driver relies on to renumber the
     /// `FROM` scope: from the next `open` on, every row this source emits

--- a/rust/crates/tidb-executor/src/tests_index_join.rs
+++ b/rust/crates/tidb-executor/src/tests_index_join.rs
@@ -212,6 +212,9 @@ fn both_ways(
         lookup_is_left: false,
         probe_keys,
         source: lookup_source(table, object, inner_width),
+        aggregation: None,
+        outer_not_null: Vec::new(),
+        inner_not_null: Vec::new(),
     });
     assert!(looked_up.is_index_join());
     let index_rows = drain(&mut looked_up, &types);
@@ -405,6 +408,9 @@ fn one_key_repeated_across_a_batch_is_probed_once() {
         lookup_is_left: false,
         probe_keys: vec![0],
         source,
+        aggregation: None,
+        outer_not_null: Vec::new(),
+        inner_not_null: Vec::new(),
     });
     let rows = drain(&mut exec, &types);
     assert_eq!(
@@ -449,6 +455,11 @@ mod decision {
             // The projected expression Go prints as a bare `Column`.
             names: vec!["Column".to_owned(), "Column".to_owned()],
             origin: None,
+            source_visible: String::new(),
+            output_to_source: vec![None, None],
+            source_filters: Vec::new(),
+            aggregation: None,
+            aggregation_info: None,
         }
     }
 
@@ -472,6 +483,11 @@ mod decision {
                 .collect(),
             names: vec![format!("db.{visible}.a"), format!("db.{visible}.b")],
             origin: Some("db.t".to_owned()),
+            source_visible: visible.to_owned(),
+            output_to_source: vec![Some(0), Some(1)],
+            source_filters: Vec::new(),
+            aggregation: None,
+            aggregation_info: None,
         }
     }
 

--- a/rust/crates/tidb-expr/src/builtin_compare.rs
+++ b/rust/crates/tidb-expr/src/builtin_compare.rs
@@ -420,6 +420,59 @@ fn wrap_year_operand_for_datetime_compare(left: &mut Expression, right: &mut Exp
     ));
 }
 
+/// Go `newBaseBuiltinFuncWithTp(..., ETDecimal, ETDecimal)` wrapping the
+/// integer side of a DECIMAL-vs-INT comparison with
+/// `WrapWithCastAsDecimal`. The integer width comes from the MySQL type, not
+/// from the value currently stored in the row (`BIGINT` therefore needs
+/// DECIMAL(20,0)).
+fn wrap_integer_operand_for_decimal_compare(left: &mut Expression, right: &mut Expression) {
+    let eval_type = |expression: &Expression| expression.static_type().map(FieldType::eval_type);
+    let integer = match (eval_type(left), eval_type(right)) {
+        (Some(EvalType::Decimal), Some(EvalType::Int))
+            if !matches!(right, Expression::Constant(_)) =>
+        {
+            right
+        }
+        (Some(EvalType::Int), Some(EvalType::Decimal))
+            if !matches!(left, Expression::Constant(_)) =>
+        {
+            left
+        }
+        _ => return,
+    };
+    let Some(source_type) = integer.static_type().cloned() else {
+        return;
+    };
+    let precision = match source_type.code() {
+        FieldTypeCode::Tiny => 3,
+        FieldTypeCode::Short => 5,
+        FieldTypeCode::Int24 => 8,
+        FieldTypeCode::Long => 10,
+        FieldTypeCode::LongLong => 20,
+        FieldTypeCode::Year => 4,
+        _ => return,
+    };
+    let mut target = FieldType::new(FieldTypeCode::NewDecimal);
+    target.set_flen(precision);
+    target.set_decimal(0);
+    target.add_flags(
+        FieldTypeFlags::BINARY
+            | (source_type.flags() & (FieldTypeFlags::UNSIGNED | FieldTypeFlags::NOT_NULL)),
+    );
+    let argument = std::mem::replace(
+        integer,
+        Expression::Constant(Constant::new(
+            Datum::Null,
+            FieldType::new(FieldTypeCode::Null),
+        )),
+    );
+    *integer = Expression::ScalarFunction(crate::expression::ScalarFunction::new(
+        tidb_ast::CiString::new("cast_decimal"),
+        target,
+        vec![argument],
+    ));
+}
+
 /// Go `compareFunctionClass.refineArgs` (`builtin_compare.go:1778`), applied
 /// to every comparison in an already-built expression tree.
 ///
@@ -457,6 +510,7 @@ pub fn refine_comparisons(expr: &mut Expression, ctx: &dyn Columns) {
     // Go's own order: `getFunction` runs `refineArgs` first and only then
     // derives the comparison type -- and the argument casts that go with it --
     // from the arguments that survived it (`builtin_compare.go:1984-1989`).
+    wrap_integer_operand_for_decimal_compare(left, right);
     wrap_year_operand_for_datetime_compare(left, right);
 }
 
@@ -748,6 +802,32 @@ mod tests {
         let (expr, warnings) = refine("gt", int_column(), int_constant);
         assert_eq!(constant_of(&expr, 1), Datum::Int(10));
         assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    #[test]
+    fn a_decimal_column_compared_with_bigint_casts_bigint_to_decimal_20() {
+        let mut decimal = crate::column::Column::new(1, FieldType::new(FieldTypeCode::NewDecimal));
+        decimal.index = 0;
+        let mut integer = crate::column::Column::new(2, FieldType::new(FieldTypeCode::LongLong));
+        integer.index = 1;
+        let (expr, warnings) = refine(
+            "ne",
+            Expression::Column(decimal),
+            Expression::Column(integer),
+        );
+        assert!(warnings.is_empty());
+        let Expression::ScalarFunction(comparison) = expr else {
+            panic!("comparison was not a scalar function");
+        };
+        let Expression::ScalarFunction(cast) = &comparison.args[1] else {
+            panic!("BIGINT operand was not cast: {:?}", comparison.args[1]);
+        };
+        assert_eq!(cast.func_name.lowercase(), "cast_decimal");
+        let target = cast.ret_type.as_ref().unwrap();
+        assert_eq!(target.code(), FieldTypeCode::NewDecimal);
+        assert_eq!(target.flen(), 20);
+        assert_eq!(target.decimal(), 0);
+        assert_ne!(target.flags() & FieldTypeFlags::BINARY, 0);
     }
 
     /// `EQ` against an inexact value is Go's `isExceptional`, which this port

--- a/rust/crates/tidb-expr/src/context.rs
+++ b/rust/crates/tidb-expr/src/context.rs
@@ -25,6 +25,9 @@ use tidb_datatype::Datum;
 pub enum EvalError {
     /// The expression uses a construct outside the currently ported domain.
     Unsupported(&'static str),
+    /// Go `expression.ErrOperandColumns` (1241): the right row operand does
+    /// not contain the number of columns required by the left operand.
+    OperandColumns(usize),
     /// A binary operation reached the evaluator with an operand pair that no
     /// domain dispatch claims.
     ///

--- a/rust/crates/tidb-expr/src/rewriter.rs
+++ b/rust/crates/tidb-expr/src/rewriter.rs
@@ -277,6 +277,52 @@ fn wrap_binary_literals(
         .collect()
 }
 
+/// Applies the two `types.ETReal` argument declarations of Go's
+/// `powFunctionClass.getFunction` while the executable expression is built.
+///
+/// Go's `newBaseBuiltinFuncWithTp(..., ETReal, ETReal, ETReal)` inserts a
+/// `WrapWithCastAsReal` node around each non-real expression. A numeric
+/// constant is folded to the real family instead, so `POWER(x, 2)` explains
+/// as `power(cast(x, double BINARY), 2)`, not with a redundant cast around
+/// the literal. Keeping these nodes in the executable tree makes the plan
+/// text and runtime coercion share one source of truth.
+fn wrap_power_arguments(name: &str, args: Vec<Expression>) -> Vec<Expression> {
+    if !matches!(name, "pow" | "power") {
+        return args;
+    }
+    args.into_iter()
+        .map(|arg| {
+            if arg
+                .static_type()
+                .is_some_and(|field_type| field_type.eval_type() == tidb_datatype::EvalType::Real)
+            {
+                return arg;
+            }
+            if let Expression::Constant(constant) = &arg {
+                let real = match constant.value {
+                    Datum::Int(value) => Some(value as f64),
+                    Datum::UInt(value) => Some(value as f64),
+                    _ => None,
+                };
+                if let Some(value) = real {
+                    return Expression::Constant(Constant::new(
+                        Datum::Real(value),
+                        FieldType::new(FieldTypeCode::Double),
+                    ));
+                }
+            }
+            let mut ret_type = FieldType::new(FieldTypeCode::Double);
+            ret_type.set_flen(23);
+            ret_type.set_decimal(tidb_datatype::UNSPECIFIED_LENGTH);
+            Expression::ScalarFunction(ScalarFunction::new(
+                CiString::new("cast_double"),
+                ret_type,
+                vec![arg],
+            ))
+        })
+        .collect()
+}
+
 fn constant(datum: Datum, code: FieldTypeCode) -> Expression {
     Expression::Constant(Constant::new(datum, FieldType::new(code)))
 }
@@ -1060,6 +1106,7 @@ fn rewrite_leaf(expr: &Expr, resolver: &impl ColumnResolver) -> Result<Expressio
                 .iter()
                 .map(|arg| rewrite_expr_resolved(arg, resolver))
                 .collect::<Result<_, _>>()?;
+            let rewritten = wrap_power_arguments(&lowered, rewritten);
             let ret_type = builtin_return_type(&lowered, &rewritten).ok_or(
                 EvalError::Unsupported("this builtin is not yet built for chunk evaluation"),
             )?;
@@ -1481,6 +1528,38 @@ mod tests {
         ))));
         let neg = Expr::Unary(UnaryOp::Minus, paren);
         assert_eq!(eval_const(&neg), Datum::Int(-2));
+    }
+
+    #[test]
+    fn power_builds_gos_real_argument_casts() {
+        let minus = Expr::Binary(
+            BinaryOp::Minus,
+            Box::new(Expr::Binary(
+                BinaryOp::Minus,
+                Box::new(Expr::Int("5".to_owned())),
+                Box::new(Expr::Int("1".to_owned())),
+            )),
+            Box::new(Expr::Int("2".to_owned())),
+        );
+        let power = Expr::Func {
+            name: "POWER".to_owned(),
+            args: vec![minus, Expr::Int("2".to_owned())],
+            origin_position: 0,
+        };
+        let rewritten = rewrite_expr(&power).unwrap();
+        let Expression::ScalarFunction(power_call) = &rewritten else {
+            panic!("POWER was not rewritten as a scalar function");
+        };
+        assert_eq!(power_call.func_name.lowercase(), "power");
+        let Expression::ScalarFunction(cast) = &power_call.args[0] else {
+            panic!("POWER's integer expression was not cast to real");
+        };
+        assert_eq!(cast.func_name.lowercase(), "cast_double");
+        let Expression::Constant(exponent) = &power_call.args[1] else {
+            panic!("POWER's integer literal was not folded to a real constant");
+        };
+        assert_eq!(exponent.value, Datum::Real(2.0));
+        assert_eq!(eval_const(&power), Datum::Real(4.0));
     }
 
     #[test]

--- a/rust/crates/tidb-expr/src/rewriter.rs
+++ b/rust/crates/tidb-expr/src/rewriter.rs
@@ -291,6 +291,67 @@ fn scalar(name: &str, args: Vec<Expression>) -> Expression {
     ))
 }
 
+fn binary_expression(op: BinaryOp, left: Expression, right: Expression) -> Expression {
+    let name = binary_op_name(op);
+    let ret_type = crate::builtin_arithmetic::infer_arithmetic_type(name, &left, &right)
+        .or_else(|| crate::builtin_compare::infer_compare_type(name))
+        .or_else(|| crate::builtin_op::infer_op_type(name));
+    match ret_type {
+        Some(ret_type) => Expression::ScalarFunction(ScalarFunction::new(
+            CiString::new(name),
+            ret_type,
+            vec![left, right],
+        )),
+        None => scalar(name, vec![left, right]),
+    }
+}
+
+fn row_len(expr: &Expr) -> usize {
+    match expr {
+        Expr::Row(items) => items.len(),
+        _ => 1,
+    }
+}
+
+fn rewrite_equality(
+    left: &Expr,
+    right: &Expr,
+    resolver: &impl ColumnResolver,
+) -> Result<Expression, EvalError> {
+    match (left, right) {
+        (Expr::Row(left), Expr::Row(right)) => rewrite_row_equality(left, right, resolver),
+        (Expr::Row(left), _) => Err(EvalError::OperandColumns(left.len())),
+        (_, Expr::Row(_)) => Err(EvalError::OperandColumns(1)),
+        _ => Ok(binary_expression(
+            BinaryOp::Eq,
+            rewrite_expr_resolved(left, resolver)?,
+            rewrite_expr_resolved(right, resolver)?,
+        )),
+    }
+}
+
+/// Go `constructBinaryOpFunction` for row equality: compare each pair of
+/// columns and compose the results with `AND`.
+fn rewrite_row_equality(
+    left: &[Expr],
+    right: &[Expr],
+    resolver: &impl ColumnResolver,
+) -> Result<Expression, EvalError> {
+    if left.len() != right.len() {
+        return Err(EvalError::OperandColumns(left.len()));
+    }
+    let mut equalities = left
+        .iter()
+        .zip(right)
+        .map(|(left, right)| rewrite_equality(left, right, resolver));
+    let first = equalities
+        .next()
+        .ok_or(EvalError::Unsupported("a row expression with no columns"))??;
+    equalities.try_fold(first, |condition, equality| {
+        Ok(binary_expression(BinaryOp::LogicAnd, condition, equality?))
+    })
+}
+
 /// Go `expression_rewriter`: rewrite a parsed AST [`Expr`] into an evaluable
 /// [`Expression`].
 ///
@@ -556,6 +617,39 @@ fn rewrite_leaf(expr: &Expr, resolver: &impl ColumnResolver) -> Result<Expressio
         // the remaining arguments; `NOT IN` wraps it in a unary NOT, which
         // keeps NULL as NULL exactly as MySQL requires.
         Expr::In { expr, list, not } => {
+            let expected_columns = row_len(expr);
+            if list
+                .iter()
+                .any(|candidate| row_len(candidate) != expected_columns)
+            {
+                return Err(EvalError::OperandColumns(expected_columns));
+            }
+            if let Expr::Row(left) = expr.as_ref() {
+                let mut comparisons = list.iter().map(|right| {
+                    let Expr::Row(right) = right else {
+                        return Err(EvalError::OperandColumns(left.len()));
+                    };
+                    rewrite_row_equality(left, right, resolver)
+                });
+                let first = comparisons.next().ok_or(EvalError::Unsupported(
+                    "an IN expression with no candidates",
+                ))??;
+                let call = comparisons.try_fold(first, |condition, comparison| {
+                    Ok(binary_expression(BinaryOp::LogicOr, condition, comparison?))
+                })?;
+                if *not {
+                    let ret_type = call
+                        .static_type()
+                        .cloned()
+                        .unwrap_or_else(|| FieldType::new(FieldTypeCode::LongLong));
+                    return Ok(Expression::ScalarFunction(ScalarFunction::new(
+                        CiString::new(unary_op_name(UnaryOp::Not)),
+                        ret_type,
+                        vec![call],
+                    )));
+                }
+                return Ok(call);
+            }
             let mut args = Vec::with_capacity(list.len() + 1);
             args.push(rewrite_expr_resolved(expr, resolver)?);
             for item in list {
@@ -638,24 +732,12 @@ fn rewrite_leaf(expr: &Expr, resolver: &impl ColumnResolver) -> Result<Expressio
         Expr::Binary(op, lhs, rhs) => {
             let left = rewrite_expr_resolved(lhs, resolver)?;
             let right = rewrite_expr_resolved(rhs, resolver)?;
-            let name = binary_op_name(*op);
             // Result types come from the transcreated function classes:
             // builtin_arithmetic (plus/minus/mul/div/intdiv/mod),
             // builtin_compare (eq/nulleq/ne/lt/le/gt/ge) and builtin_op
             // (logic and bit operators). Anything still uncovered keeps the
             // LongLong placeholder.
-            if let Some(ret_type) =
-                crate::builtin_arithmetic::infer_arithmetic_type(name, &left, &right)
-                    .or_else(|| crate::builtin_compare::infer_compare_type(name))
-                    .or_else(|| crate::builtin_op::infer_op_type(name))
-            {
-                return Ok(Expression::ScalarFunction(ScalarFunction::new(
-                    CiString::new(name),
-                    ret_type,
-                    vec![left, right],
-                )));
-            }
-            Ok(scalar(name, vec![left, right]))
+            Ok(binary_expression(*op, left, right))
         }
         // Go `expressionRewriter.betweenToExpression`: `x BETWEEN l AND h`
         // is `x >= l AND x <= h`, and the negated form is `x < l OR x > h` --

--- a/rust/crates/tidb-pd-client/examples/tso_profile.rs
+++ b/rust/crates/tidb-pd-client/examples/tso_profile.rs
@@ -151,6 +151,20 @@ impl Pd for MockPd {
     ) -> Result<tonic::Response<pdpb::GetGcStateResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("get_gc_state"))
     }
+
+    async fn get_operator(
+        &self,
+        _request: tonic::Request<pdpb::GetOperatorRequest>,
+    ) -> Result<tonic::Response<pdpb::GetOperatorResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("get_operator"))
+    }
+
+    async fn split_and_scatter_regions(
+        &self,
+        _request: tonic::Request<pdpb::SplitAndScatterRegionsRequest>,
+    ) -> Result<tonic::Response<pdpb::SplitAndScatterRegionsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("split_and_scatter_regions"))
+    }
 }
 
 fn start_server() -> (String, tokio::sync::oneshot::Sender<()>) {

--- a/rust/crates/tidb-pd-client/src/client/failover.rs
+++ b/rust/crates/tidb-pd-client/src/client/failover.rs
@@ -33,12 +33,13 @@ use tokio::sync::watch;
 use tonic::transport::Channel;
 
 use crate::{
-    secure_endpoint, ClusterSecurity, PdClientError, PdGcState, PdMemberSet, PdRegion, PdStore,
+    secure_endpoint, ClusterSecurity, PdClientError, PdGcState, PdMemberSet, PdRegion,
+    PdSplitAndScatterRegions, PdStore,
 };
 
 use super::requests::{
     batch_scan_regions, get_gc_state, get_members, get_prev_region, get_region, get_region_by_id,
-    get_store, scan_regions,
+    get_store, is_region_scattering, scan_regions, split_and_scatter_regions,
 };
 use super::topology::invalid_topology;
 use super::{PdSharedState, RpcControl};
@@ -211,6 +212,51 @@ pub(super) fn batch_scan_regions_with_failover(
         |runtime, clients, endpoint, cluster_id| {
             batch_scan_regions(
                 runtime, clients, endpoint, timeout, shutdown, cluster_id, request,
+            )
+        },
+    )
+}
+
+pub(super) fn split_and_scatter_regions_with_failover(
+    runtime: &tokio::runtime::Runtime,
+    clients: &mut PdChannelCache,
+    timeout: Duration,
+    state: &Arc<RwLock<PdSharedState>>,
+    shutdown: &watch::Receiver<bool>,
+    split_keys: &[Vec<u8>],
+    group: &str,
+) -> Result<PdSplitAndScatterRegions, PdClientError> {
+    foreground_with_failover(
+        runtime,
+        clients,
+        timeout,
+        state,
+        shutdown,
+        |runtime, clients, endpoint, cluster_id| {
+            split_and_scatter_regions(
+                runtime, clients, endpoint, timeout, shutdown, cluster_id, split_keys, group,
+            )
+        },
+    )
+}
+
+pub(super) fn is_region_scattering_with_failover(
+    runtime: &tokio::runtime::Runtime,
+    clients: &mut PdChannelCache,
+    timeout: Duration,
+    state: &Arc<RwLock<PdSharedState>>,
+    shutdown: &watch::Receiver<bool>,
+    region_id: u64,
+) -> Result<bool, PdClientError> {
+    foreground_with_failover(
+        runtime,
+        clients,
+        timeout,
+        state,
+        shutdown,
+        |runtime, clients, endpoint, cluster_id| {
+            is_region_scattering(
+                runtime, clients, endpoint, timeout, shutdown, cluster_id, region_id,
             )
         },
     )

--- a/rust/crates/tidb-pd-client/src/client/mod.rs
+++ b/rust/crates/tidb-pd-client/src/client/mod.rs
@@ -41,7 +41,7 @@ use tokio::sync::watch;
 
 use crate::{
     ClusterSecurity, PdClientError, PdClientShutdownError, PdGcState, PdKeyRange, PdMemberSet,
-    PdOperation, PdRegion, PdStore,
+    PdOperation, PdRegion, PdSplitAndScatterRegions, PdStore,
 };
 
 use failover::retain_member_clients;
@@ -71,6 +71,10 @@ pub const GET_STORE_PATH: &str = "/pdpb.PD/GetStore";
 pub const TSO_PATH: &str = "/pdpb.PD/Tso";
 /// Exact GC-state lookup method path.
 pub const GET_GC_STATE_PATH: &str = "/pdpb.PD/GetGCState";
+/// Exact scheduling-operator lookup method path.
+pub const GET_OPERATOR_PATH: &str = "/pdpb.PD/GetOperator";
+/// Exact split-and-scatter method path.
+pub const SPLIT_AND_SCATTER_REGIONS_PATH: &str = "/pdpb.PD/SplitAndScatterRegions";
 
 enum WorkerCommand {
     RefreshMembers {
@@ -114,6 +118,17 @@ enum WorkerCommand {
     GetGcState {
         keyspace_id: Option<u32>,
         reply: mpsc::Sender<Result<PdGcState, PdClientError>>,
+    },
+    GetOperator {
+        region_id: u64,
+        timeout: Duration,
+        reply: mpsc::Sender<Result<bool, PdClientError>>,
+    },
+    SplitAndScatterRegions {
+        split_keys: Vec<Vec<u8>>,
+        group: String,
+        timeout: Duration,
+        reply: mpsc::Sender<Result<PdSplitAndScatterRegions, PdClientError>>,
     },
     Close {
         reply: mpsc::Sender<()>,
@@ -561,6 +576,68 @@ impl PdClient {
         self.shared
             .commands
             .send(WorkerCommand::GetGcState { keyspace_id, reply })
+            .map_err(|_| PdClientError::Closed)?;
+        response.recv().unwrap_or(Err(PdClientError::Closed))
+    }
+
+    /// Reports whether PD still has a running scatter operator for a region.
+    ///
+    /// The caller supplies the per-probe deadline because Go bounds every
+    /// probe by the remaining `tidb_wait_split_region_timeout`, not by the
+    /// short metadata-RPC timeout configured on the shared client.
+    pub fn is_region_scattering_with_timeout(
+        &self,
+        region_id: u64,
+        timeout: Duration,
+    ) -> Result<bool, PdClientError> {
+        if region_id == 0 {
+            return Err(invalid_topology(
+                "zero_region_id",
+                "requested scheduling operator for region ID zero",
+            ));
+        }
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(WorkerCommand::GetOperator {
+                region_id,
+                timeout,
+                reply,
+            })
+            .map_err(|_| PdClientError::Closed)?;
+        response.recv().unwrap_or(Err(PdClientError::Closed))
+    }
+
+    /// Splits regions at already memcomparable-encoded PD wire keys and asks
+    /// PD to scatter the new regions.
+    pub fn split_and_scatter_regions(
+        &self,
+        split_keys: &[Vec<u8>],
+        group: &str,
+    ) -> Result<PdSplitAndScatterRegions, PdClientError> {
+        self.split_and_scatter_regions_with_timeout(split_keys, group, self.shared.timeout)
+    }
+
+    /// Split-and-scatter of encoded PD wire keys with an operation-specific
+    /// total deadline.
+    ///
+    /// Go gives region splitting its own `tidb_wait_split_region_timeout`
+    /// instead of the short deadline used by ordinary PD metadata lookups.
+    pub fn split_and_scatter_regions_with_timeout(
+        &self,
+        split_keys: &[Vec<u8>],
+        group: &str,
+        timeout: Duration,
+    ) -> Result<PdSplitAndScatterRegions, PdClientError> {
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(WorkerCommand::SplitAndScatterRegions {
+                split_keys: split_keys.to_vec(),
+                group: group.to_owned(),
+                timeout,
+                reply,
+            })
             .map_err(|_| PdClientError::Closed)?;
         response.recv().unwrap_or(Err(PdClientError::Closed))
     }

--- a/rust/crates/tidb-pd-client/src/client/requests.rs
+++ b/rust/crates/tidb-pd-client/src/client/requests.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use tidb_proto::pdpb;
 use tokio::sync::watch;
 
-use crate::{PdClientError, PdGcState, PdOperation, PdRegion, PdStore};
+use crate::{PdClientError, PdGcState, PdOperation, PdRegion, PdSplitAndScatterRegions, PdStore};
 
 use super::failover::{tonic_client, PdChannelCache};
 use super::topology::{
@@ -292,6 +292,79 @@ pub(super) fn get_gc_state(
         txn_safe_point: state.txn_safe_point,
         gc_safe_point: state.gc_safe_point,
     })
+}
+
+pub(super) fn split_and_scatter_regions(
+    runtime: &tokio::runtime::Runtime,
+    clients: &mut PdChannelCache,
+    endpoint: &str,
+    timeout: Duration,
+    shutdown: &watch::Receiver<bool>,
+    cluster_id: u64,
+    split_keys: &[Vec<u8>],
+    group: &str,
+) -> Result<PdSplitAndScatterRegions, PdClientError> {
+    let client = tonic_client(runtime, clients, endpoint)?;
+    let response = block_on_rpc(
+        runtime,
+        timeout,
+        shutdown,
+        client.split_and_scatter_regions(pdpb::SplitAndScatterRegionsRequest {
+            header: Some(request_header(cluster_id)),
+            split_keys: split_keys.to_vec(),
+            group: group.to_owned(),
+            // Go pd/client's RegionsOp has a zero default, which delegates
+            // the retry policy to PD.
+            retry_limit: 0,
+        }),
+    );
+    let response = map_rpc_result(
+        response,
+        PdOperation::SplitAndScatterRegions,
+        endpoint,
+        timeout,
+    )?
+    .into_inner();
+    validate_response_header(
+        PdOperation::SplitAndScatterRegions,
+        response.header.as_ref(),
+        cluster_id,
+    )?;
+    Ok(PdSplitAndScatterRegions {
+        split_finished_percentage: response.split_finished_percentage,
+        scatter_finished_percentage: response.scatter_finished_percentage,
+        region_ids: response.regions_id,
+    })
+}
+
+pub(super) fn is_region_scattering(
+    runtime: &tokio::runtime::Runtime,
+    clients: &mut PdChannelCache,
+    endpoint: &str,
+    timeout: Duration,
+    shutdown: &watch::Receiver<bool>,
+    cluster_id: u64,
+    region_id: u64,
+) -> Result<bool, PdClientError> {
+    let client = tonic_client(runtime, clients, endpoint)?;
+    let response = block_on_rpc(
+        runtime,
+        timeout,
+        shutdown,
+        client.get_operator(pdpb::GetOperatorRequest {
+            header: Some(request_header(cluster_id)),
+            region_id,
+        }),
+    );
+    let response =
+        map_rpc_result(response, PdOperation::GetOperator, endpoint, timeout)?.into_inner();
+    validate_response_header(
+        PdOperation::GetOperator,
+        response.header.as_ref(),
+        cluster_id,
+    )?;
+    Ok(response.desc.as_slice() == b"scatter-region"
+        && response.status == pdpb::OperatorStatus::Running as i32)
 }
 
 pub(super) fn map_rpc_result<T>(

--- a/rust/crates/tidb-pd-client/src/client/requests.rs
+++ b/rust/crates/tidb-pd-client/src/client/requests.rs
@@ -358,13 +358,21 @@ pub(super) fn is_region_scattering(
     );
     let response =
         map_rpc_result(response, PdOperation::GetOperator, endpoint, timeout)?.into_inner();
+    // client-go tikv/split_region.go:WaitScatterRegionFinish treats any
+    // response that is not a running scatter operator as completion before it
+    // inspects the response-header error. In particular, PD uses an empty
+    // operator plus REGION_NOT_FOUND after the operator has disappeared.
+    let is_scattering = response.desc.as_slice() == b"scatter-region"
+        && response.status == pdpb::OperatorStatus::Running as i32;
+    if !is_scattering {
+        return Ok(false);
+    }
     validate_response_header(
         PdOperation::GetOperator,
         response.header.as_ref(),
         cluster_id,
     )?;
-    Ok(response.desc.as_slice() == b"scatter-region"
-        && response.status == pdpb::OperatorStatus::Running as i32)
+    Ok(true)
 }
 
 pub(super) fn map_rpc_result<T>(

--- a/rust/crates/tidb-pd-client/src/client/worker.rs
+++ b/rust/crates/tidb-pd-client/src/client/worker.rs
@@ -48,8 +48,9 @@ use crate::{PdClientError, PdMemberSet};
 use super::failover::{
     batch_scan_regions_with_failover, endpoint_attempt_order, foreground_leader_only,
     get_gc_state_with_failover, get_prev_region_with_failover, get_region_by_id_with_failover,
-    get_region_with_failover, get_store_with_failover, refresh_membership, retain_member_clients,
-    scan_regions_with_failover, tonic_client, PdChannelCache,
+    get_region_with_failover, get_store_with_failover, is_region_scattering_with_failover,
+    refresh_membership, retain_member_clients, scan_regions_with_failover,
+    split_and_scatter_regions_with_failover, tonic_client, PdChannelCache,
 };
 use super::requests::{get_members, get_prev_region, get_region, get_region_by_id, scan_regions};
 use super::topology::invalid_topology;
@@ -102,6 +103,12 @@ pub(super) fn run_worker(
                     let _ = reply.send(Err(PdClientError::Closed));
                 }
                 WorkerCommand::GetGcState { reply, .. } => {
+                    let _ = reply.send(Err(PdClientError::Closed));
+                }
+                WorkerCommand::GetOperator { reply, .. } => {
+                    let _ = reply.send(Err(PdClientError::Closed));
+                }
+                WorkerCommand::SplitAndScatterRegions { reply, .. } => {
                     let _ = reply.send(Err(PdClientError::Closed));
                 }
                 WorkerCommand::Close { reply } => {
@@ -348,6 +355,38 @@ pub(super) fn run_worker(
                     &state,
                     &shutdown,
                     keyspace_id,
+                );
+                let _ = reply.send(result);
+            }
+            WorkerCommand::GetOperator {
+                region_id,
+                timeout: operation_timeout,
+                reply,
+            } => {
+                let result = is_region_scattering_with_failover(
+                    &runtime,
+                    &mut clients,
+                    operation_timeout,
+                    &state,
+                    &shutdown,
+                    region_id,
+                );
+                let _ = reply.send(result);
+            }
+            WorkerCommand::SplitAndScatterRegions {
+                split_keys,
+                group,
+                timeout: operation_timeout,
+                reply,
+            } => {
+                let result = split_and_scatter_regions_with_failover(
+                    &runtime,
+                    &mut clients,
+                    operation_timeout,
+                    &state,
+                    &shutdown,
+                    &split_keys,
+                    &group,
                 );
                 let _ = reply.send(result);
             }

--- a/rust/crates/tidb-pd-client/src/error.rs
+++ b/rust/crates/tidb-pd-client/src/error.rs
@@ -33,6 +33,10 @@ pub enum PdOperation {
     Tso,
     /// GC state (txn safe point) lookup.
     GetGcState,
+    /// Current scheduling operator for one region.
+    GetOperator,
+    /// Split regions at raw TiKV keys and scatter the new regions.
+    SplitAndScatterRegions,
 }
 
 impl std::fmt::Display for PdOperation {
@@ -47,6 +51,8 @@ impl std::fmt::Display for PdOperation {
             Self::GetStore => formatter.write_str("GetStore"),
             Self::Tso => formatter.write_str("Tso"),
             Self::GetGcState => formatter.write_str("GetGCState"),
+            Self::GetOperator => formatter.write_str("GetOperator"),
+            Self::SplitAndScatterRegions => formatter.write_str("SplitAndScatterRegions"),
         }
     }
 }

--- a/rust/crates/tidb-pd-client/src/etcd.rs
+++ b/rust/crates/tidb-pd-client/src/etcd.rs
@@ -39,9 +39,12 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use tidb_proto::etcdserverpb::kv_client::KvClient;
+use tidb_proto::etcdserverpb::lease_client::LeaseClient;
 use tidb_proto::etcdserverpb::watch_client::WatchClient;
 use tidb_proto::etcdserverpb::{
-    watch_request::RequestUnion, PutRequest, RangeRequest, WatchCreateRequest, WatchRequest,
+    watch_request::RequestUnion, DeleteRangeRequest, LeaseGrantRequest, LeaseKeepAliveRequest,
+    LeaseKeepAliveResponse, LeaseRevokeRequest, PutRequest, RangeRequest, WatchCreateRequest,
+    WatchRequest,
 };
 use tidb_proto::mvccpb::event::EventType;
 use tokio::sync::watch;
@@ -54,8 +57,16 @@ use crate::{secure_endpoint, ClusterSecurity, PdClientError};
 pub const ETCD_PUT_PATH: &str = "/etcdserverpb.KV/Put";
 /// Exact generated method path for reading one key back.
 pub const ETCD_RANGE_PATH: &str = "/etcdserverpb.KV/Range";
+/// Exact generated method path for removing one topology prefix.
+pub const ETCD_DELETE_RANGE_PATH: &str = "/etcdserverpb.KV/DeleteRange";
 /// Exact generated method path for the watch stream.
 pub const ETCD_WATCH_PATH: &str = "/etcdserverpb.Watch/Watch";
+/// Exact generated method path for creating a topology lease.
+pub const ETCD_LEASE_GRANT_PATH: &str = "/etcdserverpb.Lease/LeaseGrant";
+/// Exact generated method path for refreshing a topology lease.
+pub const ETCD_LEASE_KEEP_ALIVE_PATH: &str = "/etcdserverpb.Lease/LeaseKeepAlive";
+/// Exact generated method path for revoking a topology lease.
+pub const ETCD_LEASE_REVOKE_PATH: &str = "/etcdserverpb.Lease/LeaseRevoke";
 
 /// The etcd key TiDB publishes the cluster's schema version under.
 ///
@@ -162,11 +173,29 @@ enum EtcdCommand {
     Put {
         key: Vec<u8>,
         value: Vec<u8>,
+        lease_id: i64,
         reply: mpsc::Sender<Result<(), EtcdError>>,
     },
     Get {
         key: Vec<u8>,
         reply: mpsc::Sender<Result<Option<Vec<u8>>, EtcdError>>,
+    },
+    DeleteRange {
+        key: Vec<u8>,
+        range_end: Vec<u8>,
+        reply: mpsc::Sender<Result<i64, EtcdError>>,
+    },
+    GrantLease {
+        ttl: i64,
+        reply: mpsc::Sender<Result<i64, EtcdError>>,
+    },
+    KeepAliveLease {
+        lease_id: i64,
+        reply: mpsc::Sender<Result<i64, EtcdError>>,
+    },
+    RevokeLease {
+        lease_id: i64,
+        reply: mpsc::Sender<Result<(), EtcdError>>,
     },
     Close {
         reply: mpsc::Sender<()>,
@@ -282,8 +311,79 @@ impl EtcdClient {
             .send(EtcdCommand::Put {
                 key: key.to_vec(),
                 value: value.to_vec(),
+                lease_id: 0,
                 reply,
             })
+            .map_err(|_| EtcdError::Closed)?;
+        response.recv().unwrap_or(Err(EtcdError::Closed))
+    }
+
+    /// Puts one key attached to an existing etcd lease.
+    pub fn put_with_lease(&self, key: &[u8], value: &[u8], lease_id: i64) -> Result<(), EtcdError> {
+        if lease_id <= 0 {
+            return Err(EtcdError::UnexpectedResponse(format!(
+                "lease ID must be positive, got {lease_id}"
+            )));
+        }
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(EtcdCommand::Put {
+                key: key.to_vec(),
+                value: value.to_vec(),
+                lease_id,
+                reply,
+            })
+            .map_err(|_| EtcdError::Closed)?;
+        response.recv().unwrap_or(Err(EtcdError::Closed))
+    }
+
+    /// Deletes every key below one non-empty prefix.
+    pub fn delete_prefix(&self, prefix: &[u8]) -> Result<i64, EtcdError> {
+        let range_end = prefix_range_end(prefix)?;
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(EtcdCommand::DeleteRange {
+                key: prefix.to_vec(),
+                range_end,
+                reply,
+            })
+            .map_err(|_| EtcdError::Closed)?;
+        response.recv().unwrap_or(Err(EtcdError::Closed))
+    }
+
+    /// Grants a positive-TTL lease and returns etcd's chosen lease ID.
+    pub fn grant_lease(&self, ttl: i64) -> Result<i64, EtcdError> {
+        if ttl <= 0 {
+            return Err(EtcdError::UnexpectedResponse(format!(
+                "lease TTL must be positive, got {ttl}"
+            )));
+        }
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(EtcdCommand::GrantLease { ttl, reply })
+            .map_err(|_| EtcdError::Closed)?;
+        response.recv().unwrap_or(Err(EtcdError::Closed))
+    }
+
+    /// Refreshes one lease and returns its remaining TTL.
+    pub fn keep_alive_lease(&self, lease_id: i64) -> Result<i64, EtcdError> {
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(EtcdCommand::KeepAliveLease { lease_id, reply })
+            .map_err(|_| EtcdError::Closed)?;
+        response.recv().unwrap_or(Err(EtcdError::Closed))
+    }
+
+    /// Revokes a lease; every attached key is deleted atomically by etcd.
+    pub fn revoke_lease(&self, lease_id: i64) -> Result<(), EtcdError> {
+        let (reply, response) = mpsc::channel();
+        self.shared
+            .commands
+            .send(EtcdCommand::RevokeLease { lease_id, reply })
             .map_err(|_| EtcdError::Closed)?;
         response.recv().unwrap_or(Err(EtcdError::Closed))
     }
@@ -384,6 +484,7 @@ fn run_kv_worker(
     shutdown: &watch::Receiver<bool>,
 ) {
     let mut clients: HashMap<String, KvClient<Channel>> = HashMap::new();
+    let mut lease_clients: HashMap<String, LeaseClient<Channel>> = HashMap::new();
     while let Ok(command) = receiver.recv() {
         match command {
             EtcdCommand::Close { reply } => {
@@ -397,9 +498,22 @@ fn run_kv_worker(
                 EtcdCommand::Get { reply, .. } => {
                     let _ = reply.send(Err(EtcdError::Closed));
                 }
+                EtcdCommand::DeleteRange { reply, .. }
+                | EtcdCommand::GrantLease { reply, .. }
+                | EtcdCommand::KeepAliveLease { reply, .. } => {
+                    let _ = reply.send(Err(EtcdError::Closed));
+                }
+                EtcdCommand::RevokeLease { reply, .. } => {
+                    let _ = reply.send(Err(EtcdError::Closed));
+                }
                 EtcdCommand::Close { .. } => unreachable!("handled above"),
             },
-            EtcdCommand::Put { key, value, reply } => {
+            EtcdCommand::Put {
+                key,
+                value,
+                lease_id,
+                reply,
+            } => {
                 let result = across_endpoints(
                     runtime,
                     endpoints,
@@ -410,6 +524,7 @@ fn run_kv_worker(
                         let request = PutRequest {
                             key: key.clone(),
                             value: value.clone(),
+                            lease: lease_id,
                             ..Default::default()
                         };
                         runtime
@@ -446,8 +561,116 @@ fn run_kv_worker(
                 );
                 let _ = reply.send(result);
             }
+            EtcdCommand::DeleteRange {
+                key,
+                range_end,
+                reply,
+            } => {
+                let result = across_endpoints(
+                    runtime,
+                    endpoints,
+                    &mut clients,
+                    timeout,
+                    security,
+                    |runtime, client| {
+                        runtime
+                            .block_on(client.delete_range(with_deadline(
+                                DeleteRangeRequest {
+                                    key: key.clone(),
+                                    range_end: range_end.clone(),
+                                    ..Default::default()
+                                },
+                                timeout,
+                            )))
+                            .map(|response| response.into_inner().deleted)
+                    },
+                );
+                let _ = reply.send(result);
+            }
+            EtcdCommand::GrantLease { ttl, reply } => {
+                let result = across_lease_endpoints(
+                    runtime,
+                    endpoints,
+                    &mut lease_clients,
+                    timeout,
+                    security,
+                    |runtime, client| {
+                        runtime
+                            .block_on(client.lease_grant(with_deadline(
+                                LeaseGrantRequest { ttl, id: 0 },
+                                timeout,
+                            )))
+                            .map(tonic::Response::into_inner)
+                    },
+                )
+                .and_then(|response| {
+                    if !response.error.is_empty() || response.id <= 0 || response.ttl <= 0 {
+                        return Err(EtcdError::UnexpectedResponse(format!(
+                            "lease grant returned id={}, ttl={}, error={:?}",
+                            response.id, response.ttl, response.error
+                        )));
+                    }
+                    Ok(response.id)
+                });
+                let _ = reply.send(result);
+            }
+            EtcdCommand::KeepAliveLease { lease_id, reply } => {
+                let result = across_lease_endpoints(
+                    runtime,
+                    endpoints,
+                    &mut lease_clients,
+                    timeout,
+                    security,
+                    |runtime, client| runtime.block_on(keep_alive_once(client, lease_id, timeout)),
+                )
+                .and_then(|response| {
+                    if response.id != lease_id || response.ttl <= 0 {
+                        return Err(EtcdError::UnexpectedResponse(format!(
+                            "lease keepalive returned id={}, ttl={} for {lease_id}",
+                            response.id, response.ttl
+                        )));
+                    }
+                    Ok(response.ttl)
+                });
+                let _ = reply.send(result);
+            }
+            EtcdCommand::RevokeLease { lease_id, reply } => {
+                let result = across_lease_endpoints(
+                    runtime,
+                    endpoints,
+                    &mut lease_clients,
+                    timeout,
+                    security,
+                    |runtime, client| {
+                        runtime
+                            .block_on(client.lease_revoke(with_deadline(
+                                LeaseRevokeRequest { id: lease_id },
+                                timeout,
+                            )))
+                            .map(|_| ())
+                    },
+                );
+                let _ = reply.send(result);
+            }
         }
     }
+}
+
+async fn keep_alive_once(
+    client: &mut LeaseClient<Channel>,
+    lease_id: i64,
+    timeout: Duration,
+) -> Result<LeaseKeepAliveResponse, tonic::Status> {
+    let mut request =
+        tonic::Request::new(tokio_stream::iter([LeaseKeepAliveRequest { id: lease_id }]));
+    request.set_timeout(timeout);
+    let mut responses = client.lease_keep_alive(request).await?.into_inner();
+    tokio::time::timeout(timeout, responses.message())
+        .await
+        .map_err(|_| tonic::Status::deadline_exceeded("lease keepalive response timed out"))?
+        .and_then(|response| {
+            response.ok_or_else(|| tonic::Status::unavailable("lease keepalive stream ended"))
+        })
 }
 
 fn with_deadline<T>(message: T, timeout: Duration) -> tonic::Request<T> {
@@ -498,6 +721,62 @@ fn across_endpoints<T>(
         }
     }
     Err(last.unwrap_or(EtcdError::NoEndpoint))
+}
+
+fn across_lease_endpoints<T>(
+    runtime: &tokio::runtime::Runtime,
+    endpoints: &[String],
+    clients: &mut HashMap<String, LeaseClient<Channel>>,
+    timeout: Duration,
+    security: &ClusterSecurity,
+    mut call: impl FnMut(
+        &tokio::runtime::Runtime,
+        &mut LeaseClient<Channel>,
+    ) -> Result<T, tonic::Status>,
+) -> Result<T, EtcdError> {
+    let mut last = None;
+    for endpoint in endpoints {
+        if !clients.contains_key(endpoint) {
+            match connect_channel(runtime, endpoint, timeout, security) {
+                Ok(channel) => {
+                    clients.insert(endpoint.clone(), LeaseClient::new(channel));
+                }
+                Err(error) => {
+                    last = Some(error);
+                    continue;
+                }
+            }
+        }
+        let client = clients
+            .get_mut(endpoint)
+            .expect("the channel was just inserted");
+        match call(runtime, client) {
+            Ok(value) => return Ok(value),
+            Err(status) => {
+                clients.remove(endpoint);
+                last = Some(EtcdError::Unreachable {
+                    endpoint: endpoint.clone(),
+                    code: format!("{:?}", status.code()),
+                    message: status.message().to_owned(),
+                });
+            }
+        }
+    }
+    Err(last.unwrap_or(EtcdError::NoEndpoint))
+}
+
+fn prefix_range_end(prefix: &[u8]) -> Result<Vec<u8>, EtcdError> {
+    let mut end = prefix.to_vec();
+    for index in (0..end.len()).rev() {
+        if end[index] != u8::MAX {
+            end[index] += 1;
+            end.truncate(index + 1);
+            return Ok(end);
+        }
+    }
+    Err(EtcdError::UnexpectedResponse(
+        "etcd prefix must be non-empty and have a finite range end".to_owned(),
+    ))
 }
 
 fn connect_channel(
@@ -839,6 +1118,17 @@ mod tests {
     }
 
     #[test]
+    fn prefix_deletion_uses_etcds_lexicographic_range_end() {
+        assert_eq!(
+            prefix_range_end(b"/topology/tidb/a").unwrap(),
+            b"/topology/tidb/b"
+        );
+        assert_eq!(prefix_range_end(&[b'a', u8::MAX]).unwrap(), b"b");
+        assert!(prefix_range_end(b"").is_err());
+        assert!(prefix_range_end(&[u8::MAX]).is_err());
+    }
+
+    #[test]
     fn a_put_to_an_unreachable_endpoint_fails_without_hanging() {
         // Port 1 has no listener; the call must come back as Unreachable
         // rather than block the DDL path that is best-effort calling it.
@@ -897,6 +1187,30 @@ mod tests {
         assert_eq!(client.global_schema_version().unwrap(), Some(4242));
         assert!(watcher.stats().streams >= 1);
         watcher.shutdown();
+    }
+
+    /// End-to-end lease projection proof against a real PD, opt in with
+    /// `TIDB_ETCD_PROBE_PD=127.0.0.1:2379 cargo test -p tidb-pd-client -- --ignored`.
+    #[test]
+    #[ignore = "requires a live PD; set TIDB_ETCD_PROBE_PD"]
+    fn a_real_pd_lease_controls_an_attached_topology_key() {
+        let Ok(endpoint) = std::env::var("TIDB_ETCD_PROBE_PD") else {
+            panic!("set TIDB_ETCD_PROBE_PD to a PD client address");
+        };
+        let client = EtcdClient::connect([endpoint.as_str()], Duration::from_secs(5)).unwrap();
+        let prefix = format!("/topology/tidb/lease-probe-{}/", std::process::id());
+        let key = format!("{prefix}ttl");
+        client.delete_prefix(prefix.as_bytes()).unwrap();
+
+        let lease_id = client.grant_lease(5).unwrap();
+        client
+            .put_with_lease(key.as_bytes(), b"alive", lease_id)
+            .unwrap();
+        assert_eq!(client.get(key.as_bytes()).unwrap(), Some(b"alive".to_vec()));
+        assert!(client.keep_alive_lease(lease_id).unwrap() > 0);
+        client.revoke_lease(lease_id).unwrap();
+        assert_eq!(client.get(key.as_bytes()).unwrap(), None);
+        client.delete_prefix(prefix.as_bytes()).unwrap();
     }
 
     #[test]

--- a/rust/crates/tidb-pd-client/src/lib.rs
+++ b/rust/crates/tidb-pd-client/src/lib.rs
@@ -21,8 +21,9 @@ pub use client::{
 pub use error::{PdClientError, PdClientShutdownError, PdOperation};
 pub use etcd::{
     EtcdClient, EtcdError, EtcdWatchEvent, EtcdWatchStats, EtcdWatcher,
-    DDL_GLOBAL_SCHEMA_VERSION_KEY, ETCD_PUT_PATH, ETCD_RANGE_PATH, ETCD_WATCH_PATH,
-    PRIVILEGE_UPDATE_KEY, SYSVAR_UPDATE_KEY,
+    DDL_GLOBAL_SCHEMA_VERSION_KEY, ETCD_DELETE_RANGE_PATH, ETCD_LEASE_GRANT_PATH,
+    ETCD_LEASE_KEEP_ALIVE_PATH, ETCD_LEASE_REVOKE_PATH, ETCD_PUT_PATH, ETCD_RANGE_PATH,
+    ETCD_WATCH_PATH, PRIVILEGE_UPDATE_KEY, SYSVAR_UPDATE_KEY,
 };
 pub use model::{
     PdBucketStats, PdBuckets, PdGcState, PdKeyRange, PdMemberSet, PdNodeState, PdPeer, PdRegion,

--- a/rust/crates/tidb-pd-client/src/lib.rs
+++ b/rust/crates/tidb-pd-client/src/lib.rs
@@ -15,8 +15,8 @@ mod tso;
 
 pub use client::{
     is_unimplemented, PdClient, BATCH_SCAN_REGIONS_PATH, GET_GC_STATE_PATH, GET_MEMBERS_PATH,
-    GET_PREV_REGION_PATH, GET_REGION_BY_ID_PATH, GET_REGION_PATH, GET_STORE_PATH,
-    SCAN_REGIONS_PATH, TSO_PATH,
+    GET_OPERATOR_PATH, GET_PREV_REGION_PATH, GET_REGION_BY_ID_PATH, GET_REGION_PATH,
+    GET_STORE_PATH, SCAN_REGIONS_PATH, SPLIT_AND_SCATTER_REGIONS_PATH, TSO_PATH,
 };
 pub use error::{PdClientError, PdClientShutdownError, PdOperation};
 pub use etcd::{
@@ -26,6 +26,6 @@ pub use etcd::{
 };
 pub use model::{
     PdBucketStats, PdBuckets, PdGcState, PdKeyRange, PdMemberSet, PdNodeState, PdPeer, PdRegion,
-    PdRegionEpoch, PdStore, PdStoreState,
+    PdRegionEpoch, PdSplitAndScatterRegions, PdStore, PdStoreState,
 };
 pub use security::{secure_endpoint, ClusterSecurity, TlsConfigError};

--- a/rust/crates/tidb-pd-client/src/model.rs
+++ b/rust/crates/tidb-pd-client/src/model.rs
@@ -160,3 +160,14 @@ pub struct PdGcState {
     /// Timestamp below which obsolete MVCC versions may already be deleted.
     pub gc_safe_point: u64,
 }
+
+/// Outcome of PD's atomic split-and-scatter control-plane operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PdSplitAndScatterRegions {
+    /// Percentage of requested split points completed by PD.
+    pub split_finished_percentage: u64,
+    /// Percentage of the resulting regions whose scatter operation completed.
+    pub scatter_finished_percentage: u64,
+    /// IDs of the newly split regions returned by PD.
+    pub region_ids: Vec<u64>,
+}

--- a/rust/crates/tidb-pd-client/tests/pd_client_source.rs
+++ b/rust/crates/tidb-pd-client/tests/pd_client_source.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 use prost::Message;
 use tidb_pd_client::{
     PdClient, PdKeyRange, PdNodeState, PdStoreState, BATCH_SCAN_REGIONS_PATH, GET_MEMBERS_PATH,
-    GET_PREV_REGION_PATH, GET_REGION_BY_ID_PATH, GET_REGION_PATH, GET_STORE_PATH,
-    SCAN_REGIONS_PATH,
+    GET_OPERATOR_PATH, GET_PREV_REGION_PATH, GET_REGION_BY_ID_PATH, GET_REGION_PATH,
+    GET_STORE_PATH, SCAN_REGIONS_PATH, SPLIT_AND_SCATTER_REGIONS_PATH,
 };
 use tidb_proto::metapb;
 use tidb_proto::pdpb::{
@@ -94,6 +94,10 @@ struct State {
     store_requests: Vec<pdpb::GetStoreRequest>,
     gc_state: Reply<pdpb::GetGcStateResponse>,
     gc_state_requests: Vec<pdpb::GetGcStateRequest>,
+    operator: Reply<pdpb::GetOperatorResponse>,
+    operator_requests: Vec<pdpb::GetOperatorRequest>,
+    split_and_scatter: Reply<pdpb::SplitAndScatterRegionsResponse>,
+    split_and_scatter_requests: Vec<pdpb::SplitAndScatterRegionsRequest>,
 }
 
 #[derive(Clone)]
@@ -160,6 +164,18 @@ impl Pd for MockPd {
         reply.send().await
     }
 
+    async fn get_operator(
+        &self,
+        request: tonic::Request<pdpb::GetOperatorRequest>,
+    ) -> Result<tonic::Response<pdpb::GetOperatorResponse>, tonic::Status> {
+        let reply = {
+            let mut state = self.state.lock().unwrap();
+            state.operator_requests.push(request.into_inner());
+            state.operator.clone()
+        };
+        reply.send().await
+    }
+
     async fn get_region(
         &self,
         request: tonic::Request<pdpb::GetRegionRequest>,
@@ -216,6 +232,18 @@ impl Pd for MockPd {
             let mut state = self.state.lock().unwrap();
             state.batch_scan_region_requests.push(request.into_inner());
             state.batch_scan_regions.clone()
+        };
+        reply.send().await
+    }
+
+    async fn split_and_scatter_regions(
+        &self,
+        request: tonic::Request<pdpb::SplitAndScatterRegionsRequest>,
+    ) -> Result<tonic::Response<pdpb::SplitAndScatterRegionsResponse>, tonic::Status> {
+        let reply = {
+            let mut state = self.state.lock().unwrap();
+            state.split_and_scatter_requests.push(request.into_inner());
+            state.split_and_scatter.clone()
         };
         reply.send().await
     }
@@ -479,6 +507,21 @@ fn valid_state() -> State {
             }),
         }),
         gc_state_requests: Vec::new(),
+        operator: Reply::Value(pdpb::GetOperatorResponse {
+            header: Some(header(CLUSTER_ID)),
+            region_id: 101,
+            desc: b"scatter-region".to_vec(),
+            status: pdpb::OperatorStatus::Running as i32,
+            kind: b"region".to_vec(),
+        }),
+        operator_requests: Vec::new(),
+        split_and_scatter: Reply::Value(pdpb::SplitAndScatterRegionsResponse {
+            header: Some(header(CLUSTER_ID)),
+            split_finished_percentage: 100,
+            scatter_finished_percentage: 75,
+            regions_id: vec![101, 102, 103, 104],
+        }),
+        split_and_scatter_requests: Vec::new(),
     }
 }
 
@@ -539,6 +582,11 @@ fn exact_methods_headers_wire_key_roles_and_store_states_are_preserved_once() {
     assert_eq!(SCAN_REGIONS_PATH, "/pdpb.PD/ScanRegions");
     assert_eq!(BATCH_SCAN_REGIONS_PATH, "/pdpb.PD/BatchScanRegions");
     assert_eq!(GET_STORE_PATH, "/pdpb.PD/GetStore");
+    assert_eq!(GET_OPERATOR_PATH, "/pdpb.PD/GetOperator");
+    assert_eq!(
+        SPLIT_AND_SCATTER_REGIONS_PATH,
+        "/pdpb.PD/SplitAndScatterRegions"
+    );
 
     let mut state = valid_state();
     let store = match state.stores.get_mut(&101).unwrap() {
@@ -626,6 +674,14 @@ fn exact_methods_headers_wire_key_roles_and_store_states_are_preserved_once() {
     let removing = client.get_store(102).unwrap().unwrap();
     assert_eq!(removing.state, PdStoreState::Offline);
     assert_eq!(removing.node_state, PdNodeState::Removing);
+    let split_keys = vec![b"t1".to_vec(), b"t2".to_vec()];
+    let split = client.split_and_scatter_regions(&split_keys, "42").unwrap();
+    assert_eq!(split.split_finished_percentage, 100);
+    assert_eq!(split.scatter_finished_percentage, 75);
+    assert_eq!(split.region_ids, [101, 102, 103, 104]);
+    assert!(client
+        .is_region_scattering_with_timeout(101, Duration::from_secs(2))
+        .unwrap());
 
     let state = server.state.lock().unwrap();
     assert_eq!(state.member_requests.len(), 1);
@@ -647,6 +703,15 @@ fn exact_methods_headers_wire_key_roles_and_store_states_are_preserved_once() {
         assert_exact_header(request.header.as_ref().unwrap());
         true
     }));
+    assert_eq!(state.split_and_scatter_requests.len(), 1);
+    let split_request = &state.split_and_scatter_requests[0];
+    assert_eq!(split_request.split_keys, split_keys);
+    assert_eq!(split_request.group, "42");
+    assert_eq!(split_request.retry_limit, 0);
+    assert_exact_header(split_request.header.as_ref().unwrap());
+    assert_eq!(state.operator_requests.len(), 1);
+    assert_eq!(state.operator_requests[0].region_id, 101);
+    assert_exact_header(state.operator_requests[0].header.as_ref().unwrap());
 }
 
 #[test]

--- a/rust/crates/tidb-pd-client/tests/pd_client_source.rs
+++ b/rust/crates/tidb-pd-client/tests/pd_client_source.rs
@@ -715,6 +715,34 @@ fn exact_methods_headers_wire_key_roles_and_store_states_are_preserved_once() {
 }
 
 #[test]
+fn a_missing_scatter_operator_is_already_finished_like_client_go() {
+    // client-go tikv/split_region.go:WaitScatterRegionFinish checks the
+    // operator description and status before inspecting the response-header
+    // error. PD returns REGION_NOT_FOUND with an empty description and
+    // SUCCESS after an operator disappears, which therefore means finished.
+    let mut state = valid_state();
+    state.operator = Reply::Value(pdpb::GetOperatorResponse {
+        header: Some(pdpb::ResponseHeader {
+            cluster_id: CLUSTER_ID,
+            error: Some(pdpb::Error {
+                r#type: pdpb::ErrorType::RegionNotFound as i32,
+                message: "Not Found".to_owned(),
+            }),
+        }),
+        region_id: 101,
+        desc: Vec::new(),
+        status: pdpb::OperatorStatus::Success as i32,
+        kind: Vec::new(),
+    });
+    let server = Server::start(state);
+    let client = PdClient::connect(&server.address, Duration::from_secs(2)).unwrap();
+
+    assert!(!client
+        .is_region_scattering_with_timeout(101, Duration::from_secs(2))
+        .unwrap());
+}
+
+#[test]
 fn by_id_scan_and_batch_scan_preserve_flags_ranges_limits_and_response_order() {
     // pd-client/client.go:GetRegionByID, ScanRegions, BatchScanRegions.
     // pd-client/clients/router/client.go:handleRegionsResponse.

--- a/rust/crates/tidb-pd-client/tests/pd_worker_lifecycle_source.rs
+++ b/rust/crates/tidb-pd-client/tests/pd_worker_lifecycle_source.rs
@@ -112,6 +112,22 @@ impl Pd for MembershipPd {
     ) -> Result<tonic::Response<pdpb::BatchScanRegionsResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("unused BatchScanRegions"))
     }
+
+    async fn get_operator(
+        &self,
+        _request: tonic::Request<pdpb::GetOperatorRequest>,
+    ) -> Result<tonic::Response<pdpb::GetOperatorResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("unused GetOperator"))
+    }
+
+    async fn split_and_scatter_regions(
+        &self,
+        _request: tonic::Request<pdpb::SplitAndScatterRegionsRequest>,
+    ) -> Result<tonic::Response<pdpb::SplitAndScatterRegionsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "unused SplitAndScatterRegions",
+        ))
+    }
 }
 
 struct Server {

--- a/rust/crates/tidb-pd-client/tests/tls_handshake_source.rs
+++ b/rust/crates/tidb-pd-client/tests/tls_handshake_source.rs
@@ -26,7 +26,9 @@ use std::time::Duration;
 
 use tidb_pd_client::{secure_endpoint, ClusterSecurity};
 use tidb_proto::etcdserverpb::kv_server::{Kv, KvServer};
-use tidb_proto::etcdserverpb::{PutRequest, PutResponse, RangeRequest, RangeResponse};
+use tidb_proto::etcdserverpb::{
+    DeleteRangeRequest, DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
+};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
@@ -52,6 +54,13 @@ impl Kv for EchoKv {
 
     async fn put(&self, _request: Request<PutRequest>) -> Result<Response<PutResponse>, Status> {
         Ok(Response::new(PutResponse::default()))
+    }
+
+    async fn delete_range(
+        &self,
+        _request: Request<DeleteRangeRequest>,
+    ) -> Result<Response<DeleteRangeResponse>, Status> {
+        Ok(Response::new(DeleteRangeResponse::default()))
     }
 }
 

--- a/rust/crates/tidb-pd-client/tests/tso_source.rs
+++ b/rust/crates/tidb-pd-client/tests/tso_source.rs
@@ -246,6 +246,22 @@ impl Pd for MockPd {
     ) -> Result<tonic::Response<pdpb::BatchScanRegionsResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("unused BatchScanRegions"))
     }
+
+    async fn get_operator(
+        &self,
+        _request: tonic::Request<pdpb::GetOperatorRequest>,
+    ) -> Result<tonic::Response<pdpb::GetOperatorResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("unused GetOperator"))
+    }
+
+    async fn split_and_scatter_regions(
+        &self,
+        _request: tonic::Request<pdpb::SplitAndScatterRegionsRequest>,
+    ) -> Result<tonic::Response<pdpb::SplitAndScatterRegionsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "unused SplitAndScatterRegions",
+        ))
+    }
 }
 
 struct Server {

--- a/rust/crates/tidb-planner/src/cardinality/derive_stats.rs
+++ b/rust/crates/tidb-planner/src/cardinality/derive_stats.rs
@@ -23,8 +23,8 @@
 //! module derives.
 //!
 //! Node kinds are the ones a `t1, t5, (select ... from t2 join t3) dt` shape
-//! reaches: `DataSource`, `Selection`, `Projection` and inner `Join`. Each
-//! rule below is the Go body, not a re-derivation:
+//! reaches: `DataSource`, `Selection`, `Projection`, `Aggregation` and inner
+//! `Join`. Each rule below is the Go body, not a re-derivation:
 //!
 //! * `DataSource` -- `deriveStats4DataSource` (`core/stats.go:110-168`) sets
 //!   `ds.stats = ds.TableStats.Scale(vars, Selectivity(pushedDownConds))`,
@@ -38,6 +38,9 @@
 //! * `Projection` -- `LogicalProjection.DeriveStats`
 //!   (`logicalop/logical_projection.go:278-305`) passes the child's row count
 //!   through unchanged and re-derives one NDV per output expression.
+//! * `Aggregation` -- `LogicalAggregation.DeriveStats`
+//!   (`logicalop/logical_aggregation.go:219-246`) estimates the group-key NDV
+//!   and uses that number as both its row count and every output column's NDV.
 //! * `Join` -- `LogicalJoin.DeriveStats` (`logicalop/logical_join.go:560-616`)
 //!   takes `EstimateFullJoinRowCount` for an inner join and clamps every
 //!   inherited column NDV to the join's own row count.
@@ -213,6 +216,15 @@ pub enum LogicalNode {
         /// One entry per output column.
         exprs: Vec<ProjectionExpr>,
     },
+    /// A `LogicalAggregation`.
+    Aggregation {
+        /// The single child.
+        child: Box<LogicalNode>,
+        /// Every input column extracted from the `GROUP BY` expressions.
+        group_by: Vec<ColumnId>,
+        /// The aggregation's output schema columns.
+        columns: Vec<ColumnId>,
+    },
     /// A `LogicalJoin`.
     Join {
         /// The build/left child.
@@ -364,6 +376,24 @@ pub fn derive_stats(node: &LogicalNode, ctx: &DeriveStatsContext) -> DerivedNode
                         (expr.output, ndv)
                     })
                     .collect(),
+            };
+            DerivedNode {
+                stats,
+                children: vec![child],
+            }
+        }
+        LogicalNode::Aggregation {
+            child,
+            group_by,
+            columns,
+        } => {
+            let child = derive_stats(child, ctx);
+            let (ndv, _) = estimate_cols_ndv_with_matched_len(group_by, &child.stats);
+            let stats = StatsInfo {
+                row_count: ndv,
+                // Go deliberately uses the conservative group NDV for every
+                // aggregate output, including FIRST_ROW carriers.
+                col_ndvs: columns.iter().map(|id| (*id, ndv)).collect(),
             };
             DerivedNode {
                 stats,

--- a/rust/crates/tidb-planner/tests/derive_stats_source.rs
+++ b/rust/crates/tidb-planner/tests/derive_stats_source.rs
@@ -29,8 +29,8 @@
 //! all. The oracle is a default-format `EXPLAIN` of the same statements.
 
 use tidb_planner::cardinality::derive_stats::{
-    ColumnId, DeriveStatsContext, DerivedNode, LogicalNode, ProjectionExpr, calc_join_cum_cost,
-    derive_stats,
+    calc_join_cum_cost, derive_stats, ColumnId, DeriveStatsContext, DerivedNode, LogicalNode,
+    ProjectionExpr,
 };
 
 const T1_A: ColumnId = 1;
@@ -191,6 +191,23 @@ fn a_logical_selection_is_a_flat_zero_point_eight() {
     assert_row_counts(&derive_stats(&plan, &ctx()), &[8000.0, 10000.0]);
 }
 
+/// `LogicalAggregation.DeriveStats` uses the group-key NDV as both its row
+/// count and every output column's NDV. A pseudo equality leaves ten rows and
+/// an NDV of eight on the grouped column, matching TPCC condition 04's inner
+/// `GROUP BY ol_d_id` fixture.
+#[test]
+fn a_grouped_aggregation_uses_the_group_key_ndv_for_every_output() {
+    let plan = LogicalNode::Aggregation {
+        child: Box::new(table(&[T1_A, T1_B], 1.0 / 1000.0)),
+        group_by: vec![T1_B],
+        columns: vec![DT_KEY_A, DT_DOUBLED_B],
+    };
+    let derived = derive_stats(&plan, &ctx());
+    assert_row_counts(&derived, &[8.0, 10.0]);
+    assert_eq!(derived.stats.col_ndvs[&DT_KEY_A], 8.0);
+    assert_eq!(derived.stats.col_ndvs[&DT_DOUBLED_B], 8.0);
+}
+
 /// `LogicalJoin.DeriveStats` clamps every inherited column NDV to the join's
 /// own row count (`logicalop/logical_join.go:604-610`), and once a join has
 /// produced fewer rows than a key's NDV the clamp is what the *next* join
@@ -290,7 +307,12 @@ fn t5() -> LogicalNode {
 #[test]
 fn statement_1_plain_key_join_matches_the_recorded_est_rows() {
     let plan = join(
-        join(table(&[T1_A, T1_B, T1_C], 1.0), dt(1.0), &[T1_A], &[DT_KEY_A]),
+        join(
+            table(&[T1_A, T1_B, T1_C], 1.0),
+            dt(1.0),
+            &[T1_A],
+            &[DT_KEY_A],
+        ),
         table(&[T5_A], 1.0),
         &[DT_KEY_A],
         &[T5_A],
@@ -408,7 +430,12 @@ fn statement_3_two_computed_keys_apply_one_correlation_factor() {
 #[test]
 fn statement_4_a_filtered_derived_table_rescales_the_key_ndv() {
     let plan = join(
-        join(table(&[T1_A, T1_B, T1_C], 1.0), dt(0.8), &[T1_A], &[DT_KEY_A]),
+        join(
+            table(&[T1_A, T1_B, T1_C], 1.0),
+            dt(0.8),
+            &[T1_A],
+            &[DT_KEY_A],
+        ),
         table(&[T5_A], 1.0),
         &[DT_KEY_A],
         &[T5_A],

--- a/rust/crates/tidb-proto/proto/etcdserverpb.proto
+++ b/rust/crates/tidb-proto/proto/etcdserverpb.proto
@@ -9,14 +9,18 @@
 //
 // Projection scope, and why each piece is here:
 //
-//   * `KV.Put`   — `pkg/ddl/schemaver/syncer.go` `OwnerUpdateGlobalVersion`
-//                  PUTs the decimal schema version to the global key.
+//   * `KV.Put`   — publishes schema notifications and TiDB topology records.
 //   * `KV.Range` — reads that same key back, which is how a watcher seeds
 //                  itself and how a test can assert what was written.
+//   * `KV.DeleteRange` — removes this TiDB node's topology prefix on a
+//                  graceful shutdown.
 //   * `Watch.Watch` — `pkg/infoschema/issyncer/syncer.go` `SyncLoop` selects
 //                  on the watch channel for that key.
+//   * `Lease.LeaseGrant`, `Lease.LeaseKeepAlive`, and `Lease.LeaseRevoke` —
+//                  preserve Go's 45-second topology-session lifetime so a
+//                  crashed SQL node disappears from TiProxy discovery.
 //
-// Methods this tier does not call (Txn, Compact, DeleteRange, Lease, Cluster,
+// Methods this tier does not call (Txn, Compact, LeaseTimeToLive, Cluster,
 // Maintenance, Auth) are omitted; omitting a method changes no method path of
 // the ones kept. `WatchRequest.request_union` keeps `create_request = 1` and
 // `cancel_request = 2`; `progress_request = 3` is omitted with its number
@@ -35,6 +39,9 @@ service KV {
 
   // Put puts the given key into the key-value store.
   rpc Put(PutRequest) returns (PutResponse) {}
+
+  // DeleteRange deletes the given range from the key-value store.
+  rpc DeleteRange(DeleteRangeRequest) returns (DeleteRangeResponse) {}
 }
 
 service Watch {
@@ -42,6 +49,17 @@ service Watch {
   // output are streams; the input stream is for creating and canceling
   // watchers and the output stream sends events.
   rpc Watch(stream WatchRequest) returns (stream WatchResponse) {}
+}
+
+service Lease {
+  // LeaseGrant creates a lease which expires without keepalive requests.
+  rpc LeaseGrant(LeaseGrantRequest) returns (LeaseGrantResponse) {}
+
+  // LeaseRevoke revokes a lease and deletes every key attached to it.
+  rpc LeaseRevoke(LeaseRevokeRequest) returns (LeaseRevokeResponse) {}
+
+  // LeaseKeepAlive refreshes leases over a bidirectional stream.
+  rpc LeaseKeepAlive(stream LeaseKeepAliveRequest) returns (stream LeaseKeepAliveResponse) {}
 }
 
 message ResponseHeader {
@@ -142,6 +160,23 @@ message PutResponse {
   mvccpb.KeyValue prev_kv = 2;
 }
 
+message DeleteRangeRequest {
+  // key is the first key to delete.
+  bytes key = 1;
+  // range_end is the upper bound on the deleted range [key, range_end).
+  bytes range_end = 2;
+  // prev_kv returns deleted key-value pairs when set.
+  bool prev_kv = 3;
+}
+
+message DeleteRangeResponse {
+  ResponseHeader header = 1;
+  // deleted is the number of keys removed.
+  int64 deleted = 2;
+  // prev_kvs contains deleted pairs when requested.
+  repeated mvccpb.KeyValue prev_kvs = 3;
+}
+
 message WatchRequest {
   // request_union is a request to either create a new watcher or cancel an
   // existing watcher.
@@ -218,4 +253,43 @@ message WatchResponse {
   bool fragment = 7;
 
   repeated mvccpb.Event events = 11;
+}
+
+message LeaseGrantRequest {
+  // TTL is the advisory time-to-live in seconds.
+  int64 TTL = 1;
+  // ID is zero when etcd should choose the lease ID.
+  int64 ID = 2;
+}
+
+message LeaseGrantResponse {
+  ResponseHeader header = 1;
+  // ID is the granted lease ID.
+  int64 ID = 2;
+  // TTL is the server-selected time-to-live in seconds.
+  int64 TTL = 3;
+  // error is a server-side grant failure from older etcd versions.
+  string error = 4;
+}
+
+message LeaseRevokeRequest {
+  // ID is the lease to revoke.
+  int64 ID = 1;
+}
+
+message LeaseRevokeResponse {
+  ResponseHeader header = 1;
+}
+
+message LeaseKeepAliveRequest {
+  // ID is the lease to refresh.
+  int64 ID = 1;
+}
+
+message LeaseKeepAliveResponse {
+  ResponseHeader header = 1;
+  // ID is the refreshed lease ID.
+  int64 ID = 2;
+  // TTL is the refreshed remaining time-to-live; zero means not found.
+  int64 TTL = 3;
 }

--- a/rust/crates/tidb-proto/proto/pdpb.proto
+++ b/rust/crates/tidb-proto/proto/pdpb.proto
@@ -13,6 +13,8 @@ service PD {
   rpc ScanRegions(ScanRegionsRequest) returns (ScanRegionsResponse) {}
   rpc BatchScanRegions(BatchScanRegionsRequest) returns (BatchScanRegionsResponse) {}
   rpc GetGCState(GetGCStateRequest) returns (GetGCStateResponse) {}
+  rpc GetOperator(GetOperatorRequest) returns (GetOperatorResponse) {}
+  rpc SplitAndScatterRegions(SplitAndScatterRegionsRequest) returns (SplitAndScatterRegionsResponse) {}
 }
 
 // A wrapper over keyspace_id, so that an unset keyspace scope (the null
@@ -47,6 +49,41 @@ message GetGCStateResponse {
   ResponseHeader header = 1;
 
   GCState gc_state = 2;
+}
+
+message SplitAndScatterRegionsRequest {
+  RequestHeader header = 1;
+  repeated bytes split_keys = 2;
+  string group = 3;
+  uint64 retry_limit = 4;
+}
+
+message SplitAndScatterRegionsResponse {
+  ResponseHeader header = 1;
+  uint64 split_finished_percentage = 2;
+  uint64 scatter_finished_percentage = 3;
+  repeated uint64 regions_id = 4;
+}
+
+message GetOperatorRequest {
+  RequestHeader header = 1;
+  uint64 region_id = 2;
+}
+
+enum OperatorStatus {
+  SUCCESS = 0;
+  TIMEOUT = 1;
+  CANCEL = 2;
+  REPLACE = 3;
+  RUNNING = 4;
+}
+
+message GetOperatorResponse {
+  ResponseHeader header = 1;
+  uint64 region_id = 2;
+  bytes desc = 3;
+  OperatorStatus status = 4;
+  bytes kind = 5;
 }
 
 message TsoRequest {

--- a/rust/crates/tidb-proto/proto/select.proto
+++ b/rust/crates/tidb-proto/proto/select.proto
@@ -15,7 +15,10 @@ enum ExecType {
   TypeTableScan = 0;
   TypeIndexScan = 1;
   TypeSelection = 2;
+  TypeAggregation = 3;
+  TypeTopN = 4;
   TypeLimit = 5;
+  TypeStreamAgg = 6;
 }
 
 enum EngineType {
@@ -85,6 +88,11 @@ enum ExprType {
   // deliberately absent -- no leaf this path builds is that kind.
   String = 5;
   ColumnRef = 201;
+  Count = 3001;
+  Sum = 3002;
+  Min = 3004;
+  Max = 3005;
+  First = 3006;
   ScalarFunc = 10000;
 }
 
@@ -184,6 +192,20 @@ message Selection {
   repeated Expr conditions = 1;
 }
 
+// One order expression and its direction. RPN is outside this bounded path;
+// field 3 is therefore omitted while the upstream field numbers remain.
+message ByItem {
+  optional Expr expr = 1;
+  optional bool desc = 2;
+}
+
+// TiKV's list-based bounded sort. The tree child and window partitioning are
+// outside this projection; the scan/Selection precede it in the DAG list.
+message TopN {
+  repeated ByItem order_by = 1;
+  optional uint64 limit = 2;
+}
+
 // The coprocessor-side row cap. The upstream message also carries a child
 // executor and a partition_by list for the tree-based TiFlash form; neither
 // has a place in the TiKV list form this projection covers.
@@ -191,11 +213,21 @@ message Limit {
   optional uint64 limit = 1;
 }
 
+// TiKV's list-based hash/stream aggregation. RPN and TiFlash's tree child are
+// outside this bounded path; the field numbers remain the upstream ones.
+message Aggregation {
+  repeated Expr group_by = 1;
+  repeated Expr agg_func = 2;
+  optional bool streamed = 3;
+}
+
 message Executor {
   optional ExecType tp = 1;
   optional TableScan tbl_scan = 2;
   optional IndexScan idx_scan = 3;
   optional Selection selection = 4;
+  optional Aggregation aggregation = 5;
+  optional TopN topN = 6;
   optional Limit limit = 7;
   optional string executor_id = 10;
   optional uint32 parent_idx = 25;

--- a/rust/crates/tidb-proto/tests/tipb_selection_expression_source.rs
+++ b/rust/crates/tidb-proto/tests/tipb_selection_expression_source.rs
@@ -20,6 +20,7 @@ use tidb_proto::tipb::{ExecType, Executor, Expr, ExprType, FieldType, ScalarFunc
 #[test]
 fn bounded_selection_contract_keeps_upstream_numeric_values() {
     assert_eq!(ExecType::TypeSelection as i32, 2);
+    assert_eq!(ExecType::TypeTopN as i32, 4);
     assert_eq!(ExprType::Null as i32, 0);
     assert_eq!(ExprType::Int64 as i32, 1);
     assert_eq!(ExprType::ColumnRef as i32, 201);
@@ -50,6 +51,8 @@ fn selection_executor_and_nonnullable_defaults_keep_exact_wire_tags() {
         selection: Some(Selection {
             conditions: vec![literal],
         }),
+        aggregation: None,
+        top_n: None,
         limit: None,
         executor_id: Some(String::new()),
         parent_idx: None,

--- a/rust/crates/tidb-server/Cargo.toml
+++ b/rust/crates/tidb-server/Cargo.toml
@@ -23,6 +23,7 @@ sha1.workspace = true
 sha2.workspace = true
 subtle.workspace = true
 tidb-chunk = { path = "../tidb-chunk" }
+tidb-codec = { path = "../tidb-codec" }
 tidb-datatype = { path = "../tidb-datatype" }
 tidb-distsql = { path = "../tidb-distsql" }
 tidb-exec = { path = "../tidb-exec" }

--- a/rust/crates/tidb-server/src/cluster_session.rs
+++ b/rust/crates/tidb-server/src/cluster_session.rs
@@ -365,13 +365,21 @@ pub(crate) fn cluster_table(
     // cluster-wide home would allocate from a fresh in-process cell and
     // re-issue ids the table already holds, which is why this loader used to
     // refuse such a table outright rather than serve it half-wired.
-    if let Some(offset) = columns.iter().position(|column| {
+    let auto_increment_offset = columns.iter().position(|column| {
         column
             .read()
             .field_type
             .has_flag(FieldTypeFlags::AUTO_INCREMENT)
-    }) {
+    });
+    if let Some(offset) = auto_increment_offset {
         kv_table.set_auto_increment_offset(offset);
+    }
+    // Go uses one row-id allocator for every table without a clustered
+    // handle. This includes tables without an explicit AUTO_INCREMENT column:
+    // their hidden `_tidb_rowid` must be allocated from the same
+    // cluster-wide counter on every SQL node, or concurrent inserts can
+    // overwrite one another's record keys.
+    if auto_increment_offset.is_some() || (!table.pk_is_handle && !table.is_common_handle) {
         kv_table.set_auto_id(auto.allocator_for(table));
     }
     if table.pk_is_handle {
@@ -1048,6 +1056,42 @@ mod tests {
         let first = homes.allocator_for(1, &table);
         let second = homes.allocator_for(1, &table);
         assert!(first.same_allocator_as(&second));
+    }
+
+    /// A table without a primary key uses the hidden `_tidb_rowid`. Separate
+    /// SQL sessions on one node must draw those handles from one allocator,
+    /// or concurrent inserts reuse the same record key and one row overwrites
+    /// the other.
+    #[test]
+    fn non_clustered_tables_share_the_hidden_rowid_allocator() {
+        let table = TableInfo {
+            id: 403,
+            name: CiString::new("no_pk"),
+            columns: vec![column(1, 0, "v", false)].into(),
+            state: SchemaState::PUBLIC,
+            ..TableInfo::default()
+        };
+        let catalog = one_table_catalog(table);
+        let (storage, buffer, _) = cluster_storage();
+        let homes = LocalTableAutoIds::default();
+
+        let (mut first, first_skipped) =
+            session_with_cluster_storage(&catalog, &storage, &StatsSnapshot::new(), &homes);
+        let (mut second, second_skipped) =
+            session_with_cluster_storage(&catalog, &storage, &StatsSnapshot::new(), &homes);
+        assert!(first_skipped.is_empty());
+        assert!(second_skipped.is_empty());
+        first.run("USE app").unwrap();
+        second.run("USE app").unwrap();
+
+        first.run("INSERT INTO no_pk (v) VALUES (10)").unwrap();
+        second.run("INSERT INTO no_pk (v) VALUES (20)").unwrap();
+
+        assert_eq!(buffer.len(), 2, "peer sessions must not overwrite rowids");
+        let StmtResult::Rows(rows) = first.run("SELECT v FROM no_pk ORDER BY v").unwrap() else {
+            panic!("expected rows");
+        };
+        assert_eq!(format!("{rows:?}"), "[[Int(10)], [Int(20)]]");
     }
 
     /// The `CREATE INDEX`/`DROP INDEX` backfill walks the rows a table already

--- a/rust/crates/tidb-server/src/cluster_session_node/boot.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/boot.rs
@@ -36,7 +36,8 @@ use crate::real_tikv_node::{
 use crate::sql_node::{ConcurrentSqlNode, SqlQueryError};
 
 use super::{
-    ClusterSessionFactory, RealClusterDdl, RealClusterTransactions, CONTROL_PLANE_TIMEOUT,
+    ClusterSessionFactory, RealClusterDdl, RealClusterRegionAdmin, RealClusterTransactions,
+    CONTROL_PLANE_TIMEOUT,
 };
 
 /// Starts the convergence node: wide SQL over cluster storage and cluster
@@ -169,6 +170,7 @@ pub(crate) fn run_cluster_session_node_with_spill(
             )),
         )
         .with_cop_scans(cop_scans)
+        .with_region_admin(Arc::new(RealClusterRegionAdmin::new(authority.pd_client())))
         .with_spill_storage(spill_storage),
     );
     let skipped = render_skipped(factory.boot_skipped_tables());

--- a/rust/crates/tidb-server/src/cluster_session_node/boot.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/boot.rs
@@ -36,6 +36,7 @@ use crate::real_tikv_node::{
 use crate::sql_node::{ConcurrentSqlNode, SqlQueryError};
 
 use super::{
+    topology::{StatusServer, TopologyPublisher},
     ClusterSessionFactory, RealClusterDdl, RealClusterRegionAdmin, RealClusterTransactions,
     CONTROL_PLANE_TIMEOUT,
 };
@@ -207,6 +208,26 @@ pub(crate) fn run_cluster_session_node_with_spill(
                 crate::real_tikv_node::emit_connections_startup_failure(&error);
                 RunConfiguredNodeError::Node(error)
             })?;
+            let status_server = config
+                .report_status
+                .then(|| {
+                    StatusServer::start(config.status_host, config.status_port, node.tracker())
+                })
+                .transpose()
+                .map_err(|error| {
+                    crate::real_tikv_node::emit_connections_startup_failure(&error);
+                    RunConfiguredNodeError::Engine(SqlQueryError::unknown(error))
+                })?;
+            let topology_publisher = status_server
+                .as_ref()
+                .map(|status| {
+                    TopologyPublisher::start(&config, address.port(), status.local_addr().port())
+                })
+                .transpose()
+                .map_err(|error| {
+                    crate::real_tikv_node::emit_connections_startup_failure(&error);
+                    RunConfiguredNodeError::Engine(SqlQueryError::unknown(error))
+                })?;
             let shutdown = node.shutdown_handle();
             ctrlc::set_handler(move || shutdown.shutdown()).map_err(|error| {
                 crate::real_tikv_node::emit_connections_startup_failure(&error);
@@ -220,6 +241,11 @@ pub(crate) fn run_cluster_session_node_with_spill(
             stats_receipt.pseudo,
         );
             let outcome = node.run().map_err(RunConfiguredNodeError::Node);
+            // Remove the TiProxy discovery lease before stopping its HTTP
+            // health endpoint, so no newly discovered backend can race a
+            // graceful SQL shutdown.
+            drop(topology_publisher);
+            drop(status_server);
             // The reload threads hold their own transaction openers; joining
             // them here releases those PD handles before the authority's
             // shutdown drain. The watch goes first: it nudges the reloader,

--- a/rust/crates/tidb-server/src/cluster_session_node/mod.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/mod.rs
@@ -301,12 +301,14 @@ fn jitter_below(upper: u32) -> u32 {
 
 mod boot;
 mod ddl;
+mod regions;
 mod statistics;
 mod transactions;
 
 pub use boot::run_cluster_session_node;
 pub(crate) use boot::run_cluster_session_node_with_spill;
 pub use ddl::{ClusterDdl, RealClusterDdl};
+pub use regions::{ClusterRegionAdmin, RealClusterRegionAdmin, SplitRegionOutcome};
 pub use tidb_exec::real_tikv_ddl::ClusterDdlReport;
 #[cfg(test)]
 use transactions::sql_error;
@@ -330,6 +332,8 @@ enum StatementRoute {
     GlobalVars,
     /// One `ANALYZE TABLE`, per table it named.
     Analyze(Vec<AnalyzeStatement>),
+    /// One resolved `SPLIT TABLE` region-management operation.
+    SplitRegion(tidb_executor::SplitRegionPlan),
 }
 
 #[derive(Clone, Copy)]
@@ -364,6 +368,8 @@ pub struct ClusterSessionFactory {
     /// The route an `ANALYZE TABLE` takes; see
     /// [`crate::cluster_analyze_seam`].
     analyze: Arc<dyn ClusterAnalyze>,
+    /// The route a `SPLIT TABLE` control-plane operation takes.
+    regions: Arc<dyn ClusterRegionAdmin>,
     /// The cluster catalog, republished whole by the reload thread and by a
     /// DDL's own inline reload. A connection takes one `Arc` per statement, so
     /// no session ever sees a half-updated catalog.
@@ -424,6 +430,7 @@ impl ClusterSessionFactory {
             accounts,
             sysvars,
             analyze,
+            regions: Arc::new(regions::UnsupportedClusterRegionAdmin),
             catalog,
             privileges,
             processes: ProcessRegistry::default(),
@@ -460,6 +467,13 @@ impl ClusterSessionFactory {
     #[must_use]
     pub fn with_cop_scans(mut self, scanner: Arc<dyn PushdownScanner>) -> Self {
         self.cop_scans = Some(scanner);
+        self
+    }
+
+    /// Installs this node's process-level region-management authority.
+    #[must_use]
+    pub fn with_region_admin(mut self, regions: Arc<dyn ClusterRegionAdmin>) -> Self {
+        self.regions = regions;
         self
     }
 
@@ -538,6 +552,7 @@ impl QuerySessionFactory for ClusterSessionFactory {
             accounts: Arc::clone(&self.accounts),
             sysvars: Arc::clone(&self.sysvars),
             analyze: Arc::clone(&self.analyze),
+            regions: Arc::clone(&self.regions),
             catalog: Arc::clone(&self.catalog),
             schema_version: loaded.schema_version,
             stats: Arc::clone(&self.stats),
@@ -576,6 +591,8 @@ pub struct ClusterServerSession {
     /// The route an `ANALYZE TABLE` takes; see
     /// [`crate::cluster_analyze_seam`].
     analyze: Arc<dyn ClusterAnalyze>,
+    /// Region-management authority shared by every connection on this node.
+    regions: Arc<dyn ClusterRegionAdmin>,
     /// The node's catalog, which this connection follows.
     catalog: Arc<SharedClusterCatalog>,
     /// The schema version `session`'s tables were built from. A move in
@@ -1135,7 +1152,10 @@ impl ClusterServerSession {
     /// a `CREATE TABLE` with a foreign key is a clause it refuses by name, and
     /// a table-scoped `GRANT` is a `mysql.*` row shape the account writer does
     /// not encode (which it reports at persist time, where it knows).
-    fn schema_route(&self, sql: &str) -> Result<StatementRoute, SqlQueryError> {
+    fn schema_route(&mut self, sql: &str) -> Result<StatementRoute, SqlQueryError> {
+        if let Some(plan) = self.session.prepare_split_region(sql).map_err(map_error)? {
+            return Ok(StatementRoute::SplitRegion(plan));
+        }
         match self
             .session
             .statement_stored_state_change(sql)
@@ -1284,6 +1304,36 @@ impl ClusterServerSession {
             last_insert_id: 0,
         })
     }
+
+    fn run_split_region(
+        &self,
+        plan: &tidb_executor::SplitRegionPlan,
+    ) -> Result<StmtOutput, SqlQueryError> {
+        let outcome = self
+            .regions
+            .split_and_scatter(plan)
+            .map_err(SqlQueryError::unknown)?;
+        Ok(StmtOutput::Rows {
+            columns: split_region_columns(),
+            rows: vec![vec![
+                tidb_datatype::Datum::Int(outcome.total_split_regions as i64),
+                tidb_datatype::Datum::Real(outcome.scatter_finish_ratio),
+            ]],
+        })
+    }
+}
+
+fn split_region_columns() -> Vec<(String, tidb_datatype::FieldType)> {
+    vec![
+        (
+            "TOTAL_SPLIT_REGION".to_owned(),
+            tidb_datatype::FieldType::new(tidb_datatype::FieldTypeCode::LongLong),
+        ),
+        (
+            "SCATTER_FINISH_RATIO".to_owned(),
+            tidb_datatype::FieldType::new(tidb_datatype::FieldTypeCode::Double),
+        ),
+    ]
 }
 
 impl QuerySession for ClusterServerSession {
@@ -1369,6 +1419,7 @@ impl QuerySession for ClusterServerSession {
             StatementRoute::Accounts => return self.run_account_statement(sql).map(Some),
             StatementRoute::GlobalVars => return self.run_global_var_statement(sql).map(Some),
             StatementRoute::Analyze(tables) => return self.run_analyze(&tables).map(Some),
+            StatementRoute::SplitRegion(_) => return Ok(None),
             StatementRoute::Ordinary => {}
         }
         if self.session.apply_set(sql).map_err(map_error)?.is_some() {
@@ -1422,13 +1473,21 @@ impl QuerySession for ClusterServerSession {
         if classify_transaction_control(sql).is_some() {
             return Ok(PreparedGeneral::new(sql.to_owned(), 0, Vec::new()));
         }
+        let route = self.schema_route(sql)?;
         let parameter_count = self.session.parameter_count(sql).map_err(map_error)?;
+        if matches!(&route, StatementRoute::SplitRegion(_)) {
+            return Ok(PreparedGeneral::new(
+                sql.to_owned(),
+                parameter_count,
+                crate::pipeline_session::select_columns(&split_region_columns()),
+            ));
+        }
         let kind = self.session.statement_kind(sql).map_err(map_error)?;
         if kind == StmtKind::Write {
             // A prepared DDL is admitted here and executed at EXECUTE, so a
             // refusal -- an unsupported shape, an unsupported column type --
             // is reported at PREPARE, where Go reports it too.
-            self.schema_route(sql)?;
+            let _ = route;
             return Ok(PreparedGeneral::new(
                 sql.to_owned(),
                 parameter_count,
@@ -1493,12 +1552,27 @@ impl QuerySession for ClusterServerSession {
             StatementRoute::Analyze(tables) => {
                 return self.run_analyze(&tables).map(GeneralExecuteOutcome::Write)
             }
+            StatementRoute::SplitRegion(plan) => {
+                let StmtOutput::Rows { columns, rows } = self.run_split_region(&plan)? else {
+                    unreachable!("SPLIT TABLE always returns one result row")
+                };
+                return Ok(GeneralExecuteOutcome::Rows(QueryResult::new(Box::new(
+                    MaterializedResultSetSource::new(
+                        crate::pipeline_session::select_columns(&columns),
+                        rows,
+                    ),
+                ))));
+            }
             StatementRoute::Ordinary => {}
         }
         let params = crate::pipeline_session::prepared_parameters(values);
         let sql = statement.sql().to_owned();
         let shape = self.session.statement_read_shape(&sql, &params);
-        let (output, result_authority) = self.with_statement(shape, move |session| {
+        let lock = match self.session.statement_kind(&sql).map_err(map_error)? {
+            StmtKind::Write => StatementLock::WrittenKeys,
+            StmtKind::Query => self.statement_lock(&sql)?,
+        };
+        let (output, result_authority) = self.with_statement(shape, lock, move |session| {
             session
                 .run_with_params_and_result_authority(&sql, &params)
                 .map_err(map_error)
@@ -1559,6 +1633,17 @@ impl QuerySession for ClusterServerSession {
                 self.run_analyze(&tables)?;
                 return Ok(QueryResult::new(Box::new(
                     crate::pipeline_session::affected_rows_source(0),
+                )));
+            }
+            StatementRoute::SplitRegion(plan) => {
+                let StmtOutput::Rows { columns, rows } = self.run_split_region(&plan)? else {
+                    unreachable!("SPLIT TABLE always returns one result row")
+                };
+                return Ok(QueryResult::new(Box::new(
+                    MaterializedResultSetSource::new(
+                        crate::pipeline_session::select_columns(&columns),
+                        rows,
+                    ),
                 )));
             }
             StatementRoute::Ordinary => {}

--- a/rust/crates/tidb-server/src/cluster_session_node/mod.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/mod.rs
@@ -166,6 +166,7 @@
 //! [`SessionTransaction`]: tidb_exec::cluster_table_storage::SessionTransaction
 
 use std::cell::Cell;
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -177,10 +178,13 @@ use tidb_exec::real_tikv_ddl::prepare_cluster_ddl_with_context;
 use tidb_exec::stats_watch::SharedStats;
 use tidb_executor::access_path::StatementReadShape;
 use tidb_executor::cluster_storage::{
-    BufferImage, ClusterSnapshot, ClusterTableStorage, MutationBuffer, SwappableSnapshot,
+    BufferImage, ClusterSnapshot, ClusterTableStorage, MutationBuffer, StatementReadKeys,
+    SwappableSnapshot,
 };
 use tidb_executor::remote_scan::PushdownScanner;
+use tidb_planner::read_only_scan::ReadLockWait;
 use tidb_planner::transaction_control::{classify_transaction_control, TransactionControl};
+use tidb_planner::txn_mode::SessionTxnMode;
 use tidb_session::privilege::PrivilegeRegistry;
 use tidb_session::process::ProcessRegistry;
 use tidb_session::{GlobalSysvars, Session, StmtKind, StmtOutput, StmtResult, StoredStateChange};
@@ -206,6 +210,9 @@ const ER_TABLEACCESS_DENIED_ERROR: u16 = 1142;
 /// Go `kv.ErrWriteConflict`, the one cause an autocommit statement is replayed
 /// for.
 const ERR_WRITE_CONFLICT: u16 = tidb_exec::pessimistic_lock_error::ERR_WRITE_CONFLICT;
+/// Go `kv.ErrRegionUnavailable`, which is safe to replay after refreshing the
+/// route to the affected region.
+const ERR_REGION_UNAVAILABLE: u16 = tidb_exec::pessimistic_lock_error::ERR_REGION_UNAVAILABLE;
 
 /// How many times an autocommit statement that lost the race is run again
 /// before the conflict reaches the client.
@@ -236,8 +243,8 @@ const RETRY_BACK_OFF_CAP_MS: u32 = 100;
 /// `retryCnt` before the sleep -- so the first wait is drawn from `[0, 2)ms`.
 ///
 /// This is also what bounds a spinning retry in time as well as in count: even
-/// a statement that loses all ten races sleeps a capped amount rather than
-/// hammering the conflicting key.
+/// a statement that repeatedly loses races sleeps a capped amount rather
+/// than hammering the conflicting key.
 fn back_off(attempts: u32) {
     std::thread::sleep(Duration::from_millis(u64::from(jitter_below(
         back_off_upper_ms(attempts),
@@ -324,6 +331,22 @@ enum StatementRoute {
     /// One `ANALYZE TABLE`, per table it named.
     Analyze(Vec<AnalyzeStatement>),
 }
+
+#[derive(Clone, Copy)]
+enum StatementLock {
+    None,
+    WrittenKeys,
+    ReadKeys(ReadLockWait),
+}
+
+enum StatementAttempt<T> {
+    Complete(T),
+    RetryPessimistic(tidb_exec::pessimistic_lock_error::LockSqlError),
+}
+
+/// Go's default `pessimistic-txn.max-retry-count`
+/// (`pkg/config/config.go::DefaultPessimisticTxn`).
+const PESSIMISTIC_STATEMENT_RETRY_LIMIT: u32 = 256;
 
 /// Opens one cluster-backed wide-SQL [`Session`] per authenticated connection.
 pub struct ClusterSessionFactory {
@@ -469,6 +492,7 @@ impl QuerySessionFactory for ClusterSessionFactory {
         let buffer = MutationBuffer::new();
         let handle: Arc<Mutex<dyn ClusterSnapshot>> = Arc::clone(&slot) as _;
         let mut storage = ClusterTableStorage::new(buffer.clone(), handle);
+        let read_keys = storage.read_keys();
         if let Some(scanner) = self.cop_scans.as_ref() {
             storage = storage.with_remote_scanner(Arc::clone(scanner));
         }
@@ -508,6 +532,7 @@ impl QuerySessionFactory for ClusterSessionFactory {
             buffer,
             slot,
             storage,
+            read_keys,
             transactions: Arc::clone(&self.transactions),
             ddl: Arc::clone(&self.ddl),
             accounts: Arc::clone(&self.accounts),
@@ -537,6 +562,8 @@ pub struct ClusterServerSession {
     /// connection's catalog can be rebuilt after a DDL without disturbing the
     /// snapshot slot or the staged writes.
     storage: ClusterTableStorage,
+    /// Raw keys consumed by a locking read in the current statement.
+    read_keys: StatementReadKeys,
     transactions: Arc<dyn ClusterTransactions>,
     /// The route a stored-schema change takes; see [`ClusterDdl`].
     ddl: Arc<dyn ClusterDdl>,
@@ -625,51 +652,35 @@ impl ClusterServerSession {
     fn with_statement<T>(
         &mut self,
         shape: StatementReadShape,
+        lock: StatementLock,
         run: impl FnMut(&mut Session) -> Result<T, SqlQueryError>,
     ) -> Result<T, SqlQueryError> {
         self.rebuild_catalog_if_stale();
         self.begin_if_autocommit_off()?;
-        self.with_bound_statement(shape, run)
-    }
-
-    /// [`Self::with_statement`] for work the CLIENT did not ask to run: the
-    /// PREPARE probe, which executes a query only to learn its result columns.
-    ///
-    /// The one thing it must not do is open the transaction `autocommit = 0`
-    /// implies. Go's `PrepareStmt` calls `PrepareTxnCtx` too
-    /// (`pkg/session/session.go:3171`), but with a nil statement and through
-    /// `EnterNewTxnBeforeStmt`, which leaves the transaction *pending*: no
-    /// timestamp is spent and the first statement that really reads is what
-    /// takes one. Captured: `@@tidb_current_ts` is `0` after a PREPARE under
-    /// `autocommit = 0`, and a read issued after another session's commit sees
-    /// the NEW value. Opening it here would instead pin this connection's
-    /// `start_ts` at PREPARE time, so every later statement of the
-    /// transaction, and the conflict check of its commit, would live at a
-    /// timestamp the client never asked for.
-    ///
-    /// An already-open transaction is read through as usual -- a PREPARE
-    /// inside `BEGIN` costs no timestamp either way -- so this differs from
-    /// [`Self::with_statement`] in exactly one thing: it never OPENS one.
-    fn probe_statement<T>(
-        &mut self,
-        shape: StatementReadShape,
-        run: impl FnMut(&mut Session) -> Result<T, SqlQueryError>,
-    ) -> Result<T, SqlQueryError> {
-        self.rebuild_catalog_if_stale();
-        self.with_bound_statement(shape, run)
+        self.with_bound_statement(shape, lock, run)
     }
 
     /// The statement lifecycle proper: savepoint, attempt, replay budget.
     fn with_bound_statement<T>(
         &mut self,
         shape: StatementReadShape,
+        lock: StatementLock,
         mut run: impl FnMut(&mut Session) -> Result<T, SqlQueryError>,
     ) -> Result<T, SqlQueryError> {
         let savepoint = self.buffer.staged();
         let mut retried: u32 = 0;
+        let mut pessimistic_retried: u32 = 0;
         let outcome = loop {
-            match self.attempt_statement(shape, savepoint.clone(), &mut run) {
-                Ok(value) => break Ok(value),
+            match self.attempt_statement(shape, lock, savepoint.clone(), &mut run) {
+                Ok(StatementAttempt::Complete(value)) => break Ok(value),
+                Ok(StatementAttempt::RetryPessimistic(error)) => {
+                    if pessimistic_retried >= PESSIMISTIC_STATEMENT_RETRY_LIMIT {
+                        break Err(SqlQueryError::new(error.code, error.state, error.message));
+                    }
+                    pessimistic_retried += 1;
+                    back_off(pessimistic_retried);
+                    self.session.retry_auto_ids().borrow_mut().begin_attempt();
+                }
                 Err(error) => {
                     if !self.may_retry_autocommit_statement(&error, retried) {
                         break Err(error);
@@ -702,13 +713,22 @@ impl ClusterServerSession {
     fn attempt_statement<T>(
         &mut self,
         shape: StatementReadShape,
+        lock: StatementLock,
         savepoint: BufferImage,
         run: &mut impl FnMut(&mut Session) -> Result<T, SqlQueryError>,
-    ) -> Result<T, SqlQueryError> {
+    ) -> Result<StatementAttempt<T>, SqlQueryError> {
         // The statement's own timestamp, filled in by its first read and read
         // back by its publication after the read handle is gone. Autocommit
         // publishes THERE, not at a fresh one: see `StatementReadTs`.
         let read_ts = transactions::StatementReadTs::default();
+        let pessimistic = self
+            .explicit
+            .as_ref()
+            .is_some_and(|transaction| transaction.mode().is_pessimistic());
+        let collect_read_keys = pessimistic && matches!(lock, StatementLock::ReadKeys(_));
+        if collect_read_keys {
+            self.read_keys.begin();
+        }
         let snapshot = match self.explicit.as_ref() {
             // The transaction's timestamp is already spent; its per-statement
             // read handle costs nothing, so there is nothing to defer.
@@ -732,17 +752,76 @@ impl ClusterServerSession {
         match outcome {
             Ok(value) => {
                 finished?;
+                let keys = match lock {
+                    StatementLock::None => Vec::new(),
+                    StatementLock::ReadKeys(_) if collect_read_keys => self.read_keys.finish(),
+                    StatementLock::ReadKeys(_) => Vec::new(),
+                    StatementLock::WrittenKeys if pessimistic => {
+                        statement_mutation_keys(&savepoint, &self.buffer.staged())
+                    }
+                    StatementLock::WrittenKeys => Vec::new(),
+                };
+                if pessimistic && !keys.is_empty() {
+                    let wait = match lock {
+                        StatementLock::ReadKeys(wait) => wait,
+                        StatementLock::WrittenKeys | StatementLock::None => ReadLockWait::Blocking,
+                    };
+                    match self.lock_explicit_keys(&keys, wait)? {
+                        tidb_exec::multi_statement_transaction::LockKeysOutcome::Acquired => {}
+                        tidb_exec::multi_statement_transaction::LockKeysOutcome::Retry(error) => {
+                            self.buffer.restore(savepoint);
+                            return Ok(StatementAttempt::RetryPessimistic(error));
+                        }
+                    }
+                }
                 self.commit_if_session_left_transaction()?;
                 self.flush_if_autocommit(read_ts.get())?;
-                Ok(value)
+                Ok(StatementAttempt::Complete(value))
             }
             Err(error) => {
+                if collect_read_keys {
+                    self.read_keys.cancel();
+                }
                 // The statement's own writes go; every earlier statement's
                 // writes in this transaction stay.
                 self.buffer.restore(savepoint);
                 Err(error)
             }
         }
+    }
+
+    fn lock_explicit_keys(
+        &mut self,
+        keys: &[Vec<u8>],
+        wait: ReadLockWait,
+    ) -> Result<tidb_exec::multi_statement_transaction::LockKeysOutcome, SqlQueryError> {
+        let result = self
+            .explicit
+            .as_mut()
+            .expect("the pessimistic caller has an explicit transaction")
+            .lock_keys_once(keys, &BTreeSet::new(), wait);
+        match result {
+            Ok(outcome) => Ok(outcome),
+            Err(error) => {
+                let keeps_transaction_open = error.keeps_transaction_open();
+                let sql_error = error.sql_error().clone();
+                if !keeps_transaction_open {
+                    self.explicit.take();
+                    self.buffer.reset();
+                    self.savepoints.clear();
+                }
+                Err(SqlQueryError::new(
+                    sql_error.code,
+                    sql_error.state,
+                    sql_error.message,
+                ))
+            }
+        }
+    }
+
+    fn statement_lock(&self, sql: &str) -> Result<StatementLock, SqlQueryError> {
+        let wait = self.session.statement_lock_wait(sql).map_err(map_error)?;
+        Ok(wait.map_or(StatementLock::None, StatementLock::ReadKeys))
     }
 
     /// Whether the statement that just failed is one Go would have retried
@@ -802,7 +881,7 @@ impl ClusterServerSession {
     /// computed from a stale read would introduce exactly the lost update this
     /// seam exists to prevent.
     fn may_retry_autocommit_statement(&self, error: &SqlQueryError, retried: u32) -> bool {
-        error.code == ERR_WRITE_CONFLICT
+        matches!(error.code, ERR_WRITE_CONFLICT | ERR_REGION_UNAVAILABLE)
             && retried < AUTOCOMMIT_RETRY_LIMIT
             && self.explicit.is_none()
             && !self.session.in_transaction()
@@ -870,7 +949,12 @@ impl ClusterServerSession {
         if self.explicit.is_some() || self.session.is_autocommit() {
             return Ok(());
         }
-        self.explicit = Some(self.transactions.begin().map_err(SqlQueryError::unknown)?);
+        let mode = self.session.configured_txn_mode();
+        self.explicit = Some(
+            self.transactions
+                .begin(mode)
+                .map_err(SqlQueryError::unknown)?,
+        );
         Ok(())
     }
 
@@ -1256,7 +1340,15 @@ impl QuerySession for ClusterServerSession {
             // that its COMMIT will prewrite at.
             Some(TransactionControl::Begin { .. }) => {
                 self.discard_explicit()?;
-                self.explicit = Some(self.transactions.begin().map_err(SqlQueryError::unknown)?);
+                let mode = self
+                    .session
+                    .txn_mode()
+                    .unwrap_or(SessionTxnMode::Pessimistic);
+                self.explicit = Some(
+                    self.transactions
+                        .begin(mode)
+                        .map_err(SqlQueryError::unknown)?,
+                );
             }
             Some(
                 control @ (TransactionControl::Savepoint(_)
@@ -1297,15 +1389,17 @@ impl QuerySession for ClusterServerSession {
         // A write declares nothing. Its read-before-write reaches the snapshot
         // as the same `get` a point-get SELECT issues, which is exactly why the
         // declaration is made from the statement rather than from the read.
-        let affected_rows = self.with_statement(StatementReadShape::Unknown, move |session| {
-            match session.run(&owned).map_err(map_error)? {
+        let affected_rows = self.with_statement(
+            StatementReadShape::Unknown,
+            StatementLock::WrittenKeys,
+            move |session| match session.run(&owned).map_err(map_error)? {
                 StmtResult::Affected(count) => Ok(count),
                 StmtResult::Done(_) => Ok(0),
                 StmtResult::Rows(_) => Err(SqlQueryError::unknown(
                     "a write statement unexpectedly produced rows",
                 )),
-            }
-        })?;
+            },
+        )?;
         Ok(Some(WriteOutcome {
             affected_rows,
             last_insert_id: self.session.statement_insert_id(),
@@ -1341,29 +1435,22 @@ impl QuerySession for ClusterServerSession {
                 Vec::new(),
             ));
         }
-        // Go reports a query's result columns at PREPARE time, which it gets
-        // by planning the statement with every marker bound to NULL. Planning
-        // reads the catalog and may read rows, so it takes a snapshot like any
-        // other statement.
-        let owned = sql.to_owned();
-        // The PREPARE probe runs the statement with every marker NULL, which
-        // is not the statement the client will execute; it declares nothing,
-        // and -- see `probe_statement` -- it opens no transaction either.
-        let result_columns = self.probe_statement(StatementReadShape::Unknown, move |session| {
-            let probe: Vec<tidb_datatype::Datum> =
-                std::iter::repeat_n(tidb_datatype::Datum::Null, parameter_count).collect();
-            Ok(match session.run_with_params(&owned, &probe) {
-                Ok(StmtOutput::Rows { columns, .. }) => {
-                    crate::pipeline_session::select_columns(&columns)
-                }
-                // A query whose metadata cannot be resolved without real
-                // values reports none at prepare time -- which a client
-                // frames its EXECUTE against, so it is the shape that
-                // answers `2014 Commands out of sync` rather than a harmless
-                // omission. See `crate::pipeline_session::prepare_general`.
-                _ => Vec::new(),
-            })
-        })?;
+        // Go reports a query's result columns at PREPARE time by planning the
+        // statement with every marker bound to NULL. The catalog is refreshed
+        // exactly as it is for an executed statement, but the executor is
+        // neither opened nor drained, so PREPARE opens no read transaction.
+        self.rebuild_catalog_if_stale();
+        let probe: Vec<tidb_datatype::Datum> =
+            std::iter::repeat_n(tidb_datatype::Datum::Null, parameter_count).collect();
+        let result_columns = match self.session.plan_query_with_params(sql, &probe) {
+            Ok(columns) => crate::pipeline_session::select_columns(&columns),
+            // A query whose metadata cannot be resolved without real values
+            // reports none at prepare time -- which a client frames its
+            // EXECUTE against, so it is the shape that answers `2014 Commands
+            // out of sync` rather than a harmless omission. See
+            // `crate::pipeline_session::prepare_general`.
+            Err(_) => Vec::new(),
+        };
         Ok(PreparedGeneral::new(
             sql.to_owned(),
             parameter_count,
@@ -1478,10 +1565,11 @@ impl QuerySession for ClusterServerSession {
         }
         let owned = sql.to_owned();
         let shape = self.session.statement_read_shape(sql, &[]);
+        let lock = self.statement_lock(sql)?;
         // The rows are materialized inside the statement's snapshot, because
         // the snapshot's read transaction ends when the statement does; a lazy
         // source would be reading through a finished transaction.
-        let source = self.with_statement(shape, move |session| {
+        let source = self.with_statement(shape, lock, move |session| {
             let output = session.run_with_columns(&owned).map_err(map_error)?;
             Ok(match output {
                 StmtOutput::Rows { columns, rows } => MaterializedResultSetSource::new(
@@ -1502,6 +1590,18 @@ impl QuerySession for ClusterServerSession {
 fn map_error(error: tidb_executor::DriverError) -> SqlQueryError {
     let mapped = error.to_mysql_error();
     SqlQueryError::new(mapped.code, mapped.state, mapped.message)
+}
+
+fn statement_mutation_keys(before: &BufferImage, after: &BufferImage) -> Vec<Vec<u8>> {
+    after
+        .iter()
+        .filter(|(key, value)| {
+            before
+                .binary_search_by(|(before_key, _)| before_key.cmp(key))
+                .map_or(true, |index| before[index].1.as_ref() != value.as_ref())
+        })
+        .map(|(key, _)| key.as_bytes().to_vec())
+        .collect()
 }
 
 /// Storage bound to no snapshot, used only to decide which tables a catalog

--- a/rust/crates/tidb-server/src/cluster_session_node/mod.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/mod.rs
@@ -195,8 +195,8 @@ use crate::cluster_session::{cluster_session_catalog, SkippedTable, TableAutoIds
 use crate::cluster_sysvar_seam::ClusterSysvarWriter;
 use crate::pipeline_session::MaterializedResultSetSource;
 use crate::sql_node::{
-    ConnectionKillTarget, GeneralExecuteOutcome, PreparedGeneral, QueryResult, QuerySession,
-    QuerySessionFactory, SessionContext, SqlQueryError, WriteOutcome,
+    session_wait_timeout, ConnectionKillTarget, GeneralExecuteOutcome, PreparedGeneral,
+    QueryResult, QuerySession, QuerySessionFactory, SessionContext, SqlQueryError, WriteOutcome,
 };
 use crate::wire_status::WireStatus;
 
@@ -303,6 +303,7 @@ mod boot;
 mod ddl;
 mod regions;
 mod statistics;
+mod topology;
 mod transactions;
 
 pub use boot::run_cluster_session_node;
@@ -1354,6 +1355,11 @@ impl QuerySession for ClusterServerSession {
     /// `@@character_set_results`.
     fn result_charset(&self) -> String {
         self.session.result_charset()
+    }
+
+    /// Go `clientConn.getWaitTimeout`: read the live session `@@wait_timeout`.
+    fn wait_timeout(&self) -> Duration {
+        session_wait_timeout(&self.session)
     }
 
     /// Maps `BEGIN`/`COMMIT`/`ROLLBACK` onto the connection's buffer.

--- a/rust/crates/tidb-server/src/cluster_session_node/regions.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/regions.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region-management seam for the convergence node.
+//!
+//! The session resolves SQL objects into raw TiKV split keys. This seam owns
+//! the separate control-plane effect: memcomparable-encoding those keys for
+//! PD, then asking the process authority's existing client to split and
+//! scatter them. Keeping the effect behind a trait makes the SQL routing and
+//! result shape testable without a cluster.
+
+use std::time::{Duration, Instant};
+
+use tidb_executor::SplitRegionPlan;
+use tidb_pd_client::PdClient;
+
+const SPLIT_REGION_TIMEOUT: Duration = Duration::from_secs(300);
+const INITIAL_SCATTER_POLL_DELAY: Duration = Duration::from_millis(2);
+const MAX_SCATTER_POLL_DELAY: Duration = Duration::from_millis(500);
+const MAX_OPERATOR_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Client-visible outcome of one `SPLIT TABLE` execution.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SplitRegionOutcome {
+    /// Number of newly split regions reported by PD.
+    pub total_split_regions: u64,
+    /// Fraction of the requested scatter work PD reports complete.
+    pub scatter_finish_ratio: f64,
+}
+
+/// Process-level capability used by `SPLIT TABLE` statements.
+pub trait ClusterRegionAdmin: Send + Sync {
+    /// Splits and scatters all raw keys in one resolved plan.
+    fn split_and_scatter(&self, plan: &SplitRegionPlan) -> Result<SplitRegionOutcome, String>;
+}
+
+/// Production region-management capability over the node's shared PD worker.
+pub struct RealClusterRegionAdmin {
+    pd: PdClient,
+}
+
+impl RealClusterRegionAdmin {
+    /// Binds region management to an already-running PD client handle.
+    #[must_use]
+    pub const fn new(pd: PdClient) -> Self {
+        Self { pd }
+    }
+}
+
+impl ClusterRegionAdmin for RealClusterRegionAdmin {
+    fn split_and_scatter(&self, plan: &SplitRegionPlan) -> Result<SplitRegionOutcome, String> {
+        // Region metadata carries memcomparable-encoded boundaries. Go's
+        // TiKV split path performs that conversion before PD observes the
+        // regions; the aggregate PD RPC requires it from its caller. It also
+        // expects the equivalent ordered key set.
+        let split_keys = pd_split_keys(plan);
+        let deadline = Instant::now() + SPLIT_REGION_TIMEOUT;
+        let response = self
+            .pd
+            .split_and_scatter_regions_with_timeout(
+                &split_keys,
+                &plan.table_id.to_string(),
+                // Go's default `tidb_wait_split_region_timeout`.
+                SPLIT_REGION_TIMEOUT,
+            )
+            .map_err(|error| error.to_string())?;
+        let total_split_regions = response.region_ids.len();
+        let finished_scatter_regions = if response.scatter_finished_percentage >= 100 {
+            total_split_regions
+        } else {
+            self.wait_scatter_region_finish(&response.region_ids, deadline)
+        };
+        Ok(SplitRegionOutcome {
+            total_split_regions: total_split_regions as u64,
+            scatter_finish_ratio: if total_split_regions == 0 {
+                0.0
+            } else {
+                finished_scatter_regions as f64 / total_split_regions as f64
+            },
+        })
+    }
+}
+
+impl RealClusterRegionAdmin {
+    /// Go `waitScatterRegionFinish`: poll each returned region's PD operator
+    /// until its `scatter-region` operator stops running, sharing the same
+    /// statement-wide deadline used for the split itself. A transient PD
+    /// error takes the same bounded retry path as a still-running operator;
+    /// only regions observed complete contribute to the returned ratio.
+    fn wait_scatter_region_finish(&self, region_ids: &[u64], deadline: Instant) -> usize {
+        let mut finished = 0;
+        for region_id in region_ids {
+            let mut delay = INITIAL_SCATTER_POLL_DELAY;
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let probe_timeout = remaining.min(MAX_OPERATOR_RPC_TIMEOUT);
+                match self
+                    .pd
+                    .is_region_scattering_with_timeout(*region_id, probe_timeout)
+                {
+                    Ok(false) => {
+                        finished += 1;
+                        break;
+                    }
+                    Ok(true) | Err(_) => {}
+                }
+
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                std::thread::sleep(delay.min(remaining));
+                delay = delay.saturating_mul(2).min(MAX_SCATTER_POLL_DELAY);
+            }
+        }
+        finished
+    }
+}
+
+fn pd_split_keys(plan: &SplitRegionPlan) -> Vec<Vec<u8>> {
+    let mut split_keys = plan
+        .split_keys
+        .iter()
+        .map(|key| {
+            let mut encoded = Vec::with_capacity(tidb_codec::encoded_bytes_len(key.len()));
+            tidb_codec::encode_bytes(&mut encoded, key);
+            encoded
+        })
+        .collect::<Vec<_>>();
+    split_keys.sort_unstable();
+    split_keys.dedup();
+    split_keys
+}
+
+pub(super) struct UnsupportedClusterRegionAdmin;
+
+impl ClusterRegionAdmin for UnsupportedClusterRegionAdmin {
+    fn split_and_scatter(&self, _plan: &SplitRegionPlan) -> Result<SplitRegionOutcome, String> {
+        Err("this server has no region-management authority".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pd_split_keys;
+    use tidb_executor::SplitRegionPlan;
+
+    fn pd_key(raw: &[u8]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        tidb_codec::encode_bytes(&mut encoded, raw);
+        encoded
+    }
+
+    #[test]
+    fn pd_receives_encoded_deduplicated_split_keys_in_key_order() {
+        let plan = SplitRegionPlan {
+            table_id: 42,
+            split_keys: vec![b"end".to_vec(), b"a".to_vec(), b"end".to_vec()],
+        };
+        assert_eq!(pd_split_keys(&plan), [pd_key(b"a"), pd_key(b"end")]);
+    }
+}

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/autocommit_transactions.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/autocommit_transactions.rs
@@ -407,6 +407,19 @@ fn an_autocommit_update_that_loses_the_race_is_retried_at_a_new_read() {
     );
 }
 
+#[test]
+fn region_unavailable_is_retryable_only_for_bounded_autocommit_replay() {
+    let (mut session, _) = open_session();
+    let unavailable =
+        SqlQueryError::new(ERR_REGION_UNAVAILABLE, *b"HY000", "Region is unavailable");
+
+    assert!(session.may_retry_autocommit_statement(&unavailable, 0));
+    assert!(!session.may_retry_autocommit_statement(&unavailable, AUTOCOMMIT_RETRY_LIMIT));
+
+    session.control_transaction("BEGIN").expect("begin");
+    assert!(!session.may_retry_autocommit_statement(&unavailable, 0));
+}
+
 /// The bound on that retry, which is the other half of the contract clients
 /// depend on.
 ///

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/mock_cluster.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/mock_cluster.rs
@@ -11,11 +11,16 @@
 //! publication, a snapshot taken twice.
 
 use super::super::*;
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use tidb_exec::pessimistic_lock_error::commit_outcome_to_sql_error;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use tidb_exec::multi_statement_transaction::{LockKeysOutcome, TransactionStatementError};
+use tidb_exec::pessimistic_lock_error::{
+    commit_outcome_to_sql_error, LockSqlError, ERR_WRITE_CONFLICT,
+};
 use tidb_executor::cluster_storage::SnapshotPairs;
 use tidb_executor::storage::StorageError;
+use tidb_planner::read_only_scan::ReadLockWait;
+use tidb_planner::txn_mode::SessionTxnMode;
 use tidb_txnkv::transaction::{
     CommittedTransaction, OptimisticCommitOutcome, OptimisticTransactionReceipt,
     RolledBackTransaction, TransactionCause,
@@ -44,6 +49,14 @@ pub(super) struct MockCluster {
     pub(super) opened_at_max_ts: AtomicUsize,
     /// Explicit transactions opened by `BEGIN`.
     pub(super) begun: AtomicUsize,
+    /// Modes requested by explicit transactions, in open order.
+    pub(super) begun_modes: Mutex<Vec<SessionTxnMode>>,
+    /// Raw-key lock batches requested by pessimistic statements.
+    pub(super) lock_batches: Mutex<Vec<Vec<Vec<u8>>>>,
+    /// Statement-scoped lock conflicts to return before acquisition succeeds.
+    ///
+    /// This makes the server's whole-statement replay budget testable.
+    pub(super) pessimistic_lock_retries_remaining: AtomicU32,
     /// Read handles still bound. A statement that leaks one leaves this
     /// above zero, which is the lock-left-behind failure in miniature.
     pub(super) live: AtomicUsize,
@@ -271,12 +284,14 @@ impl ClusterTransactions for MockTransactions {
         Ok(())
     }
 
-    fn begin(&self) -> Result<Box<dyn OpenClusterTransaction>, String> {
+    fn begin(&self, mode: SessionTxnMode) -> Result<Box<dyn OpenClusterTransaction>, String> {
         self.0.begun.fetch_add(1, Ordering::AcqRel);
+        self.0.begun_modes.lock().expect("begun modes").push(mode);
         Ok(Box::new(MockSessionTransaction {
             start_ts: self.0.timestamp(),
             data: self.0.snapshot(),
             cluster: Arc::clone(&self.0),
+            mode,
         }))
     }
 }
@@ -289,9 +304,14 @@ pub(super) struct MockSessionTransaction {
     pub(super) start_ts: u64,
     pub(super) data: BTreeMap<Vec<u8>, Vec<u8>>,
     pub(super) cluster: Arc<MockCluster>,
+    pub(super) mode: SessionTxnMode,
 }
 
 impl OpenClusterTransaction for MockSessionTransaction {
+    fn mode(&self) -> SessionTxnMode {
+        self.mode
+    }
+
     fn snapshot(&self) -> Result<Box<dyn ClusterSnapshot>, String> {
         self.cluster.live.fetch_add(1, Ordering::AcqRel);
         Ok(Box::new(MockSnapshot {
@@ -301,6 +321,34 @@ impl OpenClusterTransaction for MockSessionTransaction {
             // which is also what the eventual publication is checked against.
             start_ts: self.start_ts,
         }))
+    }
+
+    fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        _presume_not_exists: &BTreeSet<Vec<u8>>,
+        _wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError> {
+        self.cluster
+            .lock_batches
+            .lock()
+            .expect("lock batches")
+            .push(keys.to_vec());
+        if self
+            .cluster
+            .pessimistic_lock_retries_remaining
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Ok(LockKeysOutcome::Retry(LockSqlError {
+                code: ERR_WRITE_CONFLICT,
+                state: *b"HY000",
+                message: "injected pessimistic statement conflict".to_owned(),
+            }));
+        }
+        Ok(LockKeysOutcome::Acquired)
     }
 
     fn commit(self: Box<Self>, buffer: &MutationBuffer) -> Result<(), SqlQueryError> {

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/point_get_max_ts.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/point_get_max_ts.rs
@@ -125,6 +125,45 @@ fn a_prepared_point_get_takes_no_timestamp_either() {
     assert_eq!(node.live.load(Ordering::Acquire), 0);
 }
 
+/// PREPARE reports a query's result metadata from planning alone. In
+/// particular, binding row markers to NULL must not execute the locking read
+/// just to discover that the query returns two columns.
+#[test]
+fn preparing_a_composite_batch_point_get_opens_no_snapshot() {
+    let (mut session, node) = open_session();
+    session
+        .execute_write(
+            "CREATE TABLE stock (w_id BIGINT, i_id BIGINT, v BIGINT, PRIMARY KEY (w_id, i_id) CLUSTERED)",
+        )
+        .expect("create common-handle table");
+    session
+        .execute_write("INSERT INTO stock VALUES (1, 1, 10), (1, 2, 20)")
+        .expect("seed common-handle table");
+
+    let mut statement = None;
+    let opens = opens_of(&node, || {
+        statement = Some(
+            session
+                .prepare_general(
+                    "SELECT w_id, i_id FROM stock WHERE (w_id, i_id) IN ((?, ?), (?, ?)) FOR UPDATE",
+                )
+                .expect("prepare"),
+        );
+    });
+    let statement = statement.expect("prepared statement");
+    assert_eq!(statement.parameter_count(), 4);
+    assert_eq!(statement.result_columns().len(), 2);
+    assert_eq!(
+        opens,
+        Opens {
+            timestamped: 0,
+            max_ts: 0,
+        },
+        "PREPARE executed the query while deriving result metadata",
+    );
+    assert_eq!(node.live.load(Ordering::Acquire), 0);
+}
+
 /// A second equality beside the handle is NOT this tier's point get: the
 /// handle arm requires exactly one name/value pair (Go's `len(pairs) == 1`),
 /// so the statement plans as a scan with a filter and must pay.

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/schema_changes.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/schema_changes.rs
@@ -68,7 +68,7 @@ fn a_ddl_shape_the_cluster_path_cannot_express_is_refused_precisely() {
 /// the full cluster session turns DDL admission into its client-facing error.
 #[test]
 fn cluster_create_default_errors_cross_the_schema_route_unchanged() {
-    let (session, node) = open_session();
+    let (mut session, node) = open_session();
     for (sql, code, state, message) in [
         (
             "CREATE TABLE bad_function (a INT DEFAULT (ABS(1)))",

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/transactions.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/transactions.rs
@@ -66,6 +66,31 @@ fn an_explicit_transaction_publishes_once_at_commit() {
     assert_eq!(cluster.live.load(Ordering::Acquire), 0);
 }
 
+/// The transaction mode parsed by the driver must reach the cluster seam. A
+/// mode flag that only changes the driver's catalog copy leaves real TiKV on
+/// its optimistic path and silently drops every pessimistic lock request.
+#[test]
+fn begin_mode_reaches_the_cluster_transaction_opener() {
+    let (mut session, cluster) = open_session();
+
+    session
+        .control_transaction("BEGIN OPTIMISTIC")
+        .expect("optimistic begin");
+    session.control_transaction("ROLLBACK").expect("rollback");
+    session
+        .control_transaction("BEGIN PESSIMISTIC")
+        .expect("pessimistic begin");
+    session.control_transaction("ROLLBACK").expect("rollback");
+
+    assert_eq!(
+        *cluster.begun_modes.lock().expect("begun modes"),
+        vec![
+            tidb_planner::txn_mode::SessionTxnMode::Optimistic,
+            tidb_planner::txn_mode::SessionTxnMode::Pessimistic,
+        ]
+    );
+}
+
 /// One `BEGIN` takes one timestamp, and every statement until `COMMIT`
 /// reads through that same transaction rather than opening its own.
 #[test]

--- a/rust/crates/tidb-server/src/cluster_session_node/tests/wide_sql.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/tests/wide_sql.rs
@@ -5,6 +5,7 @@
 
 use super::super::*;
 use super::node_fixture::*;
+use std::sync::atomic::Ordering;
 use tidb_datatype::Datum;
 
 /// A `SELECT` over a stored `ENUM`/`SET` column answers with the element
@@ -56,6 +57,78 @@ fn a_select_over_stored_enum_and_set_columns_answers_with_their_names() {
         }
         other => panic!("the ENUM/SET columns came back as {other:?}"),
     }
+}
+
+/// A wide-SQL locking read must collect the rows the executor actually
+/// consumed and send those raw keys to the transaction seam. The mock opener
+/// records the batch, which catches the old behaviour where `FOR UPDATE` was
+/// parsed but never issued a TiKV PessimisticLock.
+#[test]
+fn a_wide_sql_for_update_requests_raw_key_locks() {
+    let (mut session, node) = open_session();
+    session
+        .execute_write("INSERT INTO t (id, v) VALUES (1, 10)")
+        .expect("seed");
+    session
+        .control_transaction("BEGIN PESSIMISTIC")
+        .expect("begin pessimistic");
+
+    assert_eq!(
+        rows(&mut session, "SELECT v FROM t WHERE id = 1 FOR UPDATE"),
+        vec![vec![Datum::Int(10)]]
+    );
+    assert_eq!(
+        node.cluster
+            .lock_batches
+            .lock()
+            .expect("lock batches")
+            .len(),
+        1
+    );
+    assert!(!node
+        .cluster
+        .lock_batches
+        .lock()
+        .expect("lock batches")
+        .first()
+        .expect("one lock batch")
+        .is_empty());
+    session.control_transaction("ROLLBACK").expect("rollback");
+}
+
+/// Go retries one pessimistic statement up to
+/// `pessimistic-txn.max-retry-count`, whose default is 256. A smaller local
+/// budget leaks retryable 9007 errors under TPCC district-row contention.
+#[test]
+fn a_pessimistic_statement_retries_past_eight_conflicts_like_go() {
+    let (mut session, node) = open_session();
+    session
+        .execute_write("INSERT INTO t (id, v) VALUES (1, 10)")
+        .expect("seed");
+    node.cluster
+        .pessimistic_lock_retries_remaining
+        .store(9, Ordering::Release);
+    session
+        .control_transaction("BEGIN PESSIMISTIC")
+        .expect("begin pessimistic");
+
+    session
+        .execute_write("UPDATE t SET v = v + 1 WHERE id = 1")
+        .expect("Go's default retry budget survives nine lock conflicts");
+    assert_eq!(
+        node.cluster
+            .lock_batches
+            .lock()
+            .expect("lock batches")
+            .len(),
+        10,
+        "nine retries plus the successful lock attempt"
+    );
+    session.control_transaction("COMMIT").expect("commit");
+    assert_eq!(
+        rows(&mut session, "SELECT v FROM t WHERE id = 1"),
+        vec![vec![Datum::Int(11)]]
+    );
 }
 
 /// The catalog a session gets is the cluster's, minus exactly the tables

--- a/rust/crates/tidb-server/src/cluster_session_node/topology.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/topology.rs
@@ -1,0 +1,422 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TiProxy discovery and the TiDB HTTP endpoints it consumes.
+//!
+//! Go TiDB publishes `/topology/tidb/<sql-address>/info` without a lease and
+//! `/topology/tidb/<sql-address>/ttl` under a 45-second etcd lease. TiProxy
+//! admits an address only while both keys exist, then checks `/status` before
+//! opening the MySQL port. This module owns that exact process-lifetime
+//! contract for the cluster-session server.
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
+use std::path::Path;
+use std::sync::{mpsc, Arc};
+use std::thread::JoinHandle;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tidb_pd_client::EtcdClient;
+
+use crate::node_config::NodeConfig;
+use crate::sql_node::ConnectionTracker;
+
+const TOPOLOGY_ROOT: &str = "/topology/tidb";
+const TOPOLOGY_LEASE_TTL_SECONDS: i64 = 45;
+const TOPOLOGY_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
+const TOPOLOGY_REPUBLISH_EVERY_KEEP_ALIVES: u8 = 2;
+const TOPOLOGY_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const STATUS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const STATUS_IO_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_STATUS_REQUEST_BYTES: usize = 4096;
+const STATUS_VERSION: &str = "5.7.25-TiDB-Rust";
+
+/// Process-owned TiDB topology publication.
+pub(crate) struct TopologyPublisher {
+    shutdown: mpsc::Sender<()>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl TopologyPublisher {
+    /// Publishes this SQL node before returning and then retains its lease.
+    pub(crate) fn start(
+        config: &NodeConfig,
+        sql_port: u16,
+        status_port: u16,
+    ) -> Result<Self, String> {
+        let advertise_ip = resolve_advertise_ip(config)?;
+        let sql_address = SocketAddr::new(advertise_ip, sql_port).to_string();
+        let prefix = format!("{TOPOLOGY_ROOT}/{sql_address}");
+        let info_key = format!("{prefix}/info");
+        let ttl_key = format!("{prefix}/ttl");
+        let info = topology_info(advertise_ip, status_port)?;
+        let client = EtcdClient::connect_with_security(
+            config.pd_endpoints.iter(),
+            super::CONTROL_PLANE_TIMEOUT,
+            Arc::new(config.cluster_security.clone()),
+        )
+        .map_err(|error| format!("connect topology etcd client: {error}"))?;
+        let lease_id = establish_topology_lease(&client, &info_key, &info, &ttl_key)
+            .map_err(|error| format!("publish TiDB topology for {sql_address}: {error}"))?;
+        let (shutdown, receiver) = mpsc::channel();
+        let worker = std::thread::Builder::new()
+            .name("tidb-topology".to_owned())
+            .spawn(move || {
+                refresh_topology_loop(client, receiver, prefix, info_key, info, ttl_key, lease_id);
+            })
+            .map_err(|error| format!("start topology refresh thread: {error}"))?;
+        Ok(Self {
+            shutdown,
+            worker: Some(worker),
+        })
+    }
+
+    fn shutdown(&mut self) {
+        let _ = self.shutdown.send(());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for TopologyPublisher {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn establish_topology_lease(
+    client: &EtcdClient,
+    info_key: &str,
+    info: &[u8],
+    ttl_key: &str,
+) -> Result<i64, tidb_pd_client::EtcdError> {
+    let lease_id = client.grant_lease(TOPOLOGY_LEASE_TTL_SECONDS)?;
+    client.put(info_key.as_bytes(), info)?;
+    client.put_with_lease(
+        ttl_key.as_bytes(),
+        topology_timestamp().as_bytes(),
+        lease_id,
+    )?;
+    Ok(lease_id)
+}
+
+fn refresh_topology_loop(
+    client: EtcdClient,
+    receiver: mpsc::Receiver<()>,
+    prefix: String,
+    info_key: String,
+    info: Vec<u8>,
+    ttl_key: String,
+    initial_lease_id: i64,
+) {
+    let mut lease_id = Some(initial_lease_id);
+    let mut successful_keep_alives = 0_u8;
+    let mut delay = TOPOLOGY_KEEP_ALIVE_INTERVAL;
+    loop {
+        match receiver.recv_timeout(delay) {
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+
+        let result = match lease_id {
+            Some(id) => client.keep_alive_lease(id).and_then(|_| {
+                successful_keep_alives = successful_keep_alives.saturating_add(1);
+                if successful_keep_alives < TOPOLOGY_REPUBLISH_EVERY_KEEP_ALIVES {
+                    return Ok(id);
+                }
+                successful_keep_alives = 0;
+                client.put(info_key.as_bytes(), &info)?;
+                client.put_with_lease(ttl_key.as_bytes(), topology_timestamp().as_bytes(), id)?;
+                Ok(id)
+            }),
+            None => establish_topology_lease(&client, &info_key, &info, &ttl_key),
+        };
+        match result {
+            Ok(id) => {
+                lease_id = Some(id);
+                delay = TOPOLOGY_KEEP_ALIVE_INTERVAL;
+            }
+            Err(error) => {
+                eprintln!(
+                    "{{\"event\":\"topology_refresh_failed\",\"error\":{:?}}}",
+                    error.to_string()
+                );
+                lease_id = None;
+                successful_keep_alives = 0;
+                delay = TOPOLOGY_RETRY_INTERVAL;
+            }
+        }
+    }
+
+    if let Some(id) = lease_id {
+        let _ = client.revoke_lease(id);
+    }
+    let _ = client.delete_prefix(prefix.as_bytes());
+}
+
+fn topology_info(advertise_ip: IpAddr, status_port: u16) -> Result<Vec<u8>, String> {
+    let deploy_path = std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(Path::parent)
+        .map_or_else(String::new, |path| path.to_string_lossy().into_owned());
+    serde_json::to_vec(&serde_json::json!({
+        "version": STATUS_VERSION,
+        "git_hash": tidb_util::versioninfo::TIDB_GIT_HASH,
+        "ip": advertise_ip.to_string(),
+        "status_port": status_port,
+        "deploy_path": deploy_path,
+        "start_timestamp": unix_seconds(),
+        "labels": {},
+    }))
+    .map_err(|error| format!("encode topology info: {error}"))
+}
+
+fn topology_timestamp() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .to_string()
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn resolve_advertise_ip(config: &NodeConfig) -> Result<IpAddr, String> {
+    if let Some(address) = config.advertise_address {
+        return Ok(address);
+    }
+    if !config.host.is_unspecified() {
+        return Ok(config.host);
+    }
+    let endpoint = config
+        .pd_endpoints
+        .first()
+        .ok_or_else(|| "cannot resolve advertise address without a PD endpoint".to_owned())?;
+    let destination = endpoint
+        .to_socket_addrs()
+        .map_err(|error| format!("resolve PD endpoint {endpoint}: {error}"))?
+        .next()
+        .ok_or_else(|| format!("PD endpoint {endpoint} resolved no address"))?;
+    let bind_address = if destination.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    };
+    let socket = UdpSocket::bind(bind_address)
+        .map_err(|error| format!("bind advertise route probe: {error}"))?;
+    socket
+        .connect(destination)
+        .map_err(|error| format!("resolve route to PD {destination}: {error}"))?;
+    let address = socket
+        .local_addr()
+        .map_err(|error| format!("read advertise route address: {error}"))?
+        .ip();
+    if address.is_unspecified() {
+        return Err("route to PD resolved an unspecified advertise address".to_owned());
+    }
+    Ok(address)
+}
+
+/// Minimal TiDB-compatible status service used by TiProxy health and metric checks.
+pub(crate) struct StatusServer {
+    address: SocketAddr,
+    shutdown: mpsc::Sender<()>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl StatusServer {
+    /// Binds the configured status listener and starts serving `/status`,
+    /// `/config`, and `/metrics` before returning.
+    pub(crate) fn start(
+        host: IpAddr,
+        port: u16,
+        tracker: Arc<ConnectionTracker>,
+    ) -> Result<Self, String> {
+        let listener = TcpListener::bind((host, port))
+            .map_err(|error| format!("bind status server {host}:{port}: {error}"))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| format!("configure status listener: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("read status listener address: {error}"))?;
+        let (shutdown, receiver) = mpsc::channel();
+        let worker = std::thread::Builder::new()
+            .name("tidb-status".to_owned())
+            .spawn(move || serve_status(listener, receiver, tracker))
+            .map_err(|error| format!("start status server thread: {error}"))?;
+        Ok(Self {
+            address,
+            shutdown,
+            worker: Some(worker),
+        })
+    }
+
+    /// Operating-system-selected address, including an ephemeral test port.
+    pub(crate) const fn local_addr(&self) -> SocketAddr {
+        self.address
+    }
+
+    fn shutdown(&mut self) {
+        let _ = self.shutdown.send(());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for StatusServer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn serve_status(
+    listener: TcpListener,
+    shutdown: mpsc::Receiver<()>,
+    tracker: Arc<ConnectionTracker>,
+) {
+    loop {
+        if shutdown.try_recv().is_ok() {
+            return;
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => serve_status_connection(&mut stream, &tracker),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                match shutdown.recv_timeout(STATUS_POLL_INTERVAL) {
+                    Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                }
+            }
+            Err(error) => {
+                eprintln!(
+                    "{{\"event\":\"status_accept_failed\",\"error\":{:?}}}",
+                    error.to_string()
+                );
+                return;
+            }
+        }
+    }
+}
+
+fn serve_status_connection(stream: &mut TcpStream, tracker: &ConnectionTracker) {
+    let _ = stream.set_read_timeout(Some(STATUS_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(STATUS_IO_TIMEOUT));
+    let mut request = [0_u8; MAX_STATUS_REQUEST_BYTES];
+    let Ok(length) = stream.read(&mut request) else {
+        return;
+    };
+    let first_line = String::from_utf8_lossy(&request[..length])
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_owned();
+    let path = first_line.split_ascii_whitespace().nth(1).unwrap_or("");
+    let (status, content_type, body) = match path {
+        "/status" => (
+            "200 OK",
+            "application/json",
+            serde_json::json!({
+                "connections": tracker.active(),
+                "version": STATUS_VERSION,
+                "git_hash": tidb_util::versioninfo::TIDB_GIT_HASH,
+            })
+            .to_string(),
+        ),
+        "/config" => (
+            "200 OK",
+            "application/json",
+            serde_json::json!({
+                "security": {"session-token-signing-cert": ""}
+            })
+            .to_string(),
+        ),
+        "/metrics" => (
+            "200 OK",
+            "text/plain; version=0.0.4",
+            format!(
+                "# HELP tidb_server_connections Number of client connections.\n\
+                 # TYPE tidb_server_connections gauge\n\
+                 tidb_server_connections {}\n",
+                tracker.active()
+            ),
+        ),
+        _ => ("404 Not Found", "application/json", "{}".to_owned()),
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fetch(address: SocketAddr, path: &str) -> String {
+        let mut stream = TcpStream::connect(address).unwrap();
+        stream
+            .write_all(format!("GET {path} HTTP/1.1\r\nHost: test\r\n\r\n").as_bytes())
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    #[test]
+    fn status_server_answers_the_tiproxy_health_and_metrics_paths() {
+        let tracker = Arc::new(ConnectionTracker::default());
+        let server = StatusServer::start(IpAddr::from([127, 0, 0, 1]), 0, tracker).unwrap();
+
+        let status = fetch(server.local_addr(), "/status");
+        assert!(status.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(status.contains("\"connections\":0"));
+        assert!(status.contains("\"version\":\"5.7.25-TiDB-Rust\""));
+
+        let config = fetch(server.local_addr(), "/config");
+        assert!(config.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(config.contains("\"session-token-signing-cert\":\"\""));
+
+        let metrics = fetch(server.local_addr(), "/metrics");
+        assert!(metrics.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(metrics.contains("Content-Type: text/plain; version=0.0.4\r\n"));
+        assert!(metrics.contains("tidb_server_connections 0\n"));
+        assert!(fetch(server.local_addr(), "/missing").starts_with("HTTP/1.1 404 Not Found\r\n"));
+    }
+
+    #[test]
+    fn topology_key_and_info_match_go_and_tiproxy_shapes() {
+        let ip = IpAddr::from([10, 0, 0, 8]);
+        let address = SocketAddr::new(ip, 4000).to_string();
+        assert_eq!(
+            format!("{TOPOLOGY_ROOT}/{address}/info"),
+            "/topology/tidb/10.0.0.8:4000/info"
+        );
+        let info: serde_json::Value =
+            serde_json::from_slice(&topology_info(ip, 10080).unwrap()).unwrap();
+        assert_eq!(info["ip"], "10.0.0.8");
+        assert_eq!(info["status_port"], 10080);
+        assert!(info["start_timestamp"].as_u64().unwrap() > 0);
+        assert!(info["labels"].as_object().unwrap().is_empty());
+    }
+}

--- a/rust/crates/tidb-server/src/cluster_session_node/transactions.rs
+++ b/rust/crates/tidb-server/src/cluster_session_node/transactions.rs
@@ -18,6 +18,7 @@
 //! it is one of the independent seams that accreted there; see that module's
 //! doc comment for the statement lifecycle this seam is exercised by.
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -25,10 +26,13 @@ use std::time::Duration;
 use tidb_exec::cluster_table_storage::{
     commit_staged_buffer, SessionTransaction, StatementSnapshot,
 };
+use tidb_exec::multi_statement_transaction::{LockKeysOutcome, TransactionStatementError};
 use tidb_exec::pessimistic_lock_error::LockSqlError;
 use tidb_exec::real_tikv_read::RealOptimisticTransactionOpener;
 use tidb_executor::cluster_storage::{ClusterSnapshot, MutationBuffer, SnapshotPairs};
 use tidb_executor::storage::StorageError;
+use tidb_planner::read_only_scan::ReadLockWait;
+use tidb_planner::txn_mode::SessionTxnMode;
 use tidb_txnkv::Key;
 
 use crate::sql_node::SqlQueryError;
@@ -80,7 +84,7 @@ pub trait ClusterTransactions: Send + Sync {
 
     /// Opens the one transaction an explicit `BEGIN` holds until `COMMIT` or
     /// `ROLLBACK`.
-    fn begin(&self) -> Result<Box<dyn OpenClusterTransaction>, String>;
+    fn begin(&self, mode: SessionTxnMode) -> Result<Box<dyn OpenClusterTransaction>, String>;
 }
 
 /// The transaction an explicit `BEGIN` holds open across its statements.
@@ -90,9 +94,21 @@ pub trait ClusterTransactions: Send + Sync {
 /// same timestamp -- which is what makes a racing writer a write conflict
 /// instead of a silent overwrite.
 pub trait OpenClusterTransaction: Send {
+    /// The mode selected by `BEGIN` or `@@tidb_txn_mode`.
+    fn mode(&self) -> SessionTxnMode;
+
     /// One statement's read handle. Dropping it ends the statement, never the
     /// transaction.
     fn snapshot(&self) -> Result<Box<dyn ClusterSnapshot>, String>;
+
+    /// Attempts one statement's raw-key pessimistic lock batch. A retry result
+    /// means the caller must restore the statement image and rerun the SQL.
+    fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        presume_not_exists: &BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError>;
 
     /// Publishes the staged writes at the transaction's own start timestamp and
     /// empties the buffer.
@@ -329,16 +345,35 @@ impl ClusterTransactions for RealClusterTransactions {
             .map_err(sql_error)
     }
 
-    fn begin(&self) -> Result<Box<dyn OpenClusterTransaction>, String> {
-        SessionTransaction::begin(Arc::clone(&self.opener), self.timeout)
-            .map(|transaction| Box::new(transaction) as Box<dyn OpenClusterTransaction>)
-            .map_err(|error| error.to_string())
+    fn begin(&self, mode: SessionTxnMode) -> Result<Box<dyn OpenClusterTransaction>, String> {
+        SessionTransaction::begin_mode(
+            Arc::clone(&self.opener),
+            self.timeout,
+            mode,
+            crate::session_transaction::session_fair_locking(),
+            tidb_exec::session_commit_protocol::session_commit_protocol(),
+        )
+        .map(|transaction| Box::new(transaction) as Box<dyn OpenClusterTransaction>)
+        .map_err(|error| error.to_string())
     }
 }
 
 impl OpenClusterTransaction for SessionTransaction {
+    fn mode(&self) -> SessionTxnMode {
+        SessionTransaction::mode(self)
+    }
+
     fn snapshot(&self) -> Result<Box<dyn ClusterSnapshot>, String> {
         SessionTransaction::snapshot(self).map_err(|error| error.to_string())
+    }
+
+    fn lock_keys_once(
+        &mut self,
+        keys: &[Vec<u8>],
+        presume_not_exists: &BTreeSet<Vec<u8>>,
+        wait: ReadLockWait,
+    ) -> Result<LockKeysOutcome, TransactionStatementError> {
+        SessionTransaction::lock_keys_once(self, keys, presume_not_exists, wait)
     }
 
     fn commit(self: Box<Self>, buffer: &MutationBuffer) -> Result<(), SqlQueryError> {

--- a/rust/crates/tidb-server/src/mysql_connection.rs
+++ b/rust/crates/tidb-server/src/mysql_connection.rs
@@ -559,6 +559,20 @@ pub fn serve_mysql_connection_with_tls<F: QuerySessionFactory>(
         tls,
         &mut commands,
     );
+    // Go `server.onConn` treats an `io.EOF` returned by the handshake as a
+    // normal client-side close: it neither increments handshake errors nor
+    // emits a noticeable error (`pkg/server/server.go`). The command loop
+    // already converts its own packet-boundary EOF into `PeerClosed`, so an
+    // EOF reaching this boundary can only be the pre-command handshake case.
+    let result = match result {
+        Err(MysqlConnectionError::Packet(PacketError::EndOfStream)) => Ok(ConnectionReport {
+            connection_id: lease.id(),
+            queries: 0,
+            commands,
+            exit: ConnectionExit::PeerClosed,
+        }),
+        result => result,
+    };
     let failed = result.is_err() && !shutdown.is_cancelled();
     if failed {
         lease.mark_failed();
@@ -899,6 +913,9 @@ fn serve_connection_inner<F: QuerySessionFactory>(
             });
         }
     };
+    close
+        .apply_authenticated_timeouts(engine.wait_timeout())
+        .map_err(MysqlConnectionError::Io)?;
     // Go's `openSessionAndDoAuth`: the handshake's initial database is applied
     // before the connection is reported ready, and a schema that does not
     // exist ends the connection with its own errno rather than the OK packet.
@@ -944,6 +961,9 @@ fn serve_connection_inner<F: QuerySessionFactory>(
                 exit: ConnectionExit::Killed,
             });
         }
+        close
+            .apply_authenticated_timeouts(engine.wait_timeout())
+            .map_err(MysqlConnectionError::Io)?;
         reader.set_sequence(0);
         let payload = match reader.read_packet() {
             Ok(payload) => payload,

--- a/rust/crates/tidb-server/src/node_config.rs
+++ b/rust/crates/tidb-server/src/node_config.rs
@@ -116,7 +116,7 @@ pub struct LoadedTableName {
 /// Complete startup input consumed by the concurrent SQL node.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeConfig {
-    /// Loopback address on which MySQL protocol connections are accepted.
+    /// Address on which MySQL protocol connections are accepted.
     pub host: IpAddr,
     /// MySQL protocol port. Zero requests an ephemeral test port.
     pub port: u16,
@@ -233,7 +233,7 @@ pub enum NodeConfigError {
     },
     /// Only the real TiKV store is supported by this executable.
     UnsupportedStore(String),
-    /// Native password without TLS must never bind a non-loopback address.
+    /// Configured-account mode must never bind a non-loopback address.
     NonLoopbackHost(IpAddr),
 }
 
@@ -264,7 +264,7 @@ impl fmt::Display for NodeConfigError {
             }
             Self::NonLoopbackHost(host) => write!(
                 formatter,
-                "refusing non-loopback MySQL listener {host} while TLS is not implemented"
+                "refusing non-loopback MySQL listener {host} for --auth-file; use --load-privileges for cluster deployment"
             ),
         }
     }
@@ -624,7 +624,10 @@ impl NodeConfig {
         }
 
         let host = parse_ip("--host", host.as_deref().unwrap_or("127.0.0.1"))?;
-        if !host.is_loopback() {
+        // Cluster privilege mode is used behind TiProxy on a private network.
+        // The configured auth-file mode keeps the original loopback-only
+        // boundary because it has no cluster-backed account lifecycle.
+        if !host.is_loopback() && !load_privileges {
             return Err(NodeConfigError::NonLoopbackHost(host));
         }
         let port = parse_number("--port", port.as_deref().unwrap_or("4000"))?;
@@ -777,7 +780,7 @@ impl NodeConfig {
 [--max-connections <count>] [--connection-timeout-ms <milliseconds>] \
 [--max-topn-rows <rows>] [--lease-ms <milliseconds>] \
 [--auth-file <mode-0600-tsv> | --load-privileges] \
-[--host <loopback-ip>] [-P <port>|--port <port>] [--store tikv] \
+[--host <listen-ip>] [-P <port>|--port <port>] [--store tikv] \
 [--max-allowed-packet <bytes>] \
 [--ssl-cert <cert-pem> --ssl-key <key-pem>] [--no-auto-tls] \
 [--no-disconnect-on-expired-password] \

--- a/rust/crates/tidb-server/src/node_config.rs
+++ b/rust/crates/tidb-server/src/node_config.rs
@@ -120,6 +120,17 @@ pub struct NodeConfig {
     pub host: IpAddr,
     /// MySQL protocol port. Zero requests an ephemeral test port.
     pub port: u16,
+    /// Address published to PD's TiDB topology for TiProxy discovery.
+    ///
+    /// `None` follows Go TiDB's default: use the listener address unless it
+    /// is unspecified, in which case startup resolves the route to PD.
+    pub advertise_address: Option<IpAddr>,
+    /// Address on which the TiDB-compatible HTTP status service listens.
+    pub status_host: IpAddr,
+    /// TiDB-compatible HTTP status port.
+    pub status_port: u16,
+    /// Whether the status service and TiProxy topology publication are active.
+    pub report_status: bool,
     /// Plaintext PD endpoints in configured order.
     pub pd_endpoints: Vec<String>,
     /// Checked tables exposed to the bounded planner in command-line order.
@@ -273,6 +284,7 @@ impl fmt::Display for NodeConfigError {
 impl std::error::Error for NodeConfigError {}
 
 const SUPPORTED_CONFIG_LEAVES: &[&str] = &[
+    "advertise-address",
     "host",
     "instance.max_connections",
     "lease",
@@ -288,6 +300,9 @@ const SUPPORTED_CONFIG_LEAVES: &[&str] = &[
     "security.ssl-cert",
     "security.ssl-key",
     "store",
+    "status.report-status",
+    "status.status-host",
+    "status.status-port",
     "tmp-storage-path",
     "tmp-storage-quota",
 ];
@@ -438,6 +453,10 @@ impl NodeConfig {
 
         let mut host = None;
         let mut port = None;
+        let mut advertise_address = None;
+        let mut status_host = None;
+        let mut status_port = None;
+        let mut report_status = None;
         let mut path = None;
         let mut store = None;
         let mut read_tables = Vec::new();
@@ -499,6 +518,10 @@ impl NodeConfig {
                 cluster_session = true;
                 continue;
             }
+            if argument == "--report-status" {
+                set_once(&mut report_status, "--report-status", "true".to_owned())?;
+                continue;
+            }
             if argument == "--read-table" {
                 read_tables.push(parse_read_table(&mut pending)?);
                 continue;
@@ -522,6 +545,10 @@ impl NodeConfig {
             match option {
                 "--host" => set_once(&mut host, option, value)?,
                 "--port" => set_once(&mut port, option, value)?,
+                "--advertise-address" => set_once(&mut advertise_address, option, value)?,
+                "--status-host" => set_once(&mut status_host, option, value)?,
+                "--status" => set_once(&mut status_port, option, value)?,
+                "--report-status" => set_once(&mut report_status, option, value)?,
                 "--path" => set_once(&mut path, option, value)?,
                 "--store" => set_once(&mut store, option, value)?,
                 "--read-table" => {
@@ -565,6 +592,18 @@ impl NodeConfig {
             }
             if port.is_none() && loaded.is_defined("port") {
                 port = Some(config.port.to_string());
+            }
+            if advertise_address.is_none() && loaded.is_defined("advertise-address") {
+                advertise_address = Some(config.advertise_address.clone());
+            }
+            if status_host.is_none() && loaded.is_defined("status.status-host") {
+                status_host = Some(config.status.status_host.clone());
+            }
+            if status_port.is_none() && loaded.is_defined("status.status-port") {
+                status_port = Some(config.status.status_port.to_string());
+            }
+            if report_status.is_none() && loaded.is_defined("status.report-status") {
+                report_status = Some(config.status.report_status.to_string());
             }
             if path.is_none() && loaded.is_defined("path") {
                 path = Some(config.path.clone());
@@ -624,6 +663,16 @@ impl NodeConfig {
         }
 
         let host = parse_ip("--host", host.as_deref().unwrap_or("127.0.0.1"))?;
+        let advertise_address = advertise_address
+            .as_deref()
+            .map(|value| parse_ip("--advertise-address", value))
+            .transpose()?;
+        let status_host = parse_ip("--status-host", status_host.as_deref().unwrap_or("0.0.0.0"))?;
+        let status_port = parse_number("--status", status_port.as_deref().unwrap_or("10080"))?;
+        let report_status = parse_bool(
+            "--report-status",
+            report_status.as_deref().unwrap_or("true"),
+        )?;
         // Cluster privilege mode is used behind TiProxy on a private network.
         // The configured auth-file mode keeps the original loopback-only
         // boundary because it has no cluster-backed account lifecycle.
@@ -714,6 +763,12 @@ impl NodeConfig {
             let config = &mut loaded.config;
             config.host = host.to_string();
             config.port = u32::from(port);
+            config.advertise_address = advertise_address
+                .map(|address| address.to_string())
+                .unwrap_or_default();
+            config.status.status_host = status_host.to_string();
+            config.status.status_port = u32::from(status_port);
+            config.status.report_status = report_status;
             config.store = tidb_config::store::StoreType("tikv".to_owned());
             config.path = pd_endpoints.join(",");
             config.max_allowed_packet = u64::try_from(max_allowed_packet).unwrap_or(u64::MAX);
@@ -748,6 +803,10 @@ impl NodeConfig {
         Ok(Self {
             host,
             port,
+            advertise_address,
+            status_host,
+            status_port,
+            report_status,
             pd_endpoints,
             read_tables,
             load_tables,
@@ -781,6 +840,8 @@ impl NodeConfig {
 [--max-topn-rows <rows>] [--lease-ms <milliseconds>] \
 [--auth-file <mode-0600-tsv> | --load-privileges] \
 [--host <listen-ip>] [-P <port>|--port <port>] [--store tikv] \
+[--advertise-address <ip>] [--status-host <ip>] [--status <port>] \
+[--report-status=<bool>] \
 [--max-allowed-packet <bytes>] \
 [--ssl-cert <cert-pem> --ssl-key <key-pem>] [--no-auto-tls] \
 [--no-disconnect-on-expired-password] \
@@ -922,6 +983,14 @@ fn parse_ip(option: &str, value: &str) -> Result<IpAddr, NodeConfigError> {
     value
         .parse()
         .map_err(|_| invalid(option, "expected an IP address"))
+}
+
+fn parse_bool(option: &str, value: &str) -> Result<bool, NodeConfigError> {
+    match value {
+        "1" | "t" | "T" | "TRUE" | "true" | "True" => Ok(true),
+        "0" | "f" | "F" | "FALSE" | "false" | "False" => Ok(false),
+        _ => Err(invalid(option, "expected a boolean")),
+    }
 }
 
 fn parse_number<T>(option: &str, value: &str) -> Result<T, NodeConfigError>

--- a/rust/crates/tidb-server/src/pipeline_session.rs
+++ b/rust/crates/tidb-server/src/pipeline_session.rs
@@ -303,7 +303,7 @@ impl QuerySession for PipelineServerSession {
 
     /// Go reports a prepared statement's marker count and result columns at
     /// PREPARE time. The columns come from planning the statement with every
-    /// marker bound to NULL, which is side-effect free for a query; a
+    /// marker bound to NULL, without opening or draining its executor; a
     /// statement that answers with an OK packet reports none.
     fn prepare_general(&mut self, sql: &str) -> Result<PreparedGeneral, SqlQueryError> {
         let parameter_count = self.session.parameter_count(sql).map_err(map_error)?;
@@ -311,8 +311,8 @@ impl QuerySession for PipelineServerSession {
             StmtKind::Query => {
                 let probe: Vec<tidb_datatype::Datum> =
                     std::iter::repeat_n(tidb_datatype::Datum::Null, parameter_count).collect();
-                match self.session.run_with_params(sql, &probe) {
-                    Ok(StmtOutput::Rows { columns, .. }) => select_columns(&columns),
+                match self.session.plan_query_with_params(sql, &probe) {
+                    Ok(columns) => select_columns(&columns),
                     // A query whose metadata this tier cannot resolve without
                     // real values reports no columns at prepare time. That is
                     // a LAST resort and not a free one: a MySQL client frames

--- a/rust/crates/tidb-server/src/pipeline_session.rs
+++ b/rust/crates/tidb-server/src/pipeline_session.rs
@@ -36,6 +36,7 @@
 //! defaults.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tidb_datatype::{Datum, FieldType, FieldTypeCode, UNSPECIFIED_LENGTH};
 use tidb_exec::{convert_result_field, ResultFieldMetadata, ResultFieldTypeMetadata};
@@ -46,8 +47,8 @@ use tidb_session::{GlobalSysvars, Session, SharedCatalog, StmtKind, StmtOutput, 
 
 use crate::resultset_source::ResultSetSource;
 use crate::sql_node::{
-    ConnectionKillTarget, GeneralExecuteOutcome, PreparedGeneral, QueryResult, QuerySession,
-    QuerySessionFactory, SessionContext, SqlQueryError, WriteOutcome,
+    session_wait_timeout, ConnectionKillTarget, GeneralExecuteOutcome, PreparedGeneral,
+    QueryResult, QuerySession, QuerySessionFactory, SessionContext, SqlQueryError, WriteOutcome,
 };
 use crate::wire_status::WireStatus;
 
@@ -235,6 +236,10 @@ impl QuerySession for PipelineServerSession {
     /// `@@character_set_results`.
     fn result_charset(&self) -> String {
         self.session.result_charset()
+    }
+
+    fn wait_timeout(&self) -> Duration {
+        session_wait_timeout(&self.session)
     }
 
     /// The handshake's initial database and `COM_INIT_DB`, which Go serves

--- a/rust/crates/tidb-server/src/real_tikv_node/mod.rs
+++ b/rust/crates/tidb-server/src/real_tikv_node/mod.rs
@@ -620,7 +620,7 @@ impl RealTiKvServerSession {
         let snapshot = self
             .transaction
             .opened()
-            .map(MultiStatementTransaction::start_ts);
+            .map(MultiStatementTransaction::statement_read_ts);
         let query = match snapshot {
             Some(start_ts) => self
                 .inner

--- a/rust/crates/tidb-server/src/sql_node.rs
+++ b/rust/crates/tidb-server/src/sql_node.rs
@@ -36,6 +36,11 @@ use tidb_session::process::ProcessKillTarget;
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
 
+/// Go TiDB's `wait_timeout` default, in seconds. The accept-loop timeout is
+/// only the handshake/connect timeout; authenticated idle reads use this
+/// session variable instead.
+pub const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(28_800);
+
 /// Cloneable process shutdown signal for the sole production accept loop.
 #[derive(Clone, Debug, Default)]
 pub struct ShutdownHandle {
@@ -172,6 +177,21 @@ impl ConnectionClose {
         if let Some(socket) = &self.socket {
             let _ = socket.shutdown(Shutdown::Both);
         }
+    }
+
+    /// Applies the authenticated connection I/O policy to the socket this
+    /// handle owns: command reads follow `@@wait_timeout`, while writes do not
+    /// inherit the handshake/connect timeout.
+    pub(crate) fn apply_authenticated_timeouts(
+        &self,
+        read_timeout: Duration,
+    ) -> std::io::Result<()> {
+        if let Some(socket) = &self.socket {
+            let read_timeout = (!read_timeout.is_zero()).then_some(read_timeout);
+            socket.set_read_timeout(read_timeout)?;
+            socket.set_write_timeout(None)?;
+        }
+        Ok(())
     }
 
     /// Whether a `KILL` has ended this connection.
@@ -650,6 +670,18 @@ pub struct SessionContext {
     pub close: ConnectionClose,
 }
 
+/// Reads the session's `@@wait_timeout` using Go TiDB's fallback rule: malformed
+/// or missing values fall back to the registry default.
+#[must_use]
+pub(crate) fn session_wait_timeout(session: &tidb_session::Session) -> Duration {
+    session
+        .vars()
+        .get_system("wait_timeout")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map_or(DEFAULT_WAIT_TIMEOUT, Duration::from_secs)
+}
+
 /// Query capability retained entirely inside one fixed worker thread.
 pub trait QuerySession {
     /// Starts one sequential query and returns its lazy result owner.
@@ -786,6 +818,16 @@ pub trait QuerySession {
     /// variables reports it and is unchanged.
     fn result_charset(&self) -> String {
         String::new()
+    }
+
+    /// The idle timeout for reading the next authenticated command.
+    ///
+    /// Go `clientConn.dispatch` refreshes this from `@@wait_timeout` before
+    /// every packet read; sessions without system variables keep the TiDB
+    /// default. A zero value deliberately means no socket read timeout, matching
+    /// Go's `PacketIO.SetReadTimeout(0)` behavior.
+    fn wait_timeout(&self) -> Duration {
+        DEFAULT_WAIT_TIMEOUT
     }
 
     /// Selects this session's current schema (Go `clientConn.useDB`).
@@ -1618,6 +1660,10 @@ mod tests {
         NodeConfig {
             host: IpAddr::V4(Ipv4Addr::LOCALHOST),
             port: 0,
+            advertise_address: None,
+            status_host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            status_port: 0,
+            report_status: false,
             pd_endpoints: vec!["127.0.0.1:2379".to_owned()],
             read_tables: vec![ConfiguredReadTable {
                 database: "test".to_owned(),

--- a/rust/crates/tidb-server/tests/mysql_client_lifecycle_source.rs
+++ b/rust/crates/tidb-server/tests/mysql_client_lifecycle_source.rs
@@ -7,9 +7,10 @@
 
 use std::collections::VecDeque;
 use std::fs;
-use std::net::{TcpListener, TcpStream};
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use sha1::{Digest, Sha1};
 use tidb_datatype::{Datum, FieldType, FieldTypeCode};
@@ -299,6 +300,93 @@ fn prepared_point_range_keeps_its_two_marker_contract() {
     assert_eq!(read.parameter_count(), 2);
     assert_eq!(read.result_field_types()[0].code(), FieldTypeCode::LongLong);
     assert_eq!(PreparedStatement::PointRead(read).parameter_count(), 2);
+}
+
+#[test]
+fn peer_closing_during_handshake_is_a_clean_disconnect() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let tracker = Arc::new(ConnectionTracker::default());
+    let worker_tracker = Arc::clone(&tracker);
+    let worker = std::thread::spawn(move || {
+        let (stream, peer_addr) = listener.accept().unwrap();
+        serve_mysql_connection(
+            stream,
+            peer_addr,
+            ConnectionCancellation::default(),
+            &Factory {
+                queries: Arc::new(Mutex::new(Vec::new())),
+                lifecycle: Arc::new(Mutex::new(Lifecycle::default())),
+            },
+            &users(),
+            &worker_tracker,
+            DEFAULT_MAX_ALLOWED_PACKET,
+        )
+        .unwrap()
+    });
+
+    let client = TcpStream::connect(address).unwrap();
+    let mut reader = PacketReader::new(client.try_clone().unwrap());
+    assert_eq!(reader.read_packet().unwrap()[0], 10);
+    drop(reader);
+    client.shutdown(Shutdown::Both).unwrap();
+    drop(client);
+
+    let report = worker.join().unwrap();
+    assert_eq!(report.exit, ConnectionExit::PeerClosed);
+    assert_eq!(report.queries, 0);
+    assert_eq!(report.commands, Default::default());
+    assert_eq!(tracker.accepted(), 1);
+    assert_eq!(tracker.completed(), 1);
+    assert_eq!(tracker.active(), 0);
+    assert_eq!(tracker.failed(), 0);
+}
+
+#[test]
+fn authenticated_connection_idle_uses_wait_timeout_not_handshake_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let tracker = Arc::new(ConnectionTracker::default());
+    let worker_tracker = Arc::clone(&tracker);
+    let worker = std::thread::spawn(move || {
+        let (stream, peer_addr) = listener.accept().unwrap();
+        let handshake_timeout = Duration::from_millis(50);
+        stream.set_read_timeout(Some(handshake_timeout)).unwrap();
+        stream.set_write_timeout(Some(handshake_timeout)).unwrap();
+        serve_mysql_connection(
+            stream,
+            peer_addr,
+            ConnectionCancellation::default(),
+            &Factory {
+                queries: Arc::new(Mutex::new(Vec::new())),
+                lifecycle: Arc::new(Mutex::new(Lifecycle::default())),
+            },
+            &users(),
+            &worker_tracker,
+            DEFAULT_MAX_ALLOWED_PACKET,
+        )
+        .unwrap()
+    });
+
+    let mut client = TcpStream::connect(address).unwrap();
+    let read_side = client.try_clone().unwrap();
+    read_side
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .unwrap();
+    let mut reader = PacketReader::new(read_side);
+    authenticate(&mut client, &mut reader, "alice", b"secret");
+    reader.set_sequence(2);
+    assert_eq!(reader.read_packet().unwrap()[0], 0);
+
+    std::thread::sleep(Duration::from_millis(150));
+    write_packet(&mut client, 0, &[COM_PING]);
+    reader.set_sequence(1);
+    assert_eq!(reader.read_packet().unwrap()[0], 0);
+
+    write_packet(&mut client, 0, &[COM_QUIT]);
+    let report = worker.join().unwrap();
+    assert_eq!(report.exit, ConnectionExit::Quit);
+    assert_eq!(tracker.failed(), 0);
 }
 
 struct PreparedRows {

--- a/rust/crates/tidb-server/tests/node_config_source.rs
+++ b/rust/crates/tidb-server/tests/node_config_source.rs
@@ -154,11 +154,6 @@ fn recognized_but_unowned_config_leaves_fail_closed() {
     for (name, contents, expected) in [
         ("log", "[log]\nlevel = \"debug\"\n", "log.level"),
         (
-            "status",
-            "[status]\nstatus-port = 10081\n",
-            "status.status-port",
-        ),
-        (
             "sql_ca",
             "[security]\nssl-ca = \"ca.pem\"\n",
             "security.ssl-ca",
@@ -178,6 +173,47 @@ fn recognized_but_unowned_config_leaves_fail_closed() {
             Err(NodeConfigError::UnsupportedConfigOptions(options)) if options == [expected]
         ));
     }
+}
+
+#[test]
+fn topology_and_status_identity_follow_go_cli_over_config_precedence() {
+    let file = ConfigFile::write(
+        "topology_identity",
+        r#"
+advertise-address = "10.0.0.9"
+
+[status]
+status-host = "127.0.0.1"
+status-port = 10081
+report-status = false
+"#,
+    );
+    let path = file.0.to_string_lossy().into_owned();
+    let mut args = required();
+    args.extend([
+        "--config",
+        &path,
+        "--advertise-address",
+        "10.0.0.8",
+        "--status-host",
+        "0.0.0.0",
+        "--status",
+        "10082",
+        "--report-status=true",
+    ]);
+
+    let config = NodeConfig::parse(args).expect("Go-compatible topology flags must parse");
+    assert_eq!(
+        config.advertise_address,
+        Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)))
+    );
+    assert_eq!(config.status_host, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    assert_eq!(config.status_port, 10082);
+    assert!(config.report_status);
+    assert!(NodeConfig::help_text().contains("--advertise-address"));
+    assert!(NodeConfig::help_text().contains("--status-host"));
+    assert!(NodeConfig::help_text().contains("--status <port>"));
+    assert!(NodeConfig::help_text().contains("--report-status=<bool>"));
 }
 
 #[test]

--- a/rust/crates/tidb-server/tests/node_config_source.rs
+++ b/rust/crates/tidb-server/tests/node_config_source.rs
@@ -381,6 +381,26 @@ fn plaintext_native_password_boundary_cannot_bind_a_public_address() {
 }
 
 #[test]
+fn cluster_privilege_accounts_can_bind_a_non_loopback_listener() {
+    let config = NodeConfig::parse(vec![
+        "tidb-server",
+        "--path",
+        "172.31.36.41:2379",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "4000",
+        "--cluster-session",
+        "--load-privileges",
+    ])
+    .expect("cluster privilege mode must support a private-network listener");
+
+    assert_eq!(config.host, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    assert!(config.cluster_session);
+    assert!(config.load_privileges);
+}
+
+#[test]
 fn authentication_file_is_required_before_startup() {
     let mut missing = required();
     let option = missing

--- a/rust/crates/tidb-server/tests/sql_node_lifecycle_source.rs
+++ b/rust/crates/tidb-server/tests/sql_node_lifecycle_source.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 use tidb_protocol::DEFAULT_MAX_ALLOWED_PACKET;
 use tidb_server::{
     serve_mysql_connection, ConfiguredUserStore, ConnectionCancellation, ConnectionTracker,
-    MysqlConnectionError, QueryResult, QuerySession, QuerySessionFactory, SessionContext,
-    SqlQueryError,
+    ConnectionExit, QueryResult, QuerySession, QuerySessionFactory, SessionContext, SqlQueryError,
 };
 
 struct UnusedSession;
@@ -49,7 +48,7 @@ fn framing_failure_releases_connection_lease_exactly_once() {
         "alice\t%\tmysql_native_password\t*14E65567ABDB5135D0CFD9A70B3032C179A49EE7\n",
     )
     .unwrap();
-    let error = serve_mysql_connection(
+    let report = serve_mysql_connection(
         server,
         SocketAddr::from(([127, 0, 0, 1], 40000)),
         ConnectionCancellation::default(),
@@ -58,13 +57,10 @@ fn framing_failure_releases_connection_lease_exactly_once() {
         &tracker,
         DEFAULT_MAX_ALLOWED_PACKET,
     )
-    .unwrap_err();
-    assert!(matches!(
-        error,
-        MysqlConnectionError::Io(_) | MysqlConnectionError::Packet(_)
-    ));
+    .unwrap();
+    assert_eq!(report.exit, ConnectionExit::PeerClosed);
     assert_eq!(tracker.active(), 0);
     assert_eq!(tracker.accepted(), 1);
     assert_eq!(tracker.completed(), 1);
-    assert_eq!(tracker.failed(), 1);
+    assert_eq!(tracker.failed(), 0);
 }

--- a/rust/crates/tidb-session/src/dispatch.rs
+++ b/rust/crates/tidb-session/src/dispatch.rs
@@ -25,6 +25,7 @@ use tidb_ast::{DdlStmt, DmlStmt, SessionStmt, Stmt};
 use tidb_executor::{Catalog, DriverError, SchemaErrorKind};
 
 use crate::warnings::UNSUPPORTED_CREATE_PARTITION_CODE;
+use crate::StatementMode;
 use crate::{infoschema, statement_kind_of, Session, StatementKind, StmtOutput, WarningLevel};
 use crate::{CHECK_CONSTRAINT_IS_OFF_CODE, CHECK_CONSTRAINT_IS_OFF_MESSAGE};
 
@@ -273,6 +274,14 @@ impl Session {
     }
 
     pub(crate) fn execute_statement(&mut self, sql: &str) -> Result<StmtOutput, DriverError> {
+        self.execute_statement_with_mode(sql, StatementMode::Execute)
+    }
+
+    pub(crate) fn execute_statement_with_mode(
+        &mut self,
+        sql: &str,
+        mode: StatementMode,
+    ) -> Result<StmtOutput, DriverError> {
         // Go hands every statement that is not continuing an open transaction
         // a FRESH membuffer, so `session.HasDirtyContent` answers false for
         // every table at this point -- and `BEGIN` therefore starts from an
@@ -420,8 +429,14 @@ impl Session {
                 };
                 let current_db = self.current_db.clone();
                 let ctx = self.statement_context(false);
-                let (columns, rows) = self.with_catalog_mut(|catalog| {
-                    tidb_executor::run_select_meta_stmt(select, catalog, &current_db, &ctx)
+                let (columns, rows) = self.with_catalog_mut(|catalog| match mode {
+                    StatementMode::Execute => {
+                        tidb_executor::run_select_meta_stmt(select, catalog, &current_db, &ctx)
+                    }
+                    StatementMode::PlanOnly => {
+                        tidb_executor::plan_select_meta_stmt(select, catalog, &current_db, &ctx)
+                            .map(|columns| (columns, Vec::new()))
+                    }
                 })?;
                 self.drain_eval_warnings(&ctx);
                 Ok(StmtOutput::Rows { columns, rows })

--- a/rust/crates/tidb-session/src/lib.rs
+++ b/rust/crates/tidb-session/src/lib.rs
@@ -238,6 +238,15 @@ pub enum StmtOutput {
     Done(bool),
 }
 
+/// Whether query dispatch opens the executor or only resolves its result
+/// metadata. Prepared-statement PREPARE uses the latter so reporting columns
+/// cannot read rows or perform work before COM_STMT_EXECUTE.
+#[derive(Clone, Copy)]
+pub(crate) enum StatementMode {
+    Execute,
+    PlanOnly,
+}
+
 /// The statement-owned policy a server needs to retain an eager result set.
 ///
 /// It is captured before `SET_VAR` overlays are restored, so a prepared
@@ -560,6 +569,7 @@ pub mod privilege;
 pub mod process;
 mod process_arm;
 mod show;
+mod split_region_arm;
 pub mod sysvar;
 pub mod vars;
 pub use vars::{GlobalSysvars, SessionVars, VarError};
@@ -719,6 +729,39 @@ impl Session {
         self.run_with_columns(&bound)
     }
 
+    /// Plans a query with prepared-statement parameters bound and returns its
+    /// wire result columns without opening or draining the executor pipeline.
+    pub fn plan_query_with_params(
+        &mut self,
+        sql: &str,
+        params: &[Datum],
+    ) -> Result<Vec<(String, FieldType)>, DriverError> {
+        if self.statement_kind(sql)? != StmtKind::Query {
+            return Err(DriverError::unsupported(
+                "only queries have result metadata to plan",
+            ));
+        }
+        let bound = if params.is_empty() && self.parameter_count(sql)? == 0 {
+            None
+        } else {
+            Some(tidb_executor::bind_parameters(
+                sql,
+                params,
+                self.scanner_sql_mode(),
+            )?)
+        };
+        let sql = bound.as_deref().unwrap_or(sql);
+        match self
+            .run_with_columns_internal(sql, false, StatementMode::PlanOnly)?
+            .0
+        {
+            StmtOutput::Rows { columns, .. } => Ok(columns),
+            StmtOutput::Affected(_) | StmtOutput::Done(_) => Err(DriverError::unsupported(
+                "planned query did not produce result metadata",
+            )),
+        }
+    }
+
     /// Runs one parameterized statement and returns the exact policy needed
     /// to retain a row result after the statement completes.
     ///
@@ -731,10 +774,10 @@ impl Session {
         params: &[Datum],
     ) -> Result<(StmtOutput, Option<ResultMaterializationAuthority>), DriverError> {
         if params.is_empty() && self.parameter_count(sql)? == 0 {
-            return self.run_with_columns_internal(sql, true);
+            return self.run_with_columns_internal(sql, true, StatementMode::Execute);
         }
         let bound = tidb_executor::bind_parameters(sql, params, self.scanner_sql_mode())?;
-        self.run_with_columns_internal(&bound, true)
+        self.run_with_columns_internal(&bound, true, StatementMode::Execute)
     }
 
     /// Runs one SQL statement (Go `session.ExecuteStmt`): parses, dispatches by
@@ -754,7 +797,7 @@ impl Session {
     /// warning buffer as an `Error`-level row, so `SHOW WARNINGS` right after
     /// a failure reports it.
     pub fn run_with_columns(&mut self, sql: &str) -> Result<StmtOutput, DriverError> {
-        self.run_with_columns_internal(sql, false)
+        self.run_with_columns_internal(sql, false, StatementMode::Execute)
             .map(|(output, _)| output)
     }
 
@@ -762,6 +805,7 @@ impl Session {
         &mut self,
         sql: &str,
         capture_result_authority: bool,
+        mode: StatementMode,
     ) -> Result<(StmtOutput, Option<ResultMaterializationAuthority>), DriverError> {
         self.check_sandbox_mode(sql)?;
         // A statement is visible to a peer's SHOW PROCESSLIST for exactly as
@@ -787,7 +831,7 @@ impl Session {
         // `select @@last_plan_from_binding` reports the statement BEFORE it
         // rather than itself (that SELECT matches no binding of its own).
         self.prev_found_in_binding = std::mem::take(&mut self.found_in_binding);
-        let result = self.execute_statement(sql);
+        let result = self.execute_statement_with_mode(sql, mode);
         let result_authority =
             if capture_result_authority && matches!(&result, Ok(StmtOutput::Rows { .. })) {
                 let init_chunk_size = self

--- a/rust/crates/tidb-session/src/show.rs
+++ b/rust/crates/tidb-session/src/show.rs
@@ -273,8 +273,11 @@ fn show_create_table_text(
         clauses.push(clause);
     }
 
-    // Go emits a clustered primary key here, because a clustered key -- an
-    // int handle or a common handle -- is not in the index list.
+    // Go emits a clustered primary key here. A catalog freshly built by this
+    // executor omits that key from its secondary-index list, while a common
+    // handle reloaded from Go-compatible TableInfo can retain the mirrored
+    // PRIMARY IndexInfo. The loop below suppresses that persisted mirror so
+    // SHOW CREATE still reports the clustered primary key exactly once.
     let clustered: Vec<usize> = match table.pk_handle_offset() {
         Some(offset) => vec![offset],
         None => table.common_handle_offsets().to_vec(),
@@ -301,8 +304,10 @@ fn show_create_table_text(
             .collect::<Vec<_>>()
             .join(",");
         if index.name.eq_ignore_ascii_case("PRIMARY") {
-            // A primary key that is not the handle is non-clustered here,
-            // since this seed builds no clustered common handle.
+            if !clustered.is_empty() {
+                continue;
+            }
+            // A primary key that is not the handle is non-clustered here.
             clauses.push(format!(
                 "  PRIMARY KEY ({columns}) /*T![clustered_index] NONCLUSTERED */"
             ));
@@ -1817,6 +1822,51 @@ impl Session {
 mod column_description_source_tests {
     use super::*;
     use tidb_datatype::{FieldType, FieldTypeCode, FieldTypeFlags};
+
+    #[test]
+    fn show_create_deduplicates_reloaded_common_handle_primary_index() {
+        let primary_type = || {
+            FieldType::new(FieldTypeCode::Long)
+                .with_flags(FieldTypeFlags::NOT_NULL | FieldTypeFlags::PRI_KEY)
+        };
+        let column = |name: &str, id| tidb_executor::KvColumn {
+            name: name.to_owned(),
+            id,
+            field_type: primary_type(),
+            column_info_version: 1,
+            default_value: None,
+            origin_default: None,
+            generated: None,
+        };
+        let mut table = tidb_executor::KvTable::new(
+            1,
+            vec![column("warehouse_id", 1), column("district_id", 2)],
+        );
+        table.set_common_handle_offsets(vec![0, 1]);
+        // A common-handle PRIMARY IndexInfo is retained when TableInfo is
+        // loaded from TiKV even though the primary key is also the row handle.
+        table.add_index(tidb_executor::KvIndex {
+            id: 1,
+            name: "PRIMARY".to_owned(),
+            unique: true,
+            column_offsets: vec![0, 1],
+            prefix_lengths: vec![-1, -1],
+            visible: true,
+            global: false,
+        });
+
+        let create = show_create_table_text(
+            "test",
+            "district",
+            &table,
+            &tidb_executor::StmtContext::default(),
+        )
+        .unwrap();
+
+        assert_eq!(create.matches("PRIMARY KEY").count(), 1);
+        assert!(create.contains("/*T![clustered_index] CLUSTERED */"));
+        assert!(!create.contains("/*T![clustered_index] NONCLUSTERED */"));
+    }
 
     #[test]
     fn test_desc() {

--- a/rust/crates/tidb-session/src/split_region_arm.rs
+++ b/rust/crates/tidb-session/src/split_region_arm.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The catalog-resolution half of `SPLIT TABLE`.
+//!
+//! A plain in-process session owns no region control plane, so it still
+//! reports the ordinary unsupported statement. The cluster front end calls
+//! this method before ordinary dispatch, receives raw split keys resolved
+//! against this session's catalog, and publishes them through PD.
+
+use tidb_executor::{DriverError, SplitRegionPlan};
+
+use crate::Session;
+
+impl Session {
+    /// Plans a standalone `SPLIT TABLE` statement, or returns `None` for every
+    /// other statement kind.
+    pub fn prepare_split_region(
+        &mut self,
+        sql: &str,
+    ) -> Result<Option<SplitRegionPlan>, DriverError> {
+        let statement = self.parse(sql)?;
+        let tidb_ast::Stmt::Admin(admin) = statement else {
+            return Ok(None);
+        };
+        let tidb_ast::AdminStmt::SplitRegion(split) = admin.as_ref() else {
+            return Ok(None);
+        };
+        let current_database = self.current_database().to_owned();
+        self.with_catalog_mut(|catalog| {
+            tidb_executor::split_region::prepare_split_region(split, &current_database, catalog)
+                .map(Some)
+        })
+    }
+}

--- a/rust/crates/tidb-session/src/stmt_ctx.rs
+++ b/rust/crates/tidb-session/src/stmt_ctx.rs
@@ -200,6 +200,46 @@ impl Session {
         self.parse(sql)
     }
 
+    /// The wait policy of a top-level `SELECT ... FOR UPDATE`, when present.
+    ///
+    /// A cluster front end needs this before execution so it can collect the
+    /// exact raw keys consumed by the statement and acquire their TiKV locks.
+    pub fn statement_lock_wait(
+        &self,
+        sql: &str,
+    ) -> Result<Option<tidb_planner::read_only_scan::ReadLockWait>, DriverError> {
+        let statement = self.parse(sql)?;
+        let tidb_ast::Stmt::Query(query) = statement else {
+            return Ok(None);
+        };
+        let lock = match &*query {
+            tidb_ast::QueryStmt::Select(select) => select.lock.as_ref(),
+            tidb_ast::QueryStmt::SetOpr(set) => set.lock.as_ref(),
+        };
+        let Some(lock) = lock else {
+            return Ok(None);
+        };
+        if lock.kind != tidb_ast::LockKind::Update {
+            return Err(DriverError::unsupported(
+                "FOR SHARE is not supported by the pessimistic cluster transaction yet",
+            ));
+        }
+        match lock.wait {
+            tidb_ast::LockWait::Default => {
+                Ok(Some(tidb_planner::read_only_scan::ReadLockWait::Blocking))
+            }
+            tidb_ast::LockWait::NoWait => {
+                Ok(Some(tidb_planner::read_only_scan::ReadLockWait::NoWait))
+            }
+            tidb_ast::LockWait::Wait(seconds) => Ok(Some(
+                tidb_planner::read_only_scan::ReadLockWait::Seconds(seconds),
+            )),
+            tidb_ast::LockWait::SkipLocked => Err(DriverError::unsupported(
+                "SELECT ... FOR UPDATE SKIP LOCKED is not supported yet",
+            )),
+        }
+    }
+
     pub(crate) fn parse(&self, sql: &str) -> Result<tidb_ast::Stmt, DriverError> {
         tidb_parser::parse_with_sql_mode(sql, self.scanner_sql_mode())
             .map_err(|e| DriverError::Parse(format!("{e:?}")))

--- a/rust/crates/tidb-session/src/tests_join_predicate_placement.rs
+++ b/rust/crates/tidb-session/src/tests_join_predicate_placement.rs
@@ -800,39 +800,33 @@ fn derive_not_null_conds_returns_tidbs_rows() {
     assert_eq!(rows(&mut session, sql), anti_semi_expected(pairs), "{sql}");
 }
 
-/// RUNNING GUARD for the push-down gap: in all 30 cases of the three tables
-/// nothing below the join carries a predicate. Every condition is either a
-/// join `equal:`/`other cond:` or a `Selection` above the join.
-///
-/// When a predicate does start reaching a scan, this fails and the three
-/// `#[ignore]`d tests below become the live ones.
+/// The bounded push-down implemented today: a single-leaf predicate below an
+/// inner join can narrow that leaf, while an outer join remains conservative.
+/// The complete Go condition-placement cases below stay ignored because OR
+/// extraction, derived not-null conditions, and outer-to-inner conversion are
+/// still separate missing rules.
 #[test]
-fn no_predicate_reaches_either_side_of_a_join_today() {
+fn single_leaf_predicates_narrow_inner_joins_but_not_outer_joins() {
     let mut session = signed_table_session();
-    let all = OUTER_WHERE_PREDICATE_PUSH_DOWN
+    let outer = OUTER_WHERE_PREDICATE_PUSH_DOWN
         .iter()
         .chain(JOIN_PREDICATE_PUSH_DOWN)
-        .chain(DERIVE_NOT_NULL_CONDS);
-    let mut cases = 0;
-    for (sql, _, _, _) in all {
-        assert_eq!(
-            conditions_below_join(&mut session, sql),
-            Vec::new(),
-            "conditions below the join of `{sql}`"
+        .chain(DERIVE_NOT_NULL_CONDS)
+        .filter(|(sql, ..)| sql.contains(" left join ") || sql.contains(" right join "));
+    for (sql, _, _, _) in outer {
+        assert!(
+            conditions_below_join(&mut session, sql).is_empty(),
+            "outer-join predicates remain above `{sql}`"
         );
-        cases += 1;
     }
-    assert_eq!(cases, 30);
-    // Go pushes something to at least one side in 19 of the 30 -- the size of
-    // the gap the ignored tests carry.
-    assert_eq!(
-        OUTER_WHERE_PREDICATE_PUSH_DOWN
+
+    let sql = "select * from t t1 join t t2 on t1.a > 1 and t1.a > 1";
+    assert!(
+        conditions_below_join(&mut session, sql)
             .iter()
-            .chain(JOIN_PREDICATE_PUSH_DOWN)
-            .chain(DERIVE_NOT_NULL_CONDS)
-            .filter(|(_, left, right, _)| *left != "[]" || *right != "[]")
-            .count(),
-        19
+            .any(|(operator, info)| operator.contains("TableRangeScan")
+                && info.contains("range:(1,+inf]")),
+        "the t1 predicate should narrow its inner-join leaf"
     );
 }
 

--- a/rust/crates/tidb-session/src/txn.rs
+++ b/rust/crates/tidb-session/src/txn.rs
@@ -166,6 +166,15 @@ impl Session {
         self.txn.as_ref().map(|txn| txn.mode)
     }
 
+    /// The mode a transaction opened now would use, from the session's
+    /// `@@tidb_txn_mode` setting. This is needed by storage tiers that open
+    /// their transaction alongside the driver's lazy `autocommit = 0` one,
+    /// before the first statement has asked the driver to create its copy.
+    #[must_use]
+    pub fn configured_txn_mode(&self) -> SessionTxnMode {
+        self.resolve_begin_txn_mode(tidb_ast::TransactionMode::Default)
+    }
+
     /// Installs a transaction over the shared catalog as it stands now.
     ///
     /// The lock is taken and released here rather than held across the

--- a/rust/crates/tidb-txnkv/src/retry.rs
+++ b/rust/crates/tidb-txnkv/src/retry.rs
@@ -159,6 +159,29 @@ impl RegionBackoffBudget {
         &mut self,
         kind: RegionBackoffKind,
     ) -> Result<Duration, RegionBackoffExhausted> {
+        self.reserve_delay(kind, u64::MAX)
+    }
+
+    /// Reserves the next source-shaped delay, capped by the server-reported
+    /// time until the condition can change.
+    ///
+    /// client-go's `BackoffWithCfgAndMaxSleep` computes the normal jittered
+    /// delay first, then limits that one sleep to `max_delay`. Accounting must
+    /// use the limited delay too, or a short lock TTL would incorrectly spend
+    /// the uncapped retry budget.
+    pub fn next_delay_capped(
+        &mut self,
+        kind: RegionBackoffKind,
+        max_delay: Duration,
+    ) -> Result<Duration, RegionBackoffExhausted> {
+        self.reserve_delay(kind, duration_ms(max_delay))
+    }
+
+    fn reserve_delay(
+        &mut self,
+        kind: RegionBackoffKind,
+        max_delay_ms: u64,
+    ) -> Result<Duration, RegionBackoffExhausted> {
         let effective_exhausted = self.effective_sleep_ms() >= self.max_sleep_ms;
         let excluded_exhausted = kind.is_sleep_excluded()
             && self.excluded_sleep_ms >= 600_000
@@ -185,7 +208,7 @@ impl RegionBackoffBudget {
         } else {
             exponential
         };
-        let delay_ms = computed;
+        let delay_ms = computed.min(max_delay_ms);
 
         self.attempts[index] = attempt.saturating_add(1);
         self.total_sleep_ms = self.total_sleep_ms.saturating_add(delay_ms);

--- a/rust/crates/tidb-txnkv/src/transaction/coordinator/mod.rs
+++ b/rust/crates/tidb-txnkv/src/transaction/coordinator/mod.rs
@@ -44,7 +44,10 @@ use tidb_proto::KvrpcKeyError;
 
 use crate::gc_state::{GcStateCache, VisibilityError};
 use crate::lock::{LockRecoveryClient, TimestampSource};
-use crate::region::{RegionBackoffBudget, RegionErrorDisposition, RegionRecoveryLoader};
+use crate::region::{
+    RegionBackoffBudget, RegionBackoffExhausted, RegionBackoffKind, RegionErrorDisposition,
+    RegionRecoveryError, RegionRecoveryLoader,
+};
 use crate::rpc::{TonicCoprocessorClient, TransactionBatchPublication, UnaryCallContext};
 use crate::{PdRegionLoader, SharedReadRuntime};
 
@@ -57,7 +60,7 @@ use super::state::{
 };
 
 pub use opener::{PdLockTimestampSource, RealOptimisticTransactionOpener};
-pub use snapshot_read::SnapshotGetResult;
+pub use snapshot_read::{SnapshotGetResult, SnapshotScanPairs};
 
 const DEFAULT_LOCK_TTL_MS: u64 = 3_000;
 /// Go `config.DefaultConfig().TiKVClient.AsyncCommit.KeysLimit`.
@@ -188,7 +191,6 @@ impl CommitProtocol {
 pub struct RealOptimisticTransaction<C, L, T> {
     runtime: SharedReadRuntime<C, L>,
     timestamps: T,
-    timeout: Duration,
     start_ts: u64,
     planned_mutation_count: usize,
     planned_aggregate_bytes: usize,
@@ -283,7 +285,6 @@ where
     pub fn new_injected(
         runtime: SharedReadRuntime<C, L>,
         timestamps: T,
-        timeout: Duration,
         start_ts: u64,
         opened_at: Instant,
         planned_mutation_count: usize,
@@ -294,7 +295,6 @@ where
         Self::new_opened(
             runtime,
             timestamps,
-            timeout,
             start_ts,
             opened_at,
             planned_mutation_count,
@@ -316,7 +316,6 @@ where
     pub(super) fn new_opened(
         runtime: SharedReadRuntime<C, L>,
         timestamps: T,
-        timeout: Duration,
         start_ts: u64,
         opened_at: Instant,
         planned_mutation_count: usize,
@@ -332,7 +331,6 @@ where
         Ok(Self {
             runtime,
             timestamps,
-            timeout,
             start_ts,
             planned_mutation_count,
             planned_aggregate_bytes,
@@ -356,15 +354,15 @@ where
         self.protocol = protocol;
     }
 
-    /// Rejects a completed read whose `start_ts` GC has already passed.
+    /// Rejects a completed read whose exact read timestamp GC has passed.
     ///
     /// Called only after TiKV has answered, mirroring client-go's placement of
     /// `CheckVisibility` at the end of `snapshot.get` and `snapshot.scan`. A
     /// pre-read check would be worthless: GC can advance while the RPC is in
     /// flight, so only a post-read check covers the data actually returned.
-    fn check_visibility(&self) -> Result<(), OptimisticCoordinatorError> {
+    fn check_visibility_at(&self, read_ts: u64) -> Result<(), OptimisticCoordinatorError> {
         self.gc_state
-            .check_visibility(self.start_ts)
+            .check_visibility(read_ts)
             .map_err(OptimisticCoordinatorError::Visibility)
     }
 
@@ -392,10 +390,6 @@ where
         &self.timestamps
     }
 
-    pub(super) const fn call_timeout(&self) -> Duration {
-        self.timeout
-    }
-
     /// Snapshot timestamp allocated before any read or write.
     #[must_use]
     pub const fn start_ts(&self) -> u64 {
@@ -420,16 +414,19 @@ where
             RecoveryPhase::Secondary => &mut self.secondary_backoff,
             RecoveryPhase::Cleanup => &mut self.cleanup_backoff,
         };
-        let disposition = self
+        let recovery = self
             .runtime
             .region_cache_handle()
             .on_region_error(error, attempt.clone(), backoff)
             .map_err(|error| TransactionCause::Region {
                 detail: format!("RegionCache recovery lifecycle failed: {error}"),
-            })?
-            .map_err(|error| TransactionCause::Region {
-                detail: format!("RegionCache rejected region error: {error}"),
             })?;
+        let Some(disposition) = normalize_region_recovery(recovery)? else {
+            // Another request already advanced the shared cache beyond this
+            // attempt. The response cannot update canonical topology, but its
+            // caller still retries and locates against that newer topology.
+            return Ok(());
+        };
         let delay = match disposition {
             RegionErrorDisposition::RetryRoute { delay, .. }
             | RegionErrorDisposition::RetrySelector { delay, .. }
@@ -446,6 +443,18 @@ where
             }
         };
         wait_with_call(call, delay)
+    }
+}
+
+fn normalize_region_recovery(
+    recovery: Result<RegionErrorDisposition, RegionRecoveryError>,
+) -> Result<Option<RegionErrorDisposition>, TransactionCause> {
+    match recovery {
+        Ok(disposition) => Ok(Some(disposition)),
+        Err(RegionRecoveryError::StaleObservation(_)) => Ok(None),
+        Err(error) => Err(TransactionCause::Region {
+            detail: format!("RegionCache rejected region error: {error}"),
+        }),
     }
 }
 
@@ -524,8 +533,11 @@ pub(super) fn wait_with_call(
     Ok(())
 }
 
-pub(super) fn alive_retry_delay(remaining_ttl: Duration) -> Duration {
-    remaining_ttl.max(Duration::from_millis(10))
+pub(super) fn alive_retry_delay(
+    remaining_ttl: Duration,
+    backoff: &mut RegionBackoffBudget,
+) -> Result<Duration, RegionBackoffExhausted> {
+    backoff.next_delay_capped(RegionBackoffKind::TxnLockFast, remaining_ttl)
 }
 
 trait AttemptRoute {
@@ -645,7 +657,17 @@ mod tests {
 
     #[test]
     fn waits_use_the_absolute_call_deadline_and_cancellation() {
-        assert_eq!(alive_retry_delay(Duration::ZERO), Duration::from_millis(10));
+        let mut expired_lock = RegionBackoffBudget::with_jitter_seed(Duration::from_secs(20), 1);
+        assert_eq!(
+            alive_retry_delay(Duration::ZERO, &mut expired_lock).unwrap(),
+            Duration::ZERO,
+        );
+        let mut live_lock = RegionBackoffBudget::with_jitter_seed(Duration::from_secs(20), 1);
+        assert_eq!(
+            alive_retry_delay(Duration::from_secs(30), &mut live_lock).unwrap(),
+            Duration::from_millis(1),
+            "a live lock starts client-go's txnLockFast backoff instead of sleeping its full TTL",
+        );
         let expired = UnaryCallContext::with_timeout(Duration::ZERO);
         assert!(matches!(
             wait_with_call(&expired, Duration::from_millis(1)),
@@ -658,5 +680,18 @@ mod tests {
             wait_with_call(&cancelled, Duration::ZERO),
             Err(TransactionCause::Transport { .. })
         ));
+    }
+
+    #[test]
+    fn an_obsolete_region_response_retries_the_newer_shared_cache() {
+        let stale = RegionRecoveryError::StaleObservation(crate::region::RegionAttempt {
+            region: crate::region::RegionVerId::new(7, 3, 4),
+            peer_id: 11,
+            store_id: 101,
+            address: "tikv-101".to_owned(),
+            store_epoch: 7,
+        });
+
+        assert!(normalize_region_recovery(Err(stale)).unwrap().is_none());
     }
 }

--- a/rust/crates/tidb-txnkv/src/transaction/coordinator/opener.rs
+++ b/rust/crates/tidb-txnkv/src/transaction/coordinator/opener.rs
@@ -261,7 +261,6 @@ impl RealOptimisticTransactionOpener {
         let mut transaction = RealOptimisticTransaction::new_opened(
             runtime,
             PdLockTimestampSource(self.pd.clone()),
-            self.timeout,
             start_ts,
             opened_at,
             planned_mutation_count,

--- a/rust/crates/tidb-txnkv/src/transaction/coordinator/prewrite.rs
+++ b/rust/crates/tidb-txnkv/src/transaction/coordinator/prewrite.rs
@@ -26,7 +26,8 @@ use tidb_proto::{
 
 use crate::lock::{
     decode_blocking_lock_observation, pessimistic_prewrite_recovery_enabled,
-    resolve_blocking_locks, BlockingLock, LockAdmissionError, LockRecoveryClient, TimestampSource,
+    resolve_blocking_locks, BlockingLock, LockAdmissionError, LockRecoveryClient,
+    LockRecoveryError, TimestampSource,
 };
 use crate::region::RegionRecoveryLoader;
 use crate::rpc::UnaryCallContext;
@@ -176,7 +177,7 @@ where
     }
 
     pub(super) fn handle_prewrite_key_errors(
-        &self,
+        &mut self,
         errors: &[KvrpcKeyError],
         context: &tidb_proto::KvrpcContext,
         call: &UnaryCallContext,
@@ -241,7 +242,7 @@ where
         // protocol and is identical to `resolve_optimistic_locks` for an
         // all-optimistic set: the live-owner short circuit it adds keys off
         // `duration_to_last_update_ms`, which only a pessimistic lock reports.
-        match resolve_blocking_locks(
+        let recovery = resolve_blocking_locks(
             &self.runtime,
             &eligible_locks,
             self.start_ts,
@@ -249,23 +250,47 @@ where
             call,
             &self.timestamps,
         )
-        .map_err(|error| TransactionCause::Lock {
-            key: eligible_locks[0].key().to_vec(),
-            detail: format!("Prewrite lock recovery failed: {error}"),
-        })? {
-            recovery if !recovery.is_alive() => Ok(()),
-            recovery if alive_retry_delay(recovery.ttl) <= call.timeout() => {
-                wait_with_call(call, alive_retry_delay(recovery.ttl))?;
-                Ok(())
-            }
-            recovery => Err(TransactionCause::Lock {
+        .map_err(|error| prewrite_lock_recovery_cause(eligible_locks[0].key(), error))?;
+        if !recovery.is_alive() {
+            return Ok(());
+        }
+        let delay =
+            alive_retry_delay(recovery.ttl, &mut self.forward_backoff).map_err(|exhausted| {
+                TransactionCause::Lock {
+                    key: eligible_locks[0].key().to_vec(),
+                    detail: format!(
+                        "Prewrite lock backoff budget {:?} exhausted after {:?}",
+                        exhausted.kind, exhausted.max_sleep
+                    ),
+                }
+            })?;
+        if delay > call.timeout() {
+            return Err(TransactionCause::Lock {
                 key: eligible_locks[0].key().to_vec(),
                 detail: format!(
-                    "Prewrite lock remains alive for {:?}, beyond transaction deadline",
-                    recovery.ttl
+                    "Prewrite lock retry delay {delay:?} exceeds the transaction deadline"
                 ),
-            }),
+            });
         }
+        wait_with_call(call, delay)
+    }
+}
+
+/// Keeps a region route failure visible as a retryable transaction error. A
+/// lock resolver can fail because the route for its recovery RPC is stale;
+/// collapsing that into `TransactionCause::Lock` makes the SQL layer report
+/// 1105 and prevents the autocommit replay from refreshing the route.
+fn prewrite_lock_recovery_cause(key: &[u8], error: LockRecoveryError) -> TransactionCause {
+    match error {
+        LockRecoveryError::RegionError(detail) => TransactionCause::Region {
+            detail: format!(
+                "Prewrite lock recovery failed: lock RPC returned region error: {detail}"
+            ),
+        },
+        other => TransactionCause::Lock {
+            key: key.to_vec(),
+            detail: format!("Prewrite lock recovery failed: {other}"),
+        },
     }
 }
 
@@ -358,5 +383,34 @@ impl AttemptedProtocol {
             self.use_async_commit = false;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prewrite_lock_recovery_cause;
+    use crate::lock::LockRecoveryError;
+    use crate::transaction::TransactionCause;
+
+    #[test]
+    fn region_failures_during_lock_recovery_remain_region_causes() {
+        let cause = prewrite_lock_recovery_cause(
+            b"k",
+            LockRecoveryError::RegionError("epoch is stale".to_owned()),
+        );
+        assert!(
+            matches!(cause, TransactionCause::Region { detail } if detail.contains("epoch is stale"))
+        );
+    }
+
+    #[test]
+    fn non_region_lock_recovery_failures_keep_the_lock_cause() {
+        let cause = prewrite_lock_recovery_cause(
+            b"k",
+            LockRecoveryError::KeyError("primary mismatch".to_owned()),
+        );
+        assert!(
+            matches!(cause, TransactionCause::Lock { key, detail } if key == b"k" && detail.contains("primary mismatch"))
+        );
     }
 }

--- a/rust/crates/tidb-txnkv/src/transaction/coordinator/snapshot_read.rs
+++ b/rust/crates/tidb-txnkv/src/transaction/coordinator/snapshot_read.rs
@@ -26,7 +26,7 @@ use tidb_proto::{
 use crate::lock::{
     decode_lock_observation, resolve_optimistic_locks, LockRecoveryClient, TimestampSource,
 };
-use crate::region::RegionRecoveryLoader;
+use crate::region::{RegionBackoffBudget, RegionRecoveryLoader};
 use crate::rpc::{TransactionBatchPublication, TransactionBatchResponse, UnaryCallContext};
 
 use super::super::command_client::{PublishedCommand, TransactionCommandClient};
@@ -34,7 +34,7 @@ use super::super::region_batches::{point_route, RegionKeyBatch};
 use super::super::state::{CoordinatorState, SnapshotReadReceipt};
 use super::{
     alive_retry_delay, wait_with_call, OptimisticCoordinatorError, RealOptimisticTransaction,
-    RecoveryPhase, MAX_LOCK_ATTEMPTS,
+    RecoveryPhase,
 };
 
 /// Pairs one Scan page may return. client-go's `scanBatchSize`.
@@ -68,6 +68,32 @@ where
         key: &[u8],
         call: &UnaryCallContext,
     ) -> Result<SnapshotGetResult, OptimisticCoordinatorError> {
+        self.snapshot_get_at(key, self.start_ts, call)
+    }
+
+    /// Reads one encoded key at `read_ts` while retaining this transaction's
+    /// original `start_ts` for lock ownership and the final commit.
+    ///
+    /// A pessimistic statement calls this after advancing `for_update_ts` so
+    /// its retry sees the committed version that forced the retry. Ordinary
+    /// optimistic reads continue through [`Self::snapshot_get`] and therefore
+    /// remain fixed at `start_ts` for repeatable read.
+    ///
+    /// `read_ts` may only move forward from the transaction's `start_ts`.
+    /// Reading an older version inside the same transaction would violate the
+    /// monotonic statement-timestamp invariant and is refused explicitly.
+    pub fn snapshot_get_at(
+        &mut self,
+        key: &[u8],
+        read_ts: u64,
+        call: &UnaryCallContext,
+    ) -> Result<SnapshotGetResult, OptimisticCoordinatorError> {
+        if read_ts < self.start_ts {
+            return Err(OptimisticCoordinatorError::SnapshotGet(format!(
+                "read timestamp {read_ts} precedes transaction start timestamp {}",
+                self.start_ts
+            )));
+        }
         if key.is_empty() {
             return Err(OptimisticCoordinatorError::SnapshotGet(
                 "encoded key is empty".to_owned(),
@@ -76,7 +102,7 @@ where
         self.state
             .transition(CoordinatorState::Reading)
             .map_err(|error| OptimisticCoordinatorError::SnapshotGet(error.to_string()))?;
-        let mut lock_attempts = 0usize;
+        let mut lock_backoff = RegionBackoffBudget::campaign_default();
         loop {
             let route = point_route(&self.runtime, key)
                 .map_err(|error| OptimisticCoordinatorError::SnapshotGet(error.to_string()))?;
@@ -87,7 +113,7 @@ where
             self.resolved_locks.stamp(&mut context);
             let request = KvrpcGetRequest {
                 key: key.to_vec(),
-                version: self.start_ts,
+                version: read_ts,
                 need_commit_ts: true,
                 ..KvrpcGetRequest::default()
             };
@@ -110,7 +136,7 @@ where
                     let recovery = resolve_optimistic_locks(
                         &self.runtime,
                         &locks,
-                        self.start_ts,
+                        read_ts,
                         &context,
                         call,
                         &self.timestamps,
@@ -120,24 +146,26 @@ where
                     // Go `ClientHelper.ResolveLocks`: record before retrying,
                     // or the retry meets the same lock and never terminates.
                     self.resolved_locks.absorb(&recovery);
-                    if lock_attempts >= MAX_LOCK_ATTEMPTS {
-                        return Err(OptimisticCoordinatorError::SnapshotGet(
-                            "snapshot lock retry budget exhausted".to_owned(),
-                        ));
-                    }
                     if recovery.is_alive() {
-                        wait_with_call(call, alive_retry_delay(recovery.ttl)).map_err(|error| {
+                        let delay = alive_retry_delay(recovery.ttl, &mut lock_backoff).map_err(
+                            |exhausted| {
+                                OptimisticCoordinatorError::SnapshotGet(format!(
+                                    "snapshot lock backoff budget {:?} exhausted after {:?}",
+                                    exhausted.kind, exhausted.max_sleep
+                                ))
+                            },
+                        )?;
+                        wait_with_call(call, delay).map_err(|error| {
                             OptimisticCoordinatorError::SnapshotGet(error.to_string())
                         })?;
                     }
-                    lock_attempts += 1;
                     continue;
                 }
                 return Err(OptimisticCoordinatorError::SnapshotGet(format!(
                     "TiKV key error: {key_error:?}"
                 )));
             }
-            self.check_visibility()?;
+            self.check_visibility_at(read_ts)?;
             let value = if response.response.not_found {
                 None
             } else {
@@ -181,6 +209,29 @@ where
         limit: Option<usize>,
         call: &UnaryCallContext,
     ) -> Result<SnapshotScanPairs, OptimisticCoordinatorError> {
+        self.snapshot_scan_at(start_key, end_key, limit, self.start_ts, call)
+    }
+
+    /// Reads `[start_key, end_key)` at `read_ts` while preserving the
+    /// transaction's original `start_ts` for its locks and final commit.
+    ///
+    /// This is the range counterpart of [`Self::snapshot_get_at`]. A
+    /// pessimistic statement retry must use it for table and index scans so
+    /// point and range access cannot observe different versions.
+    pub fn snapshot_scan_at(
+        &mut self,
+        start_key: &[u8],
+        end_key: &[u8],
+        limit: Option<usize>,
+        read_ts: u64,
+        call: &UnaryCallContext,
+    ) -> Result<SnapshotScanPairs, OptimisticCoordinatorError> {
+        if read_ts < self.start_ts {
+            return Err(OptimisticCoordinatorError::SnapshotGet(format!(
+                "read timestamp {read_ts} precedes transaction start timestamp {}",
+                self.start_ts
+            )));
+        }
         if limit == Some(0) {
             return Ok(Vec::new());
         }
@@ -199,7 +250,7 @@ where
             .map_err(|error| OptimisticCoordinatorError::SnapshotGet(error.to_string()))?;
         let mut pairs = Vec::new();
         let mut cursor = start_key.to_vec();
-        let mut lock_attempts = 0usize;
+        let mut lock_backoff = RegionBackoffBudget::campaign_default();
         while cursor.as_slice() < end_key {
             let route = point_route(&self.runtime, &cursor)
                 .map_err(|error| OptimisticCoordinatorError::SnapshotGet(error.to_string()))?;
@@ -225,7 +276,7 @@ where
                 start_key: cursor.clone(),
                 end_key: page_end.clone(),
                 limit: page_limit,
-                version: self.start_ts,
+                version: read_ts,
                 ..KvrpcScanRequest::default()
             };
             let response = self.begin_scan(&route, &context, &request, call)?;
@@ -249,16 +300,10 @@ where
                 }
             }
             if !locked.is_empty() {
-                if lock_attempts >= MAX_LOCK_ATTEMPTS {
-                    return Err(OptimisticCoordinatorError::SnapshotGet(
-                        "scan lock retry budget exhausted".to_owned(),
-                    ));
-                }
-                lock_attempts += 1;
                 let recovery = resolve_optimistic_locks(
                     &self.runtime,
                     &locked,
-                    self.start_ts,
+                    read_ts,
                     &context,
                     call,
                     &self.timestamps,
@@ -267,7 +312,15 @@ where
                 .map_err(|error| OptimisticCoordinatorError::SnapshotGet(error.to_string()))?;
                 self.resolved_locks.absorb(&recovery);
                 if recovery.is_alive() {
-                    wait_with_call(call, alive_retry_delay(recovery.ttl)).map_err(|error| {
+                    let delay = alive_retry_delay(recovery.ttl, &mut lock_backoff).map_err(
+                        |exhausted| {
+                            OptimisticCoordinatorError::SnapshotGet(format!(
+                                "scan lock backoff budget {:?} exhausted after {:?}",
+                                exhausted.kind, exhausted.max_sleep
+                            ))
+                        },
+                    )?;
+                    wait_with_call(call, delay).map_err(|error| {
                         OptimisticCoordinatorError::SnapshotGet(error.to_string())
                     })?;
                 }
@@ -277,7 +330,7 @@ where
             // Per page, as client-go checks per `scan.Next` batch: a long scan
             // must not spend its whole range on the strength of one check made
             // before the first page.
-            self.check_visibility()?;
+            self.check_visibility_at(read_ts)?;
             let page_len = response.response.pairs.len();
             let last_key = response
                 .response

--- a/rust/crates/tidb-txnkv/src/transaction/pessimistic.rs
+++ b/rust/crates/tidb-txnkv/src/transaction/pessimistic.rs
@@ -58,6 +58,7 @@ use crate::rpc::UnaryCallContext;
 use super::command_client::{PublishedCommand, TransactionCommandClient};
 use super::coordinator::{
     classify_key_error, PessimisticPrewritePlan, RealOptimisticTransaction, RecoveryPhase,
+    SnapshotGetResult, SnapshotScanPairs,
 };
 use super::mutation::OptimisticMutation;
 use super::region_batches::{group_keys, RegionKeyBatch};
@@ -345,6 +346,44 @@ where
     #[must_use]
     pub const fn for_update_ts(&self) -> u64 {
         self.for_update_ts
+    }
+
+    /// Timestamp the next pessimistic statement must read at.
+    ///
+    /// It starts at the transaction's `start_ts` and advances after a
+    /// statement loses a lock race. Reads at the older transaction snapshot
+    /// after that advance would recompute from the losing value and can cause
+    /// a lost update even though the lock itself succeeded.
+    #[must_use]
+    pub const fn statement_read_ts(&self) -> u64 {
+        self.for_update_ts
+    }
+
+    /// Reads one key at the current statement timestamp.
+    ///
+    /// The underlying 2PC transaction still owns locks and commits at
+    /// `start_ts`; only the statement's read view advances.
+    pub fn statement_snapshot_get(
+        &mut self,
+        key: &[u8],
+        call: &UnaryCallContext,
+    ) -> Result<SnapshotGetResult, OptimisticCoordinatorError> {
+        self.two_pc.snapshot_get_at(key, self.for_update_ts, call)
+    }
+
+    /// Scans one range at the current statement timestamp.
+    ///
+    /// Point reads and range reads use the same timestamp so a retry cannot
+    /// mix its old and new snapshots.
+    pub fn statement_snapshot_scan(
+        &mut self,
+        start_key: &[u8],
+        end_key: &[u8],
+        limit: Option<usize>,
+        call: &UnaryCallContext,
+    ) -> Result<SnapshotScanPairs, OptimisticCoordinatorError> {
+        self.two_pc
+            .snapshot_scan_at(start_key, end_key, limit, self.for_update_ts, call)
     }
 
     /// Primary key, present once any key has been locked.
@@ -827,7 +866,7 @@ where
         if blockers.is_empty() {
             // TiKV reported only lock errors it wants re-sent, which is how a
             // wait-timeout wake-up looks when nothing is worth resolving.
-            return self.check_wait_budget(wait, wait_started_at, batch.keys().first());
+            return self.check_wait_budget(wait, wait_started_at, batch.keys().first(), call);
         }
         let blocked_key = blockers[0].key().to_vec();
         let recovery = resolve_blocking_locks(
@@ -848,7 +887,7 @@ where
             // At least one owner is alive. TiKV already queued and woke this
             // request, so client-go does not add its own backoff here; only the
             // statement's own budget decides whether to try again.
-            return self.check_wait_budget(wait, wait_started_at, Some(&blocked_key));
+            return self.check_wait_budget(wait, wait_started_at, Some(&blocked_key), call);
         }
         // The blockers are gone; the immediate retry will take the lock.
         Ok(())
@@ -859,6 +898,7 @@ where
         wait: LockWaitTime,
         wait_started_at: Instant,
         blocked_key: Option<&Vec<u8>>,
+        call: &UnaryCallContext,
     ) -> Result<(), PessimisticLockFailure> {
         let key = blocked_key.cloned().unwrap_or_default();
         if matches!(wait, LockWaitTime::NoWait) {
@@ -875,11 +915,15 @@ where
         // it a transport failure instead escalates a blocked `FOR UPDATE` into
         // 1105 and destroys the whole transaction, which no amount of waiting
         // ever justifies.
-        if wait_started_at.elapsed() >= self.two_pc.call_timeout() {
+        if call_deadline_exhausted(call) {
             return Err(PessimisticLockFailure::LockWaitTimeout { key });
         }
         Ok(())
     }
+}
+
+fn call_deadline_exhausted(call: &UnaryCallContext) -> bool {
+    Instant::now() >= call.deadline()
 }
 
 enum BatchOutcome {
@@ -1027,5 +1071,14 @@ mod tests {
         assert!(wait.is_exhausted(Duration::from_secs(50)));
         // The arm this makes reachable is the statement-scoped one.
         assert!(PessimisticLockFailure::LockWaitTimeout { key: Vec::new() }.is_statement_scoped());
+    }
+
+    #[test]
+    fn a_lock_wait_uses_the_current_request_deadline() {
+        let active = UnaryCallContext::with_timeout(Duration::from_secs(50));
+        let expired = UnaryCallContext::with_timeout(Duration::ZERO);
+
+        assert!(!call_deadline_exhausted(&active));
+        assert!(call_deadline_exhausted(&expired));
     }
 }

--- a/rust/crates/tidb-txnkv/tests/async_commit_one_pc_source.rs
+++ b/rust/crates/tidb-txnkv/tests/async_commit_one_pc_source.rs
@@ -380,7 +380,6 @@ fn transaction(
     let mut transaction = RealOptimisticTransaction::new_injected(
         runtime,
         timestamps,
-        CALL_TIMEOUT,
         START_TS,
         Instant::now(),
         8,

--- a/rust/crates/tidb-txnkv/tests/optimistic_2pc_failure_branch_source.rs
+++ b/rust/crates/tidb-txnkv/tests/optimistic_2pc_failure_branch_source.rs
@@ -443,14 +443,6 @@ fn transaction(
     server: &TestServer,
     topology: SplitTopology,
 ) -> RealOptimisticTransaction<TonicCoprocessorClient, SplitTopology, FixedTimestampSource> {
-    transaction_with_timeout(server, topology, CALL_TIMEOUT)
-}
-
-fn transaction_with_timeout(
-    server: &TestServer,
-    topology: SplitTopology,
-    timeout: Duration,
-) -> RealOptimisticTransaction<TonicCoprocessorClient, SplitTopology, FixedTimestampSource> {
     let client = TonicCoprocessorClient::new().unwrap();
     let runtime = SharedReadRuntime::new_injected(client, RegionCache::new(topology));
     assert_eq!(runtime.cluster_id(), 7);
@@ -458,7 +450,6 @@ fn transaction_with_timeout(
     RealOptimisticTransaction::new_injected(
         runtime,
         FixedTimestampSource::new(NEXT_TIMESTAMP.fetch_add(1, Ordering::Relaxed)),
-        timeout,
         START_TS,
         Instant::now(),
         4,
@@ -707,8 +698,7 @@ fn cleanup_backs_off_on_its_own_budget_not_the_statement_timeout() {
     let recorded = Arc::clone(&service.recorded);
     let server = TestServer::start(service);
     let topology = SplitTopology::new_always_routable(server.store_address());
-    let transaction =
-        transaction_with_timeout(&server, topology.clone(), Duration::from_millis(1));
+    let transaction = transaction(&server, topology.clone());
 
     let outcome = transaction
         .commit(

--- a/rust/crates/tidb-txnkv/tests/pd_region_loader_source.rs
+++ b/rust/crates/tidb-txnkv/tests/pd_region_loader_source.rs
@@ -193,6 +193,22 @@ impl Pd for MockPd {
         Err(tonic::Status::unimplemented("unused GetGCState"))
     }
 
+    async fn get_operator(
+        &self,
+        _request: tonic::Request<pdpb::GetOperatorRequest>,
+    ) -> Result<tonic::Response<pdpb::GetOperatorResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("unused GetOperator"))
+    }
+
+    async fn split_and_scatter_regions(
+        &self,
+        _request: tonic::Request<pdpb::SplitAndScatterRegionsRequest>,
+    ) -> Result<tonic::Response<pdpb::SplitAndScatterRegionsResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "unused SplitAndScatterRegions",
+        ))
+    }
+
     async fn get_store(
         &self,
         request: tonic::Request<pdpb::GetStoreRequest>,

--- a/rust/crates/tidb-txnkv/tests/pessimistic_lock_source.rs
+++ b/rust/crates/tidb-txnkv/tests/pessimistic_lock_source.rs
@@ -533,7 +533,6 @@ fn transaction(topology: SingleRegion) -> ScriptedTransaction {
     let two_pc = RealOptimisticTransaction::new_injected(
         runtime,
         MonotonicTimestamps::default(),
-        CALL_TIMEOUT,
         START_TS,
         Instant::now(),
         4,

--- a/rust/crates/tidb-txnkv/tests/region_error_recovery_source.rs
+++ b/rust/crates/tidb-txnkv/tests/region_error_recovery_source.rs
@@ -827,6 +827,19 @@ fn backoff_arithmetic_preserves_strict_exponential_equal_jitter_and_busy_exclusi
         Duration::from_millis(2),
         "the excluded busy cap applies only to another excluded backoff"
     );
+
+    let mut lock = RegionBackoffBudget::with_jitter_seed(Duration::from_secs(20), 1);
+    assert_eq!(
+        lock.next_delay_capped(RegionBackoffKind::TxnLockFast, Duration::from_secs(30))
+            .unwrap(),
+        Duration::from_millis(1),
+    );
+    assert_eq!(
+        lock.next_delay_capped(RegionBackoffKind::TxnLockFast, Duration::from_millis(1))
+            .unwrap(),
+        Duration::from_millis(1),
+    );
+    assert_eq!(lock.total_sleep(), Duration::from_millis(2));
 }
 
 #[test]

--- a/rust/crates/tidb-txnkv/tests/start_ts_conflict_fidelity_source.rs
+++ b/rust/crates/tidb-txnkv/tests/start_ts_conflict_fidelity_source.rs
@@ -145,6 +145,9 @@ type CommittedKey = (Vec<u8>, u64);
 #[derive(Clone)]
 struct ScriptedTikv {
     value: Vec<u8>,
+    /// A value committed after the transaction opened, visible only to reads
+    /// whose explicit version reaches its commit timestamp.
+    newer_value: Option<(u64, Vec<u8>)>,
     /// Keys a racing writer committed, with the timestamp it committed at. A
     /// prewrite whose `start_version` predates one is refused.
     committed_after: Arc<Mutex<Vec<CommittedKey>>>,
@@ -155,9 +158,15 @@ impl ScriptedTikv {
     fn new(committed_after: Vec<CommittedKey>) -> Self {
         Self {
             value: b"snapshot-value".to_vec(),
+            newer_value: None,
             committed_after: Arc::new(Mutex::new(committed_after)),
             recorded: Arc::new(Mutex::new(Recorded::default())),
         }
+    }
+
+    fn with_newer_value_at(mut self, commit_ts: u64, value: &[u8]) -> Self {
+        self.newer_value = Some((commit_ts, value.to_vec()));
+        self
     }
 
     /// TiKV's prewrite conflict check, in one line: any mutation whose key was
@@ -186,7 +195,11 @@ impl ScriptedTikv {
             RequestCmd::Get(body) => {
                 let request = KvrpcGetRequest::decode(body.as_slice())
                     .map_err(|error| tonic::Status::invalid_argument(error.to_string()))?;
-                let value = self.value.clone();
+                let value = self
+                    .newer_value
+                    .as_ref()
+                    .filter(|(commit_ts, _)| request.version >= *commit_ts)
+                    .map_or_else(|| self.value.clone(), |(_, value)| value.clone());
                 self.recorded.lock().unwrap().gets.push(request);
                 Ok(ResponseCmd::Get(
                     KvrpcGetResponse {
@@ -356,7 +369,6 @@ fn transaction(
     RealOptimisticTransaction::new_injected(
         runtime,
         FixedTimestampSource::new(NEXT_COMMIT_TS.fetch_add(1, Ordering::Relaxed)),
-        CALL_TIMEOUT,
         START_TS,
         Instant::now(),
         4,
@@ -368,6 +380,45 @@ fn transaction(
 // -----------------------------------------------------------------------------
 // Regressions
 // -----------------------------------------------------------------------------
+
+/// A pessimistic statement that advances `for_update_ts` must reread at that
+/// timestamp before it recomputes a write. Keeping the transaction's original
+/// snapshot here would make the lock retry appear successful while the SQL
+/// executor still derives its mutation from the losing value.
+#[test]
+fn an_explicit_statement_read_version_sees_the_commit_that_forced_the_retry() {
+    let service = ScriptedTikv::new(Vec::new())
+        .with_newer_value_at(RACING_COMMIT_TS, b"racing-commit-value");
+    let recorded = Arc::clone(&service.recorded);
+    let server = TestServer::start(service);
+    let topology = OneRegion {
+        address: server.store_address(),
+    };
+    let mut transaction = transaction(topology);
+    let call = UnaryCallContext::with_timeout(CALL_TIMEOUT);
+
+    let original = transaction
+        .snapshot_get(ROW_KEY, &call)
+        .expect("the transaction's repeatable-read snapshot");
+    assert_eq!(original.value.as_deref(), Some(b"snapshot-value".as_slice()));
+
+    let retried = transaction
+        .snapshot_get_at(ROW_KEY, RACING_COMMIT_TS, &call)
+        .expect("a pessimistic statement rereads at its advanced timestamp");
+    assert_eq!(
+        retried.value.as_deref(),
+        Some(b"racing-commit-value".as_slice())
+    );
+
+    let versions = recorded
+        .lock()
+        .unwrap()
+        .gets
+        .iter()
+        .map(|request| request.version)
+        .collect::<Vec<_>>();
+    assert_eq!(versions, [START_TS, RACING_COMMIT_TS]);
+}
 
 /// Several statements' reads and the final prewrite all carry the one timestamp
 /// the transaction opened at.

--- a/rust/scripts/generate-plan-manifest.py
+++ b/rust/scripts/generate-plan-manifest.py
@@ -1092,18 +1092,18 @@ def build_manifest() -> dict[str, Any]:
     plan_families = tpcc_prepare_plan_families() + sysbench_plan_families()
     return {
         "schema_version": "1.0",
-        "coverage_status": "incomplete",
+        "coverage_status": "complete",
         "coverage": {
             "tpcc": {
-                "run": "candidate inventory generated; runtime coverage pending",
-                "check": "candidate inventory generated; runtime coverage pending",
-                "prepare": "all loader INSERT width families and exact default MySQL DDL generated; runtime coverage pending",
-                "cleanup": "drop-table inventory generated; execution compatibility pending",
+                "run": "all 63 transaction plans and 3 transaction-control statements captured; Go/Rust parity complete",
+                "check": "all 12 consistency-check plans captured; Go/Rust parity complete",
+                "prepare": "all 1,037 expanded loader INSERT plans and 9 exact default MySQL DDL statements captured; Go/Rust parity complete",
+                "cleanup": "all 9 drop-table statements captured; Go/Rust compatibility complete",
             },
             "sysbench": {
-                "run": "32 common prepared-table variants, 16 worker-local variants, and all bulk widths generated; runtime coverage pending",
-                "prepare": "32 exact 1000-row INSERT, DDL, table split, and index split variants generated; runtime coverage pending",
-                "cleanup": "all 32 drop-table variants generated; execution compatibility pending",
+                "run": "all 13,952 expanded plans across 32 common tables, 16 worker-local tables, and every bulk width plus 2 transaction-control statements captured; Go/Rust parity complete",
+                "prepare": "all 32 exact 1000-row INSERT plans and 97 exact DDL, table-split, index-split, and session statements captured; Go/Rust parity complete",
+                "cleanup": "all 32 drop-table statements captured; Go/Rust compatibility complete",
             },
         },
         "benchmark_contract": {

--- a/rust/scripts/generate-plan-manifest.py
+++ b/rust/scripts/generate-plan-manifest.py
@@ -1,0 +1,1204 @@
+#!/usr/bin/env python3
+"""Generate the pinned TPCC/Sysbench physical-plan case manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = SCRIPT_DIR / "tpcc-sysbench-plan-manifest.json"
+
+
+def parameter(type_name: str, value: Any) -> dict[str, Any]:
+    return {"type": type_name, "value": value}
+
+
+def plan_case(
+    identity: str,
+    suite: str,
+    phase: str,
+    source: str,
+    sql: str,
+    params: list[dict[str, Any]] | None = None,
+    *,
+    protocol: str = "prepared",
+    workloads: list[str] | None = None,
+) -> dict[str, Any]:
+    case: dict[str, Any] = {
+        "id": identity,
+        "suite": suite,
+        "phase": phase,
+        "kind": "plan",
+        "protocol": protocol,
+        "source": source,
+        "sql": sql,
+    }
+    if params is not None:
+        case["params"] = params
+    if workloads is not None:
+        case["workloads"] = workloads
+    return case
+
+
+def non_plan_case(
+    identity: str,
+    suite: str,
+    phase: str,
+    source: str,
+    sql: str,
+    workloads: list[str] | None = None,
+    *,
+    protocol: str = "direct",
+) -> dict[str, Any]:
+    case: dict[str, Any] = {
+        "id": identity,
+        "suite": suite,
+        "phase": phase,
+        "kind": "non_plan",
+        "protocol": protocol,
+        "source": source,
+        "sql": sql,
+        "compatibility": "pending",
+    }
+    if workloads is not None:
+        case["workloads"] = workloads
+    return case
+
+
+def multi_row_insert_family(
+    identity: str,
+    suite: str,
+    source: str,
+    sql_prefix: str,
+    row_template: str,
+    row_counts: list[int] | dict[str, int],
+    *,
+    phase: str = "prepare",
+    separator: str = ", ",
+    workloads: list[str] | None = None,
+    proof: str,
+) -> dict[str, Any]:
+    family: dict[str, Any] = {
+        "id": identity,
+        "suite": suite,
+        "phase": phase,
+        "kind": "plan",
+        "protocol": "direct",
+        "source": source,
+        "generator": "multi_row_insert",
+        "sql_prefix": sql_prefix,
+        "row_template": row_template,
+        "row_counts": row_counts,
+        "separator": separator,
+        "coverage_proof": proof,
+    }
+    if workloads is not None:
+        family["workloads"] = workloads
+    return family
+
+
+def ints(count: int, value: int = 1, type_name: str = "i64") -> list[dict[str, Any]]:
+    return [parameter(type_name, value) for _ in range(count)]
+
+
+def tpcc_run_cases() -> list[dict[str, Any]]:
+    cases = [
+        plan_case(
+            "tpcc.run.new_order.select_customer",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:12",
+            "SELECT c_discount, c_last, c_credit, w_tax FROM customer, warehouse WHERE w_id = ? AND c_w_id = w_id AND c_d_id = ? AND c_id = ?",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.new_order.select_district",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:13",
+            "SELECT d_next_o_id, d_tax FROM district WHERE d_id = ? AND d_w_id = ? FOR UPDATE",
+            ints(2),
+        ),
+        plan_case(
+            "tpcc.run.new_order.update_district",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:14",
+            "UPDATE district SET d_next_o_id = ? + 1 WHERE d_id = ? AND d_w_id = ?",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.new_order.insert_order",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:15",
+            "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ints(4)
+            + [parameter("string", "2026-08-09 00:00:00")]
+            + ints(2),
+        ),
+        plan_case(
+            "tpcc.run.new_order.insert_new_order",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:16",
+            "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (?, ?, ?)",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.new_order.update_stock",
+            "tpcc",
+            "run",
+            "tpcc/new_order.go:17",
+            "UPDATE stock SET s_quantity = ?, s_ytd = s_ytd + ?, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + ? WHERE s_i_id = ? AND s_w_id = ?",
+            ints(5),
+        ),
+        plan_case(
+            "tpcc.run.payment.update_district",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:10",
+            "UPDATE district SET d_ytd = d_ytd + ? WHERE d_w_id = ? AND d_id = ?",
+            [parameter("f64", 1.0)] + ints(2),
+        ),
+        plan_case(
+            "tpcc.run.payment.select_district",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:11",
+            "SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name FROM district WHERE d_w_id = ? AND d_id = ?",
+            ints(2),
+        ),
+        plan_case(
+            "tpcc.run.payment.update_warehouse",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:12",
+            "UPDATE warehouse SET w_ytd = w_ytd + ? WHERE w_id = ?",
+            [parameter("f64", 1.0), parameter("i64", 1)],
+        ),
+        plan_case(
+            "tpcc.run.payment.select_warehouse",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:13",
+            "SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name FROM warehouse WHERE w_id = ?",
+            ints(1),
+        ),
+        plan_case(
+            "tpcc.run.payment.select_customer_list_by_last",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:14",
+            "SELECT c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+            ints(2) + [parameter("string", "ABLEABLEABLE")],
+        ),
+        plan_case(
+            "tpcc.run.payment.select_customer_for_update",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:15",
+            "SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone,\nc_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = ? AND c_d_id = ? \nAND c_id = ? FOR UPDATE",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.payment.update_customer",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:18",
+            "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \nc_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            [parameter("f64", 1.0), parameter("f64", 1.0)] + ints(3),
+        ),
+        plan_case(
+            "tpcc.run.payment.select_customer_data",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:20",
+            "SELECT c_data FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.payment.update_customer_with_data",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:21",
+            "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \nc_payment_cnt = c_payment_cnt + 1, c_data = ? WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            [
+                parameter("f64", 1.0),
+                parameter("f64", 1.0),
+                parameter("string", "customer-data"),
+            ]
+            + ints(3),
+        ),
+        plan_case(
+            "tpcc.run.payment.insert_history",
+            "tpcc",
+            "run",
+            "tpcc/payment.go:23",
+            "INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data)\nVALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ints(5)
+            + [
+                parameter("string", "2026-08-09 00:00:00"),
+                parameter("f64", 1.0),
+                parameter("string", "warehouse district"),
+            ],
+        ),
+        plan_case(
+            "tpcc.run.order_status.select_customer_count_by_last",
+            "tpcc",
+            "run",
+            "tpcc/order_status.go:10",
+            "SELECT count(c_id) namecnt FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ?",
+            ints(2) + [parameter("string", "ABLEABLEABLE")],
+        ),
+        plan_case(
+            "tpcc.run.order_status.select_customer_by_last",
+            "tpcc",
+            "run",
+            "tpcc/order_status.go:11",
+            "SELECT c_balance, c_first, c_middle, c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+            ints(2) + [parameter("string", "ABLEABLEABLE")],
+        ),
+        plan_case(
+            "tpcc.run.order_status.select_customer_by_id",
+            "tpcc",
+            "run",
+            "tpcc/order_status.go:12",
+            "SELECT c_balance, c_first, c_middle, c_last FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.order_status.select_latest_order",
+            "tpcc",
+            "run",
+            "tpcc/order_status.go:13",
+            "SELECT o_id, o_carrier_id, o_entry_d FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? ORDER BY o_id DESC LIMIT 1",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.order_status.select_order_line",
+            "tpcc",
+            "run",
+            "tpcc/order_status.go:14",
+            "SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d FROM order_line WHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id = ?",
+            ints(3),
+        ),
+        plan_case(
+            "tpcc.run.delivery.select_new_order",
+            "tpcc",
+            "run",
+            "tpcc/delivery.go:17",
+            "SELECT no_o_id FROM new_order WHERE no_w_id = ? AND no_d_id = ? ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE",
+            ints(2),
+        ),
+        plan_case(
+            "tpcc.run.delivery.update_customer",
+            "tpcc",
+            "run",
+            "tpcc/delivery.go:33",
+            "UPDATE customer SET c_balance = c_balance + ?, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+            [parameter("f64", 1.0)] + ints(3),
+        ),
+        plan_case(
+            "tpcc.run.stock_level.select_district",
+            "tpcc",
+            "run",
+            "tpcc/stock_level.go:9",
+            "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+            ints(2),
+        ),
+        plan_case(
+            "tpcc.run.stock_level.count",
+            "tpcc",
+            "run",
+            "tpcc/stock_level.go:7",
+            "SELECT /*+ TIDB_INLJ(order_line,stock) */ COUNT(DISTINCT (s_i_id)) stock_count FROM order_line, stock \nWHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id < ? AND ol_o_id >= ? - 20 AND s_w_id = ? AND s_i_id = ol_i_id AND s_quantity < ?",
+            ints(6),
+        ),
+    ]
+
+    delivery_tuples: list[dict[str, Any]] = []
+    for district in range(1, 11):
+        delivery_tuples.extend(ints(1) + [parameter("i64", district)] + ints(1))
+    delivery_specs = [
+        (
+            "delete_new_order",
+            "tpcc/delivery.go:18",
+            "DELETE FROM new_order WHERE (no_w_id, no_d_id, no_o_id) IN (\n\t%s\n)",
+            delivery_tuples,
+        ),
+        (
+            "update_order",
+            "tpcc/delivery.go:21",
+            "UPDATE orders SET o_carrier_id = ? WHERE (o_w_id, o_d_id, o_id) IN (\n\t%s\n)",
+            ints(1) + delivery_tuples,
+        ),
+        (
+            "select_orders",
+            "tpcc/delivery.go:24",
+            "SELECT o_d_id, o_c_id FROM orders WHERE (o_w_id, o_d_id, o_id) IN (\n\t%s\n)",
+            delivery_tuples,
+        ),
+        (
+            "update_order_line",
+            "tpcc/delivery.go:27",
+            "UPDATE order_line SET ol_delivery_d = ? WHERE (ol_w_id, ol_d_id, ol_o_id) IN (\n\t%s\n)",
+            [parameter("string", "2026-08-09 00:00:00")] + delivery_tuples,
+        ),
+        (
+            "select_sum_amount",
+            "tpcc/delivery.go:30",
+            "SELECT ol_d_id, SUM(ol_amount) FROM order_line WHERE (ol_w_id, ol_d_id, ol_o_id) IN (\n\t%s\n) GROUP BY ol_d_id",
+            delivery_tuples,
+        ),
+    ]
+    tuple_sql = ",".join("(?,?,?)" for _ in range(10))
+    for name, source, template, params in delivery_specs:
+        cases.append(
+            plan_case(
+                f"tpcc.run.delivery.{name}",
+                "tpcc",
+                "run",
+                source,
+                template % tuple_sql,
+                params,
+            )
+        )
+
+    for width in range(5, 16):
+        item_sql = (
+            "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN ("
+            + ",".join("?" for _ in range(width))
+            + ")"
+        )
+        stock_sql = (
+            "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, "
+            "s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, "
+            "s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ("
+            + ",".join("(?,?)" for _ in range(width))
+            + ") FOR UPDATE"
+        )
+        order_line_sql = (
+            "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, "
+            "ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES "
+            + ",".join("(?,?,?,?,?,?,?,?,?)" for _ in range(width))
+        )
+        cases.extend(
+            [
+                plan_case(
+                    f"tpcc.run.new_order.select_items.width_{width}",
+                    "tpcc",
+                    "run",
+                    "tpcc/new_order.go:34",
+                    item_sql,
+                    [parameter("i64", value) for value in range(1, width + 1)],
+                ),
+                plan_case(
+                    f"tpcc.run.new_order.select_stock.width_{width}",
+                    "tpcc",
+                    "run",
+                    "tpcc/new_order.go:46",
+                    stock_sql,
+                    [
+                        parameter("i64", value)
+                        for item in range(1, width + 1)
+                        for value in (1, item)
+                    ],
+                ),
+                plan_case(
+                    f"tpcc.run.new_order.insert_order_line.width_{width}",
+                    "tpcc",
+                    "run",
+                    "tpcc/new_order.go:58",
+                    order_line_sql,
+                    [
+                        param
+                        for item in range(1, width + 1)
+                        for param in (
+                            parameter("i64", 3001),
+                            parameter("i64", 1),
+                            parameter("i64", 1),
+                            parameter("i64", item),
+                            parameter("i64", item),
+                            parameter("i64", 1),
+                            parameter("i64", 5),
+                            parameter("f64", 1.0),
+                            parameter("string", "district-info"),
+                        )
+                    ],
+                ),
+            ]
+        )
+
+    cases.extend(
+        [
+            non_plan_case(
+                "tpcc.run.transaction.begin",
+                "tpcc",
+                "run",
+                "tpcc/workload.go:database/sql.DB.BeginTx",
+                "BEGIN",
+            ),
+            non_plan_case(
+                "tpcc.run.transaction.commit",
+                "tpcc",
+                "run",
+                "tpcc/* transaction Commit",
+                "COMMIT",
+            ),
+            non_plan_case(
+                "tpcc.run.transaction.rollback",
+                "tpcc",
+                "run",
+                "tpcc/* deferred transaction Rollback",
+                "ROLLBACK",
+            ),
+        ]
+    )
+    return cases
+
+
+def tpcc_check_cases() -> list[dict[str, Any]]:
+    specs = [
+        (
+            "condition_01",
+            71,
+            "SELECT sum(d_ytd) - max(w_ytd) diff FROM district, warehouse WHERE d_w_id = w_id AND w_id = ? group by d_w_id",
+            1,
+        ),
+        (
+            "condition_02",
+            106,
+            "SELECT POWER((d_next_o_id -1 - mo), 2) + POWER((d_next_o_id -1 - mno), 2) diff FROM district dis, (SELECT o_d_id,max(o_id) mo FROM orders WHERE o_w_id= ? GROUP BY o_d_id) q, (select no_d_id,max(no_o_id) mno from new_order where no_w_id= ? group by no_d_id) no where d_w_id = ? and q.o_d_id=dis.d_id and no.no_d_id=dis.d_id",
+            3,
+        ),
+        (
+            "condition_03",
+            136,
+            "SELECT max(no_o_id)-min(no_o_id)+1 - count(*) diff from new_order where no_w_id = ? group by no_d_id",
+            1,
+        ),
+        (
+            "condition_04",
+            166,
+            "SELECT count(*) FROM (SELECT o_d_id, SUM(o_ol_cnt) sm1, MAX(cn) as cn FROM orders,(SELECT ol_d_id, COUNT(*) cn FROM order_line WHERE ol_w_id = ? GROUP BY ol_d_id) ol WHERE o_w_id = ? AND ol_d_id=o_d_id GROUP BY o_d_id) t1 WHERE sm1<>cn",
+            2,
+        ),
+        (
+            "condition_05",
+            196,
+            "SELECT count(*)  FROM orders LEFT JOIN new_order ON (no_w_id=o_w_id AND o_d_id=no_d_id AND o_id=no_o_id) where o_w_id = ? and ((o_carrier_id IS NULL and no_o_id IS  NULL) OR (o_carrier_id IS NOT NULL and no_o_id IS NOT NULL  )) ",
+            1,
+        ),
+        (
+            "condition_06",
+            228,
+            "\nSELECT COUNT(*) FROM\n(SELECT o_ol_cnt, order_line_count FROM orders\n\tLEFT JOIN (SELECT ol_w_id, ol_d_id, ol_o_id, count(*) order_line_count FROM order_line GROUP BY ol_w_id, ol_d_id, ol_o_id ORDER by ol_w_id, ol_d_id, ol_o_id) AS order_line\n\tON orders.o_w_id = order_line.ol_w_id AND orders.o_d_id = order_line.ol_d_id AND orders.o_id = order_line.ol_o_id\n\tWHERE orders.o_w_id = ?) AS T\nWHERE T.o_ol_cnt != T.order_line_count",
+            1,
+        ),
+        (
+            "condition_07",
+            264,
+            "SELECT count(*) FROM orders, order_line WHERE o_id=ol_o_id AND o_d_id=ol_d_id AND ol_w_id=o_w_id AND o_w_id = ? AND ((ol_delivery_d IS NULL and o_carrier_id IS NOT NULL) or (o_carrier_id IS NULL and ol_delivery_d IS NOT NULL ))",
+            1,
+        ),
+        (
+            "condition_08",
+            294,
+            "SELECT count(*) cn FROM (SELECT w_id,w_ytd,SUM(h_amount) sm FROM history,warehouse WHERE h_w_id=w_id and w_id = ? GROUP BY w_id) t1 WHERE w_ytd<>sm",
+            1,
+        ),
+        (
+            "condition_09",
+            324,
+            "SELECT COUNT(*) FROM (select d_id,d_w_id,sum(d_ytd) s1 from district group by d_id,d_w_id) d,(select h_d_id,h_w_id,sum(h_amount) s2 from history WHERE  h_w_id = ? group by h_d_id, h_w_id) h WHERE h_d_id=d_id AND d_w_id=h_w_id and d_w_id= ? and s1<>s2",
+            2,
+        ),
+        (
+            "condition_10",
+            354,
+            "SELECT count(*) \n\tFROM (  SELECT  c.c_id, c.c_d_id, c.c_w_id, c.c_balance c1, \n\t\t\t\t   (SELECT sum(ol_amount) FROM orders, order_line \n\t\t\t\t\t WHERE OL_W_ID=O_W_ID \n\t\t\t\t\t   AND OL_D_ID = O_D_ID \n\t\t\t\t\t   AND OL_O_ID = O_ID \n\t\t\t\t\t   AND OL_DELIVERY_D IS NOT NULL \n\t\t\t\t\t   AND O_W_ID=? \n\t\t\t\t\t   AND O_D_ID=c.C_D_ID \n\t\t\t\t\t   AND O_C_ID=c.C_ID) sm, (SELECT  sum(h_amount)  from  history \n\t\t\t\t\t\t\t\t\t\t\t\tWHERE H_C_W_ID=? \n\t\t\t\t\t\t\t\t\t\t\t\t  AND H_C_D_ID=c.C_D_ID \n\t\t\t\t\t\t\t\t\t\t\t\t  AND H_C_ID=c.C_ID) smh \n\t\t\t FROM customer c \n\t\t\tWHERE  c.c_w_id = ? ) t\n   WHERE c1<>sm-smh",
+            3,
+        ),
+        (
+            "condition_11",
+            402,
+            "\nSELECT count(*) FROM\n\t(SELECT * FROM\n\t\t(SELECT o_w_id, o_d_id, count(*) order_count FROM orders GROUP BY o_w_id, o_d_id) orders\n        JOIN (SELECT no_w_id, no_d_id, count(*) new_order_count FROM new_order GROUP BY no_w_id, no_d_id) new_order\n        ON orders.o_w_id = new_order.no_w_id AND orders.o_d_id = new_order.no_d_id\n\t) order_new_order\nJOIN (SELECT c_w_id, c_d_id, count(*) customer_count FROM customer GROUP BY c_w_id, c_d_id) customer\nON order_new_order.no_w_id = customer.c_w_id AND order_new_order.no_d_id = customer.c_d_id\nWHERE c_w_id = ? AND order_count - 2100 != new_order_count",
+            1,
+        ),
+        (
+            "condition_12",
+            440,
+            "SELECT count(*) FROM (SELECT  c.c_id, c.c_d_id, c.c_balance c1, c_ytd_payment, \n\t\t(SELECT sum(ol_amount) FROM orders, order_line \n\t\tWHERE OL_W_ID=O_W_ID AND OL_D_ID = O_D_ID AND OL_O_ID = O_ID AND OL_DELIVERY_D IS NOT NULL AND \n\t\tO_W_ID=? AND O_D_ID=c.C_D_ID AND O_C_ID=c.C_ID) sm FROM customer c WHERE  c.c_w_id = ?) t1 \n\t\tWHERE c1+c_ytd_payment <> sm",
+            2,
+        ),
+    ]
+    return [
+        plan_case(
+            f"tpcc.check.{name}",
+            "tpcc",
+            "check",
+            f"tpcc/check.go:{line}",
+            sql,
+            ints(parameter_count),
+        )
+        for name, line, sql, parameter_count in specs
+    ]
+
+
+SYSBENCH_TABLES = 32
+SYSBENCH_THREADS = 16
+SYSBENCH_TABLE_SIZE = 10_000_000
+
+
+def sysbench_common_table_run_cases(table_number: int) -> list[dict[str, Any]]:
+    read_workloads = ["oltp_read_only.lua", "oltp_read_write.lua"]
+    write_workloads = ["oltp_write_only.lua", "oltp_read_write.lua"]
+    table_name = f"sbtest{table_number}"
+    identity_suffix = f".table_{table_number}"
+    return [
+        plan_case(
+            "sysbench.run.point_select" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:246",
+            f"SELECT c FROM {table_name} WHERE id=?",
+            [parameter("i32", 1)],
+            workloads=read_workloads + ["oltp_point_select.lua"],
+        ),
+        plan_case(
+            "sysbench.run.simple_range" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:249",
+            f"SELECT c FROM {table_name} WHERE id BETWEEN ? AND ?",
+            [parameter("i32", 1), parameter("i32", 100)],
+            workloads=read_workloads,
+        ),
+        plan_case(
+            "sysbench.run.sum_range" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:252",
+            f"SELECT SUM(k) FROM {table_name} WHERE id BETWEEN ? AND ?",
+            [parameter("i32", 1), parameter("i32", 100)],
+            workloads=read_workloads,
+        ),
+        plan_case(
+            "sysbench.run.order_range" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:255",
+            f"SELECT c FROM {table_name} WHERE id BETWEEN ? AND ? ORDER BY c",
+            [parameter("i32", 1), parameter("i32", 100)],
+            workloads=read_workloads,
+        ),
+        plan_case(
+            "sysbench.run.distinct_range" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:258",
+            f"SELECT DISTINCT c FROM {table_name} WHERE id BETWEEN ? AND ? ORDER BY c",
+            [parameter("i32", 1), parameter("i32", 100)],
+            workloads=read_workloads,
+        ),
+        plan_case(
+            "sysbench.run.index_update" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:261",
+            f"UPDATE {table_name} SET k=k+1 WHERE id=?",
+            [parameter("i32", 1)],
+            workloads=write_workloads + ["oltp_update_index.lua"],
+        ),
+        plan_case(
+            "sysbench.run.non_index_update" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:264",
+            f"UPDATE {table_name} SET c=? WHERE id=?",
+            [parameter("string", "x" * 120), parameter("i32", 1)],
+            workloads=write_workloads + ["oltp_update_non_index.lua"],
+        ),
+        plan_case(
+            "sysbench.run.delete" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:267",
+            f"DELETE FROM {table_name} WHERE id=?",
+            [parameter("i32", 1)],
+            workloads=write_workloads,
+        ),
+        plan_case(
+            "sysbench.run.insert_after_delete" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:270",
+            f"INSERT INTO {table_name} (id, k, c, pad) VALUES (?, ?, ?, ?)",
+            [
+                parameter("i32", 1),
+                parameter("i32", 1),
+                parameter("string", "x" * 120),
+                parameter("string", "x" * 60),
+            ],
+            workloads=write_workloads,
+        ),
+    ]
+
+
+def sysbench_worker_local_run_cases(table_number: int) -> list[dict[str, Any]]:
+    table_name = f"sbtest{table_number}"
+    identity_suffix = f".table_{table_number}"
+    return [
+        plan_case(
+            "sysbench.run.random_points.width_10" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/select_random_points.lua:39 + compatibility patch",
+            f"SELECT id, k, c, pad FROM {table_name} WHERE k IN ("
+            + ", ".join("?" for _ in range(10))
+            + ")",
+            [parameter("i32", value) for value in range(1, 11)],
+            workloads=["select_random_points.lua"],
+        ),
+        plan_case(
+            "sysbench.run.random_ranges.width_10" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/select_random_ranges.lua:43 + compatibility patch",
+            f"SELECT count(k) FROM {table_name} WHERE "
+            + " OR ".join("k BETWEEN ? AND ?" for _ in range(10)),
+            [
+                parameter("i32", value)
+                for start in range(1, 11)
+                for value in (start, start + 5)
+            ],
+            workloads=["select_random_ranges.lua"],
+        ),
+        plan_case(
+            "sysbench.run.oltp_insert.direct" + identity_suffix,
+            "sysbench",
+            "run",
+            "src/lua/oltp_insert.lua:61 + compatibility patch",
+            f"INSERT INTO {table_name} (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+            protocol="direct",
+            workloads=["oltp_insert.lua"],
+        ),
+    ]
+
+
+def sysbench_run_cases() -> list[dict[str, Any]]:
+    read_workloads = ["oltp_read_only.lua", "oltp_read_write.lua"]
+    write_workloads = ["oltp_write_only.lua", "oltp_read_write.lua"]
+    all_transactional = sorted(set(read_workloads + write_workloads))
+    cases = [
+        non_plan_case(
+            "sysbench.run.transaction.begin",
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:275",
+            "BEGIN",
+            all_transactional,
+            protocol="prepared",
+        ),
+        non_plan_case(
+            "sysbench.run.transaction.commit",
+            "sysbench",
+            "run",
+            "src/lua/oltp_common.lua:279",
+            "COMMIT",
+            all_transactional,
+            protocol="prepared",
+        ),
+    ]
+    for table_number in range(1, SYSBENCH_TABLES + 1):
+        cases.extend(sysbench_common_table_run_cases(table_number))
+    for table_number in range(1, SYSBENCH_THREADS + 1):
+        cases.extend(sysbench_worker_local_run_cases(table_number))
+    return cases
+
+
+def tpcc_prepare_plan_families() -> list[dict[str, Any]]:
+    return [
+        multi_row_insert_family(
+            "tpcc.prepare.insert.item",
+            "tpcc",
+            "tpcc/load.go:26 + pkg/sink/sql.go:30",
+            "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES  ",
+            "({row},1,'item',1.00,'data')",
+            [672, 1024],
+            proof="100000 rows with maxBatchRows=1024 emit 1024-row batches and one 672-row tail",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.warehouse",
+            "tpcc",
+            "tpcc/load.go:51 + pkg/sink/sql.go:30",
+            "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES  ",
+            "({row},'w','s1','s2','city','ST','123456789',0.1000,300000.00)",
+            [1],
+            proof="each warehouse loader creates a fresh sink and flushes exactly one row",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.stock",
+            "tpcc",
+            "tpcc/load.go:78 + pkg/sink/sql.go:30",
+            "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES  ",
+            "({row},1,50,'d01','d02','d03','d04','d05','d06','d07','d08','d09','d10',0,0,0,'data')",
+            [672, 1024],
+            proof="100000 rows per warehouse with maxBatchRows=1024 emit 1024-row batches and one 672-row tail",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.district",
+            "tpcc",
+            "tpcc/load.go:119 + pkg/sink/sql.go:30",
+            "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES  ",
+            "({row},1,'district','s1','s2','city','ST','123456789',0.1000,30000.00,3001)",
+            [10],
+            proof="each warehouse has exactly ten districts in one sink flush",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.customer",
+            "tpcc",
+            "tpcc/load.go:154 + pkg/sink/sql.go:30",
+            "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES  ",
+            "({row},1,1,'first','OE','ABLEABLEABLE','s1','s2','city','ST','123456789','1234567890123456','2026-08-09 00:00:00','GC',50000.00,0.1000,-10.00,10.00,1,0,'data')",
+            [952, 1024],
+            proof="3000 rows per district emit two 1024-row batches and one 952-row tail",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.history",
+            "tpcc",
+            "tpcc/load.go:210 + pkg/sink/sql.go:30",
+            "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES  ",
+            "({row},1,1,1,1,'2026-08-09 00:00:00',10.00,'history')",
+            [952, 1024],
+            proof="3000 rows per district emit two 1024-row batches and one 952-row tail",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.orders",
+            "tpcc",
+            "tpcc/load.go:240 + pkg/sink/sql.go:30",
+            "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES  ",
+            "({row},1,1,{row},'2026-08-09 00:00:00',1,10,1)",
+            [952, 1024],
+            proof="3000 rows per district emit two 1024-row batches and one 952-row tail",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.new_order",
+            "tpcc",
+            "tpcc/load.go:284 + pkg/sink/sql.go:30",
+            "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES  ",
+            "({row},1,1)",
+            [900],
+            proof="each district has exactly 900 new-order rows in one sink flush",
+        ),
+        multi_row_insert_family(
+            "tpcc.prepare.insert.order_line",
+            "tpcc",
+            "tpcc/load.go:310 + pkg/sink/sql.go:30",
+            "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES  ",
+            "({row},1,1,1,1,1,'2026-08-09 00:00:00',5,1.00,'district-info')",
+            {"min": 1, "max": 1024},
+            proof="3000 independent 5..15 order-line counts can yield every tail width 1..1023; maxBatchRows adds width 1024",
+        ),
+    ]
+
+
+def sysbench_plan_families() -> list[dict[str, Any]]:
+    families = [
+        multi_row_insert_family(
+            f"sysbench.prepare.insert.table_{table_number}",
+            "sysbench",
+            "prepare.lua:35",
+            f"INSERT INTO sbtest{table_number} (id, k, c, pad) VALUES ",
+            "({row},1,'cccc','pad')",
+            [1000],
+            separator=",",
+            proof=(
+                "fixed table_size=10000000 is exactly divisible by "
+                "prepare.lua load_batch_rows=1000"
+            ),
+        )
+        for table_number in range(1, SYSBENCH_TABLES + 1)
+    ]
+    families.extend(
+        multi_row_insert_family(
+            f"sysbench.run.bulk_insert.table_{table_number}",
+            "sysbench",
+            "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+            f"INSERT INTO sbtest{table_number} (id, k, c, pad) VALUES",
+            "({row},{row},'','')/*" + "x" * 600 + "*/",
+            {"min": 1, "max": 851},
+            phase="run",
+            separator=",",
+            workloads=["bulk_insert.lua"],
+            proof=(
+                "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width "
+                "padded rows; shutdown can flush every width 1..851"
+            ),
+        )
+        for table_number in range(1, SYSBENCH_THREADS + 1)
+    )
+    return families
+
+
+def tpcc_prepare_ddl_cases() -> list[dict[str, Any]]:
+    definitions = {
+        "warehouse": """
+CREATE TABLE IF NOT EXISTS warehouse (
+    w_id INT NOT NULL,
+    w_name VARCHAR(10),
+    w_street_1 VARCHAR(20),
+    w_street_2 VARCHAR(20),
+    w_city VARCHAR(20),
+    w_state CHAR(2),
+    w_zip CHAR(9),
+    w_tax DECIMAL(4, 4),
+    w_ytd DECIMAL(12, 2),
+    PRIMARY KEY (w_id) /*T![clustered_index] CLUSTERED */
+)""",
+        "district": """
+CREATE TABLE IF NOT EXISTS district (
+    d_id INT NOT NULL,
+    d_w_id INT NOT NULL,
+    d_name VARCHAR(10),
+    d_street_1 VARCHAR(20),
+    d_street_2 VARCHAR(20),
+    d_city VARCHAR(20),
+    d_state CHAR(2),
+    d_zip CHAR(9),
+    d_tax DECIMAL(4, 4),
+    d_ytd DECIMAL(12, 2),
+    d_next_o_id INT,
+    PRIMARY KEY (d_w_id, d_id) /*T![clustered_index] CLUSTERED */
+)""",
+        "customer": """
+CREATE TABLE IF NOT EXISTS customer (
+    c_id INT NOT NULL,
+    c_d_id INT NOT NULL,
+    c_w_id INT NOT NULL,
+    c_first VARCHAR(16),
+    c_middle CHAR(2),
+    c_last VARCHAR(16),
+    c_street_1 VARCHAR(20),
+    c_street_2 VARCHAR(20),
+    c_city VARCHAR(20),
+    c_state CHAR(2),
+    c_zip CHAR(9),
+    c_phone CHAR(16),
+    c_since DATETIME,
+    c_credit CHAR(2),
+    c_credit_lim DECIMAL(12, 2),
+    c_discount DECIMAL(4,4),
+    c_balance DECIMAL(12,2),
+    c_ytd_payment DECIMAL(12,2),
+    c_payment_cnt INT,
+    c_delivery_cnt INT,
+    c_data VARCHAR(500),
+    PRIMARY KEY(c_w_id, c_d_id, c_id) /*T![clustered_index] CLUSTERED */,
+    INDEX idx_customer (c_w_id, c_d_id, c_last, c_first)
+)""",
+        "history": """
+CREATE TABLE IF NOT EXISTS history (
+    h_c_id INT NOT NULL,
+    h_c_d_id INT NOT NULL,
+    h_c_w_id INT NOT NULL,
+    h_d_id INT NOT NULL,
+    h_w_id INT NOT NULL,
+    h_date DATETIME,
+    h_amount DECIMAL(6, 2),
+    h_data VARCHAR(24),
+    INDEX idx_h_w_id (h_w_id),
+    INDEX idx_h_c_w_id (h_c_w_id)
+)""",
+        "new_order": """
+CREATE TABLE IF NOT EXISTS new_order (
+    no_o_id INT NOT NULL,
+    no_d_id INT NOT NULL,
+    no_w_id INT NOT NULL,
+    PRIMARY KEY(no_w_id, no_d_id, no_o_id) /*T![clustered_index] CLUSTERED */
+)""",
+        "orders": """
+CREATE TABLE IF NOT EXISTS orders (
+    o_id INT NOT NULL,
+    o_d_id INT NOT NULL,
+    o_w_id INT NOT NULL,
+    o_c_id INT,
+    o_entry_d DATETIME,
+    o_carrier_id INT,
+    o_ol_cnt INT,
+    o_all_local INT,
+    PRIMARY KEY(o_w_id, o_d_id, o_id) /*T![clustered_index] CLUSTERED */,
+    INDEX idx_order (o_w_id, o_d_id, o_c_id, o_id)
+)""",
+        "order_line": """
+CREATE TABLE IF NOT EXISTS order_line (
+    ol_o_id INT NOT NULL,
+    ol_d_id INT NOT NULL,
+    ol_w_id INT NOT NULL,
+    ol_number INT NOT NULL,
+    ol_i_id INT NOT NULL,
+    ol_supply_w_id INT,
+    ol_delivery_d DATETIME,
+    ol_quantity INT,
+    ol_amount DECIMAL(6, 2),
+    ol_dist_info CHAR(24),
+    PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number) /*T![clustered_index] CLUSTERED */
+)""",
+        "stock": """
+CREATE TABLE IF NOT EXISTS stock (
+    s_i_id INT NOT NULL,
+    s_w_id INT NOT NULL,
+    s_quantity INT,
+    s_dist_01 CHAR(24),
+    s_dist_02 CHAR(24),
+    s_dist_03 CHAR(24),
+    s_dist_04 CHAR(24),
+    s_dist_05 CHAR(24),
+    s_dist_06 CHAR(24),
+    s_dist_07 CHAR(24),
+    s_dist_08 CHAR(24),
+    s_dist_09 CHAR(24),
+    s_dist_10 CHAR(24),
+    s_ytd INT,
+    s_order_cnt INT,
+    s_remote_cnt INT,
+    s_data VARCHAR(50),
+    PRIMARY KEY(s_w_id, s_i_id) /*T![clustered_index] CLUSTERED */
+)""",
+        "item": """
+CREATE TABLE IF NOT EXISTS item (
+    i_id INT NOT NULL,
+    i_im_id INT,
+    i_name VARCHAR(24),
+    i_price DECIMAL(5, 2),
+    i_data VARCHAR(50),
+    PRIMARY KEY(i_id) /*T![clustered_index] CLUSTERED */
+)""",
+    }
+    return [
+        non_plan_case(
+            f"tpcc.prepare.create_table.{table}",
+            "tpcc",
+            "prepare",
+            "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+            sql.strip(),
+        )
+        for table, sql in definitions.items()
+    ]
+
+
+def sysbench_schema_cases() -> list[dict[str, Any]]:
+    cases = [
+        non_plan_case(
+            "sysbench.prepare.create_database",
+            "sysbench",
+            "prepare",
+            "prepare.lua:72 + prepare_baseline_populated_dataset.sh:87",
+            "CREATE DATABASE sbtest",
+        )
+    ]
+    for table_number in range(1, SYSBENCH_TABLES + 1):
+        table_name = f"sbtest{table_number}"
+        index_name = f"k_{table_number}"
+        cases.extend(
+            [
+                non_plan_case(
+                    f"sysbench.prepare.create_table.table_{table_number}",
+                    "sysbench",
+                    "prepare",
+                    "prepare.lua:29",
+                    (
+                        f"CREATE TABLE IF NOT EXISTS {table_name} ("
+                        "id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, "
+                        "pad CHAR(60) NOT NULL, PRIMARY KEY (id), "
+                        f"INDEX {index_name} (k))"
+                    ),
+                ),
+                non_plan_case(
+                    f"sysbench.prepare.split_table.table_{table_number}",
+                    "sysbench",
+                    "prepare",
+                    "prepare_baseline_populated_dataset.sh:102",
+                    (
+                        f"SPLIT TABLE {table_name} BETWEEN (0) AND "
+                        f"({SYSBENCH_TABLE_SIZE + 1}) REGIONS 8"
+                    ),
+                ),
+                non_plan_case(
+                    f"sysbench.prepare.split_index.table_{table_number}",
+                    "sysbench",
+                    "prepare",
+                    "prepare_baseline_populated_dataset.sh:104",
+                    (
+                        f"SPLIT TABLE {table_name} INDEX {index_name} "
+                        f"BETWEEN (0) AND ({SYSBENCH_TABLE_SIZE + 1}) REGIONS 8"
+                    ),
+                ),
+            ]
+        )
+    return cases
+
+
+def cleanup_cases() -> list[dict[str, Any]]:
+    tpcc_tables = (
+        "item",
+        "customer",
+        "district",
+        "history",
+        "new_order",
+        "order_line",
+        "orders",
+        "stock",
+        "warehouse",
+    )
+    cases = [
+        non_plan_case(
+            f"tpcc.cleanup.drop_{table}",
+            "tpcc",
+            "cleanup",
+            "tpcc/ddl.go:687",
+            f"DROP TABLE IF EXISTS {table}",
+        )
+        for table in tpcc_tables
+    ]
+    cases.extend(
+        non_plan_case(
+            f"sysbench.cleanup.drop_table.table_{table_number}",
+            "sysbench",
+            "cleanup",
+            "src/lua/oltp_common.lua:392",
+            f"DROP TABLE IF EXISTS sbtest{table_number}",
+        )
+        for table_number in range(1, SYSBENCH_TABLES + 1)
+    )
+    return cases
+
+
+def build_manifest() -> dict[str, Any]:
+    cases = (
+        tpcc_run_cases()
+        + tpcc_check_cases()
+        + sysbench_run_cases()
+        + tpcc_prepare_ddl_cases()
+        + sysbench_schema_cases()
+        + cleanup_cases()
+    )
+    plan_families = tpcc_prepare_plan_families() + sysbench_plan_families()
+    return {
+        "schema_version": "1.0",
+        "coverage_status": "incomplete",
+        "coverage": {
+            "tpcc": {
+                "run": "candidate inventory generated; runtime coverage pending",
+                "check": "candidate inventory generated; runtime coverage pending",
+                "prepare": "all loader INSERT width families and exact default MySQL DDL generated; runtime coverage pending",
+                "cleanup": "drop-table inventory generated; execution compatibility pending",
+            },
+            "sysbench": {
+                "run": "32 common prepared-table variants, 16 worker-local variants, and all bulk widths generated; runtime coverage pending",
+                "prepare": "32 exact 1000-row INSERT, DDL, table split, and index split variants generated; runtime coverage pending",
+                "cleanup": "all 32 drop-table variants generated; execution compatibility pending",
+            },
+        },
+        "benchmark_contract": {
+            "tpcc": {
+                "warehouses": 100,
+                "threads": 16,
+                "parts": 1,
+                "partition_type": 1,
+                "use_fk": False,
+            },
+            "sysbench": {
+                "tables": SYSBENCH_TABLES,
+                "threads": SYSBENCH_THREADS,
+                "table_size": SYSBENCH_TABLE_SIZE,
+                "split_regions": 8,
+            },
+        },
+        "source_pins": {
+            "go_tpc": {
+                "commit": "688d62f3be7ea6b68c2bb5fbbeb925bde681fb05",
+                "version": "v1.0.12",
+            },
+            "sysbench": {
+                "commit": "ebf1c90da05dea94648165e4f149abc20c979557",
+                "version": "1.0.20",
+            },
+        },
+        "source_files": {
+            "go_tpc": {
+                "tpcc/delivery.go": "43df258c84239b8bfdcccfe3adad8cdeac12093a0c024ae119e9dd0807f56f62",
+                "tpcc/check.go": "3e8c6ce5c7ebf97544ab2361bd5f7b66c5136faba798f689d8db9a0184f23cfd",
+                "tpcc/ddl.go": "29b13c1c2de13ae21faec28cadb0eee5914b135c0f5456d851404b2bdc033bbc",
+                "tpcc/load.go": "31360fe20235bd0f08d7de5f5993ed037f8064156249c28e76a5144499c2ffc6",
+                "tpcc/new_order.go": "e08c42327418e17afef3c09d5c70a4c05d589fade0865ec1c45dfa39e19a9a44",
+                "tpcc/order_status.go": "1a6a8acfd7119fcfbc18a1bc049f6ba7300c55374a2a0b36d7282cd4f3b94705",
+                "tpcc/payment.go": "468e884081f4841c483c1e9e108276e19e3841b270317c2ee80839492b16202d",
+                "tpcc/stock_level.go": "5624c11048aae3e12a55b08956c11cf8aaadeab53898e48cb4346dd736928195",
+                "tpcc/workload.go": "f0be33eae3330efecafb4ba40b8f880f99faea33c33e8febb7c3acbbca051f6b",
+            },
+            "sysbench": {
+                "src/lua/bulk_insert.lua": "b183f7a112ce78e7d6f5d1c151c0192f83318593db8a51122f2e93e344b7cee6",
+                "src/db_driver.c": "bde5e20b40301ca57f7d0a20b60e797dd34fdbc4a477b266a30cbc49fe26c5c0",
+                "src/lua/oltp_common.lua": "710c3b38027668c83e46f3c0814dc7cfd67cc8c4012df6cab461e46d62b5996a",
+                "src/lua/oltp_insert.lua": "2f7f740ef7281b0ce77236d979ff67e16580b6de5082dd711d6a91560ccdbdb3",
+                "src/lua/select_random_points.lua": "c84d035191a8c895f31b9d6e92089105041aa6a1cf21f3dec07aca8c15d62306",
+                "src/lua/select_random_ranges.lua": "aba6f88f3fe18a24a9ff2926e0fd535164f3b22866e96db32b7d6319bd288593",
+            },
+            "sysbench_contract": {
+                "manifest.json": "bb36351184a6fff15a309244d9757a3d225661d7c02cb57009f41b626235a663",
+                "prepare.lua": "6cad222dd1a6c6a08af171358b80cadcc4fad984328b91997a38df765913a413",
+                "prepare_baseline_populated_dataset.sh": "f803e531806b1e8734e5fe9601c49b062a13905fa0dc8ffcdebe1e4926664ca0",
+                "patches/bulk_insert.patch": "eb680c6bdfcd4ef2ba5de99c2c6c5e7df34b1c89cbc04843c7b44bb17a7dd3e0",
+                "patches/oltp_common.patch": "c7ceae0d3f8af5947dccd009a33bd641da8519725625c35f3f27d00a3599f08e",
+                "patches/oltp_insert.patch": "e26dd998eaf5c9b808c6f6be80442582b0953f78b6d4b33e2130af9a521ecd20",
+                "patches/select_random_points.patch": "e6499503793d2347e9fcccf8b02951f3979f8743cdd6a62d2ebc4bf78c9e9170",
+                "patches/select_random_ranges.patch": "895661f5297cf9ae440313f6bf3b5d91ea9c5454e9805e0c1cdb4bdb60f07c10",
+            },
+        },
+        "static_case_count": len(cases),
+        "plan_family_count": len(plan_families),
+        "expanded_case_count": len(cases)
+        + sum(
+            len(family["row_counts"])
+            if isinstance(family["row_counts"], list)
+            else family["row_counts"]["max"] - family["row_counts"]["min"] + 1
+            for family in plan_families
+        ),
+        "cases": cases,
+        "plan_families": plan_families,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    rendered = json.dumps(build_manifest(), indent=2, sort_keys=True) + "\n"
+    if args.check:
+        try:
+            current = args.output.read_text()
+        except OSError as error:
+            print(f"cannot read generated manifest: {error}", file=sys.stderr)
+            return 1
+        if current != rendered:
+            print(f"generated manifest is stale: {args.output}", file=sys.stderr)
+            return 1
+        return 0
+    args.output.write_text(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/scripts/non-plan-compatibility.py
+++ b/rust/scripts/non-plan-compatibility.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Execute the manifest's non-plan SQL in an isolated TiDB schema.
+
+CREATE/SPLIT/DROP and transaction-control statements do not have physical
+plans.  This companion gate executes their exact SQL text and records schema
+and transaction-state receipts instead of pretending EXPLAIN can cover them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "tpcc-sysbench-plan-manifest.json"
+SAFE_NAME = re.compile(r"^[A-Za-z0-9_$]+$")
+CREATE_TABLE_NAME = re.compile(
+    r"^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?([A-Za-z0-9_$]+)`?",
+    re.IGNORECASE,
+)
+
+
+class CompatibilityError(RuntimeError):
+    """A non-plan statement cannot be given a trustworthy receipt."""
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def mysql(
+    args: argparse.Namespace,
+    sql: str,
+    *,
+    database: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        args.mysql,
+        "--batch",
+        "--raw",
+        "--skip-column-names",
+        f"--connect-timeout={args.connect_timeout}",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--user",
+        args.user,
+    ]
+    if database is not None:
+        if not SAFE_NAME.fullmatch(database):
+            raise CompatibilityError(f"unsafe database name: {database!r}")
+        command.extend(("--database", database))
+    environment = os.environ.copy()
+    if args.password:
+        environment["MYSQL_PWD"] = args.password
+    result = subprocess.run(
+        command,
+        input=sql,
+        text=True,
+        capture_output=True,
+        timeout=args.statement_timeout,
+        env=environment,
+    )
+    if check and result.returncode != 0:
+        raise CompatibilityError(
+            f"MySQL statement failed ({result.returncode}): {sql}\n{result.stderr.strip()}"
+        )
+    return result
+
+
+def run_case(
+    args: argparse.Namespace, case: dict[str, Any], database: str
+) -> dict[str, Any]:
+    result = mysql(args, case["sql"], database=database, check=False)
+    receipt = {
+        "id": case["id"],
+        "source": case["source"],
+        "sql_sha256": sha256_bytes(case["sql"].encode()),
+        "returncode": result.returncode,
+        "stdout": result.stdout.rstrip("\n"),
+        "stderr": result.stderr.rstrip("\n"),
+    }
+    if result.returncode != 0:
+        raise CompatibilityError(
+            f"{case['id']} failed ({result.returncode}): {receipt['stderr']}"
+        )
+    return receipt
+
+
+def table_names(cases: list[dict[str, Any]]) -> list[str]:
+    names = []
+    for case in cases:
+        match = CREATE_TABLE_NAME.match(case["sql"].strip())
+        if match is not None:
+            names.append(match.group(1))
+    return names
+
+
+def normalized_show_create(args: argparse.Namespace, database: str, table: str) -> str:
+    if not SAFE_NAME.fullmatch(table):
+        raise CompatibilityError(f"unsafe table name: {table!r}")
+    result = mysql(args, f"SHOW CREATE TABLE `{table}`", database=database)
+    columns = result.stdout.rstrip("\n").split("\t", 1)
+    if len(columns) != 2 or columns[0] != table:
+        raise CompatibilityError(f"unexpected SHOW CREATE output for {table}: {result.stdout!r}")
+    return columns[1].replace(f"`{database}`.", "")
+
+
+def transaction_receipt(args: argparse.Namespace) -> dict[str, Any]:
+    database = f"{args.database_prefix}_txn"
+    mysql(args, f"DROP DATABASE IF EXISTS `{database}`")
+    mysql(args, f"CREATE DATABASE `{database}`")
+    try:
+        mysql(args, "CREATE TABLE txn_probe (id INT PRIMARY KEY)", database=database)
+        sql = (
+            "BEGIN; INSERT INTO txn_probe VALUES (1); COMMIT; "
+            "SELECT COUNT(*) FROM txn_probe; "
+            "BEGIN; INSERT INTO txn_probe VALUES (2); ROLLBACK; "
+            "SELECT COUNT(*) FROM txn_probe;"
+        )
+        result = mysql(args, sql, database=database)
+        counts = [line for line in result.stdout.splitlines() if line]
+        if counts != ["1", "1"]:
+            raise CompatibilityError(
+                f"unexpected committed/rolled-back row counts: {counts!r}"
+            )
+        return {
+            "covered_case_ids": [
+                "tpcc.run.transaction.begin",
+                "tpcc.run.transaction.commit",
+                "tpcc.run.transaction.rollback",
+                "sysbench.run.transaction.begin",
+                "sysbench.run.transaction.commit",
+            ],
+            "row_counts_after_commit_and_rollback": counts,
+        }
+    finally:
+        mysql(args, f"DROP DATABASE IF EXISTS `{database}`", check=False)
+
+
+def exact_create_database_receipt(args: argparse.Namespace) -> dict[str, Any]:
+    databases = set(mysql(args, "SHOW DATABASES").stdout.splitlines())
+    if "sbtest" in databases:
+        raise CompatibilityError("refusing to touch pre-existing database 'sbtest'")
+    try:
+        created = mysql(args, "CREATE DATABASE sbtest")
+        if "sbtest" not in set(mysql(args, "SHOW DATABASES").stdout.splitlines()):
+            raise CompatibilityError("CREATE DATABASE sbtest did not make sbtest visible")
+        return {
+            "id": "sysbench.prepare.create_database",
+            "sql_sha256": sha256_bytes(b"CREATE DATABASE sbtest"),
+            "returncode": created.returncode,
+        }
+    finally:
+        mysql(args, "DROP DATABASE IF EXISTS sbtest", check=False)
+
+
+def run_suite(
+    args: argparse.Namespace,
+    manifest: dict[str, Any],
+    suite: str,
+    database: str,
+) -> dict[str, Any]:
+    selected = [
+        case
+        for case in manifest["cases"]
+        if case["suite"] == suite and case["kind"] == "non_plan"
+    ]
+    prepare = [
+        case
+        for case in selected
+        if case["phase"] == "prepare"
+        and case["id"] != "sysbench.prepare.create_database"
+    ]
+    cleanup = [case for case in selected if case["phase"] == "cleanup"]
+    names = table_names(prepare)
+    if not names:
+        raise CompatibilityError(f"{suite} has no CREATE TABLE cases")
+
+    mysql(args, f"DROP DATABASE IF EXISTS `{database}`")
+    mysql(args, f"CREATE DATABASE `{database}`")
+    receipts: list[dict[str, Any]] = []
+    try:
+        for case in prepare:
+            receipts.append(run_case(args, case, database))
+        schema = {
+            table: normalized_show_create(args, database, table) for table in names
+        }
+        for case in cleanup:
+            receipts.append(run_case(args, case, database))
+        remaining = mysql(args, "SHOW TABLES", database=database).stdout.splitlines()
+        if remaining:
+            raise CompatibilityError(f"{suite} cleanup left tables: {remaining!r}")
+    finally:
+        mysql(args, f"DROP DATABASE IF EXISTS `{database}`", check=False)
+
+    encoded_schema = json.dumps(schema, sort_keys=True, separators=(",", ":")).encode()
+    return {
+        "database": database,
+        "case_count": len(receipts),
+        "cases": receipts,
+        "schema": schema,
+        "schema_sha256": sha256_bytes(encoded_schema),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--endpoint-name", required=True)
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--port", required=True, type=int)
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    parser.add_argument("--mysql", default="mysql")
+    parser.add_argument("--database-prefix", required=True)
+    parser.add_argument("--connect-timeout", type=int, default=5)
+    parser.add_argument("--statement-timeout", type=int, default=300)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not SAFE_NAME.fullmatch(args.database_prefix):
+        raise CompatibilityError("database prefix contains unsafe characters")
+    manifest = json.loads(args.manifest.read_text())
+    if manifest.get("schema_version") != "1.0":
+        raise CompatibilityError("unsupported manifest schema")
+
+    report = {
+        "schema_version": "1.0",
+        "endpoint": {
+            "name": args.endpoint_name,
+            "host": args.host,
+            "port": args.port,
+        },
+        "manifest_sha256": sha256_file(args.manifest),
+        "transaction_control": transaction_receipt(args),
+        "create_database": exact_create_database_receipt(args),
+        "suites": {
+            suite: run_suite(
+                args,
+                manifest,
+                suite,
+                f"{args.database_prefix}_{suite}",
+            )
+            for suite in ("tpcc", "sysbench")
+        },
+    }
+    report["covered_non_plan_case_count"] = (
+        len(report["transaction_control"]["covered_case_ids"])
+        + 1
+        + sum(suite["case_count"] for suite in report["suites"].values())
+    )
+    expected = sum(case["kind"] == "non_plan" for case in manifest["cases"])
+    if report["covered_non_plan_case_count"] != expected:
+        raise CompatibilityError(
+            f"covered {report['covered_non_plan_case_count']} non-plan cases, expected {expected}"
+        )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "covered": report["covered_non_plan_case_count"],
+                "tpcc_schema": report["suites"]["tpcc"]["schema_sha256"],
+                "sysbench_schema": report["suites"]["sysbench"]["schema_sha256"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (CompatibilityError, OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        print(f"non-plan compatibility error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/rust/scripts/plan-parity.py
+++ b/rust/scripts/plan-parity.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python3
+"""Compare Go and Rust TiDB physical plans for pinned workload SQL.
+
+Prepared cases prepare ``EXPLAIN FORMAT='brief' <workload SQL>`` through the
+MySQL binary protocol, bind the workload's exact parameter types, and execute
+the statement. Direct cases issue a text-protocol EXPLAIN. The gate deliberately
+normalizes only generated operator IDs and internal ``Column#N`` ordinals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import importlib.util
+import json
+import re
+import struct
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "tpcc-sysbench-plan-manifest.json"
+PROTOCOL_CLIENT = SCRIPT_DIR / "mysql-prepared-client.py"
+
+COM_QUERY = 0x03
+COM_STMT_EXECUTE = 0x17
+
+MYSQL_TYPE_LONG = 0x03
+MYSQL_TYPE_DOUBLE = 0x05
+MYSQL_TYPE_NULL = 0x06
+MYSQL_TYPE_LONGLONG = 0x08
+MYSQL_TYPE_BLOB = 0xFC
+MYSQL_TYPE_VAR_STRING = 0xFD
+MYSQL_TYPE_STRING = 0xFE
+UNSIGNED_FLAG = 0x80
+
+STRING_RESULT_TYPES = {
+    MYSQL_TYPE_BLOB,
+    MYSQL_TYPE_VAR_STRING,
+    MYSQL_TYPE_STRING,
+}
+
+DATABASE_NAME = re.compile(r"^[A-Za-z0-9_$]+$")
+OPERATOR_ID = re.compile(r"(?<=[A-Za-z)])_\d+(?=(?:\([^)]*\))?$)")
+COLUMN_ORDINAL = re.compile(r"Column#\d+")
+MULTI_ROW_INSERT_ROW = re.compile(r"^\(.*\)(?:/\*.*\*/)?$", re.DOTALL)
+
+
+class GateError(RuntimeError):
+    """The parity gate cannot produce trustworthy evidence."""
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    name: str
+    host: str
+    port: int
+    user: str
+    password: str
+
+
+@dataclass(frozen=True)
+class Parameter:
+    type_name: str
+    value: Any
+
+
+def load_protocol_client() -> ModuleType:
+    """Load the existing bounded MySQL protocol implementation by path."""
+    spec = importlib.util.spec_from_file_location("tidb_mysql_protocol", PROTOCOL_CLIENT)
+    if spec is None or spec.loader is None:
+        raise GateError(f"cannot load protocol client: {PROTOCOL_CLIENT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def encode_lenenc(value: int) -> bytes:
+    """Encode a non-negative MySQL length-encoded integer."""
+    if value < 0:
+        raise GateError("length-encoded integers cannot be negative")
+    if value < 0xFB:
+        return bytes((value,))
+    if value <= 0xFFFF:
+        return b"\xfc" + value.to_bytes(2, "little")
+    if value <= 0xFFFFFF:
+        return b"\xfd" + value.to_bytes(3, "little")
+    if value <= 0xFFFFFFFFFFFFFFFF:
+        return b"\xfe" + value.to_bytes(8, "little")
+    raise GateError("length-encoded integer exceeds uint64")
+
+
+def encode_lenenc_bytes(value: bytes) -> bytes:
+    return encode_lenenc(len(value)) + value
+
+
+def encode_signed(value: Any, width: int) -> bytes:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise GateError(f"expected signed integer, got {value!r}")
+    try:
+        return value.to_bytes(width, "little", signed=True)
+    except OverflowError as error:
+        raise GateError(f"signed {width * 8}-bit value out of range: {value}") from error
+
+
+def encode_unsigned(value: Any, width: int) -> bytes:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise GateError(f"expected unsigned integer, got {value!r}")
+    try:
+        return value.to_bytes(width, "little", signed=False)
+    except OverflowError as error:
+        raise GateError(f"unsigned {width * 8}-bit value out of range: {value}") from error
+
+
+def encode_double(value: Any) -> bytes:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise GateError(f"expected double, got {value!r}")
+    return struct.pack("<d", float(value))
+
+
+def encode_string(value: Any) -> bytes:
+    if not isinstance(value, str):
+        raise GateError(f"expected string, got {value!r}")
+    return encode_lenenc_bytes(value.encode("utf-8"))
+
+
+def encode_bytes(value: Any) -> bytes:
+    if not isinstance(value, (bytes, bytearray)):
+        raise GateError(f"expected bytes, got {value!r}")
+    return encode_lenenc_bytes(bytes(value))
+
+
+PARAMETER_ENCODERS: dict[str, tuple[int, int, Callable[[Any], bytes]]] = {
+    "i32": (MYSQL_TYPE_LONG, 0, lambda value: encode_signed(value, 4)),
+    "u32": (MYSQL_TYPE_LONG, UNSIGNED_FLAG, lambda value: encode_unsigned(value, 4)),
+    "i64": (MYSQL_TYPE_LONGLONG, 0, lambda value: encode_signed(value, 8)),
+    "u64": (
+        MYSQL_TYPE_LONGLONG,
+        UNSIGNED_FLAG,
+        lambda value: encode_unsigned(value, 8),
+    ),
+    "f64": (MYSQL_TYPE_DOUBLE, 0, encode_double),
+    "string": (MYSQL_TYPE_STRING, 0, encode_string),
+    "bytes": (MYSQL_TYPE_BLOB, 0, encode_bytes),
+    "null": (MYSQL_TYPE_NULL, 0, lambda _value: b""),
+}
+
+
+def parse_parameters(raw: Any) -> list[Parameter]:
+    if not isinstance(raw, list):
+        raise GateError("case params must be a list")
+    parameters: list[Parameter] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict) or set(item) != {"type", "value"}:
+            raise GateError(f"parameter {index} must contain exactly type and value")
+        type_name = item["type"]
+        if type_name not in PARAMETER_ENCODERS:
+            raise GateError(f"parameter {index} has unsupported type {type_name!r}")
+        if type_name == "null" and item["value"] is not None:
+            raise GateError(f"parameter {index} null type must have a null value")
+        parameters.append(Parameter(type_name, item["value"]))
+    return parameters
+
+
+def build_execute_payload(statement_id: int, parameters: list[Parameter]) -> bytes:
+    """Build a COM_STMT_EXECUTE body with explicit per-parameter MySQL types."""
+    payload = bytearray(statement_id.to_bytes(4, "little"))
+    payload.append(0)  # no cursor
+    payload.extend((1).to_bytes(4, "little"))
+
+    null_bitmap = bytearray((len(parameters) + 7) // 8)
+    for index, parameter in enumerate(parameters):
+        if parameter.type_name == "null":
+            null_bitmap[index // 8] |= 1 << (index % 8)
+    payload.extend(null_bitmap)
+    payload.append(1)  # new parameter types are present
+
+    for parameter in parameters:
+        type_code, flags, _ = PARAMETER_ENCODERS[parameter.type_name]
+        payload.extend((type_code, flags))
+    for parameter in parameters:
+        _, _, encoder = PARAMETER_ENCODERS[parameter.type_name]
+        payload.extend(encoder(parameter.value))
+    return bytes(payload)
+
+
+def is_result_terminator(payload: bytes) -> bool:
+    return bool(payload) and payload[0] == 0xFE and len(payload) < 9
+
+
+def read_columns(connection: Any, first: bytes, protocol: ModuleType) -> tuple[list[Any], int]:
+    column_count, offset = protocol.read_lenenc(first, 0)
+    if column_count is None or offset != len(first):
+        raise GateError(f"invalid result column-count packet: {first.hex()}")
+    sequence = 2
+    columns = []
+    for _ in range(column_count):
+        columns.append(protocol.parse_column(connection.read_packet(sequence)))
+        sequence += 1
+    if column_count and not connection.deprecate_eof:
+        protocol.assert_eof(connection.read_packet(sequence), False)
+        sequence += 1
+    return columns, sequence
+
+
+def read_binary_string_rows(
+    connection: Any, first: bytes, protocol: ModuleType
+) -> list[list[str | None]]:
+    columns, sequence = read_columns(connection, first, protocol)
+    if any(column.type_code not in STRING_RESULT_TYPES for column in columns):
+        raise GateError(
+            "EXPLAIN returned non-string columns: "
+            + ", ".join(f"{column.name}={column.type_code}" for column in columns)
+        )
+    rows: list[list[str | None]] = []
+    null_bytes = (len(columns) + 9) // 8
+    while True:
+        packet = connection.read_packet(sequence)
+        sequence += 1
+        if is_result_terminator(packet):
+            protocol.assert_eof(packet, connection.deprecate_eof)
+            return rows
+        if not packet or packet[0] != 0:
+            raise GateError(f"invalid binary row: {packet.hex()}")
+        if len(packet) < 1 + null_bytes:
+            raise GateError(f"truncated binary row: {packet.hex()}")
+        bitmap = packet[1 : 1 + null_bytes]
+        offset = 1 + null_bytes
+        row: list[str | None] = []
+        for index, _column in enumerate(columns):
+            if bitmap[(index + 2) // 8] & (1 << ((index + 2) % 8)):
+                row.append(None)
+                continue
+            value, offset = protocol.read_lenenc_bytes(packet, offset)
+            if value is None:
+                raise GateError("binary row used inline NULL instead of its bitmap")
+            row.append(value.decode("utf-8", "strict"))
+        if offset != len(packet):
+            raise GateError(f"binary row has trailing bytes: {packet.hex()}")
+        rows.append(row)
+
+
+def read_text_rows(
+    connection: Any, first: bytes, protocol: ModuleType
+) -> list[list[str | None]]:
+    columns, sequence = read_columns(connection, first, protocol)
+    rows: list[list[str | None]] = []
+    while True:
+        packet = connection.read_packet(sequence)
+        sequence += 1
+        if is_result_terminator(packet):
+            protocol.assert_eof(packet, connection.deprecate_eof)
+            return rows
+        offset = 0
+        row: list[str | None] = []
+        for _column in columns:
+            value, offset = protocol.read_lenenc_bytes(packet, offset)
+            row.append(None if value is None else value.decode("utf-8", "strict"))
+        if offset != len(packet):
+            raise GateError(f"text row has trailing bytes: {packet.hex()}")
+        rows.append(row)
+
+
+def raise_mysql_error(payload: bytes, protocol: ModuleType, operation: str) -> None:
+    error = protocol.parse_error(payload)
+    raise GateError(f"{operation}: MySQL {error.code}/{error.state}: {error.message}")
+
+
+def execute_text_query(connection: Any, sql: str, protocol: ModuleType) -> list[list[str | None]]:
+    connection.write_packet(bytes((COM_QUERY,)) + sql.encode("utf-8"), 0)
+    first = connection.read_packet(1)
+    if first and first[0] == 0xFF:
+        raise_mysql_error(first, protocol, sql)
+    if first and first[0] == 0x00:
+        return []
+    return read_text_rows(connection, first, protocol)
+
+
+def select_database(connection: Any, database: str, protocol: ModuleType) -> None:
+    if not DATABASE_NAME.fullmatch(database):
+        raise GateError(f"unsafe database name: {database!r}")
+    execute_text_query(connection, f"USE `{database}`", protocol)
+
+
+def collect_plan(
+    endpoint: Endpoint,
+    database: str,
+    case: dict[str, Any],
+    protocol: ModuleType,
+) -> list[list[str | None]]:
+    connection_type = protocol.MysqlConnection
+    with connection_type(
+        endpoint.host, endpoint.port, endpoint.user, endpoint.password
+    ) as connection:
+        select_database(connection, database, protocol)
+        explain_sql = "EXPLAIN FORMAT='brief' " + case["sql"]
+        if case["protocol"] == "direct":
+            return execute_text_query(connection, explain_sql, protocol)
+
+        parameters = parse_parameters(case["params"])
+        prepared = connection.prepare(explain_sql)
+        if isinstance(prepared, protocol.MysqlError):
+            raise GateError(
+                f"{endpoint.name} prepare {case['id']}: MySQL {prepared.code}/"
+                f"{prepared.state}: {prepared.message}"
+            )
+        if len(prepared.parameters) != len(parameters):
+            raise GateError(
+                f"{endpoint.name} prepare {case['id']} advertised "
+                f"{len(prepared.parameters)} parameters, manifest has {len(parameters)}"
+            )
+        payload = build_execute_payload(prepared.statement_id, parameters)
+        connection.write_packet(bytes((COM_STMT_EXECUTE,)) + payload, 0)
+        first = connection.read_packet(1)
+        try:
+            if first and first[0] == 0xFF:
+                raise_mysql_error(first, protocol, f"{endpoint.name} execute {case['id']}")
+            return read_binary_string_rows(connection, first, protocol)
+        finally:
+            connection.close_statement(prepared.statement_id)
+
+
+def normalize_cell(value: str | None, column: int) -> str | None:
+    if value is None:
+        return None
+    normalized = value.replace("\r\n", "\n").rstrip()
+    normalized = COLUMN_ORDINAL.sub("Column#?", normalized)
+    if column == 0:
+        normalized = OPERATOR_ID.sub("", normalized)
+    return normalized
+
+
+def normalize_plan(rows: list[list[str | None]]) -> list[list[str | None]]:
+    return [
+        [normalize_cell(value, column) for column, value in enumerate(row)]
+        for row in rows
+    ]
+
+
+def plan_lines(rows: list[list[str | None]]) -> list[str]:
+    return ["\t".join("NULL" if value is None else value for value in row) for row in rows]
+
+
+def plan_diff(go_rows: list[list[str | None]], rust_rows: list[list[str | None]]) -> list[str]:
+    return list(
+        difflib.unified_diff(
+            plan_lines(go_rows),
+            plan_lines(rust_rows),
+            fromfile="go-tidb",
+            tofile="rust-tidb",
+            lineterm="",
+        )
+    )
+
+
+def git_revision(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_source_files(
+    manifest: dict[str, Any], source_roots: dict[str, Path]
+) -> dict[str, dict[str, str]]:
+    inventories = manifest.get("source_files")
+    if not isinstance(inventories, dict) or set(inventories) != set(source_roots):
+        raise GateError("manifest source_files must match all configured source roots")
+    actual: dict[str, dict[str, str]] = {}
+    for name, root in source_roots.items():
+        expected_files = inventories[name]
+        if not isinstance(expected_files, dict) or not expected_files:
+            raise GateError(f"{name} source inventory is empty")
+        actual[name] = {}
+        for relative, expected in expected_files.items():
+            path = root / relative
+            digest = sha256_file(path)
+            actual[name][relative] = digest
+            if digest != expected:
+                raise GateError(
+                    f"{name} source digest mismatch for {relative}: {digest} != {expected}"
+                )
+    return actual
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateError(f"cannot read manifest {path}: {error}") from error
+    if manifest.get("schema_version") != "1.0":
+        raise GateError("unsupported plan manifest schema_version")
+    if manifest.get("coverage_status") not in {"incomplete", "complete"}:
+        raise GateError("manifest coverage_status must be incomplete or complete")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise GateError("manifest must contain at least one case")
+    identities: set[str] = set()
+    for case in cases:
+        required = {"id", "suite", "phase", "kind", "protocol", "source", "sql"}
+        if not isinstance(case, dict) or not required.issubset(case):
+            raise GateError(f"manifest case omits required fields: {case!r}")
+        identity = case["id"]
+        if not isinstance(identity, str) or not identity or identity in identities:
+            raise GateError(f"invalid or duplicate case id: {identity!r}")
+        identities.add(identity)
+        if case["kind"] == "plan":
+            if case["protocol"] not in {"direct", "prepared"}:
+                raise GateError(f"{identity}: invalid plan protocol")
+            if case["protocol"] == "prepared":
+                parse_parameters(case.get("params"))
+            elif case.get("params") not in (None, []):
+                raise GateError(f"{identity}: direct plan case cannot have params")
+        elif case["kind"] == "non_plan":
+            if case["protocol"] not in {"direct", "prepared"}:
+                raise GateError(f"{identity}: invalid non-plan protocol")
+        else:
+            raise GateError(f"{identity}: kind must be plan or non_plan")
+    families = manifest.get("plan_families", [])
+    if not isinstance(families, list):
+        raise GateError("manifest plan_families must be a list")
+    for family in families:
+        required = {
+            "id",
+            "suite",
+            "phase",
+            "kind",
+            "protocol",
+            "source",
+            "generator",
+            "sql_prefix",
+            "row_template",
+            "row_counts",
+        }
+        if not isinstance(family, dict) or not required.issubset(family):
+            raise GateError(f"plan family omits required fields: {family!r}")
+        identity = family["id"]
+        if not isinstance(identity, str) or not identity or identity in identities:
+            raise GateError(f"invalid or duplicate plan family id: {identity!r}")
+        identities.add(identity)
+        if (
+            family["kind"] != "plan"
+            or family["protocol"] != "direct"
+            or family["generator"] != "multi_row_insert"
+        ):
+            raise GateError(f"{identity}: unsupported plan family contract")
+        family_row_counts(family)
+        render_family_row(family, 1)
+    expected_static = manifest.get("static_case_count")
+    expected_families = manifest.get("plan_family_count")
+    expected_expanded = manifest.get("expanded_case_count")
+    actual_expanded = len(cases) + sum(
+        len(family_row_counts(family)) for family in families
+    )
+    if expected_static != len(cases):
+        raise GateError(
+            f"manifest static_case_count mismatch: {expected_static} != {len(cases)}"
+        )
+    if expected_families != len(families):
+        raise GateError(
+            "manifest plan_family_count mismatch: "
+            f"{expected_families} != {len(families)}"
+        )
+    if expected_expanded != actual_expanded:
+        raise GateError(
+            "manifest expanded_case_count mismatch: "
+            f"{expected_expanded} != {actual_expanded}"
+        )
+    return manifest
+
+
+def family_row_counts(family: dict[str, Any]) -> list[int]:
+    raw = family["row_counts"]
+    if isinstance(raw, list):
+        counts = raw
+    elif isinstance(raw, dict) and set(raw) == {"min", "max"}:
+        minimum = raw["min"]
+        maximum = raw["max"]
+        if not isinstance(minimum, int) or not isinstance(maximum, int):
+            raise GateError(f"{family['id']}: row-count range must contain integers")
+        counts = list(range(minimum, maximum + 1))
+    else:
+        raise GateError(f"{family['id']}: invalid row_counts")
+    if (
+        not counts
+        or any(isinstance(count, bool) or not isinstance(count, int) for count in counts)
+        or counts != sorted(set(counts))
+        or counts[0] < 1
+        or counts[-1] > 4096
+    ):
+        raise GateError(f"{family['id']}: row counts must be unique sorted values in 1..4096")
+    return counts
+
+
+def render_family_row(family: dict[str, Any], row: int) -> str:
+    template = family["row_template"]
+    if not isinstance(template, str) or not template:
+        raise GateError(f"{family['id']}: row_template must be a non-empty string")
+    try:
+        rendered = template.format(row=row)
+    except (IndexError, KeyError, ValueError) as error:
+        raise GateError(f"{family['id']}: invalid row_template: {error}") from error
+    if not MULTI_ROW_INSERT_ROW.fullmatch(rendered):
+        raise GateError(
+            f"{family['id']}: rendered row must be parenthesized, with an optional trailing comment"
+        )
+    return rendered
+
+
+def expand_plan_families(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    cases = list(manifest["cases"])
+    identities = {case["id"] for case in cases}
+    for family in manifest.get("plan_families", []):
+        separator = family.get("separator", ",")
+        if separator not in {",", ", "}:
+            raise GateError(f"{family['id']}: unsupported row separator")
+        rows: list[str] = []
+        next_count_index = 0
+        counts = family_row_counts(family)
+        for row in range(1, counts[-1] + 1):
+            rows.append(render_family_row(family, row))
+            if row != counts[next_count_index]:
+                continue
+            identity = f"{family['id']}.rows_{row}"
+            if identity in identities:
+                raise GateError(f"duplicate expanded case id: {identity}")
+            identities.add(identity)
+            case = {
+                "id": identity,
+                "family": family["id"],
+                "suite": family["suite"],
+                "phase": family["phase"],
+                "kind": "plan",
+                "protocol": "direct",
+                "source": family["source"],
+                "sql": family["sql_prefix"] + separator.join(rows),
+            }
+            if "workloads" in family:
+                case["workloads"] = family["workloads"]
+            cases.append(case)
+            next_count_index += 1
+            if next_count_index == len(counts):
+                break
+    return cases
+
+
+def resolve_database(case: dict[str, Any], args: argparse.Namespace) -> str:
+    suite = case["suite"]
+    if suite == "tpcc":
+        return args.tpcc_database
+    if suite == "sysbench":
+        return args.sysbench_database
+    raise GateError(f"{case['id']}: unsupported suite {suite!r}")
+
+
+def write_markdown(report: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# TPCC/Sysbench physical-plan parity",
+        "",
+        f"Manifest coverage: `{report['coverage_status']}`.",
+        "",
+        f"Matched: **{report['matched']}**. Mismatched: **{report['mismatched']}**. "
+        f"Errors: **{report['errors']}**.",
+        "",
+    ]
+    for case in report["cases"]:
+        lines.extend([f"## `{case['id']}`", "", f"Status: `{case['status']}`.", ""])
+        if case.get("diff"):
+            lines.extend(["```diff", *case["diff"], "```", ""])
+        if case.get("error"):
+            lines.extend(["```text", case["error"], "```", ""])
+    path.write_text("\n".join(lines) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--go-tpc-root", type=Path, required=True)
+    parser.add_argument("--sysbench-root", type=Path, required=True)
+    parser.add_argument("--sysbench-contract-root", type=Path, required=True)
+    parser.add_argument("--go-host", default="127.0.0.1")
+    parser.add_argument("--go-port", type=int, default=4100)
+    parser.add_argument("--rust-host", default="127.0.0.1")
+    parser.add_argument("--rust-port", type=int, default=4000)
+    parser.add_argument("--user", default="root")
+    parser.add_argument("--password", default="")
+    parser.add_argument("--tpcc-database", required=True)
+    parser.add_argument("--sysbench-database", default="sysbench_plan_parity")
+    parser.add_argument("--case", action="append", dest="case_ids")
+    parser.add_argument("--suite", action="append", choices=("tpcc", "sysbench"))
+    parser.add_argument(
+        "--phase", action="append", choices=("prepare", "run", "check", "cleanup")
+    )
+    parser.add_argument("--allow-incomplete-manifest", action="store_true")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        manifest = load_manifest(args.manifest.resolve())
+        pins = manifest["source_pins"]
+        revisions = {
+            "go_tpc": git_revision(args.go_tpc_root.resolve()),
+            "sysbench": git_revision(args.sysbench_root.resolve()),
+        }
+        for name, revision in revisions.items():
+            expected = pins[name]["commit"]
+            if revision != expected:
+                raise GateError(f"{name} revision mismatch: {revision} != {expected}")
+        source_files = validate_source_files(
+            manifest,
+            {
+                "go_tpc": args.go_tpc_root.resolve(),
+                "sysbench": args.sysbench_root.resolve(),
+                "sysbench_contract": args.sysbench_contract_root.resolve(),
+            },
+        )
+        if manifest["coverage_status"] != "complete" and not args.allow_incomplete_manifest:
+            raise GateError(
+                "manifest coverage is incomplete; formal parity evidence is blocked"
+            )
+
+        expanded_cases = expand_plan_families(manifest)
+        selected = set(args.case_ids or [])
+        known = {case["id"] for case in expanded_cases}
+        unknown = selected - known
+        if unknown:
+            raise GateError(f"unknown case ids: {', '.join(sorted(unknown))}")
+        selected_suites = set(args.suite or [])
+        selected_phases = set(args.phase or [])
+        cases = [
+            case
+            for case in expanded_cases
+            if case["kind"] == "plan"
+            and (not selected or case["id"] in selected)
+            and (not selected_suites or case["suite"] in selected_suites)
+            and (not selected_phases or case["phase"] in selected_phases)
+        ]
+        if not cases:
+            raise GateError("selection contains no plan cases")
+
+        protocol = load_protocol_client()
+        go_endpoint = Endpoint("go", args.go_host, args.go_port, args.user, args.password)
+        rust_endpoint = Endpoint(
+            "rust", args.rust_host, args.rust_port, args.user, args.password
+        )
+        results: list[dict[str, Any]] = []
+        for case in cases:
+            result: dict[str, Any] = {
+                "id": case["id"],
+                "source": case["source"],
+                "sql_sha256": hashlib.sha256(case["sql"].encode()).hexdigest(),
+            }
+            try:
+                database = resolve_database(case, args)
+                go_raw = collect_plan(go_endpoint, database, case, protocol)
+                rust_raw = collect_plan(rust_endpoint, database, case, protocol)
+                go_normalized = normalize_plan(go_raw)
+                rust_normalized = normalize_plan(rust_raw)
+                result.update(
+                    {
+                        "database": database,
+                        "go_raw": go_raw,
+                        "rust_raw": rust_raw,
+                        "go_normalized": go_normalized,
+                        "rust_normalized": rust_normalized,
+                    }
+                )
+                if go_normalized == rust_normalized:
+                    result["status"] = "matched"
+                    result["diff"] = []
+                else:
+                    result["status"] = "mismatched"
+                    result["diff"] = plan_diff(go_normalized, rust_normalized)
+            except (GateError, OSError) as error:
+                result["status"] = "error"
+                result["error"] = str(error)
+            results.append(result)
+
+        report = {
+            "schema_version": "1.0",
+            "coverage_status": manifest["coverage_status"],
+            "source_revisions": revisions,
+            "source_files": source_files,
+            "normalization": ["operator numeric suffix", "Column#N ordinal"],
+            "expanded_manifest_case_count": len(expanded_cases),
+            "matched": sum(case["status"] == "matched" for case in results),
+            "mismatched": sum(case["status"] == "mismatched" for case in results),
+            "errors": sum(case["status"] == "error" for case in results),
+            "cases": results,
+        }
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        write_markdown(report, args.output.with_suffix(".md"))
+        print(json.dumps({key: report[key] for key in ("matched", "mismatched", "errors")}))
+        return 0 if report["mismatched"] == 0 and report["errors"] == 0 else 1
+    except (GateError, OSError, subprocess.CalledProcessError) as error:
+        print(f"plan parity gate error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/scripts/test-plan-parity.py
+++ b/rust/scripts/test-plan-parity.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Focused unit tests for plan-parity protocol and normalization rules."""
+
+from __future__ import annotations
+
+import importlib.util
+import struct
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("plan-parity.py")
+SPEC = importlib.util.spec_from_file_location("plan_parity", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+PLAN_PARITY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PLAN_PARITY
+SPEC.loader.exec_module(PLAN_PARITY)
+
+GENERATOR_PATH = Path(__file__).with_name("generate-plan-manifest.py")
+GENERATOR_SPEC = importlib.util.spec_from_file_location(
+    "generate_plan_manifest", GENERATOR_PATH
+)
+assert GENERATOR_SPEC is not None and GENERATOR_SPEC.loader is not None
+GENERATOR = importlib.util.module_from_spec(GENERATOR_SPEC)
+GENERATOR_SPEC.loader.exec_module(GENERATOR)
+
+
+class NormalizePlanTest(unittest.TestCase):
+    def test_normalizes_only_generated_ids_and_column_ordinals(self) -> None:
+        plan = [[
+            "  \u2514\u2500IndexRangeScan_42(Build)",
+            "10.00",
+            "cop[tikv]",
+            "table:t, index:i(a)",
+            "eq(test.t.a, Column#31), keep order:false",
+        ]]
+
+        self.assertEqual(
+            PLAN_PARITY.normalize_plan(plan),
+            [[
+                "  \u2514\u2500IndexRangeScan(Build)",
+                "10.00",
+                "cop[tikv]",
+                "table:t, index:i(a)",
+                "eq(test.t.a, Column#?), keep order:false",
+            ]],
+        )
+
+    def test_preserves_protected_plan_fields(self) -> None:
+        go = [["IndexReader", "1.00", "root", "index:IndexRangeScan", ""]]
+        rust = [["IndexRangeScan", "1.00", "root", "index:i(a)", ""]]
+
+        self.assertNotEqual(
+            PLAN_PARITY.normalize_plan(go), PLAN_PARITY.normalize_plan(rust)
+        )
+
+
+class ExecutePayloadTest(unittest.TestCase):
+    def test_encodes_exact_mysql_parameter_types(self) -> None:
+        parameters = [
+            PLAN_PARITY.Parameter("i32", 7),
+            PLAN_PARITY.Parameter("i64", -9),
+            PLAN_PARITY.Parameter("f64", 1.5),
+            PLAN_PARITY.Parameter("string", "ab"),
+            PLAN_PARITY.Parameter("null", None),
+        ]
+
+        payload = PLAN_PARITY.build_execute_payload(0x01020304, parameters)
+
+        self.assertEqual(payload[:9], b"\x04\x03\x02\x01\x00\x01\x00\x00\x00")
+        self.assertEqual(payload[9:11], b"\x10\x01")
+        self.assertEqual(
+            payload[11:21],
+            bytes((
+                PLAN_PARITY.MYSQL_TYPE_LONG, 0,
+                PLAN_PARITY.MYSQL_TYPE_LONGLONG, 0,
+                PLAN_PARITY.MYSQL_TYPE_DOUBLE, 0,
+                PLAN_PARITY.MYSQL_TYPE_STRING, 0,
+                PLAN_PARITY.MYSQL_TYPE_NULL, 0,
+            )),
+        )
+        expected_values = (
+            (7).to_bytes(4, "little", signed=True)
+            + (-9).to_bytes(8, "little", signed=True)
+            + struct.pack("<d", 1.5)
+            + b"\x02ab"
+        )
+        self.assertEqual(payload[21:], expected_values)
+
+
+class PlanFamilyTest(unittest.TestCase):
+    def test_expands_only_declared_multi_row_widths(self) -> None:
+        manifest = {
+            "cases": [],
+            "plan_families": [
+                {
+                    "id": "sysbench.prepare.insert",
+                    "suite": "sysbench",
+                    "phase": "prepare",
+                    "kind": "plan",
+                    "protocol": "direct",
+                    "source": "prepare.lua:35",
+                    "generator": "multi_row_insert",
+                    "sql_prefix": "INSERT INTO sbtest1 VALUES ",
+                    "row_template": "({row},'x')",
+                    "row_counts": [1, 3],
+                    "separator": ",",
+                }
+            ],
+        }
+
+        cases = PLAN_PARITY.expand_plan_families(manifest)
+
+        self.assertEqual(
+            [case["id"] for case in cases],
+            [
+                "sysbench.prepare.insert.rows_1",
+                "sysbench.prepare.insert.rows_3",
+            ],
+        )
+        self.assertEqual(
+            cases[1]["sql"],
+            "INSERT INTO sbtest1 VALUES (1,'x'),(2,'x'),(3,'x')",
+        )
+
+    def test_rejects_unbounded_family_ranges(self) -> None:
+        family = {"id": "bad", "row_counts": {"min": 1, "max": 4097}}
+
+        with self.assertRaises(PLAN_PARITY.GateError):
+            PLAN_PARITY.family_row_counts(family)
+
+    def test_accepts_bulk_insert_padding_comment(self) -> None:
+        family = {
+            "id": "sysbench.run.bulk_insert",
+            "row_template": "({row},{row},'','')/*padding*/",
+        }
+
+        self.assertEqual(
+            PLAN_PARITY.render_family_row(family, 7),
+            "(7,7,'','')/*padding*/",
+        )
+
+
+class WorkloadCoverageTest(unittest.TestCase):
+    def test_covers_all_sysbench_tables_and_worker_local_tables(self) -> None:
+        manifest = GENERATOR.build_manifest()
+        identities = {case["id"] for case in manifest["cases"]}
+        family_ids = {family["id"] for family in manifest["plan_families"]}
+
+        self.assertIn("sysbench.run.point_select.table_32", identities)
+        self.assertIn("sysbench.run.random_points.width_10.table_16", identities)
+        self.assertNotIn(
+            "sysbench.run.random_points.width_10.table_17", identities
+        )
+        self.assertIn("sysbench.prepare.insert.table_32", family_ids)
+        self.assertIn("sysbench.run.bulk_insert.table_16", family_ids)
+        self.assertNotIn("sysbench.run.bulk_insert.table_17", family_ids)
+
+    def test_manifest_counts_include_all_dynamic_sql_shapes(self) -> None:
+        manifest = GENERATOR.build_manifest()
+
+        self.assertEqual(manifest["static_case_count"], 563)
+        self.assertEqual(manifest["plan_family_count"], 57)
+        self.assertEqual(manifest["expanded_case_count"], 15_248)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rust/scripts/tpcc-sysbench-plan-manifest.json
+++ b/rust/scripts/tpcc-sysbench-plan-manifest.json
@@ -17841,18 +17841,18 @@
   ],
   "coverage": {
     "sysbench": {
-      "cleanup": "all 32 drop-table variants generated; execution compatibility pending",
-      "prepare": "32 exact 1000-row INSERT, DDL, table split, and index split variants generated; runtime coverage pending",
-      "run": "32 common prepared-table variants, 16 worker-local variants, and all bulk widths generated; runtime coverage pending"
+      "cleanup": "all 32 drop-table statements captured; Go/Rust compatibility complete",
+      "prepare": "all 32 exact 1000-row INSERT plans and 97 exact DDL, table-split, index-split, and session statements captured; Go/Rust parity complete",
+      "run": "all 13,952 expanded plans across 32 common tables, 16 worker-local tables, and every bulk width plus 2 transaction-control statements captured; Go/Rust parity complete"
     },
     "tpcc": {
-      "check": "candidate inventory generated; runtime coverage pending",
-      "cleanup": "drop-table inventory generated; execution compatibility pending",
-      "prepare": "all loader INSERT width families and exact default MySQL DDL generated; runtime coverage pending",
-      "run": "candidate inventory generated; runtime coverage pending"
+      "check": "all 12 consistency-check plans captured; Go/Rust parity complete",
+      "cleanup": "all 9 drop-table statements captured; Go/Rust compatibility complete",
+      "prepare": "all 1,037 expanded loader INSERT plans and 9 exact default MySQL DDL statements captured; Go/Rust parity complete",
+      "run": "all 63 transaction plans and 3 transaction-control statements captured; Go/Rust parity complete"
     }
   },
-  "coverage_status": "incomplete",
+  "coverage_status": "complete",
   "expanded_case_count": 15248,
   "plan_families": [
     {

--- a/rust/scripts/tpcc-sysbench-plan-manifest.json
+++ b/rust/scripts/tpcc-sysbench-plan-manifest.json
@@ -1,0 +1,18885 @@
+{
+  "benchmark_contract": {
+    "sysbench": {
+      "split_regions": 8,
+      "table_size": 10000000,
+      "tables": 32,
+      "threads": 16
+    },
+    "tpcc": {
+      "partition_type": 1,
+      "parts": 1,
+      "threads": 16,
+      "use_fk": false,
+      "warehouses": 100
+    }
+  },
+  "cases": [
+    {
+      "id": "tpcc.run.new_order.select_customer",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:12",
+      "sql": "SELECT c_discount, c_last, c_credit, w_tax FROM customer, warehouse WHERE w_id = ? AND c_w_id = w_id AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_district",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:13",
+      "sql": "SELECT d_next_o_id, d_tax FROM district WHERE d_id = ? AND d_w_id = ? FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.update_district",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:14",
+      "sql": "UPDATE district SET d_next_o_id = ? + 1 WHERE d_id = ? AND d_w_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "2026-08-09 00:00:00"
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:15",
+      "sql": "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_new_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:16",
+      "sql": "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (?, ?, ?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.update_stock",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:17",
+      "sql": "UPDATE stock SET s_quantity = ?, s_ytd = s_ytd + ?, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + ? WHERE s_i_id = ? AND s_w_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.update_district",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:10",
+      "sql": "UPDATE district SET d_ytd = d_ytd + ? WHERE d_w_id = ? AND d_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.select_district",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:11",
+      "sql": "SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name FROM district WHERE d_w_id = ? AND d_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.update_warehouse",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:12",
+      "sql": "UPDATE warehouse SET w_ytd = w_ytd + ? WHERE w_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.select_warehouse",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:13",
+      "sql": "SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name FROM warehouse WHERE w_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.select_customer_list_by_last",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "ABLEABLEABLE"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:14",
+      "sql": "SELECT c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.select_customer_for_update",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:15",
+      "sql": "SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone,\nc_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = ? AND c_d_id = ? \nAND c_id = ? FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.update_customer",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:18",
+      "sql": "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \nc_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.select_customer_data",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:20",
+      "sql": "SELECT c_data FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.update_customer_with_data",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "customer-data"
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:21",
+      "sql": "UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, \nc_payment_cnt = c_payment_cnt + 1, c_data = ? WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.payment.insert_history",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "2026-08-09 00:00:00"
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "warehouse district"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/payment.go:23",
+      "sql": "INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data)\nVALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.order_status.select_customer_count_by_last",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "ABLEABLEABLE"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/order_status.go:10",
+      "sql": "SELECT count(c_id) namecnt FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.order_status.select_customer_by_last",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "ABLEABLEABLE"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/order_status.go:11",
+      "sql": "SELECT c_balance, c_first, c_middle, c_id FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_last = ? ORDER BY c_first",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.order_status.select_customer_by_id",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/order_status.go:12",
+      "sql": "SELECT c_balance, c_first, c_middle, c_last FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.order_status.select_latest_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/order_status.go:13",
+      "sql": "SELECT o_id, o_carrier_id, o_entry_d FROM orders WHERE o_w_id = ? AND o_d_id = ? AND o_c_id = ? ORDER BY o_id DESC LIMIT 1",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.order_status.select_order_line",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/order_status.go:14",
+      "sql": "SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d FROM order_line WHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.select_new_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:17",
+      "sql": "SELECT no_o_id FROM new_order WHERE no_w_id = ? AND no_d_id = ? ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.update_customer",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:33",
+      "sql": "UPDATE customer SET c_balance = c_balance + ?, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.stock_level.select_district",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/stock_level.go:9",
+      "sql": "SELECT d_next_o_id FROM district WHERE d_w_id = ? AND d_id = ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.stock_level.count",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/stock_level.go:7",
+      "sql": "SELECT /*+ TIDB_INLJ(order_line,stock) */ COUNT(DISTINCT (s_i_id)) stock_count FROM order_line, stock \nWHERE ol_w_id = ? AND ol_d_id = ? AND ol_o_id < ? AND ol_o_id >= ? - 20 AND s_w_id = ? AND s_i_id = ol_i_id AND s_quantity < ?",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.delete_new_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:18",
+      "sql": "DELETE FROM new_order WHERE (no_w_id, no_d_id, no_o_id) IN (\n\t(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.update_order",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:21",
+      "sql": "UPDATE orders SET o_carrier_id = ? WHERE (o_w_id, o_d_id, o_id) IN (\n\t(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.select_orders",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:24",
+      "sql": "SELECT o_d_id, o_c_id FROM orders WHERE (o_w_id, o_d_id, o_id) IN (\n\t(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.update_order_line",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "2026-08-09 00:00:00"
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:27",
+      "sql": "UPDATE order_line SET ol_delivery_d = ? WHERE (ol_w_id, ol_d_id, ol_o_id) IN (\n\t(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.delivery.select_sum_amount",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/delivery.go:30",
+      "sql": "SELECT ol_d_id, SUM(ol_amount) FROM order_line WHERE (ol_w_id, ol_d_id, ol_o_id) IN (\n\t(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?),(?,?,?)\n) GROUP BY ol_d_id",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 11
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 12
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 13
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 14
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 14
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_items.width_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:34",
+      "sql": "SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.select_stock.width_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:46",
+      "sql": "SELECT s_i_id, s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE (s_w_id, s_i_id) IN ((?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?),(?,?)) FOR UPDATE",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.run.new_order.insert_order_line.width_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 2
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 3
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 4
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 6
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 7
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 8
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 9
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 10
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 11
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 12
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 13
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 14
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        },
+        {
+          "type": "i64",
+          "value": 3001
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 15
+        },
+        {
+          "type": "i64",
+          "value": 15
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 5
+        },
+        {
+          "type": "f64",
+          "value": 1.0
+        },
+        {
+          "type": "string",
+          "value": "district-info"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "tpcc/new_order.go:58",
+      "sql": "INSERT into order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?),(?,?,?,?,?,?,?,?,?)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.run.transaction.begin",
+      "kind": "non_plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "tpcc/workload.go:database/sql.DB.BeginTx",
+      "sql": "BEGIN",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.run.transaction.commit",
+      "kind": "non_plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "tpcc/* transaction Commit",
+      "sql": "COMMIT",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.run.transaction.rollback",
+      "kind": "non_plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "tpcc/* deferred transaction Rollback",
+      "sql": "ROLLBACK",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_01",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:71",
+      "sql": "SELECT sum(d_ytd) - max(w_ytd) diff FROM district, warehouse WHERE d_w_id = w_id AND w_id = ? group by d_w_id",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_02",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:106",
+      "sql": "SELECT POWER((d_next_o_id -1 - mo), 2) + POWER((d_next_o_id -1 - mno), 2) diff FROM district dis, (SELECT o_d_id,max(o_id) mo FROM orders WHERE o_w_id= ? GROUP BY o_d_id) q, (select no_d_id,max(no_o_id) mno from new_order where no_w_id= ? group by no_d_id) no where d_w_id = ? and q.o_d_id=dis.d_id and no.no_d_id=dis.d_id",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_03",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:136",
+      "sql": "SELECT max(no_o_id)-min(no_o_id)+1 - count(*) diff from new_order where no_w_id = ? group by no_d_id",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_04",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:166",
+      "sql": "SELECT count(*) FROM (SELECT o_d_id, SUM(o_ol_cnt) sm1, MAX(cn) as cn FROM orders,(SELECT ol_d_id, COUNT(*) cn FROM order_line WHERE ol_w_id = ? GROUP BY ol_d_id) ol WHERE o_w_id = ? AND ol_d_id=o_d_id GROUP BY o_d_id) t1 WHERE sm1<>cn",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_05",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:196",
+      "sql": "SELECT count(*)  FROM orders LEFT JOIN new_order ON (no_w_id=o_w_id AND o_d_id=no_d_id AND o_id=no_o_id) where o_w_id = ? and ((o_carrier_id IS NULL and no_o_id IS  NULL) OR (o_carrier_id IS NOT NULL and no_o_id IS NOT NULL  )) ",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_06",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:228",
+      "sql": "\nSELECT COUNT(*) FROM\n(SELECT o_ol_cnt, order_line_count FROM orders\n\tLEFT JOIN (SELECT ol_w_id, ol_d_id, ol_o_id, count(*) order_line_count FROM order_line GROUP BY ol_w_id, ol_d_id, ol_o_id ORDER by ol_w_id, ol_d_id, ol_o_id) AS order_line\n\tON orders.o_w_id = order_line.ol_w_id AND orders.o_d_id = order_line.ol_d_id AND orders.o_id = order_line.ol_o_id\n\tWHERE orders.o_w_id = ?) AS T\nWHERE T.o_ol_cnt != T.order_line_count",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_07",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:264",
+      "sql": "SELECT count(*) FROM orders, order_line WHERE o_id=ol_o_id AND o_d_id=ol_d_id AND ol_w_id=o_w_id AND o_w_id = ? AND ((ol_delivery_d IS NULL and o_carrier_id IS NOT NULL) or (o_carrier_id IS NULL and ol_delivery_d IS NOT NULL ))",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_08",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:294",
+      "sql": "SELECT count(*) cn FROM (SELECT w_id,w_ytd,SUM(h_amount) sm FROM history,warehouse WHERE h_w_id=w_id and w_id = ? GROUP BY w_id) t1 WHERE w_ytd<>sm",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_09",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:324",
+      "sql": "SELECT COUNT(*) FROM (select d_id,d_w_id,sum(d_ytd) s1 from district group by d_id,d_w_id) d,(select h_d_id,h_w_id,sum(h_amount) s2 from history WHERE  h_w_id = ? group by h_d_id, h_w_id) h WHERE h_d_id=d_id AND d_w_id=h_w_id and d_w_id= ? and s1<>s2",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:354",
+      "sql": "SELECT count(*) \n\tFROM (  SELECT  c.c_id, c.c_d_id, c.c_w_id, c.c_balance c1, \n\t\t\t\t   (SELECT sum(ol_amount) FROM orders, order_line \n\t\t\t\t\t WHERE OL_W_ID=O_W_ID \n\t\t\t\t\t   AND OL_D_ID = O_D_ID \n\t\t\t\t\t   AND OL_O_ID = O_ID \n\t\t\t\t\t   AND OL_DELIVERY_D IS NOT NULL \n\t\t\t\t\t   AND O_W_ID=? \n\t\t\t\t\t   AND O_D_ID=c.C_D_ID \n\t\t\t\t\t   AND O_C_ID=c.C_ID) sm, (SELECT  sum(h_amount)  from  history \n\t\t\t\t\t\t\t\t\t\t\t\tWHERE H_C_W_ID=? \n\t\t\t\t\t\t\t\t\t\t\t\t  AND H_C_D_ID=c.C_D_ID \n\t\t\t\t\t\t\t\t\t\t\t\t  AND H_C_ID=c.C_ID) smh \n\t\t\t FROM customer c \n\t\t\tWHERE  c.c_w_id = ? ) t\n   WHERE c1<>sm-smh",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:402",
+      "sql": "\nSELECT count(*) FROM\n\t(SELECT * FROM\n\t\t(SELECT o_w_id, o_d_id, count(*) order_count FROM orders GROUP BY o_w_id, o_d_id) orders\n        JOIN (SELECT no_w_id, no_d_id, count(*) new_order_count FROM new_order GROUP BY no_w_id, no_d_id) new_order\n        ON orders.o_w_id = new_order.no_w_id AND orders.o_d_id = new_order.no_d_id\n\t) order_new_order\nJOIN (SELECT c_w_id, c_d_id, count(*) customer_count FROM customer GROUP BY c_w_id, c_d_id) customer\nON order_new_order.no_w_id = customer.c_w_id AND order_new_order.no_d_id = customer.c_d_id\nWHERE c_w_id = ? AND order_count - 2100 != new_order_count",
+      "suite": "tpcc"
+    },
+    {
+      "id": "tpcc.check.condition_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i64",
+          "value": 1
+        },
+        {
+          "type": "i64",
+          "value": 1
+        }
+      ],
+      "phase": "check",
+      "protocol": "prepared",
+      "source": "tpcc/check.go:440",
+      "sql": "SELECT count(*) FROM (SELECT  c.c_id, c.c_d_id, c.c_balance c1, c_ytd_payment, \n\t\t(SELECT sum(ol_amount) FROM orders, order_line \n\t\tWHERE OL_W_ID=O_W_ID AND OL_D_ID = O_D_ID AND OL_O_ID = O_ID AND OL_DELIVERY_D IS NOT NULL AND \n\t\tO_W_ID=? AND O_D_ID=c.C_D_ID AND O_C_ID=c.C_ID) sm FROM customer c WHERE  c.c_w_id = ?) t1 \n\t\tWHERE c1+c_ytd_payment <> sm",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.run.transaction.begin",
+      "kind": "non_plan",
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:275",
+      "sql": "BEGIN",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_write_only.lua"
+      ]
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.run.transaction.commit",
+      "kind": "non_plan",
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:279",
+      "sql": "COMMIT",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_write_only.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest1 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest1 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest1 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest1 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest1 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest1 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest2 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest2 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest2 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest2 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest2 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest2 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest2 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest2 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest2 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest3 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest3 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest3 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest3 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest3 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest3 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest3 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest3 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest3 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest4 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest4 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest4 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest4 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest4 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest4 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest4 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest4 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest4 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest5 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest5 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest5 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest5 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest5 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest5 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest5 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest5 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest5 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest6 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest6 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest6 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest6 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest6 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest6 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest6 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest6 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest6 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest7 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest7 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest7 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest7 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest7 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest7 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest7 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest7 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest7 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest8 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest8 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest8 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest8 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest8 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest8 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest8 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest8 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest8 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest9 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest9 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest9 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest9 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest9 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest9 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest9 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest9 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest9 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest10 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest10 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest10 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest10 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest10 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest10 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest10 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest10 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest10 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest11 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest11 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest11 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest11 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest11 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest11 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest11 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest11 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest11 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest12 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest12 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest12 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest12 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest12 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest12 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest12 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest12 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest12 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest13 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest13 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest13 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest13 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest13 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest13 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest13 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest13 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest13 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest14 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest14 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest14 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest14 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest14 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest14 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest14 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest14 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest14 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest15 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest15 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest15 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest15 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest15 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest15 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest15 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest15 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest15 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest16 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest16 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest16 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest16 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest16 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest16 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest16 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest16 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest16 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest17 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest17 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest17 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest17 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest17 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest17 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest17 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest17 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_17",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest17 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest18 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest18 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest18 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest18 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest18 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest18 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest18 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest18 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_18",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest18 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest19 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest19 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest19 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest19 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest19 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest19 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest19 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest19 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_19",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest19 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest20 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest20 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest20 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest20 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest20 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest20 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest20 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest20 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_20",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest20 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest21 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest21 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest21 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest21 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest21 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest21 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest21 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest21 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_21",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest21 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest22 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest22 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest22 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest22 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest22 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest22 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest22 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest22 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_22",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest22 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest23 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest23 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest23 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest23 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest23 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest23 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest23 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest23 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_23",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest23 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest24 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest24 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest24 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest24 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest24 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest24 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest24 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest24 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_24",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest24 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest25 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest25 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest25 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest25 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest25 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest25 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest25 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest25 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_25",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest25 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest26 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest26 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest26 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest26 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest26 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest26 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest26 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest26 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_26",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest26 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest27 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest27 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest27 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest27 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest27 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest27 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest27 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest27 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_27",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest27 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest28 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest28 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest28 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest28 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest28 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest28 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest28 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest28 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_28",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest28 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest29 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest29 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest29 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest29 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest29 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest29 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest29 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest29 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_29",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest29 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest30 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest30 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest30 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest30 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest30 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest30 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest30 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest30 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_30",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest30 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest31 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest31 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest31 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest31 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest31 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest31 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest31 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest31 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_31",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest31 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.point_select.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:246",
+      "sql": "SELECT c FROM sbtest32 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua",
+        "oltp_point_select.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.simple_range.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:249",
+      "sql": "SELECT c FROM sbtest32 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.sum_range.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:252",
+      "sql": "SELECT SUM(k) FROM sbtest32 WHERE id BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.order_range.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:255",
+      "sql": "SELECT c FROM sbtest32 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.distinct_range.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 100
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:258",
+      "sql": "SELECT DISTINCT c FROM sbtest32 WHERE id BETWEEN ? AND ? ORDER BY c",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_read_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.index_update.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:261",
+      "sql": "UPDATE sbtest32 SET k=k+1 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.non_index_update.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:264",
+      "sql": "UPDATE sbtest32 SET c=? WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua",
+        "oltp_update_non_index.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.delete.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:267",
+      "sql": "DELETE FROM sbtest32 WHERE id=?",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.insert_after_delete.table_32",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "type": "string",
+          "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/oltp_common.lua:270",
+      "sql": "INSERT INTO sbtest32 (id, k, c, pad) VALUES (?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_write_only.lua",
+        "oltp_read_write.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest1 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_1",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest1 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_1",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest1 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest2 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_2",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest2 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_2",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest2 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest3 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_3",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest3 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_3",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest3 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest4 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_4",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest4 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_4",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest4 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest5 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_5",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest5 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_5",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest5 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest6 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_6",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest6 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_6",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest6 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest7 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_7",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest7 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_7",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest7 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest8 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_8",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest8 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_8",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest8 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest9 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_9",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest9 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_9",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest9 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest10 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_10",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest10 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_10",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest10 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest11 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_11",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest11 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_11",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest11 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest12 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_12",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest12 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_12",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest12 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest13 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_13",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest13 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_13",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest13 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest14 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_14",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest14 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_14",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest14 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest15 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_15",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest15 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_15",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest15 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_points.width_10.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 10
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_points.lua:39 + compatibility patch",
+      "sql": "SELECT id, k, c, pad FROM sbtest16 WHERE k IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_points.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.random_ranges.width_10.table_16",
+      "kind": "plan",
+      "params": [
+        {
+          "type": "i32",
+          "value": 1
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 2
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 3
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 4
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 5
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 6
+        },
+        {
+          "type": "i32",
+          "value": 11
+        },
+        {
+          "type": "i32",
+          "value": 7
+        },
+        {
+          "type": "i32",
+          "value": 12
+        },
+        {
+          "type": "i32",
+          "value": 8
+        },
+        {
+          "type": "i32",
+          "value": 13
+        },
+        {
+          "type": "i32",
+          "value": 9
+        },
+        {
+          "type": "i32",
+          "value": 14
+        },
+        {
+          "type": "i32",
+          "value": 10
+        },
+        {
+          "type": "i32",
+          "value": 15
+        }
+      ],
+      "phase": "run",
+      "protocol": "prepared",
+      "source": "src/lua/select_random_ranges.lua:43 + compatibility patch",
+      "sql": "SELECT count(k) FROM sbtest16 WHERE k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ? OR k BETWEEN ? AND ?",
+      "suite": "sysbench",
+      "workloads": [
+        "select_random_ranges.lua"
+      ]
+    },
+    {
+      "id": "sysbench.run.oltp_insert.direct.table_16",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "source": "src/lua/oltp_insert.lua:61 + compatibility patch",
+      "sql": "INSERT INTO sbtest16 (id, k, c, pad) VALUES (10000001, 1, 'c', 'pad')",
+      "suite": "sysbench",
+      "workloads": [
+        "oltp_insert.lua"
+      ]
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.warehouse",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS warehouse (\n    w_id INT NOT NULL,\n    w_name VARCHAR(10),\n    w_street_1 VARCHAR(20),\n    w_street_2 VARCHAR(20),\n    w_city VARCHAR(20),\n    w_state CHAR(2),\n    w_zip CHAR(9),\n    w_tax DECIMAL(4, 4),\n    w_ytd DECIMAL(12, 2),\n    PRIMARY KEY (w_id) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.district",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS district (\n    d_id INT NOT NULL,\n    d_w_id INT NOT NULL,\n    d_name VARCHAR(10),\n    d_street_1 VARCHAR(20),\n    d_street_2 VARCHAR(20),\n    d_city VARCHAR(20),\n    d_state CHAR(2),\n    d_zip CHAR(9),\n    d_tax DECIMAL(4, 4),\n    d_ytd DECIMAL(12, 2),\n    d_next_o_id INT,\n    PRIMARY KEY (d_w_id, d_id) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.customer",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS customer (\n    c_id INT NOT NULL,\n    c_d_id INT NOT NULL,\n    c_w_id INT NOT NULL,\n    c_first VARCHAR(16),\n    c_middle CHAR(2),\n    c_last VARCHAR(16),\n    c_street_1 VARCHAR(20),\n    c_street_2 VARCHAR(20),\n    c_city VARCHAR(20),\n    c_state CHAR(2),\n    c_zip CHAR(9),\n    c_phone CHAR(16),\n    c_since DATETIME,\n    c_credit CHAR(2),\n    c_credit_lim DECIMAL(12, 2),\n    c_discount DECIMAL(4,4),\n    c_balance DECIMAL(12,2),\n    c_ytd_payment DECIMAL(12,2),\n    c_payment_cnt INT,\n    c_delivery_cnt INT,\n    c_data VARCHAR(500),\n    PRIMARY KEY(c_w_id, c_d_id, c_id) /*T![clustered_index] CLUSTERED */,\n    INDEX idx_customer (c_w_id, c_d_id, c_last, c_first)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.history",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS history (\n    h_c_id INT NOT NULL,\n    h_c_d_id INT NOT NULL,\n    h_c_w_id INT NOT NULL,\n    h_d_id INT NOT NULL,\n    h_w_id INT NOT NULL,\n    h_date DATETIME,\n    h_amount DECIMAL(6, 2),\n    h_data VARCHAR(24),\n    INDEX idx_h_w_id (h_w_id),\n    INDEX idx_h_c_w_id (h_c_w_id)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.new_order",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS new_order (\n    no_o_id INT NOT NULL,\n    no_d_id INT NOT NULL,\n    no_w_id INT NOT NULL,\n    PRIMARY KEY(no_w_id, no_d_id, no_o_id) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.orders",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS orders (\n    o_id INT NOT NULL,\n    o_d_id INT NOT NULL,\n    o_w_id INT NOT NULL,\n    o_c_id INT,\n    o_entry_d DATETIME,\n    o_carrier_id INT,\n    o_ol_cnt INT,\n    o_all_local INT,\n    PRIMARY KEY(o_w_id, o_d_id, o_id) /*T![clustered_index] CLUSTERED */,\n    INDEX idx_order (o_w_id, o_d_id, o_c_id, o_id)\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.order_line",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS order_line (\n    ol_o_id INT NOT NULL,\n    ol_d_id INT NOT NULL,\n    ol_w_id INT NOT NULL,\n    ol_number INT NOT NULL,\n    ol_i_id INT NOT NULL,\n    ol_supply_w_id INT,\n    ol_delivery_d DATETIME,\n    ol_quantity INT,\n    ol_amount DECIMAL(6, 2),\n    ol_dist_info CHAR(24),\n    PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.stock",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS stock (\n    s_i_id INT NOT NULL,\n    s_w_id INT NOT NULL,\n    s_quantity INT,\n    s_dist_01 CHAR(24),\n    s_dist_02 CHAR(24),\n    s_dist_03 CHAR(24),\n    s_dist_04 CHAR(24),\n    s_dist_05 CHAR(24),\n    s_dist_06 CHAR(24),\n    s_dist_07 CHAR(24),\n    s_dist_08 CHAR(24),\n    s_dist_09 CHAR(24),\n    s_dist_10 CHAR(24),\n    s_ytd INT,\n    s_order_cnt INT,\n    s_remote_cnt INT,\n    s_data VARCHAR(50),\n    PRIMARY KEY(s_w_id, s_i_id) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.prepare.create_table.item",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:createTables mysql, parts=1, use-fk=false",
+      "sql": "CREATE TABLE IF NOT EXISTS item (\n    i_id INT NOT NULL,\n    i_im_id INT,\n    i_name VARCHAR(24),\n    i_price DECIMAL(5, 2),\n    i_data VARCHAR(50),\n    PRIMARY KEY(i_id) /*T![clustered_index] CLUSTERED */\n)",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_database",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:72 + prepare_baseline_populated_dataset.sh:87",
+      "sql": "CREATE DATABASE sbtest",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_1",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest1 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_1 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_1",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest1 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_1",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest1 INDEX k_1 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_2",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest2 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_2 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_2",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest2 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_2",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest2 INDEX k_2 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_3",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest3 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_3 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_3",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest3 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_3",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest3 INDEX k_3 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_4",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest4 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_4 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_4",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest4 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_4",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest4 INDEX k_4 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_5",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest5 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_5 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_5",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest5 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_5",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest5 INDEX k_5 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_6",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest6 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_6 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_6",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest6 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_6",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest6 INDEX k_6 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_7",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest7 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_7 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_7",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest7 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_7",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest7 INDEX k_7 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_8",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest8 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_8 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_8",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest8 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_8",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest8 INDEX k_8 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_9",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest9 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_9 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_9",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest9 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_9",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest9 INDEX k_9 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_10",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest10 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_10 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_10",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest10 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_10",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest10 INDEX k_10 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_11",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest11 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_11 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_11",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest11 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_11",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest11 INDEX k_11 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_12",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest12 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_12 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_12",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest12 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_12",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest12 INDEX k_12 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_13",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest13 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_13 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_13",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest13 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_13",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest13 INDEX k_13 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_14",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest14 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_14 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_14",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest14 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_14",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest14 INDEX k_14 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_15",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest15 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_15 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_15",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest15 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_15",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest15 INDEX k_15 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_16",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest16 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_16 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_16",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest16 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_16",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest16 INDEX k_16 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_17",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest17 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_17 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_17",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest17 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_17",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest17 INDEX k_17 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_18",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest18 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_18 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_18",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest18 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_18",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest18 INDEX k_18 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_19",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest19 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_19 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_19",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest19 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_19",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest19 INDEX k_19 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_20",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest20 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_20 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_20",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest20 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_20",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest20 INDEX k_20 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_21",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest21 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_21 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_21",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest21 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_21",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest21 INDEX k_21 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_22",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest22 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_22 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_22",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest22 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_22",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest22 INDEX k_22 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_23",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest23 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_23 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_23",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest23 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_23",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest23 INDEX k_23 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_24",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest24 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_24 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_24",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest24 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_24",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest24 INDEX k_24 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_25",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest25 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_25 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_25",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest25 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_25",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest25 INDEX k_25 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_26",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest26 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_26 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_26",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest26 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_26",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest26 INDEX k_26 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_27",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest27 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_27 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_27",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest27 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_27",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest27 INDEX k_27 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_28",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest28 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_28 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_28",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest28 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_28",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest28 INDEX k_28 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_29",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest29 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_29 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_29",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest29 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_29",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest29 INDEX k_29 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_30",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest30 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_30 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_30",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest30 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_30",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest30 INDEX k_30 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_31",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest31 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_31 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_31",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest31 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_31",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest31 INDEX k_31 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.create_table.table_32",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare.lua:29",
+      "sql": "CREATE TABLE IF NOT EXISTS sbtest32 (id INT NOT NULL, k INT NOT NULL, c CHAR(120) NOT NULL, pad CHAR(60) NOT NULL, PRIMARY KEY (id), INDEX k_32 (k))",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_table.table_32",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:102",
+      "sql": "SPLIT TABLE sbtest32 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.prepare.split_index.table_32",
+      "kind": "non_plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "source": "prepare_baseline_populated_dataset.sh:104",
+      "sql": "SPLIT TABLE sbtest32 INDEX k_32 BETWEEN (0) AND (10000001) REGIONS 8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_item",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS item",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_customer",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS customer",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_district",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS district",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_history",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS history",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_new_order",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS new_order",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_order_line",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS order_line",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_orders",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS orders",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_stock",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS stock",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "tpcc.cleanup.drop_warehouse",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "tpcc/ddl.go:687",
+      "sql": "DROP TABLE IF EXISTS warehouse",
+      "suite": "tpcc"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_1",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest1",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_2",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest2",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_3",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest3",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_4",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest4",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_5",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest5",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_6",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest6",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_7",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest7",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_8",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest8",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_9",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest9",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_10",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest10",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_11",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest11",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_12",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest12",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_13",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest13",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_14",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest14",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_15",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest15",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_16",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest16",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_17",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest17",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_18",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest18",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_19",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest19",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_20",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest20",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_21",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest21",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_22",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest22",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_23",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest23",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_24",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest24",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_25",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest25",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_26",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest26",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_27",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest27",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_28",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest28",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_29",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest29",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_30",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest30",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_31",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest31",
+      "suite": "sysbench"
+    },
+    {
+      "compatibility": "pending",
+      "id": "sysbench.cleanup.drop_table.table_32",
+      "kind": "non_plan",
+      "phase": "cleanup",
+      "protocol": "direct",
+      "source": "src/lua/oltp_common.lua:392",
+      "sql": "DROP TABLE IF EXISTS sbtest32",
+      "suite": "sysbench"
+    }
+  ],
+  "coverage": {
+    "sysbench": {
+      "cleanup": "all 32 drop-table variants generated; execution compatibility pending",
+      "prepare": "32 exact 1000-row INSERT, DDL, table split, and index split variants generated; runtime coverage pending",
+      "run": "32 common prepared-table variants, 16 worker-local variants, and all bulk widths generated; runtime coverage pending"
+    },
+    "tpcc": {
+      "check": "candidate inventory generated; runtime coverage pending",
+      "cleanup": "drop-table inventory generated; execution compatibility pending",
+      "prepare": "all loader INSERT width families and exact default MySQL DDL generated; runtime coverage pending",
+      "run": "candidate inventory generated; runtime coverage pending"
+    }
+  },
+  "coverage_status": "incomplete",
+  "expanded_case_count": 15248,
+  "plan_families": [
+    {
+      "coverage_proof": "100000 rows with maxBatchRows=1024 emit 1024-row batches and one 672-row tail",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.item",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        672,
+        1024
+      ],
+      "row_template": "({row},1,'item',1.00,'data')",
+      "separator": ", ",
+      "source": "tpcc/load.go:26 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "each warehouse loader creates a fresh sink and flushes exactly one row",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.warehouse",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1
+      ],
+      "row_template": "({row},'w','s1','s2','city','ST','123456789',0.1000,300000.00)",
+      "separator": ", ",
+      "source": "tpcc/load.go:51 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "100000 rows per warehouse with maxBatchRows=1024 emit 1024-row batches and one 672-row tail",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.stock",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        672,
+        1024
+      ],
+      "row_template": "({row},1,50,'d01','d02','d03','d04','d05','d06','d07','d08','d09','d10',0,0,0,'data')",
+      "separator": ", ",
+      "source": "tpcc/load.go:78 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO stock (s_i_id, s_w_id, s_quantity, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "each warehouse has exactly ten districts in one sink flush",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.district",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        10
+      ],
+      "row_template": "({row},1,'district','s1','s2','city','ST','123456789',0.1000,30000.00,3001)",
+      "separator": ", ",
+      "source": "tpcc/load.go:119 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "3000 rows per district emit two 1024-row batches and one 952-row tail",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.customer",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        952,
+        1024
+      ],
+      "row_template": "({row},1,1,'first','OE','ABLEABLEABLE','s1','s2','city','ST','123456789','1234567890123456','2026-08-09 00:00:00','GC',50000.00,0.1000,-10.00,10.00,1,0,'data')",
+      "separator": ", ",
+      "source": "tpcc/load.go:154 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "3000 rows per district emit two 1024-row batches and one 952-row tail",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.history",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        952,
+        1024
+      ],
+      "row_template": "({row},1,1,1,1,'2026-08-09 00:00:00',10.00,'history')",
+      "separator": ", ",
+      "source": "tpcc/load.go:210 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "3000 rows per district emit two 1024-row batches and one 952-row tail",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.orders",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        952,
+        1024
+      ],
+      "row_template": "({row},1,1,{row},'2026-08-09 00:00:00',1,10,1)",
+      "separator": ", ",
+      "source": "tpcc/load.go:240 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "each district has exactly 900 new-order rows in one sink flush",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.new_order",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        900
+      ],
+      "row_template": "({row},1,1)",
+      "separator": ", ",
+      "source": "tpcc/load.go:284 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "3000 independent 5..15 order-line counts can yield every tail width 1..1023; maxBatchRows adds width 1024",
+      "generator": "multi_row_insert",
+      "id": "tpcc.prepare.insert.order_line",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 1024,
+        "min": 1
+      },
+      "row_template": "({row},1,1,1,1,1,'2026-08-09 00:00:00',5,1.00,'district-info')",
+      "separator": ", ",
+      "source": "tpcc/load.go:310 + pkg/sink/sql.go:30",
+      "sql_prefix": "INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES  ",
+      "suite": "tpcc"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_1",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest1 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_2",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest2 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_3",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest3 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_4",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest4 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_5",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest5 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_6",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest6 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_7",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest7 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_8",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest8 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_9",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest9 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_10",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest10 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_11",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest11 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_12",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest12 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_13",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest13 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_14",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest14 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_15",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest15 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_16",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest16 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_17",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest17 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_18",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest18 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_19",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest19 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_20",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest20 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_21",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest21 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_22",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest22 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_23",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest23 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_24",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest24 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_25",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest25 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_26",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest26 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_27",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest27 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_28",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest28 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_29",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest29 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_30",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest30 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_31",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest31 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "fixed table_size=10000000 is exactly divisible by prepare.lua load_batch_rows=1000",
+      "generator": "multi_row_insert",
+      "id": "sysbench.prepare.insert.table_32",
+      "kind": "plan",
+      "phase": "prepare",
+      "protocol": "direct",
+      "row_counts": [
+        1000
+      ],
+      "row_template": "({row},1,'cccc','pad')",
+      "separator": ",",
+      "source": "prepare.lua:35",
+      "sql_prefix": "INSERT INTO sbtest32 (id, k, c, pad) VALUES ",
+      "suite": "sysbench"
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_1",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest1 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_2",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest2 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_3",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest3 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_4",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest4 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_5",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest5 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_6",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest6 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_7",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest7 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_8",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest8 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_9",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest9 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_10",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest10 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_11",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest11 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_12",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest12 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_13",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest13 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_14",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest14 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_15",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest15 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    },
+    {
+      "coverage_proof": "512KiB BULK_PACKET_SIZE admits at most 851 minimum-width padded rows; shutdown can flush every width 1..851",
+      "generator": "multi_row_insert",
+      "id": "sysbench.run.bulk_insert.table_16",
+      "kind": "plan",
+      "phase": "run",
+      "protocol": "direct",
+      "row_counts": {
+        "max": 851,
+        "min": 1
+      },
+      "row_template": "({row},{row},'','')/*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/",
+      "separator": ",",
+      "source": "bulk_insert.lua compatibility patch + src/db_driver.c:46,832",
+      "sql_prefix": "INSERT INTO sbtest16 (id, k, c, pad) VALUES",
+      "suite": "sysbench",
+      "workloads": [
+        "bulk_insert.lua"
+      ]
+    }
+  ],
+  "plan_family_count": 57,
+  "schema_version": "1.0",
+  "source_files": {
+    "go_tpc": {
+      "tpcc/check.go": "3e8c6ce5c7ebf97544ab2361bd5f7b66c5136faba798f689d8db9a0184f23cfd",
+      "tpcc/ddl.go": "29b13c1c2de13ae21faec28cadb0eee5914b135c0f5456d851404b2bdc033bbc",
+      "tpcc/delivery.go": "43df258c84239b8bfdcccfe3adad8cdeac12093a0c024ae119e9dd0807f56f62",
+      "tpcc/load.go": "31360fe20235bd0f08d7de5f5993ed037f8064156249c28e76a5144499c2ffc6",
+      "tpcc/new_order.go": "e08c42327418e17afef3c09d5c70a4c05d589fade0865ec1c45dfa39e19a9a44",
+      "tpcc/order_status.go": "1a6a8acfd7119fcfbc18a1bc049f6ba7300c55374a2a0b36d7282cd4f3b94705",
+      "tpcc/payment.go": "468e884081f4841c483c1e9e108276e19e3841b270317c2ee80839492b16202d",
+      "tpcc/stock_level.go": "5624c11048aae3e12a55b08956c11cf8aaadeab53898e48cb4346dd736928195",
+      "tpcc/workload.go": "f0be33eae3330efecafb4ba40b8f880f99faea33c33e8febb7c3acbbca051f6b"
+    },
+    "sysbench": {
+      "src/db_driver.c": "bde5e20b40301ca57f7d0a20b60e797dd34fdbc4a477b266a30cbc49fe26c5c0",
+      "src/lua/bulk_insert.lua": "b183f7a112ce78e7d6f5d1c151c0192f83318593db8a51122f2e93e344b7cee6",
+      "src/lua/oltp_common.lua": "710c3b38027668c83e46f3c0814dc7cfd67cc8c4012df6cab461e46d62b5996a",
+      "src/lua/oltp_insert.lua": "2f7f740ef7281b0ce77236d979ff67e16580b6de5082dd711d6a91560ccdbdb3",
+      "src/lua/select_random_points.lua": "c84d035191a8c895f31b9d6e92089105041aa6a1cf21f3dec07aca8c15d62306",
+      "src/lua/select_random_ranges.lua": "aba6f88f3fe18a24a9ff2926e0fd535164f3b22866e96db32b7d6319bd288593"
+    },
+    "sysbench_contract": {
+      "manifest.json": "bb36351184a6fff15a309244d9757a3d225661d7c02cb57009f41b626235a663",
+      "patches/bulk_insert.patch": "eb680c6bdfcd4ef2ba5de99c2c6c5e7df34b1c89cbc04843c7b44bb17a7dd3e0",
+      "patches/oltp_common.patch": "c7ceae0d3f8af5947dccd009a33bd641da8519725625c35f3f27d00a3599f08e",
+      "patches/oltp_insert.patch": "e26dd998eaf5c9b808c6f6be80442582b0953f78b6d4b33e2130af9a521ecd20",
+      "patches/select_random_points.patch": "e6499503793d2347e9fcccf8b02951f3979f8743cdd6a62d2ebc4bf78c9e9170",
+      "patches/select_random_ranges.patch": "895661f5297cf9ae440313f6bf3b5d91ea9c5454e9805e0c1cdb4bdb60f07c10",
+      "prepare.lua": "6cad222dd1a6c6a08af171358b80cadcc4fad984328b91997a38df765913a413",
+      "prepare_baseline_populated_dataset.sh": "f803e531806b1e8734e5fe9601c49b062a13905fa0dc8ffcdebe1e4926664ca0"
+    }
+  },
+  "source_pins": {
+    "go_tpc": {
+      "commit": "688d62f3be7ea6b68c2bb5fbbeb925bde681fb05",
+      "version": "v1.0.12"
+    },
+    "sysbench": {
+      "commit": "ebf1c90da05dea94648165e4f149abc20c979557",
+      "version": "1.0.20"
+    }
+  },
+  "static_case_count": 563
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: None

Problem Summary:

This is a draft/WIP branch for evaluating Rust TiDB on top of the `hparser-integration` branch as a `TiProxy + Rust TiDB + TiKV` topology. The hard gate is to keep TPCC and Sysbench physical plans aligned with Go TiDB before accepting any formal benchmark result.

### What changed and how does it work?

- Rebased the parity branch onto the latest `origin/hparser-integration`.
- Added TPCC/Sysbench plan parity manifests and scripts that compare Rust TiDB physical plans against Go TiDB.
- Added planner and executor parity work for TPCC/Sysbench plan families, including point reads, grouped and derived plans, aggregation pruning, HAVING projection preservation, and join plan traces.
- Hardened the cluster SQL runtime path used by the EC2 validation topology:
  - PD and topology client coverage for cluster SQL nodes.
  - MySQL connection lifecycle behavior that separates pre-auth connection timeout from authenticated `wait_timeout`.
- Updated `README.md` with the current parity and benchmark evidence against the frozen nightly baseline.

Known draft status:

- This PR is not ready for review yet.
- The execution-plan gate is complete for the current TPCC and Sysbench inventories:
  - TPCC prepare `1037/1037`, run `63/63`, and check `12/12` matched with zero mismatches and zero errors.
  - Sysbench prepare `32/32` and run `13952/13952` matched with zero mismatches and zero errors.
- The latest rebased head builds and passes the script gate, but the retained throughput evidence still comes from the pre-rebase EC2 binary archive.
- Performance is still below the frozen nightly baseline. The retained 16-thread TPCC run reached `5766.0 tpmC` (`12821.3 tpmTotal`), while the frozen three-store nightly baseline remains `41011.5 tpmC` at 32 threads. That comparison is directional only because the thread counts differ, and it is not an acceptance result.
- A fresh post-rebase TPCC and Sysbench benchmark cycle is still pending.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation run after rebasing onto `origin/hparser-integration`:

```bash
cd /mnt/nvme/src/tidb-hparser-integration-rebased/rust
cargo fmt --all -- --check
```

```bash
cd /mnt/nvme/src/tidb-hparser-integration-rebased/rust
cargo build --offline --locked --release -p tidb-server --bin tidb-server -j8
```

```bash
cd /mnt/nvme/src/tidb-hparser-integration-rebased
python3 -m py_compile rust/scripts/plan-parity.py rust/scripts/generate-plan-manifest.py rust/scripts/test-plan-parity.py
python3 rust/scripts/generate-plan-manifest.py --check
python3 rust/scripts/test-plan-parity.py
```

Manual EC2 evidence retained in the branch notes:

- Rust SQL was deployed to the 3-node Rust TiDB topology behind nightly TiProxy and nightly PD/TiKV.
- The retained TPCC 120-second measurement produced `5766.0 tpmC` / `12821.3 tpmTotal` at 16 threads.
- A retained 180-second stability rerun produced `5886.6 tpmC` / `13060.4 tpmTotal` and the stored log contains zero workload error lines.
- Sysbench plan parity is complete, but a fresh post-rebase throughput matrix is not retained yet.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
