### PR TITLE
*: Geospatial basic design

### DIFF
--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -462,8 +462,8 @@ Out of scope here, each with a home:
 
 | Area | Effect |
 | --- | --- |
-| Partition table, clustered index, async commit | None. Geometry cannot be a primary or clustering key, having no meaningful ordering. |
-| Indexes on a geometry column | None in v1, of any kind: not a primary, unique, secondary or composite member. The useful one is the spatial index, which is the other design; a B-tree over the stored bytes would be well-defined but not spatially meaningful, so it is deferred rather than ruled out. |
+| Partition table, clustered index | None. Geometry cannot be a primary or clustering key, having no meaningful ordering. |
+| Indexes on a geometry column | None in v1, of any kind: not a primary, unique, secondary or composite member. The useful one is the spatial index, which is the other design. |
 | Generated columns | `ST_*` are deterministic scalars, so they are usable in virtual and stored generated column expressions like any other builtin. A geometry-typed generated column is then an ordinary geometry column, and the row above governs indexing it. |
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -1,12 +1,13 @@
 # TiDB Design Documents
 
-- Author(s): [Mattias Jonsson](http://github.com/mjonss)
+- Author(s): [Mattias Jonsson](http://github.com/mjonss), [Daniël van Eeden](http://github.com/dveeden)
 - Discussion PR: https://github.com/pingcap/tidb/pull/XXXXX
 - Tracking Issue: https://github.com/pingcap/tidb/issues/6347
 
 ## Table of Contents
 
 * [Introduction](#introduction)
+* [Terminology](#terminology)
 * [Motivation or Background](#motivation-or-background)
 * [Detailed Design](#detailed-design)
     * [Types and storage](#types-and-storage)
@@ -31,20 +32,62 @@
 
 This document proposes **basic geospatial support** for TiDB: a MySQL-compatible
 `GEOMETRY` type family (`POINT`, `LINESTRING`, `POLYGON`, and the multi/collection
-variants), per-column `SRID`, EWKB storage, and a minimal-but-useful set of `ST_*`
-functions covering I/O, accessors, measurement, and the DE-9IM spatial predicates. It
-supports **SRID 0 (Cartesian plane)** and **SRID 4326 (WGS 84 geographic)** and makes
-geometry values storable, queryable, and filterable — by full table scan. It is the
-prerequisite layer that a spatial **index** builds on, but it is deliberately
-**index-free**: geometry becomes a first-class value and query surface first, and the
-index lands separately.
+variants), per-column [`SRID`](#terminology), [EWKB](#terminology) storage, and a
+minimal-but-useful set of `ST_*` functions covering I/O, accessors, measurement, and the
+[DE-9IM](#terminology) spatial predicates. It supports **SRID 0 (Cartesian plane)** and
+**SRID 4326 ([WGS 84](#terminology) geographic)** and makes geometry values storable,
+queryable, and filterable (by full table scan). It is the prerequisite layer that a
+spatial **index** builds on, but it is deliberately **index-free**: geometry becomes a
+first-class value and query surface first, and the index lands separately.
 
 The scope is intentionally the smallest slice that is independently useful and GA-able,
-and it is designed so later work — more SRIDs, the long tail of geometry-processing
-functions, coprocessor pushdown, and the spatial index — extends it **without a new
-design**. This revives and narrows the earlier geospatial design (PR #38916), which
-covered a broader surface and was not merged. The spatial index is specified separately
-in `docs/design/2026-06-25-spatial-index.md` (PR #69473) and depends on this layer.
+and it is designed so later work (more SRIDs, the long tail of geometry-processing
+functions, coprocessor pushdown, and the spatial index) extends it **without a new
+design**. This replaces the earlier geospatial design (PR #38916). The spatial index is
+specified separately in `docs/design/2026-06-25-spatial-index.md` (PR #69473) and
+depends on this layer.
+
+## Terminology
+
+Geospatial standards come with a dense vocabulary. The abbreviations used throughout this
+document, each with an external reference and the section that covers it in depth:
+
+- **[OGC](https://www.ogc.org/standard/sfa/)** (Open Geospatial Consortium): the standards
+  body behind *Simple Features*, the specification that MySQL's spatial types and `ST_*`
+  functions follow.
+- **[WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)**
+  (Well-Known Text / Well-Known Binary): the OGC text and binary encodings of a geometry,
+  for example `POINT(1 2)` and its byte form. Neither carries an SRID.
+- **[EWKB](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html)** (Extended WKB):
+  WKB with the SRID carried alongside it. MySQL stores a 4-byte little-endian SRID followed
+  by OGC WKB, which is the layout this design adopts; see
+  [Types and storage](#types-and-storage).
+- **SRS** (spatial reference system): the coordinate system a geometry's numbers are
+  expressed in, together with its units, axis order, and datum. An SRS is either
+  *projected* (flat X/Y) or *geographic* (angular latitude/longitude on an ellipsoid).
+- **[SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html)**
+  (spatial reference system identifier): the integer that names an SRS. v1 supports 0 (the
+  abstract Cartesian plane) and 4326 (WGS 84); see [SRID model](#srid-model).
+- **[EPSG](https://epsg.org/)**: the registry that assigns those identifiers, and the
+  source of the SRS catalog described in the [SRID model](#srid-model) extension path.
+- **[WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)** (World Geodetic System
+  1984): the global datum and reference ellipsoid used by GPS, registered as EPSG:4326.
+- **Planar vs geodesic**: planar measurement treats coordinates as points on a flat plane;
+  geodesic measurement follows the curved surface of the ellipsoid. Which one applies is
+  decided by the SRS class, not per SRID; see [SRID model](#srid-model).
+- **[DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)** (Dimensionally Extended
+  9-Intersection Model): the OGC model that defines what `ST_Within`, `ST_Contains`,
+  `ST_Intersects` and the other topological predicates actually mean; see
+  [Function set](#function-set).
+- **[GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)**: the JSON geometry encoding
+  (RFC 7946), the third I/O format alongside WKT and WKB.
+- **MBR** (minimum bounding rectangle): the axis-aligned box enclosing a geometry, and the
+  basis of MySQL's `MBR*` predicate family (deferred, see
+  [Scope and deferrals](#scope-and-deferrals)).
+- **[S2](http://s2geometry.io/)**: Google's spherical-geometry library, used here for the
+  geodesic 4326 paths; see [Geometry engine](#geometry-engine).
+- **[PROJ](https://proj.org/)**: the coordinate-transformation library that reprojection
+  between arbitrary SRSs would require; out of scope for this design.
 
 ## Motivation or Background
 
@@ -61,19 +104,9 @@ TiDB has no spatial support today: only the `mysql.TypeGeometry` type constant e
 Users who need geometry today must encode it into scalar columns by hand and compute
 distances in the application, losing MySQL compatibility and correctness.
 
-The earlier geospatial design (PR #38916) proposed the full surface — types, functions,
-and an eventual index — but bundled too much to land, and explicitly deferred the index
-as "needs more research". Two things have changed since:
-
-1. The index research is done (PR #69473) and validated by an end-to-end proof of
-   concept, which also **fully prototyped this basic layer** as its prerequisite. The
-   type, EWKB storage, and a broad `ST_*` surface already work in pure Go.
-2. That PoC showed the right seam: **the basic type-and-function layer is a clean,
-   independently valuable milestone** that should merge on its own before the index, so
-   review stays small and geometry is usable the moment it lands.
-
-This document is that basic layer, scoped so it can ship, stabilize, and have its
-feature flag removed before index work starts merging on top.
+This design replaces the earlier geospatial design (PR #38916). It covers the basic
+layer only, scoped so it can ship, stabilize, and have its feature flag removed before
+index work starts merging on top.
 
 ## Detailed Design
 
@@ -85,50 +118,88 @@ The `GEOMETRY` type family follows MySQL: `GEOMETRY` (any subtype), `POINT`,
 concrete subtype is a constraint on the stored value, as in MySQL. A column may carry a
 `SRID n` attribute fixing its spatial reference system (see [SRID model](#srid-model)).
 
-The **stored value is EWKB**: a 4-byte little-endian SRID prefix followed by standard
-OGC WKB (`<srid_le_u32><wkb>`), matching MySQL's internal geometry storage byte-for-byte
-so that dump/reload and wire compatibility are natural. Geometry columns are stored as a
-binary string kind at the KV layer; no new column encoding is introduced.
+The **stored value is version-tagged**: a 1-byte format version followed by the encoded
+geometry (`<format_version u8><payload>`). **Version 1 is EWKB**, a 4-byte little-endian
+SRID prefix followed by standard OGC WKB (`<srid_le_u32><wkb>`). Version numbering starts
+at 1, never 0, so a leading zero byte is always invalid and can never be mistaken for a
+version. Geometry columns are stored as a binary string kind at the KV layer; no new
+column encoding is introduced.
 
-**Pre-GA value-format lock-in (decided here).** The on-disk value format is hard to
-change after release without a migration, so it is settled in *this* design (the type's
-owner), not the index design. Two observations from the PoC (`storage-format.md`):
+**The internal format does not need to match MySQL byte-for-byte.** Only two rules bind
+it: it must be lossless (exact `f64` coordinates, full geometry structure) and it must
+round-trip every supported type. The SRID has to survive as well, though not necessarily
+inside the stored bytes: where a column carries a `SRID n` attribute the value is
+redundant, so a later format version can omit it there and restore it from the column
+metadata on decode. It cannot be omitted unconditionally, because an unrestricted
+`GEOMETRY` column holds a per-row SRID, and because a geometry that is not in a column at
+all (a function result, an intermediate value in a join or a sort) has no column metadata
+to recover it from.
 
-- Raw EWKB carries redundancy: a per-row SRID (already implied by the column's fixed
-  SRID), per-(sub)geometry byte-order flags, and WKB framing.
-- A **1-byte format-version tag** keeps the format evolvable at negligible cost, and a
-  flat-`f64` point layout could cheapen point decode.
+Dump/reload, the wire protocol, and `ST_AsBinary` are boundary concerns and they convert,
+emitting MySQL-compatible EWKB whatever is on disk. MySQL itself works this way: it
+stores coordinates longitude/easting-first internally regardless of SRID and swaps to the
+SRS axis order on every WKT/WKB read and write, so its own stored bytes are already not
+what its I/O emits (`axis-order.md`).
 
-**Recommendation:** ship a version-tagged value format (at minimum a leading
-format-version byte) so the encoding can evolve; keep the wire/`ST_AsBinary` output
-MySQL-compatible EWKB regardless of the internal form. The exact internal layout beyond
-the version byte is an implementation choice measured during development; see Unresolved
-Questions.
+Version 1 is EWKB because it is what the proof of concept (PR #69475) implements and it
+needs no conversion today, not because it is optimal. `storage-format.md` measures the
+cost: EWKB carries a per-row SRID that the column definition usually already fixes, a
+byte-order flag per (sub)geometry, and WKB framing, and geometry decode is a measurable
+share of both the index-maintenance write path and the refine read path. A later version
+can drop the per-row SRID for SRID-restricted columns, drop the byte-order flags
+(everything written is canonical little-endian), shrink the type enum, or store a point
+as two bare `f64` values, each gated on a benchmark. The version byte is what keeps that
+available: a release reads every earlier version and writes the current one, with no
+migration.
+
+**Extended data is storable, and no v1 function operates on it.** The format carries,
+losslessly:
+
+- **Z and M coordinates.** Every `ST_*` function in this design is 2D, as in MySQL, but a
+  value carrying Z/M is stored and returned unchanged rather than rejected or truncated.
+- **SRIDs outside 0 and 4326.** An unrestricted `GEOMETRY` column (one with no `SRID`
+  attribute) may hold values of any SRID, as in MySQL.
+
+Such values round-trip, in through `ST_GeomFromWKB`/`ST_GeomFromText` and out through
+`ST_AsBinary`/`ST_AsText`, with the metadata accessors (`ST_SRID`, `ST_GeometryType`)
+still answering. Every function that has to interpret the coordinates (measurement, the
+predicates, the geodesic paths) rejects them with a clear error. Storing more than v1
+computes on is deliberate: 3D/measured geometry and the wider SRS catalog then arrive as
+new *functions* over data written today, instead of needing a format change and a
+migration.
 
 ### SRID model
 
 v1 supports two spatial reference systems, chosen to cover the two coordinate-system
 *classes* that matter:
 
-- **SRID 0 — abstract Cartesian plane.** Unitless X/Y, no coordinate-range checking
+- **SRID 0: abstract Cartesian plane.** Unitless X/Y, no coordinate-range checking
   (MySQL spans the full finite IEEE-754 double range). All functions are planar
   (Cartesian).
-- **SRID 4326 — WGS 84 geographic (lat/long).** Coordinates are bounded (latitude
+- **SRID 4326: WGS 84 geographic (lat/long).** Coordinates are bounded (latitude
   `[-90, 90]`, longitude `(-180, 180]`); distance/length/area are geodesic on the WGS 84
   ellipsoid, matching MySQL.
 
 **Coordinate-system class drives planar-vs-geodesic**, exactly as MySQL decides it from
 the SRS class (SRID 0 / projected = Cartesian; geographic = geodesic). This class-based
-dispatch — not a per-SRID table of special cases — is the design's extension seam: adding
+dispatch, not a per-SRID table of special cases, is the design's extension seam: adding
 SRIDs later is adding catalog rows and per-class parameters, not new code paths.
 
-**Axis order.** MySQL's EPSG:4326 is **(latitude, longitude)** — the first coordinate is
+**Axis order.** MySQL's EPSG:4326 is **(latitude, longitude)**: the first coordinate is
 latitude. This is verifiable from MySQL's own out-of-range error wording (`POINT(100 0)`
-on 4326 errors "Latitude 100 … out of range"). v1 follows MySQL's axis order so that
-`ST_Latitude`/`ST_Longitude`, distances, and WKT round-trips match. (PostGIS uses the
-opposite long/lat order; that difference is documented, not adopted.) The full
-convention, including GeoJSON/WKB, is captured in the PoC's `axis-order.md` and should be
-folded into user docs.
+on 4326 errors "Latitude 100 ... out of range"). v1 follows MySQL's axis order so that
+`ST_Latitude`/`ST_Longitude`, distances, and WKT round-trips match.
+
+WKB carries two bare doubles with no axis labels, so **the same bytes mean different
+things in the two ecosystems**: a 4326 `POINT` written by MySQL (and by this design) is
+(latitude, longitude), while the identical bytes written by PostGIS are (longitude,
+latitude), because PostGIS uses one fixed easting/longitude-first order for every SRS
+instead of the authority-defined one. This is not specific to 4326: roughly a third of
+the SRIDs in MySQL's catalog disagree with PostGIS, across both geographic and projected
+systems. GeoJSON (RFC 7946, always longitude-first) and the explicit
+`ST_Latitude`/`ST_Longitude` accessors are the two unambiguous paths. The full
+convention, the per-SRID counts, and the migration guidance are in the PoC's
+`axis-order.md` and should be folded into user docs.
 
 **Coordinate validation.** For 4326, out-of-range latitude/longitude errors on ingest
 (matching MySQL codes/wording as closely as practical), across every constructor and I/O
@@ -138,34 +209,36 @@ For SRID 0, only non-finite overflow (Inf/NaN) is rejected, as in MySQL.
 **Extension path (documented, not built here).** Later SRID expansion, layered by cost so
 the cheap high-value part can land without the expensive part:
 
-- **SRS catalog** — populate `information_schema.st_spatial_reference_systems` from the
+- **SRS catalog**: populate `information_schema.st_spatial_reference_systems` from the
   EPSG dataset (MySQL ships ~5,200 entries) with the per-SRS metadata the engine needs:
   class (PROJECTED vs GEOGRAPHIC), axis order, coordinate bounds, unit, ellipsoid.
   Prerequisite for everything below.
-- **All PROJECTED SRSs** (e.g. 3857 Web Mercator) — low extra cost: they are planar X/Y,
+- **All PROJECTED SRSs** (e.g. 3857 Web Mercator): low extra cost, they are planar X/Y,
   so the same Cartesian functions apply; the only per-SRS input is coordinate bounds.
-- **GEOGRAPHIC SRSs beyond 4326** — moderate: exact geodesic refine per ellipsoid.
-- **PostGIS-level** (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform` between SRSs) —
+- **GEOGRAPHIC SRSs beyond 4326**: moderate, needs exact geodesic refine per ellipsoid.
+- **PostGIS-level** (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform` between SRSs):
   bigger, needs on-the-fly reprojection (a PROJ-like library); explicitly out of scope.
 
-v1 deliberately hard-restricts columns to SRID 0 or 4326 at DDL, so no partial-SRS
-behavior escapes before the catalog exists.
+v1 deliberately hard-restricts the `SRID n` column attribute to 0 or 4326 at DDL, so no
+partial-SRS behavior escapes before the catalog exists. An unrestricted `GEOMETRY` column
+can still *hold* values of any SRID, which are stored losslessly and read back unchanged
+but which no v1 function computes on (see [Types and storage](#types-and-storage)).
 
 ### Function set
 
-The v1 function set is the minimal set needed to **store, read, and query** geometry —
+The v1 function set is the minimal set needed to **store, read, and query** geometry:
 everything an application needs to put geometry in, get it out, inspect it, measure it,
 and filter rows by spatial relationship. The geometry-*processing* tail (`ST_Buffer`,
-`ST_Union`, `ST_Intersection`, …), the typed I/O aliases, the MBR predicate family,
+`ST_Union`, `ST_Intersection`, ...), the typed I/O aliases, the MBR predicate family,
 geohash, and niche accessors are a **separate later milestone** (they are pure
 expression-layer builtins, orthogonal to both this layer and the index). The
 authoritative full MySQL catalog with the v1-vs-tail split is `mysql-function-catalog.md`.
 
-v1 functions (all present in MySQL 8.0.46 / 8.4 / 9.7 — the spatial function set is
-identical across those versions):
+v1 functions (all present in MySQL 8.0.46 / 8.4 / 9.7, where the spatial function set
+is identical across those versions):
 
-- **I/O — readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
-- **I/O — writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
+- **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
+- **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
 - **Constructors (function-call syntax):** `Point`, `LineString`, `Polygon` (the
   `Multi*`/`GeometryCollection` constructors are in the tail).
 - **Accessors:** `ST_X`, `ST_Y`, `ST_Latitude`, `ST_Longitude`, `ST_SRID` (getter and the
@@ -203,9 +276,9 @@ over such an expression is correctly rejected (a spatial index is the index laye
 
 The geometry stack is **pure Go**, no cgo/libgeos:
 
-- `github.com/peterstace/simplefeatures` — OGC/DE-9IM geometry model, WKT/WKB/GeoJSON
+- `github.com/peterstace/simplefeatures`: OGC/DE-9IM geometry model, WKT/WKB/GeoJSON
   I/O, predicates, and planar measurement. Validated byte-identical to MySQL in the PoC.
-- `github.com/golang/geo` (Google's S2 port, Apache 2.0) — spherical geometry for the
+- `github.com/golang/geo` (Google's S2 port, Apache 2.0): spherical geometry for the
   geodesic 4326 paths.
 - A small in-tree geodesic helper (`pkg/util/geomrel`) for ellipsoidal distance/length
   (Andoyer) and the geodesic region refine.
@@ -213,7 +286,7 @@ The geometry stack is **pure Go**, no cgo/libgeos:
 Pure Go matters: the whole spatial stack builds with `CGO_ENABLED=0`, so there is no
 libgeos dependency in the Bazel/CI sandbox. The only Bazel follow-up is adding the new
 pure-Go deps to `DEPS.bzl` as proxy-fetch entries (no cc-toolchain wiring). The
-geometry-*processing* tail (buffer/union/…) may later need GEOS-equivalent algorithms;
+geometry-*processing* tail (buffer/union/...) may later need GEOS-equivalent algorithms;
 that is deferred with the rest of the tail and kept off this layer's critical path.
 
 ### Type plumbing
@@ -221,17 +294,17 @@ that is deferred with the rest of the tail and kept off this layer's critical pa
 `TypeGeometry` must flow correctly through the generic value machinery so that geometry
 behaves like any other column value outside the `ST_*` functions. The PoC audited ~28
 operations (GROUP BY, hash/merge join, DISTINCT, ORDER BY, UPDATE/DELETE/REPLACE, window,
-`INSERT … SELECT`, `UNION`, …); the concrete touch points are:
+`INSERT ... SELECT`, `UNION`, ...); the concrete touch points are:
 
-- `pkg/parser` — geometry type grammar and the `SRID` column attribute (regenerates
+- `pkg/parser`: geometry type grammar and the `SRID` column attribute (regenerates
   `parser.go` once; the only grammar change, since `ST_*` functions are generic calls,
   not grammar).
-- `pkg/types` / field type — the geometry field type and its flen/charset handling.
-- `pkg/util/chunk` — `Row.GetDatum` must return geometry as a binary string (the PoC
-  found `INSERT … SELECT` nulled geometry without this).
-- `pkg/expression/builtin_cast.go` — cast-to-string flen setup (the PoC found `UNION`
+- `pkg/types` / field type: the geometry field type and its flen/charset handling.
+- `pkg/util/chunk`: `Row.GetDatum` must return geometry as a binary string (the PoC
+  found `INSERT ... SELECT` nulled geometry without this).
+- `pkg/expression/builtin_cast.go`: cast-to-string flen setup (the PoC found `UNION`
   asserted without this).
-- `pkg/expression` — the `ST_*` builtins (`builtin_geo.go`) and their registration.
+- `pkg/expression`: the `ST_*` builtins (`builtin_geo.go`) and their registration.
 
 Geometry sorts/compares/hashes as its binary EWKB string; this is well-defined but not
 spatially meaningful (that is what the index and predicates are for).
@@ -280,22 +353,24 @@ index layer ships behind its own separate flag on top of this one.
 
 Explicitly **out of scope** for this design (each has a home):
 
-- The **spatial index** and its pushdown — `docs/design/2026-06-25-spatial-index.md`
+- The **spatial index** and its pushdown, in `docs/design/2026-06-25-spatial-index.md`
   (#69473). This layer is its prerequisite.
 - The **geometry-processing function tail** (`ST_Buffer`/`Union`/`Intersection`/
-  `Difference`/`ConvexHull`/`Simplify`/…), typed I/O aliases, MBR predicate family,
-  geohash functions, niche accessors — a later, parallel expression-layer milestone.
-- **SRIDs beyond 0 and 4326**, the SRS catalog, and `ST_Transform` — the documented
+  `Difference`/`ConvexHull`/`Simplify`/...), typed I/O aliases, MBR predicate family,
+  geohash functions, niche accessors: a later, parallel expression-layer milestone.
+- **SRIDs beyond 0 and 4326**, the SRS catalog, and `ST_Transform`: the documented
   extension path above.
-- **Coprocessor pushdown** of `ST_*` predicates — an optimization that lands with/after
+- **Coprocessor pushdown** of `ST_*` predicates: an optimization that lands with/after
   the index; this layer evaluates predicates at the TiDB root.
-- **3D / measured (Z/M) coordinates** — 2D only, as in MySQL/MariaDB.
+- **3D / measured (Z/M) coordinates**: computation is 2D only, as in MySQL/MariaDB. The
+  values are storable and round-trip unchanged, so the functions can be added later
+  without a format change (see [Types and storage](#types-and-storage)).
 
 ### Compatibility
 
 - **Partition table / clustered index / async commit:** geometry is an ordinary column
-  value; no interaction. (A geometry column cannot be a primary key or clustering key —
-  it has no meaningful ordering.)
+  value; no interaction. (A geometry column cannot be a primary key or clustering key,
+  since it has no meaningful ordering.)
 - **Charset & collation:** irrelevant to the geometry value (binary EWKB); a geometry
   column has no user charset/collation.
 - **Parser:** one-time geometry-type + `SRID` grammar change; `ST_*` are generic function
@@ -310,7 +385,7 @@ Explicitly **out of scope** for this design (each has a home):
 - **TiFlash / BR / TiCDC / Dumpling / Lightning:** geometry is regular column data;
   round-trips need only that the tools carry the value bytes and the `SRID`/type
   metadata. Dump/reload uses MySQL-compatible EWKB / WKT.
-- **Upgrade:** additive — new type and functions behind a flag.
+- **Upgrade:** additive, with the new type and functions behind a flag.
 - **Downgrade:** a table with a geometry column cannot be read by a release without the
   type; downgrade requires dropping geometry columns first (same as other new type kinds;
   to be confirmed during implementation).
@@ -322,7 +397,7 @@ Explicitly **out of scope** for this design (each has a home):
 - I/O round-trips: `ST_GeomFromText`/`ST_AsText`, `ST_GeomFromWKB`/`ST_AsBinary`,
   `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
   (including MySQL's `ST_AsText` spacing and axis order).
-- Accessors/measurement: `ST_X/Y/Latitude/Longitude/SRID/GeometryType/Dimension/…` and
+- Accessors/measurement: `ST_X/Y/Latitude/Longitude/SRID/GeometryType/Dimension/...` and
   `ST_Area/Length/Distance/Distance_Sphere` against cross-checked MySQL values (e.g. the
   1-degree geodesic distances in `srid-support-reference.md`).
 - Predicates: the eight DE-9IM predicates (+ `Covers`/`CoveredBy`) on curated geometry
@@ -330,8 +405,13 @@ Explicitly **out of scope** for this design (each has a home):
   covered.
 - SRID validation: 4326 out-of-range lat/long errors on every ingest path; SRID 0 Inf/NaN
   rejection; mixed-SRID predicate errors.
-- Type plumbing: geometry through GROUP BY, joins, DISTINCT, ORDER BY, `INSERT … SELECT`,
-  `UNION`, UPDATE/DELETE/REPLACE — the PoC's audited surface — returns correct bytes.
+- Extended data: values with Z/M coordinates and with SRIDs outside 0 and 4326 store and
+  read back byte-identical, while every function that interprets coordinates errors
+  clearly on them.
+- Format version: a value written with version 1 decodes; an unknown or zero version byte
+  is rejected with a clear error rather than misparsed.
+- Type plumbing: geometry through GROUP BY, joins, DISTINCT, ORDER BY, `INSERT ... SELECT`,
+  `UNION`, UPDATE/DELETE/REPLACE (the PoC's audited surface) returns correct bytes.
 
 ### Scenario Tests
 
@@ -355,8 +435,8 @@ Explicitly **out of scope** for this design (each has a home):
   decode cost is acceptable.
 - Predicate full-scan latency across selectivities (this is the pre-index baseline the
   index layer will be measured against).
-- The value-format choice (raw EWKB vs version-tagged/lean): decode ns/op on the point
-  and polygon paths, to settle the pre-GA encoding.
+- Version 1 (EWKB payload) vs a lean payload: decode ns/op on the point and polygon
+  paths, to decide whether a format version 2 is worth adding.
 
 ## Impacts & Risks
 
@@ -369,8 +449,9 @@ Risks:
 - **Prerequisite coupling (downstream):** the index and pushdown layers code against this
   type; the value-format and axis-order decisions here are lock-ins for them, so they are
   settled in this design.
-- **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by a
-  format-version byte (Unresolved Questions).
+- **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by the
+  leading format-version byte and by storing Z/M and unsupported SRIDs losslessly from
+  the start (see [Types and storage](#types-and-storage)).
 - **4326 semantics gaps:** geodesic `ST_Area`, polygon/polygon geodesic relations, and
   planar-vs-geodesic refine edge cases diverge from MySQL near poles/antimeridian;
   mitigated by documenting the v1 limitation and erroring rather than silently returning
@@ -396,16 +477,17 @@ Risks:
 
 ## Unresolved Questions
 
-- **Internal value format:** confirm the version-tagged layout beyond the leading format
-  byte — whether to strip the redundant per-row SRID / byte-order flags and adopt a
-  flat-`f64` point layout — benchmark-gated (`storage-format.md`). `ST_AsBinary` output
-  stays MySQL EWKB regardless.
+- **A leaner format version 2:** whether to add one before GA (dropping the per-row SRID
+  on SRID-restricted columns and the byte-order flags, shrinking the type enum, flat
+  `f64` points) or to ship version 1 and revisit. Benchmark-gated (`storage-format.md`),
+  and the version byte means it can also land after GA. `ST_AsBinary` output stays MySQL
+  EWKB either way.
 - **Geodesic `ST_Area` on 4326:** implement (Karney ellipsoidal area) in v1, or error
   like MySQL's Cartesian-only functions until implemented?
 - **MySQL error-code/message parity:** how closely to match MySQL's exact GIS error codes
   and wording for out-of-range coordinates, invalid geometries, and mixed-SRID errors.
 - **Feature-flag name and default:** `tidb_enable_spatial` (proposed); default off then
-  removed after stabilization — confirm naming and the removal milestone.
+  removed after stabilization; confirm naming and the removal milestone.
 - **4326 refine scope for v1:** accept planar polygon/polygon refine + the geodesic
   point-in-polygon as the documented limitation, or widen geodesic coverage before GA?
 - **Exact v1 function boundary:** confirm which accessors/aliases are v1 vs tail against

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -193,7 +193,8 @@ at every boundary; both engines emit the same WKB.
 | Fill the catalog from the full EPSG dataset, taken from EPSG or PROJ's `proj.db`, with the dataset version pinned in the docs and IOGP attribution carried. The set drifts: MySQL shipped 5,152 rows in 8.0.46 and 5,238 in 8.4 and 9.7 | moderate, and a prerequisite for the rest |
 | All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
 | Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
-| PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform`) | bigger: on-the-fly reprojection needs a PROJ-like library; out of scope |
+| `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
+| PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, user-defined SRSs) | bigger: needs a PROJ-like library for arbitrary reprojection; out of scope |
 
 DDL restricts the `SRID n` attribute to 0 or 4326. An unrestricted `GEOMETRY` column may
 still hold values of any SRID (see [Types and storage](#types-and-storage)).
@@ -379,7 +380,8 @@ Out of scope here, each with a home:
 - The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash and
   niche accessors: a later, parallel expression-layer milestone.
 - **SRIDs beyond 0 and 4326**, the full SRS catalog and `ST_Transform`: the extension path
-  above.
+  above. `ST_Transform` is MySQL functionality rather than a PostGIS extra, but it has
+  nothing to do until more SRSs exist, so it is out of scope for v1.
 - **Coprocessor pushdown.** The predicates and measurement functions are deterministic
   scalars and pushdown-eligible; pushing them filters at the storage node instead of
   shipping every candidate geometry to TiDB, with or without an index. It is cross-repo work
@@ -427,7 +429,8 @@ Out of scope here, each with a home:
 - Predicates: the eight DE-9IM predicates plus `Covers`/`CoveredBy` on curated geometry
   pairs, matched to MySQL where semantics agree, with boundary cases explicit.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN rejection,
-  mixed-SRID predicate errors.
+  and mixed-SRID arguments to a binary geometry function giving `ERROR 3033`, while the
+  SQL comparison operators keep comparing the stored bytes without erroring.
 - The catalog: `st_spatial_reference_systems` returns the two rows with the same column
   values MySQL gives for SRID 0 and 4326, and `CREATE SPATIAL REFERENCE SYSTEM` errors.
 - Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -50,7 +50,8 @@ index) extends it without a new design. This replaces the earlier geospatial des
 | --- | --- |
 | [OGC](https://www.ogc.org/standard/sfa/) | Open Geospatial Consortium, the body behind *Simple Features*, the specification MySQL's spatial surface follows. |
 | [WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) | The OGC text and byte encodings of a geometry (`POINT(1 2)` and its bytes). Neither carries an SRID. |
-| [EWKB](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html) | WKB with the SRID alongside it. MySQL uses `<srid u32 LE><WKB>`; see [Types and storage](#types-and-storage). |
+| [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb) | Extended WKB, the PostGIS/GEOS superset of WKB: type-word flags add Z, M and an embedded SRID. The stored format here; see [Types and storage](#types-and-storage). Not to be confused with [MySQL's internal format](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html), a 4-byte SRID prefix over 2D WKB. |
+| ISO WKB | The other WKB extension (SFA 1.2.1 / SQL-MM), which encodes Z/M by adding 1000/2000/3000 to the type code instead of using flags, and carries no SRID. |
 | SRS | Spatial reference system: coordinate system, units, axis order, datum. Either *projected* (flat X/Y) or *geographic* (latitude/longitude on an ellipsoid). |
 | [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | The integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
 | [EPSG](https://epsg.org/) | The registry that assigns SRIDs, and the source of the SRS catalog. |
@@ -79,6 +80,15 @@ index work merges on top.
 
 ## Detailed Design
 
+**MySQL-compatible, extensible where the extension is free.** Every v1 function behaves as
+MySQL does, and where MySQL cannot express a value the function errors rather than
+inventing behavior. The storage layer is deliberately wider: it carries Z/M coordinates
+and any SRID losslessly, and WKB input accepts them, so such values are stored and read
+back intact even though no v1 function computes on them and the MySQL-shaped writers
+(`ST_AsBinary`, `ST_AsText`, `ST_AsGeoJSON`) reject them. Widening the functions later is
+an extension that breaks MySQL parity by addition, and belongs to the release that makes
+it, not to this one.
+
 ### Types and storage
 
 Types, all reusing the existing `mysql.TypeGeometry` field type with the subtype a
@@ -91,25 +101,31 @@ encoding is introduced.
 Stored value:
 
     <format_version u8><payload>
-    version 1:  <srid u32 LE><OGC WKB>          // EWKB
+    version 1:  EWKB
+
+**Version 1 is [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb)** as defined
+by PostGIS and GEOS: standard WKB whose 32-bit type word carries three high-bit flags,
+`0x80000000` for Z, `0x40000000` for M, and `0x20000000` meaning a `u32` SRID follows the
+type word on the outermost geometry. It is chosen because it is a published format that
+already expresses everything this design has to store, and because it degrades exactly
+right: a 2D geometry with no SRID flag *is* plain OGC WKB, byte for byte.
 
 | Rule | |
 | --- | --- |
 | Versioning | Numbered from 1, so a leading `0x00` is always invalid and never a version. A release reads every earlier version and writes the current one, so a later format needs no migration. |
 | Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
-| SRID | Recoverable from the value, or from the column where it carries `SRID n`. Not droppable from the value unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata. |
-| MySQL bytes | Not matched. `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary; MySQL itself stores coordinates longitude-first internally and swaps per SRS on every WKT/WKB read and write (`axis-order.md`). |
-| Z and M coordinates | Stored and returned unchanged. Every v1 function is 2D, as in MySQL. |
+| SRID | Carried by the SRID flag. Where the column fixes it with `SRID n` the flag may be left unset, which is still valid EWKB, so this redundancy can be removed without leaving the format. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
+| Byte order | Left to EWKB, which flags it per geometry and permits both. |
+| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL itself converts too, storing coordinates longitude-first internally and swapping per SRS on every WKT/WKB read and write, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point (`axis-order.md`). |
+| Coordinate dimension | XY, XYZ, XYM and XYZM are all storable, which covers GeoJSON positions (XY and XYZ) as well as measured geometry. Every v1 function is 2D, as in MySQL. |
 | SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
-Extended data (the last two rows) round-trips through `ST_GeomFromWKB`/`ST_GeomFromText`
-and `ST_AsBinary`/`ST_AsText`, with `ST_SRID` and `ST_GeometryType` still answering, while
-every function that interprets coordinates rejects it with a clear error. Storing more
-than v1 computes on is what lets 3D/measured geometry and the wider SRS catalog arrive
-later as functions over data written today.
-
-Why EWKB is version 1 and what a version 2 would strip:
-[Investigation & Alternatives](#investigation--alternatives).
+Extended data, meaning Z/M coordinates and SRIDs the functions do not support, follows the
+compatibility rule above: stored losslessly, read back unchanged, `ST_SRID` and
+`ST_GeometryType` still answering, everything that interprets coordinates erroring.
+Storing more than v1 computes on is what lets 3D/measured geometry and the wider SRS
+catalog arrive later as functions over data written today. Why EWKB rather than the
+alternatives: [Investigation & Alternatives](#investigation--alternatives).
 
 ### SRID model
 
@@ -171,9 +187,9 @@ it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are ident
   later only if index-supported or by demand.
 
 The geometry-processing tail (`ST_Buffer`, `ST_Union`, `ST_Intersection`, ...), the typed
-I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash
-and the niche accessors are a later milestone; `mysql-function-catalog.md` holds the
-authoritative v1-vs-tail split.
+I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash,
+the niche accessors and the GeoJSON `options`/`srid` arguments are a later milestone;
+`mysql-function-catalog.md` holds the authoritative v1-vs-tail split.
 
 Semantics match MySQL, with three documented v1 limitations:
 
@@ -185,6 +201,23 @@ Semantics match MySQL, with three documented v1 limitations:
 - The predicates are OGC-correct via `simplefeatures`; on 4326 the region predicates use a
   geodesic point-in-polygon, which diverges from MySQL's planar refine near
   edges/poles/antimeridian. Polygon/polygon geodesic relations are a follow-up.
+
+**GeoJSON.** Every RFC 7946 geometry is supported, and the container and annotation members
+follow MySQL, verified against 8.4.6 and 9.7.2:
+
+| Input | Result |
+| --- | --- |
+| `Feature` | its bare geometry, so a Feature holding a point yields `POINT` |
+| `FeatureCollection` | `GEOMETRYCOLLECTION` of the features' geometries, `GEOMETRYCOLLECTION EMPTY` if there are none |
+| `"geometry": null` | SQL `NULL` |
+| `properties`, `id`, `bbox`, foreign members | ignored |
+| named `crs` URN | sets the SRID (`urn:ogc:def:crs:OGC:1.3:CRS84` is 4326, link-object CRSs are not accepted, and a nested `crs` naming a different SRID errors); absent, the SRID is 4326 |
+| position with more than two coordinates | rejected, MySQL error 3073 |
+
+MySQL's `options` argument, which accepts such positions and strips the extra coordinates,
+ships with the function tail, as do `ST_AsGeoJSON`'s bbox and CRS-URN flags. Round-trips
+are not idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a
+GeometryCollection.
 
 Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
 over such an expression is correctly rejected; a spatial index is the index layer's job.
@@ -282,7 +315,7 @@ Out of scope here, each with a home:
 | DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. |
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; predicates are ordinary `Selection`s. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
-| TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL EWKB / WKT. |
+| TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
 | Upgrade | Additive, behind the flag. |
 | Downgrade | Geometry columns must be dropped first, as with other new type kinds (to be confirmed). |
 
@@ -299,8 +332,10 @@ Out of scope here, each with a home:
   pairs, matched to MySQL where semantics agree, with boundary cases explicit.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN
   rejection, mixed-SRID predicate errors.
-- Extended data: Z/M values and SRIDs outside 0 and 4326 store and read back
-  byte-identical, while every function that interprets coordinates errors clearly.
+- Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
+  back byte-identical, while `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function
+  that interprets coordinates error clearly on them.
+- GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7.
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.
@@ -351,14 +386,28 @@ Risks:
 
 ## Investigation & Alternatives
 
-- **EWKB as format version 1, rather than a leaner layout now.** EWKB is what the proof of
-  concept (PR #69475) implements and needs no conversion today, not what is optimal:
-  `storage-format.md` measures its redundancy (a per-row SRID the column usually fixes, a
-  byte-order flag per (sub)geometry, WKB framing) and finds geometry decode a measurable
-  share of both the index-maintenance write path and the refine read path. A version 2 can
-  strip those, shrink the type enum, or store a point as two bare `f64` values. The
-  version byte defers that choice without a migration, which is why it ships in v1 even
-  though the format is the smallest of the measured performance levers.
+- **Which WKB dialect for version 1.** Three candidates, all published:
+
+  | Candidate | SRID | Z/M | Notes |
+  | --- | --- | --- | --- |
+  | MySQL internal, `<srid u32 LE><WKB>` | prefix | **no** | 2D only, so it cannot hold what this design commits to storing |
+  | ISO WKB (SFA 1.2.1 / SQL-MM) | no | type code +1000/2000/3000 | what `simplefeatures` already reads and writes |
+  | **EWKB (PostGIS/GEOS)** | type-word flag | type-word flags | chosen |
+
+  EWKB wins on coverage: one defined format carrying SRID, Z, M and XYZM, a superset of
+  what GeoJSON positions can express, with plain 2D WKB as its degenerate case. It also
+  keeps the obvious space optimization inside the format, since a value whose SRID is
+  fixed by the column can simply leave the SRID flag unset. The cost is a codec:
+  `simplefeatures` implements the ISO type-code convention (`geomCode % 1000` for the
+  type, `/ 1000` for the dimension), not EWKB's flags, so TiDB owns the EWKB header
+  encode/decode and hands the body to the library. On the TiKV side the `geo` crate is
+  2D-only and already hand-rolls its decoder, so it needs a header change and nothing
+  more; Z/M values are not pushable regardless.
+- **A leaner layout as version 1.** Rejected for now, not forever. `storage-format.md`
+  measures EWKB's redundancy (a per-row SRID the column usually fixes, a byte-order flag
+  per (sub)geometry, WKB framing) and finds geometry decode a measurable share of both the
+  index-maintenance write path and the refine read path, but the format is the smallest of
+  the measured levers. The version byte defers the choice without a migration.
 - **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a
   boundary conversion, and MySQL does the same thing internally (`axis-order.md`).
 - **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
@@ -375,7 +424,10 @@ Risks:
 
 - **A leaner format version 2:** add one before GA, or ship version 1 and revisit?
   Benchmark-gated (`storage-format.md`); the version byte means it can also land after GA.
-  `ST_AsBinary` output stays MySQL EWKB either way.
+  `ST_AsBinary` output stays MySQL-compatible plain WKB either way.
+- **Reading a Z/M value back:** the writers reject it, so today it returns only as the raw
+  column value in the stored format. Confirm that is enough, or give `ST_AsBinary` an
+  opt-in that emits EWKB with the flags set.
 - **Geodesic `ST_Area` on 4326:** implement Karney ellipsoidal area in v1, or error like
   MySQL's Cartesian-only functions until it exists?
 - **MySQL error parity:** how closely to match MySQL's GIS error codes and wording for

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -33,21 +33,18 @@
 This document proposes **basic geospatial support** for TiDB: a MySQL-compatible
 `GEOMETRY` type family, per-column [`SRID`](#terminology), versioned
 [EWKB](#terminology) storage, and the minimal `ST_*` function set that makes geometry
-storable, readable, and queryable. It covers **SRID 0** (Cartesian plane) and
-**SRID 4326** ([WGS 84](#terminology) geographic), including the
-[DE-9IM](#terminology) predicates. A geometry predicate has no index to use here, so it
-is evaluated row by row over whatever the access path returns; other predicates on the
-table pick their access path as usual.
+storable, readable and queryable. It covers **SRID 0** (Cartesian plane) and **SRID 4326**
+([WGS 84](#terminology) geographic), including the [DE-9IM](#terminology) predicates. A
+geometry predicate has no index here, so it filters row by row over whatever the access
+path returns; other predicates choose their access path as usual.
 
-It is deliberately **index-free**: the spatial index is specified separately in
-`docs/design/2026-06-25-spatial-index.md` (PR #69473) and builds on this layer. The scope
-here is the smallest slice that is independently useful and GA-able, designed so that
-later work (more SRIDs, the geometry-processing function tail, coprocessor pushdown, the
-index) extends it without a new design. This replaces the earlier geospatial design
-(PR #38916).
+It is **index-free**. The spatial index is specified in
+`docs/design/2026-06-25-spatial-index.md` (PR #69473) and builds on this layer; later work
+(more SRIDs, the function tail, coprocessor pushdown, the index) extends this design
+rather than replacing it. This replaces the earlier geospatial design (PR #38916).
 
-The MySQL behaviors and measurements quoted below were verified against running servers
-(8.4.6 and 9.7.2) and against the proof of concept, PR #69475.
+MySQL behaviors and measurements below were verified against running 8.4.6 and 9.7.2, and
+against the proof of concept, PR #69475.
 
 ## Terminology
 
@@ -55,44 +52,40 @@ The MySQL behaviors and measurements quoted below were verified against running 
 | --- | --- |
 | [OGC](https://www.ogc.org/standard/sfa/) | Open Geospatial Consortium, the body behind *Simple Features*, the specification MySQL's spatial surface follows. |
 | [WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) | Well-Known Text and Well-Known Binary, the OGC encodings of a geometry: `POINT(1 2)` and its byte form. |
-| [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb) | Extended WKB, the PostGIS/GEOS superset of WKB: type-word flags add Z, M and an embedded SRID. The stored format here; see [Types and storage](#types-and-storage). Not to be confused with [MySQL's internal format](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html), a 4-byte SRID prefix over 2D WKB. |
+| [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb) | Extended WKB, the PostGIS/GEOS superset of WKB: type-word flags add Z, M and an embedded SRID. The stored format here; see [Types and storage](#types-and-storage). Not [MySQL's internal format](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html), which is a 4-byte SRID prefix over 2D WKB. |
 | ISO WKB | The other WKB extension (OGC Simple Feature Access 1.2.1, also ISO 13249-3 SQL/MM), which encodes Z/M by adding 1000/2000/3000 to the type code instead of using flags, and carries no SRID. |
-| SRS | Spatial reference system: coordinate system, units, axis order, datum. Either *projected* (flat X/Y) or *geographic* (latitude/longitude on an ellipsoid). |
+| SRS | Spatial Reference System: coordinate system, units, axis order, datum. Either *projected* (flat X/Y) or *geographic* (latitude/longitude on an ellipsoid). |
 | [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | Spatial Reference System Identifier, the integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
-| [EPSG](https://epsg.org/) | The EPSG Geodetic Parameter Dataset, the registry that assigns SRIDs and the source of the SRS catalog. |
+| [EPSG](https://epsg.org/) | The EPSG Geodetic Parameter Dataset, published by IOGP, which assigns SRIDs. |
 | [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) | World Geodetic System 1984, the datum and reference ellipsoid used by GPS, registered as EPSG:4326. |
 | Planar vs geodesic | Measurement on a flat plane vs along the ellipsoid. Decided by SRS class, not per SRID. |
 | [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) | Dimensionally Extended 9-Intersection Model, the OGC model defining `ST_Within`, `ST_Contains`, `ST_Intersects` and the other topological predicates. |
 | [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) | JSON geometry encoding (RFC 7946), the third I/O format. |
-| MBR | Minimum bounding rectangle; basis of MySQL's `MBR*` predicates (deferred). |
+| MBR | Minimum Bounding Rectangle; basis of MySQL's `MBR*` predicates (deferred). |
 | [S2](http://s2geometry.io/) | Google's spherical-geometry library, used for the geodesic 4326 paths. |
 | [PROJ](https://proj.org/) | The reprojection library that arbitrary-SRS transforms would need; out of scope. |
 
 ## Motivation or Background
 
-Geospatial support is one of the most requested TiDB features: tracking issue #6347
-carries `feature/accepted` and ranks among the top open issues by reactions. The dominant
-workload is concrete, storing a location per row and answering "what is near me", "which
-region contains this point", or "what overlaps this box". Bike-share, ride-hailing, parcel
-delivery, and asset tracking all reduce to points plus proximity and geofence queries.
+Geospatial support is one of the most requested TiDB features: tracking issue #6347 carries
+`feature/accepted` and ranks among the top open issues by reactions. The dominant workload
+is storing a location per row and answering "what is near me", "which region contains this
+point", or "what overlaps this box". Bike-share, ride-hailing, parcel delivery and asset
+tracking all reduce to points plus proximity and geofence queries.
 
 TiDB has none of it today: only the `mysql.TypeGeometry` constant exists
 (`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions, so
 users encode geometry into scalar columns by hand and compute distances in the
-application, losing MySQL compatibility and correctness. This design covers the basic
-layer only, scoped so it can ship, stabilize, and have its feature flag removed before
-index work merges on top.
+application. This design covers the basic layer only, so it can ship, stabilize and have
+its feature flag removed before index work merges on top.
 
 ## Detailed Design
 
 **MySQL-compatible, extensible where the extension is free.** Every v1 function behaves as
-MySQL does, and where MySQL cannot express a value the function errors rather than
-inventing behavior. The storage layer is deliberately wider: it carries Z/M coordinates
-and any SRID losslessly, and WKB input accepts them, so such values are stored and read
-back intact even though no v1 function computes on them and the MySQL-shaped writers
-(`ST_AsBinary`, `ST_AsText`, `ST_AsGeoJSON`) reject them. Widening the functions later is
-an extension that breaks MySQL parity by addition, and belongs to the release that makes
-it, not to this one.
+MySQL does, and errors where MySQL cannot express a value. The storage layer is wider: WKB
+input accepts Z/M coordinates and any SRID, which are stored losslessly and read back
+intact, though no v1 function computes on them and the MySQL-shaped writers (`ST_AsBinary`,
+`ST_AsText`, `ST_AsGeoJSON`) reject them. Widening the functions later is out of scope here.
 
 ### Types and storage
 
@@ -108,30 +101,25 @@ Stored value:
     <format_version u8><payload>
     version 1:  EWKB
 
-**Version 1 is [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb)** as defined
-by PostGIS and GEOS: standard WKB whose 32-bit type word carries three high-bit flags,
+**Version 1 is [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb)** as defined by
+PostGIS and GEOS: standard WKB whose 32-bit type word carries three high-bit flags,
 `0x80000000` for Z, `0x40000000` for M, and `0x20000000` meaning a `u32` SRID follows the
-type word on the outermost geometry. It is chosen because it is a published format that
-already expresses everything this design has to store, and because it degrades exactly
-right: a 2D geometry with no SRID flag *is* plain OGC WKB, byte for byte.
+type word on the outermost geometry. Chosen because it expresses everything stored here,
+and because a 2D geometry with no SRID flag is plain OGC WKB byte for byte.
 
 | Rule | |
 | --- | --- |
-| Versioning | Numbered from 1, so a leading `0x00` is always invalid and never a version. A release reads every earlier version and writes the current one, so a later format needs no migration. |
+| Versioning | Numbered from 1, so a leading `0x00` is never a valid version. A release reads every earlier version and writes the current one, so a later format needs no migration. |
 | Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
-| SRID | Carried by the SRID flag. Where the column fixes it with `SRID n` the flag may be left unset, which is still valid EWKB, so this redundancy can be removed without leaving the format. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
+| SRID | Carried by the SRID flag, which may be left unset where the column fixes it with `SRID n`, since that is still valid EWKB. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
 | Byte order | Left to EWKB, which flags it per geometry and permits both. |
-| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL itself converts too, storing coordinates longitude-first internally and swapping per SRS on every WKT/WKB read and write, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point. |
-| Coordinate dimension | XY, XYZ, XYM and XYZM are all storable, which covers GeoJSON positions (XY and XYZ) as well as measured geometry. Every v1 function is 2D, as in MySQL. |
+| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL converts too, storing coordinates longitude-first internally, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point. |
+| Coordinate dimension | XY, XYZ, XYM and XYZM are storable, covering GeoJSON positions (XY and XYZ) and measured geometry. Every v1 function is 2D, as in MySQL. |
 | SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
-Extended data, meaning Z/M coordinates and SRIDs the functions do not support, follows the
-compatibility rule above: stored losslessly, read back unchanged, `ST_SRID` and
-`ST_GeometryType` still answering, everything that interprets coordinates erroring. Such a
-value comes back as the raw column value, which is enough for v1; giving the writers an
-opt-in that emits it is a later extension nothing here blocks.
-Storing more than v1 computes on is what lets 3D/measured geometry and the wider SRS
-catalog arrive later as functions over data written today. Why EWKB rather than the
+Extended data (Z/M coordinates, unsupported SRIDs) returns as the raw column value;
+`ST_SRID` and `ST_GeometryType` answer for it, and everything that interprets coordinates
+errors. An opt-in writer that emits it is a later extension. Why EWKB rather than the
 alternatives: [Investigation & Alternatives](#investigation--alternatives).
 
 ### SRID model
@@ -140,69 +128,74 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | --- | --- | --- |
 | Coordinate system | abstract Cartesian plane, unitless X/Y | WGS 84 geographic, latitude/longitude |
 | Bounds | none, the full finite IEEE-754 double range, as MySQL | latitude `[-90, 90]`, longitude `(-180, 180]` |
-| Rejected on ingest | Inf/NaN, MySQL `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
+| Rejected on ingest | Inf/NaN, `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
 | Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
 
-Those codes and their wording are matched as closely as possible, on `ST_GeomFromText`,
-the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike. The same goes for the
-other GIS errors (`ERROR 3618` for a function not implemented on a geographic SRS,
-`ERROR 3643` for an SRID that does not match the column). Where a message cannot be
-matched exactly it is a compatibility gap to close later, not a reason to invent a
-different code.
+Codes and wording are matched as closely as possible on every ingest path
+(`ST_GeomFromText`, the constructors, `ST_GeomFromGeoJSON`, `ST_GeomFromWKB`), as are
+`ERROR 3618` (function not implemented on a geographic SRS) and `ERROR 3643` (SRID does not
+match the column). An unmatched message is a gap to close, not grounds for a different code.
+
+Planar versus geodesic follows the **SRS class** (SRID 0 and projected are Cartesian,
+geographic is geodesic), as in MySQL. Adding SRIDs later therefore adds catalog rows and
+per-class parameters, not code paths.
 
 **Catalog.** `information_schema.st_spatial_reference_systems` ships with MySQL's shape
 (`SRS_NAME`, `SRS_ID`, `ORGANIZATION`, `ORGANIZATION_COORDSYS_ID`, `DEFINITION`,
-`DESCRIPTION`) and exactly the two supported rows, copied from MySQL: SRID 0 with an
-empty name and definition and no organization, and 4326 as `WGS 84` / `EPSG` / 4326 with
-the EPSG `GEOGCS["WGS 84",DATUM[...]]` definition string. It is read-only, so
-`CREATE SPATIAL REFERENCE SYSTEM` is rejected, and DDL validates the `SRID n` attribute
-against it rather than against a hardcoded pair, which makes widening SRID support a
-matter of adding rows. It also gives a client an honest answer to "which SRIDs does this
-server support", where today the question is an unknown-table error.
+`DESCRIPTION`) and two hard-coded rows: SRID 0 with an empty name and definition and no
+organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the `GEOGCS["WGS 84",DATUM[...]]`
+definition string. No dataset is imported: SRID 0 is not an EPSG record, and 4326 is one
+stable record taken from the [EPSG dataset](https://epsg.org/) rather than from a MySQL
+install. The table is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, and DDL
+validates `SRID n` against it rather than against a hardcoded pair. Without the table,
+asking which SRIDs a server supports is an unknown-table error.
 
-Planar versus geodesic is decided by the **SRS class** (SRID 0 and projected are
-Cartesian, geographic is geodesic), exactly as MySQL decides it, rather than by a
-per-SRID table of special cases. That class-based dispatch is the extension seam: adding
-SRIDs later adds catalog rows and per-class parameters, not code paths.
+**EPSG attribution.** The 4326 row is an EPSG record, so the dataset's terms of use apply:
+
+| Obligation | Discharged by |
+| --- | --- |
+| Acknowledge IOGP ownership "in any publication or transmission (by whatever means) thereof" | a comment on the constant, a line in the user docs, and a `LICENSES/EPSG-TERMS-OF-USE` entry beside the existing `QL-LICENSE` and `Unicode-DFS-2016-LICENSE` |
+| "Inform anyone to whom you provide the EPSG Facilities of these Terms of Use" | that entry carries the terms text, not a link to it |
+| Modified data must not be attributed to EPSG | the record is reproduced verbatim |
+| No value ascribed to the data, and no distribution for profit | nothing to do here; it constrains anyone repackaging TiDB |
+
+Acknowledgment text: *the EPSG Geodetic Parameter Dataset is owned by IOGP and used under
+its terms of use; TiDB reproduces the EPSG:4326 record unmodified.* The obligations are the
+same when the full dataset is imported later.
 
 **Axis order.** EPSG:4326 defines (latitude, longitude), so the first coordinate is the
-latitude, and v1 follows MySQL here so that `ST_Latitude`/`ST_Longitude`, distances and
-WKT round-trips match. WKB carries two unlabelled doubles, so the same bytes mean
-different things across ecosystems: PostGIS uses one fixed easting/longitude-first order
-for every SRS, and roughly a third of the SRIDs in MySQL's catalog disagree with it,
-across both geographic and projected systems. GeoJSON (RFC 7946, always longitude-first)
-and the explicit `ST_Latitude`/`ST_Longitude` accessors are the unambiguous paths.
-`ST_X`/`ST_Y` are not: they return the first and second coordinate, so on 4326 `ST_X` is
-the latitude here and in MySQL (verified: `ST_X` = `ST_Latitude` = 30 for
-`POINT(30 50)`) but the longitude in PostGIS. The per-SRID breakdown belongs in the user
-docs, as migration guidance.
+latitude, and v1 follows MySQL so that `ST_Latitude`/`ST_Longitude`, distances and WKT
+round-trips match. WKB carries two unlabelled doubles, so the same bytes mean different
+things across ecosystems: PostGIS uses one fixed easting/longitude-first order for every
+SRS, and roughly a third of the SRIDs in MySQL's catalog disagree with it, across both
+geographic and projected systems. GeoJSON (RFC 7946, always longitude-first) and the
+explicit `ST_Latitude`/`ST_Longitude` accessors are unambiguous. `ST_X`/`ST_Y` are
+positional, so on 4326 `ST_X` is the latitude here and in MySQL (verified: `ST_X` =
+`ST_Latitude` = 30 for `POINT(30 50)`) and the longitude in PostGIS. The per-SRID breakdown
+belongs in the user docs as migration guidance.
 
-Coordinates are **stored as parsed**, so latitude-first on 4326, which is also the order
-S2 wants and therefore costs no swap on the geodesic and index paths. MySQL stores the
-opposite order internally and swaps at every boundary
-([Types and storage](#types-and-storage)); both engines emit the same WKB, so the
-difference is invisible outside the stored bytes.
+Coordinates are **stored as parsed**, so latitude-first on 4326, which is the order S2 wants
+and costs no swap on the geodesic and index paths. MySQL stores the opposite order and swaps
+at every boundary; both engines emit the same WKB.
 
 **Extension path** (documented, not built here):
 
 | Step | Cost |
 | --- | --- |
-| Fill the catalog from the full EPSG dataset (MySQL ships 5,238 rows in both 8.4 and 9.7) with class, axis order, bounds, unit, ellipsoid | moderate, and a prerequisite for the rest |
+| Fill the catalog from the full EPSG dataset, taken from EPSG or PROJ's `proj.db`, with the dataset version pinned in the docs and IOGP attribution carried. The set drifts: MySQL shipped 5,152 rows in 8.0.46 and 5,238 in 8.4 and 9.7 | moderate, and a prerequisite for the rest |
 | All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
 | Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
 | PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform`) | bigger: on-the-fly reprojection needs a PROJ-like library; out of scope |
 
-DDL restricts the `SRID n` attribute to 0 or 4326, so no partial-SRS behavior escapes
-before the catalog exists. An unrestricted `GEOMETRY` column may still hold values of any
-SRID (see [Types and storage](#types-and-storage)).
+DDL restricts the `SRID n` attribute to 0 or 4326. An unrestricted `GEOMETRY` column may
+still hold values of any SRID (see [Types and storage](#types-and-storage)).
 
 ### Function set
 
-v1 is the minimal set needed to store, read, inspect, measure and filter geometry. All of
-it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical. The
-list below is an **allowlist**: only these functions are registered, and anything else
-spatial is simply an unknown function until a later milestone adds it. Growing the
-surface is then an explicit act rather than the default.
+v1 is the minimal set needed to store, read, inspect, measure and filter geometry, all of it
+present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical. The list is
+an **allowlist**: only these are registered, and anything else spatial is an unknown
+function until a later milestone adds it.
 
 - **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
 - **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
@@ -211,8 +204,7 @@ surface is then an explicit act rather than the default.
   `ST_SRID(g, srid)` setter), `ST_GeometryType`, `ST_Dimension`, `ST_Envelope`,
   `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
   `ST_ExteriorRing`, `ST_NumInteriorRings`, `ST_Centroid`. `ST_Centroid` is Cartesian-only,
-  as in MySQL, which raises `ERROR 3618` ("has not been implemented for geographic spatial
-  reference systems") for it on 4326.
+  as in MySQL, which raises `ERROR 3618` for it on 4326.
 - **Measurement:** `ST_Area`, `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`.
 - **Predicates (DE-9IM):** `ST_Within`, `ST_Contains`, `ST_Intersects`, `ST_Equals`,
   `ST_Disjoint`, `ST_Touches`, `ST_Crosses`, `ST_Overlaps`.
@@ -225,22 +217,20 @@ The geometry-processing tail (`ST_Buffer`, `ST_Union`, `ST_Intersection`, ...), 
 I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash,
 the niche accessors and the GeoJSON `options`/`srid` arguments are a later milestone.
 
-Semantics match MySQL, with three documented v1 limitations:
+Semantics match MySQL, with three v1 limitations:
 
 - On 4326, `ST_Distance`/`ST_Length` are ellipsoidal (Andoyer, matching MySQL to
   sub-metre); `ST_Distance_Sphere` is the great-circle variant.
-- `ST_Area` on 4326 **errors** in the shape MySQL uses for its own Cartesian-only
-  functions (`ERROR 3618`, "has not been implemented for geographic spatial reference
-  systems"). This is a documented divergence: MySQL does compute it geodesically
-  (12308778368.75 m2 for a 1-degree box). Erroring beats the alternatives, since a planar
-  degree2 or an off-by-0.45% spherical value would be silently wrong, and implementing
-  Karney ellipsoidal area is a later extension nothing here blocks.
+- `ST_Area` on 4326 **errors** with `ERROR 3618`, MySQL's shape for its own Cartesian-only
+  functions. This diverges: MySQL computes it geodesically (12308778368.75 m2 for a
+  1-degree box). A planar degree2 or an off-by-0.45% spherical value would be silently
+  wrong; Karney ellipsoidal area is a later extension.
 - The predicates are OGC-correct via `simplefeatures`, which is planar. On 4326 the region
-  predicates get a geodesic point-in-polygon, but polygon/polygon relations stay planar,
-  which diverges from MySQL. See Unresolved Questions: this is the one open item.
+  predicates get a geodesic point-in-polygon, but polygon/polygon relations stay planar and
+  diverge from MySQL. See [Unresolved Questions](#unresolved-questions).
 
-**GeoJSON.** Every RFC 7946 geometry is supported, and the container and annotation members
-follow MySQL, verified against 8.4.6 and 9.7.2:
+**GeoJSON.** Every RFC 7946 geometry is supported. The container and annotation members
+follow MySQL, verified on 8.4.6 and 9.7.2:
 
 | Input | Result |
 | --- | --- |
@@ -249,28 +239,27 @@ follow MySQL, verified against 8.4.6 and 9.7.2:
 | `"geometry": null` | SQL `NULL` |
 | `properties`, `id`, `bbox`, foreign members | ignored |
 | named `crs` URN | sets the SRID (`urn:ogc:def:crs:OGC:1.3:CRS84` is 4326, link-object CRSs are not accepted, and a nested `crs` naming a different SRID errors); absent, the SRID is 4326 |
-| position with more than two coordinates | rejected, MySQL error 3073 |
+| position with more than two coordinates | rejected, `ERROR 3073` |
 
 MySQL's `options` argument, which accepts such positions and strips the extra coordinates,
-ships with the function tail, as do `ST_AsGeoJSON`'s bbox and CRS-URN flags. Round-trips
-are not idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a
-GeometryCollection.
+ships with the function tail, as do `ST_AsGeoJSON`'s bbox and CRS-URN flags. Round-trips are
+not idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a GeometryCollection.
 
 Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
-over such an expression is correctly rejected; a spatial index is the index layer's job.
+over such an expression is rejected.
 
 ### Geometry engine
 
 Pure Go, no cgo, so the stack builds with `CGO_ENABLED=0` and needs no libgeos in the
-Bazel/CI sandbox (the only Bazel work is adding `DEPS.bzl` proxy-fetch entries):
+Bazel/CI sandbox; the only Bazel work is adding `DEPS.bzl` proxy-fetch entries.
 
 - `github.com/peterstace/simplefeatures`: OGC/DE-9IM model, WKT/WKB/GeoJSON I/O,
   predicates, planar measurement. Validated byte-identical to MySQL in the PoC.
 - `github.com/golang/geo` (Google's S2 port, Apache 2.0): spherical geometry for 4326.
 - `pkg/util/geomrel`: in-tree ellipsoidal distance/length (Andoyer) and geodesic refine.
 
-The processing tail may later need GEOS-equivalent algorithms; it is deferred with the
-rest of the tail and kept off this layer's critical path.
+The processing tail may need GEOS-equivalent algorithms; it is deferred with the rest of
+the tail.
 
 ### Type plumbing
 
@@ -282,13 +271,13 @@ hash/merge join, DISTINCT, ORDER BY, UPDATE/DELETE/REPLACE, window, `INSERT ... 
 - `pkg/parser`: geometry type grammar and the `SRID` column attribute. The only grammar
   change, since `ST_*` are generic calls; regenerates `parser.go` once.
 - `pkg/types` / field type: the geometry field type and its flen/charset handling.
-- `pkg/util/chunk`: `Row.GetDatum` must return geometry as a binary string (without this
-  the PoC found `INSERT ... SELECT` nulled geometry).
-- `pkg/expression/builtin_cast.go`: cast-to-string flen setup (without this the PoC found
-  `UNION` asserted).
+- `pkg/util/chunk`: `Row.GetDatum` must return geometry as a binary string; without this the
+  PoC found `INSERT ... SELECT` nulled geometry.
+- `pkg/expression/builtin_cast.go`: cast-to-string flen setup; without this the PoC found
+  `UNION` asserted.
 - `pkg/expression`: the `ST_*` builtins (`builtin_geo.go`) and their registration.
 
-Geometry sorts, compares and hashes as its binary value: well-defined, but not spatially
+Geometry sorts, compares and hashes as its binary value: well-defined, not spatially
 meaningful.
 
 ### SQL surface and examples
@@ -315,16 +304,16 @@ meaningful.
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
 
-`SHOW CREATE TABLE` emits the plain MySQL form (`loc point NOT NULL SRID 4326`). No
-spatial index syntax is part of this layer.
+`SHOW CREATE TABLE` emits the plain MySQL form (`loc point NOT NULL SRID 4326`). No spatial
+index syntax is part of this layer.
 
 ### Feature flag and rollout
 
 The layer is gated on a session/global system variable, `tidb_enable_geospatial`, default
-off. This is a **launch gate, not a compatibility switch**: there is no prior
-implementation to fall back to, so once the feature is stable in master the flag and its
-dead branches are removed in a cleanup PR, tracked in #6347. The index layer ships behind
-its own flag on top of this one.
+off. This is a **launch gate, not a compatibility switch**: there is no prior implementation
+to fall back to, so once the feature is stable in master the flag and its dead branches are
+removed in a cleanup PR, tracked in #6347. The index layer ships behind its own flag on top
+of this one.
 
 ### Scope and deferrals
 
@@ -332,42 +321,45 @@ Out of scope here, each with a home:
 
 - The **spatial index** and its pushdown: `docs/design/2026-06-25-spatial-index.md`
   (#69473), for which this layer is the prerequisite.
-- The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash,
+- The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash and
   niche accessors: a later, parallel expression-layer milestone.
-- **SRIDs beyond 0 and 4326**, the SRS catalog and `ST_Transform`: the extension path
+- **SRIDs beyond 0 and 4326**, the full SRS catalog and `ST_Transform`: the extension path
   above.
-- **Coprocessor pushdown.** The predicates and the measurement functions are ordinary
-  deterministic scalars, so they are pushdown-eligible in principle, and pushing them is
-  worthwhile *independently of the index*: it filters at the storage node instead of
-  shipping every candidate geometry to TiDB. It is out of scope here because it is
-  cross-repo work (tipb signatures plus a TiKV-side evaluator) and is specified with the
-  index design, which owns the pushdown contract. Nothing in this layer blocks it, and for
-  this design it is fine that the functions evaluate at the TiDB root.
-- **The other two spatial `information_schema` tables**: `st_geometry_columns`, one row
-  per geometry column and derivable from the schema, and `st_units_of_measure`, 47 static
-  rows in MySQL that only start to matter once projected SRSs with varied units exist.
+- **Coprocessor pushdown.** The predicates and measurement functions are deterministic
+  scalars and pushdown-eligible; pushing them filters at the storage node instead of
+  shipping every candidate geometry to TiDB, with or without an index. It is cross-repo work
+  (tipb signatures plus a TiKV-side evaluator), specified with the index design, which owns
+  the pushdown contract.
+- **The other two spatial `information_schema` tables**: `st_geometry_columns`, one row per
+  geometry column and derivable from the schema, and `st_units_of_measure`, 47 static rows
+  in MySQL that matter once projected SRSs with varied units exist.
+- **Where the per-SRS attributes come from.** MySQL's six columns do not expose the class,
+  axis order, bounds, unit or ellipsoid; those live inside the WKT `DEFINITION`, which MySQL
+  parses at runtime. The full-catalog work chooses between a WKT SRS parser, which
+  `CREATE SPATIAL REFERENCE SYSTEM` needs anyway, and internal parsed metadata. Neither
+  widens this table: extra columns belong in a TiDB-specific companion, expressed as WKT2
+  (ISO 19162) or PROJJSON.
 - **The axis-order controls**: MySQL's `axis-order=long-lat` option argument on
-  `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let
-  a client read or write longitude-first against a latitude-first SRS. Both exist in MySQL
-  and ship here with the function tail.
-- **3D / measured (Z/M) geometry**: computation is 2D only, as in MySQL/MariaDB, but the
-  values are stored and returned unchanged, so the functions can be added without a format
-  change.
+  `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let a
+  client read or write longitude-first against a latitude-first SRS. Both ship with the
+  function tail.
+- **3D / measured (Z/M) geometry**: computation is 2D only, as in MySQL/MariaDB, while the
+  values are stored and returned unchanged.
 
 ### Compatibility
 
 | Area | Effect |
 | --- | --- |
-| Partition table, clustered index, async commit | None. It cannot be a primary or clustering key, having no meaningful ordering. |
+| Partition table, clustered index, async commit | None. Geometry cannot be a primary or clustering key, having no meaningful ordering. |
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
-| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. `ALTER` follows MySQL, verified on 8.4.6: adding or changing `SRID n` validates every existing row and fails with `ERROR 3643` on the first mismatch; dropping the attribute always succeeds; narrowing the subtype (`GEOMETRY` to `POINT`) succeeds only if every value fits, else `ERROR 1416`; widening always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. No reinterpretation ever happens: an SRID change is validation, never a coordinate rewrite. |
+| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. `ALTER` follows MySQL, verified on 8.4.6: adding or changing `SRID n` validates every existing row and fails with `ERROR 3643` on the first mismatch; dropping the attribute always succeeds; narrowing the subtype (`GEOMETRY` to `POINT`) succeeds only if every value fits, else `ERROR 1416`; widening always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. An SRID change is validation, never a coordinate rewrite. |
 | `information_schema` | One new table, `st_spatial_reference_systems`, read-only with two static rows. Its two siblings in MySQL are deferred. |
-| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own, so they filter whatever rows the chosen path returns. No new operator, access path or statistics. |
+| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
 | Upgrade | Additive, behind the flag. |
-| Downgrade | The usual new-type situation: a release without the type cannot read a table that has a geometry column, so those columns have to go first, which is an ordinary `DROP COLUMN`. |
+| Downgrade | A release without the type cannot read a table that has a geometry column, so those columns must be dropped first, an ordinary `DROP COLUMN`. |
 
 ## Test Design
 
@@ -377,12 +369,12 @@ Out of scope here, each with a home:
   `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
   including its `ST_AsText` spacing and axis order.
 - Accessors and measurement against values measured on MySQL, e.g. for a 1-degree step on
-  4326: `ST_Distance` 111319.49 m, `ST_Distance_Sphere` 111195.08 m, and `ST_Area` of a
-  1-degree box 12308778368.75 m2.
+  4326: `ST_Distance` 111319.49 m, `ST_Distance_Sphere` 111195.08 m, `ST_Area` of a 1-degree
+  box 12308778368.75 m2.
 - Predicates: the eight DE-9IM predicates plus `Covers`/`CoveredBy` on curated geometry
   pairs, matched to MySQL where semantics agree, with boundary cases explicit.
-- SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN
-  rejection, mixed-SRID predicate errors.
+- SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN rejection,
+  mixed-SRID predicate errors.
 - The catalog: `st_spatial_reference_systems` returns the two rows with the same column
   values MySQL gives for SRID 0 and 4326, and `CREATE SPATIAL REFERENCE SYSTEM` errors.
 - Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
@@ -392,6 +384,8 @@ Out of scope here, each with a home:
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.
+- DDL: the `ALTER` matrix above, including `ERROR 3643` on an SRID change that existing rows
+  violate and `ERROR 1416` on a narrowing that they do not fit.
 
 ### Scenario Tests
 
@@ -404,8 +398,8 @@ Out of scope here, each with a home:
 
 - MySQL byte-identical suite for the v1 function surface (the PoC's `spatial_compat`
   integration test is the basis).
-- Dumpling/Lightning round-trip of a table with geometry columns; TiCDC and BR
-  pass-through; behavior unaffected when TiFlash is absent.
+- Dumpling/Lightning round-trip of a table with geometry columns; TiCDC and BR pass-through;
+  behavior unaffected when TiFlash is absent.
 - Parser, DDL, planner and executor as listed in Compatibility.
 - Upgrade and downgrade paths.
 
@@ -414,8 +408,6 @@ Out of scope here, each with a home:
 - Geometry ingest and read throughput vs a scalar-encoded baseline.
 - Geometry-predicate latency across selectivities with no other predicate to narrow the
   scan, the pre-index baseline the index layer will be measured against.
-- Version 1 (EWKB payload) vs a lean payload: decode ns/op on the point and polygon paths,
-  to decide whether a format version 2 is worth adding.
 
 ## Impacts & Risks
 
@@ -426,16 +418,15 @@ application-side geometry code.
 Risks:
 
 - **Prerequisite coupling:** the index and pushdown layers code against this type, so the
-  value-format and axis-order decisions here are lock-ins for them and are settled here.
+  value-format and axis-order decisions here are lock-ins for them.
 - **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by the
   version byte and by storing Z/M and unsupported SRIDs losslessly from the start.
-- **4326 semantics gaps:** geodesic `ST_Area`, polygon/polygon geodesic relations and
-  refine edge cases diverge from MySQL near poles and the antimeridian; mitigated by
-  documenting the limitation and erroring rather than returning wrong values.
+- **4326 semantics gaps:** geodesic `ST_Area` and polygon/polygon relations diverge from
+  MySQL; mitigated by erroring or documenting rather than returning wrong values.
 - **MySQL error parity:** exact codes and messages may not match initially (the PoC used
   placeholder wording); a compatibility risk, not a correctness one.
 - **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the GEOS-class
-  processing tail, which is deferred, so v1 is unaffected.
+  processing tail, which is deferred.
 
 ## Investigation & Alternatives
 
@@ -443,61 +434,55 @@ Risks:
 
   | Candidate | SRID | Z/M | Notes |
   | --- | --- | --- | --- |
-  | MySQL internal, `<srid u32 LE><WKB>` | prefix | **no** | 2D only, so it cannot hold what this design commits to storing |
+  | MySQL internal, `<srid u32 LE><WKB>` | prefix | **no** | 2D only, so it cannot hold what this design stores |
   | ISO WKB (SFA 1.2.1 / SQL-MM) | no | type code +1000/2000/3000 | what `simplefeatures` already reads and writes |
   | **EWKB (PostGIS/GEOS)** | type-word flag | type-word flags | chosen |
 
-  EWKB wins on coverage: one defined format carrying SRID, Z, M and XYZM, a superset of
-  what GeoJSON positions can express, with plain 2D WKB as its degenerate case. It also
-  keeps the obvious space optimization inside the format, since a value whose SRID is
-  fixed by the column can simply leave the SRID flag unset. The cost is a codec:
-  `simplefeatures` implements the ISO type-code convention (`geomCode % 1000` for the
-  type, `/ 1000` for the dimension), not EWKB's flags, so TiDB owns the EWKB header
-  encode/decode and hands the body to the library. On the TiKV side the `geo` crate is
-  2D-only and already hand-rolls its decoder, so it needs a header change and nothing
-  more; Z/M values are not pushable regardless.
-- **A leaner layout as version 1.** Rejected for now, not forever.
-  EWKB carries redundancy (a per-row SRID the column usually fixes, a byte-order flag per
-  (sub)geometry, WKB framing), but profiling the proof of concept put the win in
-  perspective: geometry decode is ~2% of insert CPU, and on the read side WKB parsing is
-  ~27% of query CPU of which only about half is decoding the stored value, the rest being
-  a re-parse inside the predicate library that no storage format can remove. The version
-  byte defers the choice without a migration.
-- **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a
-  boundary conversion, and MySQL does the same thing internally.
+  EWKB carries SRID, Z, M and XYZM in one defined format, with plain 2D WKB as its
+  degenerate case, and keeps the space optimization in-format: a value whose SRID the column
+  fixes leaves the SRID flag unset. The cost is a codec. `simplefeatures` implements the ISO
+  type-code convention (`geomCode % 1000` for the type, `/ 1000` for the dimension), not
+  EWKB's flags, so TiDB owns the EWKB header encode/decode and hands the body to the
+  library. TiKV's `geo` crate is 2D-only and already hand-rolls its decoder, so it needs a
+  header change and nothing more; Z/M values are not pushable regardless.
+- **A leaner layout as version 1.** Rejected for v1. EWKB carries redundancy (a per-row
+  SRID the column usually fixes, a byte-order flag per (sub)geometry, WKB framing), but
+  profiling the PoC bounded the win: geometry decode is ~2% of insert CPU, and the ~27% of
+  query CPU spent parsing WKB is only about half attributable to the stored value, the rest
+  being a re-parse inside the predicate library that no format can remove. The version byte
+  defers the choice without a migration.
+- **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a boundary
+  conversion, and MySQL does the same internally.
 - **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
   `libgeos` in the Bazel/CI sandbox, which broke the build. The PoC moved to pure-Go
-  `simplefeatures` and stayed MySQL byte-identical. Revisit only for the processing tail.
-- **The full #38916 surface at once.** Rejected as too large to review and land; this is
-  the narrowed, independently shippable slice with the rest sequenced after.
+  `simplefeatures` and stayed MySQL byte-identical. Revisit for the processing tail.
+- **The full #38916 surface at once.** Rejected as too large to review and land.
 - **Geometry as a generic BLOB with application-side functions.** The status quo; loses
   MySQL compatibility, type safety, and any path to a spatial index.
-- **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of
-  MySQL parity; the differences are documented under SRID model.
+- **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of MySQL
+  parity; the differences are documented under SRID model.
 
 ## Unresolved Questions
 
 **Polygon/polygon relations on 4326.** MySQL treats a geographic polygon's edges as
-geodesics; `simplefeatures`, and every other pure-Go option, treats them as straight
-lines in latitude/longitude. That is not a near-boundary rounding difference. For
-`POLYGON((0 0, 0 80, 60 0, 0 0))` on 4326, MySQL 8.4.6 answers `ST_Within` **true** for
-the points `(30 40)`, `(33 40)`, `(36 40)` and `(40 40)`, while the same coordinates
-against the same ring evaluated planar (SRID 0) answer **false** for all four: the
-great-circle edge bows away from the straight one by degrees, so whole regions flip.
-Small polygons, the common geofence case, are unaffected.
+geodesics; `simplefeatures`, and every other pure-Go option, treats them as straight lines
+in latitude/longitude. For `POLYGON((0 0, 0 80, 60 0, 0 0))` on 4326, MySQL 8.4.6 answers
+`ST_Within` **true** for the points `(30 40)`, `(33 40)`, `(36 40)` and `(40 40)`, while the
+same coordinates against the same ring evaluated planar answer **false** for all four: the
+great-circle edge bows away from the straight one by degrees, so whole regions flip rather
+than boundary cases. Small polygons, the common geofence case, are unaffected.
 
-Three ways to resolve it, in increasing cost:
+Three resolutions, in increasing cost:
 
-1. **Ship planar polygon/polygon and document it.** Correct for small geofences, wrong
-   for continental ones, and wrong silently, which is the objection.
-2. **Error when it would matter.** Reject a geographic polygon/polygon relate whose
-   operands exceed some extent, so the answer is never silently wrong. Needs a defensible
-   threshold, and the error is a divergence of its own since MySQL answers.
+1. **Ship planar polygon/polygon and document it.** Correct for small geofences, silently
+   wrong for continental ones.
+2. **Error when it would matter.** Reject a geographic polygon/polygon relate whose operands
+   exceed some extent. Needs a defensible threshold, and the error is itself a divergence,
+   since MySQL answers.
 3. **Implement geodesic relate.** Full parity, and the only option that makes the index
-   layer's refine exact on 4326, but it needs a geographic DE-9IM implementation on both
-   the TiDB side and, once pushdown lands, the TiKV side. No pure-Go library provides
-   it today; S2 gives coverings and predicates on spherical shapes but not the DE-9IM
-   matrix, so this is real work rather than a dependency swap.
+   layer's refine exact on 4326. It needs a geographic DE-9IM implementation on the TiDB
+   side and, once pushdown lands, the TiKV side. No pure-Go library provides one: S2 gives
+   coverings and predicates on spherical shapes, not the DE-9IM matrix.
 
-The decision belongs to this design because the type layer owns predicate semantics, and
-it is a compatibility question rather than a format one, so it does not lock any bytes in.
+This design owns the decision, since the type layer owns predicate semantics. No bytes are
+locked in either way.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -1,0 +1,415 @@
+# TiDB Design Documents
+
+- Author(s): [Mattias Jonsson](http://github.com/mjonss)
+- Discussion PR: https://github.com/pingcap/tidb/pull/XXXXX
+- Tracking Issue: https://github.com/pingcap/tidb/issues/6347
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Motivation or Background](#motivation-or-background)
+* [Detailed Design](#detailed-design)
+    * [Types and storage](#types-and-storage)
+    * [SRID model](#srid-model)
+    * [Function set](#function-set)
+    * [Geometry engine](#geometry-engine)
+    * [Type plumbing](#type-plumbing)
+    * [SQL surface and examples](#sql-surface-and-examples)
+    * [Feature flag and rollout](#feature-flag-and-rollout)
+    * [Scope and deferrals](#scope-and-deferrals)
+    * [Compatibility](#compatibility)
+* [Test Design](#test-design)
+    * [Functional Tests](#functional-tests)
+    * [Scenario Tests](#scenario-tests)
+    * [Compatibility Tests](#compatibility-tests)
+    * [Benchmark Tests](#benchmark-tests)
+* [Impacts & Risks](#impacts--risks)
+* [Investigation & Alternatives](#investigation--alternatives)
+* [Unresolved Questions](#unresolved-questions)
+
+## Introduction
+
+This document proposes **basic geospatial support** for TiDB: a MySQL-compatible
+`GEOMETRY` type family (`POINT`, `LINESTRING`, `POLYGON`, and the multi/collection
+variants), per-column `SRID`, EWKB storage, and a minimal-but-useful set of `ST_*`
+functions covering I/O, accessors, measurement, and the DE-9IM spatial predicates. It
+supports **SRID 0 (Cartesian plane)** and **SRID 4326 (WGS 84 geographic)** and makes
+geometry values storable, queryable, and filterable — by full table scan. It is the
+prerequisite layer that a spatial **index** builds on, but it is deliberately
+**index-free**: geometry becomes a first-class value and query surface first, and the
+index lands separately.
+
+The scope is intentionally the smallest slice that is independently useful and GA-able,
+and it is designed so later work — more SRIDs, the long tail of geometry-processing
+functions, coprocessor pushdown, and the spatial index — extends it **without a new
+design**. This revives and narrows the earlier geospatial design (PR #38916), which
+covered a broader surface and was not merged. The spatial index is specified separately
+in `docs/design/2026-06-25-spatial-index.md` (PR #69473) and depends on this layer.
+
+## Motivation or Background
+
+Geospatial support is one of the most requested TiDB features. Tracking issue #6347
+carries the `feature/accepted` label and ranks among the top open issues by reactions.
+The dominant real-world workload is simple and concrete: store a location per row
+(latitude/longitude or a planar coordinate) and answer "what is near me", "which region
+contains this point", or "what overlaps this box". Bike-share, ride-hailing, parcel
+delivery, and asset-tracking applications all reduce to points plus proximity and
+geofence queries.
+
+TiDB has no spatial support today: only the `mysql.TypeGeometry` type constant exists
+(`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions.
+Users who need geometry today must encode it into scalar columns by hand and compute
+distances in the application, losing MySQL compatibility and correctness.
+
+The earlier geospatial design (PR #38916) proposed the full surface — types, functions,
+and an eventual index — but bundled too much to land, and explicitly deferred the index
+as "needs more research". Two things have changed since:
+
+1. The index research is done (PR #69473) and validated by an end-to-end proof of
+   concept, which also **fully prototyped this basic layer** as its prerequisite. The
+   type, EWKB storage, and a broad `ST_*` surface already work in pure Go.
+2. That PoC showed the right seam: **the basic type-and-function layer is a clean,
+   independently valuable milestone** that should merge on its own before the index, so
+   review stays small and geometry is usable the moment it lands.
+
+This document is that basic layer, scoped so it can ship, stabilize, and have its
+feature flag removed before index work starts merging on top.
+
+## Detailed Design
+
+### Types and storage
+
+The `GEOMETRY` type family follows MySQL: `GEOMETRY` (any subtype), `POINT`,
+`LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, and
+`GEOMETRYCOLLECTION`. All reuse the existing `mysql.TypeGeometry` field type; the
+concrete subtype is a constraint on the stored value, as in MySQL. A column may carry a
+`SRID n` attribute fixing its spatial reference system (see [SRID model](#srid-model)).
+
+The **stored value is EWKB**: a 4-byte little-endian SRID prefix followed by standard
+OGC WKB (`<srid_le_u32><wkb>`), matching MySQL's internal geometry storage byte-for-byte
+so that dump/reload and wire compatibility are natural. Geometry columns are stored as a
+binary string kind at the KV layer; no new column encoding is introduced.
+
+**Pre-GA value-format lock-in (decided here).** The on-disk value format is hard to
+change after release without a migration, so it is settled in *this* design (the type's
+owner), not the index design. Two observations from the PoC (`storage-format.md`):
+
+- Raw EWKB carries redundancy: a per-row SRID (already implied by the column's fixed
+  SRID), per-(sub)geometry byte-order flags, and WKB framing.
+- A **1-byte format-version tag** keeps the format evolvable at negligible cost, and a
+  flat-`f64` point layout could cheapen point decode.
+
+**Recommendation:** ship a version-tagged value format (at minimum a leading
+format-version byte) so the encoding can evolve; keep the wire/`ST_AsBinary` output
+MySQL-compatible EWKB regardless of the internal form. The exact internal layout beyond
+the version byte is an implementation choice measured during development; see Unresolved
+Questions.
+
+### SRID model
+
+v1 supports two spatial reference systems, chosen to cover the two coordinate-system
+*classes* that matter:
+
+- **SRID 0 — abstract Cartesian plane.** Unitless X/Y, no coordinate-range checking
+  (MySQL spans the full finite IEEE-754 double range). All functions are planar
+  (Cartesian).
+- **SRID 4326 — WGS 84 geographic (lat/long).** Coordinates are bounded (latitude
+  `[-90, 90]`, longitude `(-180, 180]`); distance/length/area are geodesic on the WGS 84
+  ellipsoid, matching MySQL.
+
+**Coordinate-system class drives planar-vs-geodesic**, exactly as MySQL decides it from
+the SRS class (SRID 0 / projected = Cartesian; geographic = geodesic). This class-based
+dispatch — not a per-SRID table of special cases — is the design's extension seam: adding
+SRIDs later is adding catalog rows and per-class parameters, not new code paths.
+
+**Axis order.** MySQL's EPSG:4326 is **(latitude, longitude)** — the first coordinate is
+latitude. This is verifiable from MySQL's own out-of-range error wording (`POINT(100 0)`
+on 4326 errors "Latitude 100 … out of range"). v1 follows MySQL's axis order so that
+`ST_Latitude`/`ST_Longitude`, distances, and WKT round-trips match. (PostGIS uses the
+opposite long/lat order; that difference is documented, not adopted.) The full
+convention, including GeoJSON/WKB, is captured in the PoC's `axis-order.md` and should be
+folded into user docs.
+
+**Coordinate validation.** For 4326, out-of-range latitude/longitude errors on ingest
+(matching MySQL codes/wording as closely as practical), across every constructor and I/O
+path (`ST_GeomFromText`, the typed constructors, `ST_GeomFromGeoJSON`, `ST_GeomFromWKB`).
+For SRID 0, only non-finite overflow (Inf/NaN) is rejected, as in MySQL.
+
+**Extension path (documented, not built here).** Later SRID expansion, layered by cost so
+the cheap high-value part can land without the expensive part:
+
+- **SRS catalog** — populate `information_schema.st_spatial_reference_systems` from the
+  EPSG dataset (MySQL ships ~5,200 entries) with the per-SRS metadata the engine needs:
+  class (PROJECTED vs GEOGRAPHIC), axis order, coordinate bounds, unit, ellipsoid.
+  Prerequisite for everything below.
+- **All PROJECTED SRSs** (e.g. 3857 Web Mercator) — low extra cost: they are planar X/Y,
+  so the same Cartesian functions apply; the only per-SRS input is coordinate bounds.
+- **GEOGRAPHIC SRSs beyond 4326** — moderate: exact geodesic refine per ellipsoid.
+- **PostGIS-level** (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform` between SRSs) —
+  bigger, needs on-the-fly reprojection (a PROJ-like library); explicitly out of scope.
+
+v1 deliberately hard-restricts columns to SRID 0 or 4326 at DDL, so no partial-SRS
+behavior escapes before the catalog exists.
+
+### Function set
+
+The v1 function set is the minimal set needed to **store, read, and query** geometry —
+everything an application needs to put geometry in, get it out, inspect it, measure it,
+and filter rows by spatial relationship. The geometry-*processing* tail (`ST_Buffer`,
+`ST_Union`, `ST_Intersection`, …), the typed I/O aliases, the MBR predicate family,
+geohash, and niche accessors are a **separate later milestone** (they are pure
+expression-layer builtins, orthogonal to both this layer and the index). The
+authoritative full MySQL catalog with the v1-vs-tail split is `mysql-function-catalog.md`.
+
+v1 functions (all present in MySQL 8.0.46 / 8.4 / 9.7 — the spatial function set is
+identical across those versions):
+
+- **I/O — readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
+- **I/O — writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
+- **Constructors (function-call syntax):** `Point`, `LineString`, `Polygon` (the
+  `Multi*`/`GeometryCollection` constructors are in the tail).
+- **Accessors:** `ST_X`, `ST_Y`, `ST_Latitude`, `ST_Longitude`, `ST_SRID` (getter and the
+  `ST_SRID(g, srid)` setter), `ST_GeometryType`, `ST_Dimension`, `ST_Envelope`,
+  `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
+  `ST_ExteriorRing`, `ST_NumInteriorRings`, `ST_Centroid`.
+- **Measurement:** `ST_Area`, `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`.
+- **Predicates (DE-9IM):** `ST_Within`, `ST_Contains`, `ST_Intersects`, `ST_Equals`,
+  `ST_Disjoint`, `ST_Touches`, `ST_Crosses`, `ST_Overlaps`.
+
+**PostGIS extras policy.** `ST_Covers` / `ST_CoveredBy` are PostGIS, not MySQL. They are
+included because they become **index-eligible region predicates** in the index layer
+(`Covers ⊇ Contains`, `CoveredBy ⊇ Within`, so a covering-cell prefilter is valid with no
+false negatives). Other PostGIS-only functions are added later only if index-supported or
+by demand.
+
+Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
+over such an expression is correctly rejected (a spatial index is the index layer's job).
+
+**Semantics match MySQL, with documented v1 limitations:**
+
+- Planar vs geodesic follows the SRS class. On 4326, `ST_Distance`/`ST_Length` are
+  ellipsoidal (Andoyer geodesic, matching MySQL to sub-metre); `ST_Distance_Sphere` is
+  the great-circle sphere variant.
+- `ST_Area` on 4326 is a known gap (geodesic polygon area on the ellipsoid, Karney):
+  either implement it or error like MySQL's Cartesian-only functions do (see Unresolved
+  Questions). It must not silently return a planar (degree²) or off-by-~0.45% spherical
+  value.
+- The DE-9IM predicates are OGC-correct via `simplefeatures`; on 4326 the region
+  predicates use a geodesic point-in-polygon where MySQL's planar refine diverges near
+  edges/poles/antimeridian. Polygon/polygon geodesic relations and geodesic `ST_Area` are
+  follow-ups.
+
+### Geometry engine
+
+The geometry stack is **pure Go**, no cgo/libgeos:
+
+- `github.com/peterstace/simplefeatures` — OGC/DE-9IM geometry model, WKT/WKB/GeoJSON
+  I/O, predicates, and planar measurement. Validated byte-identical to MySQL in the PoC.
+- `github.com/golang/geo` (Google's S2 port, Apache 2.0) — spherical geometry for the
+  geodesic 4326 paths.
+- A small in-tree geodesic helper (`pkg/util/geomrel`) for ellipsoidal distance/length
+  (Andoyer) and the geodesic region refine.
+
+Pure Go matters: the whole spatial stack builds with `CGO_ENABLED=0`, so there is no
+libgeos dependency in the Bazel/CI sandbox. The only Bazel follow-up is adding the new
+pure-Go deps to `DEPS.bzl` as proxy-fetch entries (no cc-toolchain wiring). The
+geometry-*processing* tail (buffer/union/…) may later need GEOS-equivalent algorithms;
+that is deferred with the rest of the tail and kept off this layer's critical path.
+
+### Type plumbing
+
+`TypeGeometry` must flow correctly through the generic value machinery so that geometry
+behaves like any other column value outside the `ST_*` functions. The PoC audited ~28
+operations (GROUP BY, hash/merge join, DISTINCT, ORDER BY, UPDATE/DELETE/REPLACE, window,
+`INSERT … SELECT`, `UNION`, …); the concrete touch points are:
+
+- `pkg/parser` — geometry type grammar and the `SRID` column attribute (regenerates
+  `parser.go` once; the only grammar change, since `ST_*` functions are generic calls,
+  not grammar).
+- `pkg/types` / field type — the geometry field type and its flen/charset handling.
+- `pkg/util/chunk` — `Row.GetDatum` must return geometry as a binary string (the PoC
+  found `INSERT … SELECT` nulled geometry without this).
+- `pkg/expression/builtin_cast.go` — cast-to-string flen setup (the PoC found `UNION`
+  asserted without this).
+- `pkg/expression` — the `ST_*` builtins (`builtin_geo.go`) and their registration.
+
+Geometry sorts/compares/hashes as its binary EWKB string; this is well-defined but not
+spatially meaningful (that is what the index and predicates are for).
+
+### SQL surface and examples
+
+The type and function surface is MySQL-compatible. Column definition:
+
+    col_name {GEOMETRY | POINT | LINESTRING | POLYGON | MULTIPOINT | ...}
+        [NOT NULL] [SRID {0 | 4326}]
+
+Example:
+
+    CREATE TABLE stores (
+      id  BIGINT PRIMARY KEY,
+      loc POINT NOT NULL SRID 4326
+    );
+
+    INSERT INTO stores VALUES
+      (1, ST_GeomFromText('POINT(37.4 -122.1)', 4326)),          -- lat, long (MySQL order)
+      (2, ST_PointFromText('POINT(37.8 -122.3)', 4326));         -- (typed alias is tail; Point()/ST_GeomFromText are v1)
+
+    -- read back
+    SELECT id, ST_AsText(loc), ST_Latitude(loc), ST_Longitude(loc) FROM stores;
+
+    -- measure (geodesic metres on 4326)
+    SELECT id, ST_Distance(loc, ST_GeomFromText('POINT(37.5 -122.2)', 4326)) AS m FROM stores;
+
+    -- filter by spatial relationship (full scan in this layer; the index accelerates it later)
+    SELECT id FROM stores
+    WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
+
+`SHOW CREATE TABLE` emits the plain MySQL form (`loc point NOT NULL SRID 4326`). No
+spatial index syntax is part of this layer.
+
+### Feature flag and rollout
+
+Gate the whole layer behind a session/global system variable, e.g.
+`tidb_enable_spatial` (default off initially). This is a **launch gate, not a
+compatibility switch**: because this is brand-new functionality with no prior
+implementation to fall back to, once the feature is stable in master the flag (and any
+dead gated-off branches) should be **removed** in a cleanup PR, tracked in #6347. The
+index layer ships behind its own separate flag on top of this one.
+
+### Scope and deferrals
+
+Explicitly **out of scope** for this design (each has a home):
+
+- The **spatial index** and its pushdown — `docs/design/2026-06-25-spatial-index.md`
+  (#69473). This layer is its prerequisite.
+- The **geometry-processing function tail** (`ST_Buffer`/`Union`/`Intersection`/
+  `Difference`/`ConvexHull`/`Simplify`/…), typed I/O aliases, MBR predicate family,
+  geohash functions, niche accessors — a later, parallel expression-layer milestone.
+- **SRIDs beyond 0 and 4326**, the SRS catalog, and `ST_Transform` — the documented
+  extension path above.
+- **Coprocessor pushdown** of `ST_*` predicates — an optimization that lands with/after
+  the index; this layer evaluates predicates at the TiDB root.
+- **3D / measured (Z/M) coordinates** — 2D only, as in MySQL/MariaDB.
+
+### Compatibility
+
+- **Partition table / clustered index / async commit:** geometry is an ordinary column
+  value; no interaction. (A geometry column cannot be a primary key or clustering key —
+  it has no meaningful ordering.)
+- **Charset & collation:** irrelevant to the geometry value (binary EWKB); a geometry
+  column has no user charset/collation.
+- **Parser:** one-time geometry-type + `SRID` grammar change; `ST_*` are generic function
+  calls (no grammar). Regenerates `parser.go`; run `make bazel_prepare`.
+- **DDL:** new column types and the `SRID` attribute; DDL validation restricts SRID to
+  0/4326 and enforces subtype constraints.
+- **Planner/statistics/executor:** `ST_*` functions evaluate on the normal expression
+  path; predicates are ordinary `Selection`s (full scan in this layer). No new operator,
+  no new access path, no statistics change.
+- **TiKV:** geometry values are ordinary binary strings; no storage-engine change. No
+  coprocessor change in this layer (pushdown is deferred).
+- **TiFlash / BR / TiCDC / Dumpling / Lightning:** geometry is regular column data;
+  round-trips need only that the tools carry the value bytes and the `SRID`/type
+  metadata. Dump/reload uses MySQL-compatible EWKB / WKT.
+- **Upgrade:** additive — new type and functions behind a flag.
+- **Downgrade:** a table with a geometry column cannot be read by a release without the
+  type; downgrade requires dropping geometry columns first (same as other new type kinds;
+  to be confirmed during implementation).
+
+## Test Design
+
+### Functional Tests
+
+- I/O round-trips: `ST_GeomFromText`/`ST_AsText`, `ST_GeomFromWKB`/`ST_AsBinary`,
+  `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
+  (including MySQL's `ST_AsText` spacing and axis order).
+- Accessors/measurement: `ST_X/Y/Latitude/Longitude/SRID/GeometryType/Dimension/…` and
+  `ST_Area/Length/Distance/Distance_Sphere` against cross-checked MySQL values (e.g. the
+  1-degree geodesic distances in `srid-support-reference.md`).
+- Predicates: the eight DE-9IM predicates (+ `Covers`/`CoveredBy`) on curated geometry
+  pairs, OGC-correct, matched to MySQL where semantics agree; boundary cases explicitly
+  covered.
+- SRID validation: 4326 out-of-range lat/long errors on every ingest path; SRID 0 Inf/NaN
+  rejection; mixed-SRID predicate errors.
+- Type plumbing: geometry through GROUP BY, joins, DISTINCT, ORDER BY, `INSERT … SELECT`,
+  `UNION`, UPDATE/DELETE/REPLACE — the PoC's audited surface — returns correct bytes.
+
+### Scenario Tests
+
+- Store a points table and answer proximity (`ST_Distance_Sphere ≤ r`) and geofence
+  (`ST_Within(point, polygon)`) by full scan; results match MySQL.
+- 4326 edge cases: a query near a pole and across the antimeridian.
+- Application shape: lat/long ingest via WKT/GeoJSON, read back via `ST_AsGeoJSON`.
+
+### Compatibility Tests
+
+- MySQL byte-identical compatibility suite for the v1 function surface (the PoC's
+  `spatial_compat` integration test is the basis).
+- Dumpling/Lightning round-trip of a table with geometry columns; TiCDC and BR
+  pass-through; behavior unaffected when TiFlash is absent.
+- Parser/DDL/planner/executor as listed in Compatibility.
+- Upgrade and downgrade paths.
+
+### Benchmark Tests
+
+- Geometry ingest and read throughput vs a scalar-encoded baseline, to confirm EWKB
+  decode cost is acceptable.
+- Predicate full-scan latency across selectivities (this is the pre-index baseline the
+  index layer will be measured against).
+- The value-format choice (raw EWKB vs version-tagged/lean): decode ns/op on the point
+  and polygon paths, to settle the pre-GA encoding.
+
+## Impacts & Risks
+
+Impacts (intended): geometry becomes a first-class, MySQL-compatible value and query
+surface; applications can store locations and run proximity/geofence queries in SQL
+(full scan) without application-side geometry code.
+
+Risks:
+
+- **Prerequisite coupling (downstream):** the index and pushdown layers code against this
+  type; the value-format and axis-order decisions here are lock-ins for them, so they are
+  settled in this design.
+- **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by a
+  format-version byte (Unresolved Questions).
+- **4326 semantics gaps:** geodesic `ST_Area`, polygon/polygon geodesic relations, and
+  planar-vs-geodesic refine edge cases diverge from MySQL near poles/antimeridian;
+  mitigated by documenting the v1 limitation and erroring rather than silently returning
+  wrong values.
+- **MySQL error parity:** exact error codes/messages may not match MySQL initially (the
+  PoC used placeholder wording); a compatibility, not correctness, risk.
+- **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the
+  GEOS-class processing tail; that tail is deferred, so v1 is unaffected.
+
+## Investigation & Alternatives
+
+- **cgo/libgeos (go-geos):** rejected for v1. It gives OGC-correct geometry but requires
+  `libgeos` in the Bazel/CI sandbox, which broke the build; the PoC migrated to pure-Go
+  `simplefeatures` and stayed MySQL byte-identical, so cgo is unnecessary for the v1
+  surface. Revisit only for the GEOS-class processing tail.
+- **Full #38916 surface at once:** rejected as too large to review/land; this design is
+  the narrowed, independently-shippable prerequisite slice, with the rest sequenced after.
+- **Storing geometry as a generic BLOB with app-side functions:** the status quo; loses
+  MySQL compatibility, type safety, and any path to a spatial index. Rejected.
+- **PostGIS axis order / `geometry`-always-planar semantics:** rejected in favor of MySQL
+  compatibility (lat/long axis order, class-driven planar-vs-geodesic), since MySQL parity
+  is the goal (`srid-support-reference.md` documents the differences).
+
+## Unresolved Questions
+
+- **Internal value format:** confirm the version-tagged layout beyond the leading format
+  byte — whether to strip the redundant per-row SRID / byte-order flags and adopt a
+  flat-`f64` point layout — benchmark-gated (`storage-format.md`). `ST_AsBinary` output
+  stays MySQL EWKB regardless.
+- **Geodesic `ST_Area` on 4326:** implement (Karney ellipsoidal area) in v1, or error
+  like MySQL's Cartesian-only functions until implemented?
+- **MySQL error-code/message parity:** how closely to match MySQL's exact GIS error codes
+  and wording for out-of-range coordinates, invalid geometries, and mixed-SRID errors.
+- **Feature-flag name and default:** `tidb_enable_spatial` (proposed); default off then
+  removed after stabilization — confirm naming and the removal milestone.
+- **4326 refine scope for v1:** accept planar polygon/polygon refine + the geodesic
+  point-in-polygon as the documented limitation, or widen geodesic coverage before GA?
+- **Exact v1 function boundary:** confirm which accessors/aliases are v1 vs tail against
+  `mysql-function-catalog.md` (e.g. `ST_Centroid` placement, typed `*FromText`/`*FromWKB`
+  aliases).
+- **Downgrade mechanics:** confirm the drop-geometry-columns-first requirement and whether
+  any metadata-only downgrade is possible.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -16,7 +16,6 @@
     * [Geometry engine](#geometry-engine)
     * [Type plumbing](#type-plumbing)
     * [SQL surface and examples](#sql-surface-and-examples)
-    * [Feature flag and rollout](#feature-flag-and-rollout)
     * [Scope and deferrals](#scope-and-deferrals)
     * [Compatibility](#compatibility)
 * [Test Design](#test-design)
@@ -39,12 +38,14 @@ geometry predicate has no index here, so it filters row by row over whatever the
 path returns; other predicates choose their access path as usual.
 
 It is **index-free**. The spatial index is specified in
-`docs/design/2026-06-25-spatial-index.md` (PR #69473) and builds on this layer; later work
+[`docs/design/2026-06-25-spatial-index.md`](2026-06-25-spatial-index.md)
+([PR #69473](https://github.com/pingcap/tidb/pull/69473)) and builds on this layer; later work
 (more SRIDs, the function tail, coprocessor pushdown, the index) extends this design
-rather than replacing it. This replaces the earlier geospatial design (PR #38916).
+rather than replacing it. This replaces the earlier geospatial design
+([PR #38916](https://github.com/pingcap/tidb/pull/38916)).
 
 MySQL behaviors and measurements below were verified against running 8.4.6 and 9.7.2, and
-against the proof of concept, PR #69475.
+against the proof of concept, [PR #69475](https://github.com/pingcap/tidb/pull/69475).
 
 ## Terminology
 
@@ -67,7 +68,8 @@ against the proof of concept, PR #69475.
 
 ## Motivation or Background
 
-Geospatial support is one of the most requested TiDB features: tracking issue #6347 carries
+Geospatial support is one of the most requested TiDB features: [tracking issue #6347](https://github.com/pingcap/tidb/issues/6347)
+carries
 `feature/accepted` and ranks among the top open issues by reactions. The dominant workload
 is storing a location per row and answering "what is near me", "which region contains this
 point", or "what overlaps this box". Bike-share, ride-hailing, parcel delivery and asset
@@ -76,8 +78,7 @@ tracking all reduce to points plus proximity and geofence queries.
 TiDB has none of it today: only the `mysql.TypeGeometry` constant exists
 (`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions, so
 users encode geometry into scalar columns by hand and compute distances in the
-application. This design covers the basic layer only, so it can ship, stabilize and have
-its feature flag removed before index work merges on top.
+application. This design covers the basic layer only.
 
 ## Detailed Design
 
@@ -116,7 +117,7 @@ and because a 2D geometry with no SRID flag is plain OGC WKB byte for byte.
 
 | Rule | |
 | --- | --- |
-| Versioning | Numbered from 1, so a leading `0x00` is never a valid version. A release reads every earlier version and writes the current one, so a later format needs no migration. |
+| Versioning | Numbered from 1, so a leading `0x00` is never a valid version. |
 | Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
 | SRID | Carried by the SRID flag, which may be left unset where the column fixes it with `SRID n`, since that is still valid EWKB. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
 | Byte order | Left to EWKB, which flags it per geometry and permits both. |
@@ -368,20 +369,13 @@ MySQL form. No spatial index syntax belongs to this layer.
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
 
-### Feature flag and rollout
-
-The layer is gated on a session/global system variable, `tidb_enable_geospatial`, default
-off. This is a **launch gate, not a compatibility switch**: there is no prior implementation
-to fall back to, so once the feature is stable in master the flag and its dead branches are
-removed in a cleanup PR, tracked in #6347. The index layer ships behind its own flag on top
-of this one.
-
 ### Scope and deferrals
 
 Out of scope here, each with a home:
 
-- The **spatial index** and its pushdown: `docs/design/2026-06-25-spatial-index.md`
-  (#69473), for which this layer is the prerequisite.
+- The **spatial index** and its pushdown:
+  [`docs/design/2026-06-25-spatial-index.md`](2026-06-25-spatial-index.md)
+  ([#69473](https://github.com/pingcap/tidb/pull/69473)), for which this layer is the prerequisite.
 - The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash and
   niche accessors: a later, parallel expression-layer milestone.
 - **SRIDs beyond 0 and 4326**, the full SRS catalog and `ST_Transform`: the extension path
@@ -417,7 +411,7 @@ Out of scope here, each with a home:
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
-| Upgrade | Additive, behind the flag. |
+| Upgrade | Additive, and gated by no user-visible variable: the type is absent until it is complete. Any switch used while the work lands is a merge convenience, not documented surface. |
 | Downgrade | A release without the type cannot read a table that has a geometry column, so those columns must be dropped first, an ordinary `DROP COLUMN`. |
 
 ## Test Design
@@ -520,7 +514,8 @@ Risks:
 - **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
   `libgeos` in the Bazel/CI sandbox, which broke the build. The PoC moved to pure-Go
   `simplefeatures` and stayed MySQL byte-identical. Revisit for the processing tail.
-- **The full #38916 surface at once.** Rejected as too large to review and land.
+- **The full [#38916](https://github.com/pingcap/tidb/pull/38916) surface at once.** Rejected as too large to review and
+  land.
 - **Geometry as a generic BLOB with application-side functions.** The status quo; loses
   MySQL compatibility, type safety, and any path to a spatial index.
 - **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of MySQL

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -143,13 +143,39 @@ and because a 2D geometry with no SRID flag is plain OGC WKB byte for byte.
 | SRID | Carried by the SRID flag, which may be left unset where the column fixes it with `SRID n`, since that is still valid EWKB. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
 | Byte order | Left to EWKB, which flags it per geometry and permits both. |
 | MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. |
+| Binary boundary | Each format has a matching pair, so nothing is write-only or read-only. See *Binary in and out* below. |
 | Coordinate dimension | XY, XYZ, XYM and XYZM are storable, covering GeoJSON positions (XY and XYZ) and measured geometry. Every v1 function is 2D, as in MySQL. |
 | SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
-Extended data (Z/M coordinates, unsupported SRIDs) returns as the raw column value;
-`ST_SRID` and `ST_GeometryType` answer for it, and everything that interprets coordinates
-errors. An opt-in writer that emits it is a later extension. Why EWKB rather than the
-alternatives: [Investigation & Alternatives](#investigation--alternatives).
+**Binary in and out.** A value that leaves TiDB as bytes has to be acceptable coming back
+as bytes, or an ordinary client round-trip breaks: read a column, hold the bytes, bind them
+into a later `INSERT`. The storage format is deliberately wider than MySQL's, so the two
+cannot share one bare path without guessing which format arrived. Each therefore gets a
+matched pair:
+
+| Format | Out | In |
+| --- | --- | --- |
+| MySQL internal, `<srid u32 LE><WKB>` | bare `SELECT g` | bare literal, `SET g = 0x...` |
+| EWKB, the extended format | `ST_AsEWKB(g)` | `ST_GeomFromEWKB(0x...)` |
+
+The bare path is MySQL's format in both directions, so ingest never has to guess: a bare
+literal is always MySQL's format, and the stored format stays off the user surface. It is
+what makes a Dumpling to Lightning round-trip work with no function call, and what lets a
+`mysqldump` load unchanged. The SRID in those bytes is validated against `SRID n` like any
+other ingest path.
+
+Extended data (Z/M coordinates, unsupported SRIDs) has no MySQL form, so a bare `SELECT`
+of it errors, naming `ST_AsEWKB` as the way to read it. That is opt-in: such a value only
+exists if `ST_GeomFromEWKB` put it there. `ST_SRID` and `ST_GeometryType` still answer for
+it, and everything that interprets coordinates errors.
+
+Both halves are v1 choices, not properties of the format. Later versions can widen either
+end without a migration: ingest could try to recognise the format it was handed rather than
+assume MySQL's, and bare output could do something better than erroring, so long as it is
+neither silent truncation nor a format the input side will not take back.
+
+Why EWKB rather than the alternatives:
+[Investigation & Alternatives](#investigation--alternatives).
 
 ### SRID model
 
@@ -226,6 +252,10 @@ function until a later milestone adds it.
   the rest) deferred below.
 - **`ST_As*`**, an external format from a geometry: `ST_AsText` (`ST_AsWKT`),
   `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
+- **`ST_AsEWKB` and `ST_GeomFromEWKB`**, the pair for the stored format, TiDB-specific
+  because the format is. They are the only way to read and write what MySQL cannot express,
+  and the name avoids shadowing MySQL's `ST_GeomFromWKB`, which takes bare WKB and a
+  separate SRID. See *Binary in and out* in [Types and storage](#types-and-storage).
 - **Option arguments.** `axis-order` on the WKT and WKB members of both groups, taking
   `lat-long`, `long-lat` or `srid-defined` (the default), rejecting anything else with
   `ERROR 3559` and having no effect at SRID 0. It is the explicit way to read or write
@@ -467,11 +497,13 @@ Out of scope here, each with a home:
 | Generated columns | `ST_*` are deterministic scalars, so they are usable in virtual and stored generated column expressions like any other builtin. A geometry-typed generated column is then an ordinary geometry column, and the row above governs indexing it. |
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | Updated in this design. |
-| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. In v1 `ALTER` rejects as unsupported anything that would have to validate existing rows: adding, dropping or changing `SRID n`, and narrowing the subtype (`GEOMETRY` to `POINT`). A user who needs either adds a new column with the wanted type and backfills it. The rest follows MySQL, verified on 8.4.6: widening the subtype always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. |
+| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints, at `CREATE TABLE` and `ADD COLUMN`. `MODIFY`/`CHANGE COLUMN` on a geometry column is rejected as unsupported in v1, whatever the change: the `SRID` attribute, the subtype in either direction, or conversion to or from another type. The exception is `NULL`/`NOT NULL`, which the generic nullability path handles without knowing the column is geometry. Anything else means adding a new column and backfilling it. `DROP COLUMN` is ordinary. |
 | `information_schema` | One new table, `st_spatial_reference_systems`, read-only with two static rows. Its two siblings in MySQL are deferred. |
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. `ANALYZE` skips geometry as it skips JSON and the blob types, which means adding `geometry` both to the accepted values of `tidb_analyze_skip_column_types` and to its default, today `json,blob,mediumblob,longblob,mediumtext,longtext`. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
-| TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
+| BR | None. Backs up and restores bytes and metadata without interpreting column values. |
+| Dumpling, Lightning | Geometry dumps as MySQL's internal format, which reloads as a bare literal (see [Types and storage](#types-and-storage)), so the round-trip needs no function call and a `mysqldump` loads unchanged. A table holding extended values cannot be dumped that way, since a bare `SELECT` of them errors; dumping those needs `ST_AsEWKB` and emitting `ST_GeomFromEWKB(0x...)`, which is Dumpling work and TiDB-only output. |
+| TiFlash, TiCDC | Not pass-through: both decode column values against the schema, so each has to learn the type. Out of scope here and tracked separately; until then a table with a geometry column should not be assumed replicable to TiFlash. |
 | Upgrade | Additive: the type does not exist in earlier releases, so no existing schema or query changes behavior. |
 | Downgrade | A release without the type cannot read a table that has a geometry column, so those columns must be dropped first, an ordinary `DROP COLUMN`. |
 
@@ -500,9 +532,13 @@ Out of scope here, each with a home:
   SQL comparison operators keep comparing the stored bytes without erroring.
 - The catalog: `st_spatial_reference_systems` returns the two rows with the same column
   values MySQL gives for SRID 0 and 4326, and `CREATE SPATIAL REFERENCE SYSTEM` errors.
-- Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
-  back byte-identical, while `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function
-  that interprets coordinates error clearly on them.
+- Extended data: Z/M values and SRIDs outside 0 and 4326 go in through `ST_GeomFromEWKB`
+  and come back byte-identical through `ST_AsEWKB`, while a bare `SELECT` of them errors
+  naming `ST_AsEWKB`, and `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function that
+  interprets coordinates error clearly on them.
+- The bare binary boundary is symmetric: bytes from a bare `SELECT` of a MySQL-expressible
+  value insert back unchanged as a bare literal, and a `mysqldump` literal loads as the
+  same geometry.
 - GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7, plus `options` 5
   and 6 keeping a Z position and differing on a fourth element, and `ST_AsGeoJSON`'s
   `digits` rounding and each `flags` bit, byte-compared to MySQL.
@@ -512,8 +548,9 @@ Out of scope here, each with a home:
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.
-- DDL: the `ALTER` matrix above, including that adding, dropping or changing `SRID n` and
-  narrowing the subtype are all rejected, while widening and `DROP COLUMN` succeed.
+- DDL: `MODIFY`/`CHANGE COLUMN` on a geometry column is rejected for the `SRID` attribute,
+  for both subtype directions and for conversion to another type, while `NULL`/`NOT NULL`,
+  `ADD COLUMN` and `DROP COLUMN` succeed.
 
 ### Scenario Tests
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -127,7 +127,9 @@ right: a 2D geometry with no SRID flag *is* plain OGC WKB, byte for byte.
 
 Extended data, meaning Z/M coordinates and SRIDs the functions do not support, follows the
 compatibility rule above: stored losslessly, read back unchanged, `ST_SRID` and
-`ST_GeometryType` still answering, everything that interprets coordinates erroring.
+`ST_GeometryType` still answering, everything that interprets coordinates erroring. Such a
+value comes back as the raw column value, which is enough for v1; giving the writers an
+opt-in that emits it is a later extension nothing here blocks.
 Storing more than v1 computes on is what lets 3D/measured geometry and the wider SRS
 catalog arrive later as functions over data written today. Why EWKB rather than the
 alternatives: [Investigation & Alternatives](#investigation--alternatives).
@@ -141,8 +143,22 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | Rejected on ingest | Inf/NaN, MySQL `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
 | Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
 
-Those codes and their wording are matched as closely as practical, on `ST_GeomFromText`,
-the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike.
+Those codes and their wording are matched as closely as possible, on `ST_GeomFromText`,
+the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike. The same goes for the
+other GIS errors (`ERROR 3618` for a function not implemented on a geographic SRS,
+`ERROR 3643` for an SRID that does not match the column). Where a message cannot be
+matched exactly it is a compatibility gap to close later, not a reason to invent a
+different code.
+
+**Catalog.** `information_schema.st_spatial_reference_systems` ships with MySQL's shape
+(`SRS_NAME`, `SRS_ID`, `ORGANIZATION`, `ORGANIZATION_COORDSYS_ID`, `DEFINITION`,
+`DESCRIPTION`) and exactly the two supported rows, copied from MySQL: SRID 0 with an
+empty name and definition and no organization, and 4326 as `WGS 84` / `EPSG` / 4326 with
+the EPSG `GEOGCS["WGS 84",DATUM[...]]` definition string. It is read-only, so
+`CREATE SPATIAL REFERENCE SYSTEM` is rejected, and DDL validates the `SRID n` attribute
+against it rather than against a hardcoded pair, which makes widening SRID support a
+matter of adding rows. It also gives a client an honest answer to "which SRIDs does this
+server support", where today the question is an unknown-table error.
 
 Planar versus geodesic is decided by the **SRS class** (SRID 0 and projected are
 Cartesian, geographic is geodesic), exactly as MySQL decides it, rather than by a
@@ -171,7 +187,7 @@ difference is invisible outside the stored bytes.
 
 | Step | Cost |
 | --- | --- |
-| SRS catalog: populate `information_schema.st_spatial_reference_systems` from EPSG (MySQL ships ~5,200 rows) with class, axis order, bounds, unit, ellipsoid | moderate, and a prerequisite for the rest |
+| Fill the catalog from the full EPSG dataset (MySQL ships 5,238 rows in both 8.4 and 9.7) with class, axis order, bounds, unit, ellipsoid | moderate, and a prerequisite for the rest |
 | All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
 | Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
 | PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform`) | bigger: on-the-fly reprojection needs a PROJ-like library; out of scope |
@@ -183,7 +199,10 @@ SRID (see [Types and storage](#types-and-storage)).
 ### Function set
 
 v1 is the minimal set needed to store, read, inspect, measure and filter geometry. All of
-it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical.
+it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical. The
+list below is an **allowlist**: only these functions are registered, and anything else
+spatial is simply an unknown function until a later milestone adds it. Growing the
+surface is then an explicit act rather than the default.
 
 - **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
 - **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
@@ -210,14 +229,15 @@ Semantics match MySQL, with three documented v1 limitations:
 
 - On 4326, `ST_Distance`/`ST_Length` are ellipsoidal (Andoyer, matching MySQL to
   sub-metre); `ST_Distance_Sphere` is the great-circle variant.
-- `ST_Area` on 4326 is a gap. MySQL computes it geodesically (12308778368.75 m2 for a
-  1-degree box), so v1 either implements the same (Karney ellipsoidal area) or errors in
-  the shape MySQL uses for its own Cartesian-only functions, `ERROR 3618` (Unresolved
-  Questions). It must not silently return a planar degree2 or an off-by-0.45% spherical
-  value.
-- The predicates are OGC-correct via `simplefeatures`; on 4326 the region predicates use a
-  geodesic point-in-polygon, which diverges from MySQL's planar refine near
-  edges/poles/antimeridian. Polygon/polygon geodesic relations are a follow-up.
+- `ST_Area` on 4326 **errors** in the shape MySQL uses for its own Cartesian-only
+  functions (`ERROR 3618`, "has not been implemented for geographic spatial reference
+  systems"). This is a documented divergence: MySQL does compute it geodesically
+  (12308778368.75 m2 for a 1-degree box). Erroring beats the alternatives, since a planar
+  degree2 or an off-by-0.45% spherical value would be silently wrong, and implementing
+  Karney ellipsoidal area is a later extension nothing here blocks.
+- The predicates are OGC-correct via `simplefeatures`, which is planar. On 4326 the region
+  predicates get a geodesic point-in-polygon, but polygon/polygon relations stay planar,
+  which diverges from MySQL. See Unresolved Questions: this is the one open item.
 
 **GeoJSON.** Every RFC 7946 geometry is supported, and the container and annotation members
 follow MySQL, verified against 8.4.6 and 9.7.2:
@@ -300,7 +320,7 @@ spatial index syntax is part of this layer.
 
 ### Feature flag and rollout
 
-The layer is gated on a session/global system variable, `tidb_enable_spatial`, default
+The layer is gated on a session/global system variable, `tidb_enable_geospatial`, default
 off. This is a **launch gate, not a compatibility switch**: there is no prior
 implementation to fall back to, so once the feature is stable in master the flag and its
 dead branches are removed in a cleanup PR, tracked in #6347. The index layer ships behind
@@ -323,6 +343,9 @@ Out of scope here, each with a home:
   cross-repo work (tipb signatures plus a TiKV-side evaluator) and is specified with the
   index design, which owns the pushdown contract. Nothing in this layer blocks it, and for
   this design it is fine that the functions evaluate at the TiDB root.
+- **The other two spatial `information_schema` tables**: `st_geometry_columns`, one row
+  per geometry column and derivable from the schema, and `st_units_of_measure`, 47 static
+  rows in MySQL that only start to matter once projected SRSs with varied units exist.
 - **The axis-order controls**: MySQL's `axis-order=long-lat` option argument on
   `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let
   a client read or write longitude-first against a latitude-first SRS. Both exist in MySQL
@@ -338,12 +361,13 @@ Out of scope here, each with a home:
 | Partition table, clustered index, async commit | None. It cannot be a primary or clustering key, having no meaningful ordering. |
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
-| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. |
+| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. `ALTER` follows MySQL, verified on 8.4.6: adding or changing `SRID n` validates every existing row and fails with `ERROR 3643` on the first mismatch; dropping the attribute always succeeds; narrowing the subtype (`GEOMETRY` to `POINT`) succeeds only if every value fits, else `ERROR 1416`; widening always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. No reinterpretation ever happens: an SRID change is validation, never a coordinate rewrite. |
+| `information_schema` | One new table, `st_spatial_reference_systems`, read-only with two static rows. Its two siblings in MySQL are deferred. |
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own, so they filter whatever rows the chosen path returns. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
 | Upgrade | Additive, behind the flag. |
-| Downgrade | Geometry columns must be dropped first, as with other new type kinds (to be confirmed). |
+| Downgrade | The usual new-type situation: a release without the type cannot read a table that has a geometry column, so those columns have to go first, which is an ordinary `DROP COLUMN`. |
 
 ## Test Design
 
@@ -359,6 +383,8 @@ Out of scope here, each with a home:
   pairs, matched to MySQL where semantics agree, with boundary cases explicit.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN
   rejection, mixed-SRID predicate errors.
+- The catalog: `st_spatial_reference_systems` returns the two rows with the same column
+  values MySQL gives for SRID 0 and 4326, and `CREATE SPATIAL REFERENCE SYSTEM` errors.
 - Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
   back byte-identical, while `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function
   that interprets coordinates error clearly on them.
@@ -451,21 +477,27 @@ Risks:
 
 ## Unresolved Questions
 
-- **A leaner format version 2:** add one before GA, or ship version 1 and revisit?
-  Benchmark-gated; the version byte means it can also land after GA.
-  `ST_AsBinary` output stays MySQL-compatible plain WKB either way.
-- **Reading a Z/M value back:** the writers reject it, so today it returns only as the raw
-  column value in the stored format. Confirm that is enough, or give `ST_AsBinary` an
-  opt-in that emits EWKB with the flags set.
-- **Geodesic `ST_Area` on 4326:** implement Karney ellipsoidal area in v1, or error like
-  MySQL's Cartesian-only functions until it exists?
-- **MySQL error parity:** how closely to match MySQL's GIS error codes and wording for
-  out-of-range coordinates, invalid geometries and mixed-SRID errors.
-- **Feature-flag name and default:** confirm `tidb_enable_spatial` and the removal
-  milestone.
-- **4326 refine scope for v1:** accept planar polygon/polygon refine plus the geodesic
-  point-in-polygon as a documented limitation, or widen geodesic coverage before GA?
-- **Exact v1 function boundary:** confirm which accessors and aliases are v1 rather than
-  tail (e.g. `ST_Centroid`, the typed `*FromText`/`*FromWKB` aliases).
-- **Downgrade mechanics:** confirm the drop-geometry-columns-first requirement, and
-  whether any metadata-only downgrade is possible.
+**Polygon/polygon relations on 4326.** MySQL treats a geographic polygon's edges as
+geodesics; `simplefeatures`, and every other pure-Go option, treats them as straight
+lines in latitude/longitude. That is not a near-boundary rounding difference. For
+`POLYGON((0 0, 0 80, 60 0, 0 0))` on 4326, MySQL 8.4.6 answers `ST_Within` **true** for
+the points `(30 40)`, `(33 40)`, `(36 40)` and `(40 40)`, while the same coordinates
+against the same ring evaluated planar (SRID 0) answer **false** for all four: the
+great-circle edge bows away from the straight one by degrees, so whole regions flip.
+Small polygons, the common geofence case, are unaffected.
+
+Three ways to resolve it, in increasing cost:
+
+1. **Ship planar polygon/polygon and document it.** Correct for small geofences, wrong
+   for continental ones, and wrong silently, which is the objection.
+2. **Error when it would matter.** Reject a geographic polygon/polygon relate whose
+   operands exceed some extent, so the answer is never silently wrong. Needs a defensible
+   threshold, and the error is a divergence of its own since MySQL answers.
+3. **Implement geodesic relate.** Full parity, and the only option that makes the index
+   layer's refine exact on 4326, but it needs a geographic DE-9IM implementation on both
+   the TiDB side and, once pushdown lands, the TiKV side. No pure-Go library provides
+   it today; S2 gives coverings and predicates on spherical shapes but not the DE-9IM
+   matrix, so this is real work rather than a dependency swap.
+
+The decision belongs to this design because the type layer owns predicate semantics, and
+it is a compatibility question rather than a format one, so it does not lock any bytes in.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -199,7 +199,23 @@ function until a later milestone adds it.
 
 - **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
 - **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
-- **Constructors:** `Point`, `LineString`, `Polygon`.
+- **Option arguments.** `axis-order` on the WKT and WKB readers and writers, taking
+  `lat-long`, `long-lat` or `srid-defined` (the default), rejecting anything else with
+  `ERROR 3559` and having no effect at SRID 0. It is the explicit way to read or write
+  longitude-first data against a latitude-first SRS, so a client need not pre-swap.
+  `ST_GeomFromGeoJSON` takes its own `options` and `srid` arguments: `options` 1 rejects
+  coordinate dimensions above 2 and is the default, while 2, 3 and 4 accept and strip
+  them, so a GeoJSON Z position is dropped rather than stored.
+- **Constructors:** the full set of MySQL's
+  [functions that create geometry values](https://dev.mysql.com/doc/refman/8.0/en/gis-mysql-specific-functions.html):
+  `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`,
+  `GeometryCollection`.
+  `Point(x, y)` returns SRID 0; `ST_SRID(g, srid)` then stamps the SRS, validating the
+  coordinates (`ERROR 3731`, `ERROR 3732`) without transforming them. For a geographic SRS
+  that makes `Point` **(longitude, latitude)**, the opposite of WKT at 4326:
+  `ST_SRID(Point(30, 50), 4326)` is `POINT(50 30)`, latitude 50. Since values are stored
+  latitude-first at 4326, this is where the internal order becomes observable and the pair
+  must be swapped.
 - **Accessors:** `ST_X`, `ST_Y`, `ST_Latitude`, `ST_Longitude`, `ST_SRID` (getter and the
   `ST_SRID(g, srid)` setter), `ST_GeometryType`, `ST_Dimension`, `ST_Envelope`,
   `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
@@ -213,9 +229,9 @@ function until a later milestone adds it.
   covering-cell prefilter has no false negatives). Other PostGIS-only functions are added
   later only if index-supported or by demand.
 
-The geometry-processing tail (`ST_Buffer`, `ST_Union`, `ST_Intersection`, ...), the typed
-I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash,
-the niche accessors and the GeoJSON `options`/`srid` arguments are a later milestone.
+A later milestone covers the geometry-processing tail (`ST_Buffer`, `ST_Union`,
+`ST_Intersection`, ...), the typed I/O aliases, the `MBR*` family, geohash, the niche
+accessors and `ST_AsGeoJSON`'s bbox and CRS-URN flags.
 
 Semantics match MySQL, with three v1 limitations:
 
@@ -241,9 +257,9 @@ follow MySQL, verified on 8.4.6 and 9.7.2:
 | named `crs` URN | sets the SRID (`urn:ogc:def:crs:OGC:1.3:CRS84` is 4326, link-object CRSs are not accepted, and a nested `crs` naming a different SRID errors); absent, the SRID is 4326 |
 | position with more than two coordinates | rejected, `ERROR 3073` |
 
-MySQL's `options` argument, which accepts such positions and strips the extra coordinates,
-ships with the function tail, as do `ST_AsGeoJSON`'s bbox and CRS-URN flags. Round-trips are
-not idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a GeometryCollection.
+The `options` argument accepts such positions and strips the extra coordinates.
+`ST_AsGeoJSON`'s bbox and CRS-URN flags ship with the tail. Round-trips are not
+idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a GeometryCollection.
 
 Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
 over such an expression is rejected.
@@ -282,8 +298,14 @@ meaningful.
 
 ### SQL surface and examples
 
-    col_name {GEOMETRY | POINT | LINESTRING | POLYGON | MULTIPOINT | ...}
+    col_name {GEOMETRY | POINT | LINESTRING | POLYGON | MULTIPOINT
+              | MULTILINESTRING | MULTIPOLYGON | GEOMETRYCOLLECTION}
         [NOT NULL] [SRID {0 | 4326}]
+
+The type names stay usable as identifiers, as in MySQL: a column named `point` keeps
+working, and `Point(x, y)` is a function call rather than a type reference. `ST_*` are
+ordinary function calls and need no syntax of their own. `SHOW CREATE TABLE` emits the
+MySQL form. No spatial index syntax belongs to this layer.
 
     CREATE TABLE stores (
       id  BIGINT PRIMARY KEY,
@@ -303,9 +325,6 @@ meaningful.
     -- the geometry predicate is evaluated per row here; the index accelerates it later
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
-
-`SHOW CREATE TABLE` emits the plain MySQL form (`loc point NOT NULL SRID 4326`). No spatial
-index syntax is part of this layer.
 
 ### Feature flag and rollout
 
@@ -339,10 +358,8 @@ Out of scope here, each with a home:
   `CREATE SPATIAL REFERENCE SYSTEM` needs anyway, and internal parsed metadata. Neither
   widens this table: extra columns belong in a TiDB-specific companion, expressed as WKT2
   (ISO 19162) or PROJJSON.
-- **The axis-order controls**: MySQL's `axis-order=long-lat` option argument on
-  `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let a
-  client read or write longitude-first against a latitude-first SRS. Both ship with the
-  function tail.
+- **`ST_SwapXY`**, which swaps a geometry's coordinates in place. The `axis-order` option
+  covers the read and write direction in v1; this is the geometry-mutating variant.
 - **3D / measured (Z/M) geometry**: computation is 2D only, as in MySQL/MariaDB, while the
   values are stored and returned unchanged.
 
@@ -380,7 +397,11 @@ Out of scope here, each with a home:
 - Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
   back byte-identical, while `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function
   that interprets coordinates error clearly on them.
-- GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7.
+- GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7, plus the `options`
+  argument rejecting a Z position at 1 and stripping it at 2, 3 and 4.
+- `axis-order`: `long-lat` swaps on read and on write at 4326, `lat-long` and
+  `srid-defined` agree there, the option is inert at SRID 0, and a bad value gives
+  `ERROR 3559`.
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -180,10 +180,9 @@ positional, so on 4326 `ST_X` is the latitude here and in MySQL (verified: `ST_X
 `ST_Latitude` = 30 for `POINT(30 50)`) and the longitude in PostGIS. The per-SRID breakdown
 belongs in the user docs as migration guidance.
 
-Coordinates are **stored as parsed**, so latitude-first on 4326, which is the order S2 wants
-and costs no swap on the geodesic and index paths. MySQL stores the opposite order and swaps
-at every boundary, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates
-for the same 4326 point; both engines emit the same WKB.
+Coordinates are **stored as parsed**, so latitude-first on 4326. MySQL stores the opposite
+order and swaps at every boundary, visible as `HEX(g)` and `ST_AsBinary(g)` returning
+swapped coordinates for the same 4326 point; both engines emit the same WKB.
 
 **Extension path** (documented, not built here):
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -121,7 +121,7 @@ and because a 2D geometry with no SRID flag is plain OGC WKB byte for byte.
 | Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
 | SRID | Carried by the SRID flag, which may be left unset where the column fixes it with `SRID n`, since that is still valid EWKB. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
 | Byte order | Left to EWKB, which flags it per geometry and permits both. |
-| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL converts too, storing coordinates longitude-first internally, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point. |
+| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. |
 | Coordinate dimension | XY, XYZ, XYM and XYZM are storable, covering GeoJSON positions (XY and XYZ) and measured geometry. Every v1 function is 2D, as in MySQL. |
 | SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
@@ -185,7 +185,8 @@ belongs in the user docs as migration guidance.
 
 Coordinates are **stored as parsed**, so latitude-first on 4326, which is the order S2 wants
 and costs no swap on the geodesic and index paths. MySQL stores the opposite order and swaps
-at every boundary; both engines emit the same WKB.
+at every boundary, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates
+for the same 4326 point; both engines emit the same WKB.
 
 **Extension path** (documented, not built here):
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -1,4 +1,4 @@
-# TiDB Design Documents
+# Proposal: Basic Geospatial Support
 
 - Author(s): [Mattias Jonsson](http://github.com/mjonss), [Daniël van Eeden](http://github.com/dveeden)
 - Discussion PR: https://github.com/pingcap/tidb/pull/70420
@@ -16,6 +16,7 @@
     * [Geometry engine](#geometry-engine)
     * [Type plumbing](#type-plumbing)
     * [SQL surface and examples](#sql-surface-and-examples)
+    * [Phasing](#phasing)
     * [Scope and deferrals](#scope-and-deferrals)
     * [Compatibility](#compatibility)
 * [Test Design](#test-design)
@@ -26,6 +27,15 @@
 * [Impacts & Risks](#impacts--risks)
 * [Investigation & Alternatives](#investigation--alternatives)
 * [Unresolved Questions](#unresolved-questions)
+* [Future extensions](#future-extensions)
+* [Appendix: SRS catalog and axis order](#appendix-srs-catalog-and-axis-order)
+    * [Catalog row contents](#catalog-row-contents)
+    * [EPSG terms of use](#epsg-terms-of-use)
+    * [Axis order detail](#axis-order-detail)
+* [Appendix: PostGIS delta for the type layer](#appendix-postgis-delta-for-the-type-layer)
+    * [Type and surface mapping](#type-and-surface-mapping)
+    * [A GEOGRAPHY type](#a-geography-type)
+    * [Remaining delta](#remaining-delta)
 
 ## Introduction
 
@@ -59,12 +69,15 @@ against the proof of concept, [PR #69475](https://github.com/pingcap/tidb/pull/6
 | [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | Spatial Reference System Identifier, the integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
 | [EPSG](https://epsg.org/) | The EPSG Geodetic Parameter Dataset, published by IOGP, which assigns SRIDs. |
 | [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) | World Geodetic System 1984, the datum and reference ellipsoid used by GPS, registered as EPSG:4326. |
-| Planar vs geodesic | Measurement on a flat plane vs along the ellipsoid. Decided by SRS class, not per SRID. |
+| Reference surface | What a measurement or an edge is drawn on: the flat *plane*, a *sphere* of one constant radius, or the oblate WGS 84 *ellipsoid*. SRS class decides whether it is the plane or a curved surface; the function decides which curved surface. See [SRID model](#srid-model). |
+| Geodesic | The shortest path along a curved reference surface: a great circle on a sphere, a geodesic proper on an ellipsoid. Always along the surface, never the straight chord through the interior. |
+| Andoyer | The spherical law of cosines with a first-order flattening correction, approximating the ellipsoidal geodesic without iterating. MySQL uses it for *every* geographic computation, measurement and predicate alike; see [Function set](#function-set). |
 | [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) | Dimensionally Extended 9-Intersection Model, the OGC model defining `ST_Within`, `ST_Contains`, `ST_Intersects` and the other topological predicates. |
 | [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) | JSON geometry encoding (RFC 7946), the third I/O format. |
 | MBR | Minimum Bounding Rectangle; basis of MySQL's `MBR*` predicates (deferred). |
-| [S2](http://s2geometry.io/) | Google's spherical-geometry library, used for the geodesic 4326 paths. |
+| [S2](http://s2geometry.io/) | Google's spherical-geometry library. Its shapes live on a sphere, so its edges are great circles, not ellipsoidal geodesics; used here for the 4326 point-in-polygon refine. |
 | [PROJ](https://proj.org/) | The reprojection library that arbitrary-SRS transforms would need; out of scope. |
+| [PostGIS](https://postgis.net/) | The PostgreSQL spatial extension. Not a compatibility target; the delta is in [the appendix](#appendix-postgis-delta-for-the-type-layer). |
 
 ## Motivation or Background
 
@@ -137,62 +150,55 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | Coordinate system | abstract Cartesian plane, unitless X/Y | WGS 84 geographic, latitude/longitude |
 | Bounds | none, the full finite IEEE-754 double range, as MySQL | latitude `[-90, 90]`, longitude `(-180, 180]` |
 | Rejected on ingest | Inf/NaN, `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
-| Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
+| Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid for distance and length, as MySQL; stated per operation in *Reference surface* below |
 
 Codes and wording are matched as closely as possible on every ingest path:
 `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`, and the constructors `Point`,
 `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon` and
 `GeometryCollection`. The same goes for `ERROR 3618` (function not implemented on a
-geographic SRS) and `ERROR 3643` (SRID does not match the column). An unmatched message is
-a gap to close, not grounds for a different code.
+geographic SRS) and `ERROR 3643` (SRID does not match the column). A binary geometry
+function given two geometries of different SRIDs raises `ERROR 3033` and computes nothing;
+the SQL comparison operators are not geometry functions and keep comparing the stored
+bytes without erroring. An unmatched message is a gap to close, not grounds for a
+different code.
 
-Planar versus geodesic follows the **SRS class** (SRID 0 and projected are Cartesian,
-geographic is geodesic), as in MySQL. Adding SRIDs later therefore adds catalog rows and
+Planar versus curved follows the **SRS class** (SRID 0 and projected are Cartesian,
+geographic is curved), as in MySQL. Adding SRIDs later therefore adds catalog rows and
 per-class parameters, not code paths.
 
-**Catalog.** `information_schema.st_spatial_reference_systems` must be queryable and
-return exactly two rows, with MySQL's columns (`SRS_NAME`, `SRS_ID`, `ORGANIZATION`,
-`ORGANIZATION_COORDSYS_ID`, `DEFINITION`, `DESCRIPTION`): SRID 0 with an empty name and
-definition and no organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the
-`GEOGCS["WGS 84",DATUM[...]]` definition string. Whether that is a view over an internal
-table or a synthesized one is an implementation choice; MySQL uses a view over a data
-dictionary table that is itself unreadable, even by `root` (`ERROR 3554`). Both rows are
-what MySQL returns for those two SRIDs, column for column; no dataset is imported. The
-catalog is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, and supporting it
-is on the extension path. DDL validates `SRID n` against the catalog rather than against a
-hardcoded pair. Without it, asking which SRIDs a server supports is an unknown-table
-error.
+**Reference surface.** SRS class decides *whether* a measurement is planar; the function
+decides *which* curved surface it uses. On 4326 v1 is neither uniformly spherical nor
+uniformly ellipsoidal, so the surface is stated per operation:
 
-**EPSG attribution.** Filling the catalog from the
-[EPSG dataset](https://epsg.org/) later brings its terms of use with it: IOGP's ownership
-has to be acknowledged wherever the data is published, and anyone given the data has to
-be told those terms, so that work carries a `LICENSES/EPSG-TERMS-OF-USE` entry beside
-the existing `QL-LICENSE` and `Unicode-DFS-2016-LICENSE`.
+| 4326 operation | v1 | MySQL |
+| --- | --- | --- |
+| `ST_Distance`, `ST_Length` | ellipsoid (Andoyer) | ellipsoid (Andoyer) |
+| `ST_Distance_Sphere` | sphere, great circle | sphere, great circle |
+| point-in-polygon predicates | MySQL's surface, falling back to sphere (S2) | ellipsoid, Andoyer edges |
+| polygon/polygon predicates | MySQL's surface, falling back to planar | ellipsoid, Andoyer edges |
 
-**Axis order.** EPSG:4326 defines (latitude, longitude), so the first coordinate is the
-latitude, and v1 follows MySQL so that `ST_Latitude`/`ST_Longitude`, distances and WKT
-round-trips match. WKB carries two unlabelled doubles, so the same bytes mean different
-things across ecosystems: PostGIS uses one fixed easting/longitude-first order for every
-SRS, and roughly a third of the SRIDs in MySQL's catalog disagree with it, across both
-geographic and projected systems. GeoJSON (RFC 7946, always longitude-first) and the
-explicit `ST_Latitude`/`ST_Longitude` accessors are unambiguous. `ST_X`/`ST_Y` are
-positional, so on 4326 `ST_X` is the latitude here and in MySQL (verified: `ST_X` =
-`ST_Latitude` = 30 for `POINT(30 50)`) and the longitude in PostGIS. The per-SRID breakdown
-belongs in the user docs as migration guidance.
+Everything on SRID 0 is planar in both columns. Every MySQL cell above is measured against
+a running engine rather than taken from documentation.
 
-Coordinates are **stored as parsed**, so latitude-first on 4326. MySQL stores the opposite
-order and swaps at every boundary, visible as `HEX(g)` and `ST_AsBinary(g)` returning
-swapped coordinates for the same 4326 point; both engines emit the same WKB.
+The measurement rows match MySQL. The two predicate rows are targets rather than fixed
+answers: they aim at MySQL's surface, and where reaching it would cost disproportionate
+complexity the simpler surface stands with the divergence documented.
+[Unresolved Questions](#unresolved-questions) owns that decision and sizes each fallback.
 
-**Extension path** (documented, not built here):
+**Catalog.** `information_schema.st_spatial_reference_systems` returns exactly two rows,
+SRID 0 and 4326, with MySQL's columns and the values MySQL gives for them; no dataset is
+imported. It is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected and deferred to
+[Future extensions](#future-extensions). DDL validates `SRID n` against the catalog rather
+than against a hardcoded pair, so asking a server which SRIDs it supports is a query rather
+than an unknown-table error. Row contents are in
+[the appendix](#appendix-srs-catalog-and-axis-order).
 
-| Step | Cost |
-| --- | --- |
-| Fill the catalog from the full EPSG dataset, taken from EPSG or PROJ's `proj.db`, with the dataset version pinned in the docs and IOGP attribution carried. The set drifts: MySQL shipped 5,152 rows in 8.0.46 and 5,238 in 8.4 and 9.7 | moderate, and a prerequisite for the rest |
-| All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
-| Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
-| `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
-| User-defined SRSs through `CREATE [OR REPLACE] SPATIAL REFERENCE SYSTEM` and `DROP SPATIAL REFERENCE SYSTEM`, which MySQL also has (there is no `ALTER`; modification is `CREATE OR REPLACE`) | bigger: a writable catalog, a WKT SRS parser, and catalog changes that have to replicate |
+**Axis order.** EPSG:4326 defines (latitude, longitude) and v1 follows MySQL, so the first
+coordinate is the latitude and `ST_X` returns the latitude on 4326. GeoJSON (RFC 7946) is
+always longitude-first, and `ST_Latitude`/`ST_Longitude` are unambiguous everywhere.
+Coordinates are **stored as parsed**, so latitude-first on 4326. The cross-ecosystem
+detail is in [the appendix](#appendix-srs-catalog-and-axis-order) and belongs in the user
+docs as migration guidance.
 
 DDL restricts the `SRID n` attribute to 0 or 4326. An unrestricted `GEOMETRY` column may
 still hold values of any SRID (see [Types and storage](#types-and-storage)).
@@ -205,7 +211,10 @@ an **allowlist**: only these are registered, and anything else spatial is an unk
 function until a later milestone adds it.
 
 - **`ST_GeomFrom*`**, a geometry from an external format: `ST_GeomFromText`,
-  `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
+  `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`, plus MySQL's plain synonyms
+  `ST_GeometryFromText` and `ST_GeometryFromWKB`. Those two are v1: they are spellings of
+  the same function, not the per-subtype aliases (`ST_PointFromText`, `ST_PolyFromWKB` and
+  the rest) deferred below.
 - **`ST_As*`**, an external format from a geometry: `ST_AsText` (`ST_AsWKT`),
   `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
 - **Option arguments.** `axis-order` on the WKT and WKB members of both groups, taking
@@ -245,13 +254,11 @@ function until a later milestone adds it.
   `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
   `ST_ExteriorRing`, `ST_NumInteriorRings`, `ST_Centroid`. `ST_Centroid` is Cartesian-only,
   as in MySQL, which raises `ERROR 3618` for it on 4326.
-- **Measurement:** `ST_Area`, `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`.
+- **Measurement:** `ST_Length(ls)`, `ST_Distance(g1, g2)` and
+  `ST_Distance_Sphere(g1, g2 [, radius])`, whose `radius` must be positive. The default
+  radius is derived from the SRS, and is 6,370,986.0 m on SRID 0, which has none.
 - **Predicates (DE-9IM):** `ST_Within`, `ST_Contains`, `ST_Intersects`, `ST_Equals`,
   `ST_Disjoint`, `ST_Touches`, `ST_Crosses`, `ST_Overlaps`.
-- **PostGIS extras:** `ST_Covers`, `ST_CoveredBy`, included because the index layer makes
-  them index-eligible region predicates (`Covers ⊇ Contains`, `CoveredBy ⊇ Within`, so a
-  covering-cell prefilter has no false negatives). Other PostGIS-only functions are added
-  later only if index-supported or by demand.
 
 **SRID handling** differs by direction, and a round-trip hides it:
 
@@ -273,17 +280,33 @@ A later milestone covers the geometry-processing tail (`ST_Buffer`, `ST_Union`,
 `ST_Intersection`, ...), the typed I/O aliases, the `MBR*` family, geohash, the niche
 accessors.
 
-Semantics match MySQL, with three v1 limitations:
+**Compatibility is to MySQL's answer, not to the exact geodesic.** Every geographic
+computation in MySQL 9.7 uses one formula, Boost.Geometry's `strategy::andoyer`, for
+measurement and predicates alike. It is the spherical law of cosines plus a first-order
+flattening term, so it is not the exact geodesic:
+
+| Separation | MySQL minus an exact geodesic |
+| --- | --- |
+| 10 km | 9.9 cm |
+| 9,810 km | -7.9 m |
+| near-antipodal | +5,973 m |
+
+v1 targets MySQL's answer rather than the more accurate one, and inherits those errors
+deliberately: a general-purpose geodesic library diverges from MySQL by exactly those
+amounts, so here an accuracy improvement is a compatibility defect. Where matching MySQL
+would cost disproportionate complexity a spherical answer is accepted instead, with the
+divergence documented; see [Unresolved Questions](#unresolved-questions).
+
+Semantics match MySQL, with these 4326 specifics:
 
 - On 4326, `ST_Distance`/`ST_Length` are ellipsoidal (Andoyer, matching MySQL to
   sub-metre); `ST_Distance_Sphere` is the great-circle variant.
-- `ST_Area` on 4326 **errors** with `ERROR 3618`, MySQL's shape for its own Cartesian-only
-  functions. This diverges: MySQL computes it geodesically (12308778368.75 m2 for a
-  1-degree box). A planar degree2 or an off-by-0.45% spherical value would be silently
-  wrong; Karney ellipsoidal area is a later extension.
-- The predicates are OGC-correct via `simplefeatures`, which is planar. On 4326 the region
-  predicates get a geodesic point-in-polygon, but polygon/polygon relations stay planar and
-  diverge from MySQL. See [Unresolved Questions](#unresolved-questions).
+- The predicates come from `simplefeatures`, which is OGC-correct but planar, so matching
+  MySQL's ellipsoidal edges on 4326 is the open item. Where the fallback applies,
+  point-in-polygon is spherical via S2 and polygon/polygon planar, diverging from MySQL by
+  metres to kilometres and by degrees respectively. See
+  [Reference surface](#srid-model) for the surface each operation targets and
+  [Unresolved Questions](#unresolved-questions) for the size of each fallback.
 
 **GeoJSON.** Every RFC 7946 geometry is supported. The container and annotation members
 follow MySQL, verified on 8.4.6 and 9.7.2:
@@ -299,9 +322,8 @@ follow MySQL, verified on 8.4.6 and 9.7.2:
 | position with more than three coordinates | as above, except TiDB's 5 errors and 6 drops the extras |
 | unknown `type`, or a required member missing | `ERROR 3072`, and `ERROR 3070` naming the member |
 
-The `options` argument accepts such positions and strips the extra coordinates.
-`ST_AsGeoJSON`'s bbox and CRS-URN flags ship with the tail. Round-trips are not
-idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a GeometryCollection.
+Round-trips are not idempotent: a FeatureCollection returns from `ST_AsGeoJSON` as a
+GeometryCollection.
 
 Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
 over such an expression is rejected.
@@ -314,7 +336,8 @@ Bazel/CI sandbox; the only Bazel work is adding `DEPS.bzl` proxy-fetch entries.
 - `github.com/peterstace/simplefeatures`: OGC/DE-9IM model, WKT/WKB/GeoJSON I/O,
   predicates, planar measurement. Validated byte-identical to MySQL in the PoC.
 - `github.com/golang/geo` (Google's S2 port, Apache 2.0): spherical geometry for 4326.
-- `pkg/util/geomrel`: in-tree ellipsoidal distance/length (Andoyer) and geodesic refine.
+- `pkg/util/geomrel`: in-tree ellipsoidal distance/length (Andoyer) and the spherical S2
+  point-in-polygon refine.
 
 The processing tail may need GEOS-equivalent algorithms; it is deferred with the rest of
 the tail.
@@ -360,13 +383,30 @@ MySQL form. No spatial index syntax belongs to this layer.
 
     SELECT id, ST_AsText(loc), ST_Latitude(loc), ST_Longitude(loc) FROM stores;
 
-    -- geodesic metres on 4326
+    -- ellipsoidal geodesic metres on 4326
     SELECT id, ST_Distance(loc, ST_GeomFromText('POINT(37.5 -122.2)', 4326)) AS m
     FROM stores;
 
     -- the geometry predicate is evaluated per row here; the index accelerates it later
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
+
+### Phasing
+
+The v1 surface lands in dependency order, each step reviewable on its own:
+
+| Step | Contents | Done when |
+| --- | --- | --- |
+| 1. Type | Parser grammar, the field type, the `SRID` attribute, DDL validation, `SHOW CREATE TABLE`, the version byte and the EWKB codec, and the work in [Type plumbing](#type-plumbing) | a geometry column stores and returns its bytes across the audited operation surface |
+| 2. I/O | `ST_GeomFrom*`, `ST_As*`, their option arguments, and the SRID validation on every ingest path | byte-identical to MySQL on the round-trip suite |
+| 3. Catalog | `information_schema.st_spatial_reference_systems`, and DDL validating `SRID n` against it rather than against a hardcoded pair | the two rows match MySQL column for column |
+| 4. Inspection | the constructors and the accessors | matches MySQL, including the constructor axis order |
+| 5. Measurement | `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`, and `pkg/util/geomrel` | matches MySQL to the tolerances in [Functional Tests](#functional-tests) |
+| 6. Predicates | the eight DE-9IM predicates | matches MySQL where the semantics agree, with the divergences documented |
+
+Steps 1 to 3 are what the spatial index codes against, so they are the ones whose surface
+is hard to change later. Steps 4 to 6 are independent of each other and of the index, so
+they can land in parallel or in another order if review capacity says so.
 
 ### Scope and deferrals
 
@@ -377,9 +417,15 @@ Out of scope here, each with a home:
   ([#69473](https://github.com/pingcap/tidb/pull/69473)), for which this layer is the prerequisite.
 - The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash and
   niche accessors: a later, parallel expression-layer milestone.
-- **SRIDs beyond 0 and 4326**, the full SRS catalog and `ST_Transform`: the extension path
-  above. `ST_Transform` is MySQL functionality rather than a PostGIS extra, but it has
-  nothing to do until more SRSs exist, so it is out of scope for v1.
+- **`ST_Area`**, deferred whole rather than split by SRID. On 4326 MySQL computes it
+  ellipsoidally (12308778368.75 m2 for a 1-degree box), where a planar degree2 or an
+  off-by-0.45% spherical value would be silently wrong. Nothing blocks matching that, since
+  an exact ellipsoidal area already agrees with MySQL to 6e-10 relative, but shipping only
+  the SRID 0 half would put a function in v1 whose support depends on the SRID, which
+  nothing else in the set does. It lands with the tail.
+- **SRIDs beyond 0 and 4326**, the full SRS catalog and `ST_Transform`:
+  [Future extensions](#future-extensions). `ST_Transform` is MySQL functionality, but it
+  has nothing to do until more SRSs exist, so it is out of scope for v1.
 - **Coprocessor pushdown.** The predicates and measurement functions are deterministic
   scalars and pushdown-eligible; pushing them filters at the storage node instead of
   shipping every candidate geometry to TiDB, with or without an index. It is cross-repo work
@@ -387,10 +433,14 @@ Out of scope here, each with a home:
   the pushdown contract.
 - **The other two spatial `information_schema` tables**: `st_geometry_columns`, one row per
   geometry column and derivable from the schema, and `st_units_of_measure`, 47 static rows
-  in MySQL that matter once projected SRSs with varied units exist.
+  in MySQL that matter once projected SRSs with varied units exist. The `unit` argument on
+  `ST_Distance` and `ST_Length` is deferred with it, since that catalog defines the names
+  it accepts; v1 has the two-argument forms and returns metres on 4326.
 - **Where the per-SRS attributes come from.** MySQL's six columns do not expose the class,
   axis order, bounds, unit or ellipsoid; those live inside the WKT `DEFINITION`, which MySQL
-  parses at runtime. The full-catalog work chooses between a WKT SRS parser, which
+  parses at runtime. The ellipsoid is load-bearing beyond measurement: `ST_Distance_Sphere`
+  derives its default radius from it, so the catalog work has to surface `a` and `b`, not
+  just store the definition string. The full-catalog work chooses between a WKT SRS parser, which
   `CREATE SPATIAL REFERENCE SYSTEM` needs anyway, and internal parsed metadata. Neither
   widens this table: extra columns belong in a TiDB-specific companion, expressed as WKT2
   (ISO 19162) or PROJJSON.
@@ -411,7 +461,7 @@ Out of scope here, each with a home:
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
-| Upgrade | Additive, and gated by no user-visible variable: the type is absent until it is complete. Any switch used while the work lands is a merge convenience, not documented surface. |
+| Upgrade | Additive: the type does not exist in earlier releases, so no existing schema or query changes behavior. |
 | Downgrade | A release without the type cannot read a table that has a geometry column, so those columns must be dropped first, an ordinary `DROP COLUMN`. |
 
 ## Test Design
@@ -422,10 +472,18 @@ Out of scope here, each with a home:
   `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
   including its `ST_AsText` spacing and axis order.
 - Accessors and measurement against values measured on MySQL, e.g. for a 1-degree step on
-  4326: `ST_Distance` 111319.49 m, `ST_Distance_Sphere` 111195.08 m, `ST_Area` of a 1-degree
-  box 12308778368.75 m2.
-- Predicates: the eight DE-9IM predicates plus `Covers`/`CoveredBy` on curated geometry
-  pairs, matched to MySQL where semantics agree, with boundary cases explicit.
+  4326: `ST_Distance` 111319.49 m and `ST_Distance_Sphere` 111195.08 m.
+- `ST_Distance_Sphere`'s `radius` argument: the default matches MySQL on both SRID 0 and
+  4326, an explicit radius scales the result, and a zero or negative one errors as MySQL
+  does.
+- `ST_GeometryFromText` and `ST_GeometryFromWKB` behave identically to `ST_GeomFromText`
+  and `ST_GeomFromWKB`, while the deferred per-subtype aliases are unknown functions.
+- Predicates: the eight DE-9IM predicates on curated geometry pairs, matched to MySQL where
+  semantics agree, with boundary cases explicit.
+- The 4326 edge-surface divergence is pinned by a regression test rather than left to
+  drift: `POLYGON((0 0, 80 0, 0 80, 0 0))` with probes at latitude 45.000000 and 45.070155
+  on longitude 70, asserting v1's spherical answers and recording MySQL's ellipsoidal ones,
+  so a later geodesic relate flips the assertions deliberately instead of silently.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN rejection,
   and mixed-SRID arguments to a binary geometry function giving `ERROR 3033`, while the
   SQL comparison operators keep comparing the stored bytes without erroring.
@@ -467,6 +525,10 @@ Out of scope here, each with a home:
 - Geometry ingest and read throughput vs a scalar-encoded baseline.
 - Geometry-predicate latency across selectivities with no other predicate to narrow the
   scan, the pre-index baseline the index layer will be measured against.
+- Influence on the online workload: a non-geospatial workload measured with and without
+  the feature present, expected to be unchanged, since nothing on a table without a
+  geometry column takes a new code path. The one shared cost to watch is the larger
+  builtin-function registry.
 
 ## Impacts & Risks
 
@@ -480,8 +542,9 @@ Risks:
   value-format and axis-order decisions here are lock-ins for them.
 - **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by the
   version byte and by storing Z/M and unsupported SRIDs losslessly from the start.
-- **4326 semantics gaps:** geodesic `ST_Area` and polygon/polygon relations diverge from
-  MySQL; mitigated by erroring or documenting rather than returning wrong values.
+- **4326 semantics gaps:** each predicate path diverges wherever it falls back to a simpler
+  surface than MySQL's ellipsoidal edges; mitigated by documenting rather than returning
+  wrong values, and bounded by edge length, so geofence-scale polygons are unaffected.
 - **MySQL error parity:** exact codes and messages may not match initially (the PoC used
   placeholder wording); a compatibility risk, not a correctness one.
 - **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the GEOS-class
@@ -520,29 +583,205 @@ Risks:
 - **Geometry as a generic BLOB with application-side functions.** The status quo; loses
   MySQL compatibility, type safety, and any path to a spatial index.
 - **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of MySQL
-  parity; the differences are documented under SRID model.
+  parity; always-planar 4326 would also contradict the SRS-class dispatch that keeps adding
+  SRIDs a catalog change rather than a code change. Full delta in
+  [the appendix](#appendix-postgis-delta-for-the-type-layer).
 
 ## Unresolved Questions
 
-**Polygon/polygon relations on 4326.** MySQL treats a geographic polygon's edges as
-geodesics; `simplefeatures`, and every other pure-Go option, treats them as straight lines
-in latitude/longitude. For `POLYGON((0 0, 0 80, 60 0, 0 0))` on 4326, MySQL 8.4.6 answers
-`ST_Within` **true** for the points `(30 40)`, `(33 40)`, `(36 40)` and `(40 40)`, while the
-same coordinates against the same ring evaluated planar answer **false** for all four: the
-great-circle edge bows away from the straight one by degrees, so whole regions flip rather
-than boundary cases. Small polygons, the common geofence case, are unaffected.
+**Geographic relate on 4326.** MySQL's polygon edges follow the same Andoyer approximation
+it uses everywhere else, so they are neither great circles nor exact geodesics
+(`sql/gis/within_functor.h`). Asking each engine where that edge sits at longitude 70, for
+the hypotenuse of `POLYGON((0 0, 80 0, 0 80, 0 0))`, separates every surface in play:
 
-Three resolutions, in increasing cost:
+| Evaluated as | Edge crosses longitude 70 at | Off MySQL by |
+| --- | --- | --- |
+| planar, straight lat/long edges (the polygon/polygon fallback) | latitude 10.000000 | ~3,900 km |
+| sphere, S2 great-circle edges (the point-in-polygon fallback) | latitude 45.000000 | 7,796 m |
+| an exact geodesic | latitude 45.070235 | 8.9 m |
+| **MySQL 9.7.2: ellipsoid, Andoyer edges** | **latitude 45.070155** | 0 |
 
-1. **Ship planar polygon/polygon and document it.** Correct for small geofences, silently
-   wrong for continental ones.
-2. **Error when it would matter.** Reject a geographic polygon/polygon relate whose operands
-   exceed some extent. Needs a defensible threshold, and the error is itself a divergence,
-   since MySQL answers.
-3. **Implement geodesic relate.** Full parity, and the only option that makes the index
-   layer's refine exact on 4326. It needs a geographic DE-9IM implementation on the TiDB
-   side and, once pushdown lands, the TiKV side. No pure-Go library provides one: S2 gives
-   coverings and predicates on spherical shapes, not the DE-9IM matrix.
+Falling back costs very different amounts on the two paths:
+
+| Path | Fallback surface | Divergence from MySQL |
+| --- | --- | --- |
+| polygon/polygon relate | planar, straight lat/long edges | **degrees.** For `POLYGON((0 0, 0 80, 60 0, 0 0))`, MySQL 8.4.6 answers `ST_Within` true for `(30 40)`, `(33 40)`, `(36 40)` and `(40 40)`; planar answers false for all four. Whole regions flip, not boundary cases |
+| point-in-polygon | sphere, S2 great-circle edges | **metres to kilometres**, scaling with edge length. On the polygon above, MySQL and S2 disagree across a 7,796 m band at longitude 70: every point between latitude 45.000000 and 45.070155 is within for MySQL and outside for S2 |
+
+The second scales sharply with edge length, making it a continental-polygon problem rather
+than a geofence one:
+
+| Edge length | Great circle vs ellipsoidal geodesic |
+| --- | --- |
+| 8 km (city) | 4 mm |
+| 79 km (metro) | 0.4 m |
+| 394 km (region) | 10 m |
+| 1,573 km (country) | 163 m |
+| 3,501 km (continent) | 824 m |
+| 6,690 km | 3.1 km |
+
+So small polygons, the common geofence case, are barely affected by either fallback. Both
+divergences have the same root cause, MySQL's curved edges, but closing them costs very
+differently.
+
+**The rule: get as close to MySQL as the complexity allows.** Each path takes the closest
+answer that does not cost disproportionate complexity, and where that still falls short of
+MySQL the divergence is documented rather than hidden.
+
+- **Point-in-polygon** should give MySQL's ellipsoidal answer where that is achievable
+  without outsized complexity. Where it is not, the spherical answer stands: per the table
+  above it is already sub-metre for polygons up to a few hundred km across, and three
+  orders of magnitude closer than planar.
+- **Polygon/polygon** is the expensive one, since a geographic relate replaces the planar
+  DE-9IM engine rather than adjusting it. Planar stands until that cost is justified.
+
+Erroring instead of answering was considered and rejected: it needs an arbitrary extent
+threshold, and the error is itself a divergence, since MySQL answers.
+
+One consequence to state rather than hide: while the two paths use different surfaces, v1
+answers a point and an infinitesimal polygon at the same location differently.
+`ST_Within(POINT(30 70), ...)` against the polygon above is true and the same test on a
+tiny polygon there is false, where MySQL answers true for both.
 
 This design owns the decision, since the type layer owns predicate semantics. No bytes are
-locked in either way.
+locked in either way, so the outcome can change after GA.
+
+## Future extensions
+
+Documented, not built here. Each is additive over the v1 surface and needs no format
+change.
+
+| Step | Cost |
+| --- | --- |
+| Fill the catalog from the full EPSG dataset, taken from EPSG or PROJ's `proj.db`, with the dataset version pinned in the docs and IOGP attribution carried ([terms](#epsg-terms-of-use)). The set drifts: MySQL shipped 5,152 rows in 8.0.46 and 5,238 in 8.4 and 9.7 | moderate, and a prerequisite for the rest |
+| All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
+| Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
+| `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
+| User-defined SRSs through `CREATE [OR REPLACE] SPATIAL REFERENCE SYSTEM` and `DROP SPATIAL REFERENCE SYSTEM`, which MySQL also has (there is no `ALTER`; modification is `CREATE OR REPLACE`) | bigger: a writable catalog, a WKT SRS parser, and catalog changes that have to replicate |
+
+`ST_Covers` and `ST_CoveredBy` are PostGIS spellings with no MySQL equivalent, worth adding
+once the spatial index lands: they are index-eligible region predicates
+(`Covers ⊇ Contains`, `CoveredBy ⊇ Within`, so a covering-cell prefilter has no false
+negatives). Other functions outside MySQL's set follow the same rule, added only if
+index-supported or by demand.
+
+A `GEOGRAPHY` type is a further extension, covered in
+[the appendix](#appendix-postgis-delta-for-the-type-layer). The function tail, the `MBR*`
+family and the rest of the deferred surface are in
+[Scope and deferrals](#scope-and-deferrals).
+
+## Appendix: SRS catalog and axis order
+
+### Catalog row contents
+
+The two rows carry MySQL's columns (`SRS_NAME`, `SRS_ID`, `ORGANIZATION`,
+`ORGANIZATION_COORDSYS_ID`, `DEFINITION`, `DESCRIPTION`): SRID 0 with an empty name and
+definition and no organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the
+`GEOGCS["WGS 84",DATUM[...]]` definition string. Both are what MySQL returns for those two
+SRIDs, column for column. Whether the table is a view over an internal one or synthesized
+is an implementation choice; MySQL uses a view over a data dictionary table that is itself
+unreadable, even by `root` (`ERROR 3554`).
+
+### EPSG terms of use
+
+Filling the catalog from the [EPSG dataset](https://epsg.org/) later brings its terms with
+it: IOGP's ownership has to be acknowledged wherever the data is published, and anyone
+given the data has to be told those terms. That work therefore carries a
+`LICENSES/EPSG-TERMS-OF-USE` entry beside the existing `QL-LICENSE` and
+`Unicode-DFS-2016-LICENSE`.
+
+### Axis order detail
+
+Latitude-first on 4326 is what makes `ST_Latitude`/`ST_Longitude`, distances and WKT
+round-trips match MySQL. WKB carries two unlabelled doubles, so the same bytes mean
+different things across ecosystems, and `ST_X`/`ST_Y` are positional rather than named: on
+4326 `ST_X` is the latitude, here and in MySQL (verified: `ST_X` = `ST_Latitude` = 30 for
+`POINT(30 50)`). How other ecosystems order the same bytes is in
+[the PostGIS appendix](#appendix-postgis-delta-for-the-type-layer).
+
+Storing coordinates as parsed is where TiDB and MySQL differ internally without differing
+observably: MySQL stores the opposite order and swaps at every boundary, visible as
+`HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for the same 4326 point. Both
+engines emit the same WKB.
+
+## Appendix: PostGIS delta for the type layer
+
+The compatibility target is **MySQL**, so full PostGIS compatibility is a stated non-goal
+rather than an omission: MySQL's spatial surface is a strict subset of PostGIS's, and the
+syntax, the `SHOW CREATE TABLE` form, the single-`TypeGeometry`-plus-subtype model and the
+predicate semantics all anchor on MySQL. This appendix records the delta a PostGIS user
+meets at the **type and function layer**, so a deliberate MySQL-alignment choice is not
+later mistaken for a gap. The index-layer delta, and the path to parity across the whole
+stack, are the appendix of
+[`docs/design/2026-06-25-spatial-index.md`](2026-06-25-spatial-index.md).
+
+### Type and surface mapping
+
+PostGIS picks the reference surface by *type*, TiDB and MySQL pick it by *SRS class*, so
+the mapping is not type name to type name:
+
+- `SRID 0` is PostGIS `geometry`: planar, unitless coordinates, no globe. All three engines
+  agree here.
+- `SRID 4326` is PostGIS **`geography`**, not PostGIS `geometry`. PostGIS `geometry` on 4326
+  does planar arithmetic on degrees, and no TiDB spelling reproduces that, by choice: it is
+  the footgun the SRS-class model does not have.
+
+Per operation on 4326, extending the v1 and MySQL columns in [SRID model](#srid-model):
+
+| 4326 operation | PostGIS `geometry` | PostGIS `geography` |
+| --- | --- | --- |
+| `ST_Distance`, `ST_Length` | planar, in degrees | ellipsoid (default) |
+| `ST_Distance_Sphere` | n/a | `use_spheroid => false` |
+| point-in-polygon predicates | planar, in degrees | sphere, great-circle edges |
+| polygon/polygon predicates | planar, in degrees | sphere, great-circle edges |
+
+`SRID 4326` and `geography` agree closely on both axes: PostGIS geography edges are
+great-circle arcs, as the S2 refine's are, and its `ST_Distance` defaults to the spheroid,
+which Andoyer approximates.
+
+**Ellipsoidal edges are MySQL-only, so v1's gap is PostGIS's gap too.** Both compute
+ellipsoidal *measurement* and spherical *topology*, and neither offers a switch: PostGIS's
+`ST_Distance` and `ST_DWithin` take `use_spheroid`, while `ST_Covers` and `ST_Intersects`
+on `geography` do not. So a spherical point-in-polygon is not a shortfall against PostGIS;
+it is what PostGIS does, and MySQL is the outlier.
+
+PostGIS can still construct an exact geodesic by hand, out of `ST_Azimuth` and
+`ST_Project`, even though no predicate consumes it. That is the provenance of the
+exact-geodesic row in [Unresolved Questions](#unresolved-questions): PostGIS and an
+independent Vincenty computation both place that edge at latitude 45.070235.
+
+### A `GEOGRAPHY` type
+
+The extension a PostGIS user asks for, since it is how PostGIS spells ellipsoidal
+measurement. Nothing in this design forecloses it, and little of it would be new work:
+
+- **Storage costs nothing.** EWKB behind a format-version byte is exactly what PostGIS
+  stores for `geography`, so such a column needs no new bytes, no second codec and no
+  migration of existing geometry columns.
+- **The math is already scoped.** It needs the ellipsoidal work this design already names:
+  Andoyer (shipped in v1), Karney area, and a geodesic relate
+  ([Unresolved Questions](#unresolved-questions)). It adds no formula that the
+  geographic-SRS step in [Future extensions](#future-extensions) does not already require.
+- **The open question is semantic, not mechanical.** Because the surface is chosen by SRS
+  class rather than by type, `SRID 4326` is already the geography equivalent, so a
+  `GEOGRAPHY` type buys PostGIS spelling rather than a new capability, and
+  `GEOGRAPHY SRID 0` would mean nothing. Giving `GEOMETRY` PostGIS's always-planar meaning
+  at the same time would break MySQL parity, so that pairing is a fork in the road, not an
+  addition to this design.
+- **Type plumbing is the part worth deciding before it is needed**: whether `GEOGRAPHY`
+  becomes a field type of its own or a flag over `mysql.TypeGeometry` touches the parser,
+  DDL, `SHOW CREATE TABLE`, `information_schema.columns` and the tool metadata path in
+  [Compatibility](#compatibility). No constant is reserved for it here.
+
+### Remaining delta
+
+| Area | PostGIS | This design |
+| --- | --- | --- |
+| Ellipsoidal accuracy | Karney via PROJ's `geodesic.c`, exact to round-off and convergent near antipodes | Andoyer, because MySQL is Andoyer (see [Function set](#function-set)). Both are "ellipsoidal", so a PostGIS user should still expect differences: centimetres at 10 km, kilometres near antipodes |
+| Axis order | One fixed longitude-first order for every SRS, so `ST_X` on 4326 is the longitude where TiDB and MySQL give the latitude. Roughly a third of the SRIDs in MySQL's catalog disagree with that fixed order, across both geographic and projected systems | The SRS's own order, as MySQL, so latitude-first on 4326, with the `axis-order` option and `ST_Latitude`/`ST_Longitude` as the unambiguous paths |
+| SRID / CRS | Full EPSG catalog in `spatial_ref_sys`, on-the-fly `ST_Transform` | SRID 0 and 4326 only; other codes rejected by DDL but storable in an unrestricted column; no `ST_Transform`. Both are in [Future extensions](#future-extensions) |
+| Function breadth | 300+ `ST_*` | The v1 allowlist, then MySQL's ~70. Absent families include buffer/convex-hull/simplify, overlay set operations, spatial clustering and aggregates, linear referencing, `ST_MakeValid`, and the `ST_AsMVT`/KML/GML/SVG output formats |
+| Function spelling | `ST_DistanceSphere`, `ST_DistanceSpheroid` | MySQL's `ST_Distance_Sphere`; the underscore differs, and no spheroid variant exists separately because `ST_Distance` on 4326 is already ellipsoidal |
+| Geometry types | Adds CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON, POLYHEDRALSURFACE, TIN, TRIANGLE | OGC Simple Features only; no curved or TIN geometries |
+| Dimensionality | XYZ / XYM / XYZM, with ND indexing | Stored losslessly, computed 2D only, as in MySQL |
+| Subsystems | Raster, topology, SFCGAL solids, pgRouting, Tiger geocoder | None planned |

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -139,38 +139,35 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | Rejected on ingest | Inf/NaN, `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
 | Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
 
-Codes and wording are matched as closely as possible on every ingest path
-(`ST_GeomFromText`, the constructors, `ST_GeomFromGeoJSON`, `ST_GeomFromWKB`), as are
-`ERROR 3618` (function not implemented on a geographic SRS) and `ERROR 3643` (SRID does not
-match the column). An unmatched message is a gap to close, not grounds for a different code.
+Codes and wording are matched as closely as possible on every ingest path:
+`ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`, and the constructors `Point`,
+`LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon` and
+`GeometryCollection`. The same goes for `ERROR 3618` (function not implemented on a
+geographic SRS) and `ERROR 3643` (SRID does not match the column). An unmatched message is
+a gap to close, not grounds for a different code.
 
 Planar versus geodesic follows the **SRS class** (SRID 0 and projected are Cartesian,
 geographic is geodesic), as in MySQL. Adding SRIDs later therefore adds catalog rows and
 per-class parameters, not code paths.
 
-**Catalog.** `information_schema.st_spatial_reference_systems` ships with MySQL's shape
-(`SRS_NAME`, `SRS_ID`, `ORGANIZATION`, `ORGANIZATION_COORDSYS_ID`, `DEFINITION`,
-`DESCRIPTION`) and two hard-coded rows: SRID 0 with an empty name and definition and no
-organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the `GEOGCS["WGS 84",DATUM[...]]`
-definition string. No dataset is imported: SRID 0 is not an EPSG record, and 4326 is one
-stable record taken from the [EPSG dataset](https://epsg.org/) rather than from a MySQL
-install. The table is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, which is a
-MySQL-parity gap on the extension path rather than a PostGIS extra. DDL validates
-`SRID n` against the table rather than against a hardcoded pair. Without the table,
-asking which SRIDs a server supports is an unknown-table error.
+**Catalog.** `information_schema.st_spatial_reference_systems` must be queryable and
+return exactly two rows, with MySQL's columns (`SRS_NAME`, `SRS_ID`, `ORGANIZATION`,
+`ORGANIZATION_COORDSYS_ID`, `DEFINITION`, `DESCRIPTION`): SRID 0 with an empty name and
+definition and no organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the
+`GEOGCS["WGS 84",DATUM[...]]` definition string. Whether that is a view over an internal
+table or a synthesized one is an implementation choice; MySQL uses a view over a data
+dictionary table that is itself unreadable, even by `root` (`ERROR 3554`). Both rows are
+what MySQL returns for those two SRIDs, column for column; no dataset is imported. The
+catalog is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, and supporting it
+is on the extension path. DDL validates `SRID n` against the catalog rather than against a
+hardcoded pair. Without it, asking which SRIDs a server supports is an unknown-table
+error.
 
-**EPSG attribution.** The 4326 row is an EPSG record, so the dataset's terms of use apply:
-
-| Obligation | Discharged by |
-| --- | --- |
-| Acknowledge IOGP ownership "in any publication or transmission (by whatever means) thereof" | a comment on the constant, a line in the user docs, and a `LICENSES/EPSG-TERMS-OF-USE` entry beside the existing `QL-LICENSE` and `Unicode-DFS-2016-LICENSE` |
-| "Inform anyone to whom you provide the EPSG Facilities of these Terms of Use" | that entry carries the terms text, not a link to it |
-| Modified data must not be attributed to EPSG | the record is reproduced verbatim |
-| No value ascribed to the data, and no distribution for profit | nothing to do here; it constrains anyone repackaging TiDB |
-
-Acknowledgment text: *the EPSG Geodetic Parameter Dataset is owned by IOGP and used under
-its terms of use; TiDB reproduces the EPSG:4326 record unmodified.* The obligations are the
-same when the full dataset is imported later.
+**EPSG attribution.** Filling the catalog from the
+[EPSG dataset](https://epsg.org/) later brings its terms of use with it: IOGP's ownership
+has to be acknowledged wherever the data is published, and anyone given the data has to
+be told those terms, so that work carries a `LICENSES/EPSG-TERMS-OF-USE` entry beside
+the existing `QL-LICENSE` and `Unicode-DFS-2016-LICENSE`.
 
 **Axis order.** EPSG:4326 defines (latitude, longitude), so the first coordinate is the
 latitude, and v1 follows MySQL so that `ST_Latitude`/`ST_Longitude`, distances and WKT

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -31,216 +31,133 @@
 ## Introduction
 
 This document proposes **basic geospatial support** for TiDB: a MySQL-compatible
-`GEOMETRY` type family (`POINT`, `LINESTRING`, `POLYGON`, and the multi/collection
-variants), per-column [`SRID`](#terminology), [EWKB](#terminology) storage, and a
-minimal-but-useful set of `ST_*` functions covering I/O, accessors, measurement, and the
-[DE-9IM](#terminology) spatial predicates. It supports **SRID 0 (Cartesian plane)** and
-**SRID 4326 ([WGS 84](#terminology) geographic)** and makes geometry values storable,
-queryable, and filterable (by full table scan). It is the prerequisite layer that a
-spatial **index** builds on, but it is deliberately **index-free**: geometry becomes a
-first-class value and query surface first, and the index lands separately.
+`GEOMETRY` type family, per-column [`SRID`](#terminology), versioned
+[EWKB](#terminology) storage, and the minimal `ST_*` function set that makes geometry
+storable, readable, and queryable by full table scan. It covers **SRID 0** (Cartesian
+plane) and **SRID 4326** ([WGS 84](#terminology) geographic), including the
+[DE-9IM](#terminology) predicates.
 
-The scope is intentionally the smallest slice that is independently useful and GA-able,
-and it is designed so later work (more SRIDs, the long tail of geometry-processing
-functions, coprocessor pushdown, and the spatial index) extends it **without a new
-design**. This replaces the earlier geospatial design (PR #38916). The spatial index is
-specified separately in `docs/design/2026-06-25-spatial-index.md` (PR #69473) and
-depends on this layer.
+It is deliberately **index-free**: the spatial index is specified separately in
+`docs/design/2026-06-25-spatial-index.md` (PR #69473) and builds on this layer. The scope
+here is the smallest slice that is independently useful and GA-able, designed so that
+later work (more SRIDs, the geometry-processing function tail, coprocessor pushdown, the
+index) extends it without a new design. This replaces the earlier geospatial design
+(PR #38916).
 
 ## Terminology
 
-Geospatial standards come with a dense vocabulary. The abbreviations used throughout this
-document, each with an external reference and the section that covers it in depth:
-
-- **[OGC](https://www.ogc.org/standard/sfa/)** (Open Geospatial Consortium): the standards
-  body behind *Simple Features*, the specification that MySQL's spatial types and `ST_*`
-  functions follow.
-- **[WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)**
-  (Well-Known Text / Well-Known Binary): the OGC text and binary encodings of a geometry,
-  for example `POINT(1 2)` and its byte form. Neither carries an SRID.
-- **[EWKB](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html)** (Extended WKB):
-  WKB with the SRID carried alongside it. MySQL stores a 4-byte little-endian SRID followed
-  by OGC WKB, which is the layout this design adopts; see
-  [Types and storage](#types-and-storage).
-- **SRS** (spatial reference system): the coordinate system a geometry's numbers are
-  expressed in, together with its units, axis order, and datum. An SRS is either
-  *projected* (flat X/Y) or *geographic* (angular latitude/longitude on an ellipsoid).
-- **[SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html)**
-  (spatial reference system identifier): the integer that names an SRS. v1 supports 0 (the
-  abstract Cartesian plane) and 4326 (WGS 84); see [SRID model](#srid-model).
-- **[EPSG](https://epsg.org/)**: the registry that assigns those identifiers, and the
-  source of the SRS catalog described in the [SRID model](#srid-model) extension path.
-- **[WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)** (World Geodetic System
-  1984): the global datum and reference ellipsoid used by GPS, registered as EPSG:4326.
-- **Planar vs geodesic**: planar measurement treats coordinates as points on a flat plane;
-  geodesic measurement follows the curved surface of the ellipsoid. Which one applies is
-  decided by the SRS class, not per SRID; see [SRID model](#srid-model).
-- **[DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)** (Dimensionally Extended
-  9-Intersection Model): the OGC model that defines what `ST_Within`, `ST_Contains`,
-  `ST_Intersects` and the other topological predicates actually mean; see
-  [Function set](#function-set).
-- **[GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)**: the JSON geometry encoding
-  (RFC 7946), the third I/O format alongside WKT and WKB.
-- **MBR** (minimum bounding rectangle): the axis-aligned box enclosing a geometry, and the
-  basis of MySQL's `MBR*` predicate family (deferred, see
-  [Scope and deferrals](#scope-and-deferrals)).
-- **[S2](http://s2geometry.io/)**: Google's spherical-geometry library, used here for the
-  geodesic 4326 paths; see [Geometry engine](#geometry-engine).
-- **[PROJ](https://proj.org/)**: the coordinate-transformation library that reprojection
-  between arbitrary SRSs would require; out of scope for this design.
+| Term | Meaning |
+| --- | --- |
+| [OGC](https://www.ogc.org/standard/sfa/) | Open Geospatial Consortium, the body behind *Simple Features*, the specification MySQL's spatial surface follows. |
+| [WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) | The OGC text and byte encodings of a geometry (`POINT(1 2)` and its bytes). Neither carries an SRID. |
+| [EWKB](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html) | WKB with the SRID alongside it. MySQL uses `<srid u32 LE><WKB>`; see [Types and storage](#types-and-storage). |
+| SRS | Spatial reference system: coordinate system, units, axis order, datum. Either *projected* (flat X/Y) or *geographic* (latitude/longitude on an ellipsoid). |
+| [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | The integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
+| [EPSG](https://epsg.org/) | The registry that assigns SRIDs, and the source of the SRS catalog. |
+| [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) | The datum and reference ellipsoid used by GPS, EPSG:4326. |
+| Planar vs geodesic | Measurement on a flat plane vs along the ellipsoid. Decided by SRS class, not per SRID. |
+| [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) | Dimensionally Extended 9-Intersection Model, the OGC model defining `ST_Within`, `ST_Contains`, `ST_Intersects` and the other topological predicates. |
+| [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) | JSON geometry encoding (RFC 7946), the third I/O format. |
+| MBR | Minimum bounding rectangle; basis of MySQL's `MBR*` predicates (deferred). |
+| [S2](http://s2geometry.io/) | Google's spherical-geometry library, used for the geodesic 4326 paths. |
+| [PROJ](https://proj.org/) | The reprojection library that arbitrary-SRS transforms would need; out of scope. |
 
 ## Motivation or Background
 
-Geospatial support is one of the most requested TiDB features. Tracking issue #6347
-carries the `feature/accepted` label and ranks among the top open issues by reactions.
-The dominant real-world workload is simple and concrete: store a location per row
-(latitude/longitude or a planar coordinate) and answer "what is near me", "which region
-contains this point", or "what overlaps this box". Bike-share, ride-hailing, parcel
-delivery, and asset-tracking applications all reduce to points plus proximity and
-geofence queries.
+Geospatial support is one of the most requested TiDB features: tracking issue #6347
+carries `feature/accepted` and ranks among the top open issues by reactions. The dominant
+workload is concrete, storing a location per row and answering "what is near me", "which
+region contains this point", or "what overlaps this box". Bike-share, ride-hailing, parcel
+delivery, and asset tracking all reduce to points plus proximity and geofence queries.
 
-TiDB has no spatial support today: only the `mysql.TypeGeometry` type constant exists
-(`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions.
-Users who need geometry today must encode it into scalar columns by hand and compute
-distances in the application, losing MySQL compatibility and correctness.
-
-This design replaces the earlier geospatial design (PR #38916). It covers the basic
+TiDB has none of it today: only the `mysql.TypeGeometry` constant exists
+(`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions, so
+users encode geometry into scalar columns by hand and compute distances in the
+application, losing MySQL compatibility and correctness. This design covers the basic
 layer only, scoped so it can ship, stabilize, and have its feature flag removed before
-index work starts merging on top.
+index work merges on top.
 
 ## Detailed Design
 
 ### Types and storage
 
-The `GEOMETRY` type family follows MySQL: `GEOMETRY` (any subtype), `POINT`,
-`LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, and
-`GEOMETRYCOLLECTION`. All reuse the existing `mysql.TypeGeometry` field type; the
-concrete subtype is a constraint on the stored value, as in MySQL. A column may carry a
-`SRID n` attribute fixing its spatial reference system (see [SRID model](#srid-model)).
+Types, all reusing the existing `mysql.TypeGeometry` field type with the subtype a
+constraint on the stored value, as in MySQL: `GEOMETRY` (any subtype), `POINT`,
+`LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`,
+`GEOMETRYCOLLECTION`. A column may carry a `SRID n` attribute (see
+[SRID model](#srid-model)). At the KV layer a geometry is a binary string; no new column
+encoding is introduced.
 
-The **stored value is version-tagged**: a 1-byte format version followed by the encoded
-geometry (`<format_version u8><payload>`). **Version 1 is EWKB**, a 4-byte little-endian
-SRID prefix followed by standard OGC WKB (`<srid_le_u32><wkb>`). Version numbering starts
-at 1, never 0, so a leading zero byte is always invalid and can never be mistaken for a
-version. Geometry columns are stored as a binary string kind at the KV layer; no new
-column encoding is introduced.
+Stored value:
 
-**The internal format does not need to match MySQL byte-for-byte.** Only two rules bind
-it: it must be lossless (exact `f64` coordinates, full geometry structure) and it must
-round-trip every supported type. The SRID has to survive as well, though not necessarily
-inside the stored bytes: where a column carries a `SRID n` attribute the value is
-redundant, so a later format version can omit it there and restore it from the column
-metadata on decode. It cannot be omitted unconditionally, because an unrestricted
-`GEOMETRY` column holds a per-row SRID, and because a geometry that is not in a column at
-all (a function result, an intermediate value in a join or a sort) has no column metadata
-to recover it from.
+    <format_version u8><payload>
+    version 1:  <srid u32 LE><OGC WKB>          // EWKB
 
-Dump/reload, the wire protocol, and `ST_AsBinary` are boundary concerns and they convert,
-emitting MySQL-compatible EWKB whatever is on disk. MySQL itself works this way: it
-stores coordinates longitude/easting-first internally regardless of SRID and swaps to the
-SRS axis order on every WKT/WKB read and write, so its own stored bytes are already not
-what its I/O emits (`axis-order.md`).
+| Rule | |
+| --- | --- |
+| Versioning | Numbered from 1, so a leading `0x00` is always invalid and never a version. A release reads every earlier version and writes the current one, so a later format needs no migration. |
+| Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
+| SRID | Recoverable from the value, or from the column where it carries `SRID n`. Not droppable from the value unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata. |
+| MySQL bytes | Not matched. `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary; MySQL itself stores coordinates longitude-first internally and swaps per SRS on every WKT/WKB read and write (`axis-order.md`). |
+| Z and M coordinates | Stored and returned unchanged. Every v1 function is 2D, as in MySQL. |
+| SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
-Version 1 is EWKB because it is what the proof of concept (PR #69475) implements and it
-needs no conversion today, not because it is optimal. `storage-format.md` measures the
-cost: EWKB carries a per-row SRID that the column definition usually already fixes, a
-byte-order flag per (sub)geometry, and WKB framing, and geometry decode is a measurable
-share of both the index-maintenance write path and the refine read path. A later version
-can drop the per-row SRID for SRID-restricted columns, drop the byte-order flags
-(everything written is canonical little-endian), shrink the type enum, or store a point
-as two bare `f64` values, each gated on a benchmark. The version byte is what keeps that
-available: a release reads every earlier version and writes the current one, with no
-migration.
+Extended data (the last two rows) round-trips through `ST_GeomFromWKB`/`ST_GeomFromText`
+and `ST_AsBinary`/`ST_AsText`, with `ST_SRID` and `ST_GeometryType` still answering, while
+every function that interprets coordinates rejects it with a clear error. Storing more
+than v1 computes on is what lets 3D/measured geometry and the wider SRS catalog arrive
+later as functions over data written today.
 
-**Extended data is storable, and no v1 function operates on it.** The format carries,
-losslessly:
-
-- **Z and M coordinates.** Every `ST_*` function in this design is 2D, as in MySQL, but a
-  value carrying Z/M is stored and returned unchanged rather than rejected or truncated.
-- **SRIDs outside 0 and 4326.** An unrestricted `GEOMETRY` column (one with no `SRID`
-  attribute) may hold values of any SRID, as in MySQL.
-
-Such values round-trip, in through `ST_GeomFromWKB`/`ST_GeomFromText` and out through
-`ST_AsBinary`/`ST_AsText`, with the metadata accessors (`ST_SRID`, `ST_GeometryType`)
-still answering. Every function that has to interpret the coordinates (measurement, the
-predicates, the geodesic paths) rejects them with a clear error. Storing more than v1
-computes on is deliberate: 3D/measured geometry and the wider SRS catalog then arrive as
-new *functions* over data written today, instead of needing a format change and a
-migration.
+Why EWKB is version 1 and what a version 2 would strip:
+[Investigation & Alternatives](#investigation--alternatives).
 
 ### SRID model
 
-v1 supports two spatial reference systems, chosen to cover the two coordinate-system
-*classes* that matter:
+| | SRID 0 | SRID 4326 |
+| --- | --- | --- |
+| Coordinate system | abstract Cartesian plane, unitless X/Y | WGS 84 geographic, latitude/longitude |
+| Bounds | none, the full finite IEEE-754 double range, as MySQL | latitude `[-90, 90]`, longitude `(-180, 180]` |
+| Rejected on ingest | Inf/NaN | out-of-range latitude/longitude, on every constructor and I/O path |
+| Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
 
-- **SRID 0: abstract Cartesian plane.** Unitless X/Y, no coordinate-range checking
-  (MySQL spans the full finite IEEE-754 double range). All functions are planar
-  (Cartesian).
-- **SRID 4326: WGS 84 geographic (lat/long).** Coordinates are bounded (latitude
-  `[-90, 90]`, longitude `(-180, 180]`); distance/length/area are geodesic on the WGS 84
-  ellipsoid, matching MySQL.
+Ingest errors match MySQL's codes and wording as closely as practical, on
+`ST_GeomFromText`, the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike.
 
-**Coordinate-system class drives planar-vs-geodesic**, exactly as MySQL decides it from
-the SRS class (SRID 0 / projected = Cartesian; geographic = geodesic). This class-based
-dispatch, not a per-SRID table of special cases, is the design's extension seam: adding
-SRIDs later is adding catalog rows and per-class parameters, not new code paths.
+Planar versus geodesic is decided by the **SRS class** (SRID 0 and projected are
+Cartesian, geographic is geodesic), exactly as MySQL decides it, rather than by a
+per-SRID table of special cases. That class-based dispatch is the extension seam: adding
+SRIDs later adds catalog rows and per-class parameters, not code paths.
 
-**Axis order.** MySQL's EPSG:4326 is **(latitude, longitude)**: the first coordinate is
-latitude. This is verifiable from MySQL's own out-of-range error wording (`POINT(100 0)`
-on 4326 errors "Latitude 100 ... out of range"). v1 follows MySQL's axis order so that
-`ST_Latitude`/`ST_Longitude`, distances, and WKT round-trips match.
+**Axis order.** EPSG:4326 defines (latitude, longitude), so the first coordinate is the
+latitude, and v1 follows MySQL here so that `ST_Latitude`/`ST_Longitude`, distances and
+WKT round-trips match. WKB carries two unlabelled doubles, so the same bytes mean
+different things across ecosystems: PostGIS uses one fixed easting/longitude-first order
+for every SRS, and roughly a third of the SRIDs in MySQL's catalog disagree with it,
+across both geographic and projected systems. GeoJSON (RFC 7946, always longitude-first)
+and the explicit `ST_Latitude`/`ST_Longitude` accessors are the unambiguous paths.
+Per-SRID counts and migration guidance are in `axis-order.md` and belong in user docs.
 
-WKB carries two bare doubles with no axis labels, so **the same bytes mean different
-things in the two ecosystems**: a 4326 `POINT` written by MySQL (and by this design) is
-(latitude, longitude), while the identical bytes written by PostGIS are (longitude,
-latitude), because PostGIS uses one fixed easting/longitude-first order for every SRS
-instead of the authority-defined one. This is not specific to 4326: roughly a third of
-the SRIDs in MySQL's catalog disagree with PostGIS, across both geographic and projected
-systems. GeoJSON (RFC 7946, always longitude-first) and the explicit
-`ST_Latitude`/`ST_Longitude` accessors are the two unambiguous paths. The full
-convention, the per-SRID counts, and the migration guidance are in the PoC's
-`axis-order.md` and should be folded into user docs.
+**Extension path** (documented, not built here):
 
-**Coordinate validation.** For 4326, out-of-range latitude/longitude errors on ingest
-(matching MySQL codes/wording as closely as practical), across every constructor and I/O
-path (`ST_GeomFromText`, the typed constructors, `ST_GeomFromGeoJSON`, `ST_GeomFromWKB`).
-For SRID 0, only non-finite overflow (Inf/NaN) is rejected, as in MySQL.
+| Step | Cost |
+| --- | --- |
+| SRS catalog: populate `information_schema.st_spatial_reference_systems` from EPSG (MySQL ships ~5,200 rows) with class, axis order, bounds, unit, ellipsoid | moderate, and a prerequisite for the rest |
+| All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
+| Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
+| PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform`) | bigger: on-the-fly reprojection needs a PROJ-like library; out of scope |
 
-**Extension path (documented, not built here).** Later SRID expansion, layered by cost so
-the cheap high-value part can land without the expensive part:
-
-- **SRS catalog**: populate `information_schema.st_spatial_reference_systems` from the
-  EPSG dataset (MySQL ships ~5,200 entries) with the per-SRS metadata the engine needs:
-  class (PROJECTED vs GEOGRAPHIC), axis order, coordinate bounds, unit, ellipsoid.
-  Prerequisite for everything below.
-- **All PROJECTED SRSs** (e.g. 3857 Web Mercator): low extra cost, they are planar X/Y,
-  so the same Cartesian functions apply; the only per-SRS input is coordinate bounds.
-- **GEOGRAPHIC SRSs beyond 4326**: moderate, needs exact geodesic refine per ellipsoid.
-- **PostGIS-level** (`CREATE SPATIAL REFERENCE SYSTEM`, `ST_Transform` between SRSs):
-  bigger, needs on-the-fly reprojection (a PROJ-like library); explicitly out of scope.
-
-v1 deliberately hard-restricts the `SRID n` column attribute to 0 or 4326 at DDL, so no
-partial-SRS behavior escapes before the catalog exists. An unrestricted `GEOMETRY` column
-can still *hold* values of any SRID, which are stored losslessly and read back unchanged
-but which no v1 function computes on (see [Types and storage](#types-and-storage)).
+DDL restricts the `SRID n` attribute to 0 or 4326, so no partial-SRS behavior escapes
+before the catalog exists. An unrestricted `GEOMETRY` column may still hold values of any
+SRID (see [Types and storage](#types-and-storage)).
 
 ### Function set
 
-The v1 function set is the minimal set needed to **store, read, and query** geometry:
-everything an application needs to put geometry in, get it out, inspect it, measure it,
-and filter rows by spatial relationship. The geometry-*processing* tail (`ST_Buffer`,
-`ST_Union`, `ST_Intersection`, ...), the typed I/O aliases, the MBR predicate family,
-geohash, and niche accessors are a **separate later milestone** (they are pure
-expression-layer builtins, orthogonal to both this layer and the index). The
-authoritative full MySQL catalog with the v1-vs-tail split is `mysql-function-catalog.md`.
-
-v1 functions (all present in MySQL 8.0.46 / 8.4 / 9.7, where the spatial function set
-is identical across those versions):
+v1 is the minimal set needed to store, read, inspect, measure and filter geometry. All of
+it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical.
 
 - **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
 - **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
-- **Constructors (function-call syntax):** `Point`, `LineString`, `Polygon` (the
-  `Multi*`/`GeometryCollection` constructors are in the tail).
+- **Constructors:** `Point`, `LineString`, `Polygon`.
 - **Accessors:** `ST_X`, `ST_Y`, `ST_Latitude`, `ST_Longitude`, `ST_SRID` (getter and the
   `ST_SRID(g, srid)` setter), `ST_GeometryType`, `ST_Dimension`, `ST_Envelope`,
   `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
@@ -248,75 +165,66 @@ is identical across those versions):
 - **Measurement:** `ST_Area`, `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`.
 - **Predicates (DE-9IM):** `ST_Within`, `ST_Contains`, `ST_Intersects`, `ST_Equals`,
   `ST_Disjoint`, `ST_Touches`, `ST_Crosses`, `ST_Overlaps`.
+- **PostGIS extras:** `ST_Covers`, `ST_CoveredBy`, included because the index layer makes
+  them index-eligible region predicates (`Covers ⊇ Contains`, `CoveredBy ⊇ Within`, so a
+  covering-cell prefilter has no false negatives). Other PostGIS-only functions are added
+  later only if index-supported or by demand.
 
-**PostGIS extras policy.** `ST_Covers` / `ST_CoveredBy` are PostGIS, not MySQL. They are
-included because they become **index-eligible region predicates** in the index layer
-(`Covers ⊇ Contains`, `CoveredBy ⊇ Within`, so a covering-cell prefilter is valid with no
-false negatives). Other PostGIS-only functions are added later only if index-supported or
-by demand.
+The geometry-processing tail (`ST_Buffer`, `ST_Union`, `ST_Intersection`, ...), the typed
+I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash
+and the niche accessors are a later milestone; `mysql-function-catalog.md` holds the
+authoritative v1-vs-tail split.
+
+Semantics match MySQL, with three documented v1 limitations:
+
+- On 4326, `ST_Distance`/`ST_Length` are ellipsoidal (Andoyer, matching MySQL to
+  sub-metre); `ST_Distance_Sphere` is the great-circle variant.
+- `ST_Area` on 4326 is a gap (geodesic polygon area on the ellipsoid, Karney): implement
+  it, or error as MySQL's Cartesian-only functions do (Unresolved Questions). It must not
+  silently return a planar degree² or an off-by-0.45% spherical value.
+- The predicates are OGC-correct via `simplefeatures`; on 4326 the region predicates use a
+  geodesic point-in-polygon, which diverges from MySQL's planar refine near
+  edges/poles/antimeridian. Polygon/polygon geodesic relations are a follow-up.
 
 Every geometry-returning builtin is typed `GEOMETRY`, so a plain B-tree functional index
-over such an expression is correctly rejected (a spatial index is the index layer's job).
-
-**Semantics match MySQL, with documented v1 limitations:**
-
-- Planar vs geodesic follows the SRS class. On 4326, `ST_Distance`/`ST_Length` are
-  ellipsoidal (Andoyer geodesic, matching MySQL to sub-metre); `ST_Distance_Sphere` is
-  the great-circle sphere variant.
-- `ST_Area` on 4326 is a known gap (geodesic polygon area on the ellipsoid, Karney):
-  either implement it or error like MySQL's Cartesian-only functions do (see Unresolved
-  Questions). It must not silently return a planar (degree²) or off-by-~0.45% spherical
-  value.
-- The DE-9IM predicates are OGC-correct via `simplefeatures`; on 4326 the region
-  predicates use a geodesic point-in-polygon where MySQL's planar refine diverges near
-  edges/poles/antimeridian. Polygon/polygon geodesic relations and geodesic `ST_Area` are
-  follow-ups.
+over such an expression is correctly rejected; a spatial index is the index layer's job.
 
 ### Geometry engine
 
-The geometry stack is **pure Go**, no cgo/libgeos:
+Pure Go, no cgo, so the stack builds with `CGO_ENABLED=0` and needs no libgeos in the
+Bazel/CI sandbox (the only Bazel work is adding `DEPS.bzl` proxy-fetch entries):
 
-- `github.com/peterstace/simplefeatures`: OGC/DE-9IM geometry model, WKT/WKB/GeoJSON
-  I/O, predicates, and planar measurement. Validated byte-identical to MySQL in the PoC.
-- `github.com/golang/geo` (Google's S2 port, Apache 2.0): spherical geometry for the
-  geodesic 4326 paths.
-- A small in-tree geodesic helper (`pkg/util/geomrel`) for ellipsoidal distance/length
-  (Andoyer) and the geodesic region refine.
+- `github.com/peterstace/simplefeatures`: OGC/DE-9IM model, WKT/WKB/GeoJSON I/O,
+  predicates, planar measurement. Validated byte-identical to MySQL in the PoC.
+- `github.com/golang/geo` (Google's S2 port, Apache 2.0): spherical geometry for 4326.
+- `pkg/util/geomrel`: in-tree ellipsoidal distance/length (Andoyer) and geodesic refine.
 
-Pure Go matters: the whole spatial stack builds with `CGO_ENABLED=0`, so there is no
-libgeos dependency in the Bazel/CI sandbox. The only Bazel follow-up is adding the new
-pure-Go deps to `DEPS.bzl` as proxy-fetch entries (no cc-toolchain wiring). The
-geometry-*processing* tail (buffer/union/...) may later need GEOS-equivalent algorithms;
-that is deferred with the rest of the tail and kept off this layer's critical path.
+The processing tail may later need GEOS-equivalent algorithms; it is deferred with the
+rest of the tail and kept off this layer's critical path.
 
 ### Type plumbing
 
-`TypeGeometry` must flow correctly through the generic value machinery so that geometry
-behaves like any other column value outside the `ST_*` functions. The PoC audited ~28
-operations (GROUP BY, hash/merge join, DISTINCT, ORDER BY, UPDATE/DELETE/REPLACE, window,
-`INSERT ... SELECT`, `UNION`, ...); the concrete touch points are:
+`TypeGeometry` must flow through the generic value machinery so geometry behaves like any
+other column value outside the `ST_*` functions. The PoC audited ~28 operations (GROUP BY,
+hash/merge join, DISTINCT, ORDER BY, UPDATE/DELETE/REPLACE, window, `INSERT ... SELECT`,
+`UNION`); the touch points are:
 
-- `pkg/parser`: geometry type grammar and the `SRID` column attribute (regenerates
-  `parser.go` once; the only grammar change, since `ST_*` functions are generic calls,
-  not grammar).
+- `pkg/parser`: geometry type grammar and the `SRID` column attribute. The only grammar
+  change, since `ST_*` are generic calls; regenerates `parser.go` once.
 - `pkg/types` / field type: the geometry field type and its flen/charset handling.
-- `pkg/util/chunk`: `Row.GetDatum` must return geometry as a binary string (the PoC
-  found `INSERT ... SELECT` nulled geometry without this).
-- `pkg/expression/builtin_cast.go`: cast-to-string flen setup (the PoC found `UNION`
-  asserted without this).
+- `pkg/util/chunk`: `Row.GetDatum` must return geometry as a binary string (without this
+  the PoC found `INSERT ... SELECT` nulled geometry).
+- `pkg/expression/builtin_cast.go`: cast-to-string flen setup (without this the PoC found
+  `UNION` asserted).
 - `pkg/expression`: the `ST_*` builtins (`builtin_geo.go`) and their registration.
 
-Geometry sorts/compares/hashes as its binary EWKB string; this is well-defined but not
-spatially meaningful (that is what the index and predicates are for).
+Geometry sorts, compares and hashes as its binary value: well-defined, but not spatially
+meaningful.
 
 ### SQL surface and examples
 
-The type and function surface is MySQL-compatible. Column definition:
-
     col_name {GEOMETRY | POINT | LINESTRING | POLYGON | MULTIPOINT | ...}
         [NOT NULL] [SRID {0 | 4326}]
-
-Example:
 
     CREATE TABLE stores (
       id  BIGINT PRIMARY KEY,
@@ -324,16 +232,16 @@ Example:
     );
 
     INSERT INTO stores VALUES
-      (1, ST_GeomFromText('POINT(37.4 -122.1)', 4326)),          -- lat, long (MySQL order)
-      (2, ST_PointFromText('POINT(37.8 -122.3)', 4326));         -- (typed alias is tail; Point()/ST_GeomFromText are v1)
+      (1, ST_GeomFromText('POINT(37.4 -122.1)', 4326)),   -- lat, long (MySQL order)
+      (2, ST_GeomFromText('POINT(37.8 -122.3)', 4326));
 
-    -- read back
     SELECT id, ST_AsText(loc), ST_Latitude(loc), ST_Longitude(loc) FROM stores;
 
-    -- measure (geodesic metres on 4326)
-    SELECT id, ST_Distance(loc, ST_GeomFromText('POINT(37.5 -122.2)', 4326)) AS m FROM stores;
+    -- geodesic metres on 4326
+    SELECT id, ST_Distance(loc, ST_GeomFromText('POINT(37.5 -122.2)', 4326)) AS m
+    FROM stores;
 
-    -- filter by spatial relationship (full scan in this layer; the index accelerates it later)
+    -- full scan in this layer; the index accelerates it later
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
 
@@ -342,53 +250,41 @@ spatial index syntax is part of this layer.
 
 ### Feature flag and rollout
 
-Gate the whole layer behind a session/global system variable, e.g.
-`tidb_enable_spatial` (default off initially). This is a **launch gate, not a
-compatibility switch**: because this is brand-new functionality with no prior
-implementation to fall back to, once the feature is stable in master the flag (and any
-dead gated-off branches) should be **removed** in a cleanup PR, tracked in #6347. The
-index layer ships behind its own separate flag on top of this one.
+The layer is gated on a session/global system variable, `tidb_enable_spatial`, default
+off. This is a **launch gate, not a compatibility switch**: there is no prior
+implementation to fall back to, so once the feature is stable in master the flag and its
+dead branches are removed in a cleanup PR, tracked in #6347. The index layer ships behind
+its own flag on top of this one.
 
 ### Scope and deferrals
 
-Explicitly **out of scope** for this design (each has a home):
+Out of scope here, each with a home:
 
-- The **spatial index** and its pushdown, in `docs/design/2026-06-25-spatial-index.md`
-  (#69473). This layer is its prerequisite.
-- The **geometry-processing function tail** (`ST_Buffer`/`Union`/`Intersection`/
-  `Difference`/`ConvexHull`/`Simplify`/...), typed I/O aliases, MBR predicate family,
-  geohash functions, niche accessors: a later, parallel expression-layer milestone.
-- **SRIDs beyond 0 and 4326**, the SRS catalog, and `ST_Transform`: the documented
-  extension path above.
-- **Coprocessor pushdown** of `ST_*` predicates: an optimization that lands with/after
-  the index; this layer evaluates predicates at the TiDB root.
-- **3D / measured (Z/M) coordinates**: computation is 2D only, as in MySQL/MariaDB. The
-  values are storable and round-trip unchanged, so the functions can be added later
-  without a format change (see [Types and storage](#types-and-storage)).
+- The **spatial index** and its pushdown: `docs/design/2026-06-25-spatial-index.md`
+  (#69473), for which this layer is the prerequisite.
+- The **geometry-processing function tail**, typed I/O aliases, `MBR*` family, geohash,
+  niche accessors: a later, parallel expression-layer milestone.
+- **SRIDs beyond 0 and 4326**, the SRS catalog and `ST_Transform`: the extension path
+  above.
+- **Coprocessor pushdown** of `ST_*` predicates: lands with or after the index; this layer
+  evaluates predicates at the TiDB root.
+- **3D / measured (Z/M) geometry**: computation is 2D only, as in MySQL/MariaDB, but the
+  values are stored and returned unchanged, so the functions can be added without a format
+  change.
 
 ### Compatibility
 
-- **Partition table / clustered index / async commit:** geometry is an ordinary column
-  value; no interaction. (A geometry column cannot be a primary key or clustering key,
-  since it has no meaningful ordering.)
-- **Charset & collation:** irrelevant to the geometry value (binary EWKB); a geometry
-  column has no user charset/collation.
-- **Parser:** one-time geometry-type + `SRID` grammar change; `ST_*` are generic function
-  calls (no grammar). Regenerates `parser.go`; run `make bazel_prepare`.
-- **DDL:** new column types and the `SRID` attribute; DDL validation restricts SRID to
-  0/4326 and enforces subtype constraints.
-- **Planner/statistics/executor:** `ST_*` functions evaluate on the normal expression
-  path; predicates are ordinary `Selection`s (full scan in this layer). No new operator,
-  no new access path, no statistics change.
-- **TiKV:** geometry values are ordinary binary strings; no storage-engine change. No
-  coprocessor change in this layer (pushdown is deferred).
-- **TiFlash / BR / TiCDC / Dumpling / Lightning:** geometry is regular column data;
-  round-trips need only that the tools carry the value bytes and the `SRID`/type
-  metadata. Dump/reload uses MySQL-compatible EWKB / WKT.
-- **Upgrade:** additive, with the new type and functions behind a flag.
-- **Downgrade:** a table with a geometry column cannot be read by a release without the
-  type; downgrade requires dropping geometry columns first (same as other new type kinds;
-  to be confirmed during implementation).
+| Area | Effect |
+| --- | --- |
+| Partition table, clustered index, async commit | None. It cannot be a primary or clustering key, having no meaningful ordering. |
+| Charset and collation | Not applicable; the value is binary. |
+| Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
+| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. |
+| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; predicates are ordinary `Selection`s. No new operator, access path or statistics. |
+| TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
+| TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL EWKB / WKT. |
+| Upgrade | Additive, behind the flag. |
+| Downgrade | Geometry columns must be dropped first, as with other new type kinds (to be confirmed). |
 
 ## Test Design
 
@@ -396,102 +292,99 @@ Explicitly **out of scope** for this design (each has a home):
 
 - I/O round-trips: `ST_GeomFromText`/`ST_AsText`, `ST_GeomFromWKB`/`ST_AsBinary`,
   `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
-  (including MySQL's `ST_AsText` spacing and axis order).
-- Accessors/measurement: `ST_X/Y/Latitude/Longitude/SRID/GeometryType/Dimension/...` and
-  `ST_Area/Length/Distance/Distance_Sphere` against cross-checked MySQL values (e.g. the
-  1-degree geodesic distances in `srid-support-reference.md`).
-- Predicates: the eight DE-9IM predicates (+ `Covers`/`CoveredBy`) on curated geometry
-  pairs, OGC-correct, matched to MySQL where semantics agree; boundary cases explicitly
-  covered.
-- SRID validation: 4326 out-of-range lat/long errors on every ingest path; SRID 0 Inf/NaN
-  rejection; mixed-SRID predicate errors.
-- Extended data: values with Z/M coordinates and with SRIDs outside 0 and 4326 store and
-  read back byte-identical, while every function that interprets coordinates errors
-  clearly on them.
-- Format version: a value written with version 1 decodes; an unknown or zero version byte
-  is rejected with a clear error rather than misparsed.
-- Type plumbing: geometry through GROUP BY, joins, DISTINCT, ORDER BY, `INSERT ... SELECT`,
-  `UNION`, UPDATE/DELETE/REPLACE (the PoC's audited surface) returns correct bytes.
+  including its `ST_AsText` spacing and axis order.
+- Accessors and measurement against cross-checked MySQL values (e.g. the 1-degree geodesic
+  distances in `srid-support-reference.md`).
+- Predicates: the eight DE-9IM predicates plus `Covers`/`CoveredBy` on curated geometry
+  pairs, matched to MySQL where semantics agree, with boundary cases explicit.
+- SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN
+  rejection, mixed-SRID predicate errors.
+- Extended data: Z/M values and SRIDs outside 0 and 4326 store and read back
+  byte-identical, while every function that interprets coordinates errors clearly.
+- Format version: version 1 decodes; an unknown or zero version byte is rejected with a
+  clear error rather than misparsed.
+- Type plumbing: geometry through the audited operation surface returns correct bytes.
 
 ### Scenario Tests
 
-- Store a points table and answer proximity (`ST_Distance_Sphere ≤ r`) and geofence
-  (`ST_Within(point, polygon)`) by full scan; results match MySQL.
-- 4326 edge cases: a query near a pole and across the antimeridian.
+- A points table answering proximity (`ST_Distance_Sphere ≤ r`) and geofence
+  (`ST_Within(point, polygon)`) by full scan, matching MySQL.
+- 4326 edge cases: a query near a pole and one across the antimeridian.
 - Application shape: lat/long ingest via WKT/GeoJSON, read back via `ST_AsGeoJSON`.
 
 ### Compatibility Tests
 
-- MySQL byte-identical compatibility suite for the v1 function surface (the PoC's
-  `spatial_compat` integration test is the basis).
+- MySQL byte-identical suite for the v1 function surface (the PoC's `spatial_compat`
+  integration test is the basis).
 - Dumpling/Lightning round-trip of a table with geometry columns; TiCDC and BR
   pass-through; behavior unaffected when TiFlash is absent.
-- Parser/DDL/planner/executor as listed in Compatibility.
+- Parser, DDL, planner and executor as listed in Compatibility.
 - Upgrade and downgrade paths.
 
 ### Benchmark Tests
 
-- Geometry ingest and read throughput vs a scalar-encoded baseline, to confirm EWKB
-  decode cost is acceptable.
-- Predicate full-scan latency across selectivities (this is the pre-index baseline the
-  index layer will be measured against).
-- Version 1 (EWKB payload) vs a lean payload: decode ns/op on the point and polygon
-  paths, to decide whether a format version 2 is worth adding.
+- Geometry ingest and read throughput vs a scalar-encoded baseline.
+- Predicate full-scan latency across selectivities, the pre-index baseline the index layer
+  will be measured against.
+- Version 1 (EWKB payload) vs a lean payload: decode ns/op on the point and polygon paths,
+  to decide whether a format version 2 is worth adding.
 
 ## Impacts & Risks
 
-Impacts (intended): geometry becomes a first-class, MySQL-compatible value and query
-surface; applications can store locations and run proximity/geofence queries in SQL
-(full scan) without application-side geometry code.
+Intended impact: geometry becomes a first-class, MySQL-compatible value and query surface,
+so applications can store locations and run proximity and geofence queries in SQL without
+application-side geometry code.
 
 Risks:
 
-- **Prerequisite coupling (downstream):** the index and pushdown layers code against this
-  type; the value-format and axis-order decisions here are lock-ins for them, so they are
-  settled in this design.
+- **Prerequisite coupling:** the index and pushdown layers code against this type, so the
+  value-format and axis-order decisions here are lock-ins for them and are settled here.
 - **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by the
-  leading format-version byte and by storing Z/M and unsupported SRIDs losslessly from
-  the start (see [Types and storage](#types-and-storage)).
-- **4326 semantics gaps:** geodesic `ST_Area`, polygon/polygon geodesic relations, and
-  planar-vs-geodesic refine edge cases diverge from MySQL near poles/antimeridian;
-  mitigated by documenting the v1 limitation and erroring rather than silently returning
-  wrong values.
-- **MySQL error parity:** exact error codes/messages may not match MySQL initially (the
-  PoC used placeholder wording); a compatibility, not correctness, risk.
-- **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the
-  GEOS-class processing tail; that tail is deferred, so v1 is unaffected.
+  version byte and by storing Z/M and unsupported SRIDs losslessly from the start.
+- **4326 semantics gaps:** geodesic `ST_Area`, polygon/polygon geodesic relations and
+  refine edge cases diverge from MySQL near poles and the antimeridian; mitigated by
+  documenting the limitation and erroring rather than returning wrong values.
+- **MySQL error parity:** exact codes and messages may not match initially (the PoC used
+  placeholder wording); a compatibility risk, not a correctness one.
+- **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the GEOS-class
+  processing tail, which is deferred, so v1 is unaffected.
 
 ## Investigation & Alternatives
 
-- **cgo/libgeos (go-geos):** rejected for v1. It gives OGC-correct geometry but requires
-  `libgeos` in the Bazel/CI sandbox, which broke the build; the PoC migrated to pure-Go
-  `simplefeatures` and stayed MySQL byte-identical, so cgo is unnecessary for the v1
-  surface. Revisit only for the GEOS-class processing tail.
-- **Full #38916 surface at once:** rejected as too large to review/land; this design is
-  the narrowed, independently-shippable prerequisite slice, with the rest sequenced after.
-- **Storing geometry as a generic BLOB with app-side functions:** the status quo; loses
-  MySQL compatibility, type safety, and any path to a spatial index. Rejected.
-- **PostGIS axis order / `geometry`-always-planar semantics:** rejected in favor of MySQL
-  compatibility (lat/long axis order, class-driven planar-vs-geodesic), since MySQL parity
-  is the goal (`srid-support-reference.md` documents the differences).
+- **EWKB as format version 1, rather than a leaner layout now.** EWKB is what the proof of
+  concept (PR #69475) implements and needs no conversion today, not what is optimal:
+  `storage-format.md` measures its redundancy (a per-row SRID the column usually fixes, a
+  byte-order flag per (sub)geometry, WKB framing) and finds geometry decode a measurable
+  share of both the index-maintenance write path and the refine read path. A version 2 can
+  strip those, shrink the type enum, or store a point as two bare `f64` values. The
+  version byte defers that choice without a migration, which is why it ships in v1 even
+  though the format is the smallest of the measured performance levers.
+- **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a
+  boundary conversion, and MySQL does the same thing internally (`axis-order.md`).
+- **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
+  `libgeos` in the Bazel/CI sandbox, which broke the build. The PoC moved to pure-Go
+  `simplefeatures` and stayed MySQL byte-identical. Revisit only for the processing tail.
+- **The full #38916 surface at once.** Rejected as too large to review and land; this is
+  the narrowed, independently shippable slice with the rest sequenced after.
+- **Geometry as a generic BLOB with application-side functions.** The status quo; loses
+  MySQL compatibility, type safety, and any path to a spatial index.
+- **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of
+  MySQL parity (`srid-support-reference.md` documents the differences).
 
 ## Unresolved Questions
 
-- **A leaner format version 2:** whether to add one before GA (dropping the per-row SRID
-  on SRID-restricted columns and the byte-order flags, shrinking the type enum, flat
-  `f64` points) or to ship version 1 and revisit. Benchmark-gated (`storage-format.md`),
-  and the version byte means it can also land after GA. `ST_AsBinary` output stays MySQL
-  EWKB either way.
-- **Geodesic `ST_Area` on 4326:** implement (Karney ellipsoidal area) in v1, or error
-  like MySQL's Cartesian-only functions until implemented?
-- **MySQL error-code/message parity:** how closely to match MySQL's exact GIS error codes
-  and wording for out-of-range coordinates, invalid geometries, and mixed-SRID errors.
-- **Feature-flag name and default:** `tidb_enable_spatial` (proposed); default off then
-  removed after stabilization; confirm naming and the removal milestone.
-- **4326 refine scope for v1:** accept planar polygon/polygon refine + the geodesic
-  point-in-polygon as the documented limitation, or widen geodesic coverage before GA?
-- **Exact v1 function boundary:** confirm which accessors/aliases are v1 vs tail against
-  `mysql-function-catalog.md` (e.g. `ST_Centroid` placement, typed `*FromText`/`*FromWKB`
-  aliases).
-- **Downgrade mechanics:** confirm the drop-geometry-columns-first requirement and whether
-  any metadata-only downgrade is possible.
+- **A leaner format version 2:** add one before GA, or ship version 1 and revisit?
+  Benchmark-gated (`storage-format.md`); the version byte means it can also land after GA.
+  `ST_AsBinary` output stays MySQL EWKB either way.
+- **Geodesic `ST_Area` on 4326:** implement Karney ellipsoidal area in v1, or error like
+  MySQL's Cartesian-only functions until it exists?
+- **MySQL error parity:** how closely to match MySQL's GIS error codes and wording for
+  out-of-range coordinates, invalid geometries and mixed-SRID errors.
+- **Feature-flag name and default:** confirm `tidb_enable_spatial` and the removal
+  milestone.
+- **4326 refine scope for v1:** accept planar polygon/polygon refine plus the geodesic
+  point-in-polygon as a documented limitation, or widen geodesic coverage before GA?
+- **Exact v1 function boundary:** confirm v1 vs tail against `mysql-function-catalog.md`
+  (e.g. `ST_Centroid`, the typed `*FromText`/`*FromWKB` aliases).
+- **Downgrade mechanics:** confirm the drop-geometry-columns-first requirement, and
+  whether any metadata-only downgrade is possible.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -52,13 +52,13 @@ The MySQL behaviors and measurements quoted below were verified against running 
 | Term | Meaning |
 | --- | --- |
 | [OGC](https://www.ogc.org/standard/sfa/) | Open Geospatial Consortium, the body behind *Simple Features*, the specification MySQL's spatial surface follows. |
-| [WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) | The OGC text and byte encodings of a geometry (`POINT(1 2)` and its bytes). Neither carries an SRID. |
+| [WKT / WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) | Well-Known Text and Well-Known Binary, the OGC encodings of a geometry: `POINT(1 2)` and its byte form. |
 | [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb) | Extended WKB, the PostGIS/GEOS superset of WKB: type-word flags add Z, M and an embedded SRID. The stored format here; see [Types and storage](#types-and-storage). Not to be confused with [MySQL's internal format](https://dev.mysql.com/doc/refman/8.4/en/gis-data-formats.html), a 4-byte SRID prefix over 2D WKB. |
-| ISO WKB | The other WKB extension (SFA 1.2.1 / SQL-MM), which encodes Z/M by adding 1000/2000/3000 to the type code instead of using flags, and carries no SRID. |
+| ISO WKB | The other WKB extension (OGC Simple Feature Access 1.2.1, also ISO 13249-3 SQL/MM), which encodes Z/M by adding 1000/2000/3000 to the type code instead of using flags, and carries no SRID. |
 | SRS | Spatial reference system: coordinate system, units, axis order, datum. Either *projected* (flat X/Y) or *geographic* (latitude/longitude on an ellipsoid). |
-| [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | The integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
-| [EPSG](https://epsg.org/) | The registry that assigns SRIDs, and the source of the SRS catalog. |
-| [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) | The datum and reference ellipsoid used by GPS, EPSG:4326. |
+| [SRID](https://dev.mysql.com/doc/refman/8.4/en/spatial-reference-systems.html) | Spatial Reference System Identifier, the integer naming an SRS. v1 supports 0 and 4326; see [SRID model](#srid-model). |
+| [EPSG](https://epsg.org/) | The EPSG Geodetic Parameter Dataset, the registry that assigns SRIDs and the source of the SRS catalog. |
+| [WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System) | World Geodetic System 1984, the datum and reference ellipsoid used by GPS, registered as EPSG:4326. |
 | Planar vs geodesic | Measurement on a flat plane vs along the ellipsoid. Decided by SRS class, not per SRID. |
 | [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) | Dimensionally Extended 9-Intersection Model, the OGC model defining `ST_Within`, `ST_Contains`, `ST_Intersects` and the other topological predicates. |
 | [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) | JSON geometry encoding (RFC 7946), the third I/O format. |

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -1,7 +1,7 @@
 # TiDB Design Documents
 
 - Author(s): [Mattias Jonsson](http://github.com/mjonss), [Daniël van Eeden](http://github.com/dveeden)
-- Discussion PR: https://github.com/pingcap/tidb/pull/XXXXX
+- Discussion PR: https://github.com/pingcap/tidb/pull/70420
 - Tracking Issue: https://github.com/pingcap/tidb/issues/6347
 
 ## Table of Contents

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -33,9 +33,11 @@
 This document proposes **basic geospatial support** for TiDB: a MySQL-compatible
 `GEOMETRY` type family, per-column [`SRID`](#terminology), versioned
 [EWKB](#terminology) storage, and the minimal `ST_*` function set that makes geometry
-storable, readable, and queryable by full table scan. It covers **SRID 0** (Cartesian
-plane) and **SRID 4326** ([WGS 84](#terminology) geographic), including the
-[DE-9IM](#terminology) predicates.
+storable, readable, and queryable. It covers **SRID 0** (Cartesian plane) and
+**SRID 4326** ([WGS 84](#terminology) geographic), including the
+[DE-9IM](#terminology) predicates. A geometry predicate has no index to use here, so it
+is evaluated row by row over whatever the access path returns; other predicates on the
+table pick their access path as usual.
 
 It is deliberately **index-free**: the spatial index is specified separately in
 `docs/design/2026-06-25-spatial-index.md` (PR #69473) and builds on this layer. The scope
@@ -289,7 +291,7 @@ meaningful.
     SELECT id, ST_Distance(loc, ST_GeomFromText('POINT(37.5 -122.2)', 4326)) AS m
     FROM stores;
 
-    -- full scan in this layer; the index accelerates it later
+    -- the geometry predicate is evaluated per row here; the index accelerates it later
     SELECT id FROM stores
     WHERE ST_Within(loc, ST_GeomFromText('POLYGON((...))', 4326));
 
@@ -314,8 +316,13 @@ Out of scope here, each with a home:
   niche accessors: a later, parallel expression-layer milestone.
 - **SRIDs beyond 0 and 4326**, the SRS catalog and `ST_Transform`: the extension path
   above.
-- **Coprocessor pushdown** of `ST_*` predicates: lands with or after the index; this layer
-  evaluates predicates at the TiDB root.
+- **Coprocessor pushdown.** The predicates and the measurement functions are ordinary
+  deterministic scalars, so they are pushdown-eligible in principle, and pushing them is
+  worthwhile *independently of the index*: it filters at the storage node instead of
+  shipping every candidate geometry to TiDB. It is out of scope here because it is
+  cross-repo work (tipb signatures plus a TiKV-side evaluator) and is specified with the
+  index design, which owns the pushdown contract. Nothing in this layer blocks it, and for
+  this design it is fine that the functions evaluate at the TiDB root.
 - **The axis-order controls**: MySQL's `axis-order=long-lat` option argument on
   `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let
   a client read or write longitude-first against a latitude-first SRS. Both exist in MySQL
@@ -332,7 +339,7 @@ Out of scope here, each with a home:
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
 | DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. |
-| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; predicates are ordinary `Selection`s. No new operator, access path or statistics. |
+| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own, so they filter whatever rows the chosen path returns. No new operator, access path or statistics. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
 | Upgrade | Additive, behind the flag. |
@@ -363,7 +370,7 @@ Out of scope here, each with a home:
 ### Scenario Tests
 
 - A points table answering proximity (`ST_Distance_Sphere ≤ r`) and geofence
-  (`ST_Within(point, polygon)`) by full scan, matching MySQL.
+  (`ST_Within(point, polygon)`), matching MySQL.
 - 4326 edge cases: a query near a pole and one across the antimeridian.
 - Application shape: lat/long ingest via WKT/GeoJSON, read back via `ST_AsGeoJSON`.
 
@@ -379,8 +386,8 @@ Out of scope here, each with a home:
 ### Benchmark Tests
 
 - Geometry ingest and read throughput vs a scalar-encoded baseline.
-- Predicate full-scan latency across selectivities, the pre-index baseline the index layer
-  will be measured against.
+- Geometry-predicate latency across selectivities with no other predicate to narrow the
+  scan, the pre-index baseline the index layer will be measured against.
 - Version 1 (EWKB payload) vs a lean payload: decode ns/op on the point and polygon paths,
   to decide whether a format version 2 is worth adding.
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -466,8 +466,8 @@ Out of scope here, each with a home:
 | Indexes on a geometry column | None in v1, of any kind: not a primary, unique, secondary or composite member. The useful one is the spatial index, which is the other design. |
 | Generated columns | `ST_*` are deterministic scalars, so they are usable in virtual and stored generated column expressions like any other builtin. A geometry-typed generated column is then an ordinary geometry column, and the row above governs indexing it. |
 | Charset and collation | Not applicable; the value is binary. |
-| Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
-| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. `ALTER` follows MySQL, verified on 8.4.6: adding or changing `SRID n` validates every existing row and fails with `ERROR 3643` on the first mismatch; dropping the attribute always succeeds; narrowing the subtype (`GEOMETRY` to `POINT`) succeeds only if every value fits, else `ERROR 1416`; widening always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. An SRID change is validation, never a coordinate rewrite. |
+| Parser | Updated in this design. |
+| DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. In v1 `ALTER` rejects as unsupported anything that would have to validate existing rows: adding, dropping or changing `SRID n`, and narrowing the subtype (`GEOMETRY` to `POINT`). A user who needs either adds a new column with the wanted type and backfills it. The rest follows MySQL, verified on 8.4.6: widening the subtype always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. |
 | `information_schema` | One new table, `st_spatial_reference_systems`, read-only with two static rows. Its two siblings in MySQL are deferred. |
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. `ANALYZE` skips geometry as it skips JSON and the blob types, which means adding `geometry` both to the accepted values of `tidb_analyze_skip_column_types` and to its default, today `json,blob,mediumblob,longblob,mediumtext,longtext`. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
@@ -512,8 +512,8 @@ Out of scope here, each with a home:
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.
-- DDL: the `ALTER` matrix above, including `ERROR 3643` on an SRID change that existing rows
-  violate and `ERROR 1416` on a narrowing that they do not fit.
+- DDL: the `ALTER` matrix above, including that adding, dropping or changing `SRID n` and
+  narrowing the subtype are all rejected, while widening and `DROP COLUMN` succeed.
 
 ### Scenario Tests
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -81,11 +81,18 @@ its feature flag removed before index work merges on top.
 
 ## Detailed Design
 
-**MySQL-compatible, extensible where the extension is free.** Every v1 function behaves as
-MySQL does, and errors where MySQL cannot express a value. The storage layer is wider: WKB
-input accepts Z/M coordinates and any SRID, which are stored losslessly and read back
-intact, though no v1 function computes on them and the MySQL-shaped writers (`ST_AsBinary`,
-`ST_AsText`, `ST_AsGeoJSON`) reject them. Widening the functions later is out of scope here.
+**MySQL-compatible, extensible where the extension is free.** The two directions are
+deliberately asymmetric:
+
+- **`ST_GeomFrom*` accepts a superset of MySQL.** Z/M coordinates, SRIDs outside 0 and
+  4326, and option values MySQL rejects are all accepted, and the storage layer keeps them
+  losslessly. Accepting more cannot break a query that works on MySQL.
+- **`ST_As*` emits what MySQL emits.** It errors where MySQL cannot express a value,
+  because changing the bytes a client receives is where compatibility actually breaks.
+  Emitting Z/M is a later extension, and then only behind an explicit option.
+
+So a stored value can exist that no `ST_As*` can express. It reads back as the raw column
+value, and no v1 function computes on it.
 
 ### Types and storage
 
@@ -197,15 +204,32 @@ present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are identical. 
 an **allowlist**: only these are registered, and anything else spatial is an unknown
 function until a later milestone adds it.
 
-- **I/O readers:** `ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
-- **I/O writers:** `ST_AsText` (`ST_AsWKT`), `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
-- **Option arguments.** `axis-order` on the WKT and WKB readers and writers, taking
+- **`ST_GeomFrom*`**, a geometry from an external format: `ST_GeomFromText`,
+  `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`.
+- **`ST_As*`**, an external format from a geometry: `ST_AsText` (`ST_AsWKT`),
+  `ST_AsBinary` (`ST_AsWKB`), `ST_AsGeoJSON`.
+- **Option arguments.** `axis-order` on the WKT and WKB members of both groups, taking
   `lat-long`, `long-lat` or `srid-defined` (the default), rejecting anything else with
   `ERROR 3559` and having no effect at SRID 0. It is the explicit way to read or write
   longitude-first data against a latitude-first SRS, so a client need not pre-swap.
-  `ST_GeomFromGeoJSON` takes its own `options` and `srid` arguments: `options` 1 rejects
-  coordinate dimensions above 2 and is the default, while 2, 3 and 4 accept and strip
-  them, so a GeoJSON Z position is dropped rather than stored.
+  `ST_GeomFromGeoJSON` takes its own `options` and `srid` arguments. MySQL defines
+  `options` 1 to 4, where 1 rejects coordinate dimensions above 2 and is the default and
+  2, 3 and 4 strip them. TiDB extends the range with two values MySQL rejects:
+
+  | `options` | Coordinates | Anything else |
+  | --- | --- | --- |
+  | 5 | keep whatever the stored format holds, so a third element becomes Z | error |
+  | 6 | the same | ignore |
+
+  Both ignore what MySQL ignores. The difference is a position with more than three
+  elements, which RFC 7946 leaves undefined: 5 errors on it, 6 drops it.
+
+  `ST_AsGeoJSON(g [, digits [, flags]])` takes MySQL's two: `digits` rounds the
+  coordinates, defaulting to full precision and rejecting a negative value, and `flags` is
+  a bitmask from 0 to 7 where bit 0 adds `bbox`, bit 1 a short CRS URN (`EPSG:4326`) and
+  bit 2 a long one (`urn:ogc:def:crs:EPSG::4326`), long overriding short. Anything above 7
+  is an error. The `bbox` is emitted in output axis order, so it is longitude-first on
+  4326 like the coordinates beside it.
 - **Constructors:** the full set of MySQL's
   [functions that create geometry values](https://dev.mysql.com/doc/refman/8.0/en/gis-mysql-specific-functions.html):
   `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`,
@@ -229,9 +253,25 @@ function until a later milestone adds it.
   covering-cell prefilter has no false negatives). Other PostGIS-only functions are added
   later only if index-supported or by demand.
 
+**SRID handling** differs by direction, and a round-trip hides it:
+
+| Conversion | SRID from | Axis order | SRID in the result |
+| --- | --- | --- | --- |
+| `ST_GeomFromText(wkt [, srid [, opt]])` | the argument, else 0 | that SRID's SRS order, overridable by `axis-order` | yes |
+| `ST_GeomFromWKB(wkb [, srid [, opt]])` | the argument, else 0 | that SRID's SRS order, overridable by `axis-order` | yes |
+| `ST_GeomFromGeoJSON(json [, opt [, srid]])` | the `srid` argument, else the `crs` member, else 4326 | always longitude-first (RFC 7946) | yes |
+| constructors (`Point`, `LineString`, ...) | nothing, always 0 | none applied | 0; stamp it with `ST_SRID` |
+| `ST_AsText(g [, opt])`, `ST_AsBinary(g [, opt])` | the geometry | its SRS order, overridable by `axis-order` | **no**, plain WKT/WKB |
+| `ST_AsGeoJSON(g [, digits [, flags]])` | the geometry | always longitude-first | **no** by default; `flags` 2 and 4 add a CRS URN |
+
+The two **no** cells are why a WKT or WKB round-trip loses the SRID and has to be given it
+again on the way back in. The constructor row is why `ST_SRID(Point(30, 50), 4326)` and
+`ST_GeomFromText('POINT(30 50)', 4326)` are different points: the SRS is applied where the
+coordinates are parsed, and `ST_SRID` only writes metadata.
+
 A later milestone covers the geometry-processing tail (`ST_Buffer`, `ST_Union`,
 `ST_Intersection`, ...), the typed I/O aliases, the `MBR*` family, geohash, the niche
-accessors and `ST_AsGeoJSON`'s bbox and CRS-URN flags.
+accessors.
 
 Semantics match MySQL, with three v1 limitations:
 
@@ -253,9 +293,11 @@ follow MySQL, verified on 8.4.6 and 9.7.2:
 | `Feature` | its bare geometry, so a Feature holding a point yields `POINT` |
 | `FeatureCollection` | `GEOMETRYCOLLECTION` of the features' geometries, `GEOMETRYCOLLECTION EMPTY` if there are none |
 | `"geometry": null` | SQL `NULL` |
-| `properties`, `id`, `bbox`, foreign members | ignored |
+| `properties`, `id`, `bbox`, foreign members | ignored, and not validated: MySQL accepts a `bbox` that is the wrong arity, contradicts the geometry, or is not even an array |
 | named `crs` URN | sets the SRID (`urn:ogc:def:crs:OGC:1.3:CRS84` is 4326, link-object CRSs are not accepted, and a nested `crs` naming a different SRID errors); absent, the SRID is 4326 |
-| position with more than two coordinates | rejected, `ERROR 3073` |
+| position with a third coordinate | rejected under the default `options` 1 with `ERROR 3073`, stripped under 2, 3 and 4, kept as Z under TiDB's 5 and 6 |
+| position with more than three coordinates | as above, except TiDB's 5 errors and 6 drops the extras |
+| unknown `type`, or a required member missing | `ERROR 3072`, and `ERROR 3070` naming the member |
 
 The `options` argument accepts such positions and strips the extra coordinates.
 `ST_AsGeoJSON`'s bbox and CRS-URN flags ship with the tail. Round-trips are not
@@ -397,8 +439,9 @@ Out of scope here, each with a home:
 - Extended data: Z/M values entered as WKB, and SRIDs outside 0 and 4326, store and read
   back byte-identical, while `ST_AsBinary`/`ST_AsText`/`ST_AsGeoJSON` and every function
   that interprets coordinates error clearly on them.
-- GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7, plus the `options`
-  argument rejecting a Z position at 1 and stripping it at 2, 3 and 4.
+- GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7, plus `options` 5
+  and 6 keeping a Z position and differing on a fourth element, and `ST_AsGeoJSON`'s
+  `digits` rounding and each `flags` bit, byte-compared to MySQL.
 - `axis-order`: `long-lat` swaps on read and on write at 4326, `lat-long` and
   `srid-defined` agree there, the option is inert at SRID 0, and a bad value gives
   `ERROR 3559`.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -81,9 +81,17 @@ against the proof of concept, [PR #69475](https://github.com/pingcap/tidb/pull/6
 
 ## Motivation or Background
 
+TiDB is often used as unified storage because of the scalable storage,
+vector search, HTAP and FTS capabilities.
+
+Geospatial support would be a good addition to this, making this an even stronger option
+for unified storage.
+
+TiDB is used in companies that do package delivery, ride services, etc.
+where geospatial data is used in various places.
+
 Geospatial support is one of the most requested TiDB features: [tracking issue #6347](https://github.com/pingcap/tidb/issues/6347)
-carries
-`feature/accepted` and ranks among the top open issues by reactions. The dominant workload
+carries `feature/accepted` and ranks among the top open issues by reactions. The dominant workload
 is storing a location per row and answering "what is near me", "which region contains this
 point", or "what overlaps this box". Bike-share, ride-hailing, parcel delivery and asset
 tracking all reduce to points plus proximity and geofence queries.
@@ -111,11 +119,11 @@ value, and no v1 function computes on it.
 ### Types and storage
 
 Types, all reusing the existing `mysql.TypeGeometry` field type with the subtype a
-constraint on the stored value, as in MySQL: `GEOMETRY` (any subtype), `POINT`,
-`LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`,
-`GEOMETRYCOLLECTION`. A column may carry a `SRID n` attribute (see
-[SRID model](#srid-model)). At the KV layer a geometry is a binary string; no new column
-encoding is introduced.
+constraint on the stored value, as in MySQL: `GEOMETRY`, which accepts any subtype,
+then `POINT`, `LINESTRING`, `POLYGON` and `GEOMETRYCOLLECTION` with its own subtypes
+`MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`.
+A column may carry a `SRID n` attribute (see [SRID model](#srid-model)).
+At the KV layer a geometry is a binary string; no new column encoding is introduced.
 
 Stored value:
 
@@ -153,8 +161,8 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid for distance and length, as MySQL; stated per operation in *Reference surface* below |
 
 Codes and wording are matched as closely as possible on every ingest path:
-`ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`, and the constructors `Point`,
-`LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon` and
+`ST_GeomFromText`, `ST_GeomFromWKB`, `ST_GeomFromGeoJSON`, and the MySQL-specific
+constructors `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon` and
 `GeometryCollection`. The same goes for `ERROR 3618` (function not implemented on a
 geographic SRS) and `ERROR 3643` (SRID does not match the column). A binary geometry
 function given two geometries of different SRIDs raises `ERROR 3033` and computes nothing;
@@ -180,10 +188,11 @@ uniformly ellipsoidal, so the surface is stated per operation:
 Everything on SRID 0 is planar in both columns. Every MySQL cell above is measured against
 a running engine rather than taken from documentation.
 
-The measurement rows match MySQL. The two predicate rows are targets rather than fixed
-answers: they aim at MySQL's surface, and where reaching it would cost disproportionate
-complexity the simpler surface stands with the divergence documented.
-[Unresolved Questions](#unresolved-questions) owns that decision and sizes each fallback.
+Matching MySQL's output is the target. The measurement rows already do. For the two
+predicate rows a simpler surface may be used where matching is too complex, as long as it
+stays a close approximation and the difference is documented.
+[Unresolved Questions](#unresolved-questions) covers each case and how big the difference
+is.
 
 **Catalog.** `information_schema.st_spatial_reference_systems` returns exactly two rows,
 SRID 0 and 4326, with MySQL's columns and the values MySQL gives for them; no dataset is
@@ -239,7 +248,7 @@ function until a later milestone adds it.
   bit 2 a long one (`urn:ogc:def:crs:EPSG::4326`), long overriding short. Anything above 7
   is an error. The `bbox` is emitted in output axis order, so it is longitude-first on
   4326 like the coordinates beside it.
-- **Constructors:** the full set of MySQL's
+- **MySQL-specific constructors:** the full set of
   [functions that create geometry values](https://dev.mysql.com/doc/refman/8.0/en/gis-mysql-specific-functions.html):
   `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`,
   `GeometryCollection`.
@@ -280,10 +289,10 @@ A later milestone covers the geometry-processing tail (`ST_Buffer`, `ST_Union`,
 `ST_Intersection`, ...), the typed I/O aliases, the `MBR*` family, geohash, the niche
 accessors.
 
-**Compatibility is to MySQL's answer, not to the exact geodesic.** Every geographic
-computation in MySQL 9.7 uses one formula, Boost.Geometry's `strategy::andoyer`, for
-measurement and predicates alike. It is the spherical law of cosines plus a first-order
-flattening term, so it is not the exact geodesic:
+**Match MySQL's answer, not the exact geodesic.** Every geographic computation in MySQL 9.7
+uses one formula, Boost.Geometry's `strategy::andoyer`, for measurement and predicates
+alike. It is the spherical law of cosines plus a first-order flattening term, so it is not
+the exact geodesic:
 
 | Separation | MySQL minus an exact geodesic |
 | --- | --- |
@@ -291,11 +300,11 @@ flattening term, so it is not the exact geodesic:
 | 9,810 km | -7.9 m |
 | near-antipodal | +5,973 m |
 
-v1 targets MySQL's answer rather than the more accurate one, and inherits those errors
-deliberately: a general-purpose geodesic library diverges from MySQL by exactly those
-amounts, so here an accuracy improvement is a compatibility defect. Where matching MySQL
-would cost disproportionate complexity a spherical answer is accepted instead, with the
-divergence documented; see [Unresolved Questions](#unresolved-questions).
+v1 uses Andoyer and inherits those errors on purpose. A more accurate library would be off
+from MySQL by exactly those amounts, so being more accurate here makes us less compatible.
+Where matching MySQL is too complex, a simpler surface may be used instead, as long as it
+stays a close approximation and the difference is documented; see
+[Unresolved Questions](#unresolved-questions).
 
 Semantics match MySQL, with these 4326 specifics:
 
@@ -303,7 +312,7 @@ Semantics match MySQL, with these 4326 specifics:
   sub-metre); `ST_Distance_Sphere` is the great-circle variant.
 - The predicates come from `simplefeatures`, which is OGC-correct but planar, so matching
   MySQL's ellipsoidal edges on 4326 is the open item. Where the fallback applies,
-  point-in-polygon is spherical via S2 and polygon/polygon planar, diverging from MySQL by
+  point-in-polygon is spherical via S2 and polygon/polygon planar, differing from MySQL by
   metres to kilometres and by degrees respectively. See
   [Reference surface](#srid-model) for the surface each operation targets and
   [Unresolved Questions](#unresolved-questions) for the size of each fallback.
@@ -402,7 +411,7 @@ The v1 surface lands in dependency order, each step reviewable on its own:
 | 3. Catalog | `information_schema.st_spatial_reference_systems`, and DDL validating `SRID n` against it rather than against a hardcoded pair | the two rows match MySQL column for column |
 | 4. Inspection | the constructors and the accessors | matches MySQL, including the constructor axis order |
 | 5. Measurement | `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`, and `pkg/util/geomrel` | matches MySQL to the tolerances in [Functional Tests](#functional-tests) |
-| 6. Predicates | the eight DE-9IM predicates | matches MySQL where the semantics agree, with the divergences documented |
+| 6. Predicates | the eight DE-9IM predicates | matches MySQL where the semantics agree, with any differences documented |
 
 Steps 1 to 3 are what the spatial index codes against, so they are the ones whose surface
 is hard to change later. Steps 4 to 6 are independent of each other and of the index, so
@@ -454,11 +463,13 @@ Out of scope here, each with a home:
 | Area | Effect |
 | --- | --- |
 | Partition table, clustered index, async commit | None. Geometry cannot be a primary or clustering key, having no meaningful ordering. |
+| Indexes on a geometry column | None in v1, of any kind: not a primary, unique, secondary or composite member. The useful one is the spatial index, which is the other design; a B-tree over the stored bytes would be well-defined but not spatially meaningful, so it is deferred rather than ruled out. |
+| Generated columns | `ST_*` are deterministic scalars, so they are usable in virtual and stored generated column expressions like any other builtin. A geometry-typed generated column is then an ordinary geometry column, and the row above governs indexing it. |
 | Charset and collation | Not applicable; the value is binary. |
 | Parser | One-time type and `SRID` grammar change; regenerates `parser.go`, run `make bazel_prepare`. `ST_*` are generic calls. |
 | DDL | New column types and the `SRID` attribute, restricted to 0/4326, plus subtype constraints. `ALTER` follows MySQL, verified on 8.4.6: adding or changing `SRID n` validates every existing row and fails with `ERROR 3643` on the first mismatch; dropping the attribute always succeeds; narrowing the subtype (`GEOMETRY` to `POINT`) succeeds only if every value fits, else `ERROR 1416`; widening always succeeds; converting the column to a binary type carries the bytes over; `DROP COLUMN` is ordinary. An SRID change is validation, never a coordinate rewrite. |
 | `information_schema` | One new table, `st_spatial_reference_systems`, read-only with two static rows. Its two siblings in MySQL are deferred. |
-| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. |
+| Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. `ANALYZE` skips geometry as it skips JSON and the blob types, which means adding `geometry` both to the accepted values of `tidb_analyze_skip_column_types` and to its default, today `json,blob,mediumblob,longblob,mediumtext,longtext`. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | TiFlash, BR, TiCDC, Dumpling, Lightning | Regular column data. Tools need only carry the bytes and the `SRID`/type metadata; dump/reload uses MySQL's internal format or WKT, not the stored bytes. |
 | Upgrade | Additive: the type does not exist in earlier releases, so no existing schema or query changes behavior. |
@@ -480,10 +491,10 @@ Out of scope here, each with a home:
   and `ST_GeomFromWKB`, while the deferred per-subtype aliases are unknown functions.
 - Predicates: the eight DE-9IM predicates on curated geometry pairs, matched to MySQL where
   semantics agree, with boundary cases explicit.
-- The 4326 edge-surface divergence is pinned by a regression test rather than left to
-  drift: `POLYGON((0 0, 80 0, 0 80, 0 0))` with probes at latitude 45.000000 and 45.070155
-  on longitude 70, asserting v1's spherical answers and recording MySQL's ellipsoidal ones,
-  so a later geodesic relate flips the assertions deliberately instead of silently.
+- A regression test pins where the 4326 edge sits, so it cannot drift unnoticed:
+  `POLYGON((0 0, 80 0, 0 80, 0 0))` with probes at latitude 45.000000 and 45.070155 on
+  longitude 70, asserting v1's spherical answers and recording MySQL's ellipsoidal ones, so
+  a later geodesic relate flips the assertions on purpose rather than by accident.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN rejection,
   and mixed-SRID arguments to a binary geometry function giving `ERROR 3033`, while the
   SQL comparison operators keep comparing the stored bytes without erroring.
@@ -542,9 +553,10 @@ Risks:
   value-format and axis-order decisions here are lock-ins for them.
 - **Value-format lock-in:** the on-disk format is hard to change post-GA; mitigated by the
   version byte and by storing Z/M and unsupported SRIDs losslessly from the start.
-- **4326 semantics gaps:** each predicate path diverges wherever it falls back to a simpler
-  surface than MySQL's ellipsoidal edges; mitigated by documenting rather than returning
-  wrong values, and bounded by edge length, so geofence-scale polygons are unaffected.
+- **4326 semantics gaps:** each predicate path differs from MySQL wherever it falls back to
+  a simpler surface than MySQL's ellipsoidal edges; mitigated by documenting rather than
+  returning wrong values, and bounded by edge length, so geofence-scale polygons are
+  unaffected.
 - **MySQL error parity:** exact codes and messages may not match initially (the PoC used
   placeholder wording); a compatibility risk, not a correctness one.
 - **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the GEOS-class
@@ -574,7 +586,9 @@ Risks:
   being a re-parse inside the predicate library that no format can remove. The version byte
   defers the choice without a migration.
 - **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a boundary
-  conversion, and MySQL does the same internally.
+  conversion, and MySQL does the same internally. Exposing that conversion as a function
+  pair, so MySQL bytes can be loaded and converted in place, is in
+  [Future extensions](#future-extensions).
 - **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
   `libgeos` in the Bazel/CI sandbox, which broke the build. The PoC moved to pure-Go
   `simplefeatures` and stayed MySQL byte-identical. Revisit for the processing tail.
@@ -621,22 +635,22 @@ than a geofence one:
 | 6,690 km | 3.1 km |
 
 So small polygons, the common geofence case, are barely affected by either fallback. Both
-divergences have the same root cause, MySQL's curved edges, but closing them costs very
+differences come from the same thing, MySQL's curved edges, but closing them costs very
 differently.
 
 **The rule: get as close to MySQL as the complexity allows.** Each path takes the closest
-answer that does not cost disproportionate complexity, and where that still falls short of
-MySQL the divergence is documented rather than hidden.
+answer it can without getting too complex, and where that still falls short of MySQL the
+difference is documented rather than hidden.
 
-- **Point-in-polygon** should give MySQL's ellipsoidal answer where that is achievable
-  without outsized complexity. Where it is not, the spherical answer stands: per the table
-  above it is already sub-metre for polygons up to a few hundred km across, and three
-  orders of magnitude closer than planar.
+- **Point-in-polygon** should give MySQL's ellipsoidal answer if that can be done without
+  too much complexity. If it cannot, the spherical answer stands: per the table above it is
+  already sub-metre for polygons up to a few hundred km across, and three orders of
+  magnitude closer than planar.
 - **Polygon/polygon** is the expensive one, since a geographic relate replaces the planar
-  DE-9IM engine rather than adjusting it. Planar stands until that cost is justified.
+  DE-9IM engine rather than adjusting it. Planar stands until that cost is worth paying.
 
-Erroring instead of answering was considered and rejected: it needs an arbitrary extent
-threshold, and the error is itself a divergence, since MySQL answers.
+Erroring instead of answering was considered and rejected: it needs an arbitrary size
+limit, and the error is itself a difference from MySQL, which answers.
 
 One consequence to state rather than hide: while the two paths use different surfaces, v1
 answers a point and an infinitesimal polygon at the same location differently.
@@ -658,6 +672,13 @@ change.
 | Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
 | `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
 | User-defined SRSs through `CREATE [OR REPLACE] SPATIAL REFERENCE SYSTEM` and `DROP SPATIAL REFERENCE SYSTEM`, which MySQL also has (there is no `ALTER`; modification is `CREATE OR REPLACE`) | bigger: a writable catalog, a WKT SRS parser, and catalog changes that have to replicate |
+
+**MySQL byte interop.** A pair of conversion functions, `ST_FromMySQL` and `ST_AsMySQL`,
+would let a MySQL dump land in a `VARBINARY` column and be converted in place, or exposed
+through a generated column, without TiDB adopting MySQL's storage format. It is the
+migration path that
+[rejecting MySQL's stored bytes](#investigation--alternatives) leaves open. The names are
+non-standard, so whether they carry the `ST_` prefix is part of the question.
 
 `ST_Covers` and `ST_CoveredBy` are PostGIS spellings with no MySQL equivalent, worth adding
 once the spatial index lands: they are index-eligible region predicates

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -154,8 +154,9 @@ per-class parameters, not code paths.
 organization, and 4326 as `WGS 84` / `EPSG` / 4326 with the `GEOGCS["WGS 84",DATUM[...]]`
 definition string. No dataset is imported: SRID 0 is not an EPSG record, and 4326 is one
 stable record taken from the [EPSG dataset](https://epsg.org/) rather than from a MySQL
-install. The table is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, and DDL
-validates `SRID n` against it rather than against a hardcoded pair. Without the table,
+install. The table is read-only, so `CREATE SPATIAL REFERENCE SYSTEM` is rejected, which is a
+MySQL-parity gap on the extension path rather than a PostGIS extra. DDL validates
+`SRID n` against the table rather than against a hardcoded pair. Without the table,
 asking which SRIDs a server supports is an unknown-table error.
 
 **EPSG attribution.** The 4326 row is an EPSG record, so the dataset's terms of use apply:
@@ -194,7 +195,7 @@ at every boundary; both engines emit the same WKB.
 | All projected SRSs (e.g. 3857 Web Mercator) | low: planar X/Y, so the same Cartesian functions apply and only the bounds are per-SRS |
 | Geographic SRSs beyond 4326 | moderate: exact geodesic refine per ellipsoid |
 | `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
-| PostGIS level (`CREATE SPATIAL REFERENCE SYSTEM`, user-defined SRSs) | bigger: needs a PROJ-like library for arbitrary reprojection; out of scope |
+| User-defined SRSs through `CREATE [OR REPLACE] SPATIAL REFERENCE SYSTEM` and `DROP SPATIAL REFERENCE SYSTEM`, which MySQL also has (there is no `ALTER`; modification is `CREATE OR REPLACE`) | bigger: a writable catalog, a WKT SRS parser, and catalog changes that have to replicate |
 
 DDL restricts the `SRID n` attribute to 0 or 4326. An unrestricted `GEOMETRY` column may
 still hold values of any SRID (see [Types and storage](#types-and-storage)).

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -44,6 +44,9 @@ later work (more SRIDs, the geometry-processing function tail, coprocessor pushd
 index) extends it without a new design. This replaces the earlier geospatial design
 (PR #38916).
 
+The MySQL behaviors and measurements quoted below were verified against running servers
+(8.4.6 and 9.7.2) and against the proof of concept, PR #69475.
+
 ## Terminology
 
 | Term | Meaning |
@@ -116,7 +119,7 @@ right: a 2D geometry with no SRID flag *is* plain OGC WKB, byte for byte.
 | Lossless | Exact `f64` coordinates and full geometry structure, never truncated. |
 | SRID | Carried by the SRID flag. Where the column fixes it with `SRID n` the flag may be left unset, which is still valid EWKB, so this redundancy can be removed without leaving the format. It cannot be dropped unconditionally: an unrestricted `GEOMETRY` column holds a per-row SRID, and a geometry outside any column (function result, join or sort intermediate) has no column metadata to recover it from. |
 | Byte order | Left to EWKB, which flags it per geometry and permits both. |
-| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL itself converts too, storing coordinates longitude-first internally and swapping per SRS on every WKT/WKB read and write, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point (`axis-order.md`). |
+| MySQL bytes | Not matched. MySQL stores `<srid u32 LE><WKB>` and is 2D only; `ST_AsBinary`, dump/reload and the wire protocol convert at the boundary, which for a 2D value is dropping the SRID flag. MySQL itself converts too, storing coordinates longitude-first internally and swapping per SRS on every WKT/WKB read and write, visible as `HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for a 4326 point. |
 | Coordinate dimension | XY, XYZ, XYM and XYZM are all storable, which covers GeoJSON positions (XY and XYZ) as well as measured geometry. Every v1 function is 2D, as in MySQL. |
 | SRIDs outside 0 and 4326 | Stored and returned unchanged in an unrestricted `GEOMETRY` column, as in MySQL. |
 
@@ -133,11 +136,11 @@ alternatives: [Investigation & Alternatives](#investigation--alternatives).
 | --- | --- | --- |
 | Coordinate system | abstract Cartesian plane, unitless X/Y | WGS 84 geographic, latitude/longitude |
 | Bounds | none, the full finite IEEE-754 double range, as MySQL | latitude `[-90, 90]`, longitude `(-180, 180]` |
-| Rejected on ingest | Inf/NaN | out-of-range latitude/longitude, on every constructor and I/O path |
+| Rejected on ingest | Inf/NaN, MySQL `ERROR 3037` | out-of-range latitude (`ERROR 3617`) and longitude (`ERROR 3616`) |
 | Measurement | planar (Cartesian) | geodesic on the WGS 84 ellipsoid, as MySQL |
 
-Ingest errors match MySQL's codes and wording as closely as practical, on
-`ST_GeomFromText`, the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike.
+Those codes and their wording are matched as closely as practical, on `ST_GeomFromText`,
+the constructors, `ST_GeomFromGeoJSON` and `ST_GeomFromWKB` alike.
 
 Planar versus geodesic is decided by the **SRS class** (SRID 0 and projected are
 Cartesian, geographic is geodesic), exactly as MySQL decides it, rather than by a
@@ -151,7 +154,16 @@ different things across ecosystems: PostGIS uses one fixed easting/longitude-fir
 for every SRS, and roughly a third of the SRIDs in MySQL's catalog disagree with it,
 across both geographic and projected systems. GeoJSON (RFC 7946, always longitude-first)
 and the explicit `ST_Latitude`/`ST_Longitude` accessors are the unambiguous paths.
-Per-SRID counts and migration guidance are in `axis-order.md` and belong in user docs.
+`ST_X`/`ST_Y` are not: they return the first and second coordinate, so on 4326 `ST_X` is
+the latitude here and in MySQL (verified: `ST_X` = `ST_Latitude` = 30 for
+`POINT(30 50)`) but the longitude in PostGIS. The per-SRID breakdown belongs in the user
+docs, as migration guidance.
+
+Coordinates are **stored as parsed**, so latitude-first on 4326, which is also the order
+S2 wants and therefore costs no swap on the geodesic and index paths. MySQL stores the
+opposite order internally and swaps at every boundary
+([Types and storage](#types-and-storage)); both engines emit the same WKB, so the
+difference is invisible outside the stored bytes.
 
 **Extension path** (documented, not built here):
 
@@ -177,7 +189,9 @@ it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are ident
 - **Accessors:** `ST_X`, `ST_Y`, `ST_Latitude`, `ST_Longitude`, `ST_SRID` (getter and the
   `ST_SRID(g, srid)` setter), `ST_GeometryType`, `ST_Dimension`, `ST_Envelope`,
   `ST_IsEmpty`, `ST_IsValid`, `ST_StartPoint`, `ST_EndPoint`, `ST_PointN`, `ST_NumPoints`,
-  `ST_ExteriorRing`, `ST_NumInteriorRings`, `ST_Centroid`.
+  `ST_ExteriorRing`, `ST_NumInteriorRings`, `ST_Centroid`. `ST_Centroid` is Cartesian-only,
+  as in MySQL, which raises `ERROR 3618` ("has not been implemented for geographic spatial
+  reference systems") for it on 4326.
 - **Measurement:** `ST_Area`, `ST_Length`, `ST_Distance`, `ST_Distance_Sphere`.
 - **Predicates (DE-9IM):** `ST_Within`, `ST_Contains`, `ST_Intersects`, `ST_Equals`,
   `ST_Disjoint`, `ST_Touches`, `ST_Crosses`, `ST_Overlaps`.
@@ -188,16 +202,17 @@ it is present in MySQL 8.0.46 / 8.4 / 9.7, whose spatial function sets are ident
 
 The geometry-processing tail (`ST_Buffer`, `ST_Union`, `ST_Intersection`, ...), the typed
 I/O aliases, the `Multi*`/`GeometryCollection` constructors, the `MBR*` family, geohash,
-the niche accessors and the GeoJSON `options`/`srid` arguments are a later milestone;
-`mysql-function-catalog.md` holds the authoritative v1-vs-tail split.
+the niche accessors and the GeoJSON `options`/`srid` arguments are a later milestone.
 
 Semantics match MySQL, with three documented v1 limitations:
 
 - On 4326, `ST_Distance`/`ST_Length` are ellipsoidal (Andoyer, matching MySQL to
   sub-metre); `ST_Distance_Sphere` is the great-circle variant.
-- `ST_Area` on 4326 is a gap (geodesic polygon area on the ellipsoid, Karney): implement
-  it, or error as MySQL's Cartesian-only functions do (Unresolved Questions). It must not
-  silently return a planar degree² or an off-by-0.45% spherical value.
+- `ST_Area` on 4326 is a gap. MySQL computes it geodesically (12308778368.75 m2 for a
+  1-degree box), so v1 either implements the same (Karney ellipsoidal area) or errors in
+  the shape MySQL uses for its own Cartesian-only functions, `ERROR 3618` (Unresolved
+  Questions). It must not silently return a planar degree2 or an off-by-0.45% spherical
+  value.
 - The predicates are OGC-correct via `simplefeatures`; on 4326 the region predicates use a
   geodesic point-in-polygon, which diverges from MySQL's planar refine near
   edges/poles/antimeridian. Polygon/polygon geodesic relations are a follow-up.
@@ -301,6 +316,10 @@ Out of scope here, each with a home:
   above.
 - **Coprocessor pushdown** of `ST_*` predicates: lands with or after the index; this layer
   evaluates predicates at the TiDB root.
+- **The axis-order controls**: MySQL's `axis-order=long-lat` option argument on
+  `ST_GeomFromText`/`ST_GeomFromWKB`/`ST_AsText`/`ST_AsBinary`, and `ST_SwapXY`, which let
+  a client read or write longitude-first against a latitude-first SRS. Both exist in MySQL
+  and ship here with the function tail.
 - **3D / measured (Z/M) geometry**: computation is 2D only, as in MySQL/MariaDB, but the
   values are stored and returned unchanged, so the functions can be added without a format
   change.
@@ -326,8 +345,9 @@ Out of scope here, each with a home:
 - I/O round-trips: `ST_GeomFromText`/`ST_AsText`, `ST_GeomFromWKB`/`ST_AsBinary`,
   `ST_GeomFromGeoJSON`/`ST_AsGeoJSON` for every subtype, byte-compared to MySQL output
   including its `ST_AsText` spacing and axis order.
-- Accessors and measurement against cross-checked MySQL values (e.g. the 1-degree geodesic
-  distances in `srid-support-reference.md`).
+- Accessors and measurement against values measured on MySQL, e.g. for a 1-degree step on
+  4326: `ST_Distance` 111319.49 m, `ST_Distance_Sphere` 111195.08 m, and `ST_Area` of a
+  1-degree box 12308778368.75 m2.
 - Predicates: the eight DE-9IM predicates plus `Covers`/`CoveredBy` on curated geometry
   pairs, matched to MySQL where semantics agree, with boundary cases explicit.
 - SRID validation: 4326 out-of-range errors on every ingest path, SRID 0 Inf/NaN
@@ -403,13 +423,15 @@ Risks:
   encode/decode and hands the body to the library. On the TiKV side the `geo` crate is
   2D-only and already hand-rolls its decoder, so it needs a header change and nothing
   more; Z/M values are not pushable regardless.
-- **A leaner layout as version 1.** Rejected for now, not forever. `storage-format.md`
-  measures EWKB's redundancy (a per-row SRID the column usually fixes, a byte-order flag
-  per (sub)geometry, WKB framing) and finds geometry decode a measurable share of both the
-  index-maintenance write path and the refine read path, but the format is the smallest of
-  the measured levers. The version byte defers the choice without a migration.
+- **A leaner layout as version 1.** Rejected for now, not forever.
+  EWKB carries redundancy (a per-row SRID the column usually fixes, a byte-order flag per
+  (sub)geometry, WKB framing), but profiling the proof of concept put the win in
+  perspective: geometry decode is ~2% of insert CPU, and on the read side WKB parsing is
+  ~27% of query CPU of which only about half is decoding the stored value, the rest being
+  a re-parse inside the predicate library that no storage format can remove. The version
+  byte defers the choice without a migration.
 - **Matching MySQL's stored bytes.** Rejected as a non-goal: I/O compatibility is a
-  boundary conversion, and MySQL does the same thing internally (`axis-order.md`).
+  boundary conversion, and MySQL does the same thing internally.
 - **cgo/libgeos (go-geos).** Rejected for v1: it gives OGC-correct geometry but needs
   `libgeos` in the Bazel/CI sandbox, which broke the build. The PoC moved to pure-Go
   `simplefeatures` and stayed MySQL byte-identical. Revisit only for the processing tail.
@@ -418,12 +440,12 @@ Risks:
 - **Geometry as a generic BLOB with application-side functions.** The status quo; loses
   MySQL compatibility, type safety, and any path to a spatial index.
 - **PostGIS axis order and always-planar `geometry` semantics.** Rejected in favor of
-  MySQL parity (`srid-support-reference.md` documents the differences).
+  MySQL parity; the differences are documented under SRID model.
 
 ## Unresolved Questions
 
 - **A leaner format version 2:** add one before GA, or ship version 1 and revisit?
-  Benchmark-gated (`storage-format.md`); the version byte means it can also land after GA.
+  Benchmark-gated; the version byte means it can also land after GA.
   `ST_AsBinary` output stays MySQL-compatible plain WKB either way.
 - **Reading a Z/M value back:** the writers reject it, so today it returns only as the raw
   column value in the stored format. Confirm that is enough, or give `ST_AsBinary` an
@@ -436,7 +458,7 @@ Risks:
   milestone.
 - **4326 refine scope for v1:** accept planar polygon/polygon refine plus the geodesic
   point-in-polygon as a documented limitation, or widen geodesic coverage before GA?
-- **Exact v1 function boundary:** confirm v1 vs tail against `mysql-function-catalog.md`
-  (e.g. `ST_Centroid`, the typed `*FromText`/`*FromWKB` aliases).
+- **Exact v1 function boundary:** confirm which accessors and aliases are v1 rather than
+  tail (e.g. `ST_Centroid`, the typed `*FromText`/`*FromWKB` aliases).
 - **Downgrade mechanics:** confirm the drop-geometry-columns-first requirement, and
   whether any metadata-only downgrade is possible.

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -28,6 +28,7 @@
 * [Investigation & Alternatives](#investigation--alternatives)
 * [Unresolved Questions](#unresolved-questions)
 * [Future extensions](#future-extensions)
+* [Appendix: binary format lengths](#appendix-binary-format-lengths)
 * [Appendix: SRS catalog and axis order](#appendix-srs-catalog-and-axis-order)
     * [Catalog row contents](#catalog-row-contents)
     * [EPSG terms of use](#epsg-terms-of-use)
@@ -162,7 +163,25 @@ The bare path is MySQL's format in both directions, so ingest never has to guess
 literal is always MySQL's format, and the stored format stays off the user surface. It is
 what makes a Dumpling to Lightning round-trip work with no function call, and what lets a
 `mysqldump` load unchanged. The SRID in those bytes is validated against `SRID n` like any
-other ingest path.
+other ingest path, and the geometry has to consume the input exactly: a byte short or a
+byte long is rejected, as MySQL rejects both with `ERROR 3037`. See
+[the appendix](#appendix-binary-format-lengths) for what that admits.
+
+**That format is not WKB order.** MySQL has one binary representation, `<srid u32 LE><WKB>`,
+and uses it everywhere: what it stores, what a bare `SELECT` returns over the wire, what it
+accepts as a literal, and what it writes to the binlog are the same bytes. Verified on
+9.7.2 for `POINT(37.4 -122.1)` at 4326: `HEX(g)`, the raw wire response and the
+`Write_rows` row image are byte-identical, and inserting those bytes as a literal
+reproduces the row exactly.
+
+`ST_AsBinary` is the one surface that differs, because it reorders to the SRS axis order.
+For that same point the binary representation is longitude then latitude while
+`ST_AsBinary` returns latitude then longitude. At SRID 0 and on the projected SRSs checked
+the two agree. So the bare path swaps the pair on the way in and on the way out for a
+geographic SRS, and does nothing at SRID 0. The swap belongs to the SRS, not to 4326, so
+extending the catalog means taking it from the axis order in the SRS definition rather than
+from a special case (see [Scope and deferrals](#scope-and-deferrals) and
+[the appendix](#appendix-srs-catalog-and-axis-order)).
 
 Extended data (Z/M coordinates, unsupported SRIDs) has no MySQL form, so a bare `SELECT`
 of it errors, naming `ST_AsEWKB` as the way to read it. That is opt-in: such a value only
@@ -502,8 +521,9 @@ Out of scope here, each with a home:
 | Planner, statistics, executor | `ST_*` evaluate on the normal expression path; geometry predicates are ordinary `Selection`s with no access path of their own. No new operator, access path or statistics. `ANALYZE` skips geometry as it skips JSON and the blob types, which means adding `geometry` both to the accepted values of `tidb_analyze_skip_column_types` and to its default, today `json,blob,mediumblob,longblob,mediumtext,longtext`. |
 | TiKV | None. Values are ordinary binary strings; pushdown is deferred. |
 | BR | None. Backs up and restores bytes and metadata without interpreting column values. |
-| Dumpling, Lightning | Geometry dumps as MySQL's internal format, which reloads as a bare literal (see [Types and storage](#types-and-storage)), so the round-trip needs no function call and a `mysqldump` loads unchanged. A table holding extended values cannot be dumped that way, since a bare `SELECT` of them errors; dumping those needs `ST_AsEWKB` and emitting `ST_GeomFromEWKB(0x...)`, which is Dumpling work and TiDB-only output. |
-| TiFlash, TiCDC | Not pass-through: both decode column values against the schema, so each has to learn the type. Out of scope here and tracked separately; until then a table with a geometry column should not be assumed replicable to TiFlash. |
+| Dumpling, Lightning | Geometry dumps as MySQL's binary format, which reloads as a bare literal (see [Types and storage](#types-and-storage)), so the round-trip needs no function call and a `mysqldump` loads unchanged. A table holding extended values cannot be dumped that way, since a bare `SELECT` of them errors; dumping those needs `ST_AsEWKB` and emitting `ST_GeomFromEWKB(0x...)`, which is Dumpling work and TiDB-only output. |
+| DM | Replicating MySQL into TiDB carries geometry in MySQL's binary format, since the binlog row image is the same bytes MySQL stores and returns, and that is exactly what the bare ingest path takes. DM itself needs no change; the conversion, including the geographic axis swap, is TiDB-side. This is the migration case the bare path is chosen for. |
+| TiFlash, TiCDC | Not pass-through, and for a different reason than the tools above: both read the stored value from the KV layer rather than through the SQL layer, so they see the format-version byte and EWKB, not MySQL's format. TiCDC into a MySQL sink therefore has to convert before it emits, and TiFlash has to learn the type before it can replicate at all. Both are separate work; until then a table with a geometry column should not be assumed replicable to TiFlash. |
 | Upgrade | Additive: the type does not exist in earlier releases, so no existing schema or query changes behavior. |
 | Downgrade | A release without the type cannot read a table that has a geometry column, so those columns must be dropped first, an ordinary `DROP COLUMN`. |
 
@@ -538,7 +558,9 @@ Out of scope here, each with a home:
   interprets coordinates error clearly on them.
 - The bare binary boundary is symmetric: bytes from a bare `SELECT` of a MySQL-expressible
   value insert back unchanged as a bare literal, and a `mysqldump` literal loads as the
-  same geometry.
+  same geometry. Byte-compared against MySQL for both SRIDs, which is what catches the
+  geographic axis swap: at 4326 the bare bytes must be longitude-first while
+  `ST_AsBinary` of the same value is latitude-first, and at SRID 0 the two agree.
 - GeoJSON: the table above, each row matched against MySQL 8.4 and 9.7, plus `options` 5
   and 6 keeping a Z position and differing on a fourth element, and `ST_AsGeoJSON`'s
   `digits` rounding and each `flags` bit, byte-compared to MySQL.
@@ -710,6 +732,18 @@ change.
 | `ST_Transform`, which MySQL has had since 8.0.13 and which reprojects between two SRSs | moderate, and pointless before the catalog: with only 0 and 4326 there is nothing to transform to, since 4326 to 4326 is a no-op and MySQL itself rejects a transform to 0 with `ERROR 3742` |
 | User-defined SRSs through `CREATE [OR REPLACE] SPATIAL REFERENCE SYSTEM` and `DROP SPATIAL REFERENCE SYSTEM`, which MySQL also has (there is no `ALTER`; modification is `CREATE OR REPLACE`) | bigger: a writable catalog, a WKT SRS parser, and catalog changes that have to replicate |
 
+**A compact point storage version.** The format-version byte leaves room for layouts
+narrower than EWKB, and a point is the case worth it: version 2 could be
+`<version = 2><f64><f64>`, 17 bytes against the 22 that version 1 needs for the same point,
+since EWKB repeats a byte-order flag and a type word the column already implies. It carries
+no SRID, so it would apply only where a `SRID n` column fixes one, which is the same
+condition under which version 1 already omits the SRID flag.
+
+Two independent checks tell it from a MySQL value, which is what makes it safe to add: the
+first byte is the version, 2 rather than 1, and 17 bytes is a length MySQL's format can
+never produce (see [the appendix](#appendix-binary-format-lengths)). Nothing on the user
+surface changes, since the bare path exchanges MySQL's format either way.
+
 **MySQL byte interop.** A pair of conversion functions, `ST_FromMySQL` and `ST_AsMySQL`,
 would let a MySQL dump land in a `VARBINARY` column and be converted in place, or exposed
 through a generated column, without TiDB adopting MySQL's storage format. It is the
@@ -727,6 +761,35 @@ A `GEOGRAPHY` type is a further extension, covered in
 [the appendix](#appendix-postgis-delta-for-the-type-layer). The function tail, the `MBR*`
 family and the rest of the deferred surface are in
 [Scope and deferrals](#scope-and-deferrals).
+
+## Appendix: binary format lengths
+
+A MySQL binary value is `4 + WKB`, and the WKB size follows the structure rather than one
+formula: a `POINT` is 21, a `LINESTRING` of n points `9 + 16n`, a `POLYGON` of r rings and
+p points `9 + 4r + 16p`, a `MULTIPOINT` of n points `9 + 21n` since each member repeats the
+byte-order flag and type word, and any collection `9 + Σ member sizes`. Requiring the
+parse to end exactly at the input length is therefore an exact check, and the one the bare
+path applies.
+
+It is a validity check, not a format tag. What it admits, computed over those rules and
+spot-checked against 9.7.2:
+
+| | |
+| --- | --- |
+| Smallest valid lengths | 13, 22, 25, 29, 31, 33, 34, 38, 40, 42, 43, 45, 47, 49 |
+| Never valid | 1-12, 14-21, 23-24, 26-28, 30, 32, 35-37, 39, 41, 44, 46, 48, 50, 57, 66 |
+| Largest invalid length | **66**; every length from 67 up is valid |
+
+Some of the small valid ones are counter-intuitive, because this path validates framing and
+not geometry, which `ST_IsValid` covers separately. 29 is a `LINESTRING` with a single
+point, 33 a `POLYGON` whose one ring has a single point, and 22 a
+`GEOMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY)`, which nests in steps of 9 to give 31, 40
+and 49. All three were accepted by 9.7.2. Only framing errors are rejected: a `LINESTRING`
+with no points, a `POLYGON` with no rings, or any `MULTI*` with no members, since
+`GEOMETRYCOLLECTION` is the only container allowed to be empty.
+
+So no length window can be reserved for another format. Above 66 there is none free, and
+below it a geometry has nowhere to live.
 
 ## Appendix: SRS catalog and axis order
 
@@ -757,10 +820,17 @@ different things across ecosystems, and `ST_X`/`ST_Y` are positional rather than
 `POINT(30 50)`). How other ecosystems order the same bytes is in
 [the PostGIS appendix](#appendix-postgis-delta-for-the-type-layer).
 
-Storing coordinates as parsed is where TiDB and MySQL differ internally without differing
-observably: MySQL stores the opposite order and swaps at every boundary, visible as
-`HEX(g)` and `ST_AsBinary(g)` returning swapped coordinates for the same 4326 point. Both
-engines emit the same WKB.
+Storing coordinates as parsed is where TiDB and MySQL differ. MySQL's binary format orders
+them the other way on a geographic SRS, longitude-first at 4326, and converts only for the
+WKT and WKB surfaces, not at every boundary: `HEX(g)`, the wire response, a bare literal
+and the binlog row image all carry the unconverted order. So for the same 4326 point
+`HEX(g)` differs between the engines while `ST_AsBinary(g)` agrees, and both emit the same
+WKB.
+
+That is why the bare binary path has to swap in both directions for a geographic SRS; see
+*Binary in and out* under [Types and storage](#types-and-storage). Measured on 9.7.2, the
+difference is there for 4326 and not for SRID 0, 3857 or 3006, so it follows the SRS rather
+than the one SRID.
 
 ## Appendix: PostGIS delta for the type layer
 

--- a/docs/design/2026-07-29-geospatial-basic.md
+++ b/docs/design/2026-07-29-geospatial-basic.md
@@ -193,6 +193,29 @@ end without a migration: ingest could try to recognise the format it was handed 
 assume MySQL's, and bare output could do something better than erroring, so long as it is
 neither silent truncation nor a format the input side will not take back.
 
+**Bounded parsing.** Nesting costs 9 bytes a level in WKB, so a value inside
+`max_allowed_packet` can nest millions deep. MySQL guards this pre-emptively: on 9.7.2 with
+the default 1 MiB `thread_stack` a too-deep value returns `ERROR 1436 "Thread stack
+overrun"`, a clean session error, and the server stays up. The depth where it trips differs
+per path and scales with `thread_stack`: `ST_GeomFromText` accepts 4235 levels,
+`ST_GeomFromWKB` 7059, a spatial function reading a stored value 7062, and a bare literal
+into a `GEOMETRY` column 10578. That last gap is a hazard MySQL leaves open: it stores a
+geometry too deeply nested for any `ST_*` function to read back, because the insert path
+validates with less stack than the read path uses. TiDB bounds depth explicitly, since
+Go's stack overflow is a fatal, unrecoverable crash rather than MySQL's catchable guard, so
+the bound is what turns a crash into an error. It applies one bound across ingest and read,
+above real data and below MySQL's storage limit, so unlike MySQL it never persists a value
+it cannot read.
+
+**Size.** A vertex is 16 bytes and nothing compresses it, so a geometry costs 16 bytes a
+vertex plus small per-ring and per-part overhead. TiDB's 6 MiB `txn-entry-size-limit` is
+the real ceiling on a stored value, about 393k vertices, and ordinary data reaches it:
+national boundaries at OSM resolution are 172k vertices for Russia (2.6 MiB) and 369k for
+Canada (5.7 MiB), against 37k and 68k for the same two at Natural Earth 1:10m. No separate
+point-count cap is needed for a stored value, and a large geometry is slow rather than
+unbounded. `ST_Subdivide`, the PostGIS remedy for oversized polygons, is deferred with the
+rest of the processing tail.
+
 Why EWKB rather than the alternatives:
 [Investigation & Alternatives](#investigation--alternatives).
 
@@ -569,6 +592,12 @@ Out of scope here, each with a home:
   `ERROR 3559`.
 - Format version: version 1 decodes; an unknown or zero version byte is rejected with a
   clear error rather than misparsed.
+- Hostile input: WKB nested past the depth the parser bounds, truncated and over-long
+  inputs in each format, and a fuzz target over the WKT, WKB and GeoJSON parsers. The bar
+  is a clean error, never a panic or a crash, since Go's stack overflow is unrecoverable
+  where MySQL's `ERROR 1436` guard is not. One case pins the read/ingest bound as equal, a
+  value that ingests must read back, so TiDB does not repeat MySQL's store-but-unreadable
+  gap.
 - Type plumbing: geometry through the audited operation surface returns correct bytes.
 - DDL: `MODIFY`/`CHANGE COLUMN` on a geometry column is rejected for the `SRID` attribute,
   for both subtype directions and for conversion to another type, while `NULL`/`NOT NULL`,
@@ -620,6 +649,11 @@ Risks:
   placeholder wording); a compatibility risk, not a correctness one.
 - **Pure-Go library gaps:** `simplefeatures` covers the v1 surface but not the GEOS-class
   processing tail, which is deferred.
+- **Parsers take untrusted bytes:** geometry parsing is the one new path a client drives
+  with arbitrary input, so a parser bug is an availability risk for the server, not just
+  the session. Go makes this sharper than MySQL: a stack overflow is a fatal crash with no
+  `recover`, where MySQL degrades to `ERROR 1436`. Mitigated by bounding depth explicitly
+  and by fuzzing the parsers.
 
 ## Investigation & Alternatives
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6347

Problem Summary:

TiDB has no geospatial support: only the `mysql.TypeGeometry` constant exists (`pkg/parser/mysql/type.go`), with no value representation and no `ST_*` functions, so applications encode geometry into scalar columns by hand and compute distances client-side, losing MySQL compatibility and correctness. It is one of the most requested features (issue #6347, labeled `feature/accepted`).

This PR proposes the design for the basic layer: the MySQL-compatible `GEOMETRY` type family, per-column SRID, a versioned stored value format, and the minimal `ST_*` function set that makes geometry storable, readable, and queryable by full table scan. It is deliberately **index-free**; the spatial index is designed separately in PR #69473 and builds on this layer. It adds a design document only; no product code is changed.

### What changed and how does it work?

- **Types.** The MySQL `GEOMETRY` family (`GEOMETRY`, `POINT`, `LINESTRING`, `POLYGON` and the multi/collection variants), all reusing the existing `mysql.TypeGeometry` field type with the subtype as a constraint on the value, plus an optional `SRID n` column attribute.
- **Stored value.** A 1-byte format version followed by the payload, numbered from 1 so a leading zero byte is never a valid version and a later format needs no migration. Version 1 is [EWKB](https://libgeos.org/specifications/wkb/#extended-wkb) as PostGIS and GEOS define it: one published format that carries the SRID, Z, M and XYZM, and whose degenerate case (2D, no SRID flag) is plain OGC WKB byte for byte. The internal format deliberately does **not** match MySQL's; I/O compatibility is a boundary conversion, which is how MySQL itself works (it stores coordinates longitude-first internally and swaps per SRS on every WKT/WKB read and write).
- **MySQL-compatible, extensible where the extension is free.** Functions behave as MySQL does and error where MySQL cannot express a value, while the storage layer is deliberately wider: it carries Z/M coordinates and any SRID losslessly, so 3D/measured geometry and the wider SRS catalog can arrive later as functions over data written today.
- **SRIDs.** 0 (abstract Cartesian plane) and 4326 (WGS 84). Planar versus geodesic is decided by the SRS class exactly as MySQL decides it, which is the seam for adding SRIDs later without new code paths. Axis order follows MySQL (latitude first on 4326), with the PostGIS divergence documented, since roughly a third of the SRIDs in MySQL's catalog disagree with PostGIS on coordinate order.
- **Functions.** The minimal set needed to store, read, inspect, measure and filter geometry, including the eight DE-9IM predicates plus `ST_Covers`/`ST_CoveredBy` (index-eligible region predicates in the index layer). The geometry-processing tail, typed I/O aliases, the `MBR*` family and geohash are a later, parallel milestone.
- **Engine.** Pure Go (`github.com/peterstace/simplefeatures` plus `github.com/golang/geo` for S2), so the whole stack builds with `CGO_ENABLED=0` and needs no libgeos in the Bazel/CI sandbox.

The MySQL behaviors quoted in the document were verified against running MySQL **8.4.6 and 9.7.2**, which agreed on every probe: GeoJSON `Feature` and `FeatureCollection` handling, `crs` URN parsing, rejection of coordinate dimensions above 2, the coordinate-validation error codes (3617, 3616, 3037), `ST_Centroid` being Cartesian-only (3618), and the difference between MySQL's stored coordinate order and what its I/O emits.

This replaces the earlier geospatial design, PR #38916.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Expanded the geospatial design specification with MySQL-compatible binary representation and exact-length input validation.
- Clarified longitude-first storage, SRS-driven axis handling, and `ST_AsBinary` behavior.
- Documented generated-column restrictions and parser security considerations.
- Updated compatibility details for DM, TiFlash, and TiCDC format handling.
- Added hostile-input fuzzing, axis-order, conversion, gating, and pass-through test guidance.
- Added planning for a compact point storage format and revised binary-format length references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->