### PR TITLE
DO NOT MERGE: allow __force_merge_step under SEM for benchmarking #70305

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -368,8 +368,9 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 			require.ErrorIs(t, err, exeerrors.ErrLoadDataUnsupportedOption)
 			require.ErrorContains(t, err, option)
 		}
+		// DO NOT MERGE: __force_merge_step is temporarily allowed under SEM, see
+		// disallowedOptionsForSEM.
 		for _, option := range []string{
-			"__force_merge_step",
 			"__manual_recovery",
 		} {
 			err := tk.QueryToErr(fmt.Sprintf("IMPORT INTO test.t FROM 's3://bucket/*.csv?access-key=ak&secret-access-key=sk' with %s", option))

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -184,9 +184,11 @@ var (
 		recordErrorsOption:    {},
 	}
 
+	// DO NOT MERGE: forceMergeStep is temporarily allowed under SEM so that a
+	// SEM-enabled cluster can force the global-sort merge step when benchmarking
+	// https://github.com/pingcap/tidb/pull/70305. Restore it before merging.
 	disallowedOptionsForSEM = map[string]struct{}{
 		maxEngineSizeOption:  {},
-		forceMergeStep:       {},
 		manualRecoveryOption: {},
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70305

Problem Summary:

**This PR is a temporary build aid and must not be merged.**

`__force_merge_step` is listed in `disallowedOptionsForSEM`, so on a SEM-enabled
cluster there is no way to force the global-sort merge step. Benchmarking
#70305 needs both arms: the merge step skipped (which `skipMergeSort` picks
automatically when overlap is low) and the merge step forced, because the two
produce very different KV file shapes for `readAllData` — many overlapping
files with small per-file byte ranges versus few disjoint files with large
ones. Only the second shape exercises the per-file buffer cap and refill path
that #70305 changes.

### What changed and how does it work?

- Remove `forceMergeStep` from `disallowedOptionsForSEM`.
- Drop `__force_merge_step` from the SEM rejection list in
  `TestImportIntoOptionsWithSEM`, which asserts the old behavior.

Both changes carry a `DO NOT MERGE` comment.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Built and vetted locally:

```shell
go build ./pkg/executor/importer/
go vet -tags=intest ./pkg/executor/importer/
```

The change is exercised by running, on a SEM-enabled cluster:

```sql
IMPORT INTO t FROM 's3://.../*.csv' WITH __force_merge_step, cloud_storage_uri = 's3://.../';
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
