### PR TITLE
test: stabilize flaky TestTwoStates

### DIFF
--- a/pkg/ddl/db_change_test.go
+++ b/pkg/ddl/db_change_test.go
@@ -218,6 +218,7 @@ func TestTwoStates(t *testing.T) {
 		c4 timestamp on update current_timestamp,
 		key(c1, c2))`)
 	tk.MustExec("insert into t values(1, 'a', 'N', '2017-07-01')")
+	targetTableID := external.GetTableByName(t, tk, "test_db_state", "t").Meta().ID
 
 	prevState := model.StateNone
 	require.NoError(t, testInfo.parseSQLs(parser.New()))
@@ -232,6 +233,11 @@ func TestTwoStates(t *testing.T) {
 	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced")
 	tk.MustExec("drop table t_states_failpoint_probe")
 	runStateChecks := func(state model.SchemaState) {
+		switch state {
+		case model.StateDeleteOnly, model.StateWriteOnly, model.StateWriteReorganization:
+		default:
+			return
+		}
 		if state == prevState || checkErr != nil || times >= 3 {
 			return
 		}
@@ -284,6 +290,9 @@ func TestTwoStates(t *testing.T) {
 	}
 	runWithFailpointHook := func() {
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
+			if job.Type != model.ActionAddColumn || job.TableID != targetTableID {
+				return
+			}
 			runStateChecks(job.SchemaState)
 		})
 		tk.MustExec(alterTableSQL)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/67557

Problem Summary:
Flaky test `TestTwoStates` in `pkg/ddl` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Global DDL failpoint callbacks could consume TestTwoStates’ local state counter before the target add-column write-reorg callback compiled case 3.

#### Fix

Filtering by target add-column job/table and intermediate states removes only test harness noise while preserving the same DDL visibility assertions.

#### Verification

Spec:
- target: `pkg/ddl :: TestTwoStates`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_two_states_raw passed.
two_states_failpoint_path passed.

Gate checklist:
- target_two_states_raw: PASS
- two_states_failpoint_path: PASS
- pkg_ddl_runtime: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ddl -run '^TestTwoStates$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestTwoStates$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #67557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved schema state transition testing by narrowing checks to relevant intermediate states.
  * Restricted failpoint validation to add-column operations affecting the intended table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->