### PR TITLE
dumpformat: fix corrupted DECIMAL values in dictionary-encoded parquet files

### DIFF
--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -1145,6 +1145,16 @@ func TestParquetVariousTypes(t *testing.T) {
 				Scale:     2,
 				Gen:       repeatedFixedLenByteArray([]byte{0x00, 0x00, 0x30, 0x39}), // 12345
 			},
+			{
+				// maximumDecimalBytes or longer, so this one takes the string
+				// fallback path, which consumes its input in place as well.
+				Name:      "oversized",
+				Type:      parquet.Types.ByteArray,
+				Converted: schema.ConvertedTypes.Decimal,
+				Precision: 75,
+				Scale:     2,
+				Gen:       repeatedByteArray(append([]byte{0x00, 0x01}, make([]byte, 31)...)), // 2^248
+			},
 		}
 
 		dir := t.TempDir()
@@ -1153,7 +1163,9 @@ func TestParquetVariousTypes(t *testing.T) {
 
 		rdr, err := file.OpenParquetFile(filepath.Join(dir, fileName), false)
 		require.NoError(t, err)
-		defer rdr.Close()
+		t.Cleanup(func() {
+			require.NoError(t, rdr.Close())
+		})
 		for i := range pc {
 			cc, err := rdr.MetaData().RowGroup(0).ColumnChunk(i)
 			require.NoError(t, err)
@@ -1162,7 +1174,10 @@ func TestParquetVariousTypes(t *testing.T) {
 
 		reader := newParquetParserForTest(context.Background(), t, dir, fileName, 0, FileMeta{})
 
-		expectedValues := []string{"123.45", "-123.45", "123.45"}
+		expectedValues := []string{
+			"123.45", "-123.45", "123.45",
+			"4523128485832663883733241601901871400518358776001584532791311875309106626.56",
+		}
 		for range rows {
 			require.NoError(t, reader.ReadRow())
 			require.Len(t, reader.lastRow.Row, len(expectedValues))

--- a/pkg/dumpformat/parquetfile/parser_test.go
+++ b/pkg/dumpformat/parquetfile/parser_test.go
@@ -1092,6 +1092,88 @@ func TestParquetVariousTypes(t *testing.T) {
 		}
 	})
 
+	t.Run("dictionary_encoded_decimal", func(t *testing.T) {
+		// Enough repeated rows that the writer keeps the dictionary page instead of
+		// falling back to PLAIN, so every row decodes to the same shared buffer.
+		const rows = 256
+		repeatedByteArray := func(val []byte) func(int) (any, []int16) {
+			return func(numRows int) (any, []int16) {
+				values := make([]parquet.ByteArray, numRows)
+				levels := make([]int16, numRows)
+				for i := range numRows {
+					values[i] = val
+					levels[i] = 1
+				}
+				return values, levels
+			}
+		}
+		repeatedFixedLenByteArray := func(val []byte) func(int) (any, []int16) {
+			return func(numRows int) (any, []int16) {
+				values := make([]parquet.FixedLenByteArray, numRows)
+				levels := make([]int16, numRows)
+				for i := range numRows {
+					values[i] = val
+					levels[i] = 1
+				}
+				return values, levels
+			}
+		}
+
+		pc := []testutils.ParquetColumn{
+			{
+				Name:      "positive",
+				Type:      parquet.Types.ByteArray,
+				Converted: schema.ConvertedTypes.Decimal,
+				Precision: 9,
+				Scale:     2,
+				Gen:       repeatedByteArray([]byte{0x30, 0x39}), // 12345
+			},
+			{
+				Name:      "negative",
+				Type:      parquet.Types.ByteArray,
+				Converted: schema.ConvertedTypes.Decimal,
+				Precision: 9,
+				Scale:     2,
+				Gen:       repeatedByteArray([]byte{0xcf, 0xc7}), // -12345
+			},
+			{
+				Name:      "fixed_len",
+				Type:      parquet.Types.FixedLenByteArray,
+				Converted: schema.ConvertedTypes.Decimal,
+				TypeLen:   4,
+				Precision: 9,
+				Scale:     2,
+				Gen:       repeatedFixedLenByteArray([]byte{0x00, 0x00, 0x30, 0x39}), // 12345
+			},
+		}
+
+		dir := t.TempDir()
+		fileName := "test.decimal.dictionary.parquet"
+		require.NoError(t, testutils.WriteParquetFile(dir, fileName, pc, rows))
+
+		rdr, err := file.OpenParquetFile(filepath.Join(dir, fileName), false)
+		require.NoError(t, err)
+		defer rdr.Close()
+		for i := range pc {
+			cc, err := rdr.MetaData().RowGroup(0).ColumnChunk(i)
+			require.NoError(t, err)
+			require.True(t, cc.HasDictionaryPage(), "column %s is not dictionary encoded", pc[i].Name)
+		}
+
+		reader := newParquetParserForTest(context.Background(), t, dir, fileName, 0, FileMeta{})
+
+		expectedValues := []string{"123.45", "-123.45", "123.45"}
+		for range rows {
+			require.NoError(t, reader.ReadRow())
+			require.Len(t, reader.lastRow.Row, len(expectedValues))
+			for i, expectValue := range expectedValues {
+				s, err := reader.lastRow.Row[i].ToString()
+				require.NoError(t, err)
+				require.Equal(t, expectValue, s)
+			}
+		}
+	})
+
 	t.Run("boolean", func(t *testing.T) {
 		pc := []testutils.ParquetColumn{
 			{

--- a/pkg/dumpformat/parquetfile/type_converter.go
+++ b/pkg/dumpformat/parquetfile/type_converter.go
@@ -384,6 +384,17 @@ func setFloat64Data(val float64, d *types.Datum) error {
 	return nil
 }
 
+// newDecimalByteSetter returns a setter for byte array DECIMAL columns.
+// Dictionary decoded values alias the shared dictionary buffer, and the
+// conversion consumes its input in place, so copy it into our own buffer first.
+func newDecimalByteSetter[T parquet.ByteArray | parquet.FixedLenByteArray](scale int) setter[T] {
+	var buf []byte
+	return func(val T, d *types.Datum) error {
+		buf = append(buf[:0], val...)
+		return setDatumFromDecimalByte(d, buf, scale)
+	}
+}
+
 func getByteArraySetter(converted *convertedType) setter[parquet.ByteArray] {
 	switch converted.converted {
 	case schema.ConvertedTypes.None, schema.ConvertedTypes.BSON, schema.ConvertedTypes.JSON, schema.ConvertedTypes.UTF8, schema.ConvertedTypes.Enum:
@@ -393,9 +404,7 @@ func getByteArraySetter(converted *convertedType) setter[parquet.ByteArray] {
 			return nil
 		}
 	case schema.ConvertedTypes.Decimal:
-		return func(val parquet.ByteArray, d *types.Datum) error {
-			return setDatumFromDecimalByte(d, val, int(converted.decimalMeta.Scale))
-		}
+		return newDecimalByteSetter[parquet.ByteArray](int(converted.decimalMeta.Scale))
 	}
 
 	return nil
@@ -410,9 +419,7 @@ func getFixedLenByteArraySetter(converted *convertedType) setter[parquet.FixedLe
 			return nil
 		}
 	case schema.ConvertedTypes.Decimal:
-		return func(val parquet.FixedLenByteArray, d *types.Datum) error {
-			return setDatumFromDecimalByte(d, val, int(converted.decimalMeta.Scale))
-		}
+		return newDecimalByteSetter[parquet.FixedLenByteArray](int(converted.decimalMeta.Scale))
 	}
 
 	return nil

--- a/pkg/dumpformat/parquetfile/type_converter.go
+++ b/pkg/dumpformat/parquetfile/type_converter.go
@@ -384,10 +384,10 @@ func setFloat64Data(val float64, d *types.Datum) error {
 	return nil
 }
 
-// newDecimalByteSetter returns a setter for byte array DECIMAL columns.
+// getDecimalByteSetter returns a setter for byte array DECIMAL columns.
 // Dictionary decoded values alias the shared dictionary buffer, and the
 // conversion consumes its input in place, so copy it into our own buffer first.
-func newDecimalByteSetter[T parquet.ByteArray | parquet.FixedLenByteArray](scale int) setter[T] {
+func getDecimalByteSetter[T parquet.ByteArray | parquet.FixedLenByteArray](scale int) setter[T] {
 	var buf []byte
 	return func(val T, d *types.Datum) error {
 		buf = append(buf[:0], val...)
@@ -404,7 +404,7 @@ func getByteArraySetter(converted *convertedType) setter[parquet.ByteArray] {
 			return nil
 		}
 	case schema.ConvertedTypes.Decimal:
-		return newDecimalByteSetter[parquet.ByteArray](int(converted.decimalMeta.Scale))
+		return getDecimalByteSetter[parquet.ByteArray](int(converted.decimalMeta.Scale))
 	}
 
 	return nil
@@ -419,7 +419,7 @@ func getFixedLenByteArraySetter(converted *convertedType) setter[parquet.FixedLe
 			return nil
 		}
 	case schema.ConvertedTypes.Decimal:
-		return newDecimalByteSetter[parquet.FixedLenByteArray](int(converted.decimalMeta.Scale))
+		return getDecimalByteSetter[parquet.FixedLenByteArray](int(converted.decimalMeta.Scale))
 	}
 
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70365

Problem Summary:

`IMPORT INTO` silently writes wrong values for repeated dictionary-encoded Parquet DECIMAL columns. Only the first occurrence of a dictionary entry is correct; every later row referencing the same entry gets a different value (`0.00` in the reported witness). The job reports success and `ADMIN CHECK TABLE` passes, because both validate the KVs produced *after* the value was already corrupted.

Root cause is buffer ownership:

1. `types.MyDecimal.FromParquetArray` documents its input as disposable and does the radix conversion by overwriting the byte slice in place (the two's-complement negation and the long division both write into `buf`). The oversized-value fallback `getStringFromParquetByte` does the same.
2. arrow-go's `dictConverter.Fill`/`Copy` fill decoded values by assigning `dict[idx]`, i.e. only the slice header. Every row referencing the same dictionary entry shares one backing array.
3. The DECIMAL setters passed the decoded slice straight into the conversion, so converting the first row rewrote the dictionary entry, and later rows decoded from the already-consumed bytes.

### What changed and how does it work?

Copy each value into a buffer owned by the setter before converting. The column iterator drives setters sequentially (`columnIterator` is documented as not usable in parallel), so one reused buffer per column keeps the copy allocation-free — no per-row allocation is added.

Both byte-array DECIMAL setters (`BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY`) go through the shared helper, so the fix covers both physical types and both the direct `MyDecimal` path and the string fallback path for oversized values.

**AI has also checked other code paths, this is the only path need to be fixed.**

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that `IMPORT INTO` silently writes wrong values for repeated dictionary-encoded Parquet DECIMAL columns.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed decoding of dictionary-encoded decimal values, including positive, negative, variable-length, and fixed-length representations.
  - Prevented shared dictionary data from being modified during decimal conversion.

- **Tests**
  - Added coverage for repeated dictionary-encoded decimals, including oversized values, across all decoded records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->