### PR TITLE
fix: prevent send on closed channel in Pool.release (#70437)

### DIFF
--- a/pkg/lightning/membuf/buffer.go
+++ b/pkg/lightning/membuf/buffer.go
@@ -14,7 +14,10 @@
 
 package membuf
 
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
 
 const (
 	defaultPoolSize  = 1024
@@ -47,6 +50,10 @@ type Pool struct {
 	blockSize  int
 	blockCache chan []byte
 	limiter    *Limiter
+
+	// mu protects blockCache against being used after close.
+	mu     sync.Mutex
+	closed bool
 }
 
 // Option configures a pool.
@@ -112,11 +119,18 @@ func (p *Pool) takeBlock() []byte {
 }
 
 func (p *Pool) release(b []byte) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		p.allocator.Free(b)
+		return
+	}
 	select {
 	case p.blockCache <- b:
 	default:
 		p.allocator.Free(b)
 	}
+	p.mu.Unlock()
 	if p.limiter != nil {
 		p.limiter.Release(p.blockSize)
 	}
@@ -124,7 +138,10 @@ func (p *Pool) release(b []byte) {
 
 // Destroy frees all buffers.
 func (p *Pool) Destroy() {
+	p.mu.Lock()
+	p.closed = true
 	close(p.blockCache)
+	p.mu.Unlock()
 	for b := range p.blockCache {
 		p.allocator.Free(b)
 	}


### PR DESCRIPTION
## Description

Fix a panic in TiDB Lightning where `Pool.release()` panics with `send on closed channel` when `Pool.Destroy()` is called concurrently with `Buffer.Destroy()`.

The stack trace shows:
```
runtime.chansend
membuf.(*Pool).release  <- buffer.go:116
membuf.(*Buffer).Destroy <- buffer.go:238
(*MemoryIngestData).release
(*MemoryIngestData).DecRef
(*regionJob).done
```

## Root Cause

`Pool.release()` tries to send a block back to `p.blockCache` channel, but `Pool.Destroy()` may have already closed that channel. Sending on a closed channel panics in Go.

## Fix

- Added `sync.Mutex` and `closed bool` flag to `Pool` struct
- `release()` checks the `closed` flag under the mutex before sending to the channel
- `Destroy()` sets `closed = true` under the mutex before closing the channel

Fixes #70437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory pool safety during concurrent access.
  * Ensured resources are released correctly after the pool is closed.
  * Added safer cleanup when destroying the pool, preventing cached blocks from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->