### PR TITLE
executor: allow uncompress in import into assignments

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -385,7 +385,7 @@ func TestImportIntoValidateColAssignmentsWithEncodeCtx(t *testing.T) {
 		error string
 	}{
 		{
-			exprs: []string{"'x'", "1+@1", "concat('hello', 'world')", "getvar('var1')"},
+			exprs: []string{"'x'", "1+@1", "concat('hello', 'world')", "getvar('var1')", "uncompress(compress(@raw))"},
 		},
 		{
 			exprs: []string{"setvar('a', 'b')"},

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -958,6 +958,11 @@ func (b *builtinUncompressSig) Clone() builtinFunc {
 
 // RequiredOptionalEvalProps implements the RequireOptionalEvalProps interface.
 func (b *builtinUncompressSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
+	return 0
+}
+
+// AllowedOptionalEvalProps returns optional props that UNCOMPRESS may use when present.
+func (b *builtinUncompressSig) AllowedOptionalEvalProps() OptionalEvalPropKeySet {
 	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
 }
 

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -80,6 +80,10 @@ type assertionEvalContext struct {
 	fn builtinFunc
 }
 
+type allowOptionalEvalProps interface {
+	AllowedOptionalEvalProps() OptionalEvalPropKeySet
+}
+
 func wrapEvalAssert(ctx EvalContext, fn builtinFunc) (ret *assertionEvalContext) {
 	originalCtx := ctx
 	if assertCtx, ok := ctx.(*assertionEvalContext); ok {
@@ -104,14 +108,17 @@ func checkEvalCtx(ctx EvalContext) {
 }
 
 func (ctx *assertionEvalContext) GetOptionalPropProvider(key OptionalEvalPropKey) (OptionalEvalPropProvider, bool) {
-	var requiredOptionalProps OptionalEvalPropKeySet
+	var declaredOptionalProps OptionalEvalPropKeySet
 	if ctx.fn != nil {
-		requiredOptionalProps = ctx.fn.RequiredOptionalEvalProps()
+		declaredOptionalProps = ctx.fn.RequiredOptionalEvalProps()
+		if fn, ok := ctx.fn.(allowOptionalEvalProps); ok {
+			declaredOptionalProps |= fn.AllowedOptionalEvalProps()
+		}
 	}
 
 	intest.Assert(
-		requiredOptionalProps.Contains(key),
-		"optional property '%s' is read in function '%T' but not declared in RequiredOptionalEvalProps",
+		declaredOptionalProps.Contains(key),
+		"optional property '%s' is read in function '%T' but not declared in RequiredOptionalEvalProps or AllowedOptionalEvalProps",
 		key, ctx.fn,
 	)
 	return ctx.EvalContext.GetOptionalPropProvider(key)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70501

Problem Summary:

`IMPORT INTO` column assignments can run in a static encoding context without session variables. After `UNCOMPRESS()` declared `SessionVars` as a required optional eval prop for memory tracking, `IMPORT INTO` rejected
assignments such as `UNCOMPRESS(COMPRESS(@raw))` before execution, even though `UNCOMPRESS()` can evaluate without session variables.

### What changed and how does it work?

This PR adds `AllowedOptionalEvalProps()` as a soft optional-property declaration for builtin evaluation assertions.

`UNCOMPRESS()` now declares no hard-required optional eval props, so `IMPORT INTO` no longer rejects it during assignment validation. It still declares `SessionVars` as an allowed optional prop, so assertion checks permit
reading session variables when they are available for memory tracking.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional evaluation properties for decompression expressions.
  * Added support for using `uncompress(compress(`@raw`))` in import column-assignment validation.
  * Updated validation to recognize permitted session-variable properties without requiring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->