### PR TITLE
test: stabilize flaky TestMainBackupLoop

### DIFF
--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -71,6 +71,7 @@ func mockGetBackupClientCallBack(ctx context.Context, storeID uint64, reset bool
 
 type mockBackupBackupSender struct {
 	backupResponses map[uint64][]*backup.ResponseAndStore
+	afterLoad       func(storeID uint64)
 }
 
 func (m *mockBackupBackupSender) SendAsync(
@@ -99,6 +100,9 @@ func (m *mockBackupBackupSender) SendAsync(
 			lock.Lock()
 			resps = m.backupResponses[storeID]
 			lock.Unlock()
+		}
+		if m.afterLoad != nil {
+			m.afterLoad(storeID)
 		}
 		for _, r := range resps {
 			select {
@@ -609,6 +613,8 @@ func TestMainBackupLoop(t *testing.T) {
 	dropStoreID := uint64(2)
 	s.mockCluster.MarkTombstone(dropStoreID)
 	dropBackupResponses := mockBackupResponses[dropStoreID]
+	remainStoreFirstLoad := make(chan struct{})
+	var remainStoreFirstLoadOnce sync.Once
 	lock.Lock()
 	mockBackupResponses[dropStoreID] = nil
 	lock.Unlock()
@@ -616,6 +622,13 @@ func TestMainBackupLoop(t *testing.T) {
 	mainLoop = &backup.MainBackupLoop{
 		BackupSender: &mockBackupBackupSender{
 			backupResponses: mockBackupResponses,
+			afterLoad: func(storeID uint64) {
+				if storeID == remainStoreID {
+					remainStoreFirstLoadOnce.Do(func() {
+						close(remainStoreFirstLoad)
+					})
+				}
+			},
 		},
 
 		BackupReq:               backuppb.BackupRequest{},
@@ -626,10 +639,9 @@ func TestMainBackupLoop(t *testing.T) {
 		GetBackupClientCallBack: mockGetBackupClientCallBack,
 	}
 	go func() {
-		// mock region leader balance behaviour.
-		time.Sleep(500 * time.Millisecond)
+		// Mock region leader balance after store 1 has loaded its first partial response set.
+		<-remainStoreFirstLoad
 		lock.Lock()
-		// store 1 has the range after some while.
 		mockBackupResponses[remainStoreID] = append(mockBackupResponses[remainStoreID], dropBackupResponses...)
 		lock.Unlock()
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68203

Problem Summary:
Flaky test `TestMainBackupLoop` in `br/pkg/backup` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Fixed 500 ms mock leader-balance timing could fire before store 1 observed its first partial response set, so the test sometimes completed with only one store-1 connection.

#### Fix

Waiting on the mock sender’s first load removes harness timing noise while preserving the backup-loop retry behavior under test.

#### Verification

Spec:
- target: `br/pkg/backup :: TestMainBackupLoop`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_raw: SKIPPED
- build: PASS
- lint: PASS
- ci_bazel: SKIPPED

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/backup -run '^TestMainBackupLoop$' -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved backup loop test synchronization for more deterministic results.
  - Replaced a fixed time delay with event-based coordination when validating response handling.
  - Added a callback mechanism to reliably detect when initial store responses have loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->