### PR TITLE
fix: remove redundant Flen check in vectorized REPEAT inconsistent with scalar path

### DIFF
--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -115,10 +115,6 @@ func (b *builtinRepeatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 			result.AppendNull()
 			continue
 		}
-		if int64(byteLength) > int64(b.tp.GetFlen())/num {
-			result.AppendNull()
-			continue
-		}
 		result.AppendString(strings.Repeat(str, int(num)))
 	}
 	return nil


### PR DESCRIPTION
### Problem

Vectorized `REPEAT` (`builtin_string_vec.go`) has an extra Flen check that NULLs the result when `len(str) > Flen/num`, while the scalar `REPEAT` (`builtin_string.go` `evalString`) only checks `max_allowed_packet` and produces the string. This causes inconsistent results when the same query takes different execution paths.

In the reported case, a `GROUP BY` query on a plain table takes the vectorized path: `CAST(… AS CHAR(255))` is NULL. Replacing the table with the identity CTE takes the scalar path: the string is produced.

### Fix

Remove the Flen check (`if int64(byteLength) > int64(b.tp.GetFlen())/num`) from `vecEvalString`, making the vectorized path consistent with the scalar path. Both paths now only check `max_allowed_packet`, matching MySQL semantics.

Closes #70493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `REPEAT` behavior so repeated strings are no longer returned as `NULL` solely because they exceed the field length.
  * Existing packet-size validation remains in effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->