### PR TITLE
planner: decouple DML non-prepared plan cache switch

### DIFF
--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -203,7 +203,7 @@ func GetPlanFromPlanCache(ctx context.Context, sctx sessionctx.Context,
 	cacheEnabled := false
 	if isNonPrepared {
 		stmtCtx.SetCacheType(contextutil.SessionNonPrepared)
-		cacheEnabled = sessVars.EnableNonPreparedPlanCache // plan-cache might be disabled after prepare.
+		cacheEnabled = NonPreparedPlanCacheEnabledForStmt(sessVars, stmt.PreparedAst.Stmt) // plan-cache might be disabled after prepare.
 	} else {
 		stmtCtx.SetCacheType(contextutil.SessionPrepared)
 		cacheEnabled = sessVars.EnablePreparedPlanCache

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -230,6 +230,35 @@ func TestNonPreparedPlanCacheBasically(t *testing.T) {
 		tk.MustQuery(query).Sort().Check(resultNormal.Rows())                  // equal to the result without plan-cache
 		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // this plan is from plan-cache
 	}
+
+	tk.MustExec(`create table t_dml_only (a int, b int)`)
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache=0`)
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache_for_dml=1`)
+	tk.MustExec(`insert into t_dml_only values (1, 1)`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustExec(`insert into t_dml_only values (2, 2)`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	tk.MustExec(`update t_dml_only set b = 3 where a = 1`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustExec(`update t_dml_only set b = 4 where a = 2`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	tk.MustExec(`delete from t_dml_only where a = 1`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustExec(`delete from t_dml_only where a = 2`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	tk.MustQuery(`select * from t_dml_only where a = 1`)
+	tk.MustQuery(`select * from t_dml_only where a = 2`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache=1`)
+	tk.MustExec(`set tidb_enable_non_prepared_plan_cache_for_dml=0`)
+	tk.MustExec(`insert into t_dml_only values (3, 3)`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustExec(`insert into t_dml_only values (4, 4)`)
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
 }
 
 func TestNonPreparedPlanCacheInternalSQL(t *testing.T) {

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -74,16 +74,26 @@ func NonPreparedPlanCacheEnabledForStmt(vars *variable.SessionVars, stmt ast.Stm
 	if vars == nil {
 		return false
 	}
+
+	enableSelect := vars.EnableNonPreparedPlanCache
+	enableDML := vars.EnableNonPreparedPlanCacheForDML
+	if !enableSelect && !enableDML {
+		return false
+	}
+	if enableSelect && enableDML {
+		return true
+	}
+
 	switch x := stmt.(type) {
 	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
-		return vars.EnableNonPreparedPlanCacheForDML
+		return enableDML
 	case *ast.SelectStmt:
 		if x.LockInfo != nil {
-			return vars.EnableNonPreparedPlanCacheForDML
+			return enableDML
 		}
-		return vars.EnableNonPreparedPlanCache
+		return enableSelect
 	default:
-		return vars.EnableNonPreparedPlanCache
+		return enableSelect
 	}
 }
 

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -67,6 +67,26 @@ var (
 	PreparedPlanCacheMaxMemory = *atomic2.NewUint64(math.MaxUint64)
 )
 
+// NonPreparedPlanCacheEnabledForStmt reports whether the non-prepared plan
+// cache path is enabled for the current statement. The DML switch can enable
+// DML statements independently from the SELECT-oriented global switch.
+func NonPreparedPlanCacheEnabledForStmt(vars *variable.SessionVars, stmt ast.StmtNode) bool {
+	if vars == nil {
+		return false
+	}
+	switch x := stmt.(type) {
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+		return vars.EnableNonPreparedPlanCacheForDML
+	case *ast.SelectStmt:
+		if x.LockInfo != nil {
+			return vars.EnableNonPreparedPlanCacheForDML
+		}
+		return vars.EnableNonPreparedPlanCache
+	default:
+		return vars.EnableNonPreparedPlanCache
+	}
+}
+
 type paramMarkerExtractor struct {
 	markers []ast.ParamMarkerExpr
 }
@@ -140,7 +160,7 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 		reason    string
 	)
 	if (isPrepStmt && !vars.EnablePreparedPlanCache) || // prepared statement
-		(!isPrepStmt && !vars.EnableNonPreparedPlanCache) { // non-prepared statement
+		(!isPrepStmt && !NonPreparedPlanCacheEnabledForStmt(vars, paramStmt)) { // non-prepared statement
 		cacheable = false
 		reason = "plan cache is disabled"
 	} else {

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -69,7 +69,7 @@ func IsReadOnly(node ast.Node, vars *variable.SessionVars) bool {
 func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Context, stmt ast.StmtNode, is infoschema.InfoSchema) (p base.Plan, ns types.NameSlice, ok bool, err error) {
 	stmtCtx := sctx.GetSessionVars().StmtCtx
 	_, isExplain := stmt.(*ast.ExplainStmt)
-	if !sctx.GetSessionVars().EnableNonPreparedPlanCache || // disabled
+	if !core.NonPreparedPlanCacheEnabledForStmt(sctx.GetSessionVars(), stmt) || // disabled
 		stmtCtx.InPreparedPlanBuilding || // already in cached plan rebuilding phase
 		stmtCtx.EnableOptimizerCETrace || stmtCtx.EnableOptimizeTrace || // in trace
 		stmtCtx.InRestrictedSQL || // is internal SQL
@@ -276,8 +276,8 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	}
 
 	// try to get Plan from the NonPrepared Plan Cache
-	if sessVars.EnableNonPreparedPlanCache &&
-		isStmtNode &&
+	if isStmtNode &&
+		core.NonPreparedPlanCacheEnabledForStmt(sessVars, stmtNode) &&
 		!useBinding { // TODO: support binding
 		cachedPlan, names, ok, err := getPlanFromNonPreparedPlanCache(ctx, sctx, stmtNode, is)
 		if err != nil {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -416,7 +416,9 @@ func (s *session) SetCollation(coID int) error {
 
 func (s *session) GetSessionPlanCache() sessionctx.SessionPlanCache {
 	// use the prepared plan cache
-	if !s.GetSessionVars().EnablePreparedPlanCache && !s.GetSessionVars().EnableNonPreparedPlanCache {
+	if !s.GetSessionVars().EnablePreparedPlanCache &&
+		!s.GetSessionVars().EnableNonPreparedPlanCache &&
+		!s.GetSessionVars().EnableNonPreparedPlanCacheForDML {
 		return nil
 	}
 	if s.sessionPlanCache == nil { // lazy construction


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70411

Problem Summary:

`tidb_enable_non_prepared_plan_cache_for_dml` currently depends on `tidb_enable_non_prepared_plan_cache`, so users cannot enable non-prepared plan cache only for supported DML statements. This couples the DML-specific rollout knob with the general non-prepared plan cache switch for SELECT statements.

### What changed and how does it work?

This PR makes the non-prepared plan cache enablement check statement-aware:

- Ordinary `SELECT` statements are still controlled by `tidb_enable_non_prepared_plan_cache`.
- `INSERT`, `UPDATE`, `DELETE`, and `SELECT ... FOR UPDATE` are controlled by `tidb_enable_non_prepared_plan_cache_for_dml`.
- The DML switch can now enable supported DML statements independently when the general switch is off.
- When the DML switch is off, DML statements do not use non-prepared plan cache even if the general switch is on.

The statement-aware check is used by the non-prepared plan cache lookup path, cached statement generation, cached plan retrieval, and session plan cache lazy initialization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Unit test:

```bash
make failpoint-enable
go test ./pkg/planner/core -run '^TestNonPreparedPlanCacheBasically$' -tags=intest,deadlock -count=1
make failpoint-disable
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The `tidb_enable_non_prepared_plan_cache_for_dml` system variable can now independently enable non-prepared plan cache for supported DML statements without enabling `tidb_enable_non_prepared_plan_cache`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added statement-specific controls for non-prepared query plan caching.
  - DML statements and locking reads can use dedicated caching independently from ordinary `SELECT` statements.

- **Bug Fixes**
  - Plan-cache initialization and retrieval now honor DML-specific caching settings.
  - Improved caching behavior across `INSERT`, `UPDATE`, `DELETE`, and `SELECT` statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->