### PR TITLE
importinto: forbid importing into TTL-enabled tables

### DIFF
--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -121,7 +121,7 @@ go_test(
     embed = [":importer"],
     flaky = True,
     race = "on",
-    shard_count = 44,
+    shard_count = 45,
     deps = [
         "//br/pkg/mock",
         "//br/pkg/streamhelper",

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -62,11 +62,13 @@ func (e *LoadDataController) CheckRequirementsBeforeInitDataFiles(ctx context.Co
 
 func (e *LoadDataController) checkRequirements(ctx context.Context, se sessionctx.Context, checkTotalFileSize bool) error {
 	tableInfo := e.Plan.TableInfo
-	// TTL runs asynchronously and can delete data while an import is running, causing
-	// checksum mismatches. This is independent of table mode: although table mode may
-	// prevent writes, a TTL manager that merely checks table mode can still report
-	// protected-table/mode errors, and manager-side checks cannot prevent every such error.
-	// Therefore, IMPORT INTO forbids importing into a table with TTL enabled.
+	// Import table mode can prevent TTL from deleting data and causing a checksum
+	// mismatch. However, because TTL jobs run asynchronously, a job that races with the
+	// switch to import mode may still report a protected-table error. This precheck is
+	// also needed on versions that do not support table mode. Therefore, IMPORT INTO
+	// forbids importing into a table with TTL enabled. If later testing shows that IMPORT
+	// INTO can always switch table mode without an opt-out, TTL can check table mode before
+	// starting a job and this precheck can be removed.
 	if tableInfo.TTLInfo != nil && tableInfo.TTLInfo.Enable {
 		return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("target table has TTL enabled, please disable TTL before IMPORT INTO")
 	}

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -41,6 +41,7 @@ var GetEtcdClient = store.NewEtcdCli
 
 // CheckRequirements checks the requirements for IMPORT INTO.
 // we check the following things here:
+//   - target table should not have TTL enabled
 //   - when import from file
 //     1. there is no active job on the target table
 //     2. the total file size > 0
@@ -60,6 +61,16 @@ func (e *LoadDataController) CheckRequirementsBeforeInitDataFiles(ctx context.Co
 }
 
 func (e *LoadDataController) checkRequirements(ctx context.Context, se sessionctx.Context, checkTotalFileSize bool) error {
+	tableInfo := e.Plan.TableInfo
+	// TTL runs asynchronously and can delete data while an import is running, causing
+	// checksum mismatches. This is independent of table mode: although table mode may
+	// prevent writes, a TTL manager that merely checks table mode can still report
+	// protected-table/mode errors, and manager-side checks cannot prevent every such error.
+	// Therefore, IMPORT INTO forbids importing into a table with TTL enabled.
+	if tableInfo.TTLInfo != nil && tableInfo.TTLInfo.Enable {
+		return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("target table has TTL enabled, please disable TTL before IMPORT INTO")
+	}
+
 	conn := se.GetSQLExecutor()
 	if e.DataSourceType == DataSourceTypeFile {
 		cnt, err := GetActiveJobCnt(ctx, conn, e.Plan.DBName, e.Plan.TableInfo.Name.L)

--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -278,3 +278,47 @@ func TestCheckRequirements(t *testing.T) {
 	c.Plan.CloudStorageURI = fmt.Sprintf("s3://test-bucket/path?region=us-east-1&endpoint=%s&access-key=xxxxxx&secret-access-key=xxxxxx", ts.URL)
 	require.NoError(t, c.CheckRequirements(ctx, tk.Session()))
 }
+
+func TestCheckRequirementsTTL(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	ctx := util.WithInternalSourceType(context.Background(), kv.InternalImportInto)
+
+	tk.MustExec("create table test.t(id int primary key, created_at datetime) TTL = `created_at` + INTERVAL 1 DAY")
+	is := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
+	tableObj, err := is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.True(t, tableObj.Meta().TTLInfo.Enable)
+
+	c := &importer.LoadDataController{
+		Plan: &importer.Plan{
+			DBName:          "test",
+			DataSourceType:  importer.DataSourceTypeQuery,
+			DisablePrecheck: true,
+			TableInfo:       tableObj.Meta(),
+		},
+		Table: tableObj,
+	}
+	err = c.CheckRequirements(ctx, tk.Session())
+	require.ErrorIs(t, err, exeerrors.ErrLoadDataPreCheckFailed)
+	require.ErrorContains(t, err, "target table has TTL enabled, please disable TTL before IMPORT INTO")
+	err = c.CheckRequirementsBeforeInitDataFiles(ctx, tk.Session())
+	require.ErrorIs(t, err, exeerrors.ErrLoadDataPreCheckFailed)
+	require.ErrorContains(t, err, "target table has TTL enabled, please disable TTL before IMPORT INTO")
+
+	tk.MustExec("alter table test.t ttl_enable = 'OFF'")
+	is = tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
+	tableObj, err = is.TableByName(ctx, ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	c = &importer.LoadDataController{
+		Plan: &importer.Plan{
+			DBName:          "test",
+			DataSourceType:  importer.DataSourceTypeQuery,
+			DisablePrecheck: true,
+			TableInfo:       tableObj.Meta(),
+		},
+		Table: tableObj,
+	}
+	require.NoError(t, c.CheckRequirements(ctx, tk.Session()))
+	require.NoError(t, c.CheckRequirementsBeforeInitDataFiles(ctx, tk.Session()))
+}

--- a/tests/integrationtest/r/executor/import_into.result
+++ b/tests/integrationtest/r/executor/import_into.result
@@ -197,3 +197,9 @@ create table cachetbl (id int);
 alter table cachetbl cache;
 import into cachetbl from '/file.csv';
 Error 1105 (HY000): IMPORT INTO does not support cached table
+drop table if exists import_into_ttl_precheck_source, import_into_ttl_precheck_target;
+create table import_into_ttl_precheck_source (id int primary key, created_at datetime);
+create table import_into_ttl_precheck_target (id int primary key, created_at datetime) TTL = `created_at` + INTERVAL 1 DAY;
+IMPORT INTO import_into_ttl_precheck_target FROM SELECT * FROM import_into_ttl_precheck_source WITH DISABLE_PRECHECK;
+Error 8173 (HY000): PreCheck failed: target table has TTL enabled, please disable TTL before IMPORT INTO
+drop table if exists import_into_ttl_precheck_source, import_into_ttl_precheck_target;

--- a/tests/integrationtest/t/executor/import_into.test
+++ b/tests/integrationtest/t/executor/import_into.test
@@ -204,3 +204,11 @@ create table cachetbl (id int);
 alter table cachetbl cache;
 -- error 1105
 import into cachetbl from '/file.csv';
+
+# TestImportIntoTTLPrecheck
+drop table if exists import_into_ttl_precheck_source, import_into_ttl_precheck_target;
+create table import_into_ttl_precheck_source (id int primary key, created_at datetime);
+create table import_into_ttl_precheck_target (id int primary key, created_at datetime) TTL = `created_at` + INTERVAL 1 DAY;
+-- error 8173
+IMPORT INTO import_into_ttl_precheck_target FROM SELECT * FROM import_into_ttl_precheck_source WITH DISABLE_PRECHECK;
+drop table if exists import_into_ttl_precheck_source, import_into_ttl_precheck_target;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70426

Problem Summary:

`IMPORT INTO` currently permits a target table with TTL enabled. Because TTL jobs run asynchronously, they may delete rows while the import is running and cause the final checksum to mismatch. Although table mode can prevent ordinary writes, relying only on TTL-manager table-mode checks can still produce protected-table or table-mode errors in logs

### What changed and how does it work?

- Add a mandatory synchronous precheck that rejects a target table whose captured `TableInfo` has TTL enabled.
- Keep the TTL check independent of table mode and outside `DISABLE_PRECHECK`, so the option cannot bypass this safety requirement.
- Return an actionable Error 8173 message asking the user to disable TTL before importing.
- Add focused unit and SQL integration coverage for both synchronous precheck entry points, TTL-disabled acceptance, and `DISABLE_PRECHECK` non-bypassability.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```bash
./tools/check/failpoint-go-test.sh pkg/executor/importer -run '^(TestCheckRequirements|TestCheckRequirementsTTL)$' -count=1
cd tests/integrationtest && ./run-tests.sh -r executor/import_into
make lint
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
`IMPORT INTO` now rejects target tables with TTL enabled and asks users to disable TTL before importing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * `IMPORT INTO` now rejects target tables with TTL enabled, including when prechecks are disabled.
  * Returns a clear error before the import proceeds, preventing unsupported imports.

* **Tests**
  * Added coverage for TTL validation in standard and pre-file-initialization workflows.
  * Added integration coverage confirming consistent error handling and cleanup of temporary tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->