### PR TITLE
executor: executor support for full outer join

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1958,10 +1958,6 @@ func (b *executorBuilder) buildHashJoinV2FromChildExecs(leftExec, rightExec exec
 }
 
 func (b *executorBuilder) buildHashJoin(v *physicalop.PhysicalHashJoin) exec.Executor {
-	if v.JoinType == base.FullOuterJoin {
-		b.err = plannererrors.ErrNotSupportedYet.GenWithStackByArgs("FULL OUTER JOIN")
-		return nil
-	}
 	if b.sctx.GetSessionVars().UseHashJoinV2 && joinversion.IsHashJoinV2Supported() && v.CanUseHashJoinV2() {
 		return b.buildHashJoinV2(v)
 	}
@@ -1992,17 +1988,23 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 	e.HashJoinCtxV1.JoinType = v.JoinType
 	e.HashJoinCtxV1.Concurrency = v.Concurrency
 	e.HashJoinCtxV1.ChunkAllocPool = e.AllocPool
+	if v.JoinType == base.FullOuterJoin && v.UseOuterToBuild {
+		b.err = errors.Annotate(exeerrors.ErrBuildExecutor, "full outer join only supports UseOuterToBuild=false")
+		return nil
+	}
 	defaultValues := v.DefaultValues
 	lhsTypes, rhsTypes := exec.RetTypes(leftExec), exec.RetTypes(rightExec)
-	if v.InnerChildIdx == 1 {
-		if len(v.RightConditions) > 0 {
-			b.err = errors.Annotate(exeerrors.ErrBuildExecutor, "join's inner condition should be empty")
-			return nil
-		}
-	} else {
-		if len(v.LeftConditions) > 0 {
-			b.err = errors.Annotate(exeerrors.ErrBuildExecutor, "join's inner condition should be empty")
-			return nil
+	if v.JoinType != base.FullOuterJoin {
+		if v.InnerChildIdx == 1 {
+			if len(v.RightConditions) > 0 {
+				b.err = errors.Annotate(exeerrors.ErrBuildExecutor, "join's inner condition should be empty")
+				return nil
+			}
+		} else {
+			if len(v.LeftConditions) > 0 {
+				b.err = errors.Annotate(exeerrors.ErrBuildExecutor, "join's inner condition should be empty")
+				return nil
+			}
 		}
 	}
 
@@ -2041,6 +2043,18 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 			defaultValues = make([]types.Datum, buildSideExec.Schema().Len())
 		}
 	}
+	if v.JoinType == base.FullOuterJoin {
+		// full outer join keeps side filters inside hash join:
+		// build filter decides whether a build row enters hash table;
+		// probe filter decides whether a probe row enters probe matching.
+		if leftIsBuildSide {
+			e.FullOuterJoinBuildFilter = v.LeftConditions
+			e.FullOuterJoinProbeFilter = v.RightConditions
+		} else {
+			e.FullOuterJoinBuildFilter = v.RightConditions
+			e.FullOuterJoinProbeFilter = v.LeftConditions
+		}
+	}
 	probeKeyColIdx := make([]int, len(probeKeys))
 	probeNAKeColIdx := make([]int, len(probeNAKeys))
 	buildKeyColIdx := make([]int, len(buildKeys))
@@ -2063,14 +2077,55 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 		colsFromChildren = colsFromChildren[:len(colsFromChildren)-1]
 	}
 	childrenUsedSchema := markChildrenUsedCols(colsFromChildren, v.Children()[0].Schema(), v.Children()[1].Schema())
+	var fullJoinBuildJoinerJoinType, fullJoinProbeJoinerJoinType base.JoinType
+	var fullJoinBuildJoinerOuterIsRight, fullJoinProbeJoinerOuterIsRight bool
+	var fullJoinBuildJoinerDefaultValues, fullJoinProbeJoinerDefaultValues []types.Datum
+	if v.JoinType == base.FullOuterJoin {
+		// Full outer join uses two outer-joiners:
+		// 1) build joiner: handles matched rows + tail unmatched build rows.
+		// 2) probe joiner: handles unmatched probe rows.
+		// `outerIsRight` here is joiner row-layout metadata (whether joiner's
+		// outer row is from original right child), not UseOuterToBuild.
+		if leftIsBuildSide {
+			// build=left, probe=right
+			// build unmatched output: (left, NULL-right)
+			fullJoinBuildJoinerJoinType = base.LeftOuterJoin
+			fullJoinBuildJoinerOuterIsRight = false
+			fullJoinBuildJoinerDefaultValues = make([]types.Datum, len(rhsTypes))
+
+			// probe unmatched output: (NULL-left, right)
+			fullJoinProbeJoinerJoinType = base.RightOuterJoin
+			fullJoinProbeJoinerOuterIsRight = true
+			fullJoinProbeJoinerDefaultValues = make([]types.Datum, len(lhsTypes))
+		} else {
+			// build=right, probe=left
+			// build unmatched output: (NULL-left, right)
+			fullJoinBuildJoinerJoinType = base.RightOuterJoin
+			fullJoinBuildJoinerOuterIsRight = true
+			fullJoinBuildJoinerDefaultValues = make([]types.Datum, len(lhsTypes))
+
+			// probe unmatched output: (left, NULL-right)
+			fullJoinProbeJoinerJoinType = base.LeftOuterJoin
+			fullJoinProbeJoinerOuterIsRight = false
+			fullJoinProbeJoinerDefaultValues = make([]types.Datum, len(rhsTypes))
+		}
+	}
 	for i := range e.Concurrency {
-		e.ProbeWorkers[i] = &join.ProbeWorkerV1{
+		worker := &join.ProbeWorkerV1{
 			HashJoinCtx:      e.HashJoinCtxV1,
-			Joiner:           join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin),
 			ProbeKeyColIdx:   probeKeyColIdx,
 			ProbeNAKeyColIdx: probeNAKeColIdx,
 		}
-		e.ProbeWorkers[i].WorkerID = i
+		if v.JoinType == base.FullOuterJoin {
+			worker.FullJoinBuildJoiner = join.NewJoiner(b.sctx, fullJoinBuildJoinerJoinType, fullJoinBuildJoinerOuterIsRight, fullJoinBuildJoinerDefaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, false)
+			worker.FullJoinProbeJoiner = join.NewJoiner(b.sctx, fullJoinProbeJoinerJoinType, fullJoinProbeJoinerOuterIsRight, fullJoinProbeJoinerDefaultValues, nil, lhsTypes, rhsTypes, childrenUsedSchema, false)
+			// Keep Joiner as probe-mismatch joiner for shared non-full code paths.
+			worker.Joiner = worker.FullJoinProbeJoiner
+		} else {
+			worker.Joiner = join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin)
+		}
+		worker.WorkerID = i
+		e.ProbeWorkers[i] = worker
 	}
 	e.BuildWorker.BuildKeyColIdx, e.BuildWorker.BuildNAKeyColIdx, e.BuildWorker.BuildSideExec, e.BuildWorker.HashJoinCtx = buildKeyColIdx, buildNAKeyColIdx, buildSideExec, e.HashJoinCtxV1
 	e.HashJoinCtxV1.IsNullAware = isNAJoin

--- a/pkg/executor/join/hash_join_v1.go
+++ b/pkg/executor/join/hash_join_v1.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"go.uber.org/zap"
 )
 
@@ -872,7 +873,7 @@ func (w *ProbeWorkerV1) joinMatchedProbeSideRow2ChunkForFullJoin(probeKey uint64
 		}
 		rowIdx += len(outerMatchStatus)
 		if joinResult.chk.IsFull() {
-			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			ok, oneWaitTime, joinResult = w.sendingResultAndCheckSignal(joinResult)
 			waitTime += oneWaitTime
 			if !ok {
 				return false, waitTime, joinResult
@@ -1029,6 +1030,11 @@ func (w *ProbeWorkerV1) sendingResultAndCheckSignal(joinResult *hashjoinWorkerRe
 	if !ok {
 		return false, waitTime, newJoinResult
 	}
+	failpoint.Inject("killedBeforeSendingResultSignalCheck", func(val failpoint.Value) {
+		if val.(bool) {
+			w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.SendKillSignal(sqlkiller.QueryInterrupted)
+		}
+	})
 	if err := w.HashJoinCtx.SessCtx.GetSessionVars().SQLKiller.HandleSignal(); err != nil {
 		newJoinResult.err = err
 		return false, waitTime, newJoinResult

--- a/pkg/executor/join/hash_join_v1.go
+++ b/pkg/executor/join/hash_join_v1.go
@@ -65,7 +65,10 @@ type HashJoinCtxV1 struct {
 	ProbeTypes         []*types.FieldType
 	BuildTypes         []*types.FieldType
 	OuterFilter        expression.CNFExprs
-	stats              *hashJoinRuntimeStats
+	// Full outer join has two preserved sides, so keep side filters explicit.
+	FullOuterJoinBuildFilter expression.CNFExprs
+	FullOuterJoinProbeFilter expression.CNFExprs
+	stats                    *hashJoinRuntimeStats
 }
 
 // ProbeSideTupleFetcherV1 reads tuples from ProbeSideExec and send them to ProbeWorkers.
@@ -87,6 +90,8 @@ type ProbeWorkerV1 struct {
 	// We build individual joiner for each join worker when use chunk-based
 	// execution, to avoid the concurrency of joiner.chk and joiner.selected.
 	Joiner               Joiner
+	FullJoinBuildJoiner  Joiner
+	FullJoinProbeJoiner  Joiner
 	rowIters             *chunk.Iterator4Slice
 	rowContainerForProbe *hashRowContainer
 	// for every naaj probe worker,  pre-allocate the int slice for store the join column index to check.
@@ -273,6 +278,10 @@ func (w *ProbeWorkerV1) handleUnmatchedRowsFromHashTable() {
 	if !ok {
 		return
 	}
+	buildMissMatchJoiner := w.Joiner
+	if w.HashJoinCtx.JoinType == base.FullOuterJoin {
+		buildMissMatchJoiner = w.FullJoinBuildJoiner
+	}
 	numChks := w.rowContainerForProbe.NumChunks()
 	for i := int(w.WorkerID); i < numChks; i += int(w.HashJoinCtx.Concurrency) {
 		chk, err := w.rowContainerForProbe.GetChunk(i)
@@ -284,7 +293,7 @@ func (w *ProbeWorkerV1) handleUnmatchedRowsFromHashTable() {
 		}
 		for j := range chk.NumRows() {
 			if !w.HashJoinCtx.outerMatchedStatus[i].UnsafeIsSet(j) { // process unmatched Outer rows
-				w.Joiner.OnMissMatch(false, chk.GetRow(j), joinResult.chk)
+				buildMissMatchJoiner.OnMissMatch(false, chk.GetRow(j), joinResult.chk)
 			}
 			if joinResult.chk.IsFull() {
 				w.HashJoinCtx.joinResultCh <- joinResult
@@ -305,7 +314,7 @@ func (w *ProbeWorkerV1) handleUnmatchedRowsFromHashTable() {
 
 func (e *HashJoinV1Exec) waitJoinWorkersAndCloseResultChan() {
 	e.workerWg.Wait()
-	if e.UseOuterToBuild {
+	if e.UseOuterToBuild || e.JoinType == base.FullOuterJoin {
 		// Concurrently handling unmatched rows from the hash table at the tail
 		for i := range e.Concurrency {
 			var workerID = i
@@ -825,6 +834,57 @@ func (w *ProbeWorkerV1) joinMatchedProbeSideRow2Chunk(probeKey uint64, probeSide
 	return true, waitTime, joinResult
 }
 
+func (w *ProbeWorkerV1) joinMatchedProbeSideRow2ChunkForFullJoin(probeKey uint64, probeSideRow chunk.Row, hCtx *HashContext,
+	joinResult *hashjoinWorkerResult) (bool, int64, *hashjoinWorkerResult) {
+	var err error
+	waitTime := int64(0)
+	oneWaitTime := int64(0)
+	w.buildSideRows, w.buildSideRowPtrs, err = w.rowContainerForProbe.GetMatchedRowsAndPtrs(probeKey, probeSideRow, hCtx, w.buildSideRows, w.buildSideRowPtrs, true)
+	buildSideRows, rowsPtrs := w.buildSideRows, w.buildSideRowPtrs
+	if err != nil {
+		joinResult.err = err
+		return false, waitTime, joinResult
+	}
+	if len(buildSideRows) == 0 {
+		w.FullJoinProbeJoiner.OnMissMatch(false, probeSideRow, joinResult.chk)
+		return true, waitTime, joinResult
+	}
+
+	iter := w.rowIters
+	iter.Reset(buildSideRows)
+	var (
+		outerMatchStatus []outerRowStatusFlag
+		hasMatch         bool
+		rowIdx           int
+		ok               bool
+	)
+	for iter.Begin(); iter.Current() != iter.End(); {
+		outerMatchStatus, err = w.FullJoinBuildJoiner.TryToMatchOuters(iter, probeSideRow, joinResult.chk, outerMatchStatus)
+		if err != nil {
+			joinResult.err = err
+			return false, waitTime, joinResult
+		}
+		for i := range outerMatchStatus {
+			if outerMatchStatus[i] == outerRowMatched {
+				hasMatch = true
+				w.HashJoinCtx.outerMatchedStatus[rowsPtrs[rowIdx+i].ChkIdx].Set(int(rowsPtrs[rowIdx+i].RowIdx))
+			}
+		}
+		rowIdx += len(outerMatchStatus)
+		if joinResult.chk.IsFull() {
+			ok, oneWaitTime, joinResult = w.sendingResult(joinResult)
+			waitTime += oneWaitTime
+			if !ok {
+				return false, waitTime, joinResult
+			}
+		}
+	}
+	if !hasMatch {
+		w.FullJoinProbeJoiner.OnMissMatch(false, probeSideRow, joinResult.chk)
+	}
+	return true, waitTime, joinResult
+}
+
 func (w *ProbeWorkerV1) getNewJoinResult() (bool, *hashjoinWorkerResult) {
 	joinResult := &hashjoinWorkerResult{
 		src: w.joinChkResourceCh,
@@ -843,7 +903,13 @@ func (w *ProbeWorkerV1) join2Chunk(probeSideChk *chunk.Chunk, hCtx *HashContext,
 	var err error
 	waitTime = 0
 	oneWaitTime := int64(0)
-	selected, err = expression.VectorizedFilter(w.HashJoinCtx.SessCtx.GetExprCtx().GetEvalCtx(), w.HashJoinCtx.SessCtx.GetSessionVars().EnableVectorizedExpression, w.HashJoinCtx.OuterFilter, chunk.NewIterator4Chunk(probeSideChk), selected)
+	probeFilter := w.HashJoinCtx.OuterFilter
+	if w.HashJoinCtx.JoinType == base.FullOuterJoin {
+		// Full join has two preserved sides, so probe-side single-table ON filters
+		// are kept explicitly instead of reusing OuterFilter semantics.
+		probeFilter = w.HashJoinCtx.FullOuterJoinProbeFilter
+	}
+	selected, err = expression.VectorizedFilter(w.HashJoinCtx.SessCtx.GetExprCtx().GetEvalCtx(), w.HashJoinCtx.SessCtx.GetSessionVars().EnableVectorizedExpression, probeFilter, chunk.NewIterator4Chunk(probeSideChk), selected)
 	if err != nil {
 		joinResult.err = err
 		return false, waitTime, joinResult
@@ -918,12 +984,21 @@ func (w *ProbeWorkerV1) join2Chunk(probeSideChk *chunk.Chunk, hCtx *HashContext,
 				}
 			}
 		} else {
-			// since this is the case of using inner to build, so for an outer row unselected, we should fill the result when it's outer join.
+			// Since this is the case of using inner to build, for an unselected probe row,
+			// we should fill the result when the probe side is preserved.
+			missMatchJoiner := w.Joiner
+			if w.HashJoinCtx.JoinType == base.FullOuterJoin {
+				missMatchJoiner = w.FullJoinProbeJoiner
+			}
 			if !selected[i] || hCtx.HasNull[i] { // process unmatched probe side rows
-				w.Joiner.OnMissMatch(false, probeSideChk.GetRow(i), joinResult.chk)
+				missMatchJoiner.OnMissMatch(false, probeSideChk.GetRow(i), joinResult.chk)
 			} else { // process matched probe side rows
 				probeKey, probeRow := hCtx.HashVals[i].Sum64(), probeSideChk.GetRow(i)
-				ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2Chunk(probeKey, probeRow, hCtx, joinResult)
+				if w.HashJoinCtx.JoinType == base.FullOuterJoin {
+					ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2ChunkForFullJoin(probeKey, probeRow, hCtx, joinResult)
+				} else {
+					ok, oneWaitTime, joinResult = w.joinMatchedProbeSideRow2Chunk(probeKey, probeRow, hCtx, joinResult)
+				}
 				waitTime += oneWaitTime
 				if !ok {
 					return false, waitTime, joinResult
@@ -1120,25 +1195,32 @@ func (w *BuildWorkerV1) BuildHashTableForList(buildSideResultCh <-chan *chunk.Ch
 		})
 		w.HashJoinCtx.SessCtx.GetSessionVars().MemTracker.FallbackOldAndSetNewAction(actionSpill)
 	}
+	needTrackBuildRows := w.HashJoinCtx.UseOuterToBuild || w.HashJoinCtx.JoinType == base.FullOuterJoin
+	var buildFilter expression.CNFExprs
+	if w.HashJoinCtx.JoinType == base.FullOuterJoin {
+		// Full join keeps build-side single-table ON filters explicitly.
+		buildFilter = w.HashJoinCtx.FullOuterJoinBuildFilter
+	} else if w.HashJoinCtx.UseOuterToBuild {
+		// Legacy outer-build path uses OuterFilter as build-side filter.
+		buildFilter = w.HashJoinCtx.OuterFilter
+	}
 	for chk := range buildSideResultCh {
 		if w.HashJoinCtx.finished.Load() {
 			return nil
 		}
-		if !w.HashJoinCtx.UseOuterToBuild {
-			err = rowContainer.PutChunk(chk, w.HashJoinCtx.IsNullEQ)
-		} else {
+		if needTrackBuildRows {
 			var bitMap = bitmap.NewConcurrentBitmap(chk.NumRows())
 			w.HashJoinCtx.outerMatchedStatus = append(w.HashJoinCtx.outerMatchedStatus, bitMap)
 			w.HashJoinCtx.memTracker.Consume(bitMap.BytesConsumed())
-			if len(w.HashJoinCtx.OuterFilter) == 0 {
-				err = w.HashJoinCtx.RowContainer.PutChunk(chk, w.HashJoinCtx.IsNullEQ)
-			} else {
-				selected, err = expression.VectorizedFilter(w.HashJoinCtx.SessCtx.GetExprCtx().GetEvalCtx(), w.HashJoinCtx.SessCtx.GetSessionVars().EnableVectorizedExpression, w.HashJoinCtx.OuterFilter, chunk.NewIterator4Chunk(chk), selected)
-				if err != nil {
-					return err
-				}
-				err = rowContainer.PutChunkSelected(chk, selected, w.HashJoinCtx.IsNullEQ)
+		}
+		if len(buildFilter) == 0 {
+			err = rowContainer.PutChunk(chk, w.HashJoinCtx.IsNullEQ)
+		} else {
+			selected, err = expression.VectorizedFilter(w.HashJoinCtx.SessCtx.GetExprCtx().GetEvalCtx(), w.HashJoinCtx.SessCtx.GetSessionVars().EnableVectorizedExpression, buildFilter, chunk.NewIterator4Chunk(chk), selected)
+			if err != nil {
+				return err
 			}
+			err = rowContainer.PutChunkSelected(chk, selected, w.HashJoinCtx.IsNullEQ)
 		}
 		failpoint.Inject("ConsumeRandomPanic", nil)
 		if err != nil {

--- a/pkg/executor/test/jointest/hashjoin/BUILD.bazel
+++ b/pkg/executor/test/jointest/hashjoin/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 21,
+    shard_count = 24,
     deps = [
         "//pkg/config",
         "//pkg/executor/join",

--- a/pkg/executor/test/jointest/hashjoin/hash_join_test.go
+++ b/pkg/executor/test/jointest/hashjoin/hash_join_test.go
@@ -432,6 +432,29 @@ func TestFullOuterJoinHashJoinV1(t *testing.T) {
 		"<nil> <nil> 1 20",
 		"<nil> <nil> 4 7",
 	))
+
+	// A full join can fill a result chunk while processing one probe row.
+	// Check the SQL killer after the flush rather than after the probe row finishes.
+	tk.MustExec("set @@tidb_init_chunk_size=1")
+	tk.MustExec("set @@tidb_max_chunk_size=32")
+	tk.MustExec("drop table if exists t19, t20")
+	tk.MustExec("create table t19(a int)")
+	tk.MustExec("create table t20(a int)")
+	tk.MustExec("insert into t19 values (1)")
+	tk.MustExec("insert into t20 values (1)")
+	for range 5 {
+		tk.MustExec("insert into t20 select * from t20")
+	}
+	fullJoinFlushSQL := "select /*+ HASH_JOIN_BUILD(t20) */ * from t19 full outer join t20 on t19.a = t20.a"
+	assertBuildSideForTables(fullJoinFlushSQL, "t19", "t20", "t20")
+	fpName := "github.com/pingcap/tidb/pkg/executor/join/killedBeforeSendingResultSignalCheck"
+	require.NoError(t, failpoint.Enable(fpName, "return(true)"))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(fpName))
+		tk.Session().GetSessionVars().SQLKiller.Reset()
+	})
+	err := tk.QueryToErr(fullJoinFlushSQL)
+	require.ErrorIs(t, err, exeerrors.ErrQueryInterrupted)
 }
 
 func TestFullOuterJoinHashJoinV1Spill(t *testing.T) {

--- a/pkg/executor/test/jointest/hashjoin/hash_join_test.go
+++ b/pkg/executor/test/jointest/hashjoin/hash_join_test.go
@@ -207,6 +207,339 @@ func TestHashJoin(t *testing.T) {
 	require.Equal(t, "5", outerActRows)
 }
 
+func TestFullOuterJoinHashJoinV1(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_full_outer_join = 1")
+	tk.MustExec(join.DisableHashJoinV2)
+
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int, b int, c int)")
+	tk.MustExec("create table t2(a int, b int, c int)")
+	tk.MustExec("insert into t1 values (1,10,1), (2,20,0), (3,30,1), (null,40,1)")
+	tk.MustExec("insert into t2 values (1,100,1), (3,300,0), (4,400,1), (null,500,1)")
+
+	planSQL := "select * from t1 full outer join t2 on t1.a = t2.a"
+	tk.MustHavePlan(planSQL, "HashJoin")
+	tk.MustNotHavePlan(planSQL, "MergeJoin")
+	tk.MustNotHavePlan(planSQL, "IndexJoin")
+	tk.MustNotHavePlan(planSQL, "IndexHashJoin")
+
+	expectedBasicRows := testkit.Rows(
+		"1 10 1 100",
+		"2 20 <nil> <nil>",
+		"3 30 3 300",
+		"<nil> <nil> 4 400",
+		"<nil> <nil> <nil> 500",
+		"<nil> 40 <nil> <nil>",
+	)
+	basicSQL := "select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b"
+	tk.MustQuery(basicSQL).Check(expectedBasicRows)
+
+	// No equi keys: full join should still work via cartesian hash-join path.
+	tk.MustExec("drop table if exists t13, t14")
+	tk.MustExec("create table t13(a int)")
+	tk.MustExec("create table t14(a int)")
+	tk.MustExec("insert into t13 values (1), (2)")
+	tk.MustExec("insert into t14 values (10)")
+
+	onTrueSQL := "select t13.a, t14.a from t13 full outer join t14 on true order by t13.a, t14.a"
+	tk.MustHavePlan(onTrueSQL, "HashJoin")
+	onTrueExplain := tk.MustQuery("explain format = 'brief' " + onTrueSQL).Rows()
+	onTruePlan := make([]string, 0, len(onTrueExplain))
+	for _, row := range onTrueExplain {
+		onTruePlan = append(onTruePlan, fmt.Sprint(row))
+	}
+	require.Contains(t, strings.Join(onTruePlan, "\n"), "CARTESIAN", "sql=%s, explain=%v", onTrueSQL, onTrueExplain)
+	tk.MustQuery(onTrueSQL).Check(testkit.Rows(
+		"1 10",
+		"2 10",
+	))
+
+	onFalseSQL := "select t13.a, t14.a from t13 full outer join t14 on false order by isnull(t13.a), t13.a, isnull(t14.a), t14.a"
+	tk.MustHavePlan(onFalseSQL, "HashJoin")
+	tk.MustQuery(onFalseSQL).Check(testkit.Rows(
+		"1 <nil>",
+		"2 <nil>",
+		"<nil> 10",
+	))
+
+	onNullSQL := "select t13.a, t14.a from t13 full outer join t14 on null order by isnull(t13.a), t13.a, isnull(t14.a), t14.a"
+	tk.MustHavePlan(onNullSQL, "HashJoin")
+	tk.MustQuery(onNullSQL).Check(testkit.Rows(
+		"1 <nil>",
+		"2 <nil>",
+		"<nil> 10",
+	))
+
+	nonEquiOnlySQL := "select t13.a, t14.a from t13 full outer join t14 on t13.a > t14.a order by isnull(t13.a), t13.a, isnull(t14.a), t14.a"
+	tk.MustHavePlan(nonEquiOnlySQL, "HashJoin")
+	nonEquiOnlyExplain := tk.MustQuery("explain format = 'brief' " + nonEquiOnlySQL).Rows()
+	nonEquiOnlyPlan := make([]string, 0, len(nonEquiOnlyExplain))
+	for _, row := range nonEquiOnlyExplain {
+		nonEquiOnlyPlan = append(nonEquiOnlyPlan, fmt.Sprint(row))
+	}
+	require.Contains(t, strings.Join(nonEquiOnlyPlan, "\n"), "CARTESIAN", "sql=%s, explain=%v", nonEquiOnlySQL, nonEquiOnlyExplain)
+	tk.MustQuery(nonEquiOnlySQL).Check(testkit.Rows(
+		"1 <nil>",
+		"2 <nil>",
+		"<nil> 10",
+	))
+
+	assertBuildSideForTables := func(sql, leftTable, rightTable, buildTable string) {
+		rows := tk.MustQuery("explain format = 'brief' " + sql).Rows()
+		explain := make([]string, 0, len(rows))
+		for _, row := range rows {
+			explain = append(explain, fmt.Sprint(row))
+		}
+		all := strings.Join(explain, "\n")
+		require.Contains(t, all, "TableReader(Build)", "sql=%s, explain=%v", sql, rows)
+		leftIdx, rightIdx := strings.Index(all, "table:"+leftTable), strings.Index(all, "table:"+rightTable)
+		require.NotEqual(t, -1, leftIdx, "sql=%s, explain=%v", sql, rows)
+		require.NotEqual(t, -1, rightIdx, "sql=%s, explain=%v", sql, rows)
+		if buildTable == leftTable {
+			require.Less(t, leftIdx, rightIdx, "build side is not %s, sql=%s, explain=%v", buildTable, sql, rows)
+		} else {
+			require.Less(t, rightIdx, leftIdx, "build side is not %s, sql=%s, explain=%v", buildTable, sql, rows)
+		}
+	}
+	assertBuildSide := func(sql, buildTable string) {
+		assertBuildSideForTables(sql, "t1", "t2", buildTable)
+	}
+
+	// Both build directions should be executable for full outer join.
+	sqlBuildT1 := "select /*+ HASH_JOIN_BUILD(t1) */ t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b"
+	sqlBuildT2 := "select /*+ HASH_JOIN_BUILD(t2) */ t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b"
+	assertBuildSide(sqlBuildT1, "t1")
+	assertBuildSide(sqlBuildT2, "t2")
+	tk.MustQuery(sqlBuildT1).Check(expectedBasicRows)
+	tk.MustQuery(sqlBuildT2).Check(expectedBasicRows)
+
+	// Build-side ON filters should only decide hash-table membership. A build row
+	// filtered out before probing is still a preserved full-join row and must be
+	// emitted by the tail unmatched scan.
+	tk.MustExec("drop table if exists t15, t16, t17, t18")
+	tk.MustExec("create table t15(a int, b int, c int)")
+	tk.MustExec("create table t16(a int, b int)")
+	tk.MustExec("insert into t15 values (1,10,0), (1,11,1)")
+	tk.MustExec("insert into t16 values (1,100)")
+	buildFilterT15SQL := "select /*+ HASH_JOIN_BUILD(t15) */ t15.a, t15.b, t15.c, t16.a, t16.b from t15 full outer join t16 on t15.a = t16.a and t15.c = 1 order by isnull(t15.b), t15.b, isnull(t16.b), t16.b"
+	assertBuildSideForTables(buildFilterT15SQL, "t15", "t16", "t15")
+	tk.MustQuery(buildFilterT15SQL).Check(testkit.Rows(
+		"1 10 0 <nil> <nil>",
+		"1 11 1 1 100",
+	))
+
+	tk.MustExec("create table t17(a int, b int)")
+	tk.MustExec("create table t18(a int, b int, c int)")
+	tk.MustExec("insert into t17 values (1,10)")
+	tk.MustExec("insert into t18 values (1,100,0), (1,101,1)")
+	buildFilterT18SQL := "select /*+ HASH_JOIN_BUILD(t18) */ t17.a, t17.b, t18.a, t18.b, t18.c from t17 full outer join t18 on t17.a = t18.a and t18.c = 1 order by isnull(t17.b), t17.b, isnull(t18.b), t18.b"
+	assertBuildSideForTables(buildFilterT18SQL, "t17", "t18", "t18")
+	tk.MustQuery(buildFilterT18SQL).Check(testkit.Rows(
+		"1 10 1 101 1",
+		"<nil> <nil> 1 100 0",
+	))
+
+	// t1/t2 side filters in ON should not be pushed down as child selections in full join.
+	tk.MustQuery("select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a and t1.c = 1 and t2.c = 1 order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b").Check(testkit.Rows(
+		"1 10 1 100",
+		"2 20 <nil> <nil>",
+		"3 30 <nil> <nil>",
+		"<nil> <nil> 3 300",
+		"<nil> <nil> 4 400",
+		"<nil> <nil> <nil> 500",
+		"<nil> 40 <nil> <nil>",
+	))
+
+	// Key bucket exists but other condition filters all rows: both sides must be preserved as unmatched.
+	tk.MustExec("drop table if exists t3, t4")
+	tk.MustExec("create table t3(a int, b int)")
+	tk.MustExec("create table t4(a int, b int)")
+	tk.MustExec("insert into t3 values (1,1)")
+	tk.MustExec("insert into t4 values (1,2)")
+	tk.MustQuery("select t3.a, t3.b, t4.a, t4.b from t3 full outer join t4 on t3.a = t4.a and t3.b > t4.b order by isnull(t3.a), t3.a, isnull(t4.a), t4.a, t3.b, t4.b").Check(testkit.Rows(
+		"1 1 <nil> <nil>",
+		"<nil> <nil> 1 2",
+	))
+
+	// Null-safe equality can match NULL keys, while normal equality cannot.
+	tk.MustQuery("select t1.b, t2.b from t1 full outer join t2 on t1.a = t2.a where t1.a is null and t2.a is null order by t1.b, t2.b").Check(testkit.Rows(
+		"<nil> 500",
+		"40 <nil>",
+	))
+	tk.MustQuery("select t1.b, t2.b from t1 full outer join t2 on t1.a <=> t2.a where t1.a is null and t2.a is null order by t1.b, t2.b").Check(testkit.Rows(
+		"40 500",
+	))
+
+	// NULL-safe equality with duplicated NULL keys should produce N x M matches.
+	tk.MustExec("drop table if exists t5, t6")
+	tk.MustExec("create table t5(a int, b int)")
+	tk.MustExec("create table t6(a int, b int)")
+	tk.MustExec("insert into t5 values (null,1), (null,2), (1,10)")
+	tk.MustExec("insert into t6 values (null,100), (null,200), (2,20)")
+	tk.MustQuery("select t5.b, t6.b from t5 full outer join t6 on t5.a <=> t6.a where t5.a is null and t6.a is null order by t5.b, t6.b").Check(testkit.Rows(
+		"1 100",
+		"1 200",
+		"2 100",
+		"2 200",
+	))
+	tk.MustQuery("select t5.b, t6.b from t5 full outer join t6 on t5.a = t6.a where t5.a is null or t6.a is null order by isnull(t5.b), t5.b, isnull(t6.b), t6.b").Check(testkit.Rows(
+		"1 <nil>",
+		"2 <nil>",
+		"10 <nil>",
+		"<nil> 20",
+		"<nil> 100",
+		"<nil> 200",
+	))
+
+	// Multi-row key bucket + other-condition all filtered: every row on both sides should remain unmatched.
+	tk.MustExec("drop table if exists t7, t8")
+	tk.MustExec("create table t7(a int, b int)")
+	tk.MustExec("create table t8(a int, b int)")
+	tk.MustExec("insert into t7 values (1,1), (1,2)")
+	tk.MustExec("insert into t8 values (1,3), (1,4)")
+	tk.MustQuery("select t7.a, t7.b, t8.a, t8.b from t7 full outer join t8 on t7.a = t8.a and t7.b > t8.b order by isnull(t7.b), t7.b, isnull(t8.b), t8.b").Check(testkit.Rows(
+		"1 1 <nil> <nil>",
+		"1 2 <nil> <nil>",
+		"<nil> <nil> 1 3",
+		"<nil> <nil> 1 4",
+	))
+
+	// In one key bucket, only matched build rows should be marked as matched.
+	tk.MustExec("drop table if exists t9, t10")
+	tk.MustExec("create table t9(a int, b int)")
+	tk.MustExec("create table t10(a int, b int)")
+	tk.MustExec("insert into t9 values (1,1), (1,10)")
+	tk.MustExec("insert into t10 values (1,5)")
+	tk.MustQuery("select t9.a, t9.b, t10.a, t10.b from t9 full outer join t10 on t9.a = t10.a and t9.b > t10.b order by isnull(t9.b), t9.b, isnull(t10.b), t10.b").Check(testkit.Rows(
+		"1 1 <nil> <nil>",
+		"1 10 1 5",
+	))
+
+	// Complex other conditions should still keep unmatched rows from both sides.
+	tk.MustExec("drop table if exists t11, t12")
+	tk.MustExec("create table t11(a int, b int, c int)")
+	tk.MustExec("create table t12(a int, b int, c int)")
+	tk.MustExec("insert into t11 values (1,10,1), (1,2,0), (2,5,1), (3,8,0)")
+	tk.MustExec("insert into t12 values (1,3,1), (1,20,0), (2,4,0), (4,7,1)")
+	tk.MustQuery("select t11.a, t11.b, t12.a, t12.b from t11 full outer join t12 on t11.a = t12.a and ((t11.b > t12.b and t12.c = 1) or (t11.c = 1 and t12.b < 5)) order by isnull(t11.a), t11.a, isnull(t12.a), t12.a, isnull(t11.b), t11.b, isnull(t12.b), t12.b").Check(testkit.Rows(
+		"1 10 1 3",
+		"1 2 <nil> <nil>",
+		"2 5 2 4",
+		"3 8 <nil> <nil>",
+		"<nil> <nil> 1 20",
+		"<nil> <nil> 4 7",
+	))
+}
+
+func TestFullOuterJoinHashJoinV1Spill(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_full_outer_join = 1")
+	tk.MustExec(join.DisableHashJoinV2)
+
+	fpName := "github.com/pingcap/tidb/pkg/executor/join/testRowContainerSpill"
+	require.NoError(t, failpoint.Enable(fpName, "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(fpName))
+	}()
+
+	originEnableTmpStorageOnOOM := fmt.Sprint(tk.MustQuery("select @@global.tidb_enable_tmp_storage_on_oom").Rows()[0][0])
+	tk.MustExec("set global tidb_enable_tmp_storage_on_oom=on")
+	defer tk.MustExec(fmt.Sprintf("set global tidb_enable_tmp_storage_on_oom=%s", originEnableTmpStorageOnOOM))
+
+	originMemOOMAction := fmt.Sprint(tk.MustQuery("select @@global.tidb_mem_oom_action").Rows()[0][0])
+	tk.MustExec("set global tidb_mem_oom_action='LOG'")
+	defer tk.MustExec(fmt.Sprintf("set global tidb_mem_oom_action='%s'", originMemOOMAction))
+
+	tk.MustExec("set @@tidb_mem_quota_query=1")
+
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int, b int)")
+	tk.MustExec("create table t2(a int, b int)")
+	tk.MustExec("insert into t1 values (1,10), (2,20), (2,21), (null,30)")
+	tk.MustExec("insert into t2 values (2,200), (3,300), (null,400)")
+
+	sql := "select /*+ HASH_JOIN_BUILD(t2) */ t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a"
+	explainRows := tk.MustQuery("explain analyze " + sql).Rows()
+	foundHashJoin := false
+	for _, row := range explainRows {
+		line := fmt.Sprint(row)
+		if strings.Contains(line, "HashJoin") {
+			disk := fmt.Sprint(row[len(row)-1])
+			require.NotContains(t, disk, "0 Bytes", "hash join should spill, row=%v", row)
+			foundHashJoin = true
+		}
+	}
+	require.True(t, foundHashJoin, "explain rows=%v", explainRows)
+
+	tk.MustQuery(sql).Sort().Check(testkit.Rows(
+		"1 10 <nil> <nil>",
+		"2 20 2 200",
+		"2 21 2 200",
+		"<nil> 30 <nil> <nil>",
+		"<nil> <nil> 3 300",
+		"<nil> <nil> <nil> 400",
+	))
+}
+
+func TestFullOuterJoinHashJoinV1AgainstRewriteOracle(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_full_outer_join = 1")
+	tk.MustExec(join.DisableHashJoinV2)
+
+	tk.MustExec("drop table if exists l, r")
+	tk.MustExec("create table l(id int primary key, k int, v int, f int)")
+	tk.MustExec("create table r(id int primary key, k int, v int, f int)")
+	tk.MustExec("insert into l values (1,1,10,1), (2,1,2,0), (3,2,5,1), (4,null,7,1), (5,3,8,0)")
+	tk.MustExec("insert into r values (11,1,3,1), (12,1,20,0), (13,2,4,0), (14,null,30,1), (15,4,9,1)")
+
+	assertEquivalent := func(fojSQL, rewriteSQL string) {
+		for _, hinted := range []string{
+			fojSQL,
+			strings.Replace(fojSQL, "select ", "select /*+ HASH_JOIN_BUILD(l) */ ", 1),
+			strings.Replace(fojSQL, "select ", "select /*+ HASH_JOIN_BUILD(r) */ ", 1),
+		} {
+			got := tk.MustQuery(hinted).Sort()
+			expected := tk.MustQuery(rewriteSQL).Sort()
+			got.Check(expected.Rows())
+		}
+	}
+
+	assertEquivalent(
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l full outer join r on l.k = r.k",
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l left join r on l.k = r.k "+
+			"union all "+
+			"select l2.id, l2.k, l2.v, r2.id, r2.k, r2.v from r r2 left join l l2 on l2.k = r2.k where l2.id is null",
+	)
+
+	assertEquivalent(
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l full outer join r on l.k <=> r.k",
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l left join r on l.k <=> r.k "+
+			"union all "+
+			"select l2.id, l2.k, l2.v, r2.id, r2.k, r2.v from r r2 left join l l2 on l2.k <=> r2.k where l2.id is null",
+	)
+
+	assertEquivalent(
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l full outer join r on l.k = r.k and l.f = 1 and r.f = 1",
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l left join r on l.k = r.k and l.f = 1 and r.f = 1 "+
+			"union all "+
+			"select l2.id, l2.k, l2.v, r2.id, r2.k, r2.v from r r2 left join l l2 on l2.k = r2.k and l2.f = 1 and r2.f = 1 where l2.id is null",
+	)
+
+	assertEquivalent(
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l full outer join r on l.k = r.k and ((l.v > r.v and r.f = 1) or (l.f = 1 and r.v < 5))",
+		"select l.id, l.k, l.v, r.id, r.k, r.v from l left join r on l.k = r.k and ((l.v > r.v and r.f = 1) or (l.f = 1 and r.v < 5)) "+
+			"union all "+
+			"select l2.id, l2.k, l2.v, r2.id, r2.k, r2.v from r r2 left join l l2 on l2.k = r2.k and ((l2.v > r2.v and r2.f = 1) or (l2.f = 1 and r2.v < 5)) where l2.id is null",
+	)
+}
+
 func TestOuterTableBuildHashTableIsuse13933(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -101,19 +101,24 @@ func TestFullOuterJoinSyntaxUnsupported(t *testing.T) {
 	tk.MustExec("create table t1(a int)")
 	tk.MustExec("create table t2(a int)")
 
-	sqls := []string{
-		"select * from t1 full outer join t2 on t1.a = t2.a",
+	fullOuterJoinSQL := "select * from t1 full outer join t2 on t1.a = t2.a"
+	unsupportedSQLs := []string{
 		"select * from t1 full outer join lateral (select 1 as a) as t2 on false",
 		"select * from t1 full outer join lateral (select t1.a) as t2 on true",
 		"select * from t1 full outer join (t2 join lateral (select t2.a) as t3 on true) on false",
 	}
 	expectedErr := plannererrors.ErrNotSupportedYet.GenWithStackByArgs("FULL OUTER JOIN")
-	for _, enableFullOuterJoin := range []string{"off", "on"} {
-		tk.MustExec("set @@tidb_enable_full_outer_join=" + enableFullOuterJoin)
-		for _, sql := range sqls {
-			err := tk.ExecToErr(sql)
-			require.Truef(t, terror.ErrorEqual(expectedErr, err), "sql: %s, err: %v", sql, err)
-		}
+	tk.MustExec("set @@tidb_enable_full_outer_join=off")
+	for _, sql := range append([]string{fullOuterJoinSQL}, unsupportedSQLs...) {
+		err := tk.ExecToErr(sql)
+		require.Truef(t, terror.ErrorEqual(expectedErr, err), "sql: %s, err: %v", sql, err)
+	}
+
+	tk.MustExec("set @@tidb_enable_full_outer_join=on")
+	require.NoError(t, tk.ExecToErr(fullOuterJoinSQL))
+	for _, sql := range unsupportedSQLs {
+		err := tk.ExecToErr(sql)
+		require.Truef(t, terror.ErrorEqual(expectedErr, err), "sql: %s, err: %v", sql, err)
 	}
 }
 

--- a/tests/integrationtest/r/executor/jointest/full_outer_join.result
+++ b/tests/integrationtest/r/executor/jointest/full_outer_join.result
@@ -1,0 +1,74 @@
+set @@tidb_enable_cascades_planner = 0;
+set @@tidb_enable_full_outer_join = 1;
+set @@tidb_hash_join_version = legacy;
+drop table if exists t1, t2;
+create table t1(a int, b int, c int);
+create table t2(a int, b int, c int);
+insert into t1 values (1,10,1), (2,20,0), (3,30,1), (null,40,1);
+insert into t2 values (1,100,1), (3,300,0), (4,400,1), (null,500,1);
+select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b;
+a	b	a	b
+1	10	1	100
+2	20	NULL	NULL
+3	30	3	300
+NULL	NULL	4	400
+NULL	NULL	NULL	500
+NULL	40	NULL	NULL
+select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a and t1.c = 1 and t2.c = 1 order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b;
+a	b	a	b
+1	10	1	100
+2	20	NULL	NULL
+3	30	NULL	NULL
+NULL	NULL	3	300
+NULL	NULL	4	400
+NULL	NULL	NULL	500
+NULL	40	NULL	NULL
+select t1.b, t2.b from t1 full outer join t2 on t1.a = t2.a where t1.a is null and t2.a is null order by t1.b, t2.b;
+b	b
+NULL	500
+40	NULL
+select t1.b, t2.b from t1 full outer join t2 on t1.a <=> t2.a where t1.a is null and t2.a is null order by t1.b, t2.b;
+b	b
+40	500
+drop table if exists t3, t4;
+create table t3(a int, b int);
+create table t4(a int, b int);
+insert into t3 values (null,1), (null,2), (1,10);
+insert into t4 values (null,100), (null,200), (2,20);
+select t3.b, t4.b from t3 full outer join t4 on t3.a <=> t4.a where t3.a is null and t4.a is null order by t3.b, t4.b;
+b	b
+1	100
+1	200
+2	100
+2	200
+select t3.b, t4.b from t3 full outer join t4 on t3.a = t4.a where t3.a is null or t4.a is null order by isnull(t3.b), t3.b, isnull(t4.b), t4.b;
+b	b
+1	NULL
+2	NULL
+10	NULL
+NULL	20
+NULL	100
+NULL	200
+drop table if exists t5, t6;
+create table t5(a int, b int, c int);
+create table t6(a int, b int, c int);
+insert into t5 values (1,10,1), (1,2,0), (2,5,1), (3,8,0);
+insert into t6 values (1,3,1), (1,20,0), (2,4,0), (4,7,1);
+select t5.a, t5.b, t6.a, t6.b from t5 full outer join t6 on t5.a = t6.a and ((t5.b > t6.b and t6.c = 1) or (t5.c = 1 and t6.b < 5)) order by isnull(t5.a), t5.a, isnull(t6.a), t6.a, isnull(t5.b), t5.b, isnull(t6.b), t6.b;
+a	b	a	b
+1	10	1	3
+1	2	NULL	NULL
+2	5	2	4
+3	8	NULL	NULL
+NULL	NULL	1	20
+NULL	NULL	4	7
+select * from t1 full outer join t2 using (a);
+Error 1235 (42000): This version of TiDB doesn't yet support 'FULL OUTER JOIN'
+select * from t1 natural full outer join t2;
+Error 1235 (42000): This version of TiDB doesn't yet support 'FULL OUTER JOIN'
+set @@tidb_enable_cascades_planner = 1;
+select * from t1 full outer join t2 on t1.a = t2.a;
+Error 1235 (42000): This version of TiDB doesn't yet support 'FULL OUTER JOIN with cascades planner'
+set @@tidb_enable_cascades_planner = default;
+set @@tidb_enable_full_outer_join = default;
+set @@tidb_hash_join_version = default;

--- a/tests/integrationtest/t/executor/jointest/full_outer_join.test
+++ b/tests/integrationtest/t/executor/jointest/full_outer_join.test
@@ -1,0 +1,47 @@
+# TestFullOuterJoinHashJoinV1Basic
+set @@tidb_enable_cascades_planner = 0;
+set @@tidb_enable_full_outer_join = 1;
+set @@tidb_hash_join_version = legacy;
+
+drop table if exists t1, t2;
+create table t1(a int, b int, c int);
+create table t2(a int, b int, c int);
+insert into t1 values (1,10,1), (2,20,0), (3,30,1), (null,40,1);
+insert into t2 values (1,100,1), (3,300,0), (4,400,1), (null,500,1);
+
+select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b;
+select t1.a, t1.b, t2.a, t2.b from t1 full outer join t2 on t1.a = t2.a and t1.c = 1 and t2.c = 1 order by isnull(t1.a), t1.a, isnull(t2.a), t2.a, t1.b, t2.b;
+select t1.b, t2.b from t1 full outer join t2 on t1.a = t2.a where t1.a is null and t2.a is null order by t1.b, t2.b;
+select t1.b, t2.b from t1 full outer join t2 on t1.a <=> t2.a where t1.a is null and t2.a is null order by t1.b, t2.b;
+
+# TestFullOuterJoinNullAndOtherCondition
+
+drop table if exists t3, t4;
+create table t3(a int, b int);
+create table t4(a int, b int);
+insert into t3 values (null,1), (null,2), (1,10);
+insert into t4 values (null,100), (null,200), (2,20);
+
+select t3.b, t4.b from t3 full outer join t4 on t3.a <=> t4.a where t3.a is null and t4.a is null order by t3.b, t4.b;
+select t3.b, t4.b from t3 full outer join t4 on t3.a = t4.a where t3.a is null or t4.a is null order by isnull(t3.b), t3.b, isnull(t4.b), t4.b;
+
+drop table if exists t5, t6;
+create table t5(a int, b int, c int);
+create table t6(a int, b int, c int);
+insert into t5 values (1,10,1), (1,2,0), (2,5,1), (3,8,0);
+insert into t6 values (1,3,1), (1,20,0), (2,4,0), (4,7,1);
+select t5.a, t5.b, t6.a, t6.b from t5 full outer join t6 on t5.a = t6.a and ((t5.b > t6.b and t6.c = 1) or (t5.c = 1 and t6.b < 5)) order by isnull(t5.a), t5.a, isnull(t6.a), t6.a, isnull(t5.b), t5.b, isnull(t6.b), t6.b;
+
+# TestFullOuterJoinUnsupportedForms
+--error 1235
+select * from t1 full outer join t2 using (a);
+--error 1235
+select * from t1 natural full outer join t2;
+
+set @@tidb_enable_cascades_planner = 1;
+--error 1235
+select * from t1 full outer join t2 on t1.a = t2.a;
+
+set @@tidb_enable_cascades_planner = default;
+set @@tidb_enable_full_outer_join = default;
+set @@tidb_hash_join_version = default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69998

Problem Summary:

### What changed and how does it work?
This is the executor part support for full outer join.
Currently, only hash join v1 is supported.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for full outer joins in the V1 hash join engine.
  - Preserves unmatched rows from both sides, including correct handling of filters, NULL values, duplicate keys, and complex join conditions.
  - Supports spilling and equality, NULL-safe, and non-equality join predicates.

- **Bug Fixes**
  - Corrected handling of unmatched rows and side-specific filtering.

- **Tests**
  - Added comprehensive coverage for full outer joins, unsupported syntax, and planner scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->