### PR TITLE
server: limit the size for COM_STMT_SEND_LONG_DATA in each connection (release-7.5-20260724-v7.5.7) (#70350) | tidb-test=release-7.5.7 tikv=v7.5.7 pd=v7.5.7 tiflash=v7.5.7

### DIFF
--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/arena"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -564,6 +565,56 @@ func TestStmtSendLongDataMaxAllowedPacket(t *testing.T) {
 	require.Nil(t, stmt.BoundParams()[0])
 	require.Nil(t, stmt.BoundParams()[1])
 	require.NoError(t, stmt.CheckLongDataSize())
+}
+
+func TestStmtSendLongDataMemQuotaQuery(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	srv := CreateMockServer(t, store)
+	srv.SetDomain(dom)
+	defer srv.Close()
+
+	c := CreateMockConn(t, srv).(*mockConn)
+	c.capability = mysql.ClientProtocol41
+
+	tk := testkit.NewTestKitWithSession(t, store, c.Context().Session)
+	tk.MustExec("use test")
+
+	stmt, _, _, err := c.Context().Prepare("select ?")
+	require.NoError(t, err)
+
+	vars := c.Context().GetSessionVars()
+	vars.MaxAllowedPacket = 64 << 20
+	require.NoError(t, vars.SetSystemVar("tidb_mem_quota_query", "1024"))
+	require.Equal(t, int64(1024), vars.MemQuotaQuery)
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+
+	base := vars.MemTracker.BytesConsumed()
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'a'}, 600)))
+	require.Equal(t, base+600, vars.MemTracker.BytesConsumed())
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+	require.NoError(t, stmt.CheckLongDataSize())
+
+	// Further long-data that would reach/exceed tidb_mem_quota_query is refused.
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'b'}, 500)))
+	require.Equal(t, int64(1024), vars.MemTracker.GetBytesLimit())
+	require.Len(t, stmt.BoundParams()[0], 600)
+	require.Equal(t, base+600, vars.MemTracker.BytesConsumed())
+
+	err = c.Dispatch(context.Background(), append(
+		binary.LittleEndian.AppendUint32([]byte{mysql.ComStmtExecute}, uint32(stmt.ID())),
+		0x0, 0x1, 0x0, 0x0, 0x0,
+		0x0, 0x0,
+	))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), memory.PanicMemoryExceedWarnMsg+memory.WarnMsgSuffixForSingleQuery)
+	require.Equal(t, base, vars.MemTracker.BytesConsumed())
+
+	// After release, the session can accept long-data again within the quota.
+	require.NoError(t, dispatchSendLongData(c, stmt.ID(), 0, bytes.Repeat([]byte{'c'}, 1023)))
+	require.Len(t, stmt.BoundParams()[0], 1023)
+	require.Equal(t, base+1023, vars.MemTracker.BytesConsumed())
+	require.NoError(t, stmt.Close())
+	require.Equal(t, base, vars.MemTracker.BytesConsumed())
 }
 
 func TestCursorFetchSendLongData(t *testing.T) {

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/sessionstates"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tidb/pkg/util/topsql/stmtstats"
 )
@@ -66,8 +67,14 @@ type TiDBStatement struct {
 	boundParams [][]byte
 	// boundParamsTooLarge tracks whether a single COM_STMT_SEND_LONG_DATA parameter has exceeded max_allowed_packet.
 	boundParamsTooLarge bool
-	paramsType          []byte
-	ctx                 *TiDBContext
+	// boundParamsMemQuotaExceeded tracks whether further COM_STMT_SEND_LONG_DATA
+	// was refused because the session MemTracker would exceed tidb_mem_quota_query.
+	boundParamsMemQuotaExceeded bool
+	// boundLongDataBytes is the number of COM_STMT_SEND_LONG_DATA bytes currently
+	// held by this statement and charged to the session MemTracker.
+	boundLongDataBytes int64
+	paramsType         []byte
+	ctx                *TiDBContext
 	// this result set should have been closed before stored here. Only the `rowIterator` are used here. This field is
 	// not moved out to reuse the logic inside functions `writeResultSet...`
 	// TODO: move the `fetchedRows` into the statement, and remove the `ResultSet` from statement.
@@ -105,21 +112,51 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	}
 	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
 	if len(data) == 0 {
-		ts.boundParams[paramID] = []byte{}
-	} else {
-		if uint64(len(ts.boundParams[paramID]))+uint64(len(data)) > ts.ctx.GetSessionVars().MaxAllowedPacket {
-			// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
-			// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
-			ts.boundParamsTooLarge = true
-			return nil
+		released := int64(len(ts.boundParams[paramID]))
+		if released > 0 {
+			ts.ctx.GetSessionVars().MemTracker.Consume(-released)
+			ts.boundLongDataBytes -= released
 		}
-		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+		ts.boundParams[paramID] = []byte{}
+		return nil
 	}
+	// Once either limit has been exceeded for this statement, keep SEND_LONG_DATA
+	// silent and refuse further growth until RESET/EXECUTE clears the buffers.
+	if ts.boundParamsTooLarge || ts.boundParamsMemQuotaExceeded {
+		return nil
+	}
+
+	chunkSize := int64(len(data))
+	vars := ts.ctx.GetSessionVars()
+	if uint64(len(ts.boundParams[paramID]))+uint64(chunkSize) > vars.MaxAllowedPacket {
+		// MySQL reports the packet-too-large error on the following EXECUTE, not on SEND_LONG_DATA.
+		// Stop appending more bytes once the limit is exceeded so the statement cannot grow unboundedly.
+		ts.boundParamsTooLarge = true
+		return nil
+	}
+
+	// Charge COM_STMT_SEND_LONG_DATA to the session MemTracker so it counts toward
+	// tidb_mem_quota_query. Refuse before Consume to avoid triggering OOM actions
+	// on a protocol command that has no response packet.
+	memTracker := vars.MemTracker
+	quota := vars.MemQuotaQuery
+	if quota > 0 && memTracker.BytesConsumed()+chunkSize >= quota {
+		ts.boundParamsMemQuotaExceeded = true
+		return nil
+	}
+
+	memTracker.Consume(chunkSize)
+	ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+	ts.boundLongDataBytes += chunkSize
 	return nil
 }
 
 // CheckLongDataSize implements PreparedStatement CheckLongDataSize method.
 func (ts *TiDBStatement) CheckLongDataSize() error {
+	if ts.boundParamsMemQuotaExceeded {
+		return errors.Errorf("%s%s[conn=%d]", memory.PanicMemoryExceedWarnMsg,
+			memory.WarnMsgSuffixForSingleQuery, ts.ctx.GetSessionVars().ConnectionID)
+	}
 	if ts.boundParamsTooLarge {
 		return servererr.ErrNetPacketTooLarge
 	}
@@ -130,6 +167,18 @@ func (ts *TiDBStatement) CheckLongDataSize() error {
 		}
 	}
 	return nil
+}
+
+func (ts *TiDBStatement) releaseBoundLongData() {
+	if ts.boundLongDataBytes > 0 {
+		ts.ctx.GetSessionVars().MemTracker.Consume(-ts.boundLongDataBytes)
+		ts.boundLongDataBytes = 0
+	}
+	for i := range ts.boundParams {
+		ts.boundParams[i] = nil
+	}
+	ts.boundParamsTooLarge = false
+	ts.boundParamsMemQuotaExceeded = false
 }
 
 // NumParams implements PreparedStatement NumParams method.
@@ -166,10 +215,7 @@ func (ts *TiDBStatement) GetResultSet() resultset.CursorResultSet {
 
 // Reset implements PreparedStatement Reset method.
 func (ts *TiDBStatement) Reset() error {
-	for i := range ts.boundParams {
-		ts.boundParams[i] = nil
-	}
-	ts.boundParamsTooLarge = false
+	ts.releaseBoundLongData()
 	ts.hasActiveCursor = false
 
 	if ts.rs != nil && ts.rs.GetRowContainerReader() != nil {
@@ -195,6 +241,8 @@ func (ts *TiDBStatement) Reset() error {
 
 // Close implements PreparedStatement Close method.
 func (ts *TiDBStatement) Close() error {
+	ts.releaseBoundLongData()
+
 	if ts.rs != nil && ts.rs.GetRowContainerReader() != nil {
 		ts.rs.GetRowContainerReader().Close()
 	}

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -71,6 +71,11 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 	defer func() {
 		config.StoreGlobalConfig(origConfig)
 	}()
+	// Adapted from #67206: earlier tests in this package (e.g. via
+	// testkit.CreateMockStoreAndDomain -> session.DisableStats4Test) may leave the
+	// process-global stats lease at -1, which would stop the init-stats session from
+	// blocking GC. Reset it to the default so this test is order-independent.
+	session.SetStatsLease(3 * time.Second)
 	newConfig := *origConfig
 	for _, lite := range []bool{false, true} {
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats", "pause"))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70349

Problem Summary:
Cherry-pick #70350 (limit connection-scoped `COM_STMT_SEND_LONG_DATA` memory usage) to `release-7.5-20260724-v7.5.7`.

### What changed and how does it work?

Cherry-pick of bff1263528838d27f3ecf74a8c360dcce236c4e9. Conflict adaptations for release-7.5:

- Kept this branch's cursor cleanup through `GetRowContainerReader()` while adding the new long-data release call to statement reset/close.
- Release-7.5 predates the structured `ErrMemoryExceedForQuery` error introduced by #47063, so the quota-exceeded path returns the equivalent release-7.5 single-query memory-limit message from `pkg/util/memory`.
- Dropped master-only imports that are unused on this branch.

The prepared-statement long-data buffers are charged to the session memory tracker, rejected before the existing query-memory quota is reached, and uncharged when the statement is executed, reset, or closed.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Local validation:

```text
GOFLAGS=-buildvcs=false go test ./pkg/server -run '^TestStmtSendLongData(MaxAllowedPacket|MemQuotaQuery)$' -count=1
```

The focused tests pass. With local Go 1.25.8, `go vet ./pkg/server/` additionally reports two pre-existing `append with no values` diagnostics in `conn_stmt_test.go`; both calls are already present in the target branch and are outside this patch.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added memory-quota enforcement for large prepared-statement parameter data.
  * Clearer handling distinguishes memory-quota errors from packet-size errors.
  * Memory is now released correctly after execution failures, parameter resets, and statement closure.
  * Empty parameter data no longer retains previously allocated memory.
  * Prepared statements can accept new data after memory has been released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->