### PR TITLE
ddl: quote identifiers for internal SQLs in modify column

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -848,6 +848,10 @@ func checkModifyColumnData(
 	return true, nil
 }
 
+func quoteSQLIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
 // buildCheckSQLFromModifyColumn builds the SQL to check whether the data
 // is valid after modifying to new type.
 func buildCheckSQLFromModifyColumn(
@@ -860,8 +864,8 @@ func buildCheckSQLFromModifyColumn(
 
 	var conditions []string
 	template := "SELECT %s FROM %s WHERE %s LIMIT 1"
-	checkColName := fmt.Sprintf("`%s`", oldCol.Name.O)
-	tableName := fmt.Sprintf("`%s`.`%s`", dbName.O, tblName.O)
+	checkColName := quoteSQLIdentifier(oldCol.Name.O)
+	tableName := fmt.Sprintf("%s.%s", quoteSQLIdentifier(dbName.O), quoteSQLIdentifier(tblName.O))
 
 	if checkValueRange {
 		if mysql.IsIntegerType(oldTp) && mysql.IsIntegerType(changingTp) {
@@ -877,7 +881,7 @@ func buildCheckSQLFromModifyColumn(
 
 	if isNullToNotNullChange(oldCol, changingCol) {
 		if !(oldTp != mysql.TypeTimestamp && changingTp == mysql.TypeTimestamp) {
-			conditions = append(conditions, fmt.Sprintf("`%s` IS NULL", oldCol.Name.O))
+			conditions = append(conditions, fmt.Sprintf("%s IS NULL", checkColName))
 		}
 	}
 
@@ -893,7 +897,7 @@ func buildCheckRangeForIntegerTypes(oldCol, changingCol *model.ColumnInfo) strin
 	changingTp := changingCol.GetType()
 	changingUnsigned := mysql.HasUnsignedFlag(changingCol.GetFlag())
 
-	columnName := fmt.Sprintf("`%s`", oldCol.Name.O)
+	columnName := quoteSQLIdentifier(oldCol.Name.O)
 
 	if changingUnsigned {
 		upperBound := types.IntegerUnsignedUpperBound(changingTp)

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/generatedexpr"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -848,10 +849,6 @@ func checkModifyColumnData(
 	return true, nil
 }
 
-func quoteSQLIdentifier(identifier string) string {
-	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
-}
-
 // buildCheckSQLFromModifyColumn builds the SQL to check whether the data
 // is valid after modifying to new type.
 func buildCheckSQLFromModifyColumn(
@@ -864,8 +861,8 @@ func buildCheckSQLFromModifyColumn(
 
 	var conditions []string
 	template := "SELECT %s FROM %s WHERE %s LIMIT 1"
-	checkColName := quoteSQLIdentifier(oldCol.Name.O)
-	tableName := fmt.Sprintf("%s.%s", quoteSQLIdentifier(dbName.O), quoteSQLIdentifier(tblName.O))
+	checkColName := dbutil.ColumnName(oldCol.Name.O)
+	tableName := dbutil.TableName(dbName.O, tblName.O)
 
 	if checkValueRange {
 		if mysql.IsIntegerType(oldTp) && mysql.IsIntegerType(changingTp) {
@@ -897,7 +894,7 @@ func buildCheckRangeForIntegerTypes(oldCol, changingCol *model.ColumnInfo) strin
 	changingTp := changingCol.GetType()
 	changingUnsigned := mysql.HasUnsignedFlag(changingCol.GetFlag())
 
-	columnName := quoteSQLIdentifier(oldCol.Name.O)
+	columnName := dbutil.ColumnName(oldCol.Name.O)
 
 	if changingUnsigned {
 		upperBound := types.IntegerUnsignedUpperBound(changingTp)

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -384,6 +384,29 @@ func TestModifyColumnBetweenStringTypes(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1265|Data truncated for column 'a', value is '10000'"))
 
 	tk.MustExec("drop table tt;")
+	tk.MustExec("set @@sql_mode=default")
+	tk.MustExec("set @@global.tidb_ddl_error_count_limit=3")
+	defer tk.MustExec("set @@global.tidb_ddl_error_count_limit=default")
+
+	// issue 70285: identifiers in the generated check SQL can contain backticks.
+	tk.MustExec("create database `issue``70285`")
+	tk.MustExec("create table `issue``70285`.`range``check` (`value``col` int not null)")
+	tk.MustExec("insert into `issue``70285`.`range``check` values (1)")
+	tk.MustExec("alter table `issue``70285`.`range``check` modify column `value``col` tinyint not null")
+	rangeCol := external.GetModifyColumn(t, tk, "issue`70285", "range`check", "value`col", false)
+	require.Equal(t, mysql.TypeTiny, rangeCol.GetType())
+
+	tk.MustExec("create table `issue``70285`.`length``check` (`value``col` varchar(10))")
+	tk.MustExec("insert into `issue``70285`.`length``check` values ('value')")
+	tk.MustExec("alter table `issue``70285`.`length``check` modify column `value``col` varchar(5)")
+	lengthCol := external.GetModifyColumn(t, tk, "issue`70285", "length`check", "value`col", false)
+	require.Equal(t, 5, lengthCol.GetFlen())
+
+	tk.MustExec("create table `issue``70285`.`null``check` (`value``col` int)")
+	tk.MustExec("insert into `issue``70285`.`null``check` values (1)")
+	tk.MustExec("alter table `issue``70285`.`null``check` modify column `value``col` int not null")
+	nullCol := external.GetModifyColumn(t, tk, "issue`70285", "null`check", "value`col", false)
+	require.True(t, mysql.HasNotNullFlag(nullCol.GetFlag()))
 }
 
 func TestModifyColumnCharset(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70285

Problem Summary:

The no-reorg `MODIFY COLUMN` path builds an internal validation query by enclosing database, table, and column names in backticks without escaping embedded backticks. A valid identifier containing a backtick therefore produces invalid SQL and causes the DDL job to roll back.

### What changed and how does it work?

Reuse `dbutil.ColumnName` and `dbutil.TableName` to quote identifiers consistently in the qualified table name and the range, length, and nullability checks generated by `MODIFY COLUMN`.

Extend the existing modify-column unit test with database, table, and column names containing backticks. The test exercises integer range validation, string length validation, and NULL validation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

- `./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestModifyColumnBetweenStringTypes$' -count=1 -timeout=90s`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where `MODIFY COLUMN` could fail when a database, table, or column name contains a backtick.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when modifying columns in databases, tables, or columns with escaped backticks in their names.
  * Ensured validation checks work correctly for integer conversions, VARCHAR length changes, and nullable-to-NOT NULL updates.

* **Tests**
  * Added regression coverage for escaped SQL identifiers and related column modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->