### PR TITLE
domain: release the resource group controller on Domain close

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -511,6 +511,18 @@ func (do *Domain) Close() {
 
 	do.runawayManager.Stop()
 
+	// Unset the process-global resource control interceptor first so that no
+	// new request is routed to a stopped controller, then stop the controller
+	// to release its process-wide ownership, so that a later Domain (bootstrap
+	// handoff, initialization retry) can acquire a replacement controller
+	// (see tikv/pd#11080).
+	if control := do.resourceGroupsController.Load(); control != nil {
+		tikv.UnsetResourceControlInterceptor()
+		if err := control.Stop(); err != nil {
+			logutil.BgLogger().Warn("stop resource group controller failed", zap.Error(err))
+		}
+	}
+
 	do.slowQuery.Close()
 
 	do.cancelFns.mu.Lock()

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -515,7 +515,8 @@ func (do *Domain) Close() {
 	// new request is routed to a stopped controller, then stop the controller
 	// to release its process-wide ownership, so that a later Domain (bootstrap
 	// handoff, initialization retry) can acquire a replacement controller
-	// (see tikv/pd#11080).
+	// (see tikv/pd#11080). The unconditional unset relies on the fact that at
+	// most one TiKV-backed Domain is live in a process at a time.
 	if control := do.resourceGroupsController.Load(); control != nil {
 		tikv.UnsetResourceControlInterceptor()
 		if err := control.Stop(); err != nil {

--- a/pkg/domain/runaway.go
+++ b/pkg/domain/runaway.go
@@ -35,6 +35,15 @@ func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.
 		return nil
 	}
 
+	// Fetch the server info before creating the controller, so that no
+	// fallible step remains between creating the controller and installing
+	// it on the Domain. Otherwise an error return would leak a started
+	// controller that nobody stops, while it still holds the process-wide
+	// controller ownership (see tikv/pd#11080).
+	serverInfo, err := infosync.GetServerInfo()
+	if err != nil {
+		return err
+	}
 	keyspaceID := constants.NullKeyspaceID
 	if codec := do.Store().GetCodec(); codec != nil {
 		keyspaceID = uint32(codec.GetKeyspaceID())
@@ -44,10 +53,6 @@ func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.
 		return err
 	}
 	control.Start(ctx)
-	serverInfo, err := infosync.GetServerInfo()
-	if err != nil {
-		return err
-	}
 	serverAddr := net.JoinHostPort(serverInfo.IP, strconv.Itoa(int(serverInfo.Port)))
 	do.runawayManager = runaway.NewRunawayManager(control, serverAddr,
 		do.sysSessionPool, do.exit, do.infoCache, do.ddl)


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70455, ref tikv/pd#11080

Problem Summary: TiDB creates one `ResourceGroupsController` per process and installs it into process-global integrations (client-go's global resource-control interceptor, the PD client's process-global controller state), but its lifecycle management has two gaps. `Domain.Close` neither unsets the global interceptor nor stops the controller, and `initResourceGroupsController` starts the controller before a later fallible step (`infosync.GetServerInfo`), so an error return can leak a started controller that nobody stops.

### What changed and how does it work?

This is the TiDB side of the single-controller lifecycle contract tracked in tikv/pd#11080. The pd/client side, which enforces at most one active `ResourceGroupsController` per process and requires an explicit `Stop` to release ownership, is implemented in tikv/pd#11132.

- `Domain.Close` now unsets the process-global resource-control interceptor first (so no new request is routed to a stopped controller) and then stops the controller. This releases the controller before a replacement Domain is created, which covers both bootstrap temporary-Domain handoff (`runInBootstrapSession` closes the bootstrap Domain before the main Domain is created) and Domain initialization retries (`pkg/session/tidb.go` closes the partially initialized Domain before retrying `Init`).
- `initResourceGroupsController` now fetches the server info before creating the controller, so no fallible step remains between creating the controller and installing it on the Domain.

Both changes are compatible with the current pd/client dependency and do not require tikv/pd#11132 to land first. Once TiDB upgrades to a pd/client version that includes the enforcement, the explicit release in `Domain.Close` becomes load-bearing: without it, a replacement Domain could not acquire a new controller.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation performed locally:

```
go build ./pkg/domain/... ./pkg/session/...
go vet ./pkg/domain/...
go test --tags=intest ./pkg/executor/internal/calibrateresource/ -count=1   # exercises SetResourceGroupsController interplay
go test --tags=intest ./pkg/executor/ -run 'TestResourceGroup|TestAdapter' -count=1
go test --tags=intest ./pkg/domain/ -run 'TestInfo|TestDomain' -count=1
```

The new `Domain.Close` branch only activates when a controller exists (real PD-backed stores), so unit tests with unistore skip it by design; `tests/realtikvtest` suites exercise it against a real cluster. The replacement-after-release behavior itself is covered by the contract tests in tikv/pd#11132.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-control shutdown to ensure system-wide interception is cleared before the controller stops.
  * Prevented resource-group initialization when required server information cannot be retrieved.
  * Added warning visibility when resource-group controller shutdown encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->