### PR TITLE
planner: give every appended handle column a length in selectivity

### DIFF
--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -191,8 +191,15 @@ func Selectivity(
 			// (idx_col1, ...., idx_coln, handle_col1, ..., handle_colm). That is one column for an
 			// int handle and possibly several for a clustered common handle. Every appended column
 			// needs its own length entry, because range building indexes lengths in step with the
-			// columns. The handle columns are assumed full-length here, which is exact for an int
-			// handle and an approximation for a prefixed clustered handle column.
+			// columns.
+			//
+			// The appended columns are given the full length even when the clustered index declares
+			// a prefix for them. These lengths only shape the ranges built here for estimation -
+			// the ranges the storage layer scans come from path.IdxColLens, which fillIndexPath
+			// fills from the primary key prefix metadata, and getMaskAndRanges takes those ranges
+			// verbatim whenever a filled path exists. The appended dimensions are estimated from
+			// the handle columns' own column statistics, which hold untruncated values, so bounds
+			// truncated to the stored prefix would be compared against the wrong domain.
 			for range len(idxCols) - len(lengths) {
 				lengths = append(lengths, types.UnspecifiedLength)
 			}

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -186,9 +186,14 @@ func Selectivity(
 			for i := 0; i < len(idxCols) && i < len(idxStats.Info.Columns); i++ {
 				lengths = append(lengths, idxStats.Info.Columns[i].Length)
 			}
-			// If the found columns are more than the columns held by the index. We are appending the int pk to the tail of it.
-			// When storing index data to key-value store, we use (idx_col1, ...., idx_coln, handle_col) as its key.
-			if len(idxCols) > len(idxStats.Info.Columns) {
+			// The found columns can outnumber the columns held by the index, because the handle is
+			// appended to the index key when storing index data to key-value store:
+			// (idx_col1, ...., idx_coln, handle_col1, ..., handle_colm). That is one column for an
+			// int handle and possibly several for a clustered common handle. Every appended column
+			// needs its own length entry, because range building indexes lengths in step with the
+			// columns. The handle columns are assumed full-length here, which is exact for an int
+			// handle and an approximation for a prefixed clustered handle column.
+			for range len(idxCols) - len(lengths) {
 				lengths = append(lengths, types.UnspecifiedLength)
 			}
 			maskCovered, ranges, partCover, minAccessCondsForDNFCond, err :=

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1864,6 +1864,75 @@ func TestIndexRangeEstimationWithTruncatedHandleRange(t *testing.T) {
 	require.Equal(t, "10.00", estRows)
 }
 
+// TestIndexRangeEstimationWithPrefixedCommonHandle covers a clustered handle whose leading
+// column is a prefixed index column. The handle appended to a non-unique secondary index
+// stores that column truncated, so the execution ranges must keep prefix semantics and
+// re-check the predicate as a filter. Estimation follows a different route: a tuple
+// comparison spanning the index column and the whole handle reaches Selectivity() without
+// a filled access path (through the index merge OR path estimation), where the ranges are
+// built from the length slice assembled in Selectivity() itself. That slice must hold one
+// entry per column of the extended index key; see issue #70532, where the appended handle
+// counted as a single column and range building read past the end of the slice.
+func TestIndexRangeEstimationWithPrefixedCommonHandle(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(p1 varchar(64), p2 int, c int, primary key(p1(2), p2) clustered, key ic(c))")
+	vals := make([]string, 0, 100)
+	for i := 1; i <= 100; i++ {
+		// Every p1 shares the same 2-character prefix, so the prefix stored in the index
+		// key carries no information beyond "some row of this table".
+		vals = append(vals, fmt.Sprintf("('pp_%03d', %d, %d)", i, i, i%10))
+	}
+	tk.MustExec("insert into t values " + strings.Join(vals, ","))
+	tk.MustExec("analyze table t all columns")
+
+	// Returns the estRows and operator info of the named operator in the plan.
+	planRow := func(sql, operator string) (estRows, operatorInfo string) {
+		rows := tk.MustQuery("explain format='brief' " + sql).Rows()
+		for _, row := range rows {
+			if strings.Contains(row[0].(string), operator) {
+				return row[1].(string), row[4].(string)
+			}
+		}
+		t.Fatalf("no %s in plan for %q", operator, sql)
+		return "", ""
+	}
+
+	// Equality on the prefixed handle column ranges over the stored prefix only, and the
+	// full predicate stays as a filter on the table side, where the untruncated value is
+	// available.
+	sql := "select * from t use index(ic) where c = 5 and p1 = 'pp_055'"
+	_, opInfo := planRow(sql, "IndexRangeScan")
+	require.Contains(t, opInfo, `range:[5 "pp",5 "pp"]`, "the handle range must use the stored prefix")
+	_, opInfo = planRow(sql, "Selection")
+	require.Contains(t, opInfo, `eq(test.t.p1, "pp_055")`, "the prefixed predicate must be re-checked")
+	tk.MustQuery(sql).Check(testkit.Rows("pp_055 55 5"))
+
+	// The column after the prefixed one is still ranged over: the prefix only widens its
+	// own dimension of the key.
+	sql = "select * from t use index(ic) where c = 5 and p1 = 'pp_055' and p2 = 55"
+	_, opInfo = planRow(sql, "IndexRangeScan")
+	require.Contains(t, opInfo, `range:[5 "pp" 55,5 "pp" 55]`, "the handle range must keep the p2 dimension")
+	tk.MustQuery(sql).Check(testkit.Rows("pp_055 55 5"))
+
+	// A tuple comparison spanning the index column and the whole handle. Planning this
+	// panicked before the length slice was extended per appended column. The estimate is
+	// the Selectivity() result over the tuple predicate: the appended dimensions are
+	// estimated from the handle columns' own statistics, which hold untruncated values,
+	// so the bounds handed to estimation stay untruncated as well.
+	sql = "select * from t where (c, p1, p2) > (5, 'pp_055', 55)"
+	estRows, _ := planRow(sql, "Selection")
+	require.Equal(t, "40.00", estRows)
+	require.Len(t, tk.MustQuery(sql).Rows(), 44)
+
+	sql = "select * from t use index(ic) where (c, p1, p2) > (5, 'pp_055', 55)"
+	estRows, opInfo = planRow(sql, "IndexRangeScan")
+	require.Contains(t, opInfo, `range:[5 "pp",5 +inf], (5,+inf]`, "the handle range must use the stored prefix")
+	require.Equal(t, "50.00", estRows)
+	require.Len(t, tk.MustQuery(sql).Rows(), 44)
+}
+
 func TestDeriveTablePathStatsNoAccessConds(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -22,7 +22,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
+++ b/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
@@ -309,6 +309,11 @@ func TestCommonHandleIndexRangesWithTupleCompare(t *testing.T) {
 		KEY ia(a)
 	)`)
 	tk.MustExec(`insert into t_chr_tuple3 values (1, 2, 3, 4), (1, 2, 3, 5), (1, 2, 4, 1)`)
+	rows = tk.MustQuery(
+		"explain format = 'plan_tree' select * from t_chr_tuple3 use index(ia) where (a, b, c, d) > (1, 2, 3, 4)",
+	).Rows()
+	require.True(t, explainHas(rows, "range:(1 2 3 4,1 2 3 +inf], (1 2 3,1 2 +inf], (1 2,1 +inf], (1,+inf]"),
+		"expected ranges reaching the third appended handle column")
 	tk.MustQuery(
 		"select * from t_chr_tuple3 where (a, b, c, d) > (1, 2, 3, 4) order by a, b, c, d",
 	).Check(testkit.Rows("1 2 3 5", "1 2 4 1"))

--- a/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
+++ b/pkg/planner/core/casetest/rule/rule_common_handle_range_test.go
@@ -264,3 +264,52 @@ func TestCommonHandleIndexRanges(t *testing.T) {
 		).Check(testkit.Rows("2.50 10"))
 	})
 }
+
+// TestCommonHandleIndexRangesWithTupleCompare covers a tuple comparison that spans the
+// declared index column and the whole appended common handle. Its DNF form has an
+// equality prefix reaching into the second handle column, which estimation must be able
+// to build ranges for; see issue #70532, where the appended handle columns were counted
+// as a single column and the extra columns had no matching prefix length.
+func TestCommonHandleIndexRangesWithTupleCompare(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_chr_tuple")
+	tk.MustExec(`CREATE TABLE t_chr_tuple (
+		a bigint not null,
+		b bigint not null,
+		c bigint not null,
+		PRIMARY KEY(b, c) CLUSTERED,
+		KEY ia(a)
+	)`)
+	tk.MustExec(`insert into t_chr_tuple values
+		(1, 2, 3),
+		(1, 2, 4),
+		(1, 3, 1),
+		(2, 1, 1)`)
+
+	// The index key is (a, b, c), so the tuple comparison is fully covered by ranges.
+	rows := tk.MustQuery(
+		"explain format = 'plan_tree' select * from t_chr_tuple where (a, b, c) > (1, 2, 3)",
+	).Rows()
+	require.True(t, explainHas(rows, "range:(1 2 3,1 2 +inf], (1 2,1 +inf], (1,+inf]"),
+		"expected the tuple comparison to become index ranges over the appended handle")
+	tk.MustQuery(
+		"select * from t_chr_tuple where (a, b, c) > (1, 2, 3) order by a, b, c",
+	).Check(testkit.Rows("1 2 4", "1 3 1", "2 1 1"))
+
+	// A three-column handle reaches one column further into the appended tail.
+	tk.MustExec("drop table if exists t_chr_tuple3")
+	tk.MustExec(`CREATE TABLE t_chr_tuple3 (
+		a bigint not null,
+		b bigint not null,
+		c bigint not null,
+		d bigint not null,
+		PRIMARY KEY(b, c, d) CLUSTERED,
+		KEY ia(a)
+	)`)
+	tk.MustExec(`insert into t_chr_tuple3 values (1, 2, 3, 4), (1, 2, 3, 5), (1, 2, 4, 1)`)
+	tk.MustQuery(
+		"select * from t_chr_tuple3 where (a, b, c, d) > (1, 2, 3, 4) order by a, b, c, d",
+	).Check(testkit.Rows("1 2 3 5", "1 2 4 1"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70532

Problem Summary:

A tuple comparison spanning a secondary index column and a clustered primary key fails with an internal error:

```sql
CREATE TABLE t (
    a BIGINT NOT NULL,
    b BIGINT NOT NULL,
    c BIGINT NOT NULL,
    PRIMARY KEY (b, c) CLUSTERED,
    INDEX idx_a (a)
);

EXPLAIN SELECT * FROM t WHERE (a, b, c) > (1, 2, 3);
-- ERROR 1105 (HY000): runtime error: index out of range [2] with length 2
```

`Selectivity` builds the per-column length slice for an index by copying the declared index column lengths and then appending exactly **one** `types.UnspecifiedLength` for the handle column the index key carries past them — the long-standing int-handle assumption. Since #69745 a non-unique secondary index path on a clustered table carries the **whole** common handle, so the found columns can outnumber the declared ones by more than one and `lengths` ends up shorter than the column slice. Range building indexes the two in step (`d.lengths[eqOrInCount]` in `detacher.go`), so the missing entries are read as an out-of-range index.

Two conditions have to line up, which is why the regression was not caught by #69745:

- the DNF form of the predicate needs an equality prefix reaching the **second** appended handle column. `(a, b, c) > (1, 2, 3)` expands to `a > 1 or (a = 1 and b > 2) or (a = 1 and b = 2 and c > 3)`, whose last item gives `eqOrInCount == 2`. A two-column tuple such as `(a, b) > (1, 2)` stops one column short and does not panic.
- `Selectivity` has to be called without filled paths — index merge OR estimation does that. When a cached path is available, `getMaskAndRanges` returns before touching `lengths`, so a `USE INDEX()` hint suppresses the index merge path and hides the crash.

### What changed and how does it work?

Append one length entry per extra column rather than exactly one, so `lengths` always matches the column slice that range building walks alongside it:

```go
for range len(idxCols) - len(lengths) {
    lengths = append(lengths, types.UnspecifiedLength)
}
```

The appended handle columns are assumed full-length. That is exact for an int handle and is the assumption already made for the single appended column; it is an approximation for a prefixed clustered handle column, which affects estimation only (no table info is reachable from `HistColl` at this point).

With the fix the tuple comparison is fully covered by index ranges, since the physical key of `idx_a` is `(a, b, c)`:

```
IndexReader
└─IndexRangeScan cop[tikv] table:t, index:idx_a(a)
    range:(1 2 3,1 2 +inf], (1 2,1 +inf], (1,+inf]
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New regression test `TestCommonHandleIndexRangesWithTupleCompare` (`pkg/planner/core/casetest/rule`) covers a two-column and a three-column clustered handle, asserting both the generated ranges and the returned rows. It panics without the fix and passes with it. Deliberately hint-free, because a `USE INDEX()` hint suppresses the index merge path that triggers the crash.

Validation:

```bash
make failpoint-enable
go test -tags=intest ./pkg/planner/cardinality/...
go test -tags=intest ./pkg/planner/core/casetest/... ./pkg/util/ranger/...
make failpoint-disable
make bazel_prepare
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an internal error ("index out of range") when a tuple comparison covers both a non-unique secondary index column and the clustered primary key columns of the same table.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved index range construction for queries involving appended integer or clustered-handle columns.
- Enhanced tuple comparison handling across secondary-index and clustered-handle columns.
- Improved cardinality estimates and filtering for prefixed clustered-handle indexes.

## Tests
- Added coverage for multi-column clustered handles, tuple comparisons, prefixed indexes, and expanded index-range scenarios.
- Increased test parallelization to support the expanded planner test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->