### PR TITLE
planner: recognize order on common handle PK (#66645)

### DIFF
--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "main_test.go",
         "rule_cdc_join_reorder_test.go",
+        "rule_common_handle_ordering_test.go",
         "rule_correlate_test.go",
         "rule_derive_topn_from_window_test.go",
         "rule_eliminate_projection_test.go",
@@ -17,7 +18,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/rule_common_handle_ordering_test.go
+++ b/pkg/planner/core/casetest/rule/rule_common_handle_ordering_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// explainHas scans EXPLAIN output rows and returns whether any line contains
+// the given substring.
+func explainHas(rows [][]any, substr string) bool {
+	for _, row := range rows {
+		for _, col := range row {
+			if s, ok := col.(string); ok && strings.Contains(s, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestCommonHandleIndexOrdering(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists t_ch")
+		tk.MustExec(`CREATE TABLE t_ch (
+			a1 varchar(64),
+			a2 int,
+			b int,
+			c int,
+			d int,
+			PRIMARY KEY(a1, a2) CLUSTERED,
+			KEY ic(d),
+			KEY ic_overlap(d, a1),
+			KEY ic_multi(b, d),
+			UNIQUE KEY uic(c)
+		)`)
+		// Multiple rows share d=0 and b=10,d=0 so ORDER BY assertions are meaningful.
+		// Each row has a distinct c for the UNIQUE KEY uic(c).
+		tk.MustExec(`insert into t_ch values
+			('x', 1, 10, 1, 0),
+			('y', 2, 20, 2, 0),
+			('a', 3, 10, 3, 0),
+			('m', 4, 30, 4, 1)`)
+
+		// ---------------------------------------------------------------
+		// Case 1: Basic — single-column secondary index, ORDER BY full PK.
+		// The optimizer should recognise that ic stores (d, a1, a2) and
+		// satisfy ORDER BY a1, a2 with keep order:true (no TopN).
+		// ---------------------------------------------------------------
+		rows := tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(ic) where d = 0 order by a1, a2 limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 1: expected keep order:true for basic CommonHandle ordering")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 1: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_ch use index(ic) where d = 0 order by a1, a2 limit 100",
+		).Check(testkit.Rows(
+			"a 3 10 3 0",
+			"x 1 10 1 0",
+			"y 2 20 2 0",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 2: Partial PK overlap — index ic_overlap(d, a1) already
+		// contains PK column a1. Only a2 should be appended. ORDER BY
+		// a1, a2 should still use keep order:true.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(ic_overlap) where d = 0 order by a1, a2 limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 2: expected keep order:true with partial PK overlap index")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 2: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_ch use index(ic_overlap) where d = 0 order by a1, a2 limit 100",
+		).Check(testkit.Rows(
+			"a 3 10 3 0",
+			"x 1 10 1 0",
+			"y 2 20 2 0",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 3: Multi-column secondary index — ic_multi(b, d) with all
+		// access conditions satisfied, ORDER BY PK should use keep order.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(ic_multi) where b = 10 and d = 0 order by a1, a2 limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 3: expected keep order:true for multi-column secondary index")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 3: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_ch use index(ic_multi) where b = 10 and d = 0 order by a1, a2 limit 100",
+		).Check(testkit.Rows(
+			"a 3 10 3 0",
+			"x 1 10 1 0",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 4: Unique index — PK columns should NOT be appended to a
+		// unique secondary index, so ORDER BY PK cannot use keep order.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(uic) where c > 0 order by a1, a2 limit 100",
+		).Rows()
+		// For a unique index with a range scan, the optimizer should not
+		// be able to satisfy ORDER BY PK via keep order on the index.
+		hasKeepOrderTrue := explainHas(rows, "keep order:true")
+		hasSortOp := explainHas(rows, "TopN") || explainHas(rows, "Sort")
+		require.True(t, !hasKeepOrderTrue || hasSortOp,
+			"case 4: unique index should not satisfy ORDER BY PK without sort")
+
+		// ---------------------------------------------------------------
+		// Case 5: DESC ordering — the index scan should satisfy
+		// ORDER BY a1 DESC, a2 DESC via a reverse scan.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(ic) where d = 0 order by a1 desc, a2 desc limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 5: expected keep order:true for DESC ordering")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 5: unexpected TopN sort for DESC ordering")
+
+		tk.MustQuery(
+			"select * from t_ch use index(ic) where d = 0 order by a1 desc, a2 desc limit 100",
+		).Check(testkit.Rows(
+			"y 2 20 2 0",
+			"x 1 10 1 0",
+			"a 3 10 3 0",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 6: Mixed ASC/DESC — ORDER BY a1 ASC, a2 DESC cannot be
+		// satisfied by the index since all PK columns share one direction.
+		// ---------------------------------------------------------------
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_ch use index(ic) where d = 0 order by a1 asc, a2 desc limit 100",
+		).Rows()
+		hasKeepOrderTrue = explainHas(rows, "keep order:true")
+		hasSortOp = explainHas(rows, "TopN") || explainHas(rows, "Sort")
+		require.True(t, !hasKeepOrderTrue || hasSortOp,
+			"case 6: mixed ASC/DESC should not be satisfied by keep order alone")
+
+		// ---------------------------------------------------------------
+		// Case 7: Prefixed clustered PK — PRIMARY KEY(p1(2), p2) stores
+		// only the first 2 bytes of p1 in the handle. ORDER BY on the
+		// full p1, p2 columns must NOT use keep order:true because the
+		// physical sort key is by the truncated prefix, not the full value.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_prefix")
+		tk.MustExec(`CREATE TABLE t_prefix (
+			p1 varchar(64),
+			p2 int,
+			c int,
+			PRIMARY KEY(p1(2), p2) CLUSTERED,
+			KEY ic_p(c)
+		)`)
+		// ('abz',1) and ('abc',2) share the 2-char prefix 'ab', so handle
+		// sort is by (prefix,p2): ('ab',1)=abz < ('ab',2)=abc < ('ax',3)=axy.
+		// Full ORDER BY p1,p2 gives: abc < abz < axy — a different order.
+		tk.MustExec(`insert into t_prefix values ('abz', 1, 0), ('abc', 2, 0), ('axy', 3, 0)`)
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_prefix use index(ic_p) where c = 0 order by p1, p2 limit 100",
+		).Rows()
+		hasKeepOrderTrue = explainHas(rows, "keep order:true")
+		hasSortOp = explainHas(rows, "TopN") || explainHas(rows, "Sort")
+		// The prefixed PK column cannot satisfy ORDER BY on the full column,
+		// so either keep order should be false or a TopN/Sort must be present.
+		require.True(t, !hasKeepOrderTrue || hasSortOp,
+			"case 7: prefixed clustered PK should not satisfy ORDER BY without sort")
+
+		tk.MustQuery(
+			"select * from t_prefix use index(ic_p) where c = 0 order by p1, p2 limit 100",
+		).Check(testkit.Rows(
+			"abc 2 0",
+			"abz 1 0",
+			"axy 3 0",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 8: Single varchar clustered PK — a single non-integer column
+		// PK uses CommonHandle. The secondary index stores (idx_col, pk_col)
+		// and should satisfy ORDER BY on the PK.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_varchar_pk")
+		tk.MustExec(`CREATE TABLE t_varchar_pk (
+			pk varchar(64) PRIMARY KEY CLUSTERED,
+			c int,
+			d int,
+			KEY ic_vc(c)
+		)`)
+		tk.MustExec(`insert into t_varchar_pk values
+			('banana', 0, 1),
+			('apple', 0, 2),
+			('cherry', 0, 3),
+			('date', 1, 4)`)
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_varchar_pk use index(ic_vc) where c = 0 order by pk limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 8: expected keep order:true for single varchar clustered PK")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 8: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_varchar_pk use index(ic_vc) where c = 0 order by pk limit 100",
+		).Check(testkit.Rows(
+			"apple 0 2",
+			"banana 0 1",
+			"cherry 0 3",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 9: Single varbinary clustered PK — binary types also use
+		// CommonHandle. Ordering should work the same as varchar.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_binary_pk")
+		tk.MustExec(`CREATE TABLE t_binary_pk (
+			pk varbinary(64) PRIMARY KEY CLUSTERED,
+			c int,
+			d int,
+			KEY ic_bin(c)
+		)`)
+		tk.MustExec(`insert into t_binary_pk values
+			(x'CC', 0, 1),
+			(x'AA', 0, 2),
+			(x'DD', 0, 3),
+			(x'BB', 1, 4)`)
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_binary_pk use index(ic_bin) where c = 0 order by pk limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 9: expected keep order:true for single varbinary clustered PK")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 9: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_binary_pk use index(ic_bin) where c = 0 order by pk limit 100",
+		).Check(testkit.Rows(
+			"\xaa 0 2",
+			"\xcc 0 1",
+			"\xdd 0 3",
+		))
+
+		// ---------------------------------------------------------------
+		// Case 10: Multi-type composite PK — (int, varchar) to verify
+		// ordering works with mixed types in the PK.
+		// ---------------------------------------------------------------
+		tk.MustExec("drop table if exists t_int_varchar_pk")
+		tk.MustExec(`CREATE TABLE t_int_varchar_pk (
+			pk1 int,
+			pk2 varchar(64),
+			c int,
+			KEY ic_iv(c)
+		, PRIMARY KEY(pk1, pk2) CLUSTERED)`)
+		tk.MustExec(`insert into t_int_varchar_pk values
+			(1, 'b', 0),
+			(1, 'a', 0),
+			(2, 'a', 0),
+			(3, 'x', 1)`)
+		rows = tk.MustQuery(
+			"explain format = 'brief' select * from t_int_varchar_pk use index(ic_iv) where c = 0 order by pk1, pk2 limit 100",
+		).Rows()
+		require.True(t, explainHas(rows, "keep order:true"),
+			"case 10: expected keep order:true for (int, varchar) clustered PK")
+		require.False(t, explainHas(rows, "TopN"),
+			"case 10: unexpected TopN sort")
+
+		tk.MustQuery(
+			"select * from t_int_varchar_pk use index(ic_iv) where c = 0 order by pk1, pk2 limit 100",
+		).Check(testkit.Rows(
+			"1 a 0",
+			"1 b 0",
+			"2 a 0",
+		))
+	})
+}

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -888,6 +888,24 @@ func isFullIndexMatch(candidate *candidatePath) bool {
 	return candidate.path.EqOrInCondCount > 0 && len(candidate.indexCondsColMap) >= len(candidate.path.Index.Columns)
 }
 
+// hasV0NewCollationStringHandle reports whether ds has CommonHandleVersion == 0
+// with new collation enabled and at least one non-binary string column in the
+// handle. In this combination the handle bytes stored in the index are collation
+// sortKey weights, not original values, so collation-aware comparison on those
+// bytes during merge-sort would be incorrect.
+func hasV0NewCollationStringHandle(ds *logicalop.DataSource) bool {
+	if ds.TableInfo.CommonHandleVersion != 0 || !collate.NewCollationEnabled() {
+		return false
+	}
+	for _, col := range ds.CommonHandleCols {
+		if col != nil && col.RetType.EvalType() == types.ETString &&
+			!mysql.HasBinaryFlag(col.RetType.GetFlag()) {
+			return true
+		}
+	}
+	return false
+}
+
 func matchProperty(ds *logicalop.DataSource, path *util.AccessPath, prop *property.PhysicalProperty) property.PhysicalPropMatchResult {
 	// This function may set the two fields below for the PropMatchedNeedMergeSort case, so we reset them here to
 	// avoid leaving the AccessPath with an inconsistent state when there are multiple calls to matchProperty with
@@ -927,11 +945,57 @@ func matchProperty(ds *logicalop.DataSource, path *util.AccessPath, prop *proper
 	all, _ := prop.AllSameOrder()
 	// When the prop is empty or `all` is false, `matchProperty` is better to be `PropNotMatched` because
 	// it needs not to keep order for index scan.
-	if prop.IsSortItemEmpty() || !all || len(path.IdxCols) < len(prop.SortItems) {
+	if prop.IsSortItemEmpty() || !all {
 		return property.PropNotMatched
 	}
 
-	// Basically, if `prop.SortItems` is the prefix of `path.IdxCols`, then the property is matched.
+	// For non-unique secondary indexes on CommonHandle tables, the index physically
+	// stores (index_cols, PK_cols). Build an effective column list that includes the
+	// PK suffix so that ORDER BY on PK columns can be recognised.
+	//
+	// Skip this when CommonHandleVersion == 0 with new collation enabled and
+	// the handle contains non-binary string columns. In v0, string handle columns
+	// are stored as sortKey bytes (collation weight), not original values. If we
+	// extend idxCols and the query triggers PropMatchedNeedMergeSort (e.g. IN
+	// predicate), the merge-sort comparator would apply the column's collation to
+	// sortKey bytes, producing incorrect ordering.
+	idxCols := path.IdxCols
+	idxColLens := path.IdxColLens
+	if path.Index != nil && !path.Index.Unique && !path.Index.Primary &&
+		ds.TableInfo.IsCommonHandle && len(ds.CommonHandleCols) > 0 &&
+		len(path.Index.Columns) == len(path.IdxCols) &&
+		!hasV0NewCollationStringHandle(ds) {
+		extended := false
+		for i, handleCol := range ds.CommonHandleCols {
+			if handleCol == nil {
+				continue
+			}
+			alreadyInIndex := false
+			for _, col := range idxCols {
+				if col != nil && col.EqualColumn(handleCol) {
+					alreadyInIndex = true
+					break
+				}
+			}
+			if !alreadyInIndex {
+				if !extended {
+					idxCols = make([]*expression.Column, len(path.IdxCols), len(path.IdxCols)+len(ds.CommonHandleCols))
+					copy(idxCols, path.IdxCols)
+					idxColLens = make([]int, len(path.IdxColLens), len(path.IdxColLens)+len(ds.CommonHandleCols))
+					copy(idxColLens, path.IdxColLens)
+					extended = true
+				}
+				idxCols = append(idxCols, handleCol)
+				idxColLens = append(idxColLens, ds.CommonHandleLens[i])
+			}
+		}
+	}
+
+	if len(idxCols) < len(prop.SortItems) {
+		return property.PropNotMatched
+	}
+
+	// Basically, if `prop.SortItems` is the prefix of `idxCols`, then the property is matched.
 	// However, we need to consider the situations when some columns of `path.IdxCols` are evaluated as constant.
 	// For example:
 	// ```
@@ -953,9 +1017,9 @@ func matchProperty(ds *logicalop.DataSource, path *util.AccessPath, prop *proper
 	colIdx := 0
 	for _, sortItem := range prop.SortItems {
 		found := false
-		for ; colIdx < len(path.IdxCols); colIdx++ {
+		for ; colIdx < len(idxCols); colIdx++ {
 			// Case 1: this sort item is satisfied by the index column, go to match the next sort item.
-			if path.IdxColLens[colIdx] == types.UnspecifiedLength && sortItem.Col.EqualColumn(path.IdxCols[colIdx]) {
+			if idxColLens[colIdx] == types.UnspecifiedLength && sortItem.Col.EqualColumn(idxCols[colIdx]) {
 				found = true
 				colIdx++
 				break


### PR DESCRIPTION
This is a manual cherry-pick of #66645 to release-8.5, replacing the automated cherry-pick #67107 which contains unresolved merge conflict markers in `pkg/planner/core/casetest/rule/BUILD.bazel` (causing its `build` / `unit-test` / `check-dev2` CI jobs to fail).

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #66644

Problem Summary:

Common handle PKs were not recognized as providing order after the index columns, while integer PKs were. This caused unnecessary TopN/Sort operators for `ORDER BY <pk columns>` queries on clustered (common handle) tables scanned via a secondary index.

### What changed and how does it work?

Manual cherry-pick of #66645 (commit 3032ee10c2) onto release-8.5.

- `pkg/planner/core/find_best_task.go` applies cleanly (no conflicts).
- The only conflict was in `pkg/planner/core/casetest/rule/BUILD.bazel`; resolved by adding `rule_common_handle_ordering_test.go` to `srcs` and bumping `shard_count` from 21 to 22 (master is at 23 because it has an extra test file that does not exist on release-8.5).

As in the original PR: `matchProperty` now builds an effective index column list that includes the common handle PK suffix for non-unique secondary indexes, so ORDER BY on PK columns can be satisfied with `keep order:true`. The v0 CommonHandleVersion + new collation string handle case is excluded for correctness.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Local verification on this branch:
- `make bazel_prepare` (no diff beyond the resolved BUILD.bazel)
- `go test --tags=intest ./pkg/planner/core/casetest/rule/ -run TestCommonHandleIndexOrdering` passes (all 10 cases, with failpoints enabled)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query ordering for CommonHandle indexes, including multi-column, unique, descending, and mixed-direction indexes.
  * Corrected ordering detection for clustered keys with string, binary, and mixed data types.
  * Added safeguards for legacy collations to prevent incorrect ordering assumptions.

* **Tests**
  * Expanded coverage for ordered scans, partial key matches, clustered keys, and sort-plan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->