### PR TITLE
OWNERS_ALIASES: replace Benjamin2037 with bb7133

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,7 +22,7 @@ aliases:
     - XuHuaiyu
     - zanmato1984
     - cfzjywxk
-    - Benjamin2037
+    - bb7133
   sig-approvers-executor: # approvers for executor pkg
     - windtalker
     - XuHuaiyu
@@ -36,7 +36,7 @@ aliases:
     - XuHuaiyu
     - zanmato1984
   sig-approvers-lightning: # approvers for lightning module
-    - Benjamin2037
+    - bb7133
     - D3Hunter
     - gmhdbjd
     - lance6716
@@ -50,13 +50,13 @@ aliases:
     - tangenta
     - wjhuang2016
   sig-approvers-ddl: # approvers for ddl pkg
-    - Benjamin2037
+    - bb7133
     - tangenta
     - wjhuang2016
     - ywqzzy
     - zimulala
   sig-approvers-disttask: # approvers for disttask pkg
-    - Benjamin2037
+    - bb7133
     - D3Hunter
     - gmhdbjd
     - lance6716
@@ -64,7 +64,7 @@ aliases:
     - wjhuang2016
     - ywqzzy
   sig-approvers-dumpling: # approvers for dumpling module
-    - Benjamin2037
+    - bb7133
     - gmhdbjd
     - lichunzhu
     - okJiang
@@ -76,17 +76,17 @@ aliases:
     - tangenta
     - ywqzzy
     - D3Hunter
-    - Benjamin2037
+    - bb7133
     - gmhdbjd
   sig-approvers-meta: # approvers for meta pkg
-    - Benjamin2037
+    - bb7133
     - gmhdbjd
     - tangenta
     - wjhuang2016
     - ywqzzy
     - zimulala
   sig-approvers-owner: # approvers for `owner` pkg
-    - Benjamin2037
+    - bb7133
     - lichunzhu
     - tangenta
     - wjhuang2016
@@ -98,7 +98,7 @@ aliases:
     - D3Hunter
     - tangenta
   sig-approvers-resourcemanager: # approvers for resourcemanager pkg
-    - Benjamin2037
+    - bb7133
     - D3Hunter
     - gmhdbjd
     - lance6716
@@ -106,7 +106,7 @@ aliases:
     - wjhuang2016
     - ywqzzy
   sig-approvers-table: # approvers for table packages.
-    - Benjamin2037
+    - bb7133
     - cfzjywxk
     - gmhdbjd
     - tangenta
@@ -114,13 +114,13 @@ aliases:
     - ywqzzy
     - zimulala
   sig-approvers-lock: # approvers for lock pkg
-    - Benjamin2037
+    - bb7133
     - lance6716
     - tangenta
     - wjhuang2016
     - zimulala
   sig-approvers-tidb-binlog: # approvers for tidb-binlog module
-    - Benjamin2037
+    - bb7133
     - gmhdbjd
     - lichunzhu
   sig-approvers-planner: # approvers for planner module


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70419

Problem Summary:

Replace member `Benjamin2037` with `bb7133` in `OWNERS_ALIASES`, deduplicating members within each SIG. `sig-community-*` entries are left untouched (they are synced from pingcap/community).

### What changed and how does it work?

- `OWNERS_ALIASES`: `Benjamin2037` -> `bb7133` in all SIGs except `sig-community-*`; removed duplicate `bb7133` entries where the same SIG already listed it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
