### PR TITLE
store/copr: resolve locks reported by store-batched cop tasks

### DIFF
--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -119,6 +119,8 @@ go_test(
         "@com_github_tikv_client_go_v2//testutils",
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//tikvrpc",
+        "@com_github_tikv_client_go_v2//txnkv/txnsnapshot",
+        "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_client_go_v2//util/async",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_zap//:zap",

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2414,7 +2414,7 @@ func (worker *copIteratorWorker) handleBatchCopResponse(bo *Backoffer, rpcCtx *t
 		}
 		//TODO: handle locks in batch
 		if lockErr := batchResp.GetLocked(); lockErr != nil {
-			if err := worker.handleLockErr(bo, resp.pbResp.GetLocked(), task); err != nil {
+			if err := worker.handleLockErr(bo, lockErr, task); err != nil {
 				return batchRespList, nil, err
 			}
 			task.meetLockFallback = true

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -1097,12 +1097,12 @@ func TestStoreBatchTasksPreserveChildBucketsVersion(t *testing.T) {
 }
 
 func TestHandleBatchCopResponse(t *testing.T) {
-	t.Run("ignores a child lock", testHandleBatchCopResponseIgnoresChildLock)
+	t.Run("resolves a child lock", testHandleBatchCopResponseResolvesChildLock)
 	t.Run("updates child buckets on version mismatch", testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch)
 	t.Run("counts fallbacks after Region split", testHandleBatchCopResponseFallbackCountersAfterRegionSplit)
 }
 
-func testHandleBatchCopResponseIgnoresChildLock(t *testing.T) {
+func testHandleBatchCopResponseResolvesChildLock(t *testing.T) {
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
 	require.NoError(t, err)
 	testutils.BootstrapWithSingleStore(cluster)
@@ -1137,9 +1137,7 @@ func testHandleBatchCopResponseIgnoresChildLock(t *testing.T) {
 		map[uint64]*batchedCopTask{child.taskID: {task: child}},
 	)
 	require.NoError(t, err)
-	// The parent response's lock, which is always nil here, is passed to
-	// handleLockErr, so the child's lock is not resolved.
-	require.Zero(t, kvClient.Stats.GetRPCStatsCount())
+	require.Equal(t, 1, kvClient.Stats.GetRPCStatsCount())
 }
 
 func testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T) {

--- a/pkg/store/copr/coprocessor_test.go
+++ b/pkg/store/copr/coprocessor_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/errorpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/store/driver/backoff"
 	"github.com/pingcap/tidb/pkg/util/paging"
@@ -29,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
+	tikvutil "github.com/tikv/client-go/v2/util"
 )
 
 func buildTestCopTasks(bo *Backoffer, cache *RegionCache, ranges *KeyRanges, req *kv.Request, eventCb trxevents.EventCallback) ([]*copTask, error) {
@@ -1094,8 +1097,49 @@ func TestStoreBatchTasksPreserveChildBucketsVersion(t *testing.T) {
 }
 
 func TestHandleBatchCopResponse(t *testing.T) {
+	t.Run("ignores a child lock", testHandleBatchCopResponseIgnoresChildLock)
 	t.Run("updates child buckets on version mismatch", testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch)
 	t.Run("counts fallbacks after Region split", testHandleBatchCopResponseFallbackCountersAfterRegionSplit)
+}
+
+func testHandleBatchCopResponseIgnoresChildLock(t *testing.T) {
+	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	require.NoError(t, err)
+	testutils.BootstrapWithSingleStore(cluster)
+	tikvStore, err := tikv.NewTestTiKVStore(mockClient, pdClient, nil, nil, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tikvStore.Close()) })
+
+	var resolvedLocks, committedLocks tikvutil.TSSet
+	kvClient := txnsnapshot.NewClientHelper(tikvStore, &resolvedLocks, &committedLocks, false)
+	kvClient.Stats = tikv.NewRegionRequestRuntimeStats()
+	child := &copTask{taskID: 1}
+	worker := &copIteratorWorker{
+		req:                     &kv.Request{StartTs: 10},
+		kvclient:                kvClient,
+		storeBatchedNum:         &atomic.Uint64{},
+		storeBatchedFallbackNum: &atomic.Uint64{},
+	}
+
+	_, _, err = worker.handleBatchCopResponse(
+		backoff.NewBackofferWithVars(context.Background(), 3000, nil),
+		nil,
+		&coprocessor.Response{BatchResponses: []*coprocessor.StoreBatchTaskResponse{{
+			TaskId: child.taskID,
+			Locked: &kvrpcpb.LockInfo{
+				Key:         []byte("key"),
+				PrimaryLock: []byte("primary"),
+				LockVersion: 1,
+				// Keep lock cleanup synchronous with the test.
+				LockType: kvrpcpb.Op_PessimisticLock,
+			},
+		}}},
+		map[uint64]*batchedCopTask{child.taskID: {task: child}},
+	)
+	require.NoError(t, err)
+	// The parent response's lock, which is always nil here, is passed to
+	// handleLockErr, so the child's lock is not resolved.
+	require.Zero(t, kvClient.Stats.GetRPCStatsCount())
 }
 
 func testHandleBatchCopResponseUpdatesChildBucketsOnVersionNotMatch(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70520

Problem Summary: When a store-batched cop task returns a lock error, `handleBatchCopResponse` passes the parent response's lock to `handleLockErr`. That field is always nil in the batched-response loop, so the child's lock is never resolved and the task retries without backoff.

### What changed and how does it work?

The first commit adds a test that records the current behavior: the child's lock is not resolved. The second commit passes the child's lock to `handleLockErr` and flips the test to expect one resolve-lock RPC, so the behavior change is visible in its diff.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
./tools/check/failpoint-go-test.sh pkg/store/copr -run 'TestHandleBatchCopResponse' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that a lock reported by a store-batched coprocessor task was ignored, causing an extra retry round trip.
```
