### PR TITLE
test: stabilize flaky TestPauseSchedulersByKeyRange

### DIFF
--- a/br/pkg/pdutil/pd_serial_test.go
+++ b/br/pkg/pdutil/pd_serial_test.go
@@ -107,7 +107,7 @@ func TestPDResetTSCompatibility(t *testing.T) {
 }
 
 func TestPauseSchedulersByKeyRange(t *testing.T) {
-	const ttl = time.Second
+	const ttl = 3 * time.Second
 
 	labelExpires := make(map[string]time.Time)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70424

Problem Summary:
Flaky test `TestPauseSchedulersByKeyRange` in `br/pkg/pdutil` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The 1s test TTL made the mock expiry assertion measure CI scheduling delay instead of the intended periodic scheduler-label renewal behavior.

#### Fix

A 3s TTL preserves the same renewal-before-expiry assertion and `3 * ttl` multi-renewal test shape while avoiding a fragile 1s scheduling cliff far below the production 5m TTL.

#### Verification

Spec:
- target: `br/pkg/pdutil :: TestPauseSchedulersByKeyRange`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- native_repeat: SKIPPED
- timing_hook: SKIPPED
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS
- prow_bazel: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/pdutil -run '^TestPauseSchedulersByKeyRange$' -count=1`
- `go test -json -tags=intest,deadlock ./br/pkg/pdutil -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the label time-to-live used by the scheduler pause test to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->