### PR TITLE
planner: cherry-pick all 4 PRs of #58361

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1191,18 +1191,28 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 	determinedIndexPartialPaths := make([]*util.AccessPath, 0, len(path.PartialAlternativeIndexPaths))
 	partialPathMatchResults := make([]property.PhysicalPropMatchResult, 0, len(path.PartialAlternativeIndexPaths))
 	usedIndexMap := make(map[int64]struct{}, 1)
+	useMVIndex := false
 	for _, oneORBranch := range path.PartialAlternativeIndexPaths {
 		matchIdxes := make([]int, 0, 1)
-		// altMatchResults[i] stores the matchProperty result for
-		// oneORBranch[i]. It is populated during advisory or fallback matching.
-		altMatchResults := make([]property.PhysicalPropMatchResult, len(oneORBranch))
+		// altMatchResults[i] stores matchProperty results for each access path
+		// in oneORBranch[i]. It is populated during advisory or fallback matching.
+		var altMatchResults [][]property.PhysicalPropMatchResult
 
 		if useAdvisorySortItems {
 			// First pass: prefer alternatives that satisfy AdvisorySortItems.
+			altMatchResults = make([][]property.PhysicalPropMatchResult, len(oneORBranch))
 			for i, oneAlternative := range oneORBranch {
-				result := matchProperty(ds, oneAlternative, advisoryProp)
-				altMatchResults[i] = result
-				if result.Matched() {
+				match := true
+				results := make([]property.PhysicalPropMatchResult, 0, len(oneAlternative))
+				for _, oneAccessPath := range oneAlternative {
+					result := matchProperty(ds, oneAccessPath, advisoryProp)
+					results = append(results, result)
+					if !result.Matched() {
+						match = false
+					}
+				}
+				altMatchResults[i] = results
+				if match {
 					matchIdxes = append(matchIdxes, i)
 				}
 			}
@@ -1211,14 +1221,23 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 		// If no matches are found with advisory items, fall back to the default
 		// matching logic.
 		if len(matchIdxes) == 0 {
+			altMatchResults = make([][]property.PhysicalPropMatchResult, len(oneORBranch))
 			for i, oneAlternative := range oneORBranch {
 				// if there is some sort items and this path doesn't match this prop, continue.
-				var result property.PhysicalPropMatchResult
-				if !noSortItem {
-					result = matchProperty(ds, oneAlternative, prop)
+				match := true
+				results := make([]property.PhysicalPropMatchResult, 0, len(oneAlternative))
+				for _, oneAccessPath := range oneAlternative {
+					var result property.PhysicalPropMatchResult
+					if !noSortItem {
+						result = matchProperty(ds, oneAccessPath, prop)
+					}
+					results = append(results, result)
+					if !noSortItem && !result.Matched() {
+						match = false
+					}
 				}
-				altMatchResults[i] = result
-				if !noSortItem && !result.Matched() {
+				altMatchResults[i] = results
+				if !match {
 					continue
 				}
 				// two possibilities here:
@@ -1234,47 +1253,43 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 		}
 		if len(matchIdxes) > 1 {
 			// if matchIdxes greater than 1, we should sort this match alternative path by its CountAfterAccess.
-			tmpOneItemAlternatives := oneORBranch
+			alternatives := oneORBranch
 			slices.SortStableFunc(matchIdxes, func(a, b int) int {
-				lhsCountAfter := tmpOneItemAlternatives[a].CountAfterAccess
-				if len(tmpOneItemAlternatives[a].IndexFilters) > 0 {
-					lhsCountAfter = tmpOneItemAlternatives[a].CountAfterIndex
-				}
-				rhsCountAfter := tmpOneItemAlternatives[b].CountAfterAccess
-				if len(tmpOneItemAlternatives[b].IndexFilters) > 0 {
-					rhsCountAfter = tmpOneItemAlternatives[b].CountAfterIndex
-				}
-				res := cmp.Compare(lhsCountAfter, rhsCountAfter)
+				res := cmpAlternatives(ds.SCtx().GetSessionVars())(alternatives[a], alternatives[b])
 				if res != 0 {
 					return res
 				}
 				// If CountAfterAccess is same, any path is global index should be the first one.
 				var lIsGlobalIndex, rIsGlobalIndex int
-				if !tmpOneItemAlternatives[a].IsTablePath() && tmpOneItemAlternatives[a].Index.Global {
+				if !alternatives[a][0].IsTablePath() && alternatives[a][0].Index.Global {
 					lIsGlobalIndex = 1
 				}
-				if !tmpOneItemAlternatives[b].IsTablePath() && tmpOneItemAlternatives[b].Index.Global {
+				if !alternatives[b][0].IsTablePath() && alternatives[b][0].Index.Global {
 					rIsGlobalIndex = 1
 				}
 				return -cmp.Compare(lIsGlobalIndex, rIsGlobalIndex)
 			})
 		}
 		lowestCountAfterAccessIdx := matchIdxes[0]
-		determinedIndexPartialPaths = append(determinedIndexPartialPaths, oneORBranch[lowestCountAfterAccessIdx])
-		partialPathMatchResults = append(partialPathMatchResults, altMatchResults[lowestCountAfterAccessIdx])
+		determinedIndexPartialPaths = append(determinedIndexPartialPaths, util.SliceDeepClone(oneORBranch[lowestCountAfterAccessIdx])...)
+		partialPathMatchResults = append(partialPathMatchResults, altMatchResults[lowestCountAfterAccessIdx]...)
 		// record the index usage info to avoid choosing a single index for all partial paths
 		var indexID int64
-		if oneORBranch[lowestCountAfterAccessIdx].IsTablePath() {
+		if oneORBranch[lowestCountAfterAccessIdx][0].IsTablePath() {
 			indexID = -1
 		} else {
-			indexID = oneORBranch[lowestCountAfterAccessIdx].Index.ID
+			indexID = oneORBranch[lowestCountAfterAccessIdx][0].Index.ID
+			// record mv index because it's not affected by the all single index limitation.
+			if oneORBranch[lowestCountAfterAccessIdx][0].Index.MVIndex {
+				useMVIndex = true
+			}
 		}
 		// record the lowestCountAfterAccessIdx's chosen index.
 		usedIndexMap[indexID] = struct{}{}
 	}
 	// since all the choice is done, check the all single index limitation, skip check for mv index.
 	// since ds index merge hints will prune other path ahead, lift the all single index limitation here.
-	if len(usedIndexMap) == 1 && len(ds.IndexMergeHints) <= 0 {
+	if len(usedIndexMap) == 1 && !useMVIndex && len(ds.IndexMergeHints) <= 0 {
 		// if all partial path are using a same index, meaningless and fail over.
 		return nil, nil, false, property.PropNotMatched
 	}
@@ -1287,6 +1302,7 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 
 	// step2: gen a new **concrete** index merge path.
 	indexMergePath := &util.AccessPath{
+		IndexMergeAccessMVIndex:  useMVIndex,
 		PartialIndexPaths:        determinedIndexPartialPaths,
 		IndexMergeIsIntersection: false,
 		// inherit those determined can't pushed-down table filters.
@@ -1294,26 +1310,11 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 	}
 	// path.ShouldBeKeptCurrentFilter record that whether there are some part of the cnf item couldn't be pushed down to tikv already.
 	shouldKeepCurrentFilter := path.KeepIndexMergeORSourceFilter
-	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
-	for _, path := range determinedIndexPartialPaths {
-		// If any partial path contains table filters, we need to keep the whole DNF filter in the Selection.
-		if len(path.TableFilters) > 0 {
-			if !expression.CanExprsPushDown(pushDownCtx, path.TableFilters, kv.TiKV) {
-				// if this table filters can't be pushed down, all of them should be kept in the table side, cleaning the lookup side here.
-				path.TableFilters = nil
-			}
+	for _, p := range determinedIndexPartialPaths {
+		if p.KeepIndexMergeORSourceFilter {
 			shouldKeepCurrentFilter = true
+			break
 		}
-		// If any partial path's index filter cannot be pushed to TiKV, we should keep the whole DNF filter.
-		if len(path.IndexFilters) != 0 && !expression.CanExprsPushDown(pushDownCtx, path.IndexFilters, kv.TiKV) {
-			shouldKeepCurrentFilter = true
-			// Clear IndexFilter, the whole filter will be put in indexMergePath.TableFilters.
-			path.IndexFilters = nil
-		}
-	}
-	// Keep this filter as a part of table filters for safety if it has any parameter.
-	if expression.MaybeOverOptimized4PlanCache(ds.SCtx().GetExprCtx(), []expression.Expression{path.IndexMergeORSourceFilter}) {
-		shouldKeepCurrentFilter = true
 	}
 	if shouldKeepCurrentFilter {
 		// add the cnf expression back as table filer.
@@ -1321,21 +1322,7 @@ func matchPropForIndexMergeAlternatives(ds *logicalop.DataSource, path *util.Acc
 	}
 
 	// step3: after the index merge path is determined, compute the countAfterAccess as usual.
-	accessConds := make([]expression.Expression, 0, len(determinedIndexPartialPaths))
-	for _, p := range determinedIndexPartialPaths {
-		indexCondsForP := p.AccessConds[:]
-		indexCondsForP = append(indexCondsForP, p.IndexFilters...)
-		if len(indexCondsForP) > 0 {
-			accessConds = append(accessConds, expression.ComposeCNFCondition(ds.SCtx().GetExprCtx(), indexCondsForP...))
-		}
-	}
-	accessDNF := expression.ComposeDNFCondition(ds.SCtx().GetExprCtx(), accessConds...)
-	sel, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, []expression.Expression{accessDNF}, nil)
-	if err != nil {
-		logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
-		sel = cost.SelectionFactor
-	}
-	indexMergePath.CountAfterAccess = sel * ds.TableStats.RowCount
+	indexMergePath.CountAfterAccess = estimateCountAfterAccessForIndexMergeOR(ds, determinedIndexPartialPaths)
 	if noSortItem {
 		// since there is no sort property, index merge case is generated by random combination, each alternative with the lower/lowest
 		// countAfterAccess, here the returned matchProperty should be PropNotMatched.

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"cmp"
-	"math"
 	"slices"
 	"strings"
 
@@ -81,15 +80,20 @@ func generateIndexMergePath(ds *logicalop.DataSource) error {
 	}
 
 	regularPathCount := len(ds.PossibleAccessPaths)
+
+	// Now we have 3 entry functions to generate IndexMerge paths:
+	// 1. Generate AND type IndexMerge for non-MV indexes and all OR type IndexMerge.
 	var err error
-	if warningMsg, err = generateIndexMerge4NormalIndex(ds, regularPathCount, indexMergeConds); err != nil {
+	if warningMsg, err = generateOtherIndexMerge(ds, regularPathCount, indexMergeConds); err != nil {
 		return err
 	}
-	if err := generateIndexMerge4MVIndex(ds, regularPathCount, indexMergeConds); err != nil {
+	// 2. Generate AND type IndexMerge for MV indexes. Tt can only use one index in an IndexMerge path.
+	if err := generateANDIndexMerge4MVIndex(ds, regularPathCount, indexMergeConds); err != nil {
 		return err
 	}
 	oldIndexMergeCount := len(ds.PossibleAccessPaths)
-	if err := generateIndexMerge4ComposedIndex(ds, regularPathCount, indexMergeConds); err != nil {
+	// 3. Generate AND type IndexMerge for MV indexes. It can use multiple MV and non-MV indexes in an IndexMerge path.
+	if err := generateANDIndexMerge4ComposedIndex(ds, regularPathCount, indexMergeConds); err != nil {
 		return err
 	}
 
@@ -133,277 +137,34 @@ func generateIndexMergePath(ds *logicalop.DataSource) error {
 	return nil
 }
 
-func generateNormalIndexPartialPaths4DNF(
+func generateNormalIndexPartialPath(
 	ds *logicalop.DataSource,
-	dnfItems []expression.Expression,
-	candidatePaths []*util.AccessPath,
-) (paths []*util.AccessPath, needSelection bool, usedMap []bool) {
-	paths = make([]*util.AccessPath, 0, len(dnfItems))
-	usedMap = make([]bool, len(dnfItems))
-	candidatePaths = slices.DeleteFunc(candidatePaths, func(path *util.AccessPath) bool {
-		return path.Index != nil && path.Index.HasCondition()
-	})
-	if len(candidatePaths) == 0 {
-		return nil, false, usedMap
+	item expression.Expression,
+	candidatePath *util.AccessPath,
+) (paths *util.AccessPath, needSelection bool) {
+	// Reject partial index first.
+	if candidatePath.Index != nil && candidatePath.Index.HasCondition() {
+		return nil, false
 	}
 	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
-	for offset, item := range dnfItems {
-		cnfItems := expression.SplitCNFItems(item)
-		pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
-		for _, cnfItem := range cnfItems {
-			if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
-				pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
-			} else {
-				needSelection = true
-			}
-		}
-		itemPaths := accessPathsForConds(ds, pushedDownCNFItems, candidatePaths)
-		if len(itemPaths) == 0 {
-			// for this dnf item, we couldn't generate an index merge partial path.
-			// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
-			// the entire index merge is not valid anymore.
-			return nil, false, usedMap
-		}
-		partialPath := buildIndexMergePartialPath(itemPaths)
-		if partialPath == nil {
-			// for this dnf item, we couldn't generate an index merge partial path.
-			// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
-			// the entire index merge is not valid anymore.
-			return nil, false, usedMap
-		}
-
-		// identify whether all pushedDownCNFItems are fully used.
-		// If any partial path contains table filters, we need to keep the whole DNF filter in the Selection.
-		if len(partialPath.TableFilters) > 0 {
-			needSelection = true
-			partialPath.TableFilters = nil
-		}
-		// If any partial path's index filter cannot be pushed to TiKV, we should keep the whole DNF filter.
-		if len(partialPath.IndexFilters) != 0 && !expression.CanExprsPushDown(pushDownCtx, partialPath.IndexFilters, kv.TiKV) {
-			needSelection = true
-			// Clear IndexFilter, the whole filter will be put in indexMergePath.TableFilters.
-			partialPath.IndexFilters = nil
-		}
-		// Keep this filter as a part of table filters for safety if it has any parameter.
-		if expression.MaybeOverOptimized4PlanCache(ds.SCtx().GetExprCtx(), cnfItems) {
+	cnfItems := expression.SplitCNFItems(item)
+	pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
+	for _, cnfItem := range cnfItems {
+		if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
+			pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
+		} else {
 			needSelection = true
 		}
-		usedMap[offset] = true
-		paths = append(paths, partialPath)
 	}
-	return paths, needSelection, usedMap
-}
-
-// getIndexMergeOrPath generates all possible IndexMergeOrPaths.
-// For index merge union case, the order property from its partial
-// path can be kept and multi-way merged and output. So we don't
-// generate a concrete index merge path out, but an un-determined
-// alternatives set index merge path instead.
-//
-//	    `create table t (a int, b int, c int, key a(a), key b(b), key ac(a, c), key bc(b, c))`
-//		`explain format='verbose' select * from t where a=1 or b=1 order by c`
-//
-// like the case here:
-// normal index merge OR path should be:
-// for a=1, it has two partial alternative paths: [a, ac]
-// for b=1, it has two partial alternative paths: [b, bc]
-// and the index merge path:
-//
-//	indexMergePath: {
-//	    PartialIndexPaths: empty                          // 1D array here, currently is not decided yet.
-//	    PartialAlternativeIndexPaths: [[a, ac], [b, bc]]  // 2D array here, each for one DNF item choices.
-//	}
-func generateIndexMergeOrPaths(ds *logicalop.DataSource, filters []expression.Expression) error {
-	usedIndexCount := len(ds.PossibleAccessPaths)
-	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
-	for k, cond := range filters {
-		sf, ok := cond.(*expression.ScalarFunction)
-		if !ok || sf.FuncName.L != ast.LogicOr {
-			continue
-		}
-		// shouldKeepCurrentFilter means the partial paths can't cover the current filter completely, so we must add
-		// the current filter into a Selection after partial paths.
-		shouldKeepCurrentFilter := false
-		var partialAlternativePaths = make([][]*util.AccessPath, 0, usedIndexCount)
-		dnfItems := expression.FlattenDNFConditions(sf)
-		for _, item := range dnfItems {
-			cnfItems := expression.SplitCNFItems(item)
-
-			pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
-			for _, cnfItem := range cnfItems {
-				if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
-					pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
-				} else {
-					shouldKeepCurrentFilter = true
-				}
-			}
-
-			itemPaths := accessPathsForConds(ds, pushedDownCNFItems, ds.PossibleAccessPaths[:usedIndexCount])
-			if len(itemPaths) == 0 {
-				partialAlternativePaths = nil
-				break
-			}
-			// we don't prune other possible index merge path here.
-			// keep all the possible index merge partial paths here to let the property choose.
-			partialAlternativePaths = append(partialAlternativePaths, itemPaths)
-		}
-		if len(partialAlternativePaths) <= 1 {
-			continue
-		}
-		// in this loop we do two things.
-		// 1: If all the partialPaths use the same index, we will not use the indexMerge.
-		// 2: Compute a theoretical best countAfterAccess(pick its accessConds) for every alternative path(s).
-		indexMap := make(map[int64]struct{}, 1)
-		accessConds := make([]expression.Expression, 0, len(partialAlternativePaths))
-		for _, oneAlternativeSet := range partialAlternativePaths {
-			// 1: mark used map.
-			for _, oneAlternativePath := range oneAlternativeSet {
-				if oneAlternativePath.IsTablePath() {
-					// table path
-					indexMap[-1] = struct{}{}
-				} else {
-					// index path
-					indexMap[oneAlternativePath.Index.ID] = struct{}{}
-				}
-			}
-			// 2.1: trade off on countAfterAccess.
-			minCountAfterAccessPath := buildIndexMergePartialPath(oneAlternativeSet)
-			indexCondsForP := minCountAfterAccessPath.AccessConds[:]
-			indexCondsForP = append(indexCondsForP, minCountAfterAccessPath.IndexFilters...)
-			if len(indexCondsForP) > 0 {
-				accessConds = append(accessConds, expression.ComposeCNFCondition(ds.SCtx().GetExprCtx(), indexCondsForP...))
-			}
-		}
-		if len(indexMap) == 1 {
-			continue
-		}
-		// 2.2 get the theoretical whole count after access for index merge.
-		accessDNF := expression.ComposeDNFCondition(ds.SCtx().GetExprCtx(), accessConds...)
-		sel, _, err := cardinality.Selectivity(ds.SCtx(), ds.TableStats.HistColl, []expression.Expression{accessDNF}, nil)
-		if err != nil {
-			logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
-			sel = cost.SelectionFactor
-		}
-
-		possiblePath := buildIndexMergeOrPath(filters, partialAlternativePaths, k, shouldKeepCurrentFilter)
-		if possiblePath == nil {
-			return nil
-		}
-		possiblePath.CountAfterAccess = sel * ds.TableStats.RowCount
-		// only after all partial path is determined, can the countAfterAccess be done, delay it to converging.
-		ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, possiblePath)
-	}
-	// release-8.5 does not have the unified OR IndexMerge path from master
-	// (#58396). Keep the old direct DNF generator above, then run a narrow
-	// fallback for OR branches that need top-level AND filters to form ranges.
-	generateIndexMergeOrPathsWithTopLevelFilters(ds, filters, ds.PossibleAccessPaths[:usedIndexCount])
-	return nil
-}
-
-// generateIndexMergeOrPathsWithTopLevelFilters is a release-8.5 backport shim
-// for the master behavior introduced by #58396. On master, #68962 only needs to
-// teach checkAccessFilter4IdxCol() that ordinary-column IN can be an access
-// filter, because the unified OR IndexMerge path already retries OR branches
-// with top-level AND filters. release-8.5 still uses the old direct DNF
-// generator, so cases like e=1 AND (a IN (...) OR b IN (...)) need this
-// fallback to compose e=1 with each OR branch.
-func generateIndexMergeOrPathsWithTopLevelFilters(
-	ds *logicalop.DataSource,
-	filters []expression.Expression,
-	candidatePaths []*util.AccessPath,
-) {
-	normalCandidatePaths := make([]*util.AccessPath, 0, len(candidatePaths))
-	for _, path := range candidatePaths {
-		if !isMVIndexPath(path) {
-			normalCandidatePaths = append(normalCandidatePaths, path)
-		}
-	}
-	if len(normalCandidatePaths) <= 1 {
-		return
+	partialPath := accessPathsForConds(ds, pushedDownCNFItems, candidatePath)
+	if partialPath == nil {
+		// for this dnf item, we couldn't generate an index merge partial path.
+		// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
+		// the entire index merge is not valid anymore.
+		return nil, false
 	}
 
-	for current, filter := range filters {
-		sf, ok := filter.(*expression.ScalarFunction)
-		if !ok || sf.FuncName.L != ast.LogicOr {
-			continue
-		}
-		dnfItems := expression.SplitDNFItems(sf)
-		// If the old release-8.5 OR generator can already build a normal
-		// multi-index OR path directly, do not add a duplicate fallback path.
-		if normalORIndexMergeDirectlyUsable(ds, dnfItems, normalCandidatePaths) {
-			continue
-		}
-		unfinishedIndexMergePath := generateUnfinishedIndexMergePathFromORList(
-			ds,
-			dnfItems,
-			normalCandidatePaths,
-		)
-		finishedIndexMergePath := handleTopLevelANDListAndGenFinishedPath(
-			ds,
-			filters,
-			current,
-			normalCandidatePaths,
-			unfinishedIndexMergePath,
-		)
-		if indexMergeUsesMultipleAccessPaths(finishedIndexMergePath) {
-			ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, finishedIndexMergePath)
-		}
-	}
-}
-
-// normalORIndexMergeDirectlyUsable mirrors the success condition of the old
-// direct DNF generator for ordinary indexes. It is intentionally conservative:
-// if every OR item already maps to usable paths and those paths span multiple
-// access paths, the fallback is unnecessary.
-func normalORIndexMergeDirectlyUsable(
-	ds *logicalop.DataSource,
-	dnfItems []expression.Expression,
-	candidatePaths []*util.AccessPath,
-) bool {
-	if len(dnfItems) <= 1 {
-		return false
-	}
-	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
-	indexMap := make(map[int64]struct{})
-	for _, item := range dnfItems {
-		cnfItems := expression.SplitCNFItems(item)
-		pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
-		for _, cnfItem := range cnfItems {
-			if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
-				pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
-			}
-		}
-		itemPaths := accessPathsForConds(ds, pushedDownCNFItems, candidatePaths)
-		if len(itemPaths) == 0 {
-			return false
-		}
-		for _, path := range itemPaths {
-			if path.IsTablePath() {
-				indexMap[-1] = struct{}{}
-			} else if path.Index != nil {
-				indexMap[path.Index.ID] = struct{}{}
-			}
-		}
-	}
-	return len(indexMap) > 1
-}
-
-// indexMergeUsesMultipleAccessPaths keeps the fallback aligned with normal
-// non-MV OR IndexMerge behavior. A single access path wrapped in IndexMerge does
-// not provide a useful alternative and may only disturb plan selection.
-func indexMergeUsesMultipleAccessPaths(path *util.AccessPath) bool {
-	if path == nil {
-		return false
-	}
-	indexMap := make(map[int64]struct{})
-	for _, partialPath := range path.PartialIndexPaths {
-		if partialPath.IsTablePath() {
-			indexMap[-1] = struct{}{}
-		} else if partialPath.Index != nil {
-			indexMap[partialPath.Index.ID] = struct{}{}
-		}
-	}
-	return len(indexMap) > 1
+	return partialPath, needSelection
 }
 
 // isInIndexMergeHints returns true if the input index name is not excluded by the IndexMerge hints, which means either
@@ -455,129 +216,66 @@ func isSpecifiedInIndexMergeHints(ds *logicalop.DataSource, name string) bool {
 	return false
 }
 
-// accessPathsForConds generates all possible index paths for conditions.
+// accessPathsForConds generates an AccessPath for given candidate access path and filters.
 func accessPathsForConds(
 	ds *logicalop.DataSource,
 	conditions []expression.Expression,
-	candidatePaths []*util.AccessPath,
-) []*util.AccessPath {
-	var results = make([]*util.AccessPath, 0, len(candidatePaths))
-	for _, path := range candidatePaths {
-		newPath := &util.AccessPath{}
-		if path.IsTablePath() {
-			if !isInIndexMergeHints(ds, "primary") {
-				continue
-			}
-			if ds.TableInfo.IsCommonHandle {
-				newPath.IsCommonHandlePath = true
-				newPath.Index = path.Index
-			} else {
-				newPath.IsIntHandlePath = true
-			}
-			err := deriveTablePathStats(ds, newPath, conditions, true)
-			if err != nil {
-				logutil.BgLogger().Debug("can not derive statistics of a path", zap.Error(err))
-				continue
-			}
-			var unsignedIntHandle bool
-			if newPath.IsIntHandlePath && ds.TableInfo.PKIsHandle {
-				if pkColInfo := ds.TableInfo.GetPkColInfo(); pkColInfo != nil {
-					unsignedIntHandle = mysql.HasUnsignedFlag(pkColInfo.GetFlag())
-				}
-			}
-			// If the newPath contains a full range, ignore it.
-			if ranger.HasFullRange(newPath.Ranges, unsignedIntHandle) {
-				continue
-			}
-			// If we have point or empty range, just remove other possible paths.
-			if len(newPath.Ranges) == 0 || newPath.OnlyPointRange(ds.SCtx().GetSessionVars().StmtCtx.TypeCtx()) {
-				if len(results) == 0 {
-					results = append(results, newPath)
-				} else {
-					results[0] = newPath
-					results = results[:1]
-				}
-				break
-			}
-		} else {
-			newPath.Index = path.Index
-			if !isInIndexMergeHints(ds, newPath.Index.Name.L) {
-				continue
-			}
-			err := fillIndexPath(ds, newPath, conditions)
-			if err != nil {
-				logutil.BgLogger().Debug("can not derive statistics of a path", zap.Error(err))
-				continue
-			}
-			deriveIndexPathStats(ds, newPath, conditions, true)
-			// If the newPath contains a full range, ignore it.
-			if ranger.HasFullRange(newPath.Ranges, false) {
-				continue
-			}
-			// If we have empty range, or point range on unique index, just remove other possible paths.
-			if len(newPath.Ranges) == 0 || (newPath.OnlyPointRange(ds.SCtx().GetSessionVars().StmtCtx.TypeCtx()) && newPath.Index.Unique) {
-				if len(results) == 0 {
-					results = append(results, newPath)
-				} else {
-					results[0] = newPath
-					results = results[:1]
-				}
-				break
-			}
-		}
-		results = append(results, newPath)
-	}
-	return results
-}
-
-// buildIndexMergePartialPath chooses the best index path from all possible paths.
-// Now we choose the index with minimal estimate row count.
-func buildIndexMergePartialPath(indexAccessPaths []*util.AccessPath) *util.AccessPath {
-	if len(indexAccessPaths) == 1 {
-		return indexAccessPaths[0]
-	}
-
-	minEstRowIndex := 0
-	minEstRow := math.MaxFloat64
-	for i := 0; i < len(indexAccessPaths); i++ {
-		rc := indexAccessPaths[i].CountAfterAccess
-		if len(indexAccessPaths[i].IndexFilters) > 0 {
-			rc = indexAccessPaths[i].CountAfterIndex
-		}
-		if rc < minEstRow {
-			minEstRowIndex = i
-			minEstRow = rc
-		}
-	}
-	return indexAccessPaths[minEstRowIndex]
-}
-
-// buildIndexMergeOrPath generates one possible IndexMergePath.
-func buildIndexMergeOrPath(
-	filters []expression.Expression,
-	partialAlternativePaths [][]*util.AccessPath,
-	current int,
-	shouldKeepCurrentFilter bool,
+	path *util.AccessPath,
 ) *util.AccessPath {
-	indexMergePath := &util.AccessPath{PartialAlternativeIndexPaths: partialAlternativePaths}
-	indexMergePath.TableFilters = append(indexMergePath.TableFilters, filters[:current]...)
-	indexMergePath.TableFilters = append(indexMergePath.TableFilters, filters[current+1:]...)
-	// since shouldKeepCurrentFilter may be changed in alternative paths converging, kept the filer expression anyway here.
-	indexMergePath.KeepIndexMergeORSourceFilter = shouldKeepCurrentFilter
-	// this filter will be merged into indexPath's table filters when converging.
-	indexMergePath.IndexMergeORSourceFilter = filters[current]
-	return indexMergePath
+	newPath := &util.AccessPath{}
+	if path.IsTablePath() {
+		if !isInIndexMergeHints(ds, "primary") {
+			return nil
+		}
+		if ds.TableInfo.IsCommonHandle {
+			newPath.IsCommonHandlePath = true
+			newPath.Index = path.Index
+		} else {
+			newPath.IsIntHandlePath = true
+		}
+		err := deriveTablePathStats(ds, newPath, conditions, true)
+		if err != nil {
+			logutil.BgLogger().Debug("can not derive statistics of a path", zap.Error(err))
+			return nil
+		}
+		var unsignedIntHandle bool
+		if newPath.IsIntHandlePath && ds.TableInfo.PKIsHandle {
+			if pkColInfo := ds.TableInfo.GetPkColInfo(); pkColInfo != nil {
+				unsignedIntHandle = mysql.HasUnsignedFlag(pkColInfo.GetFlag())
+			}
+		}
+		// If the newPath contains a full range, ignore it.
+		if ranger.HasFullRange(newPath.Ranges, unsignedIntHandle) {
+			return nil
+		}
+	} else {
+		newPath.Index = path.Index
+		if !isInIndexMergeHints(ds, newPath.Index.Name.L) {
+			return nil
+		}
+		err := fillIndexPath(ds, newPath, conditions)
+		if err != nil {
+			logutil.BgLogger().Debug("can not derive statistics of a path", zap.Error(err))
+			return nil
+		}
+		deriveIndexPathStats(ds, newPath, conditions, true)
+		// If the newPath contains a full range, ignore it.
+		if ranger.HasFullRange(newPath.Ranges, false) {
+			return nil
+		}
+	}
+	return newPath
 }
 
 func generateNormalIndexPartialPath4And(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap map[string]expression.Expression) []*util.AccessPath {
-	if res := generateIndexMergeAndPaths(ds, normalPathCnt, usedAccessMap); res != nil {
+	if res := generateANDIndexMerge4NormalIndex(ds, normalPathCnt, usedAccessMap); res != nil {
 		return res.PartialIndexPaths
 	}
 	return nil
 }
 
-// generateIndexMergeAndPaths generates IndexMerge paths for `AND` (a.k.a. intersection type IndexMerge)
-func generateIndexMergeAndPaths(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap map[string]expression.Expression) *util.AccessPath {
+// generateANDIndexMerge4NormalIndex generates IndexMerge paths for `AND` (a.k.a. intersection type IndexMerge)
+func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap map[string]expression.Expression) *util.AccessPath {
 	// For now, we only consider intersection type IndexMerge when the index names are specified in the hints.
 	if !indexMergeHintsHasSpecifiedIdx(ds) {
 		return nil
@@ -818,7 +516,9 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 	return mvAndPartialPath, usedAccessCondsMap, nil
 }
 
-func generateIndexMerge4NormalIndex(ds *logicalop.DataSource, regularPathCount int, indexMergeConds []expression.Expression) (string, error) {
+// generateOtherIndexMerge is the entry point for generateORIndexMerge() and generateANDIndexMerge4NormalIndex(), plus
+// some extra logic to keep some specific behaviors the same as before.
+func generateOtherIndexMerge(ds *logicalop.DataSource, regularPathCount int, indexMergeConds []expression.Expression) (string, error) {
 	isPossibleIdxMerge := len(indexMergeConds) > 0 && // have corresponding access conditions, and
 		len(ds.PossibleAccessPaths) > 1 // have multiple index paths
 	if !isPossibleIdxMerge {
@@ -858,77 +558,44 @@ func generateIndexMerge4NormalIndex(ds *logicalop.DataSource, regularPathCount i
 		}
 	}
 
-	if !needConsiderIndexMerge {
-		return "IndexMerge is inapplicable or disabled. ", nil // IndexMerge is inapplicable
-	}
-
 	// 1. Generate possible IndexMerge paths for `OR`.
-	err := generateIndexMergeOrPaths(ds, indexMergeConds)
+	err := generateORIndexMerge(ds, indexMergeConds)
 	if err != nil {
 		return "", err
 	}
 	// 2. Generate possible IndexMerge paths for `AND`.
-	indexMergeAndPath := generateIndexMergeAndPaths(ds, regularPathCount, nil)
+	indexMergeAndPath := generateANDIndexMerge4NormalIndex(ds, regularPathCount, nil)
 	if indexMergeAndPath != nil {
 		ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, indexMergeAndPath)
+	}
+
+	if needConsiderIndexMerge {
+		return "", nil
+	}
+
+	var containMVPath bool
+	for i := regularPathCount; i < len(ds.PossibleAccessPaths); i++ {
+		path := ds.PossibleAccessPaths[i]
+		for _, p := range util.SliceRecursiveFlattenIter[*util.AccessPath](path.PartialAlternativeIndexPaths) {
+			if isMVIndexPath(p) {
+				containMVPath = true
+				break
+			}
+		}
+
+		if !containMVPath {
+			ds.PossibleAccessPaths = slices.Delete(ds.PossibleAccessPaths, i, i+1)
+		}
+	}
+	if len(ds.PossibleAccessPaths) == regularPathCount {
+		return "IndexMerge is inapplicable or disabled. ", nil
 	}
 	return "", nil
 }
 
-// generateIndexMergeOnDNF4MVIndex generates IndexMerge paths for MVIndex upon DNF filters.
+// generateANDIndexMerge4ComposedIndex tries to generate AND type index merge AccessPath for ( json_member_of /
+// json_overlaps / json_contains) on multiple multi-valued or normal indexes.
 /*
-	select * from t where ((1 member of (a) and b=1) or (2 member of (a) and b=2)) and (c > 10)
-		IndexMerge(OR)
-			IndexRangeScan(a, b, [1 1, 1 1])
-			IndexRangeScan(a, b, [2 2, 2 2])
-			Selection(c > 10)
-				TableRowIdScan(t)
-	Two limitations now:
-	1). all filters in the DNF have to be used as access-filters: ((1 member of (a)) or (2 member of (a)) or b > 10) cannot be used to access the MVIndex.
-	2). cannot support json_contains: (json_contains(a, '[1, 2]') or json_contains(a, '[3, 4]')) is not supported since a single IndexMerge cannot represent this SQL.
-*/
-func generateIndexMergeOnDNF4MVIndex(ds *logicalop.DataSource, normalPathCnt int, filters []expression.Expression) (mvIndexPaths []*util.AccessPath, err error) {
-	for idx := 0; idx < normalPathCnt; idx++ {
-		if !isMVIndexPath(ds.PossibleAccessPaths[idx]) {
-			continue // not a MVIndex path
-		}
-
-		// for single MV index usage, if specified use the specified one, if not, all can be access and chosen by cost model.
-		if !isInIndexMergeHints(ds, ds.PossibleAccessPaths[idx].Index.Name.L) {
-			continue
-		}
-
-		for current, filter := range filters {
-			sf, ok := filter.(*expression.ScalarFunction)
-			if !ok || sf.FuncName.L != ast.LogicOr {
-				continue
-			}
-			dnfFilters := expression.SplitDNFItems(sf) // [(1 member of (a) and b=1), (2 member of (a) and b=2)]
-
-			unfinishedIndexMergePath := generateUnfinishedIndexMergePathFromORList(
-				ds,
-				dnfFilters,
-				[]*util.AccessPath{ds.PossibleAccessPaths[idx]},
-			)
-			finishedIndexMergePath := handleTopLevelANDListAndGenFinishedPath(
-				ds,
-				filters,
-				current,
-				[]*util.AccessPath{ds.PossibleAccessPaths[idx]},
-				unfinishedIndexMergePath,
-			)
-			if finishedIndexMergePath != nil {
-				mvIndexPaths = append(mvIndexPaths, finishedIndexMergePath)
-			}
-		}
-	}
-	return
-}
-
-// generateIndexMerge4ComposedIndex generates index path composed of multi indexes including multivalued index from
-// (json_member_of / json_overlaps / json_contains) and single-valued index from normal indexes.
-/*
-CNF path
 	1. select * from t where ((1 member of (a) and c=1) and (2 member of (b) and d=2) and (other index predicates))
 		flatten as: select * from t where 1 member of (a) and 2 member of (b) and c=1 and c=2 and other index predicates
 		analyze: find and utilize index access filter items as much as possible:
@@ -960,37 +627,8 @@ CNF path
 				IndexRangeScan(a, [3,3])              --- COP
 			IndexRangeScan(non-mv-index-if-any)(?)    --- COP
 			TableRowIdScan(t)                         --- COP
-DNF path
-	Note: in DNF pattern, every dnf item should be utilized as index path with full range or prefix range. Otherwise,index merge is invalid.
-	1. select * from t where ((1 member of (a)) or (2 member of (b)) or (other index predicates))
-		analyze: find and utilize index access filter items as much as possible:
-		IndexMerge(OR-UNION)                         --- ROOT
-			IndexRangeScan(mv-index-a)(1)             --- COP  ---> simplified from member-of index merge, defer TableRowIdScan(t) to the outer index merge.
-			IndexRangeScan(mv-index-b)(2)             --- COP
-			IndexRangeScan(non-mv-index-if-any)(?)    --- COP
-			TableRowIdScan(t)                         --- COP
-	2. select * from t where ((1 member of (a)) or (json_contains(b, '[1, 2, 3]')) or (other index predicates))
-		analyze: find and utilize index access filter items as much as possible:
-		IndexMerge(OR-UNION)                          --- ROOT
-			IndexRangeScan(mv-index-a)(1)             --- COP
-			IndexMerge(mv-index-b AND-INTERSECTION)   --- ROOT (embedded index merge) ---> can't be simplified
-				IndexRangeScan(a, [1,1])              --- COP
-				IndexRangeScan(a, [2,2])              --- COP
-				IndexRangeScan(a, [3,3])              --- COP
-			IndexRangeScan(non-mv-index-if-any)(?)    --- COP
-			TableRowIdScan(t)                         --- COP
-	3. select * from t where ((1 member of (a) and c=1) or (json_overlap(a, '[1, 2,3]') and d=2) or (other index predicates)
-		analyze: find and utilize index access filter items as much as possible:
-		IndexMerge(OR-UNION)                          --- ROOT
-			IndexRangeScan(mv-index-a)(1)             --- COP
-			IndexMerge(mv-index-b OR-UNION)           --- ROOT (embedded index merge) ---> simplify: we can merge with outer index union merge, and defer TableRowIdScan(t).
-				IndexRangeScan(a, [1,1])              --- COP
-				IndexRangeScan(a, [2,2])              --- COP
-				IndexRangeScan(a, [3,3])              --- COP
-			IndexRangeScan(non-mv-index-if-any)(?)    --- COP
-			TableRowIdScan(t)                         --- COP
 */
-func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt int, indexMergeConds []expression.Expression) error {
+func generateANDIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt int, indexMergeConds []expression.Expression) error {
 	isPossibleIdxMerge := len(indexMergeConds) > 0 && // have corresponding access conditions, and
 		len(ds.PossibleAccessPaths) > 1 // have multiple index paths
 	if !isPossibleIdxMerge {
@@ -1000,7 +638,7 @@ func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt in
 	// Collect access paths that satisfy the hints, and make sure there is at least one MV index path.
 	var mvIndexPathCnt int
 	candidateAccessPaths := make([]*util.AccessPath, 0, len(ds.PossibleAccessPaths))
-	for idx := 0; idx < normalPathCnt; idx++ {
+	for idx := range normalPathCnt {
 		if (ds.PossibleAccessPaths[idx].IsTablePath() &&
 			!isInIndexMergeHints(ds, "primary")) ||
 			(!ds.PossibleAccessPaths[idx].IsTablePath() &&
@@ -1015,49 +653,6 @@ func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt in
 	if mvIndexPathCnt == 0 {
 		return nil
 	}
-
-	for current, filter := range indexMergeConds {
-		// DNF path.
-		sf, ok := filter.(*expression.ScalarFunction)
-		if !ok || sf.FuncName.L != ast.LogicOr {
-			// targeting: cond1 or cond2 or cond3
-			continue
-		}
-		dnfFilters := expression.SplitDNFItems(sf)
-
-		unfinishedIndexMergePath := generateUnfinishedIndexMergePathFromORList(
-			ds,
-			dnfFilters,
-			candidateAccessPaths,
-		)
-		finishedIndexMergePath := handleTopLevelANDListAndGenFinishedPath(
-			ds,
-			indexMergeConds,
-			current,
-			candidateAccessPaths,
-			unfinishedIndexMergePath,
-		)
-		if finishedIndexMergePath == nil {
-			return nil
-		}
-
-		var mvIndexPartialPathCnt, normalIndexPartialPathCnt int
-		for _, path := range finishedIndexMergePath.PartialIndexPaths {
-			if isMVIndexPath(path) {
-				mvIndexPartialPathCnt++
-			} else {
-				normalIndexPartialPathCnt++
-			}
-		}
-
-		// Keep the same behavior with previous implementation, we only handle the "composed" case here.
-		if mvIndexPartialPathCnt == 0 || (mvIndexPartialPathCnt == 1 && normalIndexPartialPathCnt == 0) {
-			return nil
-		}
-		ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, finishedIndexMergePath)
-		return nil
-	}
-	// CNF path.
 
 	// after fillIndexPath, all cnf items are filled into the suitable index paths, for these normal index paths,
 	// fetch them out as partialIndexPaths of a outerScope index merge.
@@ -1128,7 +723,8 @@ func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt in
 	return nil
 }
 
-// generateIndexMerge4MVIndex generates paths for (json_member_of / json_overlaps / json_contains) on multi-valued index.
+// generateANDIndexMerge4MVIndex tries to generate AND type index merge AccessPath for ( json_member_of /
+// json_overlaps / json_contains) on a single multi-valued index.
 /*
 	1. select * from t where 1 member of (a)
 		IndexMerge(AND)
@@ -1140,20 +736,8 @@ func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt in
 			IndexRangeScan(a, [2,2])
 			IndexRangeScan(a, [3,3])
 			TableRowIdScan(t)
-	3. select * from t where json_overlap(a, '[1, 2, 3]')
-		IndexMerge(OR)
-			IndexRangeScan(a, [1,1])
-			IndexRangeScan(a, [2,2])
-			IndexRangeScan(a, [3,3])
-			TableRowIdScan(t)
 */
-func generateIndexMerge4MVIndex(ds *logicalop.DataSource, normalPathCnt int, filters []expression.Expression) error {
-	dnfMVIndexPaths, err := generateIndexMergeOnDNF4MVIndex(ds, normalPathCnt, filters)
-	if err != nil {
-		return err
-	}
-	ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, dnfMVIndexPaths...)
-
+func generateANDIndexMerge4MVIndex(ds *logicalop.DataSource, normalPathCnt int, filters []expression.Expression) error {
 	for idx := 0; idx < normalPathCnt; idx++ {
 		if !isMVIndexPath(ds.PossibleAccessPaths[idx]) {
 			continue // not a MVIndex path
@@ -1484,7 +1068,7 @@ func collectFilters4MVIndex(
 // 2: `x=1 and x=2 and (1 member of a) and z=1`, remaining: `x+z>0`.
 // Note: x=1 and x=2 will derive an invalid range in ranger detach, for now because of heuristic rule above, we ignore this case here.
 //
-// just as the 3rd point as we said in generateIndexMerge4ComposedIndex
+// just as the 3rd point as we said in generateANDIndexMerge4ComposedIndex
 //
 // 3: The predicate of mv index can not converge to a linear interval range at physical phase like EQ and
 // GT in normal index. Among the predicates in mv index (member-of/contains/overlap), multi conditions

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -573,9 +573,17 @@ func generateOtherIndexMerge(ds *logicalop.DataSource, regularPathCount int, ind
 		return "", nil
 	}
 
-	var containMVPath bool
-	for i := regularPathCount; i < len(ds.PossibleAccessPaths); i++ {
-		path := ds.PossibleAccessPaths[i]
+	ds.PossibleAccessPaths = removeNonMVIndexMergePaths(ds.PossibleAccessPaths, regularPathCount)
+	if len(ds.PossibleAccessPaths) == regularPathCount {
+		return "IndexMerge is inapplicable or disabled. ", nil
+	}
+	return "", nil
+}
+
+func removeNonMVIndexMergePaths(paths []*util.AccessPath, regularPathCount int) []*util.AccessPath {
+	for i := len(paths) - 1; i >= regularPathCount; i-- {
+		path := paths[i]
+		containMVPath := false
 		for _, p := range util.SliceRecursiveFlattenIter[*util.AccessPath](path.PartialAlternativeIndexPaths) {
 			if isMVIndexPath(p) {
 				containMVPath = true
@@ -584,13 +592,10 @@ func generateOtherIndexMerge(ds *logicalop.DataSource, regularPathCount int, ind
 		}
 
 		if !containMVPath {
-			ds.PossibleAccessPaths = slices.Delete(ds.PossibleAccessPaths, i, i+1)
+			paths = slices.Delete(paths, i, i+1)
 		}
 	}
-	if len(ds.PossibleAccessPaths) == regularPathCount {
-		return "IndexMerge is inapplicable or disabled. ", nil
-	}
-	return "", nil
+	return paths
 }
 
 // generateANDIndexMerge4ComposedIndex tries to generate AND type index merge AccessPath for ( json_member_of /

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -573,16 +573,8 @@ func generateOtherIndexMerge(ds *logicalop.DataSource, regularPathCount int, ind
 		return "", nil
 	}
 
-	ds.PossibleAccessPaths = removeNonMVIndexMergePaths(ds.PossibleAccessPaths, regularPathCount)
-	if len(ds.PossibleAccessPaths) == regularPathCount {
-		return "IndexMerge is inapplicable or disabled. ", nil
-	}
-	return "", nil
-}
-
-func removeNonMVIndexMergePaths(paths []*util.AccessPath, regularPathCount int) []*util.AccessPath {
-	for i := len(paths) - 1; i >= regularPathCount; i-- {
-		path := paths[i]
+	for i := len(ds.PossibleAccessPaths) - 1; i >= regularPathCount; i-- {
+		path := ds.PossibleAccessPaths[i]
 		containMVPath := false
 		for _, p := range util.SliceRecursiveFlattenIter[*util.AccessPath](path.PartialAlternativeIndexPaths) {
 			if isMVIndexPath(p) {
@@ -592,10 +584,13 @@ func removeNonMVIndexMergePaths(paths []*util.AccessPath, regularPathCount int) 
 		}
 
 		if !containMVPath {
-			paths = slices.Delete(paths, i, i+1)
+			ds.PossibleAccessPaths = slices.Delete(ds.PossibleAccessPaths, i, i+1)
 		}
 	}
-	return paths
+	if len(ds.PossibleAccessPaths) == regularPathCount {
+		return "IndexMerge is inapplicable or disabled. ", nil
+	}
+	return "", nil
 }
 
 // generateANDIndexMerge4ComposedIndex tries to generate AND type index merge AccessPath for ( json_member_of /

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -348,15 +348,15 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 		notCoveredConds := make([]expression.Expression, 0, len(path.IndexFilters)+len(path.TableFilters))
 		// AccessConds can be covered by partial path.
 		coveredConds = append(coveredConds, path.AccessConds...)
-		for i, cond := range path.IndexFilters {
+		path.IndexFilters = slices.DeleteFunc(path.IndexFilters, func(cond expression.Expression) bool {
 			// IndexFilters can be covered by partial path if it can be pushed down to TiKV.
 			if !expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cond}, kv.TiKV) {
-				path.IndexFilters = append(path.IndexFilters[:i], path.IndexFilters[i+1:]...)
 				notCoveredConds = append(notCoveredConds, cond)
-			} else {
-				coveredConds = append(coveredConds, cond)
+				return true
 			}
-		}
+			coveredConds = append(coveredConds, cond)
+			return false
+		})
 		// TableFilters can't be covered by partial path.
 		notCoveredConds = append(notCoveredConds, path.TableFilters...)
 
@@ -637,7 +637,6 @@ func generateANDIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt
 
 	// Collect access paths that satisfy the hints, and make sure there is at least one MV index path.
 	var mvIndexPathCnt int
-	candidateAccessPaths := make([]*util.AccessPath, 0, len(ds.PossibleAccessPaths))
 	for idx := range normalPathCnt {
 		if (ds.PossibleAccessPaths[idx].IsTablePath() &&
 			!isInIndexMergeHints(ds, "primary")) ||
@@ -648,7 +647,6 @@ func generateANDIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt
 		if isMVIndexPath(ds.PossibleAccessPaths[idx]) {
 			mvIndexPathCnt++
 		}
-		candidateAccessPaths = append(candidateAccessPaths, ds.PossibleAccessPaths[idx])
 	}
 	if mvIndexPathCnt == 0 {
 		return nil

--- a/pkg/planner/core/indexmerge_test.go
+++ b/pkg/planner/core/indexmerge_test.go
@@ -124,3 +124,32 @@ func TestIndexMergePathGeneration(t *testing.T) {
 		domain.GetDomain(sctx).StatsHandle().Close()
 	}
 }
+
+func TestRemoveNonMVIndexMergePaths(t *testing.T) {
+	regularPath := &util.AccessPath{}
+	mvPartialPath := &util.AccessPath{Index: &model.IndexInfo{MVIndex: true}}
+	nonMVPartialPath := &util.AccessPath{Index: &model.IndexInfo{}}
+	newIndexMergePath := func(partialPath *util.AccessPath) *util.AccessPath {
+		return &util.AccessPath{PartialAlternativeIndexPaths: [][][]*util.AccessPath{{{partialPath}}}}
+	}
+
+	mvIndexMergePath := newIndexMergePath(mvPartialPath)
+	paths := []*util.AccessPath{
+		regularPath,
+		mvIndexMergePath,
+		newIndexMergePath(nonMVPartialPath),
+		newIndexMergePath(nonMVPartialPath),
+	}
+	paths = removeNonMVIndexMergePaths(paths, 1)
+	require.Len(t, paths, 2)
+	require.Same(t, regularPath, paths[0])
+	require.Same(t, mvIndexMergePath, paths[1])
+
+	paths = []*util.AccessPath{
+		regularPath,
+		newIndexMergePath(nonMVPartialPath),
+		newIndexMergePath(nonMVPartialPath),
+	}
+	paths = removeNonMVIndexMergePaths(paths, 1)
+	require.Equal(t, []*util.AccessPath{regularPath}, paths)
+}

--- a/pkg/planner/core/indexmerge_test.go
+++ b/pkg/planner/core/indexmerge_test.go
@@ -124,32 +124,3 @@ func TestIndexMergePathGeneration(t *testing.T) {
 		domain.GetDomain(sctx).StatsHandle().Close()
 	}
 }
-
-func TestRemoveNonMVIndexMergePaths(t *testing.T) {
-	regularPath := &util.AccessPath{}
-	mvPartialPath := &util.AccessPath{Index: &model.IndexInfo{MVIndex: true}}
-	nonMVPartialPath := &util.AccessPath{Index: &model.IndexInfo{}}
-	newIndexMergePath := func(partialPath *util.AccessPath) *util.AccessPath {
-		return &util.AccessPath{PartialAlternativeIndexPaths: [][][]*util.AccessPath{{{partialPath}}}}
-	}
-
-	mvIndexMergePath := newIndexMergePath(mvPartialPath)
-	paths := []*util.AccessPath{
-		regularPath,
-		mvIndexMergePath,
-		newIndexMergePath(nonMVPartialPath),
-		newIndexMergePath(nonMVPartialPath),
-	}
-	paths = removeNonMVIndexMergePaths(paths, 1)
-	require.Len(t, paths, 2)
-	require.Same(t, regularPath, paths[0])
-	require.Same(t, mvIndexMergePath, paths[1])
-
-	paths = []*util.AccessPath{
-		regularPath,
-		newIndexMergePath(nonMVPartialPath),
-		newIndexMergePath(nonMVPartialPath),
-	}
-	paths = removeNonMVIndexMergePaths(paths, 1)
-	require.Equal(t, []*util.AccessPath{regularPath}, paths)
-}

--- a/pkg/planner/core/indexmerge_unfinished_path.go
+++ b/pkg/planner/core/indexmerge_unfinished_path.go
@@ -548,7 +548,7 @@ func estimateCountAfterAccessForIndexMergeOR(ds *logicalop.DataSource, decidedPa
 		if isMVIndexPath(p) {
 			containMVPath = true
 		}
-		indexCondsForP := p.AccessConds[:]
+		indexCondsForP := slices.Clone(p.AccessConds)
 		indexCondsForP = append(indexCondsForP, p.IndexFilters...)
 		if len(indexCondsForP) > 0 {
 			accessConds = append(accessConds, expression.ComposeCNFCondition(ds.SCtx().GetExprCtx(), indexCondsForP...))

--- a/pkg/planner/core/indexmerge_unfinished_path.go
+++ b/pkg/planner/core/indexmerge_unfinished_path.go
@@ -15,59 +15,87 @@
 package core
 
 import (
-	"math"
+	"cmp"
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/planner/cardinality"
+	"github.com/pingcap/tidb/pkg/planner/core/cost"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
 )
 
-// Note that at this moment, the implementation related to unfinishedAccessPath only aims to handle OR list nested in
-// AND list, which is like ... AND (... OR ... OR ...) AND ..., and build an MV IndexMerge access path. So some struct
-// definition and code logic are specially designed for this case or only consider this case.
-// This may be changed in the future.
+// generateORIndexMerge handles all (MV and non-MV index) OR type IndexMerge path generation.
+// The input filters are implicitly connected by AND.
+func generateORIndexMerge(ds *logicalop.DataSource, filters []expression.Expression) error {
+	usedIndexCount := len(ds.PossibleAccessPaths)
+	// 1. Iterate the input filters and try to find an OR list.
+	for k, cond := range filters {
+		sf, ok := cond.(*expression.ScalarFunction)
+		if !ok || sf.FuncName.L != ast.LogicOr {
+			continue
+		}
 
-// unfinishedAccessPath is for collecting access filters for an access path.
+		dnfFilters := expression.SplitDNFItems(sf)
+		candidatesAccessPaths := ds.PossibleAccessPaths[:usedIndexCount]
+
+		// 2. Try to collect usable filters for each candidate access path using the OR list.
+		unfinishedIndexMergePath := genUnfinishedPathFromORList(ds, dnfFilters, candidatesAccessPaths)
+		// 3. Try to collect more usable filters from the top level AND list and build it into a valid AccessPath.
+		indexMergePath := handleTopLevelANDList(ds, filters, k, candidatesAccessPaths, unfinishedIndexMergePath)
+		if indexMergePath != nil {
+			ds.PossibleAccessPaths = append(ds.PossibleAccessPaths, indexMergePath)
+		}
+	}
+	return nil
+}
+
+// unfinishedAccessPath collects usable filters in preparation for building an OR type IndexMerge access path.
 // It maintains the information during iterating all filters. Importantly, it maintains incomplete access filters, which
 // means they may not be able to build a valid range, but could build a valid range after collecting more access filters.
 // After iterating all filters, we can check and build it into a valid util.AccessPath.
+// Similar to AccessPath, unfinishedAccessPath has 2 meanings:
+// 1. When orBranches is nil, it collects usable filters for a single candidate access path.
+// 2. When orBranches is not nil, it's a container of partial paths, and each element in the slice corresponds to one
+// OR branch in the input expression.
 type unfinishedAccessPath struct {
 	index *model.IndexInfo
 
-	accessFilters []expression.Expression
+	usableFilters []expression.Expression
 
 	// To avoid regression and keep the same behavior as the previous implementation, we collect access filters in two
 	// methods:
 	//
 	// 1. Use the same functions as the previous implementation to collect access filters. They are able to handle some
-	// complicated expressions, but the expressions must be able to build into a valid range at once (that's also what
-	// "finished" implies).
-	// In this case, idxColHasAccessFilter will be nil and initedAsFinished will be true.
+	// complicated expressions, but the expressions must be able to build into a valid range at once.
+	// In this case, idxColHasUsableFilter will be nil and initedWithValidRange will be true.
 	//
 	// 2. Use the new logic, which is to collect access filters for each column respectively, gradually collect more
 	// access filters during iterating all filters and try to form a valid range at last.
-	// In this case, initedAsFinished will be false, and idxColHasAccessFilter will record if we have already collected
-	// a valid access filter for each column of the index.
-	idxColHasAccessFilter []bool
-	initedAsFinished      bool
+	// In this case, initedWithValidRange will be false, and idxColHasUsableFilter will record if we have collected
+	// usable filters for each column of the index.
+	idxColHasUsableFilter []bool
+	initedWithValidRange  bool
 
 	// needKeepFilter means the OR list need to become a filter in the final Selection.
 	needKeepFilter bool
 
-	// Similar to AccessPath.PartialIndexPaths, each element in the slice is expected to build into a partial AccessPath.
-	// Currently, it can only mean an OR type IndexMerge.
-	indexMergeORPartialPaths []unfinishedAccessPathList
+	// Similar to AccessPath.PartialIndexPaths, each element in the slice is for one OR branch.
+	// It will build into AccessPath.PartialAlternativeIndexPaths.
+	orBranches []unfinishedAccessPathList
 }
 
-// unfinishedAccessPathList is for collecting access filters for a slice of candidate access paths.
-// This type is useful because usually we have several candidate index/table paths. When we are iterating the
-// expressions, we want to match them against all index/table paths and try to find access filter for every path. After
-// iterating all expressions, we check if any of them can form a valid range so that we can build a valid AccessPath.
+// unfinishedAccessPathList collects usable filters for a slice of candidate access paths in preparation for building an
+// OR type IndexMerge access path.
 type unfinishedAccessPathList []*unfinishedAccessPath
 
-// generateUnfinishedIndexMergePathFromORList handles a list of filters connected by OR, collects access filters for
+// genUnfinishedPathFromORList handles a list of filters connected by OR, collects access filters for
 // each candidate access path, and returns an unfinishedAccessPath, which must be an index merge OR unfinished path,
 // each partial path of which corresponds to one filter in the input orList.
 /*
@@ -77,15 +105,15 @@ Example:
    candidateAccessPaths: [idx1(a, j->'$.a' unsigned array), idx2(j->'$.b' unsigned array, a)]
  Output:
    unfinishedAccessPath{
-     indexMergeORPartialPaths: [
-       // Collect access filters for (1 member of j->'$.a') using two candidates respectively.
-       [unfinishedAccessPath{idx1,1 member of j->'$.a'}, nil]
-       // Collect access filters for (2 member of j->'$.b') using two candidates respectively.
-       [nil, unfinishedAccessPath{idx2,2 member of j->'$.b'}]
+     orBranches: [
+       // Collect usable filters for (1 member of j->'$.a') using two candidates respectively.
+       [ unfinishedAccessPath{idx1,1 member of j->'$.a'}, nil (no usable filters for idx2)                ]
+       // Collect usable filters for (2 member of j->'$.b') using two candidates respectively.
+       [ nil (no usable filters for idx1)               , unfinishedAccessPath{idx2,2 member of j->'$.b'} ]
      ]
   }
 */
-func generateUnfinishedIndexMergePathFromORList(
+func genUnfinishedPathFromORList(
 	ds *logicalop.DataSource,
 	orList []expression.Expression,
 	candidateAccessPaths []*util.AccessPath,
@@ -102,7 +130,7 @@ func generateUnfinishedIndexMergePathFromORList(
 		unfinishedPartialPaths = append(unfinishedPartialPaths, unfinishedPathList)
 	}
 	return &unfinishedAccessPath{
-		indexMergeORPartialPaths: unfinishedPartialPaths,
+		orBranches: unfinishedPartialPaths,
 	}
 }
 
@@ -112,7 +140,7 @@ func generateUnfinishedIndexMergePathFromORList(
 // will be nil.
 // If we failed to collect access filters for all candidate access paths, this function will return nil.
 /*
-Example1 (consistent with the one in generateUnfinishedIndexMergePathFromORList()):
+Example1 (consistent with the one in genUnfinishedPathFromORList()):
   Input:
     expr: 1 member of j->'$.a'
     candidateAccessPaths: [idx1(a, j->'$.a' unsigned array), idx2(j->'$.b' unsigned array, a)]
@@ -140,24 +168,15 @@ func initUnfinishedPathsFromExpr(
 		ret[i].index = path.Index
 		// case 1: try to use the previous logic to handle non-mv index
 		if !isMVIndexPath(path) {
-			// generateNormalIndexPartialPaths4DNF is introduced for handle a slice of DNF items and a slice of
-			// candidate AccessPaths before, now we reuse it to handle single filter and single candidate AccessPath,
-			// so we need to wrap them in a slice here.
-			paths, needSelection, usedMap := generateNormalIndexPartialPaths4DNF(
+			partialPath, needSelection := generateNormalIndexPartialPath(
 				ds,
-				[]expression.Expression{expr},
-				[]*util.AccessPath{path},
+				expr,
+				path,
 			)
-			if len(usedMap) == 1 && usedMap[0] && len(paths) == 1 {
-				ret[i].initedAsFinished = true
-				ret[i].accessFilters = paths[0].AccessConds
+			if partialPath != nil {
+				ret[i].initedWithValidRange = true
 				ret[i].needKeepFilter = needSelection
-				// Here is a special case, if this expr is always false and this path is a dual path, it will run to
-				// this point, and paths[0].AccessConds and paths[0].Ranges will be nil.
-				// In this case, we set the accessFilters to the original expr.
-				if len(ret[i].accessFilters) <= 0 {
-					ret[i].accessFilters = []expression.Expression{expr}
-				}
+				ret[i].usableFilters = []expression.Expression{expr}
 				continue
 			}
 		}
@@ -173,13 +192,19 @@ func initUnfinishedPathsFromExpr(
 			continue
 		}
 		cnfItems := expression.SplitCNFItems(expr)
+		pushDownCtx := util.GetPushDownCtx(ds.SCtx())
+		for _, cnfItem := range cnfItems {
+			if !expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
+				ret[i].needKeepFilter = true
+			}
+		}
 
 		// case 2: try to use the previous logic to handle mv index
 		if isMVIndexPath(path) {
 			accessFilters, remainingFilters, tp := collectFilters4MVIndex(ds.SCtx(), cnfItems, idxCols)
 			if len(accessFilters) > 0 && (tp == multiValuesOROnMVColTp || tp == singleValueOnMVColTp) {
-				ret[i].initedAsFinished = true
-				ret[i].accessFilters = accessFilters
+				ret[i].initedWithValidRange = true
+				ret[i].usableFilters = accessFilters
 				ret[i].needKeepFilter = len(remainingFilters) > 0
 				continue
 			}
@@ -187,7 +212,7 @@ func initUnfinishedPathsFromExpr(
 
 		// case 3: use the new logic if the previous logic didn't succeed to collect access filters that can build a
 		// valid range directly.
-		ret[i].idxColHasAccessFilter = make([]bool, len(idxCols))
+		ret[i].idxColHasUsableFilter = make([]bool, len(idxCols))
 		// If every CNF item in this OR branch is collected as an access filter, the original OR branch does not need
 		// to be rechecked by a Selection, which means we don't need to set the `needKeepFilter` flag if we found that
 		// `collectedCNFItems` does not contain false after the loop.
@@ -201,8 +226,8 @@ func initUnfinishedPathsFromExpr(
 					// Since we only handle the OR list nested in the AND list, and only generate IndexMerge OR path,
 					// we disable the multiValuesANDOnMVColTp case here.
 					(tp == eqOrInOnNonMVColTp || tp == multiValuesOROnMVColTp || tp == singleValueOnMVColTp) {
-					ret[i].accessFilters = append(ret[i].accessFilters, cnfItem)
-					ret[i].idxColHasAccessFilter[j] = true
+					ret[i].usableFilters = append(ret[i].usableFilters, cnfItem)
+					ret[i].idxColHasUsableFilter[j] = true
 					collectedCNFItems[k] = true
 					// Once we find one valid access filter for this column, we directly go to the next column without
 					// looking into other filters.
@@ -216,8 +241,8 @@ func initUnfinishedPathsFromExpr(
 	validCnt := 0
 	// remove useless paths
 	for i, path := range ret {
-		if !path.initedAsFinished &&
-			!slices.Contains(path.idxColHasAccessFilter, true) {
+		if !path.initedWithValidRange &&
+			!slices.Contains(path.idxColHasUsableFilter, true) {
 			ret[i] = nil
 		} else {
 			validCnt++
@@ -229,14 +254,13 @@ func initUnfinishedPathsFromExpr(
 	return ret
 }
 
-// handleTopLevelANDListAndGenFinishedPath is expected to be used together with
-// generateUnfinishedIndexMergePathFromORList() to handle the expression like ... AND (... OR ... OR ...) AND ...
-// for mv index.
+// handleTopLevelANDList is expected to be used together with genUnfinishedPathFromORList() to handle the expression
+// like ... AND (... OR ... OR ...) AND ... for mv index.
 // It will try to collect possible access filters from other items in the top level AND list and try to merge them into
-// the unfinishedAccessPath from generateUnfinishedIndexMergePathFromORList(), and try to build it into a valid
+// the unfinishedAccessPath from genUnfinishedPathFromORList(), and try to build it into a valid
 // util.AccessPath.
-// The input candidateAccessPaths argument should be the same with generateUnfinishedIndexMergePathFromORList().
-func handleTopLevelANDListAndGenFinishedPath(
+// The input candidateAccessPaths argument should be the same with genUnfinishedPathFromORList().
+func handleTopLevelANDList(
 	ds *logicalop.DataSource,
 	allConds []expression.Expression,
 	orListIdxInAllConds int,
@@ -266,21 +290,21 @@ func handleTopLevelANDListAndGenFinishedPath(
 }
 
 /*
-Example (consistent with the one in generateUnfinishedIndexMergePathFromORList()):
+Example (consistent with the one in genUnfinishedPathFromORList()):
 
 	idx1: (a, j->'$.a' unsigned array)  idx2: (j->'$.b' unsigned array, a)
 	Input:
 	  indexMergePath:
-	    unfinishedAccessPath{ indexMergeORPartialPaths:[
-	      [unfinishedAccessPath{idx1,1 member of j->'$.a'}, nil]
-	      [nil, unfinishedAccessPath{idx2,2 member of j->'$.b'}]
+	    unfinishedAccessPath{ orBranches:[
+	      [ unfinishedAccessPath{idx1,1 member of j->'$.a'}, nil                                             ]
+	      [ nil                                            , unfinishedAccessPath{idx2,2 member of j->'$.b'} ]
 	    ]}
 	  pathListFromANDItem:
 	    [unfinishedAccessPath{idx1,a=3}, unfinishedAccessPath{idx2,a=3}]
 	Output:
-	  unfinishedAccessPath{ indexMergeORPartialPaths:[
-	    [unfinishedAccessPath{idx1,1 member of j->'$.a', a=3}, nil]
-	    [nil, unfinishedAccessPath{idx2,2 member of j->'$.b', a=3}]
+	  unfinishedAccessPath{ orBranches:[
+	    [ unfinishedAccessPath{idx1,1 member of j->'$.a', a=3}, nil                                                  ]
+	    [ nil                                                 , unfinishedAccessPath{idx2,2 member of j->'$.b', a=3} ]
 	  ]}
 */
 func mergeANDItemIntoUnfinishedIndexMergePath(
@@ -289,7 +313,7 @@ func mergeANDItemIntoUnfinishedIndexMergePath(
 ) *unfinishedAccessPath {
 	// Currently, we only handle the case where indexMergePath is an index merge OR unfinished path and
 	// pathListFromANDItem is a normal unfinished path or nil
-	if indexMergePath == nil || len(indexMergePath.indexMergeORPartialPaths) == 0 {
+	if indexMergePath == nil || len(indexMergePath.orBranches) == 0 {
 		return nil
 	}
 	// This means we failed to find any valid access filter from other expressions in the top level AND list.
@@ -297,7 +321,7 @@ func mergeANDItemIntoUnfinishedIndexMergePath(
 	if pathListFromANDItem == nil {
 		return indexMergePath
 	}
-	for _, pathListForSinglePartialPath := range indexMergePath.indexMergeORPartialPaths {
+	for _, pathListForSinglePartialPath := range indexMergePath.orBranches {
 		if len(pathListForSinglePartialPath) != len(pathListFromANDItem) {
 			continue
 		}
@@ -309,9 +333,9 @@ func mergeANDItemIntoUnfinishedIndexMergePath(
 			// access filters from the AND item.
 			// We just collect as many possibly useful access filters as possible, buildIntoAccessPath() should handle
 			// them correctly.
-			if pathListFromANDItem[i].initedAsFinished ||
-				slices.Contains(pathListFromANDItem[i].idxColHasAccessFilter, true) {
-				path.accessFilters = append(path.accessFilters, pathListFromANDItem[i].accessFilters...)
+			if pathListFromANDItem[i].initedWithValidRange ||
+				slices.Contains(pathListFromANDItem[i].idxColHasUsableFilter, true) {
+				path.usableFilters = append(path.usableFilters, pathListFromANDItem[i].usableFilters...)
 			}
 		}
 	}
@@ -325,29 +349,22 @@ func buildIntoAccessPath(
 	allConds []expression.Expression,
 	orListIdxInAllConds int,
 ) *util.AccessPath {
-	if indexMergePath == nil || len(indexMergePath.indexMergeORPartialPaths) == 0 {
+	if indexMergePath == nil || len(indexMergePath.orBranches) == 0 {
 		return nil
 	}
-	var needSelectionGlobal bool
+	// 1. Use the collected usable filters to build partial paths for each alternative of each OR branch.
+	allAlternativePaths := make([][][]*util.AccessPath, 0, len(indexMergePath.orBranches))
 
-	// 1. Generate one or more partial access path for each partial unfinished path (access filter on mv index may
-	// produce several partial paths).
-	partialPaths := make([]*util.AccessPath, 0, len(indexMergePath.indexMergeORPartialPaths))
+	// for each OR branch
+	for _, orBranch := range indexMergePath.orBranches {
+		var alternativesForORBranch [][]*util.AccessPath
 
-	// for each partial path
-	for _, unfinishedPathList := range indexMergePath.indexMergeORPartialPaths {
-		var (
-			bestPaths            []*util.AccessPath
-			bestCountAfterAccess float64
-			bestNeedSelection    bool
-		)
-
-		// for each possible access path of this partial path
-		for i, unfinishedPath := range unfinishedPathList {
+		// for each alternative of this OR branch
+		for i, unfinishedPath := range orBranch {
 			if unfinishedPath == nil {
 				continue
 			}
-			var paths []*util.AccessPath
+			var oneAlternative []*util.AccessPath
 			var needSelection bool
 			if unfinishedPath.index != nil && unfinishedPath.index.MVIndex {
 				// case 1: mv index
@@ -362,7 +379,7 @@ func buildIntoAccessPath(
 				}
 				accessFilters, remainingFilters, _ := collectFilters4MVIndex(
 					ds.SCtx(),
-					unfinishedPath.accessFilters,
+					unfinishedPath.usableFilters,
 					idxCols,
 				)
 				if len(accessFilters) == 0 {
@@ -370,69 +387,192 @@ func buildIntoAccessPath(
 				}
 				var isIntersection bool
 				var err error
-				paths, isIntersection, ok, err = buildPartialPaths4MVIndex(
+				oneAlternative, isIntersection, ok, err = buildPartialPaths4MVIndex(
 					ds.SCtx(),
 					accessFilters,
 					idxCols,
 					unfinishedPath.index,
 					ds.TableStats.HistColl,
 				)
-				if err != nil || !ok || (isIntersection && len(paths) > 1) {
+				if err != nil || !ok || (isIntersection && len(oneAlternative) > 1) {
 					continue
 				}
 				needSelection = len(remainingFilters) > 0
 			} else {
 				// case 2: non-mv index
-				var usedMap []bool
+				var path *util.AccessPath
 				// Reuse the previous implementation. The same usage as in initUnfinishedPathsFromExpr().
-				paths, needSelection, usedMap = generateNormalIndexPartialPaths4DNF(
+				path, needSelection = generateNormalIndexPartialPath(
 					ds,
-					[]expression.Expression{
-						expression.ComposeCNFCondition(
-							ds.SCtx().GetExprCtx(),
-							unfinishedPath.accessFilters...,
-						),
-					},
-					[]*util.AccessPath{originalPaths[i]},
+					expression.ComposeCNFCondition(
+						ds.SCtx().GetExprCtx(),
+						unfinishedPath.usableFilters...,
+					),
+					originalPaths[i],
 				)
-				if len(paths) != 1 || slices.Contains(usedMap, false) {
+				if path == nil {
 					continue
 				}
+				oneAlternative = []*util.AccessPath{path}
 			}
 			needSelection = needSelection || unfinishedPath.needKeepFilter
-			// If there are several partial paths, we use the max CountAfterAccess for comparison.
-			maxCountAfterAccess := -1.0
-			for _, p := range paths {
-				maxCountAfterAccess = math.Max(maxCountAfterAccess, p.CountAfterAccess)
+
+			if needSelection {
+				// only need to set one of the paths to true
+				oneAlternative[0].KeepIndexMergeORSourceFilter = true
 			}
-			// Choose the best partial path for this partial path.
-			if len(bestPaths) == 0 {
-				bestPaths = paths
-				bestCountAfterAccess = maxCountAfterAccess
-				bestNeedSelection = needSelection
-			} else if bestCountAfterAccess > maxCountAfterAccess {
-				bestPaths = paths
-				bestCountAfterAccess = maxCountAfterAccess
-				bestNeedSelection = needSelection
-			}
+			alternativesForORBranch = append(alternativesForORBranch, oneAlternative)
 		}
-		if len(bestPaths) == 0 {
+		if len(alternativesForORBranch) == 0 {
 			return nil
 		}
-		// Succeeded to get valid path(s) for this partial path.
-		partialPaths = append(partialPaths, bestPaths...)
-		needSelectionGlobal = needSelectionGlobal || bestNeedSelection
+		allAlternativePaths = append(allAlternativePaths, alternativesForORBranch)
 	}
 
-	// 2. Collect the final table filter
-	// We always put all filters in the top level AND list except for the OR list into the final table filters.
-	// Whether to put the OR list into the table filters also depends on the needSelectionGlobal.
-	tableFilter := slices.Clone(allConds)
-	if !needSelectionGlobal {
-		tableFilter = slices.Delete(tableFilter, orListIdxInAllConds, orListIdxInAllConds+1)
+	// 2. Some extra setup and checks.
+
+	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
+	possibleIdxIDs := make(map[int64]struct{}, len(allAlternativePaths))
+	var containMVPath bool
+	// We do two things in this loop:
+	// 1. Clean/Set KeepIndexMergeORSourceFilter, InexFilters and TableFilters for each partial path.
+	// 2. Collect all index IDs and check if there is any MV index.
+	for _, p := range util.SliceRecursiveFlattenIter[*util.AccessPath](allAlternativePaths) {
+		// A partial path can handle TableFilters only if it's a table path, and the filters can be pushed to TiKV.
+		// Otherwise, we should clear TableFilters and set KeepIndexMergeORSourceFilter to true.
+		if len(p.TableFilters) > 0 {
+			// Note: Theoretically, we don't need to set KeepIndexMergeORSourceFilter to true if we can handle the
+			// TableFilters. But filters that contain non-handle columns will be unexpectedly removed in
+			// convertToPartialTableScan(). Not setting it to true will cause the final plan to miss those filters.
+			// The behavior related to convertToPartialTableScan() needs more investigation.
+			// Anyway, now we set it to true here, and it's also consistent with the previous implementation.
+			p.KeepIndexMergeORSourceFilter = true
+			if !expression.CanExprsPushDown(pushDownCtx, p.TableFilters, kv.TiKV) || !p.IsTablePath() {
+				p.TableFilters = nil
+			}
+		}
+		// A partial path can handle IndexFilters if the filters can be pushed to TiKV.
+		if len(p.IndexFilters) != 0 && !expression.CanExprsPushDown(pushDownCtx, p.IndexFilters, kv.TiKV) {
+			p.KeepIndexMergeORSourceFilter = true
+			p.IndexFilters = nil
+		}
+
+		if p.IsTablePath() {
+			possibleIdxIDs[-1] = struct{}{}
+		} else {
+			possibleIdxIDs[p.Index.ID] = struct{}{}
+		}
+		if isMVIndexPath(p) {
+			containMVPath = true
+		}
 	}
 
-	// 3. Build the final access path
-	ret := buildPartialPathUp4MVIndex(partialPaths, false, tableFilter, ds.TableStats.HistColl)
-	return ret
+	if !containMVPath && len(possibleIdxIDs) <= 1 {
+		return nil
+	}
+
+	// Keep this filter as a part of table filters for safety if it has any parameter.
+	needKeepORSourceFilter := expression.MaybeOverOptimized4PlanCache(ds.SCtx().GetExprCtx(),
+		[]expression.Expression{allConds[orListIdxInAllConds]},
+	)
+
+	// 3. Build the final access path.
+	possiblePath := &util.AccessPath{
+		PartialAlternativeIndexPaths: allAlternativePaths,
+		TableFilters:                 slices.Delete(slices.Clone(allConds), orListIdxInAllConds, orListIdxInAllConds+1),
+		IndexMergeORSourceFilter:     allConds[orListIdxInAllConds],
+		KeepIndexMergeORSourceFilter: needKeepORSourceFilter,
+	}
+
+	// For estimation, we need the decided partial paths. So we use a simple heuristic to choose the partial paths by
+	// comparing the row count just for estimation here.
+	pathsForEstimate := make([]*util.AccessPath, 0, len(allAlternativePaths))
+	for _, oneORBranch := range allAlternativePaths {
+		pathsWithMinRowCount := slices.MinFunc(oneORBranch, cmpAlternatives(ds.SCtx().GetSessionVars()))
+		pathsForEstimate = append(pathsForEstimate, pathsWithMinRowCount...)
+	}
+	possiblePath.CountAfterAccess = estimateCountAfterAccessForIndexMergeOR(ds, pathsForEstimate)
+
+	return possiblePath
+}
+
+func cmpAlternatives(sessionVars *variable.SessionVars) func(lhs, rhs []*util.AccessPath) int {
+	allPointOrEmptyRange := func(paths []*util.AccessPath) bool {
+		// Prefer the path with empty range or all point ranges.
+		for _, path := range paths {
+			// 1. It's not empty range.
+			if len(path.Ranges) > 0 &&
+				// 2-1. It's not point range on table path.
+				((path.IsTablePath() &&
+					!path.OnlyPointRange(sessionVars.StmtCtx.TypeCtx())) ||
+					// 2-2. It's not point range on unique index.
+					(!path.IsTablePath() &&
+						len(path.Ranges) > 0 &&
+						!(path.OnlyPointRange(sessionVars.StmtCtx.TypeCtx()) && path.Index.Unique))) {
+				return false
+			}
+		}
+		return true
+	}
+	// If one alternative consists of multiple AccessPath, we use the maximum row count of them to compare.
+	getMaxRowCountFromPaths := func(paths []*util.AccessPath) float64 {
+		maxRowCount := 0.0
+		for _, path := range paths {
+			rowCount := path.CountAfterAccess
+			if len(path.IndexFilters) > 0 {
+				rowCount = path.CountAfterIndex
+			}
+			maxRowCount = max(maxRowCount, rowCount)
+		}
+		return maxRowCount
+	}
+	return func(a, b []*util.AccessPath) int {
+		lhsBetterRange := allPointOrEmptyRange(a)
+		rhsBetterRange := allPointOrEmptyRange(b)
+		if lhsBetterRange != rhsBetterRange {
+			if lhsBetterRange {
+				return -1
+			}
+			return 1
+		}
+		lhsRowCount := getMaxRowCountFromPaths(a)
+		rhsRowCount := getMaxRowCountFromPaths(b)
+		return cmp.Compare(lhsRowCount, rhsRowCount)
+	}
+}
+
+func estimateCountAfterAccessForIndexMergeOR(ds *logicalop.DataSource, decidedPartialPaths []*util.AccessPath) float64 {
+	accessConds := make([]expression.Expression, 0, len(decidedPartialPaths))
+	containMVPath := false
+	for _, p := range decidedPartialPaths {
+		if isMVIndexPath(p) {
+			containMVPath = true
+		}
+		indexCondsForP := p.AccessConds[:]
+		indexCondsForP = append(indexCondsForP, p.IndexFilters...)
+		if len(indexCondsForP) > 0 {
+			accessConds = append(accessConds, expression.ComposeCNFCondition(ds.SCtx().GetExprCtx(), indexCondsForP...))
+		}
+	}
+	accessDNF := expression.ComposeDNFCondition(ds.SCtx().GetExprCtx(), accessConds...)
+	var sel float64
+	if containMVPath {
+		sel = cardinality.CalcTotalSelectivityForMVIdxPath(ds.TableStats.HistColl,
+			decidedPartialPaths,
+			false,
+		)
+	} else {
+		var err error
+		sel, _, err = cardinality.Selectivity(
+			ds.SCtx(),
+			ds.TableStats.HistColl,
+			[]expression.Expression{accessDNF},
+			nil,
+		)
+		if err != nil {
+			logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
+			sel = cost.SelectionFactor
+		}
+	}
+	return sel * ds.TableStats.RowCount
 }

--- a/pkg/planner/util/BUILD.bazel
+++ b/pkg/planner/util/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "main_test.go",
         "null_misc_test.go",
         "path_test.go",
+        "slice_recursive_flatten_iter_test.go",
     ],
     embed = [":util"],
     flaky = True,

--- a/pkg/planner/util/misc.go
+++ b/pkg/planner/util/misc.go
@@ -17,7 +17,9 @@ package util
 import (
 	"encoding/binary"
 	"fmt"
+	"iter"
 	"math"
+	"reflect"
 	"time"
 	"unsafe"
 
@@ -30,8 +32,76 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/types"
 	h "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 )
+
+// SliceDeepClone uses Clone() to clone a slice.
+// The elements in the slice must implement func (T) Clone() T.
+func SliceDeepClone[T interface{ Clone() T }](s []T) []T {
+	if s == nil {
+		return nil
+	}
+	cloned := make([]T, 0, len(s))
+	for _, item := range s {
+		cloned = append(cloned, item.Clone())
+	}
+	return cloned
+}
+
+// SliceRecursiveFlattenIter returns an iterator (iter.Seq2) that recursively iterates over all elements of an
+// any-dimensional slice of any type.
+// Performance note:
+// For each slice, this function need to check the dynamic type before iterating over it. For each non-leaf slice, this
+// function uses reflect to iterate over it. Be careful when trying to use this function in performance-critical code.
+/*
+Example:
+	paths := [][][]*AccessPath{...}
+	for idx, path := range SliceRecursiveFlattenIter[*AccessPath](paths) {
+		// path is a *AccessPath here
+	}
+*/
+func SliceRecursiveFlattenIter[E any, T any, Slice ~[]T](s Slice) iter.Seq2[int, E] {
+	return func(yield func(int, E) bool) {
+		sliceRecursiveFlattenIterHelper(s, yield, 0)
+	}
+}
+
+func sliceRecursiveFlattenIterHelper[E any, Slice any](
+	s Slice,
+	yield func(int, E) bool,
+	startIdx int,
+) (nextIdx int, stop bool) {
+	intest.AssertFunc(func() bool {
+		return reflect.TypeOf(s).Kind() == reflect.Slice
+	})
+	// Case 1: Input slice is []E, which means it's already the lowest level.
+	if leafSlice, isLeafSlice := any(s).([]E); isLeafSlice {
+		idx := startIdx
+		for _, v := range leafSlice {
+			if !yield(idx, v) {
+				return idx + 1, true
+			}
+			idx++
+		}
+		return idx, false
+	}
+	// Case 2: Otherwise, element of Slice is still a slice, we need to flatten it recursively.
+	idx := startIdx
+	// We have to use reflect to iterate over the slice here.
+	v := reflect.ValueOf(s)
+	for i := range v.Len() {
+		val := v.Index(i).Interface()
+		intest.AssertFunc(func() bool {
+			return reflect.TypeOf(val).Kind() == reflect.Slice
+		})
+		idx, stop = sliceRecursiveFlattenIterHelper[E](val, yield, idx)
+		if stop {
+			return idx, true
+		}
+	}
+	return idx, false
+}
 
 // CloneFieldNames uses types.FieldName.Clone to clone a slice of types.FieldName.
 func CloneFieldNames(names []*types.FieldName) []*types.FieldName {

--- a/pkg/planner/util/path.go
+++ b/pkg/planner/util/path.go
@@ -65,17 +65,41 @@ type AccessPath struct {
 	// If there are extra filters, store them in TableFilters.
 	PartialIndexPaths []*AccessPath
 
-	// ************************************************** special field below *********************************************************
-	// For every dnf/cnf item, there maybe several matched partial index paths to be determined later in property detecting and cost model.
-	// when PartialAlternativeIndexPaths is not empty, it means a special state for index merge path, and it can't have PartialIndexPaths
-	// at same time. Normal single index or table path also doesn't use this field.
-	PartialAlternativeIndexPaths [][]*AccessPath
-	// KeepIndexMergeORSourceFilter and IndexMergeORSourceFilter are only used with PartialAlternativeIndexPaths, which means for
-	// the new state/type of access path. (undetermined index merge path)
+	// The 3 fields below are for another case for building IndexMerge path besides AccessPath.PartialIndexPaths.
+	// Currently, it only applies to OR type IndexMerge.
+	// For every item in the OR list, there might be multiple candidate paths that satisfy the filters.
+	// The AccessPath.PartialIndexPaths case decides on one of them when building AccessPath. But here, we keep all the
+	// alternatives and make the decision later in findBestTask (see matchPropForIndexMergeAlternatives()).
+	// It's because we only know the required Sort property at that time. Delaying the decision to findBestTask can make
+	// us able to consider and try to satisfy the required Sort property.
+	/* For example:
+		create table t (a int, b int, c int, key a(a), key b(b), key ac(a, c), key bc(b, c));
+		explain format='verbose' select * from t where a=1 or b=1 order by c;
+	For a=1, it has two partial alternative paths: [a, ac]
+	For b=1, it has two partial alternative paths: [b, bc]
+	Then we build such a AccessPath:
+		AccessPath {
+			PartialAlternativeIndexPaths: [[[a], [ac]], [[b], [bc]]]
+			IndexMergeORSourceFilter: a = 1 or b = 1
+		}
+	*/
+
+	// PartialAlternativeIndexPaths stores all the alternative paths for each OR branch.
+	// meaning of the 3 dimensions:
+	// each OR branch -> each alternative for this OR branch -> each access path of this alternative (One JSON filter on
+	// MV index may build into multiple partial paths. For example, json_overlap(a, '[1, 2, 3]') builds into 3 partial
+	// paths in the final plan. For non-MV index, each alternative only has one AccessPath.)
+	PartialAlternativeIndexPaths [][][]*AccessPath
+	// KeepIndexMergeORSourceFilter indicates if we need to keep IndexMergeORSourceFilter in the final Selection of the
+	// IndexMerge plan.
+	// It has 2 cases:
+	// 1. The AccessPath.PartialAlternativeIndexPaths is set.
+	// If this field is true, the final plan should keep the filter.
+	// 2. It's a children of AccessPath.PartialAlternativeIndexPaths.
+	// If the final plan contains this alternative, it should keep the filter.
 	KeepIndexMergeORSourceFilter bool
-	// IndexMergeORSourceFilter indicates that there are some expression inside this dnf that couldn't be pushed down, and we should keep the entire dnf above.
+	// IndexMergeORSourceFilter is the original OR list for building the IndexMerge path.
 	IndexMergeORSourceFilter expression.Expression
-	// ********************************************************************************************************************************
 
 	// IndexMergeIsIntersection means whether it's intersection type or union type IndexMerge path.
 	// It's only valid for a IndexMerge path.
@@ -178,15 +202,15 @@ func (path *AccessPath) Clone() *AccessPath {
 	if path.IndexMergeORSourceFilter != nil {
 		ret.IndexMergeORSourceFilter = path.IndexMergeORSourceFilter.Clone()
 	}
-	for _, partialPath := range path.PartialIndexPaths {
-		ret.PartialIndexPaths = append(ret.PartialIndexPaths, partialPath.Clone())
-	}
-	for _, onePartialAlternative := range path.PartialAlternativeIndexPaths {
-		tmp := make([]*AccessPath, 0, len(onePartialAlternative))
-		for _, oneAlternative := range onePartialAlternative {
-			tmp = append(tmp, oneAlternative.Clone())
+	ret.PartialIndexPaths = SliceDeepClone(path.PartialIndexPaths)
+	ret.PartialAlternativeIndexPaths = make([][][]*AccessPath, 0, len(path.PartialAlternativeIndexPaths))
+	for _, oneORBranch := range path.PartialAlternativeIndexPaths {
+		clonedORBranch := make([][]*AccessPath, 0, len(oneORBranch))
+		for _, oneAlternative := range oneORBranch {
+			clonedOneAlternative := SliceDeepClone(oneAlternative)
+			clonedORBranch = append(clonedORBranch, clonedOneAlternative)
 		}
-		ret.PartialAlternativeIndexPaths = append(ret.PartialAlternativeIndexPaths, tmp)
+		ret.PartialAlternativeIndexPaths = append(ret.PartialAlternativeIndexPaths, clonedORBranch)
 	}
 	for _, ranges := range path.GroupedRanges {
 		ret.GroupedRanges = append(ret.GroupedRanges, CloneRanges(ranges))

--- a/pkg/planner/util/slice_recursive_flatten_iter_test.go
+++ b/pkg/planner/util/slice_recursive_flatten_iter_test.go
@@ -1,0 +1,130 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/stretchr/testify/require"
+)
+
+type input struct {
+	slice        [][][]string
+	continueVals []string
+	breakVal     string
+}
+
+type outputItem struct {
+	idx   int
+	value string
+}
+
+func TestSliceRecursiveFlattenIter(t *testing.T) {
+	var testCases = []struct {
+		in  input
+		out []outputItem
+	}{
+		{
+			in: input{
+				slice: nil,
+			},
+			out: []outputItem{},
+		},
+		{
+			in: input{
+				slice: [][][]string{{{}, nil}, nil, {}, {{}, {}}, nil, {}, {{}}, {nil, nil}},
+			},
+			out: []outputItem{},
+		},
+		{
+			in: input{
+				slice: [][][]string{{{"111", "", "333"}}},
+			},
+			out: []outputItem{
+				{0, "111"},
+				{1, ""},
+				{2, "333"},
+			},
+		},
+		{
+			in: input{
+				slice: [][][]string{nil, {{"111", "", "333"}, nil, {"234"}}, nil},
+			},
+			out: []outputItem{
+				{0, "111"},
+				{1, ""},
+				{2, "333"},
+				{3, "234"},
+			},
+		},
+		{
+			in: input{
+				slice:        [][][]string{{{"111", "", "333"}, {}, {"444", "555", "666"}}},
+				continueVals: []string{"444"},
+			},
+			out: []outputItem{
+				{0, "111"},
+				{1, ""},
+				{2, "333"},
+				{4, "555"},
+				{5, "666"},
+			},
+		},
+		{
+			in: input{
+				slice:        [][][]string{{{"111", "", "333"}, nil, {"444", "555", "666"}}},
+				continueVals: []string{"111"},
+				breakVal:     "555",
+			},
+			out: []outputItem{
+				{1, ""},
+				{2, "333"},
+				{3, "444"},
+			},
+		},
+		{
+			in: input{
+				slice:        [][][]string{{nil, {"", "", "998877"}, nil, {}, {}, nil, {"321"}}, {{"555", "222", "1"}}},
+				continueVals: []string{"321"},
+				breakVal:     "222",
+			},
+			out: []outputItem{
+				{0, ""},
+				{1, ""},
+				{2, "998877"},
+				{4, "555"},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Case #%d", i), func(t *testing.T) {
+			out := make([]outputItem, 0, len(tc.out))
+			for idx, val := range util.SliceRecursiveFlattenIter[string](tc.in.slice) {
+				if slices.Contains(tc.in.continueVals, val) {
+					continue
+				}
+				if tc.in.breakVal != "" && val == tc.in.breakVal {
+					break
+				}
+				out = append(out, outputItem{idx, val})
+			}
+			require.Equal(t, tc.out, out)
+		})
+	}
+}

--- a/pkg/planner/util/slice_recursive_flatten_iter_test.go
+++ b/pkg/planner/util/slice_recursive_flatten_iter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -767,11 +767,11 @@ c1	c2	c3	c4	c5
 explain select /*+ use_index_merge(t1) */ * from t1 where (c1 < 10 or c2 < 10) and (c1 between 1 and 2) order by 1;
 id	estRows	task	access object	operator info
 Sort_5	138.56	root		index_merge.t1.c1
-└─IndexMerge_12	138.56	root		type: union
-  ├─IndexRangeScan_8(Build)	3323.33	cop[tikv]	table:t1, index:c1(c1)	range:[-inf,10), keep order:false, stats:pseudo
+└─IndexMerge_12	87.26	root		type: union
+  ├─IndexRangeScan_8(Build)	250.00	cop[tikv]	table:t1, index:c1(c1)	range:[1,2], keep order:false, stats:pseudo
   ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t1, index:c2(c2)	range:[-inf,10), keep order:false, stats:pseudo
-  └─Selection_11(Probe)	138.56	cop[tikv]		ge(index_merge.t1.c1, 1), le(index_merge.t1.c1, 2)
-    └─TableRowIDScan_10	5542.21	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─Selection_11(Probe)	87.26	cop[tikv]		ge(index_merge.t1.c1, 1), le(index_merge.t1.c1, 2)
+    └─TableRowIDScan_10	3490.25	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ use_index_merge(t1) */ * from t1 where (c1 < 10 or c2 < 10) and (c1 between 1 and 2) order by 1;
 c1	c2	c3	c4	c5
 1	1	1	1	1

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3631,34 +3631,31 @@ Level	Code	Message
 explain format = 'brief' select * from t where (a = 1 or b = 2) and c = 3 order by c limit 2;
 id	estRows	task	access object	operator info
 TopN	0.02	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	0.02	root		type: union
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx2(b, c)	range:[2,2], keep order:false, stats:pseudo
-  └─TopN(Probe)	0.02	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─Selection	0.02	cop[tikv]		eq(planner__core__casetest__physicalplantest__physical_plan.t.c, 3)
-      └─TableRowIDScan	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexMerge	0.20	root		type: union
+  ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx(a, c)	range:[1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx2(b, c)	range:[2 3,2 3], keep order:false, stats:pseudo
+  └─TopN(Probe)	0.20	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
+    └─TableRowIDScan	0.20	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'brief' select * from t where (a = 1 or b = 2) and c in (1, 2, 3) order by c limit 2;
 id	estRows	task	access object	operator info
 TopN	0.06	root		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-└─IndexMerge	0.06	root		type: union
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx2(b, c)	range:[2,2], keep order:false, stats:pseudo
-  └─TopN(Probe)	0.06	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
-    └─Selection	0.06	cop[tikv]		in(planner__core__casetest__physicalplantest__physical_plan.t.c, 1, 2, 3)
-      └─TableRowIDScan	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexMerge	0.60	root		type: union
+  ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t, index:idx(a, c)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t, index:idx2(b, c)	range:[2 1,2 1], [2 2,2 2], [2 3,2 3], keep order:false, stats:pseudo
+  └─TopN(Probe)	0.60	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.c, offset:0, count:2
+    └─TableRowIDScan	0.60	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'brief' select * from t where (a = 1 or b = 2) and c in (1, 2, 3) order by b limit 2;
 id	estRows	task	access object	operator info
 TopN	0.06	root		planner__core__casetest__physicalplantest__physical_plan.t.b, offset:0, count:2
-└─IndexMerge	0.06	root		type: union
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx(a, c)	range:[1,1], keep order:false, stats:pseudo
-  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx2(b, c)	range:[2,2], keep order:false, stats:pseudo
-  └─TopN(Probe)	0.06	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.b, offset:0, count:2
-    └─Selection	0.06	cop[tikv]		in(planner__core__casetest__physicalplantest__physical_plan.t.c, 1, 2, 3)
-      └─TableRowIDScan	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexMerge	0.60	root		type: union
+  ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t, index:idx(a, c)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
+  ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t, index:idx2(b, c)	range:[2 1,2 1], [2 2,2 2], [2 3,2 3], keep order:false, stats:pseudo
+  └─TopN(Probe)	0.60	cop[tikv]		planner__core__casetest__physicalplantest__physical_plan.t.b, offset:0, count:2
+    └─TableRowIDScan	0.60	cop[tikv]	table:t	keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
 explain format = 'brief' select * from tcommon where a = 1 or b = 1 order by c limit 2;

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -1360,7 +1360,7 @@ Projection	19.99	root		planner__core__indexmerge_path.t.a, planner__core__indexm
 INSERT INTO t VALUES (2, 2, 2, '[1,2,3]', '[4,5,6]');
 INSERT INTO t VALUES (5, 1, 5, '[]', '[2]');
 INSERT INTO t VALUES (10, 10, 10, '[1,2,3]', '[4,5,6]');
-INSERT INTO t VALUES (1, 2, 3, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (1, 3, 3, '[1,2,3]', '[4,5,6]');
 INSERT INTO t VALUES (4, 5, 6, '[7,8,5]', '[10,11,2]');
 INSERT INTO t VALUES (7, 8, 9, '[13,14,15]', '[16,17,18]');
 INSERT INTO t VALUES (10, 11, 12, '[19,20,21]', '[22,23,24]');
@@ -1375,7 +1375,7 @@ INSERT INTO t VALUES (34, 35, 36, '[67,68,69]', '[70,71,72]');
 INSERT INTO t VALUES (37, 38, 39, '[73,74,2]', '[76,2,2]');
 select /*+ use_index_merge(t) */ * from t where json_overlaps(j1, '[1,3,5]') or 2 member of (j2) order by a limit 2;
 a	b	c	j1	j2
-1	2	3	[1, 2, 3]	[4, 5, 6]
+1	3	3	[1, 2, 3]	[4, 5, 6]
 2	2	2	[1, 2, 3]	[4, 5, 6]
 select /*+ use_index_merge(t) */ * from t where 1 member of (j1) or 2 member of (j2) order by b desc;
 a	b	c	j1	j2
@@ -1385,8 +1385,8 @@ a	b	c	j1	j2
 13	14	15	[25, 1, 27]	[2, 29, 30]
 10	10	10	[1, 2, 3]	[4, 5, 6]
 4	5	6	[7, 8, 5]	[10, 11, 2]
+1	3	3	[1, 2, 3]	[4, 5, 6]
 2	2	2	[1, 2, 3]	[4, 5, 6]
-1	2	3	[1, 2, 3]	[4, 5, 6]
 5	1	5	[]	[2]
 drop table if exists t;
 create table t (a int, b int, c int, d int, e int, j1 json, j2 json,

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -988,16 +988,16 @@ key kb (id, b)
 );
 explain format='brief' select /*+ use_index_merge(t, primary, kb) */ * from t where id=1 and (a=1 or b=1);
 id	estRows	task	access object	operator info
-IndexMerge	1.10	root		type: union
+IndexMerge	8.00	root		type: union
 ├─IndexRangeScan(Build)	1.00	cop[tikv]	table:t, index:PRIMARY(id, a)	range:[1 1,1 1], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:kb(id, b)	range:[1 1,1 1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	1.10	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format='brief' select /*+ use_index_merge(t, ka, kb) */ * from t where id=1 and (a=1 or b=1);
 id	estRows	task	access object	operator info
-IndexMerge	0.20	root		type: union
+IndexMerge	8.00	root		type: union
 ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:ka(id, a)	range:[1 1,1 1], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:kb(id, b)	range:[1 1,1 1], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.20	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 drop table if exists t;
 create table t(pk varbinary(255) primary key, a int, b varchar(50), c int, d varchar(45), index ia(a), index ib(b), index ic(c), index id(d));
@@ -1234,32 +1234,32 @@ drop table if exists t1;
 create table t1(a int, b int, c int, d int, e int, index iea(e,a), index ieb(e,b), index iec(e,c), index ied(e,d));
 explain format = 'brief' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5));
 id	estRows	task	access object	operator info
-IndexMerge	0.90	root		type: union
+IndexMerge	8.00	root		type: union
 ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.90	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain format = 'brief' select /*+ use_index_merge(t1) */ * from t1 where e = 1 and (a in (1,2,3) or b in (2,3,4) or c in (3,4,5)) limit 3;
 id	estRows	task	access object	operator info
-IndexMerge	0.90	root		type: union, limit embedded(offset:0, count:3)
+IndexMerge	8.00	root		type: union, limit embedded(offset:0, count:3)
 ├─Limit(Build)	0.30	cop[tikv]		offset:0, count:3
 │ └─IndexRangeScan	0.30	cop[tikv]	table:t1, index:iea(e, a)	range:[1 1,1 1], [1 2,1 2], [1 3,1 3], keep order:false, stats:pseudo
 ├─Limit(Build)	0.30	cop[tikv]		offset:0, count:3
 │ └─IndexRangeScan	0.30	cop[tikv]	table:t1, index:ieb(e, b)	range:[1 2,1 2], [1 3,1 3], [1 4,1 4], keep order:false, stats:pseudo
 ├─Limit(Build)	0.30	cop[tikv]		offset:0, count:3
 │ └─IndexRangeScan	0.30	cop[tikv]	table:t1, index:iec(e, c)	range:[1 3,1 3], [1 4,1 4], [1 5,1 5], keep order:false, stats:pseudo
-└─TableRowIDScan(Probe)	0.90	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int, c int, d int,
 index iab(a,b),
 index iad(a,d));
 explain format = 'brief' select /*+ use_index_merge(t) */ * from t where a = 1 and ((b = 2 and c = 9) or d = 4);
 id	estRows	task	access object	operator info
-IndexMerge	0.20	root		type: union
+IndexMerge	0.01	root		type: union
 ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iab(a, b)	range:[1 2,1 2], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iad(a, d)	range:[1 4,1 4], keep order:false, stats:pseudo
-└─Selection(Probe)	0.20	cop[tikv]		or(and(eq(planner__core__indexmerge_path.t.b, 2), eq(planner__core__indexmerge_path.t.c, 9)), eq(planner__core__indexmerge_path.t.d, 4))
-  └─TableRowIDScan	0.20	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─Selection(Probe)	0.01	cop[tikv]		or(and(eq(planner__core__indexmerge_path.t.b, 2), eq(planner__core__indexmerge_path.t.c, 9)), eq(planner__core__indexmerge_path.t.d, 4))
+  └─TableRowIDScan	8.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int, c int, index idx_ac(a, c), index idx_bc(b, c));
 insert into t values(1, 1, 100), (1, 2, 50), (1, 3, 150), (6, 6, 10), (7, 7, 20), (8, 8, 30), (9, 9, 5);
@@ -1293,3 +1293,133 @@ a	b	c
 6	6	10
 7	7	20
 8	8	30
+drop table if exists t;
+create table t (a int, b int, c int, d int,
+index iab(a,b),
+index iac(a,c),
+index iad(a,d));
+explain format = brief select /*+ use_index_merge(t) */ * from t where a = 1 and (b = 2 or c = 3 or d = 4);
+id	estRows	task	access object	operator info
+IndexMerge	8.00	root		type: union
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iab(a, b)	range:[1 2,1 2], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iac(a, c)	range:[1 3,1 3], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iad(a, d)	range:[1 4,1 4], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t(a int, b int, c int, d int,
+index iab(b,a),
+index iac(c,a,d),
+index iad(a,d));
+explain format = brief select /*+ use_index_merge(t) */ * from t where a = 1 and (b = 2 or (c = 3 and d = 4) or d = 5);
+id	estRows	task	access object	operator info
+IndexMerge	8.00	root		type: union
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iab(b, a)	range:[2 1,2 1], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.00	cop[tikv]	table:t, index:iac(c, a, d)	range:[3 1 4,3 1 4], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:iad(a, d)	range:[1 5,1 5], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t (a int, b int, c int, j1 json, j2 json,
+key mvi1((cast(j1 as unsigned array)), a),
+key mvi2((cast(j1 as unsigned array)), b),
+key mvi3((cast(j2 as unsigned array)), a),
+key mvi4((cast(j2 as unsigned array)), b) );
+explain format = brief select * from t where 1 member of (j1) or 2 member of (j2) order by a;
+id	estRows	task	access object	operator info
+Projection	19.99	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+└─IndexMerge	19.99	root		type: union
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a)	range:[1,1], keep order:true, stats:pseudo
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:mvi3(cast(`j2` as unsigned array), a)	range:[2,2], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = brief select * from t where 1 member of (j1) or 2 member of (j2) order by b;
+id	estRows	task	access object	operator info
+Projection	19.99	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+└─IndexMerge	19.99	root		type: union
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:mvi2(cast(`j1` as unsigned array), b)	range:[1,1], keep order:true, stats:pseudo
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:mvi4(cast(`j2` as unsigned array), b)	range:[2,2], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = brief select * from t where json_overlaps(j1, '[1,3,5]') or 2 member of (j2) order by a desc limit 10;
+id	estRows	task	access object	operator info
+Limit	10.00	root		offset:0, count:10
+└─Selection	10.00	root		or(json_overlaps(planner__core__indexmerge_path.t.j1, cast("[1,3,5]", json BINARY)), json_memberof(cast(2, json BINARY), planner__core__indexmerge_path.t.j2))
+  └─Projection	10.00	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+    └─IndexMerge	10.00	root		type: union
+      ├─IndexRangeScan(Build)	2.50	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a)	range:[1,1], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	2.50	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a)	range:[3,3], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	2.50	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a)	range:[5,5], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	2.50	cop[tikv]	table:t, index:mvi3(cast(`j2` as unsigned array), a)	range:[2,2], keep order:true, desc, stats:pseudo
+      └─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = brief select * from t where 1 member of (j1) or json_contains(j2, '[5]') order by b limit 10000;
+id	estRows	task	access object	operator info
+Projection	19.99	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+└─IndexMerge	19.99	root		type: union, limit embedded(offset:0, count:10000)
+  ├─Limit(Build)	10.00	cop[tikv]		offset:0, count:10000
+  │ └─IndexRangeScan	10.00	cop[tikv]	table:t, index:mvi2(cast(`j1` as unsigned array), b)	range:[1,1], keep order:true, stats:pseudo
+  ├─Limit(Build)	10.00	cop[tikv]		offset:0, count:10000
+  │ └─IndexRangeScan	10.00	cop[tikv]	table:t, index:mvi4(cast(`j2` as unsigned array), b)	range:[5,5], keep order:true, stats:pseudo
+  └─TableRowIDScan(Probe)	19.99	cop[tikv]	table:t	keep order:false, stats:pseudo
+INSERT INTO t VALUES (2, 2, 2, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (5, 1, 5, '[]', '[2]');
+INSERT INTO t VALUES (10, 10, 10, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (1, 2, 3, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (4, 5, 6, '[7,8,5]', '[10,11,2]');
+INSERT INTO t VALUES (7, 8, 9, '[13,14,15]', '[16,17,18]');
+INSERT INTO t VALUES (10, 11, 12, '[19,20,21]', '[22,23,24]');
+INSERT INTO t VALUES (13, 14, 15, '[25,1,27]', '[2,29,30]');
+INSERT INTO t VALUES (16, 17, 18, '[31,32,33]', '[34,35,36]');
+INSERT INTO t VALUES (19, 20, 21, '[37,38,39]', '[40,2,42]');
+INSERT INTO t VALUES (22, 23, 24, '[5,44,45]', '[46,47,48]');
+INSERT INTO t VALUES (25, 26, 27, '[49,50,3]', '[52,53,54]');
+INSERT INTO t VALUES (28, 29, 30, '[5,56,57]', '[58,2,60]');
+INSERT INTO t VALUES (31, 32, 33, '[61,3,63]', '[64,65,66]');
+INSERT INTO t VALUES (34, 35, 36, '[67,68,69]', '[70,71,72]');
+INSERT INTO t VALUES (37, 38, 39, '[73,74,2]', '[76,2,2]');
+select /*+ use_index_merge(t) */ * from t where json_overlaps(j1, '[1,3,5]') or 2 member of (j2) order by a limit 2;
+a	b	c	j1	j2
+1	2	3	[1, 2, 3]	[4, 5, 6]
+2	2	2	[1, 2, 3]	[4, 5, 6]
+select /*+ use_index_merge(t) */ * from t where 1 member of (j1) or 2 member of (j2) order by b desc;
+a	b	c	j1	j2
+37	38	39	[73, 74, 2]	[76, 2, 2]
+28	29	30	[5, 56, 57]	[58, 2, 60]
+19	20	21	[37, 38, 39]	[40, 2, 42]
+13	14	15	[25, 1, 27]	[2, 29, 30]
+10	10	10	[1, 2, 3]	[4, 5, 6]
+4	5	6	[7, 8, 5]	[10, 11, 2]
+2	2	2	[1, 2, 3]	[4, 5, 6]
+1	2	3	[1, 2, 3]	[4, 5, 6]
+5	1	5	[]	[2]
+drop table if exists t;
+create table t (a int, b int, c int, d int, e int, j1 json, j2 json,
+key mvi1((cast(j1 as unsigned array)), a, e),
+key idx1(a, b, e),
+key mvi2(b, (cast(j2 as unsigned array)), e),
+key idx2(d, e, c) );
+explain format = brief select /*+ use_index_merge(t) */ * from t where
+a = 5 and
+(1 member of (j1) or b = 3 or b = 4 and json_overlaps(j2, '[3,4,5]') or d = 10)
+order by e;
+id	estRows	task	access object	operator info
+Selection	8.00	root		or(or(json_memberof(cast(1, json BINARY), planner__core__indexmerge_path.t.j1), eq(planner__core__indexmerge_path.t.b, 3)), or(and(eq(planner__core__indexmerge_path.t.b, 4), json_overlaps(planner__core__indexmerge_path.t.j2, cast("[3,4,5]", json BINARY))), eq(planner__core__indexmerge_path.t.d, 10)))
+└─Projection	0.01	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.d, planner__core__indexmerge_path.t.e, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+  └─IndexMerge	0.01	root		type: union
+    ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a, e)	range:[1 5,1 5], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx1(a, b, e)	range:[5 3,5 3], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx1(a, b, e)	range:[5 4,5 4], keep order:true, stats:pseudo
+    ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx2(d, e, c)	range:[10,10], keep order:true, stats:pseudo
+    └─Selection(Probe)	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 5)
+      └─TableRowIDScan	10.30	cop[tikv]	table:t	keep order:false, stats:pseudo
+explain format = brief select /*+ use_index_merge(t) */ * from t where
+a = 5 and
+(1 member of (j1) or b = 3 or b = 4 and json_overlaps(j2, '[3,4,5]') or d = 10)
+order by e desc limit 10;
+id	estRows	task	access object	operator info
+Limit	8.00	root		offset:0, count:10
+└─Selection	8.00	root		or(or(json_memberof(cast(1, json BINARY), planner__core__indexmerge_path.t.j1), eq(planner__core__indexmerge_path.t.b, 3)), or(and(eq(planner__core__indexmerge_path.t.b, 4), json_overlaps(planner__core__indexmerge_path.t.j2, cast("[3,4,5]", json BINARY))), eq(planner__core__indexmerge_path.t.d, 10)))
+  └─Projection	0.01	root		planner__core__indexmerge_path.t.a, planner__core__indexmerge_path.t.b, planner__core__indexmerge_path.t.c, planner__core__indexmerge_path.t.d, planner__core__indexmerge_path.t.e, planner__core__indexmerge_path.t.j1, planner__core__indexmerge_path.t.j2
+    └─IndexMerge	0.01	root		type: union
+      ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:mvi1(cast(`j1` as unsigned array), a, e)	range:[1 5,1 5], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx1(a, b, e)	range:[5 3,5 3], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t, index:idx1(a, b, e)	range:[5 4,5 4], keep order:true, desc, stats:pseudo
+      ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:idx2(d, e, c)	range:[10,10], keep order:true, desc, stats:pseudo
+      └─Selection(Probe)	0.01	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 5)
+        └─TableRowIDScan	10.30	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -541,3 +541,68 @@ explain format = brief select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t
 select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3;
 explain format = brief select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3 offset 1;
 select /*+ use_index_merge(t, idx_ac, idx_bc) */ * from t where a = 1 or b > 5 order by c limit 3 offset 1;
+# TestIssue58361
+
+# Test non-MV index OR IndexMerge can collect usable filters (only support eq now) from the top level AND filters
+drop table if exists t;
+create table t (a int, b int, c int, d int,
+index iab(a,b),
+index iac(a,c),
+index iad(a,d));
+explain format = brief select /*+ use_index_merge(t) */ * from t where a = 1 and (b = 2 or c = 3 or d = 4);
+
+drop table if exists t;
+create table t(a int, b int, c int, d int,
+index iab(b,a),
+index iac(c,a,d),
+index iad(a,d));
+explain format = brief select /*+ use_index_merge(t) */ * from t where a = 1 and (b = 2 or (c = 3 and d = 4) or d = 5);
+
+# Test MV index OR IndexMerge can satisfy Sort property when there are multiple indexes to choose from
+drop table if exists t;
+create table t (a int, b int, c int, j1 json, j2 json,
+key mvi1((cast(j1 as unsigned array)), a),
+key mvi2((cast(j1 as unsigned array)), b),
+key mvi3((cast(j2 as unsigned array)), a),
+key mvi4((cast(j2 as unsigned array)), b) );
+explain format = brief select * from t where 1 member of (j1) or 2 member of (j2) order by a;
+explain format = brief select * from t where 1 member of (j1) or 2 member of (j2) order by b;
+explain format = brief select * from t where json_overlaps(j1, '[1,3,5]') or 2 member of (j2) order by a desc limit 10;
+explain format = brief select * from t where 1 member of (j1) or json_contains(j2, '[5]') order by b limit 10000;
+
+INSERT INTO t VALUES (2, 2, 2, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (5, 1, 5, '[]', '[2]');
+INSERT INTO t VALUES (10, 10, 10, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (1, 2, 3, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (4, 5, 6, '[7,8,5]', '[10,11,2]');
+INSERT INTO t VALUES (7, 8, 9, '[13,14,15]', '[16,17,18]');
+INSERT INTO t VALUES (10, 11, 12, '[19,20,21]', '[22,23,24]');
+INSERT INTO t VALUES (13, 14, 15, '[25,1,27]', '[2,29,30]');
+INSERT INTO t VALUES (16, 17, 18, '[31,32,33]', '[34,35,36]');
+INSERT INTO t VALUES (19, 20, 21, '[37,38,39]', '[40,2,42]');
+INSERT INTO t VALUES (22, 23, 24, '[5,44,45]', '[46,47,48]');
+INSERT INTO t VALUES (25, 26, 27, '[49,50,3]', '[52,53,54]');
+INSERT INTO t VALUES (28, 29, 30, '[5,56,57]', '[58,2,60]');
+INSERT INTO t VALUES (31, 32, 33, '[61,3,63]', '[64,65,66]');
+INSERT INTO t VALUES (34, 35, 36, '[67,68,69]', '[70,71,72]');
+INSERT INTO t VALUES (37, 38, 39, '[73,74,2]', '[76,2,2]');
+
+select /*+ use_index_merge(t) */ * from t where json_overlaps(j1, '[1,3,5]') or 2 member of (j2) order by a limit 2;
+select /*+ use_index_merge(t) */ * from t where 1 member of (j1) or 2 member of (j2) order by b desc;
+
+drop table if exists t;
+create table t (a int, b int, c int, d int, e int, j1 json, j2 json,
+key mvi1((cast(j1 as unsigned array)), a, e),
+key idx1(a, b, e),
+key mvi2(b, (cast(j2 as unsigned array)), e),
+key idx2(d, e, c) );
+
+explain format = brief select /*+ use_index_merge(t) */ * from t where
+a = 5 and
+(1 member of (j1) or b = 3 or b = 4 and json_overlaps(j2, '[3,4,5]') or d = 10)
+order by e;
+
+explain format = brief select /*+ use_index_merge(t) */ * from t where
+a = 5 and
+(1 member of (j1) or b = 3 or b = 4 and json_overlaps(j2, '[3,4,5]') or d = 10)
+order by e desc limit 10;

--- a/tests/integrationtest/t/planner/core/indexmerge_path.test
+++ b/tests/integrationtest/t/planner/core/indexmerge_path.test
@@ -573,7 +573,7 @@ explain format = brief select * from t where 1 member of (j1) or json_contains(j
 INSERT INTO t VALUES (2, 2, 2, '[1,2,3]', '[4,5,6]');
 INSERT INTO t VALUES (5, 1, 5, '[]', '[2]');
 INSERT INTO t VALUES (10, 10, 10, '[1,2,3]', '[4,5,6]');
-INSERT INTO t VALUES (1, 2, 3, '[1,2,3]', '[4,5,6]');
+INSERT INTO t VALUES (1, 3, 3, '[1,2,3]', '[4,5,6]');
 INSERT INTO t VALUES (4, 5, 6, '[7,8,5]', '[10,11,2]');
 INSERT INTO t VALUES (7, 8, 9, '[13,14,15]', '[16,17,18]');
 INSERT INTO t VALUES (10, 11, 12, '[19,20,21]', '[22,23,24]');


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #58361

Problem Summary:

PR #66219 backported the four OR IndexMerge changes from #58361 to the v8.5.5 hotfix branch. The upcoming v8.5.8 release (`release-8.5`) needs the same fixes, but the release branch has accumulated later IndexMerge backports that conflict with the original patch.

### What changed and how does it work?

- Cherry-pick the squashed change from #66219 onto `release-8.5` for the upcoming v8.5.8 release.
- Keep the three-dimensional `PartialAlternativeIndexPaths` representation introduced by #66219 while preserving the existing `release-8.5` capabilities for partial indexes, nested `IN`, IndexMerge Limit/TopN pushdown, and redundant-filter removal.
- Remove the release-only nested-`IN` fallback that was added because release-8.5 did not have the unified OR IndexMerge implementation from #58396. The unified implementation now handles this case directly.
- Regenerate the affected integration-test results. In particular, filters covered by every selected partial path no longer produce redundant probe-side `Selection` operators.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Tested with Go 1.25.12:

```text
go test -tags=intest -run '^TestSliceRecursiveFlattenIter$' ./pkg/planner/util
go test -tags=intest -run '^TestIndexMergePathGeneration$' ./pkg/planner/core
go test -tags=intest -run '^TestTraceCE$' ./pkg/planner/cardinality
GOFLAGS=-buildvcs=false make server_check

integrationtest/planner/core/indexmerge_path: 292 cases passed
integrationtest/index_merge: 165 cases passed
integrationtest/planner/core/casetest/physicalplantest/physical_plan: 868 cases passed
integrationtest/imdbload: 62 cases passed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved index-merge planning for combined `AND`/`OR` predicates.
  * Added support for multivalued and composite indexes, ordered scans, limits, and residual filters.
  * Enhanced `EXPLAIN` plans with more accurate access paths and row estimates.

* **Bug Fixes**
  * Improved index selection for range, equality, nested, and `BETWEEN` queries.
  * Prevented invalid single-index merges and duplicate access paths.

* **Tests**
  * Expanded coverage for ordered scans, JSON indexes, composite predicates, nested conditions, and query-plan execution results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
