### PR TITLE
util: prevent SQLKiller state races during concurrent reset

### DIFF
--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sqlkiller",
@@ -11,5 +11,17 @@ go_library(
         "//pkg/util/logutil",
         "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "sqlkiller_test",
+    timeout = "short",
+    srcs = ["sqlkiller_test.go"],
+    embed = [":sqlkiller"],
+    flaky = True,
+    deps = [
+        "//pkg/testkit/testfailpoint",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -22,6 +22,9 @@ go_test(
     flaky = True,
     deps = [
         "//pkg/testkit/testfailpoint",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -128,7 +128,6 @@ func (killer *SQLKiller) sendKillSignal(reason killSignal) {
 
 func (killer *SQLKiller) sendKillSignalLocked(reason killSignal) (bool, string) {
 	if atomic.CompareAndSwapUint32(&killer.Signal, 0, reason) {
-		failpoint.InjectCall("afterSendKillSignalCAS")
 		return true, killer.killEvent.desc
 	}
 	return false, ""
@@ -147,6 +146,7 @@ func (killer *SQLKiller) SendKillSignal(reason killSignal) {
 	killer.killEvent.Unlock()
 
 	if signalSent {
+		failpoint.InjectCall("beforeLogKillSignal")
 		killer.logKillSignal(reason, eventDesc)
 	}
 }

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -48,6 +48,7 @@ type SQLKiller struct {
 	killEvent struct {
 		ch   chan struct{}
 		desc string
+		// Mutex serializes Signal writers with ch, desc, and triggered.
 		sync.Mutex
 		triggered bool
 	}
@@ -82,10 +83,7 @@ func (killer *SQLKiller) GetKillEventChan() <-chan struct{} {
 	return killer.killEvent.ch
 }
 
-func (killer *SQLKiller) triggerKillEvent() {
-	killer.killEvent.Lock()
-	defer killer.killEvent.Unlock()
-
+func (killer *SQLKiller) triggerKillEventLocked() {
 	if killer.killEvent.triggered {
 		return
 	}
@@ -96,10 +94,7 @@ func (killer *SQLKiller) triggerKillEvent() {
 	killer.killEvent.triggered = true
 }
 
-func (killer *SQLKiller) resetKillEvent() {
-	killer.killEvent.Lock()
-	defer killer.killEvent.Unlock()
-
+func (killer *SQLKiller) resetKillEventLocked() {
 	if !killer.killEvent.triggered && killer.killEvent.ch != nil {
 		close(killer.killEvent.ch)
 	}
@@ -110,27 +105,50 @@ func (killer *SQLKiller) resetKillEvent() {
 
 // SendKillSignalWithKillEventReason sets the reason for the kill event and sends a kill signal.
 func (killer *SQLKiller) SendKillSignalWithKillEventReason(killSignal killSignal, desc string) {
-	{
-		killer.killEvent.Lock()
-		killer.killEvent.desc = desc
-		killer.killEvent.Unlock()
+	killer.killEvent.Lock()
+	killer.killEvent.desc = desc
+	signalSent, eventDesc := killer.sendKillSignalLocked(killSignal)
+	killer.triggerKillEventLocked()
+	killer.killEvent.Unlock()
+
+	if signalSent {
+		killer.logKillSignal(killSignal, eventDesc)
 	}
-	killer.sendKillSignal(killSignal)
-	killer.triggerKillEvent()
 }
 
 func (killer *SQLKiller) sendKillSignal(reason killSignal) {
+	killer.killEvent.Lock()
+	signalSent, eventDesc := killer.sendKillSignalLocked(reason)
+	killer.killEvent.Unlock()
+
+	if signalSent {
+		killer.logKillSignal(reason, eventDesc)
+	}
+}
+
+func (killer *SQLKiller) sendKillSignalLocked(reason killSignal) (bool, string) {
 	if atomic.CompareAndSwapUint32(&killer.Signal, 0, reason) {
 		failpoint.InjectCall("afterSendKillSignalCAS")
-		err := killer.getKillError(reason)
-		logutil.BgLogger().Warn("kill initiated", zap.Uint64("connection ID", killer.ConnID.Load()), zap.String("reason", err.Error()))
+		return true, killer.killEvent.desc
 	}
+	return false, ""
+}
+
+func (killer *SQLKiller) logKillSignal(reason killSignal, desc string) {
+	err := killer.getKillError(reason, desc)
+	logutil.BgLogger().Warn("kill initiated", zap.Uint64("connection ID", killer.ConnID.Load()), zap.String("reason", err.Error()))
 }
 
 // SendKillSignal sends a kill signal to the query.
 func (killer *SQLKiller) SendKillSignal(reason killSignal) {
-	killer.sendKillSignal(reason)
-	killer.triggerKillEvent()
+	killer.killEvent.Lock()
+	signalSent, eventDesc := killer.sendKillSignalLocked(reason)
+	killer.triggerKillEventLocked()
+	killer.killEvent.Unlock()
+
+	if signalSent {
+		killer.logKillSignal(reason, eventDesc)
+	}
 }
 
 // GetKillSignal gets the kill signal.
@@ -138,17 +156,8 @@ func (killer *SQLKiller) GetKillSignal() killSignal {
 	return atomic.LoadUint32(&killer.Signal)
 }
 
-func (killer *SQLKiller) getKillEventReason() (res string) {
-	killer.killEvent.Lock()
-	//
-	res = killer.killEvent.desc
-	//
-	killer.killEvent.Unlock()
-	return res
-}
-
 // getKillError gets the error according to the kill signal.
-func (killer *SQLKiller) getKillError(status killSignal) error {
+func (killer *SQLKiller) getKillError(status killSignal, desc string) error {
 	switch status {
 	case QueryInterrupted:
 		return exeerrors.ErrQueryInterrupted.GenWithStackByArgs()
@@ -161,7 +170,7 @@ func (killer *SQLKiller) getKillError(status killSignal) error {
 	case RunawayQueryExceeded:
 		return exeerrors.ErrResourceGroupQueryRunawayInterrupted.FastGenByArgs("runaway exceed tidb side")
 	case KilledByMemArbitrator:
-		return exeerrors.ErrQueryExecStopped.GenWithStackByArgs(killer.getKillEventReason(), killer.ConnID.Load())
+		return exeerrors.ErrQueryExecStopped.GenWithStackByArgs(desc, killer.ConnID.Load())
 	default:
 	}
 	return nil
@@ -199,7 +208,9 @@ func (killer *SQLKiller) HandleSignal() error {
 			if rand.Float64() > (float64)(p)/1000 {
 				if killer.ConnID.Load() != 0 {
 					targetStatus := rand.Int31n(5)
+					killer.killEvent.Lock()
 					atomic.StoreUint32(&killer.Signal, uint32(targetStatus))
+					killer.killEvent.Unlock()
 				}
 			}
 		}
@@ -226,7 +237,14 @@ func (killer *SQLKiller) HandleSignal() error {
 	}
 
 	status := atomic.LoadUint32(&killer.Signal)
-	err := killer.getKillError(status)
+	var desc string
+	if status == KilledByMemArbitrator {
+		killer.killEvent.Lock()
+		status = atomic.LoadUint32(&killer.Signal)
+		desc = killer.killEvent.desc
+		killer.killEvent.Unlock()
+	}
+	err := killer.getKillError(status, desc)
 	if status == ServerMemoryExceeded {
 		logutil.BgLogger().Warn("global memory controller, NeedKill signal is received successfully",
 			zap.Uint64("conn", killer.ConnID.Load()))
@@ -244,14 +262,16 @@ func (killer *SQLKiller) CheckConnectionAlive() {
 
 // Reset resets the SqlKiller.
 func (killer *SQLKiller) Reset() {
+	killer.killEvent.Lock()
 	status := atomic.SwapUint32(&killer.Signal, UnspecifiedKillSignal)
-	if status != UnspecifiedKillSignal {
-		logutil.BgLogger().Warn("kill finished", zap.Uint64("conn", killer.ConnID.Load()))
-	}
-
 	// Keep this hook immediately after the atomic clear. If Reset is ever split
 	// into separate observation and clear operations, place it between them.
 	failpoint.InjectCall("afterResetKillSignalSwap")
-	killer.resetKillEvent()
+	killer.resetKillEventLocked()
+	killer.killEvent.Unlock()
+
+	if status != UnspecifiedKillSignal {
+		logutil.BgLogger().Warn("kill finished", zap.Uint64("conn", killer.ConnID.Load()))
+	}
 	killer.lastCheckTime.Store(nil)
 }

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -121,8 +121,8 @@ func (killer *SQLKiller) SendKillSignalWithKillEventReason(killSignal killSignal
 
 func (killer *SQLKiller) sendKillSignal(reason killSignal) {
 	if atomic.CompareAndSwapUint32(&killer.Signal, 0, reason) {
-		status := atomic.LoadUint32(&killer.Signal)
-		err := killer.getKillError(status)
+		failpoint.InjectCall("afterSendKillSignalCAS")
+		err := killer.getKillError(reason)
 		logutil.BgLogger().Warn("kill initiated", zap.Uint64("connection ID", killer.ConnID.Load()), zap.String("reason", err.Error()))
 	}
 }
@@ -244,11 +244,14 @@ func (killer *SQLKiller) CheckConnectionAlive() {
 
 // Reset resets the SqlKiller.
 func (killer *SQLKiller) Reset() {
-	if atomic.LoadUint32(&killer.Signal) != 0 {
+	status := atomic.SwapUint32(&killer.Signal, UnspecifiedKillSignal)
+	if status != UnspecifiedKillSignal {
 		logutil.BgLogger().Warn("kill finished", zap.Uint64("conn", killer.ConnID.Load()))
 	}
 
-	atomic.StoreUint32(&killer.Signal, 0)
+	// Keep this hook immediately after the atomic clear. If Reset is ever split
+	// into separate observation and clear operations, place it between them.
+	failpoint.InjectCall("afterResetKillSignalSwap")
 	killer.resetKillEvent()
 	killer.lastCheckTime.Store(nil)
 }

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlkiller
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLKillerConcurrentReset(t *testing.T) {
+	t.Run("reset after successful kill signal CAS", func(t *testing.T) {
+		killer := &SQLKiller{}
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/util/sqlkiller/afterSendKillSignalCAS", func() {
+			resetDone := make(chan struct{})
+			go func() {
+				killer.Reset()
+				close(resetDone)
+			}()
+			<-resetDone
+		})
+
+		require.NotPanics(t, func() {
+			killer.SendKillSignal(QueryInterrupted)
+		})
+	})
+
+	t.Run("kill signal after reset clear", func(t *testing.T) {
+		killer := &SQLKiller{}
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/util/sqlkiller/afterResetKillSignalSwap", func() {
+			killSent := make(chan struct{})
+			go func() {
+				killer.sendKillSignal(QueryInterrupted)
+				close(killSent)
+			}()
+			<-killSent
+		})
+
+		killer.Reset()
+		require.Equal(t, QueryInterrupted, killer.GetKillSignal())
+	})
+}

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -22,34 +22,77 @@ import (
 )
 
 func TestSQLKillerConcurrentReset(t *testing.T) {
+	assertStateLockHeld := func(t *testing.T, killer *SQLKiller) {
+		t.Helper()
+		if killer.killEvent.TryLock() {
+			killer.killEvent.Unlock()
+			require.FailNow(t, "the SQLKiller state mutex is not held")
+		}
+	}
+	getKillEventState := func(killer *SQLKiller) (bool, string) {
+		killer.killEvent.Lock()
+		defer killer.killEvent.Unlock()
+		return killer.killEvent.triggered, killer.killEvent.desc
+	}
+	assertChanOpen := func(t *testing.T, ch <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-ch:
+			require.Fail(t, "kill event channel is closed")
+		default:
+		}
+	}
+	assertChanClosed := func(t *testing.T, ch <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "kill event channel is open")
+		}
+	}
+
 	t.Run("reset after successful kill signal CAS", func(t *testing.T) {
 		killer := &SQLKiller{}
+		resetDone := make(chan struct{})
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/util/sqlkiller/afterSendKillSignalCAS", func() {
-			resetDone := make(chan struct{})
+			assertStateLockHeld(t, killer)
 			go func() {
+				defer close(resetDone)
 				killer.Reset()
-				close(resetDone)
 			}()
-			<-resetDone
 		})
 
-		require.NotPanics(t, func() {
-			killer.SendKillSignal(QueryInterrupted)
-		})
+		killer.SendKillSignal(QueryInterrupted)
+		<-resetDone
+
+		require.Equal(t, UnspecifiedKillSignal, killer.GetKillSignal())
+		require.NoError(t, killer.HandleSignal())
+		triggered, desc := getKillEventState(killer)
+		require.False(t, triggered)
+		require.Empty(t, desc)
+		assertChanOpen(t, killer.GetKillEventChan())
 	})
 
 	t.Run("kill signal after reset clear", func(t *testing.T) {
 		killer := &SQLKiller{}
+		killSent := make(chan struct{})
+		const reason = "memory usage exceeds the instance limit"
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/util/sqlkiller/afterResetKillSignalSwap", func() {
-			killSent := make(chan struct{})
+			assertStateLockHeld(t, killer)
 			go func() {
-				killer.sendKillSignal(QueryInterrupted)
-				close(killSent)
+				defer close(killSent)
+				killer.SendKillSignalWithKillEventReason(KilledByMemArbitrator, reason)
 			}()
-			<-killSent
 		})
 
 		killer.Reset()
-		require.Equal(t, QueryInterrupted, killer.GetKillSignal())
+		<-killSent
+
+		require.Equal(t, KilledByMemArbitrator, killer.GetKillSignal())
+		require.ErrorContains(t, killer.HandleSignal(), reason)
+		triggered, desc := getKillEventState(killer)
+		require.True(t, triggered)
+		require.Equal(t, reason, desc)
+		assertChanClosed(t, killer.GetKillEventChan())
 	})
 }

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -17,8 +17,11 @@ package sqlkiller
 import (
 	"testing"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestSQLKillerConcurrentReset(t *testing.T) {
@@ -53,17 +56,26 @@ func TestSQLKillerConcurrentReset(t *testing.T) {
 
 	t.Run("reset after successful kill signal CAS", func(t *testing.T) {
 		killer := &SQLKiller{}
-		resetDone := make(chan struct{})
-		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/util/sqlkiller/afterSendKillSignalCAS", func() {
-			assertStateLockHeld(t, killer)
-			go func() {
-				defer close(resetDone)
-				killer.Reset()
-			}()
+		core, logs := observer.New(zap.WarnLevel)
+		restoreLogger := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{
+			Core:  core,
+			Level: zap.NewAtomicLevelAt(zap.WarnLevel),
+		})
+		defer restoreLogger()
+
+		const beforeLogFailpoint = "github.com/pingcap/tidb/pkg/util/sqlkiller/" +
+			"beforeLogKillSignal"
+		testfailpoint.EnableCall(t, beforeLogFailpoint, func() {
+			killer.Reset()
 		})
 
-		killer.SendKillSignal(QueryInterrupted)
-		<-resetDone
+		require.NotPanics(t, func() {
+			killer.SendKillSignal(QueryInterrupted)
+		})
+		initiatedLogs := logs.FilterMessage("kill initiated").All()
+		require.Len(t, initiatedLogs, 1)
+		require.Equal(t, killer.getKillError(QueryInterrupted, "").Error(),
+			initiatedLogs[0].ContextMap()["reason"])
 
 		require.Equal(t, UnspecifiedKillSignal, killer.GetKillSignal())
 		require.NoError(t, killer.HandleSignal())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70545

Problem Summary:

`SQLKiller` updated its atomic kill signal separately from the related kill-event channel, description, and triggered state. When signal delivery raced with `Reset`, these independent transitions could leave the signal and event state inconsistent. For example, a successful kill signal could be cleared while its event remained triggered, or a new signal could survive with its event description reset.

The same race also allowed `sendKillSignal` to reload a cleared signal after a successful compare-and-swap. `getKillError` then returned `nil`, and the KILL statement panicked while formatting the `kill initiated` log. The panic is recovered by the statement execution layer, so the TiDB process remains available, but the KILL statement fails and its client connection is dropped.

### What changed and how does it work?

- Use the kill-event mutex as the state mutex for signal writers and the related channel, description, and triggered state.
- Perform signal installation and event triggering in one critical section, and perform signal clearing and event reset in another, so concurrent send and reset operations observe a consistent ordering.
- Capture the installed signal and event description while the state is stable, then construct and write logs after releasing the mutex. This avoids reloading mutable state and keeps logging outside the critical section.
- Read the memory-arbitrator signal and its description together when constructing the corresponding kill error.
- Add deterministic failpoint-backed unit tests for both send/reset orderings, including a race-detector run.
- Add the generated Bazel test target for the new `pkg/util/sqlkiller` unit test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/util/sqlkiller -run TestSQLKillerConcurrentReset -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/util/sqlkiller -run TestSQLKillerConcurrentReset -count=1 -race`
  - `make lint`
  - `make bazel_prepare`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix races between KILL signal delivery and connection reset that could make a KILL statement fail with a nil-pointer panic or leave cancellation state inconsistent.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resetting and sending cancellation signals concurrently.
  * Prevented race-condition failures during signal delivery and reset operations.
  * Preserved accurate termination reasons and event status during simultaneous operations.
  * Ensured completed resets leave signal handling ready for subsequent operations.

* **Tests**
  * Expanded concurrency coverage for signal delivery, reset behavior, event state, termination reasons, logging, and channel handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
