### PR TITLE
executor: report statement RU for unary operators

### DIFF
--- a/pkg/executor/statement_ru_plan_walk.go
+++ b/pkg/executor/statement_ru_plan_walk.go
@@ -300,6 +300,8 @@ func calculateStatementRUPlanChildFirst(
 
 	switch origin := operator.Origin.(type) {
 	case *physicalop.PhysicalTableReader:
+		// Scan-byte accounting is performed at Reader boundaries. A TableReader
+		// contributes scan evidence from its single TiKV table request exactly once.
 		if !operator.IsRoot || origin.StoreType != kv.TiKV || origin.ReadReqType != physicalop.Cop ||
 			origin.TablePlan == nil || len(operator.ChildrenIdx) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
@@ -310,6 +312,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: state}
 		}
 	case *physicalop.PhysicalIndexReader:
+		// Scan-byte accounting is performed at Reader boundaries. An IndexReader
+		// contributes scan evidence from its single TiKV index request exactly once.
 		if !operator.IsRoot || origin.IndexPlan == nil || len(operator.ChildrenIdx) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -319,6 +323,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: state}
 		}
 	case *physicalop.PhysicalIndexLookUpReader:
+		// An IndexLookUpReader owns distinct index/build and table/probe requests.
+		// Each request-root contribution is collected exactly once at this boundary.
 		if !operator.IsRoot || origin.IndexLookUpPushDown ||
 			origin.IndexPlan == nil || origin.TablePlan == nil || origin.IndexPlan == origin.TablePlan ||
 			len(operator.ChildrenIdx) != 2 {
@@ -341,6 +347,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: state}
 		}
 	case *physicalop.PhysicalSelection:
+		// CPU work for Selection is defined as the child output-row count
+		// multiplied by the number of conditions evaluated per row.
 		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -348,6 +356,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
 	case *physicalop.PhysicalSort:
+		// For n > 0, CPU work for Sort is defined as n * log2(max(n, 2)), where n
+		// is the child output-row count. Only root Sort is supported.
 		if !operator.IsRoot || len(children) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -356,6 +366,9 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
 	case *physicalop.PhysicalTopN:
+		// For n > 0 and k > 0, CPU work for TopN is defined as
+		// n * log2(max(min(n, k), 2)). Root k is Offset + Count; for pushed TopN,
+		// the planner has already folded Offset into Count.
 		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -380,6 +393,7 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
 	case *physicalop.PhysicalLimit:
+		// CPU work for Limit is defined as its child output-row count.
 		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -387,6 +401,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
 	case *physicalop.PhysicalTableScan, *physicalop.PhysicalIndexScan:
+		// TableScan and IndexScan do not contribute units directly. Their scan
+		// evidence is accounted for by the owning Reader boundary.
 		if operator.IsRoot || len(operator.ChildrenIdx) != 0 {
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
@@ -394,6 +410,8 @@ func calculateStatementRUPlanChildFirst(
 			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
 	default:
+		// Operators not listed above, including Projection, are outside the
+		// supported statement-RU model and therefore fail closed.
 		return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 	}
 

--- a/pkg/executor/statement_ru_plan_walk.go
+++ b/pkg/executor/statement_ru_plan_walk.go
@@ -15,23 +15,45 @@
 package executor
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
+	plannercoreutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 type statementRUFinalOutcome uint32
+
+type statementRUOperatorState uint8
 
 const (
 	statementRUFinalOutcomeUnknown statementRUFinalOutcome = iota
 	statementRUFinalOutcomeSuccess
 	statementRUFinalOutcomeFailure
 )
+
+const (
+	statementRUOperatorUnknown statementRUOperatorState = iota
+	statementRUOperatorComplete
+	statementRUOperatorUnsupported
+	statementRUOperatorInvalid
+)
+
+// statementRUOperatorResult is a value-only occurrence result. Complete means
+// that this supported occurrence was calculated from the evidence currently
+// visible at finalization; it does not claim producer-side evidence coverage.
+type statementRUOperatorResult struct {
+	state      statementRUOperatorState
+	outputRows int64
+}
 
 // statementRUOwner owns the first-record-wins outcome and the first terminal
 // finalization for one ExecStmt. Its calculation setup is released when the
@@ -184,116 +206,296 @@ func calculateStatementRU(
 	setup statementRUCalculationSetup,
 	rootEOF bool,
 ) (statementRUFinalizedSnapshot, bool) {
-	if flat == nil || len(flat.Main) == 0 || len(flat.CTEs) != 0 || len(flat.ScalarSubQueries) != 0 {
+	if !rootEOF || flat == nil || len(flat.Main) == 0 || len(flat.CTEs) != 0 || len(flat.ScalarSubQueries) != 0 {
 		return statementRUFinalizedSnapshot{}, false
 	}
 	calculator := newStatementRUCalculator(setup)
-	evidenceComplete := rootEOF
 	// Transport bytes are statement evidence in both the current producer and
 	// the demo model. Read them once; do not attribute the same aggregate to
-	// every Reader occurrence.
-	if metrics == nil || metrics.Bypass() {
-		evidenceComplete = false
-	} else {
+	// every Reader occurrence. Missing evidence contributes zero to the
+	// best-effort ResultOnly value.
+	if metrics != nil && !metrics.Bypass() {
 		netBytes := metrics.TiKVCoprocessorResponseBytes()
-		switch {
-		case netBytes < 0:
-			calculator.invalidEvidence = true
-		case netBytes == 0:
-			evidenceComplete = false
-		default:
-			calculator.units.NetBytes = float64(netBytes)
+		if netBytes < 0 {
+			return statementRUFinalizedSnapshot{}, false
 		}
+		calculator.units.NetBytes = float64(netBytes)
 	}
 
-	planSupported, planEvidenceComplete := calculateStatementRUPlan(
+	planResult := calculateStatementRUPlan(
 		flat.Main,
 		0,
 		runtimeStatsColl,
 		&calculator,
 	)
-	if !planSupported {
+	if planResult.state != statementRUOperatorComplete {
 		return statementRUFinalizedSnapshot{}, false
 	}
-	evidenceComplete = evidenceComplete && planEvidenceComplete
-	return calculator.finalize(evidenceComplete), true
+	return calculator.finalize()
 }
 
 // calculateStatementRUPlan evaluates one subtree from a canonical
-// preorder-serialized tree, visiting children before their parent. A parent
-// that needs direct-child output as formula input can use each ChildrenIdx
-// occurrence's Origin.ID() with runtimeStatsColl; that evidence is not the
-// child's already-calculated RU and does not require a retained child-result
-// graph. FlatPhysicalPlan owns the
-// serialized layout; this calculation follows only its explicit child edges.
+// preorder-serialized tree, visiting children before their parent. ChildrenIdx
+// is the only production edge routing. Each parent receives its direct-child
+// value result, so later operators can consume child rows without changing the
+// traversal framework. FlatPhysicalPlan owns the serialized layout; this
+// calculation follows only its explicit child edges.
 func calculateStatementRUPlan(
 	tree plannercore.FlatPlanTree,
 	operatorIndex int,
 	runtimeStatsColl *execdetails.RuntimeStatsColl,
 	calculator *statementRUCalculator,
-) (supported bool, evidenceComplete bool) {
-	if operatorIndex < 0 || operatorIndex >= len(tree) || calculator == nil {
-		return false, false
+) statementRUOperatorResult {
+	return calculateStatementRUPlanChildFirst(
+		tree,
+		operatorIndex,
+		runtimeStatsColl,
+		calculator,
+		len(tree),
+	)
+}
+
+func calculateStatementRUPlanChildFirst(
+	tree plannercore.FlatPlanTree,
+	operatorIndex int,
+	runtimeStatsColl *execdetails.RuntimeStatsColl,
+	calculator *statementRUCalculator,
+	remainingDepth int,
+) statementRUOperatorResult {
+	if operatorIndex < 0 || operatorIndex >= len(tree) || calculator == nil || remainingDepth <= 0 {
+		return statementRUOperatorResult{state: statementRUOperatorInvalid}
 	}
 	operator := tree[operatorIndex]
 	if operator == nil || operator.Origin == nil {
-		return false, false
+		return statementRUOperatorResult{state: statementRUOperatorInvalid}
 	}
 
-	supported = true
-	evidenceComplete = true
-	for _, childIndex := range operator.ChildrenIdx {
-		childSupported, childEvidenceComplete := calculateStatementRUPlan(
+	children := make([]statementRUOperatorResult, len(operator.ChildrenIdx))
+	childState := statementRUOperatorComplete
+	for childOrdinal, childIndex := range operator.ChildrenIdx {
+		children[childOrdinal] = calculateStatementRUPlanChildFirst(
 			tree,
 			childIndex,
 			runtimeStatsColl,
 			calculator,
+			remainingDepth-1,
 		)
-		supported = supported && childSupported
-		evidenceComplete = evidenceComplete && childEvidenceComplete
+		childState = mergeStatementRUOperatorState(childState, children[childOrdinal].state)
+	}
+	if childState != statementRUOperatorComplete {
+		return statementRUOperatorResult{state: childState}
+	}
+
+	outputRows := int64(0)
+	if runtimeStatsColl != nil {
+		if operator.IsRoot {
+			outputRows = runtimeStatsColl.GetPlanActRows(operator.Origin.ID())
+		} else {
+			_, outputRows = runtimeStatsColl.GetCopCountAndRows(operator.Origin.ID())
+		}
+	}
+	if outputRows < 0 {
+		return statementRUOperatorResult{state: statementRUOperatorInvalid}
 	}
 
 	switch origin := operator.Origin.(type) {
 	case *physicalop.PhysicalTableReader:
 		if !operator.IsRoot || origin.StoreType != kv.TiKV || origin.ReadReqType != physicalop.Cop ||
 			origin.TablePlan == nil || len(operator.ChildrenIdx) != 1 {
-			return false, evidenceComplete
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
 		}
-		childIndex := operator.ChildrenIdx[0]
-		if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil ||
-			tree[childIndex].Origin != origin.TablePlan {
-			return false, evidenceComplete
+		if state := collectStatementRUReaderScanBytes(
+			tree, operator, runtimeStatsColl, calculator, []base.Plan{origin.TablePlan},
+		); state != statementRUOperatorComplete {
+			return statementRUOperatorResult{state: state}
+		}
+	case *physicalop.PhysicalIndexReader:
+		if !operator.IsRoot || origin.IndexPlan == nil || len(operator.ChildrenIdx) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		if state := collectStatementRUReaderScanBytes(
+			tree, operator, runtimeStatsColl, calculator, []base.Plan{origin.IndexPlan},
+		); state != statementRUOperatorComplete {
+			return statementRUOperatorResult{state: state}
+		}
+	case *physicalop.PhysicalIndexLookUpReader:
+		if !operator.IsRoot || origin.IndexLookUpPushDown ||
+			origin.IndexPlan == nil || origin.TablePlan == nil || origin.IndexPlan == origin.TablePlan ||
+			len(operator.ChildrenIdx) != 2 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		indexChild := tree[operator.ChildrenIdx[0]]
+		tableChild := tree[operator.ChildrenIdx[1]]
+		if indexChild == nil || tableChild == nil ||
+			indexChild.Label != plannercore.BuildSide || indexChild.IsINLProbeChild ||
+			tableChild.Label != plannercore.ProbeSide || !tableChild.IsINLProbeChild {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		if state := collectStatementRUReaderScanBytes(
+			tree,
+			operator,
+			runtimeStatsColl,
+			calculator,
+			[]base.Plan{origin.IndexPlan, origin.TablePlan},
+		); state != statementRUOperatorComplete {
+			return statementRUOperatorResult{state: state}
+		}
+	case *physicalop.PhysicalSelection:
+		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		if !addStatementRUCPUWork(calculator, float64(children[0].outputRows)*float64(len(origin.Conditions))) {
+			return statementRUOperatorResult{state: statementRUOperatorInvalid}
+		}
+	case *physicalop.PhysicalSort:
+		if !operator.IsRoot || len(children) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		statementRUAssertOrderingMaterialized(origin.ByItems)
+		if !addStatementRUCPUWork(calculator, statementRUSortWork(children[0].outputRows, uint64(children[0].outputRows))) {
+			return statementRUOperatorResult{state: statementRUOperatorInvalid}
+		}
+	case *physicalop.PhysicalTopN:
+		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		statementRUAssertOrderingMaterialized(origin.ByItems)
+		var retainedRows uint64
+		if operator.IsRoot {
+			if origin.Count == 0 {
+				retainedRows = 0
+			} else {
+				if origin.Offset > math.MaxUint64-origin.Count {
+					return statementRUOperatorResult{state: statementRUOperatorInvalid}
+				}
+				retainedRows = origin.Offset + origin.Count
+			}
+		} else {
+			if origin.Offset != 0 {
+				return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+			}
+			retainedRows = origin.Count
+		}
+		if !addStatementRUCPUWork(calculator, statementRUSortWork(children[0].outputRows, retainedRows)) {
+			return statementRUOperatorResult{state: statementRUOperatorInvalid}
+		}
+	case *physicalop.PhysicalLimit:
+		if !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		if !addStatementRUCPUWork(calculator, float64(children[0].outputRows)) {
+			return statementRUOperatorResult{state: statementRUOperatorInvalid}
+		}
+	case *physicalop.PhysicalTableScan, *physicalop.PhysicalIndexScan:
+		if operator.IsRoot || len(operator.ChildrenIdx) != 0 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+		if operator.StoreType != kv.TiKV || operator.ReqType != physicalop.Cop {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+	default:
+		return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+	}
+
+	return statementRUOperatorResult{state: statementRUOperatorComplete, outputRows: outputRows}
+}
+
+func mergeStatementRUOperatorState(left, right statementRUOperatorState) statementRUOperatorState {
+	if left == statementRUOperatorInvalid || right == statementRUOperatorInvalid {
+		return statementRUOperatorInvalid
+	}
+	if left != statementRUOperatorComplete || right != statementRUOperatorComplete {
+		return statementRUOperatorUnsupported
+	}
+	return statementRUOperatorComplete
+}
+
+func statementRUOperatorRunsAtSupportedSite(operator *plannercore.FlatOperator) bool {
+	return operator.IsRoot || (operator.StoreType == kv.TiKV && operator.ReqType == physicalop.Cop)
+}
+
+func collectStatementRUReaderScanBytes(
+	tree plannercore.FlatPlanTree,
+	operator *plannercore.FlatOperator,
+	runtimeStatsColl *execdetails.RuntimeStatsColl,
+	calculator *statementRUCalculator,
+	requestRoots []base.Plan,
+) statementRUOperatorState {
+	if len(operator.ChildrenIdx) != len(requestRoots) {
+		return statementRUOperatorUnsupported
+	}
+	for branchOrdinal, requestRoot := range requestRoots {
+		childIndex := operator.ChildrenIdx[branchOrdinal]
+		if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil {
+			return statementRUOperatorInvalid
+		}
+		child := tree[childIndex]
+		if child.Origin != requestRoot || child.IsRoot ||
+			child.StoreType != kv.TiKV || child.ReqType != physicalop.Cop {
+			return statementRUOperatorUnsupported
 		}
 		if runtimeStatsColl == nil {
-			return supported, false
+			continue
 		}
-		detail, found := runtimeStatsColl.GetCopScanDetail(origin.TablePlan.ID())
+		detail, found := runtimeStatsColl.GetCopScanDetail(requestRoot.ID())
 		if !found {
-			return supported, false
+			continue
 		}
-		scanBytes, state := statementRUScanBytes(
+		scanEvidence := classifyStatementRUScanEvidence(
 			detail.TotalKeys,
 			detail.ProcessedKeys,
 			detail.ProcessedKeysSize,
 		)
-		switch state {
-		case statementRUCalibrationUnknown:
-			calculator.invalidEvidence = true
-		case statementRUCalibrationIncomplete:
-			evidenceComplete = false
-		case statementRUCalibrationComplete:
-			calculator.units.ScanBytes += scanBytes
+		switch scanEvidence.state {
+		case statementRUScanEvidenceUnavailable:
+			continue
+		case statementRUScanEvidenceValid:
+			if !addStatementRUScanBytes(calculator, scanEvidence.scanBytes) {
+				return statementRUOperatorInvalid
+			}
+		default:
+			return statementRUOperatorInvalid
 		}
-	case *physicalop.PhysicalSelection:
-		if operator.IsRoot || len(operator.ChildrenIdx) != 1 {
-			return false, evidenceComplete
-		}
-	case *physicalop.PhysicalTableScan:
-		if operator.IsRoot || len(operator.ChildrenIdx) != 0 {
-			return false, evidenceComplete
-		}
-	default:
-		return false, evidenceComplete
 	}
-	return supported, evidenceComplete
+	return statementRUOperatorComplete
+}
+
+func statementRUSortWork(inputRows int64, retainedRows uint64) float64 {
+	if inputRows <= 0 || retainedRows == 0 {
+		return 0
+	}
+	rowsToRetain := math.Min(float64(inputRows), float64(retainedRows))
+	return float64(inputRows) * math.Log2(math.Max(rowsToRetain, 2))
+}
+
+// statementRUAssertOrderingMaterialized checks a planner invariant in intest
+// builds without making it another production RU eligibility condition.
+func statementRUAssertOrderingMaterialized(byItems []*plannercoreutil.ByItems) {
+	intest.AssertFunc(func() bool {
+		for _, item := range byItems {
+			if item == nil || item.Expr == nil {
+				return false
+			}
+			if _, scalar := item.Expr.(*expression.ScalarFunction); scalar {
+				return false
+			}
+		}
+		return true
+	}, "statement RU expects Sort/TopN ordering expressions to be materialized")
+}
+
+func addStatementRUCPUWork(calculator *statementRUCalculator, work float64) bool {
+	if calculator == nil || work < 0 || math.IsNaN(work) || math.IsInf(work, 0) {
+		return false
+	}
+	calculator.units.CPUWork += work
+	return !math.IsInf(calculator.units.CPUWork, 0)
+}
+
+func addStatementRUScanBytes(calculator *statementRUCalculator, scanBytes float64) bool {
+	if calculator == nil || scanBytes < 0 || math.IsNaN(scanBytes) || math.IsInf(scanBytes, 0) {
+		return false
+	}
+	calculator.units.ScanBytes += scanBytes
+	return !math.IsInf(calculator.units.ScanBytes, 0)
 }

--- a/pkg/executor/statement_ru_plan_walk_bench_test.go
+++ b/pkg/executor/statement_ru_plan_walk_bench_test.go
@@ -18,16 +18,13 @@ import (
 	"testing"
 
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
-	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 )
 
 var (
 	statementRUExecStmtSink   *ExecStmt
 	statementRUCalculatorSink statementRUCalculator
 	statementRUFinalizedSink  statementRUFinalizedSnapshot
-	statementRUResultSink     statementRUResultOnly
-	statementRUScanBytesSink  float64
-	statementRUStateSink      statementRUCalibrationState
+	statementRUOperatorSink   statementRUOperatorResult
 	statementRUCalculatedSink bool
 )
 
@@ -58,103 +55,66 @@ func BenchmarkStatementRUNilHooks(b *testing.B) {
 	})
 }
 
-func BenchmarkStatementRUComponents(b *testing.B) {
+func BenchmarkStatementRUOperatorCalculation(b *testing.B) {
+	// This timer contains only representative occurrence-local formulas and
+	// typed accumulation. It excludes tree routing, runtime-stat lookup,
+	// finalization, and publication.
+	b.ReportAllocs()
+	for b.Loop() {
+		calculator := statementRUCalculator{}
+		valid := addStatementRUCPUWork(&calculator, statementRUSortWork(100, 10))
+		statementRUCalculatorSink = calculator
+		statementRUCalculatedSink = valid
+	}
+}
+
+func BenchmarkStatementRUTreeTraversal(b *testing.B) {
 	fixture := newStatementRUSimpleSelectFixture(b)
 	flat := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
 	setup := fixture.owner.calculationSetup
+	stmtCtx := fixture.stmt.Ctx.GetSessionVars().StmtCtx
 
-	b.Run("calculator-setup", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			statementRUCalculatorSink = newStatementRUCalculator(setup)
-		}
-	})
-
-	b.Run("calculate", func(b *testing.B) {
-		stmtCtx := fixture.stmt.Ctx.GetSessionVars().StmtCtx
-		metrics := fixture.stmt.Ctx.GetSessionVars().RUV2Metrics
-		b.ReportAllocs()
-		for b.Loop() {
-			statementRUFinalizedSink, statementRUCalculatedSink = calculateStatementRU(
-				flat,
-				stmtCtx.RuntimeStatsColl,
-				metrics,
-				setup,
-				true,
-			)
-		}
-	})
-
-	b.Run("scan-detail-lookup", func(b *testing.B) {
-		stmtCtx := fixture.stmt.Ctx.GetSessionVars().StmtCtx
-		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
-		b.ReportAllocs()
-		for b.Loop() {
-			detail, _ := stmtCtx.RuntimeStatsColl.GetCopScanDetail(reader.TablePlan.ID())
-			statementRUScanBytesSink = float64(detail.ProcessedKeysSize)
-		}
-	})
-
-	b.Run("scan-byte-estimate", func(b *testing.B) {
-		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
-		detail, _ := fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetCopScanDetail(reader.TablePlan.ID())
-		b.ReportAllocs()
-		for b.Loop() {
-			statementRUScanBytesSink, statementRUStateSink = statementRUScanBytes(
-				detail.TotalKeys,
-				detail.ProcessedKeys,
-				detail.ProcessedKeysSize,
-			)
-		}
-	})
-
-	b.Run("finalize", func(b *testing.B) {
-		calculator := statementRUCalculator{
-			units: statementRURawUnits{
-				ScanBytes:            10,
-				NetBytes:             20,
-				FrontendCompileBytes: setup.frontendCompileBytes,
-			},
-		}
-		b.ReportAllocs()
-		for b.Loop() {
-			statementRUFinalizedSink = calculator.finalize(true)
-		}
-	})
-
-	b.Run("result-construction", func(b *testing.B) {
-		units := statementRURawUnits{ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
-		b.ReportAllocs()
-		for b.Loop() {
-			statementRUResultSink = calculateStatementRUResultOnly(units)
-		}
-	})
-
-	b.Run("result-publication/ruv3-metrics", func(b *testing.B) {
-		finalized := statementRUFinalizedSnapshot{
-			units:     statementRURawUnits{ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15},
-			result:    statementRUResultOnly{TotalRU: 45},
-			hasResult: true,
-		}
-		b.ReportAllocs()
-		for b.Loop() {
-			publishStatementRUMetricsSafely(finalized)
-		}
-	})
-
-	b.Run("calibration-publication/dormant-consumer", func(b *testing.B) {
-		units := statementRURawUnits{ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
-		b.ReportAllocs()
-		for b.Loop() {
-			publishStatementRUCalibrationSafely(fixture.stmt, statementRUCalibrationSnapshot{
-				State: statementRUCalibrationComplete,
-				Units: units,
-			})
-		}
-	})
+	// This timer starts with the canonical root occurrence and ends after the
+	// single child-first walk. It includes runtime-stat lookups and typed
+	// accumulation, but excludes statement aggregates and finalization.
+	b.ReportAllocs()
+	for b.Loop() {
+		calculator := newStatementRUCalculator(setup)
+		statementRUOperatorSink = calculateStatementRUPlan(
+			flat.Main,
+			0,
+			stmtCtx.RuntimeStatsColl,
+			&calculator,
+		)
+		statementRUCalculatorSink = calculator
+	}
 }
 
-func BenchmarkStatementRUSyntheticFinalization(b *testing.B) {
+func BenchmarkStatementRUFinalizePublication(b *testing.B) {
+	fixture := newStatementRUSimpleSelectFixture(b)
+	calculator := statementRUCalculator{
+		units: statementRURawUnits{
+			CPUWork:              5,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: fixture.owner.calculationSetup.frontendCompileBytes,
+		},
+	}
+
+	// This timer covers value-only freeze plus both existing publication
+	// boundaries. It excludes operator traversal and terminal lifecycle.
+	b.ReportAllocs()
+	for b.Loop() {
+		finalized, ok := calculator.finalize()
+		if !ok {
+			b.Fatal("valid benchmark units failed to finalize")
+		}
+		publishStatementRUFinalizedSnapshot(fixture.stmt, finalized)
+		statementRUFinalizedSink = finalized
+	}
+}
+
+func BenchmarkStatementRUSyntheticTerminal(b *testing.B) {
 	fixture := newStatementRUSimpleSelectFixture(b)
 	stmt := fixture.stmt
 	stmtCtx := stmt.Ctx.GetSessionVars().StmtCtx

--- a/pkg/executor/statement_ru_plan_walk_integration_test.go
+++ b/pkg/executor/statement_ru_plan_walk_integration_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
@@ -38,7 +40,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const statementRUOwnerInstallFailpoint = "github.com/pingcap/tidb/pkg/executor/observeStatementRUOwnerInstallForTest"
+const (
+	statementRUOwnerInstallFailpoint     = "github.com/pingcap/tidb/pkg/executor/observeStatementRUOwnerInstallForTest"
+	statementRUCalibrationUnitsFailpoint = "github.com/pingcap/tidb/pkg/executor/observeStatementRUCalibrationUnitsForTest"
+)
 
 type statementRUObservation struct {
 	stmt  *executor.ExecStmt
@@ -87,6 +92,11 @@ func countStatementRUFlatOccurrences(flat *plannercore.FlatPhysicalPlan) (total,
 	return total, scalar
 }
 
+func isStatementRUPlanType[T base.Plan](plan base.Plan) bool {
+	_, ok := plan.(T)
+	return ok
+}
+
 func drainStatementRURecordSet(t *testing.T, rs sqlexec.RecordSet) error {
 	t.Helper()
 	chk := rs.NewChunk(nil)
@@ -102,6 +112,133 @@ func drainStatementRURecordSet(t *testing.T, rs sqlexec.RecordSet) error {
 }
 
 func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
+	t.Run("producer plans publish only supported operator trees", func(t *testing.T) {
+		store := testkit.CreateMockStore(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("create table t(a int primary key, b int, c int, index idx_b(b))")
+		tk.MustExec("insert into t values (1, 10, 100), (2, 20, 200), (3, 30, 300)")
+		tk.MustExec("set @@tidb_enable_non_prepared_plan_cache = off")
+
+		var observation *statementRUObservation
+		testfailpoint.EnableCall(t, statementRUOwnerInstallFailpoint, func(stmt *executor.ExecStmt) {
+			if stmt.Ctx == tk.Session() {
+				observation = observeInstalledStatementRUOwner(stmt)
+			}
+		})
+		type calibrationObservation struct {
+			count         int
+			state         string
+			cpuWork       float64
+			scanBytes     float64
+			netBytes      float64
+			frontendBytes float64
+		}
+		connectionID := tk.Session().GetSessionVars().ConnectionID
+		var calibrationMu sync.Mutex
+		var calibration calibrationObservation
+		testfailpoint.EnableCall(t, statementRUCalibrationUnitsFailpoint, func(
+			observedConnectionID uint64,
+			state string,
+			cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
+		) {
+			if observedConnectionID != connectionID {
+				return
+			}
+			calibrationMu.Lock()
+			defer calibrationMu.Unlock()
+			calibration.count++
+			calibration.state = state
+			calibration.cpuWork = cpuWork
+			calibration.scanBytes = scanBytes
+			calibration.netBytes = netBytes
+			calibration.frontendBytes = frontendCompileBytes
+		})
+		type operatorExpectation func(base.Plan) bool
+		testCases := []struct {
+			name           string
+			query          string
+			rows           [][]any
+			expectOperator operatorExpectation
+			sortRows       bool
+			wantPublish    bool
+			wantCPUWork    bool
+		}{
+			{name: "Selection", query: "select * from t ignore index (idx_b) where b > 10", rows: testkit.Rows("2 20 200", "3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSelection], sortRows: true, wantPublish: true, wantCPUWork: true},
+			{name: "Sort", query: "select * from t ignore index (idx_b) order by b desc", rows: testkit.Rows("3 30 300", "2 20 200", "1 10 100"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSort], wantPublish: true, wantCPUWork: true},
+			{name: "TopN", query: "select * from t ignore index (idx_b) order by b desc limit 2", rows: testkit.Rows("3 30 300", "2 20 200"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalTopN], wantPublish: true, wantCPUWork: true},
+			{name: "Limit", query: "select * from t ignore index (idx_b) limit 2", rows: testkit.Rows("1 10 100", "2 20 200"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalLimit], wantPublish: true, wantCPUWork: true},
+			{name: "IndexReader", query: "select b from t use index (idx_b) where b >= 20", rows: testkit.Rows("20", "30"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexReader], sortRows: true, wantPublish: true},
+			{name: "IndexLookup", query: "select * from t use index (idx_b) where b >= 20", rows: testkit.Rows("2 20 200", "3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexLookUpReader], sortRows: true, wantPublish: true},
+			{name: "unsupported Projection", query: "select b + 1 from t ignore index (idx_b)", rows: testkit.Rows("11", "21", "31"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalProjection], sortRows: true},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				observation = nil
+				calibrationMu.Lock()
+				calibration = calibrationObservation{}
+				calibrationMu.Unlock()
+				result := tk.MustQuery(tc.query)
+				if tc.sortRows {
+					result = result.Sort()
+				}
+				result.Check(tc.rows)
+
+				require.NotNil(t, observation)
+				require.True(t, observation.owner.ConsumedForTest())
+				require.True(t, observation.owner.RecordedSuccessForTest())
+				flat := requireStatementRUTerminalFlatPlan(t, observation.stmt)
+				runtimeStats := observation.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
+				planSummary := make([]string, 0, len(flat.Main))
+				for index, operator := range flat.Main {
+					if operator == nil || operator.Origin == nil {
+						planSummary = append(planSummary, fmt.Sprintf("%d:<nil>", index))
+						continue
+					}
+					rootRows := runtimeStats.GetPlanActRows(operator.Origin.ID())
+					_, copRows := runtimeStats.GetCopCountAndRows(operator.Origin.ID())
+					detail, detailFound := runtimeStats.GetCopScanDetail(operator.Origin.ID())
+					planSummary = append(planSummary, fmt.Sprintf(
+						"%d:%T(root=%v,store=%v,req=%v,label=%v,probe=%v,children=%v,rootRows=%d,copRows=%d,scanFound=%v,scan=[%d,%d,%d])",
+						index,
+						operator.Origin,
+						operator.IsRoot,
+						operator.StoreType,
+						operator.ReqType,
+						operator.Label,
+						operator.IsINLProbeChild,
+						operator.ChildrenIdx,
+						rootRows,
+						copRows,
+						detailFound,
+						detail.TotalKeys,
+						detail.ProcessedKeys,
+						detail.ProcessedKeysSize,
+					))
+				}
+				require.True(t, slices.ContainsFunc(flat.Main, func(operator *plannercore.FlatOperator) bool {
+					return operator != nil && operator.Origin != nil && tc.expectOperator(operator.Origin)
+				}), "query plan does not contain expected operator: %s; flat plan: %v", tc.query, planSummary)
+
+				calibrationMu.Lock()
+				published := calibration
+				calibrationMu.Unlock()
+				if !tc.wantPublish {
+					require.Zero(t, published.count)
+					return
+				}
+				require.Equal(t, 1, published.count, "flat plan: %v", planSummary)
+				require.Equal(t, "incomplete", published.state)
+				require.Equal(t, float64(len(tc.query)), published.frontendBytes)
+				require.GreaterOrEqual(t, published.scanBytes, float64(0))
+				require.GreaterOrEqual(t, published.netBytes, float64(0))
+				if tc.wantCPUWork {
+					require.Positive(t, published.cpuWork)
+				}
+			})
+		}
+	})
+
 	t.Run("post-compile panic consumes owner", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/statement_ru_plan_walk_test.go
+++ b/pkg/executor/statement_ru_plan_walk_test.go
@@ -17,16 +17,23 @@ package executor
 import (
 	"context"
 	"errors"
+	"math"
 	"sync/atomic"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
+	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/sqlkiller"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
@@ -94,6 +101,91 @@ func (observation *StatementRUOwnerObservationForTest) RecordedSuccessForTest() 
 }
 
 func TestStatementRUCalculationTraversal(t *testing.T) {
+	setPlan := func(fixture statementRUSimpleSelectFixture, plan base.PhysicalPlan) {
+		fixture.stmt.Plan = plan
+		stmtCtx := fixture.stmt.Ctx.GetSessionVars().StmtCtx
+		stmtCtx.SetPlan(plan)
+		stmtCtx.SetFlatPlan(plannercore.FlattenPhysicalPlan(plan, false))
+	}
+	recordRootRows := func(fixture statementRUSimpleSelectFixture, plan base.Plan, rows int64) {
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
+			GetBasicRuntimeStats(plan.ID(), true).SetRowNum(rows)
+	}
+	recordCopRows := func(fixture statementRUSimpleSelectFixture, plan base.Plan, rows uint64) {
+		zero := uint64(0)
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RecordOneCopTask(
+			plan.ID(),
+			kv.TiKV,
+			&tipb.ExecutorExecutionSummary{
+				TimeProcessedNs: &zero,
+				NumProducedRows: &rows,
+				NumIterations:   &zero,
+				Concurrency:     &zero,
+			},
+		)
+	}
+	recordScan := func(
+		fixture statementRUSimpleSelectFixture,
+		requestRoot base.Plan,
+		totalKeys, processedKeys, processedKeysSize int64,
+	) {
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RecordCopStats(
+			requestRoot.ID(),
+			kv.TiKV,
+			&util.ScanDetail{
+				TotalKeys:         totalKeys,
+				ProcessedKeys:     processedKeys,
+				ProcessedKeysSize: processedKeysSize,
+			},
+			util.TimeDetail{},
+			nil,
+			nil,
+		)
+	}
+	newIndexLookupPlan := func(fixture statementRUSimpleSelectFixture) (
+		*physicalop.PhysicalIndexLookUpReader,
+		*physicalop.PhysicalIndexScan,
+		*physicalop.PhysicalTableScan,
+	) {
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		indexScan := (&physicalop.PhysicalIndexScan{
+			Table:            &model.TableInfo{},
+			Index:            &model.IndexInfo{},
+			DataSourceSchema: expression.NewSchema(),
+		}).Init(planCtx, 0)
+		tableScan := (&physicalop.PhysicalTableScan{
+			Table:     &model.TableInfo{},
+			StoreType: kv.TiKV,
+		}).Init(planCtx, 0)
+		tableScan.SetSchema(expression.NewSchema())
+		indexLookup := (physicalop.PhysicalIndexLookUpReader{
+			IndexPlan: indexScan,
+			TablePlan: tableScan,
+		}).Init(planCtx, 0, plannerutil.IndexLookUpPushDownNone)
+		return indexLookup, indexScan, tableScan
+	}
+	requirePublication := func(
+		t *testing.T,
+		fixture statementRUSimpleSelectFixture,
+		wantUnits statementRURawUnits,
+	) {
+		var calibrationCount atomic.Int64
+		var snapshot statementRUCalibrationSnapshot
+		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
+			calibrationCount.Add(1)
+			snapshot = published
+		})
+		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
+		fixture.stmt.RecordStatementRUFinalOutcome(true)
+		fixture.stmt.finishStatementRUForTest(nil)
+		fixture.stmt.finishStatementRUForTest(nil)
+		require.Equal(t, int64(1), calibrationCount.Load())
+		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
+		require.Equal(t, wantUnits, snapshot.Units)
+		require.InDelta(t, calculateStatementRUResultOnly(wantUnits).TotalRU,
+			testutil.ToFloat64(metrics.RUV3Total)-totalBefore, 1e-9)
+		require.Zero(t, fixture.owner.calculationSetup)
+	}
 	requireNoPublication := func(t *testing.T, fixture statementRUSimpleSelectFixture) {
 		var calibrationCount atomic.Int64
 		observeStatementRUCalibrationForTest(t, func(statementRUCalibrationSnapshot) {
@@ -115,58 +207,347 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 			ProcessedKeys:     100,
 			ProcessedKeysSize: 10000,
 		})
-		var snapshot statementRUCalibrationSnapshot
-		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
-			snapshot = published
-		})
-		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
-		fixture.stmt.RecordStatementRUFinalOutcome(true)
-		fixture.stmt.finishStatementRUForTest(nil)
-		require.Equal(t, float64(45), testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
-		require.Equal(t, statementRURawUnits{
+		requirePublication(t, fixture, statementRURawUnits{
 			ScanBytes:            10,
 			NetBytes:             20,
 			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
-		}, snapshot.Units)
+		})
 	})
 
-	t.Run("pushed Selection does not duplicate Reader scan evidence", func(t *testing.T) {
+	t.Run("pushed Selection uses child rows without duplicating Reader scan evidence", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		planCtx := fixture.stmt.Ctx.(*mock.Context)
 		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
 		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
-		selection := physicalop.PhysicalSelection{}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
+		selection := physicalop.PhysicalSelection{
+			Conditions: []expression.Expression{expression.NewOne(), expression.NewOne()},
+		}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
 		selection.SetChildren(scan)
 		reader.TablePlan = selection
 		reader.TablePlans = physicalop.FlattenListPushDownPlan(selection)
 		fixture.recordReaderScanDetail(reader, 1, 1, 10)
-		fixture.stmt.Ctx.GetSessionVars().StmtCtx.SetFlatPlan(plannercore.FlattenPhysicalPlan(reader, false))
+		recordCopRows(fixture, scan, 7)
+		setPlan(fixture, reader)
 
-		var calibrationCount atomic.Int64
-		var snapshot statementRUCalibrationSnapshot
-		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
-			calibrationCount.Add(1)
-			snapshot = published
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              14,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
 		})
-		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
-		fixture.stmt.RecordStatementRUFinalOutcome(true)
-		fixture.stmt.finishStatementRUForTest(nil)
-		fixture.stmt.finishStatementRUForTest(nil)
-		require.Equal(t, float64(45), testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
-		require.Equal(t, int64(1), calibrationCount.Load())
-		require.Equal(t, statementRUCalibrationComplete, snapshot.State)
-		require.Equal(t, float64(10), snapshot.Units.ScanBytes)
-		require.Zero(t, fixture.owner.calculationSetup)
 	})
 
-	t.Run("root Selection is outside the current slice", func(t *testing.T) {
+	t.Run("root Selection uses direct child output rows", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		planCtx := fixture.stmt.Ctx.(*mock.Context)
 		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
-		selection := physicalop.PhysicalSelection{}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
+		selection := physicalop.PhysicalSelection{
+			Conditions: []expression.Expression{expression.NewOne(), expression.NewOne(), expression.NewOne()},
+		}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
 		selection.SetChildren(reader)
-		fixture.stmt.Plan = selection
-		fixture.stmt.Ctx.GetSessionVars().StmtCtx.SetFlatPlan(plannercore.FlattenPhysicalPlan(selection, false))
+		recordRootRows(fixture, reader, 4)
+		setPlan(fixture, selection)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              12,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("root Sort uses direct child output rows", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		sort := physicalop.PhysicalSort{}.Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		sort.SetChildren(reader)
+		recordRootRows(fixture, reader, 8)
+		setPlan(fixture, sort)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              24,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("intest catches root Sort with unmaterialized scalar ordering", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		sort := physicalop.PhysicalSort{
+			ByItems: []*plannerutil.ByItems{{Expr: &expression.ScalarFunction{}}},
+		}.Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		require.Panics(t, func() {
+			statementRUAssertOrderingMaterialized(sort.ByItems)
+		})
+		sort.SetChildren(reader)
+		setPlan(fixture, sort)
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("root TopN uses checked offset plus count", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		topN := physicalop.PhysicalTopN{Offset: 5, Count: 5}.
+			Init(planCtx, &property.StatsInfo{RowCount: 5}, 0)
+		topN.SetChildren(reader)
+		recordRootRows(fixture, reader, 100)
+		setPlan(fixture, topN)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              100 * math.Log2(10),
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("root TopN count zero ignores offset without overflow", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		topN := physicalop.PhysicalTopN{Offset: math.MaxUint64, Count: 0}.
+			Init(planCtx, &property.StatsInfo{}, 0)
+		topN.SetChildren(reader)
+		recordRootRows(fixture, reader, 100)
+		setPlan(fixture, topN)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("root TopN offset plus count overflow fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		topN := physicalop.PhysicalTopN{Offset: math.MaxUint64, Count: 1}.
+			Init(planCtx, &property.StatsInfo{}, 0)
+		topN.SetChildren(reader)
+		setPlan(fixture, topN)
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("root Limit uses direct child output rows", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		limit := physicalop.PhysicalLimit{Count: 8}.
+			Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		limit.SetChildren(reader)
+		recordRootRows(fixture, reader, 13)
+		setPlan(fixture, limit)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              13,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("zero-count root Limit still charges visible Reader scan evidence", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		limit := physicalop.PhysicalLimit{Count: 0}.
+			Init(planCtx, &property.StatsInfo{}, 0)
+		limit.SetChildren(reader)
+		setPlan(fixture, limit)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("pushed TopN uses zero offset contract", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
+		topN := physicalop.PhysicalTopN{Count: 8}.
+			Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		topN.SetChildren(scan)
+		reader.TablePlan = topN
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(topN)
+		recordCopRows(fixture, scan, 100)
+		fixture.recordReaderScanDetail(reader, 1, 1, 10)
+		setPlan(fixture, reader)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              300,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("pushed TopN with nonzero offset fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
+		topN := physicalop.PhysicalTopN{Offset: 1, Count: 8}.
+			Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		topN.SetChildren(scan)
+		reader.TablePlan = topN
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(topN)
+		setPlan(fixture, reader)
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("pushed Limit uses direct child output rows", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
+		limit := physicalop.PhysicalLimit{Count: 8}.
+			Init(planCtx, &property.StatsInfo{RowCount: 8}, 0)
+		limit.SetChildren(scan)
+		reader.TablePlan = limit
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(limit)
+		recordCopRows(fixture, scan, 11)
+		fixture.recordReaderScanDetail(reader, 1, 1, 10)
+		setPlan(fixture, reader)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              11,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("missing child row evidence contributes zero", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
+		selection := physicalop.PhysicalSelection{
+			Conditions: []expression.Expression{expression.NewOne()},
+		}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
+		selection.SetChildren(scan)
+		reader.TablePlan = selection
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(selection)
+		fixture.recordReaderScanDetail(reader, 1, 1, 10)
+		setPlan(fixture, reader)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexReader owns one optional request branch", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		indexScan := (&physicalop.PhysicalIndexScan{
+			Table:            &model.TableInfo{},
+			Index:            &model.IndexInfo{},
+			DataSourceSchema: expression.NewSchema(),
+		}).Init(planCtx, 0)
+		indexReader := (&physicalop.PhysicalIndexReader{IndexPlan: indexScan}).Init(planCtx, 0)
+		recordScan(fixture, indexScan, 4, 2, 6)
+		setPlan(fixture, indexReader)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            12,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexReader partial scan detail contributes zero", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		indexScan := (&physicalop.PhysicalIndexScan{
+			Table:            &model.TableInfo{},
+			Index:            &model.IndexInfo{},
+			DataSourceSchema: expression.NewSchema(),
+		}).Init(planCtx, 0)
+		indexReader := (&physicalop.PhysicalIndexReader{IndexPlan: indexScan}).Init(planCtx, 0)
+		recordScan(fixture, indexScan, 0, 2, 0)
+		setPlan(fixture, indexReader)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexReader contradictory scan detail fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		indexScan := (&physicalop.PhysicalIndexScan{
+			Table:            &model.TableInfo{},
+			Index:            &model.IndexInfo{},
+			DataSourceSchema: expression.NewSchema(),
+		}).Init(planCtx, 0)
+		indexReader := (&physicalop.PhysicalIndexReader{IndexPlan: indexScan}).Init(planCtx, 0)
+		recordScan(fixture, indexScan, 10, 0, 1)
+		setPlan(fixture, indexReader)
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("IndexLookup sums visible index and table request branches", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		indexLookup, indexScan, tableScan := newIndexLookupPlan(fixture)
+		recordScan(fixture, indexScan, 4, 2, 6)
+		recordScan(fixture, tableScan, 3, 3, 21)
+		setPlan(fixture, indexLookup)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            33,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexLookup missing table branch contributes zero", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		indexLookup, indexScan, _ := newIndexLookupPlan(fixture)
+		recordScan(fixture, indexScan, 4, 2, 6)
+		setPlan(fixture, indexLookup)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            12,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexLookup missing index branch contributes zero", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		indexLookup, _, tableScan := newIndexLookupPlan(fixture)
+		recordScan(fixture, tableScan, 3, 3, 21)
+		setPlan(fixture, indexLookup)
+
+		requirePublication(t, fixture, statementRURawUnits{
+			ScanBytes:            21,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("IndexLookup branch role mismatch fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		indexLookup, _, _ := newIndexLookupPlan(fixture)
+		setPlan(fixture, indexLookup)
+		flat := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
+		flat.Main[flat.Main[0].ChildrenIdx[0]].Label = plannercore.Empty
 
 		requireNoPublication(t, fixture)
 	})
@@ -204,17 +585,47 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 		requireNoPublication(t, fixture)
 	})
 
+	t.Run("self-referential child edge fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		flat := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
+		flat.Main[0].ChildrenIdx = []int{0}
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("two-node child cycle fails closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		flat := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
+		flat.Main[1].ChildrenIdx = []int{0}
+
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("present negative child rows fail closed", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		selection := physicalop.PhysicalSelection{
+			Conditions: []expression.Expression{expression.NewOne()},
+		}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
+		selection.SetChildren(reader)
+		recordRootRows(fixture, reader, -1)
+		setPlan(fixture, selection)
+
+		requireNoPublication(t, fixture)
+	})
+
 	t.Run("unsupported intermediate operator publishes nothing", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		planCtx := fixture.stmt.Ctx.(*mock.Context)
 		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
 		scan := reader.TablePlan.(*physicalop.PhysicalTableScan)
-		limit := physicalop.PhysicalLimit{}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
-		limit.SetChildren(scan)
-		reader.TablePlan = limit
-		reader.TablePlans = physicalop.FlattenListPushDownPlan(limit)
+		projection := physicalop.PhysicalProjection{}.Init(planCtx, &property.StatsInfo{RowCount: 1}, 0)
+		projection.SetChildren(scan)
+		reader.TablePlan = projection
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(projection)
 		fixture.recordReaderScanDetail(reader, 1, 1, 10)
-		fixture.stmt.Ctx.GetSessionVars().StmtCtx.SetFlatPlan(plannercore.FlattenPhysicalPlan(reader, false))
+		setPlan(fixture, reader)
 
 		requireNoPublication(t, fixture)
 	})

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -27,12 +27,16 @@ import (
 // only together with the external model documentation until a later PR adds a
 // configured model.
 const (
+	statementRUCPUWorkWeight             = 1.0
 	statementRUScanByteWeight            = 1.0
 	statementRUNetByteWeight             = 1.0
 	statementRUFrontendCompileByteWeight = 1.0
 )
 
 type statementRURawUnits struct {
+	// CPUWork is the sum of occurrence-local operator work from the supported
+	// root and coprocessor operators in the flat plan.
+	CPUWork float64
 	// ScanBytes is the sum of physical-byte estimates from supported Reader
 	// request components. Each contribution is collected once from the pushed
 	// plan root recorded for that Reader.
@@ -50,10 +54,12 @@ type statementRUResultOnly struct {
 	TotalRU float64
 }
 
-// Complete means the supported traversal consumed every unit required by the
-// current model after the result reached EOF. Incomplete snapshots are still
-// passed through the dormant calibration publication boundary so a future
-// consumer can reject them explicitly.
+// The current producers cannot prove that all successful or canceled remote
+// work contributed execution details. ResultOnly therefore publishes a
+// best-effort value from visible evidence, while every supported snapshot is
+// marked incomplete for the dormant calibration consumer. "Best-effort lower
+// bound" means missing units are not imputed; the aggregate scan-byte proxy is
+// non-monotone, so it is not a strict mathematical bound.
 type statementRUCalibrationState uint8
 
 const (
@@ -62,6 +68,19 @@ const (
 	statementRUCalibrationComplete
 	statementRUCalibrationIncomplete
 )
+
+func (state statementRUCalibrationState) String() string {
+	switch state {
+	case statementRUCalibrationUnknown:
+		return "unknown"
+	case statementRUCalibrationComplete:
+		return "complete"
+	case statementRUCalibrationIncomplete:
+		return "incomplete"
+	default:
+		return "invalid"
+	}
+}
 
 type statementRUCalibrationSnapshot struct {
 	State statementRUCalibrationState
@@ -81,7 +100,6 @@ type statementRUFinalizedSnapshot struct {
 	units            statementRURawUnits
 	result           statementRUResultOnly
 	calibrationState statementRUCalibrationState
-	hasResult        bool
 }
 
 func installStatementRUOwner(stmt *ExecStmt) {
@@ -128,11 +146,9 @@ func statementRUFrontendCompileBytes(stmt *ExecStmt) float64 {
 }
 
 // statementRUCalculator is terminal-local. It accumulates only typed scalar
-// units and invalid evidence; no plan or execution-detail pointer survives
-// calculateStatementRU.
+// units; no plan or execution-detail pointer survives calculateStatementRU.
 type statementRUCalculator struct {
-	units           statementRURawUnits
-	invalidEvidence bool
+	units statementRURawUnits
 }
 
 func newStatementRUCalculator(setup statementRUCalculationSetup) statementRUCalculator {
@@ -143,62 +159,79 @@ func newStatementRUCalculator(setup statementRUCalculationSetup) statementRUCalc
 	}
 }
 
-// statementRUScanBytes converts a value copy of one Reader's scan evidence into
-// one raw-unit contribution. It does not retain RuntimeStatsColl or ScanDetail.
-func statementRUScanBytes(totalKeys, processedKeys, processedBytes int64) (float64, statementRUCalibrationState) {
+type statementRUScanEvidenceState uint8
+
+const (
+	statementRUScanEvidenceInvalid statementRUScanEvidenceState = iota
+	statementRUScanEvidenceUnavailable
+	statementRUScanEvidenceValid
+)
+
+type statementRUScanEvidence struct {
+	state     statementRUScanEvidenceState
+	scanBytes float64
+}
+
+// classifyStatementRUScanEvidence converts a value copy of one Reader's scan
+// evidence into one raw-unit contribution. Zero-valued fields have no presence
+// bit, so a tuple that cannot run the demo formula is unavailable unless it is
+// provably contradictory. No RuntimeStatsColl or ScanDetail pointer survives.
+func classifyStatementRUScanEvidence(totalKeys, processedKeys, processedBytes int64) statementRUScanEvidence {
 	if totalKeys < 0 || processedKeys < 0 || processedBytes < 0 {
-		return 0, statementRUCalibrationUnknown
+		return statementRUScanEvidence{state: statementRUScanEvidenceInvalid}
 	}
-	if processedKeys == 0 && (totalKeys != 0 || processedBytes != 0) {
-		return 0, statementRUCalibrationUnknown
+	if processedKeys == 0 {
+		// A branch with no processed-key evidence contributes zero even when
+		// TotalKeys is present. Processed bytes without processed keys is
+		// contradictory evidence and remains fail closed.
+		if processedBytes == 0 {
+			return statementRUScanEvidence{state: statementRUScanEvidenceValid}
+		}
+		return statementRUScanEvidence{state: statementRUScanEvidenceInvalid}
 	}
-	if totalKeys == 0 || processedKeys == 0 || processedBytes == 0 {
-		return 0, statementRUCalibrationIncomplete
+	if totalKeys == 0 || processedBytes == 0 {
+		return statementRUScanEvidence{state: statementRUScanEvidenceUnavailable}
 	}
 
 	scanBytes := float64(processedBytes) / float64(processedKeys) * float64(totalKeys)
-	if scanBytes > math.MaxFloat64 {
-		return 0, statementRUCalibrationUnknown
+	if scanBytes < 0 || math.IsNaN(scanBytes) || math.IsInf(scanBytes, 0) {
+		return statementRUScanEvidence{state: statementRUScanEvidenceInvalid}
 	}
-	return scanBytes, statementRUCalibrationComplete
+	return statementRUScanEvidence{state: statementRUScanEvidenceValid, scanBytes: scanBytes}
 }
 
-func (calculator statementRUCalculator) finalize(evidenceComplete bool) statementRUFinalizedSnapshot {
-	finalized := statementRUFinalizedSnapshot{
+func (calculator statementRUCalculator) finalize() (statementRUFinalizedSnapshot, bool) {
+	if !validStatementRURawUnits(calculator.units) {
+		return statementRUFinalizedSnapshot{}, false
+	}
+	result := calculateStatementRUResultOnly(calculator.units)
+	if result.TotalRU < 0 || math.IsNaN(result.TotalRU) || math.IsInf(result.TotalRU, 0) {
+		return statementRUFinalizedSnapshot{}, false
+	}
+	return statementRUFinalizedSnapshot{
 		units:            calculator.units,
-		calibrationState: statementRUCalibrationComplete,
-	}
-	if calculator.invalidEvidence {
-		finalized.calibrationState = statementRUCalibrationUnknown
-		return finalized
-	}
-	if !evidenceComplete || calculator.units.ScanBytes <= 0 {
-		// A successful statement may still be closed before the client consumes
-		// the result to EOF (for example, after a connection write failure). In
-		// that case the recorded aggregates describe only the work observed before
-		// close. Traversal also fails closed when it cannot associate the existing
-		// statement evidence with a supported operator occurrence.
-		finalized.calibrationState = statementRUCalibrationIncomplete
-		return finalized
-	}
+		result:           result,
+		calibrationState: statementRUCalibrationIncomplete,
+	}, true
+}
 
-	if finalized.units.FrontendCompileBytes == 0 {
-		// Frontend text is optional for ResultOnly in this first slice, where its
-		// contribution is explicitly projected as zero. Calibration still marks
-		// the same finalized evidence incomplete rather than learning from that zero.
-		finalized.calibrationState = statementRUCalibrationIncomplete
+func validStatementRURawUnits(units statementRURawUnits) bool {
+	for _, unit := range []float64{
+		units.CPUWork,
+		units.ScanBytes,
+		units.NetBytes,
+		units.FrontendCompileBytes,
+	} {
+		if unit < 0 || math.IsNaN(unit) || math.IsInf(unit, 0) {
+			return false
+		}
 	}
-	finalized.result = calculateStatementRUResultOnly(finalized.units)
-	if finalized.result.TotalRU < 0 || math.IsNaN(finalized.result.TotalRU) || math.IsInf(finalized.result.TotalRU, 0) {
-		finalized.calibrationState = statementRUCalibrationUnknown
-		return finalized
-	}
-	finalized.hasResult = true
-	return finalized
+	return true
 }
 
 func calculateStatementRUResultOnly(units statementRURawUnits) statementRUResultOnly {
-	return statementRUResultOnly{TotalRU: statementRUScanByteWeight*units.ScanBytes +
+	return statementRUResultOnly{TotalRU: statementRUCPUWorkWeight*units.CPUWork +
+		statementRUScanByteWeight*units.ScanBytes +
 		statementRUNetByteWeight*units.NetBytes +
 		statementRUFrontendCompileByteWeight*units.FrontendCompileBytes}
 }
@@ -207,21 +240,18 @@ func publishStatementRUFinalizedSnapshot(
 	stmt *ExecStmt,
 	finalized statementRUFinalizedSnapshot,
 ) {
-	if finalized.hasResult {
-		publishStatementRUMetricsSafely(finalized)
-	}
-	if finalized.calibrationState != statementRUCalibrationUnknown {
-		publishStatementRUCalibrationSafely(stmt, statementRUCalibrationSnapshot{
-			State: finalized.calibrationState,
-			Units: finalized.units,
-		})
-	}
+	publishStatementRUMetricsSafely(finalized)
+	publishStatementRUCalibrationSafely(stmt, statementRUCalibrationSnapshot{
+		State: finalized.calibrationState,
+		Units: finalized.units,
+	})
 }
 
 // publishStatementRUMetricsSafely projects one immutable finalized snapshot to
-// the RU v3 counters. The supported slice is read-only and TiKV-only. The
-// engine counter excludes frontend compilation because that work belongs to
-// TiDB rather than the storage engine.
+// the existing RU v3 counters. ResultOnly retains aggregate CPUWork rather than
+// a site split, so this layer preserves the lower-layer engine boundary:
+// TiKV receives only scan and network work, while Total and SQLType receive the
+// complete best-effort result.
 func publishStatementRUMetricsSafely(finalized statementRUFinalizedSnapshot) {
 	defer func() {
 		_ = recover()
@@ -252,7 +282,8 @@ func publishStatementRUCalibrationSafely(
 	failpoint.InjectCall(
 		"observeStatementRUCalibrationUnitsForTest",
 		connectionID,
-		uint8(snapshot.State),
+		snapshot.State.String(),
+		snapshot.Units.CPUWork,
 		snapshot.Units.ScanBytes,
 		snapshot.Units.NetBytes,
 		snapshot.Units.FrontendCompileBytes,

--- a/pkg/executor/statement_ru_result_test.go
+++ b/pkg/executor/statement_ru_result_test.go
@@ -129,12 +129,22 @@ func observeStatementRUCalibrationForTest(
 	t.Helper()
 	testfailpoint.EnableCall(t, statementRUCalibrationFailpointForTest, func(
 		_ uint64,
-		state uint8,
-		scanBytes, netBytes, frontendCompileBytes float64,
+		stateName string,
+		cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
 	) {
+		state := statementRUCalibrationUnknown
+		switch stateName {
+		case statementRUCalibrationComplete.String():
+			state = statementRUCalibrationComplete
+		case statementRUCalibrationIncomplete.String():
+			state = statementRUCalibrationIncomplete
+		default:
+			require.FailNow(t, "unexpected calibration state", stateName)
+		}
 		observe(statementRUCalibrationSnapshot{
-			State: statementRUCalibrationState(state),
+			State: state,
 			Units: statementRURawUnits{
+				CPUWork:              cpuWork,
 				ScanBytes:            scanBytes,
 				NetBytes:             netBytes,
 				FrontendCompileBytes: frontendCompileBytes,
@@ -147,13 +157,15 @@ func TestStatementRUResultFinalizationAndPublication(t *testing.T) {
 	fixture := newStatementRUSimpleSelectFixture(t)
 	var calibrationCount atomic.Int64
 	var snapshot statementRUCalibrationSnapshot
-	observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
-		calibrationCount.Add(1)
-		snapshot = published
-	})
 	totalBefore := testutil.ToFloat64(metrics.RUV3Total)
 	readBefore := testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))
 	tikvBefore := testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))
+	var totalAtCalibration float64
+	observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
+		calibrationCount.Add(1)
+		snapshot = published
+		totalAtCalibration = testutil.ToFloat64(metrics.RUV3Total) - totalBefore
+	})
 
 	fixture.stmt.RecordStatementRUFinalOutcome(true)
 	const callers = 32
@@ -168,13 +180,14 @@ func TestStatementRUResultFinalizationAndPublication(t *testing.T) {
 	wg.Wait()
 
 	require.Equal(t, int64(1), calibrationCount.Load())
-	require.Equal(t, statementRUCalibrationComplete, snapshot.State)
+	require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
 	require.Equal(t, statementRURawUnits{
 		ScanBytes:            10,
 		NetBytes:             20,
 		FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
 	}, snapshot.Units)
 	expectedResult := calculateStatementRUResultOnly(snapshot.Units)
+	require.Equal(t, expectedResult.TotalRU, totalAtCalibration)
 	require.Equal(t, expectedResult.TotalRU, testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
 	require.Equal(t, expectedResult.TotalRU,
 		testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))-readBefore)
@@ -195,17 +208,17 @@ func TestStatementRUResultFinalizationAndPublication(t *testing.T) {
 
 func TestStatementRUResultProjectionCompleteness(t *testing.T) {
 	t.Run("frontend missing is zero only for ResultOnly", func(t *testing.T) {
-		finalized := (statementRUCalculator{units: statementRURawUnits{
+		finalized, ok := (statementRUCalculator{units: statementRURawUnits{
 			ScanBytes: 10,
 			NetBytes:  20,
-		}}).finalize(true)
-		require.True(t, finalized.hasResult)
+		}}).finalize()
+		require.True(t, ok)
 		require.Equal(t, statementRUResultOnly{TotalRU: 30}, finalized.result)
 		require.Equal(t, statementRUCalibrationIncomplete, finalized.calibrationState)
 		require.Zero(t, finalized.units.FrontendCompileBytes)
 	})
 
-	t.Run("scan missing suppresses RU v3 metrics", func(t *testing.T) {
+	t.Run("scan missing contributes zero to best effort result", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl(nil)
 		var snapshot statementRUCalibrationSnapshot
@@ -215,13 +228,13 @@ func TestStatementRUResultProjectionCompleteness(t *testing.T) {
 		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
 		fixture.stmt.RecordStatementRUFinalOutcome(true)
 		fixture.stmt.finishStatementRUForTest(nil)
-		require.Equal(t, totalBefore, testutil.ToFloat64(metrics.RUV3Total))
+		require.Equal(t, float64(35), testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
 		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
 		require.Zero(t, snapshot.Units.ScanBytes)
 		require.Equal(t, float64(20), snapshot.Units.NetBytes)
 	})
 
-	t.Run("net missing suppresses RU v3 metrics", func(t *testing.T) {
+	t.Run("net missing contributes zero to best effort result", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		fixture.stmt.Ctx.GetSessionVars().RUV2Metrics = execdetails.NewRUV2Metrics()
 		var snapshot statementRUCalibrationSnapshot
@@ -231,20 +244,35 @@ func TestStatementRUResultProjectionCompleteness(t *testing.T) {
 		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
 		fixture.stmt.RecordStatementRUFinalOutcome(true)
 		fixture.stmt.finishStatementRUForTest(nil)
-		require.Equal(t, totalBefore, testutil.ToFloat64(metrics.RUV3Total))
+		require.Equal(t, float64(25), testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
 		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
 		require.Equal(t, float64(10), snapshot.Units.ScanBytes)
 		require.Zero(t, snapshot.Units.NetBytes)
+	})
+
+	t.Run("runtime stats missing contributes zero to best effort result", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = nil
+		var snapshot statementRUCalibrationSnapshot
+		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
+			snapshot = published
+		})
+		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
+		fixture.stmt.RecordStatementRUFinalOutcome(true)
+		fixture.stmt.finishStatementRUForTest(nil)
+		require.Equal(t, float64(35), testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
+		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
+		require.Zero(t, snapshot.Units.CPUWork)
+		require.Zero(t, snapshot.Units.ScanBytes)
+		require.Equal(t, float64(20), snapshot.Units.NetBytes)
 	})
 
 	t.Run("early close suppresses RU v3 metrics", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		fixture.owner.rootEOF.Store(false)
 		var calibrationCount atomic.Int64
-		var snapshot statementRUCalibrationSnapshot
 		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
 			calibrationCount.Add(1)
-			snapshot = published
 		})
 		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
 
@@ -253,13 +281,7 @@ func TestStatementRUResultProjectionCompleteness(t *testing.T) {
 		fixture.stmt.finishStatementRUForTest(nil)
 
 		require.Equal(t, totalBefore, testutil.ToFloat64(metrics.RUV3Total))
-		require.Equal(t, int64(1), calibrationCount.Load())
-		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
-		require.Equal(t, statementRURawUnits{
-			ScanBytes:            10,
-			NetBytes:             20,
-			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
-		}, snapshot.Units)
+		require.Zero(t, calibrationCount.Load())
 	})
 
 	t.Run("invalid evidence suppresses both publications", func(t *testing.T) {
@@ -328,24 +350,98 @@ func TestStatementRUResultValueContracts(t *testing.T) {
 	t.Run("calculator finalizes typed units without plan input", func(t *testing.T) {
 		calculator := statementRUCalculator{
 			units: statementRURawUnits{
+				CPUWork:              5,
 				ScanBytes:            10,
 				NetBytes:             20,
 				FrontendCompileBytes: 15,
 			},
 		}
-		finalized := calculator.finalize(true)
-		require.True(t, finalized.hasResult)
-		require.Equal(t, statementRUResultOnly{TotalRU: 45}, finalized.result)
+		finalized, ok := calculator.finalize()
+		require.True(t, ok)
+		require.Equal(t, statementRUResultOnly{TotalRU: 50}, finalized.result)
+		require.Equal(t, statementRUCalibrationIncomplete, finalized.calibrationState)
 	})
 
 	t.Run("placeholder formula stays pinned", func(t *testing.T) {
-		units := statementRURawUnits{ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
-		require.Equal(t, statementRUResultOnly{TotalRU: 45}, calculateStatementRUResultOnly(units))
+		units := statementRURawUnits{CPUWork: 5, ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
+		require.Equal(t, statementRUResultOnly{TotalRU: 50}, calculateStatementRUResultOnly(units))
+	})
+
+	t.Run("engine projection preserves the lower layer boundary", func(t *testing.T) {
+		units := statementRURawUnits{CPUWork: 5, ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
+		finalized := statementRUFinalizedSnapshot{
+			units:  units,
+			result: calculateStatementRUResultOnly(units),
+		}
+		tikvBefore := testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))
+		publishStatementRUMetricsSafely(finalized)
+		require.Equal(t, float64(30),
+			testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))-tikvBefore)
+	})
+
+	t.Run("publisher uses the frozen snapshot after live evidence changes", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		sessVars := fixture.stmt.Ctx.GetSessionVars()
+		flat := sessVars.StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
+		finalized, ok := calculateStatementRU(
+			flat,
+			sessVars.StmtCtx.RuntimeStatsColl,
+			sessVars.RUV2Metrics,
+			fixture.owner.calculationSetup,
+			true,
+		)
+		require.True(t, ok)
+		require.Equal(t, float64(10), finalized.units.ScanBytes)
+		require.Equal(t, float64(20), finalized.units.NetBytes)
+
+		reader := fixture.stmt.Plan.(*physicalop.PhysicalTableReader)
+		fixture.recordReaderScanDetail(reader, 9, 3, 30)
+		sessVars.RUV2Metrics.AddTiKVCoprocessorResponseBytes(100)
+		liveDetail, found := sessVars.StmtCtx.RuntimeStatsColl.GetCopScanDetail(reader.TablePlan.ID())
+		require.True(t, found)
+		liveScanEvidence := classifyStatementRUScanEvidence(
+			liveDetail.TotalKeys,
+			liveDetail.ProcessedKeys,
+			liveDetail.ProcessedKeysSize,
+		)
+		require.Equal(t, statementRUScanEvidenceValid, liveScanEvidence.state)
+		require.NotEqual(t, finalized.units.ScanBytes, liveScanEvidence.scanBytes)
+		require.NotEqual(t, finalized.units.NetBytes, float64(sessVars.RUV2Metrics.TiKVCoprocessorResponseBytes()))
+
+		var calibrationCount atomic.Int64
+		var snapshot statementRUCalibrationSnapshot
+		observeStatementRUCalibrationForTest(t, func(published statementRUCalibrationSnapshot) {
+			calibrationCount.Add(1)
+			snapshot = published
+		})
+		totalBefore := testutil.ToFloat64(metrics.RUV3Total)
+		publishStatementRUFinalizedSnapshot(fixture.stmt, finalized)
+
+		require.Equal(t, int64(1), calibrationCount.Load())
+		require.Equal(t, statementRUCalibrationIncomplete, snapshot.State)
+		require.Equal(t, finalized.units, snapshot.Units)
+		require.Equal(t, finalized.result.TotalRU, testutil.ToFloat64(metrics.RUV3Total)-totalBefore)
+	})
+
+	t.Run("scan evidence has one valid unavailable invalid classification", func(t *testing.T) {
+		evidence := classifyStatementRUScanEvidence(10, 2, 6)
+		require.Equal(t, statementRUScanEvidenceValid, evidence.state)
+		require.Equal(t, float64(30), evidence.scanBytes)
+
+		evidence = classifyStatementRUScanEvidence(10, 0, 0)
+		require.Equal(t, statementRUScanEvidenceValid, evidence.state)
+		require.Zero(t, evidence.scanBytes)
+
+		require.Equal(t, statementRUScanEvidenceInvalid, classifyStatementRUScanEvidence(10, 0, 1).state)
+		require.Equal(t, statementRUScanEvidenceInvalid, classifyStatementRUScanEvidence(-1, 1, 1).state)
+		require.Equal(t, statementRUScanEvidenceUnavailable, classifyStatementRUScanEvidence(0, 1, 1).state)
+		require.Equal(t, statementRUScanEvidenceUnavailable, classifyStatementRUScanEvidence(1, 1, 0).state)
 	})
 
 	t.Run("finalized and published payloads contain no live references", func(t *testing.T) {
 		for _, value := range []any{
 			statementRUCalculator{},
+			statementRUOperatorResult{},
 			statementRURawUnits{},
 			statementRUFinalizedSnapshot{},
 			statementRUResultOnly{},
@@ -359,10 +455,9 @@ func TestStatementRUResultValueContracts(t *testing.T) {
 		calculatorType := reflect.TypeOf(statementRUCalculator{})
 		require.Equal(t, []string{
 			"units",
-			"invalidEvidence",
 		}, statementRUFieldNames(calculatorType))
 		unitsType := reflect.TypeOf(statementRURawUnits{})
-		require.Equal(t, []string{"ScanBytes", "NetBytes", "FrontendCompileBytes"}, statementRUFieldNames(unitsType))
+		require.Equal(t, []string{"CPUWork", "ScanBytes", "NetBytes", "FrontendCompileBytes"}, statementRUFieldNames(unitsType))
 		resultType := reflect.TypeOf(statementRUResultOnly{})
 		require.Equal(t, []string{"TotalRU"}, statementRUFieldNames(resultType))
 		snapshotType := reflect.TypeOf(statementRUCalibrationSnapshot{})

--- a/tests/realtikvtest/sessiontest/statement_ru_test.go
+++ b/tests/realtikvtest/sessiontest/statement_ru_test.go
@@ -35,7 +35,8 @@ const (
 type statementRURealTiKVObservation struct {
 	sync.Mutex
 	calibrationUnits int
-	state            uint8
+	calibrationState string
+	cpuWork          float64
 	scanBytes        float64
 	netBytes         float64
 	frontendBytes    float64
@@ -61,8 +62,8 @@ func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
 	tikvBefore := testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))
 	testfailpoint.EnableCall(t, statementRUCalibrationUnitsFailpoint, func(
 		observedConnectionID uint64,
-		state uint8,
-		scanBytes, netBytes, frontendCompileBytes float64,
+		calibrationState string,
+		cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
 	) {
 		if observedConnectionID != connectionID {
 			return
@@ -70,7 +71,8 @@ func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
 		observation.Lock()
 		defer observation.Unlock()
 		observation.calibrationUnits++
-		observation.state = state
+		observation.calibrationState = calibrationState
+		observation.cpuWork = cpuWork
 		observation.scanBytes = scanBytes
 		observation.netBytes = netBytes
 		observation.frontendBytes = frontendCompileBytes
@@ -100,17 +102,18 @@ func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
 	require.NoError(t, rs.Close())
 	observation.Lock()
 	defer observation.Unlock()
-	t.Logf("statement RU observation: calibration=%d state=%d scan=%v net=%v frontend=%v",
+	t.Logf("statement RU observation: calibration=%d state=%s cpu=%v scan=%v net=%v frontend=%v",
 		observation.calibrationUnits,
-		observation.state, observation.scanBytes, observation.netBytes, observation.frontendBytes)
+		observation.calibrationState, observation.cpuWork, observation.scanBytes, observation.netBytes, observation.frontendBytes)
 	require.Equal(t, 1, observation.calibrationUnits)
-	require.Equal(t, uint8(1), observation.state)
+	require.Equal(t, "incomplete", observation.calibrationState)
+	require.Zero(t, observation.cpuWork)
 	require.Positive(t, observation.scanBytes)
 	require.Positive(t, observation.netBytes)
 	require.Equal(t, float64(len(query)), observation.frontendBytes)
-	require.InDelta(t, observation.scanBytes+observation.netBytes+observation.frontendBytes,
+	require.InDelta(t, observation.cpuWork+observation.scanBytes+observation.netBytes+observation.frontendBytes,
 		testutil.ToFloat64(metrics.RUV3Total)-totalBefore, 1e-9)
-	require.InDelta(t, observation.scanBytes+observation.netBytes+observation.frontendBytes,
+	require.InDelta(t, observation.cpuWork+observation.scanBytes+observation.netBytes+observation.frontendBytes,
 		testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))-readBefore, 1e-9)
 	require.InDelta(t, observation.scanBytes+observation.netBytes,
 		testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))-tikvBefore, 1e-9)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/70445

Problem Summary:

#70422 freezes one statement-local RU snapshot for the initial `TableReader -> TableScan` case. This stack layer extends that value-only calculation to Selection, Sort, TopN, IndexReader, IndexLookup, and Limit without changing the lower-layer producer, completion, metric, or debug publication boundaries.

The current runtime producers cannot prove that every successful or canceled remote attempt contributed execution details. This layer therefore reports a best-effort ResultOnly value from visible evidence while preventing the dormant calibration path from treating those samples as complete.

### What changed and how does it work?

- Replace the initial fixed two-occurrence calculation with one child-first traversal over `FlatPlanTree.ChildrenIdx`. Each supported occurrence returns value-only state and output rows to its parent; plan IDs are used only for runtime-stat lookup.
- Add typed CPU work for root or TiKV-coprocessor Selection, root Sort, root or TiKV-coprocessor TopN, and root or TiKV-coprocessor Limit. Root TopN uses checked `Offset + Count`; pushed TopN requires the planner-folded zero Offset.
- Collect scan bytes at Reader request boundaries. TableReader and IndexReader consume one request root; ordinary IndexLookup consumes distinct index Build and table Probe branches. Scan leaves never add the same bytes again.
- Treat missing row, scan, network, or frontend evidence as a zero contribution to the best-effort result. Present malformed topology, contradictory numeric evidence, overflow, NaN, infinity, unsupported operators, and unsupported execution sites still fail closed.
- Mark every supported calibration snapshot Incomplete because current producers cannot establish physical-attempt/detail coverage. ResultOnly and the dormant calibration snapshot are still derived exactly once from the same immutable value freeze.
- Keep the existing RU v3 publication boundary: total/read receive CPU, scan, network, and frontend units; the TiKV engine counter receives scan and network units only. All weights remain provisional `1.0` placeholders.
- Keep Sort/TopN ordering materialization as an `intest` planner invariant rather than another production eligibility walk.
- Add producer-backed flat-plan tests for occurrence-local formulas, direct-child rows, IndexReader and both IndexLookup branches, missing and invalid evidence, exactly-once/same-freeze behavior, and unchanged real SQL results. Add separate benchmark boundaries for operator calculation, tree traversal, finalize/publication, and a synthetic terminal.

“Best-effort lower bound” here means that missing contributions are not imputed. It is not a strict mathematical bound because the demo-compatible aggregate scan-byte proxy is non-monotone when partial aggregates are combined.

This is stack layer 3 and depends on #70422. Join, aggregation, IndexMerge, CTEs, scalar subqueries, prepared/retry paths, cursors, DML, new variables, and new publication surfaces remain unsupported or out of scope.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Ready validation:

- `make bazel_prepare`
- `./tools/check/failpoint-go-test.sh pkg/executor -run '^TestStatementRU' -count=1`
- `tiup playground nightly --mode tikv-slim --tag realtikvtest`
- `./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -run '^TestStatementRUSimpleSelectRealTiKV$' -count=1 -args -tikv-path 'tikv://127.0.0.1:2379?disableGC=true'`
- `make lint`
- `git diff --check`

The RealTiKV validation used explicit TiUP nightly, not TiUP's default version. TiUP selected `v9.0.0-beta.2.pre-nightly` for PD and TiKV, and the running PD endpoint reported `v9.0.0-beta.2.pre-363-g8cabcf1`. The test retained positive assertions for both scan and network bytes, passed, and the playground was stopped and cleaned afterward.

WIP benchmark smoke also ran all four independent boundaries with `-benchtime=1x`; these runs prove execution only and are not stable performance measurements. The final post-review tree-traversal smoke reported `1780 ns/op` and `0 allocs/op`.

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Eligible supported statements perform one bounded child-first traversal and the occurrence-local arithmetic described above. The finalized values retain no live plan or runtime-stat pointers, and the final tree-traversal benchmark smoke reported no heap allocations.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved statement resource-unit calculation across supported query operators, including scans, filtering, sorting, limiting, and top-N operations.
  * Added CPU work and scan-byte accounting for more complete usage metrics.
  * Added calibration status reporting to clarify when results are complete or incomplete.

* **Bug Fixes**
  * Invalid, missing, contradictory, or overflowing execution evidence is now rejected safely.
  * Malformed or unsupported query plans no longer produce unreliable calculations.
  * Finalized metrics are consistently published only when terminal conditions are valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->