### PR TITLE
fix: add nil check in CheckRegionEpoch to prevent PITR restore panic [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/br/pkg/restore/split/client.go
+++ b/br/pkg/restore/split/client.go
@@ -1096,6 +1096,9 @@ func isScatterRegionFinished(resp *pdpb.GetOperatorResponse) (
 
 // CheckRegionEpoch check region epoch.
 func CheckRegionEpoch(_new, _old *RegionInfo) bool {
+	if _new == nil || _old == nil {
+		return false
+	}
 	return _new.Region.GetId() == _old.Region.GetId() &&
 		_new.Region.GetRegionEpoch().GetVersion() == _old.Region.GetRegionEpoch().GetVersion() &&
 		_new.Region.GetRegionEpoch().GetConfVer() == _old.Region.GetRegionEpoch().GetConfVer()


### PR DESCRIPTION
fix: add nil check in CheckRegionEpoch to prevent PITR restore panic

### Issue
Issue Number: close #70494

### Problem
When `GetRegionByID` returns `(nil, nil)` — the region is stale and no longer tracked by PD — the caller passes `nil` to `CheckRegionEpoch`, which immediately dereferences `_new.Region.GetId()` causing a nil-pointer panic. This crashes the BR PITR restore process.

### Root cause
`GetRegionByID` (line 343-344) returns `nil, nil` when the region is not found:
```go
if region == nil {
    return nil, nil
}
```

The caller at line 473-477 only checks `findLeaderErr != nil`, not `newRegionInfo == nil`:
```go
newRegionInfo, findLeaderErr := c.GetRegionByID(ctx, nl.RegionId)
if findLeaderErr != nil {
    return false, nil, findLeaderErr
}
if !CheckRegionEpoch(newRegionInfo, regionInfo) {  // panic when newRegionInfo is nil
```

### Fix
Add nil check at the start of `CheckRegionEpoch` as a defensive guard. When either input is nil, the epoch cannot match, so returning `false` is the safe behavior.

### Release note
```release-note
Fix a potential nil-pointer panic in BR PITR restore when PD returns no region for a stale region ID
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region validation to safely handle missing region information.
  * Prevented errors when comparing region details that are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->