### PR TITLE
executor: track range memory for IndexJoin under dynamic partition pruning

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -5310,6 +5310,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 		err = e.open(ctx, kvRanges)
 		return e, err
 	}
+	e.rangeMemTracker = memoryTracker
 
 	is := v.IndexPlans[0].(*physicalop.PhysicalIndexScan)
 	if is.Index.Global {
@@ -5370,6 +5371,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 		err = e.open(ctx)
 		return e, err
 	}
+	e.rangeMemTracker = memTracker
 
 	is := v.IndexPlans[0].(*physicalop.PhysicalIndexScan)
 	if is.Index.Global {

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -259,6 +259,8 @@ type IndexReaderExecutor struct {
 	plans          []base.PhysicalPlan
 
 	memTracker *memory.Tracker
+	// rangeMemTracker tracks KV range construction for an Index Join inner task.
+	rangeMemTracker *memory.Tracker
 
 	selectResultHook // for testing
 
@@ -351,7 +353,7 @@ func (e *IndexReaderExecutor) buildKVRangesForIndexReader() ([]kv.KeyRange, erro
 
 	results := make([]kv.KeyRange, 0, len(groupedRanges))
 	for _, ranges := range groupedRanges {
-		kvRanges, err := buildKeyRanges(e.dctx, ranges, e.partRangeMap, tableIDs, e.index.ID, nil)
+		kvRanges, err := buildKeyRanges(e.dctx, ranges, e.partRangeMap, tableIDs, e.index.ID, e.rangeMemTracker)
 		if err != nil {
 			return nil, err
 		}
@@ -515,6 +517,8 @@ type IndexLookUpExecutor struct {
 
 	// memTracker is used to track the memory usage of this executor.
 	memTracker *memory.Tracker
+	// rangeMemTracker tracks KV range construction for an Index Join inner task.
+	rangeMemTracker *memory.Tracker
 
 	// checkIndexValue is used to check the consistency of the index data.
 	*checkIndexValue
@@ -675,8 +679,12 @@ func (e *IndexLookUpExecutor) buildTableKeyRanges() (err error) {
 
 	kvRanges := make([][]kv.KeyRange, 0, len(groupedRanges))
 	physicalTblIDsForPartitionKVRanges := make([]int64, 0, len(tableIDs)*len(groupedRanges))
+	rangeMemTracker := e.memTracker
+	if e.rangeMemTracker != nil {
+		rangeMemTracker = e.rangeMemTracker
+	}
 	for _, ranges := range groupedRanges {
-		kvRange, err := buildKeyRanges(e.dctx, ranges, e.partitionRangeMap, tableIDs, e.index.ID, e.memTracker)
+		kvRange, err := buildKeyRanges(e.dctx, ranges, e.partitionRangeMap, tableIDs, e.index.ID, rangeMemTracker)
 		if err != nil {
 			return err
 		}

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"testing"
@@ -130,6 +131,49 @@ func TestBuildKvRangesForIndexJoinWithoutCwcAndWithMemoryTracker(t *testing.T) {
 
 	require.Equal(t, 2*bytesConsumed1, bytesConsumed2)
 	require.Equal(t, int64(23640), bytesConsumed1)
+}
+
+func TestIndexReaderPartitionRangesUseMemoryTracker(t *testing.T) {
+	sctx := mock.NewContext()
+	partition0 := tables.MockTableFromMeta(&model.TableInfo{ID: 101})
+	partition1 := tables.MockTableFromMeta(&model.TableInfo{ID: 102})
+	rangeMemTracker := memory.NewTracker(memory.LabelForIndexWorker, -1)
+	e := &IndexReaderExecutor{
+		indexReaderExecutorContext: newIndexReaderExecutorContext(sctx),
+		index:                      &model.IndexInfo{ID: 1},
+		partitions:                 []table.PhysicalTable{partition0.(table.PhysicalTable), partition1.(table.PhysicalTable)},
+		ranges:                     []*ranger.Range{generateIndexRange(1, 1)},
+		rangeMemTracker:            rangeMemTracker,
+		dummy:                      true,
+	}
+
+	require.NoError(t, e.Open(context.Background()))
+	require.Greater(t, rangeMemTracker.BytesConsumed(), int64(0))
+	require.Nil(t, e.memTracker)
+}
+
+func TestIndexLookUpPartitionRangesUseMemoryTracker(t *testing.T) {
+	sctx := mock.NewContext()
+	partition0 := tables.MockTableFromMeta(&model.TableInfo{ID: 101})
+	partition1 := tables.MockTableFromMeta(&model.TableInfo{ID: 102})
+	rangeMemTracker := memory.NewTracker(memory.LabelForIndexWorker, -1)
+	e := &IndexLookUpExecutor{
+		indexLookUpExecutorContext: newIndexLookUpExecutorContext(sctx),
+		index:                      &model.IndexInfo{ID: 1},
+		prunedPartitions:           []table.PhysicalTable{partition0.(table.PhysicalTable), partition1.(table.PhysicalTable)},
+		partitionTableMode:         true,
+		ranges:                     []*ranger.Range{generateIndexRange(1, 1)},
+		rangeMemTracker:            rangeMemTracker,
+	}
+
+	require.NoError(t, e.buildTableKeyRanges())
+	require.Greater(t, rangeMemTracker.BytesConsumed(), int64(0))
+
+	executorMemTracker := memory.NewTracker(memory.LabelForIndexWorker, -1)
+	e.rangeMemTracker = nil
+	e.memTracker = executorMemTracker
+	require.NoError(t, e.buildTableKeyRanges())
+	require.Greater(t, executorMemTracker.BytesConsumed(), int64(0))
 }
 
 func generateIndexRange(vals ...int64) *ranger.Range {

--- a/pkg/executor/executor_pkg_test.go
+++ b/pkg/executor/executor_pkg_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/join"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -140,6 +141,7 @@ func TestIndexReaderPartitionRangesUseMemoryTracker(t *testing.T) {
 	rangeMemTracker := memory.NewTracker(memory.LabelForIndexWorker, -1)
 	e := &IndexReaderExecutor{
 		indexReaderExecutorContext: newIndexReaderExecutorContext(sctx),
+		BaseExecutorV2:             exec.NewBaseExecutorV2(sctx.GetSessionVars(), nil, 0),
 		index:                      &model.IndexInfo{ID: 1},
 		partitions:                 []table.PhysicalTable{partition0.(table.PhysicalTable), partition1.(table.PhysicalTable)},
 		ranges:                     []*ranger.Range{generateIndexRange(1, 1)},
@@ -159,6 +161,7 @@ func TestIndexLookUpPartitionRangesUseMemoryTracker(t *testing.T) {
 	rangeMemTracker := memory.NewTracker(memory.LabelForIndexWorker, -1)
 	e := &IndexLookUpExecutor{
 		indexLookUpExecutorContext: newIndexLookUpExecutorContext(sctx),
+		BaseExecutorV2:             exec.NewBaseExecutorV2(sctx.GetSessionVars(), nil, 0),
 		index:                      &model.IndexInfo{ID: 1},
 		prunedPartitions:           []table.PhysicalTable{partition0.(table.PhysicalTable), partition1.(table.PhysicalTable)},
 		partitionTableMode:         true,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70319 

Problem Summary:
Memory allocations produced while building KV ranges for dynamic partition index joins are not consistently tracked. In the index reader path, the executor tracker is initialized after range construction; in the index lookup path, the range allocations can be cleared when the executor tracker is reset. This causes memory usage to be under-reported, particularly for lookups spanning multiple partitions.
### What changed and how does it work?
Introduce a dedicated range memory tracker for IndexReaderExecutor and IndexLookUpExecutor. The Index Join inner worker's tracker is propagated through the dynamic partition index join builder and used during partitioned index range-to-KV-range conversion. Existing paths retain their previous behavior, with the executor tracker used as a fallback when no dedicated range tracker is provided. Regression tests cover both partitioned index reader and index lookup reader paths.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory tracking during index joins and partitioned index lookups.
  * Ensured range-building operations use the appropriate memory tracker, with reliable fallback behavior when needed.
  * Enhanced consistency across global, non-partitioned, and partitioned index access paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->