### PR TITLE
planner: support TiFlash MPP full outer join

### DIFF
--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
@@ -656,8 +656,8 @@
           "  └─TableFullScan cop[tikv] table:t keep order:true, stats:pseudo"
         ],
         "Warn": [
-          "MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information.",
-          "MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information."
+          "MPP mode may be blocked because left conditions are only supported for `left outer join` and `full outer join` now.",
+          "MPP mode may be blocked because left conditions are only supported for `left outer join` and `full outer join` now."
         ]
       }
     ]

--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_xut.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_xut.json
@@ -656,8 +656,8 @@
           "  └─TableFullScan cop[tikv] table:t keep order:true, stats:pseudo"
         ],
         "Warn": [
-          "MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information.",
-          "MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information."
+          "MPP mode may be blocked because left conditions are only supported for `left outer join` and `full outer join` now.",
+          "MPP mode may be blocked because left conditions are only supported for `left outer join` and `full outer join` now."
         ]
       }
     ]

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1984,11 +1984,11 @@ func tryToGetMppHashJoin(super base.LogicalPlan, prop *property.PhysicalProperty
 		}
 	}
 	if len(p.LeftConditions) != 0 && p.JoinType != base.LeftOuterJoin && p.JoinType != base.FullOuterJoin {
-		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information.")
+		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because left conditions are only supported for `left outer join` and `full outer join` now.")
 		return nil
 	}
 	if len(p.RightConditions) != 0 && p.JoinType != base.RightOuterJoin && p.JoinType != base.FullOuterJoin {
-		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because there is a join that is not `right join` but has right conditions, which is not supported by mpp now.")
+		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because right conditions are only supported for `right outer join` and `full outer join` now.")
 		return nil
 	}
 

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2263,6 +2263,9 @@ func exhaustPhysicalPlans4LogicalJoin(super base.LogicalPlan, prop *property.Phy
 		// Non-MPP full outer join keeps the phase-1 restriction: root HashJoin v1 only.
 		hashJoins, forced := getHashJoins(super, prop)
 		joins = append(joins, hashJoins...)
+		if forced && len(hashJoins) > 0 {
+			return joins, true, nil
+		}
 		if p.PreferJoinType > 0 {
 			// recordWarnings only reports index-join-family hint failures for LogicalJoin.
 			// Since full outer join does not support merge join, report the merge-join

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1885,6 +1885,9 @@ func getJoinChildStatsAndSchema(ge base.GroupExpression, p base.LogicalPlan) (st
 // If we can use mpp broadcast join, that's our first choice.
 func preferMppBCJ(super base.LogicalPlan) bool {
 	ge, p := base.GetGEAndLogicalOp[*logicalop.LogicalJoin](super)
+	if p.JoinType == base.FullOuterJoin {
+		return false
+	}
 	if len(p.EqualConditions) == 0 && p.SCtx().GetSessionVars().AllowCartesianBCJ == 2 {
 		return true
 	}
@@ -1961,8 +1964,12 @@ func tryToGetMppHashJoin(super base.LogicalPlan, prop *property.PhysicalProperty
 		return nil
 	}
 
-	if p.JoinType != base.InnerJoin && p.JoinType != base.LeftOuterJoin && p.JoinType != base.RightOuterJoin && p.JoinType != base.SemiJoin && p.JoinType != base.AntiSemiJoin && p.JoinType != base.LeftOuterSemiJoin && p.JoinType != base.AntiLeftOuterSemiJoin {
+	if p.JoinType != base.InnerJoin && p.JoinType != base.LeftOuterJoin && p.JoinType != base.RightOuterJoin && p.JoinType != base.FullOuterJoin && p.JoinType != base.SemiJoin && p.JoinType != base.AntiSemiJoin && p.JoinType != base.LeftOuterSemiJoin && p.JoinType != base.AntiLeftOuterSemiJoin {
 		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because join type `" + p.JoinType.String() + "` is not supported now.")
+		return nil
+	}
+	if p.JoinType == base.FullOuterJoin && useBCJ {
+		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because `full outer join` is only supported by shuffle join now.")
 		return nil
 	}
 
@@ -1976,11 +1983,11 @@ func tryToGetMppHashJoin(super base.LogicalPlan, prop *property.PhysicalProperty
 			return nil
 		}
 	}
-	if len(p.LeftConditions) != 0 && p.JoinType != base.LeftOuterJoin {
+	if len(p.LeftConditions) != 0 && p.JoinType != base.LeftOuterJoin && p.JoinType != base.FullOuterJoin {
 		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because there is a join that is not `left join` but has left conditions, which is not supported by mpp now, see github.com/pingcap/tidb/issues/26090 for more information.")
 		return nil
 	}
-	if len(p.RightConditions) != 0 && p.JoinType != base.RightOuterJoin {
+	if len(p.RightConditions) != 0 && p.JoinType != base.RightOuterJoin && p.JoinType != base.FullOuterJoin {
 		p.SCtx().GetSessionVars().RaiseWarningWhenMPPEnforced("MPP mode may be blocked because there is a join that is not `right join` but has right conditions, which is not supported by mpp now.")
 		return nil
 	}
@@ -2035,7 +2042,7 @@ func tryToGetMppHashJoin(super base.LogicalPlan, prop *property.PhysicalProperty
 			fixedBuildSide = true
 		}
 	}
-	if p.JoinType == base.LeftOuterJoin || p.JoinType == base.RightOuterJoin {
+	if p.JoinType == base.LeftOuterJoin || p.JoinType == base.RightOuterJoin || p.JoinType == base.FullOuterJoin {
 		// TiFlash does not require that the build side must be the inner table for outer join.
 		// so we can choose the build side based on the row count, except that:
 		// 1. it is a broadcast join(for broadcast join, it makes sense to use the broadcast side as the build side)
@@ -2107,6 +2114,9 @@ func tryToGetMppHashJoin(super base.LogicalPlan, prop *property.PhysicalProperty
 	} else {
 		lPartitionKeys, rPartitionKeys := p.GetPotentialPartitionKeys()
 		if prop.MPPPartitionTp == property.HashType {
+			if p.JoinType == base.FullOuterJoin {
+				return nil
+			}
 			var matches []int
 			switch p.JoinType {
 			case base.InnerJoin:
@@ -2208,32 +2218,6 @@ func exhaustPhysicalPlans4LogicalJoin(super base.LogicalPlan, prop *property.Phy
 	if prop.MPPPartitionTp == property.BroadcastType {
 		return nil, false, nil
 	}
-	if p.JoinType == base.FullOuterJoin {
-		// Planner-only/root phase restriction: full outer join uses root hash
-		// join only. TiFlash MPP is introduced in a later PR.
-		if prop.IsFlashProp() {
-			return nil, true, nil
-		}
-		hashJoins, forced := getHashJoins(p, prop)
-		if forced && len(hashJoins) > 0 {
-			return hashJoins, true, nil
-		}
-		if p.PreferJoinType > 0 {
-			// recordWarnings only reports index-join-family hint failures for LogicalJoin.
-			// Since full outer join returns before merge join enumeration, report the
-			// merge-join hint here while leaving index-join-family hints to that path.
-			if p.PreferJoinType&h.PreferMergeJoin > 0 {
-				var mergeJoinTables []h.HintedTable
-				if p.HintInfo != nil {
-					mergeJoinTables = p.HintInfo.SortMergeJoin
-				}
-				p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf("Optimizer Hint %s or %s is inapplicable",
-					h.Restore2JoinHint(h.HintSMJ, mergeJoinTables), h.Restore2JoinHint(h.TiDBMergeJoin, mergeJoinTables)))
-			}
-			return hashJoins, false, nil
-		}
-		return hashJoins, true, nil
-	}
 	joins := make([]base.PhysicalPlan, 0, 8)
 	// we lift the p.canPushToTiFlash check here, because we want to generate all the plans to be decided by the attachment layer.
 	if prop.IndexJoinProp == nil {
@@ -2273,6 +2257,27 @@ func exhaustPhysicalPlans4LogicalJoin(super base.LogicalPlan, prop *property.Phy
 		if prop.IsFlashProp() {
 			return joins, true, nil
 		}
+	}
+
+	if p.JoinType == base.FullOuterJoin {
+		// Non-MPP full outer join keeps the phase-1 restriction: root HashJoin v1 only.
+		hashJoins, forced := getHashJoins(super, prop)
+		joins = append(joins, hashJoins...)
+		if p.PreferJoinType > 0 {
+			// recordWarnings only reports index-join-family hint failures for LogicalJoin.
+			// Since full outer join does not support merge join, report the merge-join
+			// hint here while leaving index-join-family hints to that path.
+			if p.PreferJoinType&h.PreferMergeJoin > 0 {
+				var mergeJoinTables []h.HintedTable
+				if p.HintInfo != nil {
+					mergeJoinTables = p.HintInfo.SortMergeJoin
+				}
+				p.SCtx().GetSessionVars().StmtCtx.SetHintWarning(fmt.Sprintf("Optimizer Hint %s or %s is inapplicable",
+					h.Restore2JoinHint(h.HintSMJ, mergeJoinTables), h.Restore2JoinHint(h.TiDBMergeJoin, mergeJoinTables)))
+			}
+			return joins, false, nil
+		}
+		return joins, forced || len(joins) > 0, nil
 	}
 
 	hashJoins, forced := getHashJoins(super, prop)

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -562,6 +562,8 @@ func (p *PhysicalHashJoin) ToPB(ctx *base.BuildPBContext, storeType kv.StoreType
 		pbJoinType = tipb.JoinType_TypeLeftOuterJoin
 	case base.RightOuterJoin:
 		pbJoinType = tipb.JoinType_TypeRightOuterJoin
+	case base.FullOuterJoin:
+		pbJoinType = tipb.JoinType_TypeFullOuterJoin
 	case base.SemiJoin:
 		pbJoinType = tipb.JoinType_TypeSemiJoin
 	case base.AntiSemiJoin:

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -338,6 +338,73 @@ func TestJoinHintCompatibilityWithVariable(t *testing.T) {
 	})
 }
 
+func prepareMPPFullOuterJoinTest(t *testing.T, tk *testkit.TestKit) {
+	t.Helper()
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_cost_model_version=2")
+	tk.MustExec("set @@tidb_allow_mpp=1")
+	tk.MustExec("set @@tidb_enforce_mpp=1")
+	tk.MustExec("set @@tidb_enable_full_outer_join=1")
+	tk.MustExec("create table t1 (a int, b int)")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("alter table t1 set tiflash replica 1")
+	tk.MustExec("alter table t2 set tiflash replica 1")
+	for _, tableName := range []string{"t1", "t2"} {
+		tb := external.GetTableByName(t, tk, "test", tableName)
+		err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+		require.NoError(t, err)
+	}
+}
+
+func findMPPFullOuterHashJoin(t *testing.T, tk *testkit.TestKit, sql string) *physicalop.PhysicalHashJoin {
+	t.Helper()
+	stmt, err := parser.New().ParseOneStmt(sql, "", "")
+	require.NoError(t, err)
+	nodeW := resolve.NewNodeW(stmt)
+	plan, _, err := planner.Optimize(context.Background(), tk.Session(), nodeW, domain.GetDomain(tk.Session()).InfoSchema())
+	require.NoError(t, err)
+
+	flat := core.FlattenPhysicalPlan(plan, true)
+	for _, op := range flat.Main {
+		hashJoin, ok := op.Origin.(*physicalop.PhysicalHashJoin)
+		if !ok {
+			continue
+		}
+		if hashJoin.StoreTp == kv.TiFlash && hashJoin.MppShuffleJoin && hashJoin.GetJoinType() == base.FullOuterJoin {
+			return hashJoin
+		}
+	}
+	require.FailNow(t, "expected MPP TiFlash full outer hash join")
+	return nil
+}
+
+func TestMPPFullOuterJoinToPB(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	prepareMPPFullOuterJoinTest(t, tk)
+
+	sql := "select /*+ shuffle_join(t1, t2), read_from_storage(tiflash[t1, t2]) */ * from t1 full outer join t2 on t1.a = t2.a and t1.b > 1 and t2.b > 1"
+	hashJoin := findMPPFullOuterHashJoin(t, tk, sql)
+	require.Len(t, hashJoin.LeftConditions, 1)
+	require.Len(t, hashJoin.RightConditions, 1)
+
+	pb, err := hashJoin.ToPB(tk.Session().GetBuildPBCtx(), kv.TiFlash)
+	require.NoError(t, err)
+	require.Equal(t, tipb.JoinType_TypeFullOuterJoin, pb.Join.JoinType)
+}
+
+func TestMPPFullOuterJoinWithoutShuffleHint(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	prepareMPPFullOuterJoinTest(t, tk)
+	tk.MustExec("set @@tidb_broadcast_join_threshold_count=1000000000")
+	tk.MustExec("set @@tidb_broadcast_join_threshold_size=1000000000")
+
+	sql := "select /*+ read_from_storage(tiflash[t1, t2]) */ * from t1 full outer join t2 on t1.a = t2.a and t1.b > 1 and t2.b > 1"
+	findMPPFullOuterHashJoin(t, tk, sql)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+}
+
 func TestHintAlias(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -465,8 +465,10 @@ func attach2TaskForMpp4PhysicalHashJoin(pp base.PhysicalPlan, tasks ...base.Task
 	// for broadcast inner join, it should be the non-broadcast side, since broadcast side is always the build side, so
 	// just use the probe side is ok.
 	// for hash inner join, both side is ok, by default, we use the probe side
-	// for outer join, it should always be the outer side of the join
+	// for left/right outer join, it should always be the outer side of the join
 	// for semi join, it should be the left side(the same as left out join)
+	// for full outer join, both sides are preserved, so neither side's partition property
+	// can be passed to the join result. Use AnyType instead.
 	partTp := property.AnyType
 	var hashCols []*property.MPPPartitionColumn
 	if p.JoinType != base.FullOuterJoin {

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -467,22 +467,28 @@ func attach2TaskForMpp4PhysicalHashJoin(pp base.PhysicalPlan, tasks ...base.Task
 	// for hash inner join, both side is ok, by default, we use the probe side
 	// for outer join, it should always be the outer side of the join
 	// for semi join, it should be the left side(the same as left out join)
-	outerTaskIndex := 1 - p.InnerChildIdx
-	if p.JoinType != base.InnerJoin {
-		if p.JoinType == base.RightOuterJoin {
-			outerTaskIndex = 1
-		} else {
-			outerTaskIndex = 0
+	partTp := property.AnyType
+	var hashCols []*property.MPPPartitionColumn
+	if p.JoinType != base.FullOuterJoin {
+		outerTaskIndex := 1 - p.InnerChildIdx
+		if p.JoinType != base.InnerJoin {
+			if p.JoinType == base.RightOuterJoin {
+				outerTaskIndex = 1
+			} else {
+				outerTaskIndex = 0
+			}
 		}
-	}
-	// can not use the task from tasks because it maybe updated.
-	outerTask := lTask
-	if outerTaskIndex == 1 {
-		outerTask = rTask
+		// can not use the task from tasks because it maybe updated.
+		outerTask := lTask
+		if outerTaskIndex == 1 {
+			outerTask = rTask
+		}
+		partTp = outerTask.GetPartitionType()
+		hashCols = outerTask.GetHashCols()
 	}
 	task := physicalop.NewMppTask(p,
-		outerTask.GetPartitionType(),
-		outerTask.GetHashCols(),
+		partTp,
+		hashCols,
 		nil, rTask.GetWarnings(), lTask.GetWarnings())
 	// Current TiFlash doesn't support receive Join executors' schema info directly from TiDB.
 	// Instead, it calculates Join executors' output schema using algorithm like BuildPhysicalJoinSchema which


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69998

Problem Summary:

`FULL OUTER JOIN` support has been ported to TiDB in stages. Root HashJoin v1 execution is available, but the TiFlash MPP planner path still needs to generate a correct distributed full outer join plan.

### What changed and how does it work?

- Add TiFlash MPP physical plan generation for `FULL OUTER JOIN`.
- Support both left-side and right-side single-table join conditions for MPP full outer join.
- Encode the join as `tipb.JoinType_TypeFullOuterJoin` when building the TiFlash DAG request.
- Keep non-MPP full outer join on root HashJoin v1.
- Reject MPP broadcast join for full outer join; MPP full outer join is supported by shuffle join only.
- Keep the MPP full outer join task partition type unconstrained because both input sides are preserved sides.
- Add planner tests for MPP plan generation, join conditions, ToPB conversion, and broadcast-join rejection.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `make bazel_prepare`
  - `./tools/check/failpoint-go-test.sh ./pkg/planner/core -run '^TestMPPFullOuterJoin(ToPB|WithoutShuffleHint)$|^TestFullOuterJoinSyntaxUnsupported$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
TiDB now supports executing `FULL OUTER JOIN` with TiFlash MPP shuffle join.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MPP shuffle-join support for full outer joins.
  * Full outer joins can now select an MPP hash join without an explicit shuffle hint.
  * Preserved full outer join types and conditions when plans are converted for execution.

* **Bug Fixes**
  * Prevented unsupported MPP broadcast plans for full outer joins.
  * Improved partition handling and validation for full outer joins.
  * Updated MPP warnings to clearly describe supported join conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->