### PR TITLE
expression: fix GREATEST type inference with DATE columns through views [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -476,6 +476,24 @@ func resolveType4Extremum(ctx EvalContext, args []Expression) (_ *types.FieldTyp
 		timeType = GLRetDate
 	} else if aggType.GetType() == mysql.TypeDatetime || aggType.GetType() == mysql.TypeTimestamp {
 		timeType = GLRetDatetime
+		// When the merged type is Datetime/Timestamp, check if the only temporal
+		// type among the args is DATE. This handles the case where a string
+		// constant is folded to Datetime but the actual column is DATE, causing
+		// an incorrect promotion to Datetime.
+		// See https://github.com/pingcap/tidb/issues/70503
+		var hasDate, hasDatetimeOrTimestamp bool
+		for _, arg := range args {
+			t := arg.GetType(ctx).GetType()
+			if t == mysql.TypeDate {
+				hasDate = true
+			}
+			if t == mysql.TypeDatetime || t == mysql.TypeTimestamp {
+				hasDatetimeOrTimestamp = true
+			}
+		}
+		if hasDate && !hasDatetimeOrTimestamp {
+			timeType = GLRetDate
+		}
 	}
 	return aggType, timeType, cmpStringMode
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70503

Problem Summary:
`GREATEST('2016-05-04 10:10:10.100000', date_col)` returns DATE when queried directly on a table, but returns DATETIME when queried through a view.

### What is changed and how it works?

When `resolveType4Extremum` determines the return type as Datetime/Timestamp, it now checks whether the actual temporal columns among the arguments are all DATE. If so, the return type is narrowed back to Date.

### Release note

```release-note
Fix GREATEST type inference inconsistency when used with DATE columns through views
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date comparisons involving folded datetime constants to preserve the `DATE` result type when all temporal arguments are date-only.
  * Prevented unnecessary promotion of date values to `DATETIME` or `TIMESTAMP`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->