### PR TITLE
ddl: fix pre split region for clustered common handles

### DIFF
--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/regionsplit"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -133,7 +134,10 @@ func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableS
 
 	// Split table region.
 	var ft *types.FieldType
-	if pkCol := tbInfo.GetPkColInfo(); pkCol != nil {
+	if tbInfo.IsCommonHandle {
+		primaryKey := tbInfo.GetPrimaryKey()
+		ft = &tbInfo.Columns[primaryKey.Columns[0].Offset].FieldType
+	} else if pkCol := tbInfo.GetPkColInfo(); pkCol != nil {
 		ft = &pkCol.FieldType
 	} else {
 		ft = types.NewFieldType(mysql.TypeLonglong)
@@ -146,7 +150,13 @@ func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableS
 	for p := step; p < maxv; p += step {
 		recordID := p << shardFmt.IncrementalBits
 		recordPrefix := tablecodec.GenTableRecordPrefix(physicalID)
-		key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(recordID))
+		handle, err := buildPreSplitRecordHandle(tbInfo, ft, recordID)
+		if err != nil {
+			logutil.DDLLogger().Warn("build pre-split record handle failed",
+				zap.Stringer("table", tbInfo.Name), zap.Int64("record ID", recordID), zap.Error(err))
+			continue
+		}
+		key := tablecodec.EncodeRecordKey(recordPrefix, handle)
 		splitTableKeys = append(splitTableKeys, key)
 	}
 	scatter, tableID := getScatterConfig(scatterScope, tbInfo.ID)
@@ -157,6 +167,24 @@ func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableS
 	}
 	regionIDs = append(regionIDs, splitIndexRegion(store, tbInfo, scatter, physicalID)...)
 	return regionIDs
+}
+
+func buildPreSplitRecordHandle(tbInfo *model.TableInfo, ft *types.FieldType, recordID int64) (kv.Handle, error) {
+	if !tbInfo.IsCommonHandle {
+		return kv.IntHandle(recordID), nil
+	}
+
+	// AUTO_RANDOM must be the first primary-key column, so its encoded value is a
+	// valid prefix of the common handle used as a region boundary.
+	datum := types.NewIntDatum(recordID)
+	if mysql.HasUnsignedFlag(ft.GetFlag()) {
+		datum = types.NewUintDatum(uint64(recordID))
+	}
+	encoded, err := codec.EncodeKey(nil, nil, datum)
+	if err != nil {
+		return nil, err
+	}
+	return kv.NewCommonHandle(encoded)
 }
 
 // SplitRecordRegion is to split region in store by table prefix.

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -64,7 +64,7 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 		// Try to split global index region here.
 		regionIDs = append(regionIDs, splitIndexRegion(store, tbInfo, scatter, tableID)...)
 		for _, def := range parts {
-			regionIDs = append(regionIDs, preSplitPhysicalTableByShardRowID(ctxWithTimeout, store, tbInfo, def.ID, scatterScope)...)
+			regionIDs = append(regionIDs, preSplitPhysicalTableByShardBits(ctxWithTimeout, store, tbInfo, def.ID, scatterScope)...)
 		}
 	} else {
 		regionIDs = make([]uint64, 0, len(parts))
@@ -86,7 +86,7 @@ func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *
 	if hasSplitPolicies(tbInfo) {
 		regionIDs = applySplitPoliciesForTable(ctxWithTimeout, ctx, store, tbInfo, tbInfo.ID)
 	} else if shardingBits(tbInfo) > 0 && tbInfo.PreSplitRegions > 0 {
-		regionIDs = preSplitPhysicalTableByShardRowID(ctxWithTimeout, store, tbInfo, tbInfo.ID, scatterScope)
+		regionIDs = preSplitPhysicalTableByShardBits(ctxWithTimeout, store, tbInfo, tbInfo.ID, scatterScope)
 	} else {
 		regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, tbInfo.ID, tbInfo.ID, scatterScope))
 	}
@@ -108,7 +108,7 @@ func getScatterConfig(scope string, tableID int64) (scatter bool, tID int64) {
 	}
 }
 
-func preSplitPhysicalTableByShardRowID(ctx context.Context, store kv.SplittableStore, tbInfo *model.TableInfo, physicalID int64, scatterScope string) []uint64 {
+func preSplitPhysicalTableByShardBits(ctx context.Context, store kv.SplittableStore, tbInfo *model.TableInfo, physicalID int64, scatterScope string) []uint64 {
 	// Example:
 	// sharding_bits = 4
 	// PreSplitRegions = 2

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -130,9 +130,10 @@ func preSplitPhysicalTableByShardBits(ctx context.Context, store kv.SplittableSt
 	// 4611686018427387904 ~ 6917529027641081856
 	// 6917529027641081856 ~ 9223372036854775807 ( (1 << 63) - 1 )
 	//
-	// And the max _tidb_rowid is 9223372036854775807, it won't be negative number.
+	// This example assumes a signed BIGINT. NewShardIDFormat adjusts IncrementalBits
+	// for unsigned AUTO_RANDOM columns.
 
-	// Split table region.
+	// Select the field type that determines the shard-bit layout.
 	var ft *types.FieldType
 	if tbInfo.IsCommonHandle {
 		primaryKey := tbInfo.GetPrimaryKey()

--- a/pkg/ddl/table_split_test.go
+++ b/pkg/ddl/table_split_test.go
@@ -63,6 +63,17 @@ func TestTableSplit(t *testing.T) {
 		partition p0 values less than (10),
 		partition p1 values less than (20)
 	)`)
+	// issue 70291: PRE_SPLIT_REGIONS must use common-handle record keys.
+	tk.MustExec(`create table t_common_signed (
+		ts datetime(6) not null,
+		id bigint not null auto_random(2),
+		primary key (id, ts) clustered
+	) pre_split_regions = 2`)
+	tk.MustExec(`create table t_common_unsigned (
+		ts datetime(6) not null,
+		id bigint unsigned not null auto_random(2),
+		primary key (id, ts) clustered
+	) pre_split_regions = 2`)
 	defer dom.Close()
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
 	infoSchema := dom.InfoSchema()
@@ -85,6 +96,21 @@ func TestTableSplit(t *testing.T) {
 	for _, def := range pi.Definitions {
 		checkRegionStartWithTableID(t, def.ID, store.(kvStore))
 	}
+	checkCommonHandleSplitKeys := func(tableName, encodedPrefix string) {
+		rows := tk.MustQuery("show table " + tableName + " regions").Rows()
+		require.Len(t, rows, 5)
+		splitKeyCount := 0
+		for _, row := range rows {
+			startKey := row[1].(string)
+			if strings.Contains(startKey, "_r_") {
+				require.Contains(t, startKey, encodedPrefix)
+				splitKeyCount++
+			}
+		}
+		require.Equal(t, 3, splitKeyCount)
+	}
+	checkCommonHandleSplitKeys("t_common_signed", "_r_03")
+	checkCommonHandleSplitKeys("t_common_unsigned", "_r_04")
 }
 
 // TestScatterRegion test the behavior of the tidb_scatter_region system variable, for verifying:

--- a/pkg/ddl/table_split_test.go
+++ b/pkg/ddl/table_split_test.go
@@ -96,6 +96,7 @@ func TestTableSplit(t *testing.T) {
 	for _, def := range pi.Definitions {
 		checkRegionStartWithTableID(t, def.ID, store.(kvStore))
 	}
+	// 0x03 and 0x04 are the memcomparable codec flags for signed and unsigned integers, respectively.
 	checkCommonHandleSplitKeys := func(tableName, encodedPrefix string) {
 		rows := tk.MustQuery("show table " + tableName + " regions").Rows()
 		require.Len(t, rows, 5)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70291

Problem Summary:

`PRE_SPLIT_REGIONS` always encoded `AUTO_RANDOM` shard boundaries as integer handles. For a clustered composite primary key, row keys use common-handle encoding instead, so the generated boundaries are outside the actual row-key space and the pre-created regions remain unused.

### What changed and how does it work?

- Encode `AUTO_RANDOM` shard boundaries as common-handle prefixes for clustered composite primary keys.
- Preserve the first primary-key column's signed or unsigned encoding, including unsigned values whose bit pattern exceeds `math.MaxInt64`.
- Read the `AUTO_RANDOM` type from the first primary-index column rather than column declaration order.
- Add regression coverage for signed and unsigned `AUTO_RANDOM` composite primary keys.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where PRE_SPLIT_REGIONS does not take effect for AUTO_RANDOM tables with a clustered composite primary key.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-splitting now supports partitioned and non-partitioned tables using common handles, including signed and unsigned primary-key types.
  * Region boundaries are generated using the appropriate encoded key format and shard-bit configuration.
  * Existing integer-handle table splitting remains supported.

* **Bug Fixes**
  * Improved handling of invalid handle encodings by safely skipping unusable split boundaries without interrupting table setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->