### PR TITLE
test: stabilize flaky TestPause

### DIFF
--- a/pkg/lightning/common/pause_test.go
+++ b/pkg/lightning/common/pause_test.go
@@ -25,25 +25,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func assertUnblocksBetween(t *testing.T, wg *sync.WaitGroup, minv, maxv time.Duration) {
-	ch := make(chan time.Duration)
-	start := time.Now()
+const (
+	waitTimeout          = 10 * time.Second
+	blockedCheckDuration = 100 * time.Millisecond
+)
+
+func waitGroupDone(wg *sync.WaitGroup) <-chan struct{} {
+	ch := make(chan struct{})
 	go func() {
 		wg.Wait()
-		ch <- time.Since(start)
+		close(ch)
 	}()
+	return ch
+}
+
+func waitUnblocked(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
 	select {
-	case dur := <-ch:
-		if dur < minv {
-			t.Fatal("WaitGroup unblocked before minimum duration, it was " + dur.String())
-		}
-	case <-time.After(maxv):
-		select {
-		case dur := <-ch:
-			t.Fatal("WaitGroup did not unblock after maximum duration, it was " + dur.String())
-		case <-time.After(1 * time.Second):
-			t.Fatal("WaitGroup did not unblock after maximum duration")
-		}
+	case <-ch:
+	case <-time.After(waitTimeout):
+		t.Fatal("WaitGroup did not unblock")
+	}
+}
+
+func assertStillBlocked(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("WaitGroup unblocked before pause was released")
+	case <-time.After(blockedCheckDuration):
 	}
 }
 
@@ -62,8 +72,8 @@ func TestPause(t *testing.T) {
 		}()
 	}
 
-	// Give them more time to unblock in case of time exceeding due to high pressure of CI.
-	assertUnblocksBetween(t, &wg, 0*time.Millisecond, 100*time.Millisecond)
+	done := waitGroupDone(&wg)
+	waitUnblocked(t, done)
 
 	// after calling Pause(), these should be blocking...
 
@@ -78,15 +88,12 @@ func TestPause(t *testing.T) {
 		}()
 	}
 
+	done = waitGroupDone(&wg)
+	assertStillBlocked(t, done)
+
 	// ... until we call Resume()
-
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		p.Resume()
-	}()
-
-	// Give them more time to unblock in case of time exceeding due to high pressure of CI.
-	assertUnblocksBetween(t, &wg, 500*time.Millisecond, 800*time.Millisecond)
+	p.Resume()
+	waitUnblocked(t, done)
 
 	// if the context is canceled, Wait() should immediately unblock...
 
@@ -103,9 +110,10 @@ func TestPause(t *testing.T) {
 		}()
 	}
 
+	done = waitGroupDone(&wg)
+	assertStillBlocked(t, done)
 	cancel()
-	// Give them more time to unblock in case of time exceeding due to high pressure of CI.
-	assertUnblocksBetween(t, &wg, 0*time.Millisecond, 100*time.Millisecond)
+	waitUnblocked(t, done)
 
 	// canceling the context does not affect the state of the pauser
 
@@ -116,13 +124,11 @@ func TestPause(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		p.Resume()
-	}()
+	done = waitGroupDone(&wg)
+	assertStillBlocked(t, done)
 
-	// Give them more time to unblock in case of time exceeding due to high pressure of CI.
-	assertUnblocksBetween(t, &wg, 500*time.Millisecond, 800*time.Millisecond)
+	p.Resume()
+	waitUnblocked(t, done)
 }
 
 // Run `go test github.com/pingcap/tidb/pkg/lightning/common -check.b -test.v` to get benchmark result.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70539

Problem Summary:
Flaky test `TestPause` in `pkg/lightning/common` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestPause conflated Pauser semantics with scheduler timing by requiring waiters to complete within fixed 100ms/800ms windows.

#### Fix

The test now verifies blocked-before-release and unblocked-after-release semantics without depending on CI wall-clock scheduling.

#### Verification

Spec:
- target: `pkg/lightning/common :: TestPause`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package_failpoint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_failpoint: PASS
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/lightning/common -run '^TestPause$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/lightning/common -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pause and resume test reliability by replacing timing-based checks with deterministic blocking and unblocking assertions.
  * Added coverage to confirm operations remain blocked until explicitly resumed or canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->