### PR TITLE
tests: enable shared lock RealTiKV tests on next-gen

### DIFF
--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/config"
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/stretchr/testify/require"
 )
@@ -45,9 +45,6 @@ func allowForeignKeyCheckInSharedLockForTest(t *testing.T) {
 func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 	allowForeignKeyCheckInSharedLockForTest(t)
 
@@ -105,9 +102,6 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
-	}
 	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
@@ -161,9 +155,6 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 func TestSharedLockChildTableConflict(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 	allowForeignKeyCheckInSharedLockForTest(t)
 
@@ -267,9 +258,6 @@ func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
-	}
 	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
@@ -307,9 +295,6 @@ func TestSharedLockCascadeUpdateExplicitPessimisticTxn(t *testing.T) {
 func TestSharedLockLockView(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
-	}
-	if kerneltype.IsNextGen() {
-		t.Skip("does not support shared lock in next-gen TiKV")
 	}
 	allowForeignKeyCheckInSharedLockForTest(t)
 
@@ -402,4 +387,85 @@ func TestSharedLockLockView(t *testing.T) {
 
 	tk1.MustExec("commit")
 	require.NoError(t, <-exclusiveLockDoneCh)
+}
+
+func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	testTk := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	testTk.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/dataLockWaitsSkipResolvingLocks", "return(true)")
+	prepareForeignKeyTables(tk1)
+
+	conn2 := tk2.MustQuery("select connection_id()").Rows()[0][0].(string)
+
+	tk1.MustExec("begin pessimistic")
+	tk1.MustExec("select * from parent where id=1 for update")
+	insertDoneCh := make(chan error, 1)
+	insertDone := false
+	t.Cleanup(func() {
+		_, _ = tk1.Exec("rollback")
+		if !insertDone {
+			select {
+			case <-insertDoneCh:
+			case <-time.After(time.Second):
+			}
+		}
+	})
+
+	tk2.MustExec("begin pessimistic")
+	conn2TxnID := tk2.Session().TxnInfo().StartTS
+	go func() {
+		_, err := tk2.Exec("insert into child values (1, 1)")
+		if err == nil {
+			_, err = tk2.Exec("commit")
+		}
+		insertDoneCh <- err
+	}()
+
+	var (
+		insertErr            error
+		insertFinishedEarly  bool
+		waitingTxnAndSession [][]any
+	)
+	require.Eventually(t, func() bool {
+		select {
+		case insertErr = <-insertDoneCh:
+			insertDone = true
+			insertFinishedEarly = true
+			return true
+		default:
+		}
+
+		waitingTxnAndSession = testTk.MustQuery(fmt.Sprintf(
+			"select TRX_ID, SESSION_ID from INFORMATION_SCHEMA.DATA_LOCK_WAITS as l left join INFORMATION_SCHEMA.TIDB_TRX as trx on l.trx_id = trx.id where l.trx_id = %d and trx.session_id = %s",
+			conn2TxnID, conn2,
+		)).Rows()
+		return len(waitingTxnAndSession) > 0
+	}, 10*time.Second, 100*time.Millisecond)
+	require.Falsef(t, insertFinishedEarly, "insert should be blocked before DATA_LOCK_WAITS row is observed, err: %v", insertErr)
+	require.Len(t, waitingTxnAndSession, 1)
+	waitingTxnID := waitingTxnAndSession[0][0].(string)
+	sessionID := waitingTxnAndSession[0][1].(string)
+	require.Equal(t, waitingTxnID, fmt.Sprintf("%d", conn2TxnID))
+	require.Equal(t, sessionID, conn2)
+
+	tk1.MustExec("commit")
+	insertErr = <-insertDoneCh
+	insertDone = true
+	require.NoError(t, insertErr)
+	tk1.MustQuery("select * from child").Check(testkit.Rows("1 1"))
 }

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -91,6 +91,8 @@ func TestForeignKeySharedLockPessimisticReverseReferenceOrder(t *testing.T) {
 	tk2.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -42,6 +42,75 @@ func allowForeignKeyCheckInSharedLockForTest(t *testing.T) {
 	})
 }
 
+func TestForeignKeySharedLockOptimisticReverseReferenceOrder(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+	allowForeignKeyCheckInSharedLockForTest(t)
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+
+	prepareForeignKeyTables(tk1)
+
+	// Foreign-key shared locks do not support optimistic transactions. The checks below reference
+	// parent rows in reverse orders, so the second optimistic transaction should fail at commit
+	// time with a write conflict.
+	tk1.MustExec("begin optimistic")
+	tk2.MustExec("begin optimistic")
+
+	tk1.MustExec("insert into child values (1, 1)")
+	tk2.MustExec("insert into child values (3, 2)")
+
+	tk1.MustExec("insert into child values (2, 2)")
+	tk2.MustExec("insert into child values (4, 1)")
+
+	tk1.MustExec("commit")
+	err := tk2.ExecToErr("commit")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Write conflict")
+
+	tk1.MustQuery("select * from child order by id").Check(testkit.Rows("1 1", "2 2"))
+}
+
+func TestForeignKeySharedLockPessimisticReverseReferenceOrder(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("requires real TiKV")
+	}
+	allowForeignKeyCheckInSharedLockForTest(t)
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+
+	prepareForeignKeyTables(tk1)
+
+	// Pessimistic transactions can acquire compatible foreign-key shared locks, so the same
+	// reverse reference order should let both transactions commit.
+	tk1.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+
+	tk1.MustExec("insert into child values (1, 1)")
+	tk2.MustExec("insert into child values (3, 2)")
+
+	tk1.MustExec("insert into child values (2, 2)")
+	tk2.MustExec("insert into child values (4, 1)")
+
+	tk1.MustExec("commit")
+	tk2.MustExec("commit")
+
+	tk1.MustQuery("select * from child order by id").Check(testkit.Rows("1 1", "2 2", "3 2", "4 1"))
+}
+
 func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
@@ -417,11 +486,17 @@ func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
 	insertDoneCh := make(chan error, 1)
 	insertDone := false
 	t.Cleanup(func() {
-		_, _ = tk1.Exec("rollback")
+		if _, err := tk1.Exec("rollback"); err != nil {
+			t.Errorf("rollback blocker transaction: %v", err)
+		}
 		if !insertDone {
 			select {
-			case <-insertDoneCh:
+			case err := <-insertDoneCh:
+				if err != nil {
+					t.Errorf("insert goroutine failed after rolling back blocker transaction: %v", err)
+				}
 			case <-time.After(time.Second):
+				t.Errorf("insert goroutine did not finish after rolling back blocker transaction")
 			}
 		}
 	})

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -128,8 +128,11 @@ func TestSharedLockBlockedByExclusiveLock(t *testing.T) {
 	tk2.MustExec("use test")
 	tk3.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk3.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk3.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 
@@ -184,8 +187,11 @@ func TestSharedLockBlockExclusiveLock(t *testing.T) {
 	tk2.MustExec("use test")
 	tk3.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk3.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk3.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 
@@ -238,8 +244,11 @@ func TestSharedLockChildTableConflict(t *testing.T) {
 	tk2.MustExec("use test")
 	tk3.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk3.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk3.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 
@@ -378,7 +387,9 @@ func TestSharedLockLockView(t *testing.T) {
 	tk2.MustExec("use test")
 	testTk.MustExec("use test")
 	tk1.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk1.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 	tk2.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+	tk2.MustExec("set @@tidb_pessimistic_txn_fair_locking = 0")
 
 	prepareForeignKeyTables(tk1)
 
@@ -464,6 +475,7 @@ func TestSharedLockDataLockWaitsFromStorageWaitTable(t *testing.T) {
 	if !*realtikvtest.WithRealTiKV {
 		t.Skip("requires real TiKV")
 	}
+	allowForeignKeyCheckInSharedLockForTest(t)
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69236

Problem Summary:

This PR ports #69268 to the `release-nextgen-202603` branch.

### What changed and how does it work?

- Cherry-pick the three commits from #69268.
- Remove the next-gen skips from existing shared-lock RealTiKV tests.
- Add shared-lock `DATA_LOCK_WAITS` coverage for the TiKV storage wait-table path.
- Add foreign-key shared-lock coverage for reverse parent-row reference order in optimistic and pessimistic transactions.
- Preserve the release-only foreign-key shared-lock configuration gate in the backported tests.
- Restore the fair-locking setup already present on master so the newly enabled next-gen cases use the same prerequisites as #69268.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Local validation:

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh tests/realtikvtest/txntest -tags=intest,nextgen -run '^$' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for foreign-key shared locking in both optimistic and pessimistic transaction modes, including reverse reference orders.
  * Added validation that lock-wait information is visible while an operation is blocked.
  * Improved shared-lock test reliability by covering additional locking configurations and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->