### PR TITLE
crossks: clean up virtual server info on close and bootstrap failure

### DIFF
--- a/pkg/domain/crossks/cross_ks.go
+++ b/pkg/domain/crossks/cross_ks.go
@@ -251,8 +251,14 @@ func (*Manager) createSessionManager(
 	}
 	failpoint.InjectCall("injectETCDCli", &etcdCli, ks)
 	ctx, cancel := context.WithCancel(context.Background())
+	var svrInfoSyncer *serverinfo.Syncer
+	serverInfoRegistered := false
 	defer func() {
 		if err != nil {
+			if serverInfoRegistered {
+				svrInfoSyncer.RemoveServerInfo()
+				svrInfoSyncer.RevokeSession()
+			}
 			cancel()
 			err2 := etcdCli.Close()
 			if err2 != nil {
@@ -262,7 +268,7 @@ func (*Manager) createSessionManager(
 	}()
 
 	virtualSvrID := uuid.New().String()
-	svrInfoSyncer := serverinfo.NewCrossKSSyncer(
+	svrInfoSyncer = serverinfo.NewCrossKSSyncer(
 		virtualSvrID,
 		func() uint64 {
 			// this ID is used to allocate connection ID, since we don't accept
@@ -276,6 +282,7 @@ func (*Manager) createSessionManager(
 	if err = svrInfoSyncer.NewSessionAndStoreServerInfo(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
+	serverInfoRegistered = true
 
 	schemaVerSyncer := schemaver.NewEtcdSyncer(etcdCli, virtualSvrID)
 	if err = schemaVerSyncer.Init(ctx); err != nil {
@@ -524,6 +531,7 @@ func (m *SessionManager) close() {
 	m.wg.Wait()
 	if m.svrInfoSyncer != nil {
 		m.svrInfoSyncer.RemoveServerInfo()
+		m.svrInfoSyncer.RevokeSession()
 	}
 	m.schemaVerSyncer.Close()
 	if err := m.etcdCli.Close(); err != nil {

--- a/pkg/domain/crossks/cross_ks.go
+++ b/pkg/domain/crossks/cross_ks.go
@@ -522,6 +522,9 @@ func (m *SessionManager) close() {
 	close(m.exitCh)
 	m.cancel()
 	m.wg.Wait()
+	if m.svrInfoSyncer != nil {
+		m.svrInfoSyncer.RemoveServerInfo()
+	}
 	m.schemaVerSyncer.Close()
 	if err := m.etcdCli.Close(); err != nil {
 		logger.Warn("failed to close etcd client", zap.Error(err))

--- a/pkg/domain/crossks/cross_ks_test.go
+++ b/pkg/domain/crossks/cross_ks_test.go
@@ -54,6 +54,71 @@ import (
 
 var registerUnistoreOnce sync.Once
 
+type failAfterServerInfoPutKV struct {
+	clientv3.KV
+	serverInfoKey   string
+	serverInfoLease clientv3.LeaseID
+	failNextTxn     bool
+}
+
+func (kv *failAfterServerInfoPutKV) Put(
+	ctx context.Context,
+	key, value string,
+	opts ...clientv3.OpOption,
+) (*clientv3.PutResponse, error) {
+	resp, err := kv.KV.Put(ctx, key, value, opts...)
+	if err != nil {
+		return nil, err
+	}
+	const serverInfoPrefix = "/tidb/server/info/"
+	if len(key) >= len(serverInfoPrefix) && key[:len(serverInfoPrefix)] == serverInfoPrefix {
+		getResp, getErr := kv.KV.Get(ctx, key)
+		if getErr != nil {
+			return nil, getErr
+		}
+		if len(getResp.Kvs) == 1 {
+			kv.serverInfoKey = key
+			kv.serverInfoLease = clientv3.LeaseID(getResp.Kvs[0].Lease)
+			kv.failNextTxn = true
+		}
+	}
+	return resp, nil
+}
+
+func (kv *failAfterServerInfoPutKV) Txn(ctx context.Context) clientv3.Txn {
+	if kv.failNextTxn {
+		kv.failNextTxn = false
+		return &failedTxn{err: errors.New("injected schema syncer init failure")}
+	}
+	return kv.KV.Txn(ctx)
+}
+
+type failedTxn struct {
+	err error
+}
+
+func (txn *failedTxn) If(...clientv3.Cmp) clientv3.Txn {
+	return txn
+}
+
+func (txn *failedTxn) Then(...clientv3.Op) clientv3.Txn {
+	return txn
+}
+
+func (txn *failedTxn) Else(...clientv3.Op) clientv3.Txn {
+	return txn
+}
+
+func (txn *failedTxn) Commit() (*clientv3.TxnResponse, error) {
+	return nil, txn.err
+}
+
+func requireLeaseRevoked(t *testing.T, cli *clientv3.Client, leaseID clientv3.LeaseID) {
+	resp, err := cli.TimeToLive(context.Background(), leaseID)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), resp.TTL)
+}
+
 func registerUnistore(t *testing.T) {
 	var err error
 	registerUnistoreOnce.Do(func() {
@@ -86,6 +151,7 @@ func TestManager(t *testing.T) {
 		"ks2":           3,
 		"ks3":           4,
 		"ksmdl":         5,
+		"ks-bootstrap":  6,
 	}
 	getETCDCli := func(ks string, ksID uint32) *clientv3.Client {
 		for i := range clientCount {
@@ -107,11 +173,18 @@ func TestManager(t *testing.T) {
 	defer func() {
 		require.NoError(t, serverInfoObserver.Close())
 	}()
+	var failSchemaInitForKS string
+	var faultKV *failAfterServerInfoPutKV
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/injectETCDCli",
 		func(cliP **clientv3.Client, ks string) {
 			id, ok := keyspaceIDs[ks]
 			require.True(t, ok)
-			*cliP = getETCDCli(ks, id)
+			cli := getETCDCli(ks, id)
+			if ks == failSchemaInitForKS {
+				faultKV = &failAfterServerInfoPutKV{KV: cli.KV}
+				cli.KV = faultKV
+			}
+			*cliP = cli
 		},
 	)
 
@@ -137,11 +210,49 @@ func TestManager(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resp.Kvs, 1)
 		require.Contains(t, string(resp.Kvs[0].Value), `"assumed_keyspace":"SYSTEM"`)
+		serverInfoLease := clientv3.LeaseID(resp.Kvs[0].Lease)
 
 		userKSDom.GetCrossKSMgr().CloseKS(keyspace.System)
 		resp, err = serverInfoObserver.Get(context.Background(), serverInfoKey)
 		require.NoError(t, err)
 		require.Empty(t, resp.Kvs, "virtual server info should be removed when the runtime closes")
+		requireLeaseRevoked(t, serverInfoObserver, serverInfoLease)
+	})
+
+	t.Run("bootstrap failure removes virtual server info", func(t *testing.T) {
+		const targetKS = "ks-bootstrap"
+		targetStore, err := mockstore.NewMockStore(mockstore.WithCurrentKeyspaceMeta(&keyspacepb.KeyspaceMeta{
+			Keyspace: &keyspacepb.KeyspaceMeta_Id{Id: keyspaceIDs[targetKS]},
+			Name:     targetKS,
+		}))
+		require.NoError(t, err)
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/beforeGetStore",
+			func(fnP *func(string) (store kv.Storage, err error)) {
+				*fnP = func(ks string) (kv.Storage, error) {
+					require.Equal(t, targetKS, ks)
+					return targetStore, nil
+				}
+			},
+		)
+		observer := getETCDCli(targetKS, keyspaceIDs[targetKS])
+		defer func() {
+			require.NoError(t, observer.Close())
+		}()
+
+		failSchemaInitForKS = targetKS
+		defer func() {
+			failSchemaInitForKS = ""
+		}()
+		_, err = sysKSDom.GetKSSessPool(targetKS)
+		require.ErrorContains(t, err, "injected schema syncer init failure")
+		require.NotNil(t, faultKV)
+		require.NotEmpty(t, faultKV.serverInfoKey)
+		require.NotZero(t, faultKV.serverInfoLease)
+
+		resp, err := observer.Get(context.Background(), faultKV.serverInfoKey)
+		require.NoError(t, err)
+		require.Empty(t, resp.Kvs, "failed bootstrap should remove its virtual server info")
+		requireLeaseRevoked(t, observer, faultKV.serverInfoLease)
 	})
 
 	t.Run("failed to get store in cross keyspace manager", func(t *testing.T) {

--- a/pkg/domain/crossks/cross_ks_test.go
+++ b/pkg/domain/crossks/cross_ks_test.go
@@ -103,6 +103,10 @@ func TestManager(t *testing.T) {
 		require.Fail(t, "cannot find etcd client for keyspace %s", ks)
 		return nil
 	}
+	serverInfoObserver := getETCDCli(keyspace.System, keyspaceIDs[keyspace.System])
+	defer func() {
+		require.NoError(t, serverInfoObserver.Close())
+	}()
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/domain/crossks/injectETCDCli",
 		func(cliP **clientv3.Client, ks string) {
 			id, ok := keyspaceIDs[ks]
@@ -120,6 +124,24 @@ func TestManager(t *testing.T) {
 	t.Run("same keyspace access", func(t *testing.T) {
 		_, err := sysKSDom.GetKSSessPool(keyspace.System)
 		require.ErrorContains(t, err, "cross keyspace is not available in classic kernel or current keyspace")
+	})
+
+	t.Run("close removes virtual server info", func(t *testing.T) {
+		const userKS = "ks-server-info"
+		_, userKSDom := testkit.CreateMockStoreAndDomainForKS(t, userKS)
+		sessMgr, ok := userKSDom.GetCrossKSMgr().Get(keyspace.System)
+		require.True(t, ok)
+
+		serverInfoKey := "/tidb/server/info/" + sessMgr.ServerInfoID()
+		resp, err := serverInfoObserver.Get(context.Background(), serverInfoKey)
+		require.NoError(t, err)
+		require.Len(t, resp.Kvs, 1)
+		require.Contains(t, string(resp.Kvs[0].Value), `"assumed_keyspace":"SYSTEM"`)
+
+		userKSDom.GetCrossKSMgr().CloseKS(keyspace.System)
+		resp, err = serverInfoObserver.Get(context.Background(), serverInfoKey)
+		require.NoError(t, err)
+		require.Empty(t, resp.Kvs, "virtual server info should be removed when the runtime closes")
 	})
 
 	t.Run("failed to get store in cross keyspace manager", func(t *testing.T) {

--- a/pkg/domain/crossks/export_test.go
+++ b/pkg/domain/crossks/export_test.go
@@ -35,3 +35,8 @@ func (m *Manager) CloseKS(targetKS string) {
 func (m *SessionManager) ServerStateSyncer() serverstate.Syncer {
 	return m.serverStateSyncer
 }
+
+// ServerInfoID returns the virtual server ID in tests.
+func (m *SessionManager) ServerInfoID() string {
+	return m.svrInfoSyncer.GetLocalServerInfo().ID
+}

--- a/pkg/domain/serverinfo/info.go
+++ b/pkg/domain/serverinfo/info.go
@@ -135,6 +135,18 @@ func (info *ServerInfo) Marshal() ([]byte, error) {
 	return infoBuf, nil
 }
 
+// String implements fmt.Stringer.
+func (info *ServerInfo) String() string {
+	if info == nil {
+		return "<nil>"
+	}
+	infoBuf, err := info.Marshal()
+	if err != nil {
+		return "<failed to marshal server info: " + err.Error() + ">"
+	}
+	return string(infoBuf)
+}
+
 // Unmarshal `ServerInfo` from bytes.
 func (info *ServerInfo) Unmarshal(v []byte) error {
 	if err := json.Unmarshal(v, info); err != nil {

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -347,6 +347,24 @@ func (s *Syncer) RemoveServerInfo() {
 	}
 }
 
+// RevokeSession stops refreshing the current server-info session and revokes its lease.
+// The caller must stop ServerInfoSyncLoop first so it cannot recreate the session.
+func (s *Syncer) RevokeSession() {
+	if s.etcdCli == nil || s.session == nil {
+		return
+	}
+	session := s.session
+	lease := session.Lease()
+	session.Orphan()
+
+	ctx, cancel := context.WithTimeout(context.Background(), KeyOpDefaultTimeout)
+	defer cancel()
+	if _, err := s.etcdCli.Revoke(ctx, lease); err != nil {
+		logutil.BgLogger().Error("revoke server info lease failed",
+			zap.Int64("lease", int64(lease)), zap.Error(err))
+	}
+}
+
 // ServerInfoSyncLoop syncs the server information periodically.
 func (s *Syncer) ServerInfoSyncLoop(store tidbkv.Storage, exitCh chan struct{}) {
 	defer func() {

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -360,8 +360,10 @@ func (s *Syncer) RevokeSession() {
 	ctx, cancel := context.WithTimeout(context.Background(), KeyOpDefaultTimeout)
 	defer cancel()
 	if _, err := s.etcdCli.Revoke(ctx, lease); err != nil {
-		logutil.BgLogger().Error("revoke server info lease failed",
-			zap.Int64("lease", int64(lease)), zap.Error(err))
+		logutil.BgLogger().Warn("revoke server info lease failed",
+			zap.Int64("lease", int64(lease)),
+			zap.Any("serverInfo", s.GetLocalServerInfo()),
+			zap.Error(err))
 	}
 }
 

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -362,7 +362,7 @@ func (s *Syncer) RevokeSession() {
 	if _, err := s.etcdCli.Revoke(ctx, lease); err != nil {
 		logutil.BgLogger().Warn("revoke server info lease failed",
 			zap.Int64("lease", int64(lease)),
-			zap.Any("serverInfo", s.GetLocalServerInfo()),
+			zap.Stringer("serverInfo", s.GetLocalServerInfo()),
 			zap.Error(err))
 	}
 }

--- a/pkg/domain/serverinfo/syncer_test.go
+++ b/pkg/domain/serverinfo/syncer_test.go
@@ -1145,4 +1145,11 @@ func TestAssumedServerInfoSyncer(t *testing.T) {
 	require.True(t, info.IsAssumed())
 	require.Equal(t, "ks1", info.AssumedKeyspace)
 	require.EqualValues(t, keyspace.System, info.Keyspace)
+
+	var decoded ServerInfo
+	require.NoError(t, json.Unmarshal([]byte(info.String()), &decoded))
+	require.Equal(t, info.ID, decoded.ID)
+	require.Equal(t, info.Keyspace, decoded.Keyspace)
+	require.Equal(t, info.AssumedKeyspace, decoded.AssumedKeyspace)
+	require.Equal(t, uint64(1), decoded.JSONServerID)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70518

Problem Summary:

Closing or idle-GC-evicting a cross-keyspace runtime stopped its keeper goroutines and closed its namespaced etcd client without removing the runtime's virtual server-info record. The lease-backed record remained visible for up to 90 seconds and could cause cluster-table fanout to include stale assumed-server membership.

The same leak occurred when runtime bootstrap failed after `NewSessionAndStoreServerInfo` succeeded. The failed runtime was never added to the manager, so normal close could not reach it. Each retry registered another virtual server, and target-keyspace DDL owners could wait for those phantom nodes to report a schema version until their leases expired.

### What changed and how does it work?

- Remove the cross-keyspace runtime's exact virtual server-info record after all runtime goroutines exit.
- When bootstrap fails after server-info registration, remove the record and revoke its session lease before canceling the runtime context or closing the namespaced etcd client.
- Revoke the server-info session through a bounded background context so normal close still works after the runtime context has been canceled.
- Preserve lightweight test managers that intentionally omit a server-info syncer.
- Add deterministic regression coverage for both normal close and post-registration bootstrap failure, verifying immediate removal of the exact key and revocation of its lease.

The fix uses the established `RemoveServerInfo` lifecycle instead of filtering `AssumedKeyspace` entries during reads, so cluster-table enumeration and schema-sync semantics remain unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/domain/crossks -run 'Test(Manager|EvictRuntime|RuntimeHandleManagerCloseClosesAllEntriesRegardlessOfIdleTimeout)$' -count=1 -tags=intest,deadlock,nextgen`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix stale virtual TiDB server-info records left by closed or partially initialized cross-keyspace runtimes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual server information is now removed when a cross-keyspace session closes.
  * Prevents stale server entries and leases from remaining after shutdown.
  * Failed session initialization now cleans up registered server information and revokes its session.
  * Session resources are released more reliably, even when setup encounters an error.

* **Tests**
  * Added coverage for cleanup during initialization failures and normal keyspace closure.
  * Verified that virtual server information and associated leases are revoked correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
