### PR TITLE
*: fix typo "lighting/cmd" in codecov ignore path

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -92,6 +92,6 @@ ignore:
   - "pkg/store/mockstore/unistore/testutil.go"
   - "k8s.io/apimachinery/pkg"
   - "build"
-  - "lighting/cmd"
+  - "lightning/cmd"
   - "pkg/parser/generate_keyword/genkeyword.go"
   - "pkg/planner/core/generator"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70565

Problem Summary: `.codecov.yml` line 95 ignores `lighting/cmd`. The directory in the tree is `lightning/cmd`. A path named `lighting` never existed in the repository history, so this ignore has never matched anything since it was added in 6b3f20a (January 2026), and `lightning/cmd` is counted in the coverage total it was meant to exclude.

### What changed and how does it work?

Fix in `.codecov.yml`: `lighting/cmd` becomes `lightning/cmd`, so the ignore matches the directory it was written for.

To verify:

    ls lightning/cmd | head -3
    git log --oneline -1 -- lighting   # empty: the path never existed

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```