### PR TITLE
expression: fix UNCOMPRESS regression in IMPORT INTO column assignments

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -385,7 +385,7 @@ func TestImportIntoValidateColAssignmentsWithEncodeCtx(t *testing.T) {
 		error string
 	}{
 		{
-			exprs: []string{"'x'", "1+@1", "concat('hello', 'world')", "getvar('var1')"},
+			exprs: []string{"'x'", "1+@1", "concat('hello', 'world')", "getvar('var1')", "uncompress(compress('test'))" },
 		},
 		{
 			exprs: []string{"setvar('a', 'b')"},

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -958,7 +958,10 @@ func (b *builtinUncompressSig) Clone() builtinFunc {
 
 // RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
 func (b *builtinUncompressSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
+	// getMemTracker() handles a missing OptPropSessionVars gracefully (returns
+	// a nil tracker).  Declaring it as required would make IMPORT INTO reject
+	// UNCOMPRESS in column assignments (see #70501), so we return an empty set.
+	return exprctx.OptionalEvalPropKeySet{}
 }
 
 func (b *builtinUncompressSig) getMemTracker(ctx EvalContext) (*memory.Tracker, error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70501

Problem Summary:
PR #70199 added memory-DoS hardening for `UNCOMPRESS()` by embedding `SessionVarsPropReader` and declaring `OptPropSessionVars` as a required optional eval property. However, `getMemTracker()` already handles a missing `OptPropSessionVars` gracefully (returns a nil tracker). 

The `IMPORT INTO` encoding context evaluates column assignments in a static context that does not provide `OptPropSessionVars`, and `ValidateImportIntoColAssignmentsWithEncodeCtx` rejects any function whose declared required props are unavailable. This causes a regression where a valid `UNCOMPRESS(COMPRESS(@raw))` assignment is rejected after a patch upgrade.

### What is changed and how it works?

`builtinUncompressSig.RequiredOptionalEvalProps()` now returns an empty `OptionalEvalPropKeySet` instead of delegating to `SessionVarsPropReader.RequiredOptionalEvalProps()`. 

This is safe because:
- `getMemTracker()` independently checks `ctx.GetOptionalPropSet().Contains(OptPropSessionVars)` and returns a nil tracker when it is absent - no memory tracking degradation in normal SQL execution
- The `inflate()` function's `limitedBuffer` output cap still applies regardless of the tracker
- `IMPORT INTO` no longer rejects `UNCOMPRESS` in column assignments (the fix)

### Check List

Tests
- [x] Unit test: added `uncompress(compress('test'))` to the accepted expressions list in `TestImportIntoValidateColAssignmentsWithEncodeCtx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `UNCOMPRESS` so it can evaluate without requiring session variables.
  * Validated compressed and uncompressed expressions as acceptable import column assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->