### PR TITLE
session: initialize MDL before starting the DDL scheduler during upgrade

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -108,7 +108,7 @@ func (g Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 		return nil, errors.Trace(err)
 	}
 	if existDom == nil {
-		err = session.InitMDLVariable(store)
+		_, err = session.InitMDLVariable(store, session.MDLInitKeepDisabledOnNull)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +200,7 @@ func (g Glue) UseOneShotSession(store kv.Storage, closeDomain bool, fn func(glue
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = session.InitMDLVariable(store); err != nil {
+	if _, err = session.InitMDLVariable(store, session.MDLInitKeepDisabledOnNull); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -63,10 +63,6 @@ var bootstrapOwnerKey = "/tidb/distributeDDLOwnerLock/"
 // bootstrap initiates system DB for a store.
 func bootstrap(s sessionapi.Session) {
 	startTime := time.Now()
-	err := InitMDLVariableForBootstrap(s.GetStore())
-	if err != nil {
-		logutil.BgLogger().Fatal("init metadata lock failed during bootstrap", zap.Error(err))
-	}
 	dom := domain.GetDomain(s)
 	bootLogger := logutil.SampleLoggerFactory(30*time.Second, 1)()
 	for {
@@ -77,7 +73,9 @@ func bootstrap(s sessionapi.Session) {
 		}
 		// For rolling upgrade, we can't do upgrade only in the owner.
 		if b {
-			upgrade(s)
+			// Bootstrap initialization has already persisted and enabled MDL
+			// before the domain started, so no legacy MDL migration is needed.
+			upgradeWithMDLState(s, false)
 			logutil.BgLogger().Info("upgrade successful in bootstrap",
 				zap.Duration("take time", time.Since(startTime)))
 			return

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4325,19 +4325,6 @@ func createAndSplitTables(store kv.Storage, t *meta.Mutator, dbID int64, tables 
 	return nil
 }
 
-// InitMDLVariableForBootstrap initializes the metadata lock variable.
-func InitMDLVariableForBootstrap(store kv.Storage) error {
-	err := kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, true, func(_ context.Context, txn kv.Transaction) error {
-		t := meta.NewMutator(txn)
-		return t.SetMetadataLock(true)
-	})
-	if err != nil {
-		return err
-	}
-	vardef.SetEnableMDL(true)
-	return nil
-}
-
 // InitTiDBSchemaCacheSize initializes the tidb schema cache size.
 func InitTiDBSchemaCacheSize(store kv.Storage) error {
 	var (
@@ -4362,32 +4349,6 @@ func InitTiDBSchemaCacheSize(store kv.Storage) error {
 	}
 	vardef.SchemaCacheSize.Store(size)
 	return nil
-}
-
-// InitMDLVariable initializes the metadata lock variable.
-func InitMDLVariable(store kv.Storage) error {
-	isNull := false
-	enable := false
-	var err error
-	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, true, func(_ context.Context, txn kv.Transaction) error {
-		t := meta.NewMutator(txn)
-		enable, isNull, err = t.GetMetadataLock()
-		if err != nil {
-			return err
-		}
-		if isNull {
-			// Workaround for version: nightly-2022-11-07 to nightly-2022-11-17.
-			enable = true
-			logutil.BgLogger().Warn("metadata lock is null")
-			err = t.SetMetadataLock(true)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	vardef.SetEnableMDL(enable)
-	return err
 }
 
 // BootstrapSession bootstrap session and domain.
@@ -4463,7 +4424,7 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 		}
 	} else {
 		logutil.BgLogger().Info("cluster already bootstrapped", zap.Int64("version", ver))
-		err = InitMDLVariable(store)
+		_, err = InitMDLVariable(store, MDLInitEnableOnNull)
 		if err != nil {
 			return nil, err
 		}
@@ -4759,6 +4720,29 @@ func runInBootstrapSession(store kv.Storage, ver int64, opts domainCreateOptions
 			}
 		}
 	}
+	// The DDL scheduler can start running jobs as soon as dom.Start returns, so
+	// persist any MDL change and initialize the runtime state first.
+	var (
+		mdlIsNull bool
+		err       error
+	)
+	switch startMode {
+	case ddl.Bootstrap:
+		mdlIsNull, err = InitMDLVariable(store, MDLInitForceEnable)
+	case ddl.Upgrade:
+		mdlIsNull, err = InitMDLVariable(store, MDLInitKeepDisabledOnNull)
+	case ddl.Normal:
+		// The initial mode was Upgrade, but another TiDB completed the upgrade
+		// before this instance acquired the upgrade lock.
+		// See https://github.com/pingcap/tidb/issues/64539.
+		mdlIsNull, err = InitMDLVariable(store, MDLInitEnableOnNull)
+	default:
+		return errors.Errorf("unknown start mode %q when initializing metadata lock", startMode)
+	}
+	if err != nil {
+		logutil.BgLogger().Fatal("init metadata lock before starting domain failed",
+			zap.String("startMode", string(startMode)), zap.Error(err))
+	}
 	s, err := createSessionWithDomainOptions(store, opts)
 	if err != nil {
 		// Bootstrap fail will cause program exit.
@@ -4784,13 +4768,7 @@ func runInBootstrapSession(store kv.Storage, ver int64, opts domainCreateOptions
 		// below sleep is used to mitigate https://github.com/pingcap/tidb/issues/57003,
 		// to let the older owner have time to notice that it's already retired.
 		time.Sleep(owner.WaitTimeOnForceOwner)
-		upgrade(s)
-	case ddl.Normal:
-		// We need to init MDL variable before start the domain to prevent potential stuck issue
-		// when upgrade is skipped. See https://github.com/pingcap/tidb/issues/64539.
-		if err := InitMDLVariable(store); err != nil {
-			logutil.BgLogger().Fatal("init metadata lock failed during normal startup", zap.Error(err))
-		}
+		upgradeWithMDLState(s, mdlIsNull)
 	}
 	finishBootstrap(store)
 	s.ClearValue(sessionctx.Initing)

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -325,6 +325,29 @@ func TestUpgradeVersion75(t *testing.T) {
 }
 
 func TestUpgradeVersionMockLatest(t *testing.T) {
+	t.Run("bootstrap initializes MDL before scheduler starts", func(t *testing.T) {
+		vardef.SetEnableMDL(false)
+		t.Cleanup(func() { vardef.SetEnableMDL(true) })
+		mdlAtFirstSchedulerDispatch := make(chan bool, 1)
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeLoadAndDeliverJobs", func() {
+			select {
+			case mdlAtFirstSchedulerDispatch <- vardef.IsMDLEnabled():
+			default:
+			}
+		})
+
+		store, dom := session.CreateStoreAndBootstrap(t)
+		dom.Close()
+		require.NoError(t, store.Close())
+		select {
+		case mdlEnabled := <-mdlAtFirstSchedulerDispatch:
+			require.True(t, mdlEnabled,
+				"MDL must be initialized before the bootstrap DDL scheduler starts")
+		default:
+			require.FailNow(t, "the bootstrap DDL scheduler did not dispatch")
+		}
+	})
+
 	mock := true
 	session.WithMockUpgrade = &mock
 
@@ -346,9 +369,27 @@ func TestUpgradeVersionMockLatest(t *testing.T) {
 	require.Equal(t, session.CurrentBootstrapVersion-1, ver)
 	startUpgrade(store)
 	dom.Close()
+	// Simulate the process-wide default on a newly started TiDB instance. The
+	// persisted MDL setting is still enabled in the store.
+	vardef.SetEnableMDL(false)
+	t.Cleanup(func() { vardef.SetEnableMDL(true) })
+	mdlAtFirstSchedulerDispatch := make(chan bool, 1)
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeLoadAndDeliverJobs", func() {
+		select {
+		case mdlAtFirstSchedulerDispatch <- vardef.IsMDLEnabled():
+		default:
+		}
+	})
 	domLatestV, err := session.BootstrapSession(store)
 	require.NoError(t, err)
 	defer domLatestV.Close()
+	select {
+	case mdlEnabled := <-mdlAtFirstSchedulerDispatch:
+		require.True(t, mdlEnabled,
+			"the persisted MDL setting must be loaded before the upgrade DDL scheduler starts")
+	default:
+		require.FailNow(t, "the upgrade DDL scheduler did not dispatch")
+	}
 
 	finishUpgrade(store)
 

--- a/pkg/session/upgrade_run.go
+++ b/pkg/session/upgrade_run.go
@@ -27,17 +27,11 @@ import (
 	"go.uber.org/zap"
 )
 
-// upgrade function  will do some upgrade works, when the system is bootstrapped by low version TiDB server
-// For example, add new system variables into mysql.global_variables table.
-func upgrade(s sessionapi.Session) {
+// upgradeWithMDLState runs upgrade work after the persisted MDL state has been loaded.
+func upgradeWithMDLState(s sessionapi.Session, mdlIsNull bool) {
 	// Do upgrade works then update bootstrap version.
-	isNull, err := InitMDLVariableForUpgrade(s.GetStore())
-	if err != nil {
-		logutil.BgLogger().Fatal("init metadata lock failed during upgrade", zap.Error(err))
-	}
-
 	var ver int64
-	ver, err = getBootstrapVersion(s)
+	ver, err := getBootstrapVersion(s)
 	terror.MustNil(err)
 	if ver >= currentBootstrapVersion {
 		// It is already bootstrapped/upgraded by a higher version TiDB server.
@@ -48,7 +42,7 @@ func upgrade(s sessionapi.Session) {
 
 	// when upgrade from v6.4.0 or earlier, enables metadata lock automatically,
 	// but during upgrade we disable it.
-	if isNull {
+	if mdlIsNull {
 		upgradeToVer99Before(s)
 	}
 
@@ -63,7 +57,7 @@ func upgrade(s sessionapi.Session) {
 				zap.Int64("target-version", currentBootstrapVersion))
 		}
 	}
-	if isNull {
+	if mdlIsNull {
 		upgradeToVer99After(s)
 	}
 
@@ -92,25 +86,55 @@ func upgrade(s sessionapi.Session) {
 	}
 }
 
-// InitMDLVariableForUpgrade initializes the metadata lock variable.
-func InitMDLVariableForUpgrade(store kv.Storage) (bool, error) {
-	isNull := false
+// MDLInitPolicy controls how InitMDLVariable handles a missing persisted MDL value.
+type MDLInitPolicy int
+
+const (
+	// MDLInitForceEnable is used by Bootstrap. It always persists and enables MDL.
+	MDLInitForceEnable MDLInitPolicy = iota
+	// MDLInitEnableOnNull is used by Normal startup. It repairs a missing key
+	// as enabled for compatibility with nightly-2022-11-07 to nightly-2022-11-17.
+	MDLInitEnableOnNull
+	// MDLInitKeepDisabledOnNull is used by Upgrade and BR. It leaves a missing
+	// key untouched and preserves the legacy non-MDL behavior.
+	MDLInitKeepDisabledOnNull
+)
+
+// InitMDLVariable applies the policy-specific MDL change in one transaction.
+// It initializes the process-wide runtime setting only after that transaction
+// succeeds. For policies that read the existing value, isNull reports whether
+// the key was missing before the policy was applied.
+func InitMDLVariable(store kv.Storage, policy MDLInitPolicy) (isNull bool, err error) {
 	enable := false
-	var err error
 	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, true, func(_ context.Context, txn kv.Transaction) error {
 		t := meta.NewMutator(txn)
+		if policy == MDLInitForceEnable {
+			enable = true
+			return t.SetMetadataLock(true)
+		}
 		enable, isNull, err = t.GetMetadataLock()
 		if err != nil {
 			return err
 		}
+		switch policy {
+		case MDLInitEnableOnNull:
+			if isNull {
+				enable = true
+				logutil.BgLogger().Warn("metadata lock is null")
+				return t.SetMetadataLock(true)
+			}
+		case MDLInitKeepDisabledOnNull:
+			// Keep the value returned from meta KV. A missing key is read as false.
+		default:
+			panic("invalid MDL initialization policy")
+		}
 		return nil
 	})
-	if isNull || !enable {
-		vardef.SetEnableMDL(false)
-	} else {
-		vardef.SetEnableMDL(true)
+	if err != nil {
+		return isNull, err
 	}
-	return isNull, err
+	vardef.SetEnableMDL(enable)
+	return isNull, nil
 }
 
 func printClusterState(s sessionapi.Session, ver int64) {


### PR DESCRIPTION
<!--

  Thank you for contributing to TiDB!

  PR Title Format:
  1. pkg [, pkg2, pkg3]: what's changed
  2. *: what's changed

  -->

### What problem does this PR solve?


Issue Number: close #70383

Problem Summary:

During bootstrap or upgrade, TiDB starts the DDL scheduler as part of `dom.Start`. Previously, the persisted metadata lock state was initialized after `dom.Start`.

A newly upgraded TiDB instance could therefore start processing DDL jobs using the default non-MDL synchronization path, while other TiDB instances used the persisted MDL configuration. When schema versions continued to
advance, the inconsistent synchronization paths could cause DDL jobs to wait indefinitely and block the TiDB upgrade.

### What changed and how does it work?

This PR initializes the metadata lock state before starting the domain and DDL scheduler.

The initialization preserves the existing behavior for each startup mode:

- Bootstrap always persists and enables MDL.
- Normal startup loads the persisted value and enables MDL when the value is missing, preserving the existing compatibility behavior.
- Upgrade loads the persisted value without modifying a missing value and passes the original missing-value state to the existing upgrade migration.

The KV operation completes before the process-wide in-memory MDL state is updated.  TiDB and BR now use a single policy-driven MDL initialization API, with each caller explicitly selecting the required missing-value behavior.

Regression tests verify that the DDL scheduler observes the initialized MDL state on its first dispatch during bootstrap and upgrade.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note
<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to Release Notes Language Style Guide (https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata-lock initialization during startup and rolling upgrades.
  - Ensured metadata locking is enabled before bootstrap and upgrade operations begin.
  - Preserved intentionally disabled metadata-lock settings where appropriate.
  - Improved handling of missing metadata-lock settings for more reliable upgrade behavior.
  - Applied metadata-lock state changes only after successful upgrade transactions.

- **Tests**
  - Added coverage verifying metadata locking is active before initial bootstrap and upgrade tasks run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->