### PR TITLE
ddl: preserve cloud storage mode across owner failover

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3258,6 +3258,15 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 		})
 	} else {
 		job := reorgInfo.Job
+		workerCntLimit := job.ReorgMeta.GetConcurrency()
+		requiredSlots, err := adjustConcurrency(ctx, taskManager, workerCntLimit)
+		if err != nil {
+			return err
+		}
+		logutil.DDLLogger().Info("adjusted add-index task required slots",
+			zap.Int("worker-cnt", workerCntLimit), zap.Int("required-slots", requiredSlots),
+			zap.String("task-key", taskKey))
+		rowSize := estimateTableRowSize(w.workCtx, w.store, w.sess.GetRestrictedSQLExecutor(), t)
 		cloudStorageURI, err := w.cloudStorageURIForNewBackfillTask(job, reorgInfo.mergingTmpIdx)
 		if err != nil {
 			return err
@@ -3268,23 +3277,9 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 			EleTypeKey:      reorgInfo.currElement.TypeKey,
 			CloudStorageURI: cloudStorageURI,
 			MergeTempIndex:  reorgInfo.mergingTmpIdx,
+			EstimateRowSize: rowSize,
 			Version:         BackfillTaskMetaVersion1,
 		}
-		failpoint.InjectCall("afterNewBackfillTaskMeta", taskMeta)
-		failpoint.Inject("returnAfterNewBackfillTaskMeta", func() {
-			failpoint.Return(errors.New("stopped after constructing new backfill task meta"))
-		})
-
-		workerCntLimit := job.ReorgMeta.GetConcurrency()
-		requiredSlots, err := adjustConcurrency(ctx, taskManager, workerCntLimit)
-		if err != nil {
-			return err
-		}
-		logutil.DDLLogger().Info("adjusted add-index task required slots",
-			zap.Int("worker-cnt", workerCntLimit), zap.Int("required-slots", requiredSlots),
-			zap.String("task-key", taskKey))
-		rowSize := estimateTableRowSize(w.workCtx, w.store, w.sess.GetRestrictedSQLExecutor(), t)
-		taskMeta.EstimateRowSize = rowSize
 
 		metaData, err := json.Marshal(taskMeta)
 		if err != nil {
@@ -3293,7 +3288,6 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 
 		targetScope := reorgInfo.ReorgMeta.TargetScope
 		maxNodeCnt := reorgInfo.ReorgMeta.MaxNodeCount
-		failpoint.InjectCall("beforeSubmitNewBackfillTask")
 		task, err := handle.SubmitTaskWithExtraParams(ctx, taskKey, taskType, w.store.GetKeyspace(),
 			requiredSlots, targetScope, maxNodeCnt, proto.ExtraParams{PauseOnKVDiskFull: true}, metaData)
 		if err != nil {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3161,7 +3161,10 @@ func (w *worker) resolveCloudStorageURI(job *model.Job, mergeTempIndex bool) (st
 
 	jc.cloudStorageURI = handle.GetCloudStorageURI(w.workCtx, w.store)
 	if jc.cloudStorageURI == "" {
-		return "", errors.Errorf("cloud storage URI is empty for add-index job %d with cloud storage enabled", job.ID)
+		// Recovering requires the user to restore the cloud storage URI. Retrying could leave the DDL job
+		// in write reorganization for a long time before the configuration problem is noticed, so fail it.
+		return "", dbterror.ErrIngestFailed.GenWithStackByArgs(
+			fmt.Sprintf("cloud storage URI is empty for add-index job %d with cloud storage enabled", job.ID))
 	}
 	return jc.cloudStorageURI, nil
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3150,6 +3150,19 @@ func shouldAutoPauseExistingKVDiskFullTask(job *model.Job, task *proto.Task) boo
 		!job.HasResumeReason(model.JobResumeReasonKVDiskFull)
 }
 
+func (w *worker) cloudStorageURIForNewBackfillTask(job *model.Job, mergeTempIndex bool) (string, error) {
+	jc := w.jobContext(job.ID, job.ReorgMeta)
+	if mergeTempIndex || !job.ReorgMeta.UseCloudStorage || jc.cloudStorageURI != "" {
+		return jc.cloudStorageURI, nil
+	}
+
+	jc.cloudStorageURI = handle.GetCloudStorageURI(w.workCtx, w.store)
+	if jc.cloudStorageURI == "" {
+		return "", errors.Errorf("cloud storage URI is empty for add-index job %d with cloud storage enabled", job.ID)
+	}
+	return jc.cloudStorageURI, nil
+}
+
 func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *reorgInfo) error {
 	stepCtx := jobCtx.stepCtx
 	taskType := proto.Backfill
@@ -3245,6 +3258,23 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 		})
 	} else {
 		job := reorgInfo.Job
+		cloudStorageURI, err := w.cloudStorageURIForNewBackfillTask(job, reorgInfo.mergingTmpIdx)
+		if err != nil {
+			return err
+		}
+		taskMeta := &BackfillTaskMeta{
+			Job:             *job.Clone(),
+			EleIDs:          extractElemIDs(reorgInfo),
+			EleTypeKey:      reorgInfo.currElement.TypeKey,
+			CloudStorageURI: cloudStorageURI,
+			MergeTempIndex:  reorgInfo.mergingTmpIdx,
+			Version:         BackfillTaskMetaVersion1,
+		}
+		failpoint.InjectCall("afterNewBackfillTaskMeta", taskMeta)
+		failpoint.Inject("returnAfterNewBackfillTaskMeta", func() {
+			failpoint.Return(errors.New("stopped after constructing new backfill task meta"))
+		})
+
 		workerCntLimit := job.ReorgMeta.GetConcurrency()
 		requiredSlots, err := adjustConcurrency(ctx, taskManager, workerCntLimit)
 		if err != nil {
@@ -3254,15 +3284,7 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 			zap.Int("worker-cnt", workerCntLimit), zap.Int("required-slots", requiredSlots),
 			zap.String("task-key", taskKey))
 		rowSize := estimateTableRowSize(w.workCtx, w.store, w.sess.GetRestrictedSQLExecutor(), t)
-		taskMeta := &BackfillTaskMeta{
-			Job:             *job.Clone(),
-			EleIDs:          extractElemIDs(reorgInfo),
-			EleTypeKey:      reorgInfo.currElement.TypeKey,
-			CloudStorageURI: w.jobContext(job.ID, job.ReorgMeta).cloudStorageURI,
-			MergeTempIndex:  reorgInfo.mergingTmpIdx,
-			EstimateRowSize: rowSize,
-			Version:         BackfillTaskMetaVersion1,
-		}
+		taskMeta.EstimateRowSize = rowSize
 
 		metaData, err := json.Marshal(taskMeta)
 		if err != nil {
@@ -3271,6 +3293,7 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 
 		targetScope := reorgInfo.ReorgMeta.TargetScope
 		maxNodeCnt := reorgInfo.ReorgMeta.MaxNodeCount
+		failpoint.InjectCall("beforeSubmitNewBackfillTask")
 		task, err := handle.SubmitTaskWithExtraParams(ctx, taskKey, taskType, w.store.GetKeyspace(),
 			requiredSlots, targetScope, maxNodeCnt, proto.ExtraParams{PauseOnKVDiskFull: true}, metaData)
 		if err != nil {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -3150,7 +3150,10 @@ func shouldAutoPauseExistingKVDiskFullTask(job *model.Job, task *proto.Task) boo
 		!job.HasResumeReason(model.JobResumeReasonKVDiskFull)
 }
 
-func (w *worker) cloudStorageURIForNewBackfillTask(job *model.Job, mergeTempIndex bool) (string, error) {
+// resolveCloudStorageURI reloads the URI when a new DDL owner resumes the job.
+// UseCloudStorage is persisted in the job, but the URI loaded by loadCloudStorageURI
+// is cached only in the previous owner's in-memory ReorgContext.
+func (w *worker) resolveCloudStorageURI(job *model.Job, mergeTempIndex bool) (string, error) {
 	jc := w.jobContext(job.ID, job.ReorgMeta)
 	if mergeTempIndex || !job.ReorgMeta.UseCloudStorage || jc.cloudStorageURI != "" {
 		return jc.cloudStorageURI, nil
@@ -3267,7 +3270,7 @@ func (w *worker) executeDistTask(jobCtx *jobContext, t table.Table, reorgInfo *r
 			zap.Int("worker-cnt", workerCntLimit), zap.Int("required-slots", requiredSlots),
 			zap.String("task-key", taskKey))
 		rowSize := estimateTableRowSize(w.workCtx, w.store, w.sess.GetRestrictedSQLExecutor(), t)
-		cloudStorageURI, err := w.cloudStorageURIForNewBackfillTask(job, reorgInfo.mergingTmpIdx)
+		cloudStorageURI, err := w.resolveCloudStorageURI(job, reorgInfo.mergingTmpIdx)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -17,6 +17,7 @@ package ddl_test
 import (
 	"context"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,6 +25,8 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -35,6 +38,150 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalDistTask)
+	taskMgr, err := storage.GetDXFSvcTaskMgr()
+	require.NoError(t, err)
+
+	originalURI := vardef.CloudStorageURI.Load()
+	t.Cleanup(func() {
+		vardef.CloudStorageURI.Store(originalURI)
+	})
+
+	var (
+		metaMu         sync.Mutex
+		capturedMetas  []*ddl.BackfillTaskMeta
+		preSubmitCalls atomic.Int32
+	)
+	resetCaptured := func() {
+		metaMu.Lock()
+		capturedMetas = nil
+		metaMu.Unlock()
+		preSubmitCalls.Store(0)
+	}
+	getCaptured := func() []*ddl.BackfillTaskMeta {
+		metaMu.Lock()
+		defer metaMu.Unlock()
+		return append([]*ddl.BackfillTaskMeta(nil), capturedMetas...)
+	}
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterNewBackfillTaskMeta", func(taskMeta *ddl.BackfillTaskMeta) {
+		captured := *taskMeta
+		captured.Job = *taskMeta.Job.Clone()
+		metaMu.Lock()
+		capturedMetas = append(capturedMetas, &captured)
+		metaMu.Unlock()
+	})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/returnAfterNewBackfillTaskMeta", "return(true)")
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeSubmitNewBackfillTask", func() {
+		preSubmitCalls.Add(1)
+	})
+
+	const firstJobID int64 = 900001
+	newJob := func(id int64, useCloudStorage bool) *model.Job {
+		return &model.Job{
+			ID: id,
+			ReorgMeta: &model.DDLReorgMeta{
+				UseCloudStorage: useCloudStorage,
+			},
+		}
+	}
+	execute := func(job *model.Job, mergeTempIndex bool, cachedURI string) (string, error) {
+		return ddl.ExecuteDistTaskForCloudStorageTest(dom.DDL(), job, mergeTempIndex, cachedURI)
+	}
+	requireStoppedAfterConstruction := func(err error) {
+		require.ErrorContains(t, err, "stopped after constructing new backfill task meta")
+		require.Zero(t, preSubmitCalls.Load())
+	}
+
+	t.Run("empty configured URI fails before submission", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("")
+		job := newJob(firstJobID, true)
+		_, err := execute(job, false, "")
+		require.ErrorContains(t, err, "cloud storage URI is empty for add-index job 900001 with cloud storage enabled")
+		require.True(t, ddl.IsRetryableJobErrorForTest(err, 0))
+		require.Empty(t, getCaptured())
+		require.Zero(t, preSubmitCalls.Load())
+	})
+
+	t.Run("configured URI recovers retry", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("s3://bucket")
+		job := newJob(firstJobID+1, true)
+		cachedURI, err := execute(job, false, "")
+		requireStoppedAfterConstruction(err)
+		metas := getCaptured()
+		require.Len(t, metas, 1)
+		require.Equal(t, "s3://bucket/dxf/", metas[0].CloudStorageURI)
+		require.True(t, metas[0].Job.ReorgMeta.UseCloudStorage)
+		require.Equal(t, "s3://bucket/dxf/", cachedURI)
+	})
+
+	t.Run("local sort permits empty URI", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("")
+		job := newJob(firstJobID+2, false)
+		_, err := execute(job, false, "")
+		requireStoppedAfterConstruction(err)
+		metas := getCaptured()
+		require.Len(t, metas, 1)
+		require.Empty(t, metas[0].CloudStorageURI)
+		require.False(t, metas[0].Job.ReorgMeta.UseCloudStorage)
+	})
+
+	t.Run("cached URI wins over changed configuration", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("s3://new-bucket")
+		job := newJob(firstJobID+3, true)
+		_, err := execute(job, false, "s3://cached-bucket/dxf/")
+		requireStoppedAfterConstruction(err)
+		metas := getCaptured()
+		require.Len(t, metas, 1)
+		require.Equal(t, "s3://cached-bucket/dxf/", metas[0].CloudStorageURI)
+	})
+
+	t.Run("merge temp index does not require cloud storage", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("")
+		job := newJob(firstJobID+4, true)
+		_, err := execute(job, true, "")
+		requireStoppedAfterConstruction(err)
+		metas := getCaptured()
+		require.Len(t, metas, 1)
+		require.Empty(t, metas[0].CloudStorageURI)
+		require.True(t, metas[0].MergeTempIndex)
+	})
+
+	t.Run("succeeded existing task bypasses new task URI resolution", func(t *testing.T) {
+		resetCaptured()
+		vardef.CloudStorageURI.Store("")
+		job := newJob(firstJobID+5, true)
+		taskKey := ddl.NewTaskKeyBuilder().Build(job.ID)
+		taskID, err := taskMgr.CreateTask(ctx, taskKey, proto.Backfill, store.GetKeyspace(),
+			0, "", 0, proto.ExtraParams{}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, cleanupErr := taskMgr.ExecuteSQLWithNewSession(ctx,
+				"delete from mysql.tidb_global_task where task_key = %?", taskKey)
+			require.NoError(t, cleanupErr)
+			_, cleanupErr = taskMgr.ExecuteSQLWithNewSession(ctx,
+				"delete from mysql.tidb_global_task_history where task_key = %?", taskKey)
+			require.NoError(t, cleanupErr)
+		})
+		task, err := taskMgr.GetTaskByID(ctx, taskID)
+		require.NoError(t, err)
+		require.NoError(t, taskMgr.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepOne, nil))
+		require.NoError(t, taskMgr.SucceedTask(ctx, taskID))
+
+		cachedURI, err := execute(job, false, "")
+		require.NoError(t, err)
+		require.Empty(t, cachedURI)
+		require.Empty(t, getCaptured())
+		require.Zero(t, preSubmitCalls.Load())
+	})
+}
 
 func TestIndexChange(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -17,7 +17,6 @@ package ddl_test
 import (
 	"context"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,8 +24,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
-	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
-	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -38,150 +35,6 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 )
-
-func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalDistTask)
-	taskMgr, err := storage.GetDXFSvcTaskMgr()
-	require.NoError(t, err)
-
-	originalURI := vardef.CloudStorageURI.Load()
-	t.Cleanup(func() {
-		vardef.CloudStorageURI.Store(originalURI)
-	})
-
-	var (
-		metaMu         sync.Mutex
-		capturedMetas  []*ddl.BackfillTaskMeta
-		preSubmitCalls atomic.Int32
-	)
-	resetCaptured := func() {
-		metaMu.Lock()
-		capturedMetas = nil
-		metaMu.Unlock()
-		preSubmitCalls.Store(0)
-	}
-	getCaptured := func() []*ddl.BackfillTaskMeta {
-		metaMu.Lock()
-		defer metaMu.Unlock()
-		return append([]*ddl.BackfillTaskMeta(nil), capturedMetas...)
-	}
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterNewBackfillTaskMeta", func(taskMeta *ddl.BackfillTaskMeta) {
-		captured := *taskMeta
-		captured.Job = *taskMeta.Job.Clone()
-		metaMu.Lock()
-		capturedMetas = append(capturedMetas, &captured)
-		metaMu.Unlock()
-	})
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/returnAfterNewBackfillTaskMeta", "return(true)")
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeSubmitNewBackfillTask", func() {
-		preSubmitCalls.Add(1)
-	})
-
-	const firstJobID int64 = 900001
-	newJob := func(id int64, useCloudStorage bool) *model.Job {
-		return &model.Job{
-			ID: id,
-			ReorgMeta: &model.DDLReorgMeta{
-				UseCloudStorage: useCloudStorage,
-			},
-		}
-	}
-	execute := func(job *model.Job, mergeTempIndex bool, cachedURI string) (string, error) {
-		return ddl.ExecuteDistTaskForCloudStorageTest(dom.DDL(), job, mergeTempIndex, cachedURI)
-	}
-	requireStoppedAfterConstruction := func(err error) {
-		require.ErrorContains(t, err, "stopped after constructing new backfill task meta")
-		require.Zero(t, preSubmitCalls.Load())
-	}
-
-	t.Run("empty configured URI fails before submission", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("")
-		job := newJob(firstJobID, true)
-		_, err := execute(job, false, "")
-		require.ErrorContains(t, err, "cloud storage URI is empty for add-index job 900001 with cloud storage enabled")
-		require.True(t, ddl.IsRetryableJobErrorForTest(err, 0))
-		require.Empty(t, getCaptured())
-		require.Zero(t, preSubmitCalls.Load())
-	})
-
-	t.Run("configured URI recovers retry", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("s3://bucket")
-		job := newJob(firstJobID+1, true)
-		cachedURI, err := execute(job, false, "")
-		requireStoppedAfterConstruction(err)
-		metas := getCaptured()
-		require.Len(t, metas, 1)
-		require.Equal(t, "s3://bucket/dxf/", metas[0].CloudStorageURI)
-		require.True(t, metas[0].Job.ReorgMeta.UseCloudStorage)
-		require.Equal(t, "s3://bucket/dxf/", cachedURI)
-	})
-
-	t.Run("local sort permits empty URI", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("")
-		job := newJob(firstJobID+2, false)
-		_, err := execute(job, false, "")
-		requireStoppedAfterConstruction(err)
-		metas := getCaptured()
-		require.Len(t, metas, 1)
-		require.Empty(t, metas[0].CloudStorageURI)
-		require.False(t, metas[0].Job.ReorgMeta.UseCloudStorage)
-	})
-
-	t.Run("cached URI wins over changed configuration", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("s3://new-bucket")
-		job := newJob(firstJobID+3, true)
-		_, err := execute(job, false, "s3://cached-bucket/dxf/")
-		requireStoppedAfterConstruction(err)
-		metas := getCaptured()
-		require.Len(t, metas, 1)
-		require.Equal(t, "s3://cached-bucket/dxf/", metas[0].CloudStorageURI)
-	})
-
-	t.Run("merge temp index does not require cloud storage", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("")
-		job := newJob(firstJobID+4, true)
-		_, err := execute(job, true, "")
-		requireStoppedAfterConstruction(err)
-		metas := getCaptured()
-		require.Len(t, metas, 1)
-		require.Empty(t, metas[0].CloudStorageURI)
-		require.True(t, metas[0].MergeTempIndex)
-	})
-
-	t.Run("succeeded existing task bypasses new task URI resolution", func(t *testing.T) {
-		resetCaptured()
-		vardef.CloudStorageURI.Store("")
-		job := newJob(firstJobID+5, true)
-		taskKey := ddl.NewTaskKeyBuilder().Build(job.ID)
-		taskID, err := taskMgr.CreateTask(ctx, taskKey, proto.Backfill, store.GetKeyspace(),
-			0, "", 0, proto.ExtraParams{}, nil)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_, cleanupErr := taskMgr.ExecuteSQLWithNewSession(ctx,
-				"delete from mysql.tidb_global_task where task_key = %?", taskKey)
-			require.NoError(t, cleanupErr)
-			_, cleanupErr = taskMgr.ExecuteSQLWithNewSession(ctx,
-				"delete from mysql.tidb_global_task_history where task_key = %?", taskKey)
-			require.NoError(t, cleanupErr)
-		})
-		task, err := taskMgr.GetTaskByID(ctx, taskID)
-		require.NoError(t, err)
-		require.NoError(t, taskMgr.SwitchTaskStep(ctx, task, proto.TaskStateRunning, proto.StepOne, nil))
-		require.NoError(t, taskMgr.SucceedTask(ctx, taskID))
-
-		cachedURI, err := execute(job, false, "")
-		require.NoError(t, err)
-		require.Empty(t, cachedURI)
-		require.Empty(t, getCaptured())
-		require.Zero(t, preSubmitCalls.Load())
-	})
-}
 
 func TestIndexChange(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)

--- a/pkg/ddl/index_nokit_test.go
+++ b/pkg/ddl/index_nokit_test.go
@@ -26,52 +26,76 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/ingestor/errdef"
-	"github.com/pingcap/tidb/pkg/kv"
-	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
-// ExecuteDistTaskForCloudStorageTest runs executeDistTask with the minimum
-// internal DDL state needed by the cloud-storage URI regression test.
-func ExecuteDistTaskForCloudStorageTest(
-	d DDL,
-	job *model.Job,
-	mergeTempIndex bool,
-	cachedURI string,
-) (string, error) {
-	impl := d.(*ddl)
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalDistTask)
-	w := newWorker(ctx, addIdxWorker, impl.sessPool, impl.delRangeMgr, impl.ddlCtx)
-	jc := NewReorgContext()
-	jc.cloudStorageURI = cachedURI
-	impl.jobCtx.Lock()
-	impl.jobCtx.jobCtxMap[job.ID] = jc
-	impl.jobCtx.Unlock()
-	impl.newReorgCtx(job.ID, 0)
-	defer func() {
-		impl.removeReorgCtx(job.ID)
-		impl.jobCtx.Lock()
-		delete(impl.jobCtx.jobCtxMap, job.ID)
-		impl.jobCtx.Unlock()
-	}()
-	reorgInfo := &reorgInfo{
-		Job:           job,
-		mergingTmpIdx: mergeTempIndex,
-		currElement: &meta.Element{
-			ID:      1,
-			TypeKey: meta.IndexElementKey,
-		},
-	}
-	err := w.executeDistTask(&jobContext{stepCtx: ctx}, nil, reorgInfo)
-	return jc.cloudStorageURI, err
-}
+func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
+	originalURI := vardef.CloudStorageURI.Load()
+	t.Cleanup(func() {
+		vardef.CloudStorageURI.Store(originalURI)
+	})
 
-// IsRetryableJobErrorForTest exposes the DDL retry classification to external tests.
-func IsRetryableJobErrorForTest(err error, jobErrCnt int64) bool {
-	return isRetryableJobError(err, jobErrCnt)
+	const jobID int64 = 900001
+	newTestWorker := func(cachedURI string) (*worker, *ReorgContext) {
+		jc := NewReorgContext()
+		jc.cloudStorageURI = cachedURI
+		dc := &ddlCtx{}
+		dc.jobCtx.jobCtxMap = map[int64]*ReorgContext{jobID: jc}
+		return &worker{workCtx: context.Background(), ddlCtx: dc}, jc
+	}
+	newJob := func(useCloudStorage bool) *model.Job {
+		return &model.Job{
+			ID: jobID,
+			ReorgMeta: &model.DDLReorgMeta{
+				UseCloudStorage: useCloudStorage,
+			},
+		}
+	}
+
+	t.Run("configured URI recovers empty owner cache", func(t *testing.T) {
+		vardef.CloudStorageURI.Store("s3://bucket")
+		w, jc := newTestWorker("")
+		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		require.NoError(t, err)
+		require.Equal(t, "s3://bucket/dxf/", uri)
+		require.Equal(t, uri, jc.cloudStorageURI)
+	})
+
+	t.Run("missing configured URI is retryable", func(t *testing.T) {
+		vardef.CloudStorageURI.Store("")
+		w, _ := newTestWorker("")
+		_, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		require.ErrorContains(t, err, "cloud storage URI is empty for add-index job 900001 with cloud storage enabled")
+		require.True(t, isRetryableJobError(err, 0))
+	})
+
+	t.Run("cached URI wins over changed configuration", func(t *testing.T) {
+		vardef.CloudStorageURI.Store("s3://new-bucket")
+		w, _ := newTestWorker("s3://cached-bucket/dxf/")
+		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		require.NoError(t, err)
+		require.Equal(t, "s3://cached-bucket/dxf/", uri)
+	})
+
+	t.Run("local sort permits empty URI", func(t *testing.T) {
+		vardef.CloudStorageURI.Store("")
+		w, _ := newTestWorker("")
+		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(false), false)
+		require.NoError(t, err)
+		require.Empty(t, uri)
+	})
+
+	t.Run("merge temp index does not require cloud storage", func(t *testing.T) {
+		vardef.CloudStorageURI.Store("")
+		w, _ := newTestWorker("")
+		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), true)
+		require.NoError(t, err)
+		require.Empty(t, uri)
+	})
 }
 
 func TestShouldAutoPauseExistingKVDiskFullTask(t *testing.T) {

--- a/pkg/ddl/index_nokit_test.go
+++ b/pkg/ddl/index_nokit_test.go
@@ -26,11 +26,53 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/ingestor/errdef"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+// ExecuteDistTaskForCloudStorageTest runs executeDistTask with the minimum
+// internal DDL state needed by the cloud-storage URI regression test.
+func ExecuteDistTaskForCloudStorageTest(
+	d DDL,
+	job *model.Job,
+	mergeTempIndex bool,
+	cachedURI string,
+) (string, error) {
+	impl := d.(*ddl)
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalDistTask)
+	w := newWorker(ctx, addIdxWorker, impl.sessPool, impl.delRangeMgr, impl.ddlCtx)
+	jc := NewReorgContext()
+	jc.cloudStorageURI = cachedURI
+	impl.jobCtx.Lock()
+	impl.jobCtx.jobCtxMap[job.ID] = jc
+	impl.jobCtx.Unlock()
+	impl.newReorgCtx(job.ID, 0)
+	defer func() {
+		impl.removeReorgCtx(job.ID)
+		impl.jobCtx.Lock()
+		delete(impl.jobCtx.jobCtxMap, job.ID)
+		impl.jobCtx.Unlock()
+	}()
+	reorgInfo := &reorgInfo{
+		Job:           job,
+		mergingTmpIdx: mergeTempIndex,
+		currElement: &meta.Element{
+			ID:      1,
+			TypeKey: meta.IndexElementKey,
+		},
+	}
+	err := w.executeDistTask(&jobContext{stepCtx: ctx}, nil, reorgInfo)
+	return jc.cloudStorageURI, err
+}
+
+// IsRetryableJobErrorForTest exposes the DDL retry classification to external tests.
+func IsRetryableJobErrorForTest(err error, jobErrCnt int64) bool {
+	return isRetryableJobError(err, jobErrCnt)
+}
 
 func TestShouldAutoPauseExistingKVDiskFullTask(t *testing.T) {
 	task := &proto.Task{

--- a/pkg/ddl/index_nokit_test.go
+++ b/pkg/ddl/index_nokit_test.go
@@ -65,12 +65,12 @@ func TestResolveCloudStorageURI(t *testing.T) {
 		require.Equal(t, uri, jc.cloudStorageURI)
 	})
 
-	t.Run("missing configured URI is retryable", func(t *testing.T) {
+	t.Run("missing configured URI is unretryable", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("")
 		w, _ := newTestWorker("")
 		_, err := w.resolveCloudStorageURI(newJob(true), false)
 		require.ErrorContains(t, err, "cloud storage URI is empty for add-index job 900001 with cloud storage enabled")
-		require.True(t, isRetryableJobError(err, 0))
+		require.False(t, isRetryableJobError(err, 0))
 	})
 
 	t.Run("cached URI wins over changed configuration", func(t *testing.T) {

--- a/pkg/ddl/index_nokit_test.go
+++ b/pkg/ddl/index_nokit_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
+func TestResolveCloudStorageURI(t *testing.T) {
 	originalURI := vardef.CloudStorageURI.Load()
 	t.Cleanup(func() {
 		vardef.CloudStorageURI.Store(originalURI)
@@ -59,7 +59,7 @@ func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
 	t.Run("configured URI recovers empty owner cache", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("s3://bucket")
 		w, jc := newTestWorker("")
-		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		uri, err := w.resolveCloudStorageURI(newJob(true), false)
 		require.NoError(t, err)
 		require.Equal(t, "s3://bucket/dxf/", uri)
 		require.Equal(t, uri, jc.cloudStorageURI)
@@ -68,7 +68,7 @@ func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
 	t.Run("missing configured URI is retryable", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("")
 		w, _ := newTestWorker("")
-		_, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		_, err := w.resolveCloudStorageURI(newJob(true), false)
 		require.ErrorContains(t, err, "cloud storage URI is empty for add-index job 900001 with cloud storage enabled")
 		require.True(t, isRetryableJobError(err, 0))
 	})
@@ -76,7 +76,7 @@ func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
 	t.Run("cached URI wins over changed configuration", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("s3://new-bucket")
 		w, _ := newTestWorker("s3://cached-bucket/dxf/")
-		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), false)
+		uri, err := w.resolveCloudStorageURI(newJob(true), false)
 		require.NoError(t, err)
 		require.Equal(t, "s3://cached-bucket/dxf/", uri)
 	})
@@ -84,7 +84,7 @@ func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
 	t.Run("local sort permits empty URI", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("")
 		w, _ := newTestWorker("")
-		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(false), false)
+		uri, err := w.resolveCloudStorageURI(newJob(false), false)
 		require.NoError(t, err)
 		require.Empty(t, uri)
 	})
@@ -92,7 +92,7 @@ func TestCloudStorageURIForNewBackfillTask(t *testing.T) {
 	t.Run("merge temp index does not require cloud storage", func(t *testing.T) {
 		vardef.CloudStorageURI.Store("")
 		w, _ := newTestWorker("")
-		uri, err := w.cloudStorageURIForNewBackfillTask(newJob(true), true)
+		uri, err := w.resolveCloudStorageURI(newJob(true), true)
 		require.NoError(t, err)
 		require.Empty(t, uri)
 	})

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -30,7 +30,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func propagateUseCloudStorageMode(parentJob, proxyJob *model.Job) {
+// updateParentJobFromProxy copies state discovered while executing a temporary
+// proxy job that belongs to the durable parent rather than the SubJob. ToProxyJob
+// gives each proxy a copy of the parent's ReorgMeta, and FromProxyJob does not
+// copy UseCloudStorage back. Without this step, later proxies can revert to local
+// sort, including after a DDL owner failover.
+func updateParentJobFromProxy(parentJob, proxyJob *model.Job) {
 	if parentJob.ReorgMeta != nil && proxyJob.ReorgMeta != nil && proxyJob.ReorgMeta.UseCloudStorage {
 		parentJob.ReorgMeta.UseCloudStorage = true
 	}
@@ -53,7 +58,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 				}
 				proxyJob := sub.ToProxyJob(job, i)
 				ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
-				propagateUseCloudStorageMode(job, &proxyJob)
+				updateParentJobFromProxy(job, &proxyJob)
 				err = handleRollbackException(err, proxyJob.Error)
 				if err != nil {
 					return ver, err
@@ -79,7 +84,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			prevSubState := sub.State
 			proxyJob := sub.ToProxyJob(job, i)
 			ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
-			propagateUseCloudStorageMode(job, &proxyJob)
+			updateParentJobFromProxy(job, &proxyJob)
 			sub.FromProxyJob(&proxyJob, ver)
 			job.ResumeReason = proxyJob.ResumeReason
 			if promoteProxyKVDiskFullPause(job, sub, prevSubState, &proxyJob) {
@@ -118,7 +123,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			}
 			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob)
 			failpoint.InjectCall("beforeBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
-			propagateUseCloudStorageMode(job, &proxyJob)
+			updateParentJobFromProxy(job, &proxyJob)
 			failpoint.InjectCall("afterBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
 			if !schemaVersionGenerated && proxyJobVer != 0 {
 				schemaVersionGenerated = true
@@ -174,7 +179,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 		prevSubState := sub.State
 		proxyJob := sub.ToProxyJob(job, i)
 		ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
-		propagateUseCloudStorageMode(job, &proxyJob)
+		updateParentJobFromProxy(job, &proxyJob)
 		sub.FromProxyJob(&proxyJob, ver)
 		job.ResumeReason = proxyJob.ResumeReason
 		if promoteProxyKVDiskFullPause(job, sub, prevSubState, &proxyJob) {

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -15,6 +15,7 @@
 package ddl
 
 import (
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -28,6 +29,12 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/zap"
 )
+
+func propagateUseCloudStorageMode(parentJob, proxyJob *model.Job) {
+	if parentJob.ReorgMeta != nil && proxyJob.ReorgMeta != nil && proxyJob.ReorgMeta.UseCloudStorage {
+		parentJob.ReorgMeta.UseCloudStorage = true
+	}
+}
 
 func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	jobCtx.inInnerRunOneJobStep = true
@@ -46,6 +53,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 				}
 				proxyJob := sub.ToProxyJob(job, i)
 				ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
+				propagateUseCloudStorageMode(job, &proxyJob)
 				err = handleRollbackException(err, proxyJob.Error)
 				if err != nil {
 					return ver, err
@@ -71,6 +79,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			prevSubState := sub.State
 			proxyJob := sub.ToProxyJob(job, i)
 			ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
+			propagateUseCloudStorageMode(job, &proxyJob)
 			sub.FromProxyJob(&proxyJob, ver)
 			job.ResumeReason = proxyJob.ResumeReason
 			if promoteProxyKVDiskFullPause(job, sub, prevSubState, &proxyJob) {
@@ -108,6 +117,9 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 				proxyJob.MultiSchemaInfo.SkipVersion = true
 			}
 			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob)
+			failpoint.InjectCall("beforeBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
+			propagateUseCloudStorageMode(job, &proxyJob)
+			failpoint.InjectCall("afterBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
 			if !schemaVersionGenerated && proxyJobVer != 0 {
 				schemaVersionGenerated = true
 				ver = proxyJobVer
@@ -162,6 +174,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 		prevSubState := sub.State
 		proxyJob := sub.ToProxyJob(job, i)
 		ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
+		propagateUseCloudStorageMode(job, &proxyJob)
 		sub.FromProxyJob(&proxyJob, ver)
 		job.ResumeReason = proxyJob.ResumeReason
 		if promoteProxyKVDiskFullPause(job, sub, prevSubState, &proxyJob) {

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -35,6 +35,8 @@ import (
 // gives each proxy a copy of the parent's ReorgMeta, and FromProxyJob does not
 // copy UseCloudStorage back. Without this step, later proxies can revert to local
 // sort, including after a DDL owner failover.
+// This cannot reconstruct a selection made by an older binary before the field
+// was copied to the parent, because neither the parent nor SubJob persists it.
 func updateParentJobFromProxy(parentJob, proxyJob *model.Job) {
 	if parentJob.ReorgMeta != nil && proxyJob.ReorgMeta != nil && proxyJob.ReorgMeta.UseCloudStorage {
 		parentJob.ReorgMeta.UseCloudStorage = true

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -122,9 +122,9 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 				proxyJob.MultiSchemaInfo.SkipVersion = true
 			}
 			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob)
-			failpoint.InjectCall("beforeBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
+			failpoint.InjectCall("beforeBatchedMultiSchemaParentJobUpdate", job, &proxyJob)
 			updateParentJobFromProxy(job, &proxyJob)
-			failpoint.InjectCall("afterBatchedMultiSchemaCloudModePropagation", job, &proxyJob)
+			failpoint.InjectCall("afterBatchedMultiSchemaParentJobUpdate", job, &proxyJob)
 			if !schemaVersionGenerated && proxyJobVer != 0 {
 				schemaVersionGenerated = true
 				ver = proxyJobVer

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -887,7 +887,7 @@ func TestMultiSchemaChangeBlockedByRowLevelChecksum(t *testing.T) {
 	tk.MustGetErrCode("alter table t add (c1 int, c2 int)", errno.ErrUnsupportedDDLOperation)
 }
 
-func TestMultiSchemaChangePersistsCloudStorageMode(t *testing.T) {
+func TestMultiSchemaChangePreservesCloudStorageMode(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -906,15 +906,16 @@ func TestMultiSchemaChangePersistsCloudStorageMode(t *testing.T) {
 
 	tk.MustExec("create table t (a int)")
 
+	type cloudModeObservation struct {
+		seen      bool
+		parent    bool
+		nextProxy bool
+	}
 	var (
-		observationMu              sync.Mutex
-		ordinaryRevertibleObserved bool
-		ordinaryParentCloud        bool
-		ordinaryNextProxyCloud     bool
-		batchedBeforeObserved      bool
-		batchedAfterObserved       bool
-		batchedParentCloud         bool
-		batchedNextProxyCloud      bool
+		mu              sync.Mutex
+		revertible      cloudModeObservation
+		batched         cloudModeObservation
+		batchedInjected bool
 	)
 
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
@@ -926,50 +927,55 @@ func TestMultiSchemaChangePersistsCloudStorageMode(t *testing.T) {
 				continue
 			}
 			nextProxy := subJob.ToProxyJob(job, i)
-			observationMu.Lock()
-			ordinaryRevertibleObserved = true
-			ordinaryParentCloud = job.ReorgMeta.UseCloudStorage
-			ordinaryNextProxyCloud = nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage
-			observationMu.Unlock()
+			mu.Lock()
+			revertible = cloudModeObservation{
+				seen:      true,
+				parent:    job.ReorgMeta.UseCloudStorage,
+				nextProxy: nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage,
+			}
+			mu.Unlock()
 		}
 	})
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeBatchedMultiSchemaCloudModePropagation", func(parentJob, proxyJob *model.Job) {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeBatchedMultiSchemaParentJobUpdate", func(parentJob, proxyJob *model.Job) {
 		if proxyJob.Type != model.ActionAddIndex || parentJob.ReorgMeta == nil || proxyJob.ReorgMeta == nil {
 			return
 		}
-		observationMu.Lock()
-		defer observationMu.Unlock()
-		batchedBeforeObserved = true
+		mu.Lock()
+		defer mu.Unlock()
+		batchedInjected = true
 		parentJob.ReorgMeta.UseCloudStorage = false
 		proxyJob.ReorgMeta.UseCloudStorage = true
 	})
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterBatchedMultiSchemaCloudModePropagation", func(parentJob, proxyJob *model.Job) {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterBatchedMultiSchemaParentJobUpdate", func(parentJob, proxyJob *model.Job) {
 		if proxyJob.Type != model.ActionAddIndex || parentJob.ReorgMeta == nil || proxyJob.MultiSchemaInfo == nil {
 			return
 		}
-		observationMu.Lock()
-		defer observationMu.Unlock()
-		if !batchedBeforeObserved {
+		mu.Lock()
+		defer mu.Unlock()
+		if !batchedInjected {
 			return
 		}
-		batchedAfterObserved = true
-		batchedParentCloud = parentJob.ReorgMeta.UseCloudStorage
 		seq := int(proxyJob.MultiSchemaInfo.Seq)
 		nextProxy := parentJob.MultiSchemaInfo.SubJobs[seq].ToProxyJob(parentJob, seq)
-		batchedNextProxyCloud = nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage
+		batched = cloudModeObservation{
+			seen:      true,
+			parent:    parentJob.ReorgMeta.UseCloudStorage,
+			nextProxy: nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage,
+		}
 	})
 
 	tk.MustExec("alter table t add column b int, add index idx_a(a)")
 
-	observationMu.Lock()
-	defer observationMu.Unlock()
-	require.True(t, ordinaryRevertibleObserved)
-	require.True(t, ordinaryParentCloud)
-	require.True(t, ordinaryNextProxyCloud)
-	require.True(t, batchedBeforeObserved)
-	require.True(t, batchedAfterObserved)
-	require.True(t, batchedParentCloud)
-	require.True(t, batchedNextProxyCloud)
+	want := cloudModeObservation{
+		seen:      true,
+		parent:    true,
+		nextProxy: true,
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, want, revertible)
+	require.True(t, batchedInjected)
+	require.Equal(t, want, batched)
 }
 
 func TestMultiSchemaChangePollJobCount(t *testing.T) {

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -887,6 +887,91 @@ func TestMultiSchemaChangeBlockedByRowLevelChecksum(t *testing.T) {
 	tk.MustGetErrCode("alter table t add (c1 int, c2 int)", errno.ErrUnsupportedDDLOperation)
 }
 
+func TestMultiSchemaChangePersistsCloudStorageMode(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	originalCloudStorageURI := vardef.CloudStorageURI.Load()
+	originalEnableDistTask := vardef.EnableDistTask.Load()
+	originalEnableFastReorg := vardef.EnableFastReorg.Load()
+	t.Cleanup(func() {
+		vardef.CloudStorageURI.Store(originalCloudStorageURI)
+		vardef.EnableDistTask.Store(originalEnableDistTask)
+		vardef.EnableFastReorg.Store(originalEnableFastReorg)
+	})
+	vardef.CloudStorageURI.Store("s3://bucket")
+	vardef.EnableDistTask.Store(true)
+	vardef.EnableFastReorg.Store(true)
+
+	tk.MustExec("create table t (a int)")
+
+	var (
+		observationMu              sync.Mutex
+		ordinaryRevertibleObserved bool
+		ordinaryParentCloud        bool
+		ordinaryNextProxyCloud     bool
+		batchedBeforeObserved      bool
+		batchedAfterObserved       bool
+		batchedParentCloud         bool
+		batchedNextProxyCloud      bool
+	)
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
+		if job.Type != model.ActionMultiSchemaChange || job.MultiSchemaInfo == nil || job.ReorgMeta == nil {
+			return
+		}
+		for i, subJob := range job.MultiSchemaInfo.SubJobs {
+			if subJob.Type != model.ActionAddIndex || subJob.SchemaState != model.StateDeleteOnly {
+				continue
+			}
+			nextProxy := subJob.ToProxyJob(job, i)
+			observationMu.Lock()
+			ordinaryRevertibleObserved = true
+			ordinaryParentCloud = job.ReorgMeta.UseCloudStorage
+			ordinaryNextProxyCloud = nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage
+			observationMu.Unlock()
+		}
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeBatchedMultiSchemaCloudModePropagation", func(parentJob, proxyJob *model.Job) {
+		if proxyJob.Type != model.ActionAddIndex || parentJob.ReorgMeta == nil || proxyJob.ReorgMeta == nil {
+			return
+		}
+		observationMu.Lock()
+		defer observationMu.Unlock()
+		batchedBeforeObserved = true
+		parentJob.ReorgMeta.UseCloudStorage = false
+		proxyJob.ReorgMeta.UseCloudStorage = true
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterBatchedMultiSchemaCloudModePropagation", func(parentJob, proxyJob *model.Job) {
+		if proxyJob.Type != model.ActionAddIndex || parentJob.ReorgMeta == nil || proxyJob.MultiSchemaInfo == nil {
+			return
+		}
+		observationMu.Lock()
+		defer observationMu.Unlock()
+		if !batchedBeforeObserved {
+			return
+		}
+		batchedAfterObserved = true
+		batchedParentCloud = parentJob.ReorgMeta.UseCloudStorage
+		seq := int(proxyJob.MultiSchemaInfo.Seq)
+		nextProxy := parentJob.MultiSchemaInfo.SubJobs[seq].ToProxyJob(parentJob, seq)
+		batchedNextProxyCloud = nextProxy.ReorgMeta != nil && nextProxy.ReorgMeta.UseCloudStorage
+	})
+
+	tk.MustExec("alter table t add column b int, add index idx_a(a)")
+
+	observationMu.Lock()
+	defer observationMu.Unlock()
+	require.True(t, ordinaryRevertibleObserved)
+	require.True(t, ordinaryParentCloud)
+	require.True(t, ordinaryNextProxyCloud)
+	require.True(t, batchedBeforeObserved)
+	require.True(t, batchedAfterObserved)
+	require.True(t, batchedParentCloud)
+	require.True(t, batchedNextProxyCloud)
+}
+
 func TestMultiSchemaChangePollJobCount(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("add-index always runs on DXF with ingest mode in nextgen")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70478

Problem Summary:

When an ingest ADD INDEX job selects cloud storage and the DDL owner fails before the DXF backfill task is submitted, the new owner loses the cloud storage URI cached in memory. The retry can then submit a local-sort task even though the persisted job requires cloud storage, which can leave the job stuck in write reorganization. Multi-schema change jobs can also lose the selected cloud-storage mode when recreating proxy jobs.

### What changed and how does it work?

- Restore the cloud storage URI from the cluster configuration before submitting a new cloud backfill task after owner failover.
- Return a retryable error instead of submitting the task with an empty URI when the job requires cloud storage.
- Propagate the cloud-storage mode selected by an ADD INDEX proxy job to its parent multi-schema change job so later proxy jobs preserve the decision.
- Add regression coverage for URI recovery, missing and cached URIs, local sort, merge-temp-index tasks, and ordinary and batched multi-schema changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/ddl -run '^(TestResolveCloudStorageURI|TestMultiSchemaChangePersistsCloudStorageMode)$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where ingest ADD INDEX could fall back to local sort and become stuck after a DDL owner failover.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of distributed index creation after ownership changes by correctly restoring cloud-storage settings.
  * Preserved cloud-storage sorting behavior throughout multi-schema changes, including rollback and batched operations.
  * Added validation and retryable errors when cloud-storage configuration is unavailable.
  * Ensured local sorting continues to work when cloud storage is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->