### PR TITLE
session, meta: add materialized view bootstrap system tables

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -129,6 +129,14 @@ var unRecoverableTable = map[string]map[string]struct{}{
 		// TiDB internal timers.
 		"tidb_timers": {},
 
+		// MV maintenance metadata uses cluster-local table IDs and TSOs, so it
+		// cannot be meaningfully restored into another cluster.
+		"tidb_mview_refresh_info":  {},
+		"tidb_mlog_purge_info":     {},
+		"tidb_mview_refresh_hist":  {},
+		"tidb_mview_refresh_alert": {},
+		"tidb_mlog_purge_hist":     {},
+
 		// gc info don't need to recover.
 		"gc_delete_range":       {},
 		"gc_delete_range_done":  {},

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -393,7 +393,7 @@ func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(284), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(285), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -190,6 +190,8 @@ const (
 	BaseNextGenBootTableVersion NextGenBootTableVersion = 1
 	// MaskingPolicyNextGenBootTableVersion adds mysql.tidb_masking_policy.
 	MaskingPolicyNextGenBootTableVersion NextGenBootTableVersion = 2
+	// MaterializedViewNextGenBootTableVersion adds materialized view maintenance metadata tables.
+	MaterializedViewNextGenBootTableVersion NextGenBootTableVersion = 3
 )
 
 // DDLTableVersion is to display ddl related table versions

--- a/pkg/meta/metadef/system.go
+++ b/pkg/meta/metadef/system.go
@@ -156,6 +156,16 @@ const (
 	TiDBSoftDeleteTableStatusTableID = ReservedGlobalIDUpperBound - 61
 	// TiDBMaskingPolicyTableID is the table ID of `tidb_masking_policy`.
 	TiDBMaskingPolicyTableID = ReservedGlobalIDUpperBound - 62
+	// TiDBMViewRefreshInfoTableID is the table ID of `tidb_mview_refresh_info`.
+	TiDBMViewRefreshInfoTableID = ReservedGlobalIDUpperBound - 63
+	// TiDBMLogPurgeInfoTableID is the table ID of `tidb_mlog_purge_info`.
+	TiDBMLogPurgeInfoTableID = ReservedGlobalIDUpperBound - 64
+	// TiDBMViewRefreshHistTableID is the table ID of `tidb_mview_refresh_hist`.
+	TiDBMViewRefreshHistTableID = ReservedGlobalIDUpperBound - 65
+	// TiDBMViewRefreshAlertTableID is the table ID of `tidb_mview_refresh_alert`.
+	TiDBMViewRefreshAlertTableID = ReservedGlobalIDUpperBound - 66
+	// TiDBMLogPurgeHistTableID is the table ID of `tidb_mlog_purge_hist`.
+	TiDBMLogPurgeHistTableID = ReservedGlobalIDUpperBound - 67
 )
 
 // IsReservedID checks if the given ID is a reserved global ID.

--- a/pkg/meta/metadef/system_tables_def.go
+++ b/pkg/meta/metadef/system_tables_def.go
@@ -812,6 +812,86 @@ const (
 		UNIQUE KEY uk_table_policy(table_id, policy_name),
 		UNIQUE KEY uk_table_column(table_id, column_id)
 		);`
+
+	// CreateTiDBMViewRefreshInfoTable is a table to store current refresh scheduling info for each materialized view.
+	CreateTiDBMViewRefreshInfoTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_info (
+		MVIEW_ID bigint NOT NULL,
+		LAST_SUCCESS_READ_TSO bigint unsigned DEFAULT NULL,
+		LAST_SUCCESS_REFRESH_END_UNIX_SECONDS bigint DEFAULT NULL,
+		NEXT_REFRESH_UNIX_SECONDS bigint DEFAULT NULL,
+		PRIMARY KEY(MVIEW_ID))`
+
+	// CreateTiDBMLogPurgeInfoTable is a table to store current purge scheduling info for each materialized view log.
+	CreateTiDBMLogPurgeInfoTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_info (
+		MLOG_ID bigint NOT NULL,
+		NEXT_PURGE_UNIX_SECONDS bigint DEFAULT NULL,
+		LAST_PURGED_TSO bigint unsigned DEFAULT NULL,
+		PRIMARY KEY(MLOG_ID))`
+
+	// CreateTiDBMViewRefreshHistTable is a table to store materialized view refresh history.
+	CreateTiDBMViewRefreshHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_hist (
+		REFRESH_JOB_ID bigint unsigned NOT NULL,
+		MVIEW_ID bigint NOT NULL,
+		MVIEW_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MVIEW_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		REFRESH_METHOD varchar(32) NOT NULL,
+		REFRESH_START_TIME datetime(6) DEFAULT NULL,
+		REFRESH_END_TIME datetime(6) DEFAULT NULL,
+		REFRESH_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		REFRESH_SCHEDULE_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		REFRESH_STATUS varchar(16) DEFAULT NULL,
+		REFRESH_ROWS bigint DEFAULT NULL,
+		REFRESH_READ_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_COMMIT_TSO bigint unsigned DEFAULT NULL,
+		REFRESH_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUEST_TIME datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_TIME datetime(6) DEFAULT NULL,
+		PRIMARY KEY(REFRESH_JOB_ID),
+		KEY idx_mview_start_time (MVIEW_ID, REFRESH_START_TIME),
+		KEY idx_mview_name_start_time (MVIEW_SCHEMA, MVIEW_NAME, REFRESH_START_TIME),
+		KEY idx_mview_name_commit_tso (MVIEW_SCHEMA, MVIEW_NAME, REFRESH_COMMIT_TSO),
+		KEY idx_mview_status_start_time (MVIEW_ID, REFRESH_STATUS, REFRESH_START_TIME),
+		KEY idx_refresh_duration_sec (REFRESH_DURATION_SEC),
+		KEY idx_refresh_schedule_duration_sec (REFRESH_SCHEDULE_DURATION_SEC),
+		KEY idx_refresh_start_time (REFRESH_START_TIME),
+		KEY idx_refresh_status_start_time (REFRESH_STATUS, REFRESH_START_TIME))`
+
+	// CreateTiDBMViewRefreshAlertTable is a table to store the current refresh alert level for each materialized view.
+	CreateTiDBMViewRefreshAlertTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mview_refresh_alert (
+		MVIEW_ID bigint NOT NULL,
+		MVIEW_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		MVIEW_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		ALERT_LEVEL varchar(16) DEFAULT NULL,
+		REFRESH_FAILED varchar(3) DEFAULT NULL,
+		LAST_SUCCESS_SNAPSHOT_TIME datetime(6) DEFAULT NULL,
+		UPDATE_TIME datetime(6) DEFAULT NULL,
+		PRIMARY KEY(MVIEW_ID))`
+
+	// CreateTiDBMLogPurgeHistTable is a table to store materialized view log purge history.
+	CreateTiDBMLogPurgeHistTable = `CREATE TABLE IF NOT EXISTS mysql.tidb_mlog_purge_hist (
+		PURGE_JOB_ID bigint unsigned NOT NULL,
+		MLOG_ID bigint NOT NULL,
+		BASE_TABLE_SCHEMA varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		BASE_TABLE_NAME varchar(64) CHARSET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+		PURGE_METHOD varchar(32) NOT NULL,
+		PURGE_START_TIME datetime(6) DEFAULT NULL,
+		PURGE_END_TIME datetime(6) DEFAULT NULL,
+		PURGE_DURATION_SEC decimal(18,6) DEFAULT NULL,
+		PURGE_ROWS bigint NOT NULL,
+		PURGE_STATUS varchar(16) DEFAULT NULL,
+		PURGE_CUTOFF_TSO bigint unsigned DEFAULT NULL,
+		PURGE_FAILED_REASON text DEFAULT NULL,
+		CANCEL_REQUEST_TIME datetime(6) DEFAULT NULL,
+		CANCEL_REQUESTED_BY varchar(512) DEFAULT NULL,
+		LAST_HEARTBEAT_TIME datetime(6) DEFAULT NULL,
+		PRIMARY KEY(PURGE_JOB_ID),
+		KEY idx_mlog_start_time (MLOG_ID, PURGE_START_TIME),
+		KEY idx_table_name_start_time (BASE_TABLE_SCHEMA, BASE_TABLE_NAME, PURGE_START_TIME),
+		KEY idx_mlog_status_start_time (MLOG_ID, PURGE_STATUS, PURGE_START_TIME),
+		KEY idx_purge_duration_sec (PURGE_DURATION_SEC),
+		KEY idx_purge_start_time (PURGE_START_TIME),
+		KEY idx_purge_status_start_time (PURGE_STATUS, PURGE_START_TIME))`
 )
 
 // all below are related to DDL or DXF tables

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -336,6 +336,14 @@ var (
 	systemTablesOfMaskingPolicyNextGenVersion = []TableBasicInfo{
 		{ID: metadef.TiDBMaskingPolicyTableID, Name: "tidb_masking_policy", SQL: metadef.CreateTiDBMaskingPolicyTable},
 	}
+	// systemTablesOfMaterializedViewNextGenVersion contains system tables introduced for materialized view maintenance.
+	systemTablesOfMaterializedViewNextGenVersion = []TableBasicInfo{
+		{ID: metadef.TiDBMViewRefreshInfoTableID, Name: "tidb_mview_refresh_info", SQL: metadef.CreateTiDBMViewRefreshInfoTable},
+		{ID: metadef.TiDBMLogPurgeInfoTableID, Name: "tidb_mlog_purge_info", SQL: metadef.CreateTiDBMLogPurgeInfoTable},
+		{ID: metadef.TiDBMViewRefreshHistTableID, Name: "tidb_mview_refresh_hist", SQL: metadef.CreateTiDBMViewRefreshHistTable},
+		{ID: metadef.TiDBMViewRefreshAlertTableID, Name: "tidb_mview_refresh_alert", SQL: metadef.CreateTiDBMViewRefreshAlertTable},
+		{ID: metadef.TiDBMLogPurgeHistTableID, Name: "tidb_mlog_purge_hist", SQL: metadef.CreateTiDBMLogPurgeHistTable},
+	}
 )
 
 type versionedBootstrapSchema struct {
@@ -355,6 +363,9 @@ var versionedBootstrapSchemas = []versionedBootstrapSchema{
 	}},
 	{ver: meta.MaskingPolicyNextGenBootTableVersion, databases: []DatabaseBasicInfo{
 		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfMaskingPolicyNextGenVersion},
+	}},
+	{ver: meta.MaterializedViewNextGenBootTableVersion, databases: []DatabaseBasicInfo{
+		{ID: metadef.SystemDatabaseID, Name: mysql.SystemDB, Tables: systemTablesOfMaterializedViewNextGenVersion},
 	}},
 }
 

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 46,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/boot_test.go
+++ b/pkg/session/test/bootstraptest/boot_test.go
@@ -107,6 +107,105 @@ func TestBootstrapMaskingPolicyTable(t *testing.T) {
 	checkTiDBMaskingPolicyTableSchema(t, tk)
 }
 
+func TestBootstrapMaterializedViewSystemTables(t *testing.T) {
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+	defer dom.Close()
+
+	tk := testkit.NewTestKit(t, store)
+	checkMaterializedViewBootstrapSchema(t, tk)
+}
+
+func checkMaterializedViewBootstrapSchema(t *testing.T, tk *testkit.TestKit) {
+	tables := []string{
+		"tidb_mview_refresh_info",
+		"tidb_mlog_purge_info",
+		"tidb_mview_refresh_hist",
+		"tidb_mview_refresh_alert",
+		"tidb_mlog_purge_hist",
+	}
+	for _, tableName := range tables {
+		tk.MustQuery("SELECT table_name FROM information_schema.tables WHERE table_schema='mysql' AND table_name=?", tableName).
+			Check(testkit.Rows(tableName))
+	}
+
+	columnNames := []struct {
+		table string
+		cols  []string
+	}{
+		{
+			table: "tidb_mview_refresh_info",
+			cols:  []string{"MVIEW_ID", "LAST_SUCCESS_READ_TSO", "LAST_SUCCESS_REFRESH_END_UNIX_SECONDS", "NEXT_REFRESH_UNIX_SECONDS"},
+		},
+		{
+			table: "tidb_mlog_purge_info",
+			cols:  []string{"MLOG_ID", "NEXT_PURGE_UNIX_SECONDS", "LAST_PURGED_TSO"},
+		},
+		{
+			table: "tidb_mview_refresh_hist",
+			cols: []string{
+				"REFRESH_JOB_ID", "MVIEW_ID", "MVIEW_SCHEMA", "MVIEW_NAME", "REFRESH_METHOD",
+				"REFRESH_START_TIME", "REFRESH_END_TIME", "REFRESH_DURATION_SEC", "REFRESH_SCHEDULE_DURATION_SEC",
+				"REFRESH_STATUS", "REFRESH_ROWS", "REFRESH_READ_TSO", "REFRESH_COMMIT_TSO", "REFRESH_FAILED_REASON",
+				"CANCEL_REQUEST_TIME", "CANCEL_REQUESTED_BY", "LAST_HEARTBEAT_TIME",
+			},
+		},
+		{
+			table: "tidb_mview_refresh_alert",
+			cols:  []string{"MVIEW_ID", "MVIEW_SCHEMA", "MVIEW_NAME", "ALERT_LEVEL", "REFRESH_FAILED", "LAST_SUCCESS_SNAPSHOT_TIME", "UPDATE_TIME"},
+		},
+		{
+			table: "tidb_mlog_purge_hist",
+			cols: []string{
+				"PURGE_JOB_ID", "MLOG_ID", "BASE_TABLE_SCHEMA", "BASE_TABLE_NAME", "PURGE_METHOD",
+				"PURGE_START_TIME", "PURGE_END_TIME", "PURGE_DURATION_SEC", "PURGE_ROWS", "PURGE_STATUS",
+				"PURGE_CUTOFF_TSO", "PURGE_FAILED_REASON", "CANCEL_REQUEST_TIME", "CANCEL_REQUESTED_BY", "LAST_HEARTBEAT_TIME",
+			},
+		},
+	}
+	for _, table := range columnNames {
+		tk.MustQuery("SELECT column_name FROM information_schema.columns WHERE table_schema='mysql' AND table_name=? ORDER BY ordinal_position", table.table).
+			Check(testkit.Rows(table.cols...))
+	}
+
+	indexNames := []struct {
+		table   string
+		indexes []string
+	}{
+		{
+			table:   "tidb_mview_refresh_info",
+			indexes: []string{"PRIMARY"},
+		},
+		{
+			table:   "tidb_mlog_purge_info",
+			indexes: []string{"PRIMARY"},
+		},
+		{
+			table: "tidb_mview_refresh_hist",
+			indexes: []string{
+				"PRIMARY", "idx_mview_name_commit_tso", "idx_mview_name_start_time", "idx_mview_start_time",
+				"idx_mview_status_start_time", "idx_refresh_duration_sec", "idx_refresh_schedule_duration_sec",
+				"idx_refresh_start_time", "idx_refresh_status_start_time",
+			},
+		},
+		{
+			table:   "tidb_mview_refresh_alert",
+			indexes: []string{"PRIMARY"},
+		},
+		{
+			table: "tidb_mlog_purge_hist",
+			indexes: []string{
+				"PRIMARY", "idx_mlog_start_time", "idx_mlog_status_start_time", "idx_purge_duration_sec",
+				"idx_purge_start_time", "idx_purge_status_start_time", "idx_table_name_start_time",
+			},
+		},
+	}
+	for _, table := range indexNames {
+		tk.MustQuery("SELECT DISTINCT index_name FROM information_schema.statistics WHERE table_schema='mysql' AND table_name=? ORDER BY index_name", table.table).
+			Check(testkit.Rows(table.indexes...))
+	}
+}
+
 func TestANSISQLMode(t *testing.T) {
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1208,7 +1208,7 @@ func TestUpgradeVersion280MaskingPolicy(t *testing.T) {
 	}
 }
 
-func TestUpgradeVersion284MaterializedViewBootstrap(t *testing.T) {
+func TestUpgradeVersion285MaterializedViewBootstrap(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1208,6 +1208,51 @@ func TestUpgradeVersion280MaskingPolicy(t *testing.T) {
 	}
 }
 
+func TestUpgradeVersion284MaterializedViewBootstrap(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	tk := testkit.NewTestKit(t, store)
+	for _, tableName := range []string{
+		"tidb_mview_refresh_info",
+		"tidb_mlog_purge_info",
+		"tidb_mview_refresh_hist",
+		"tidb_mview_refresh_alert",
+		"tidb_mlog_purge_hist",
+	} {
+		tk.MustExec("DROP TABLE mysql." + tableName)
+	}
+
+	se := session.CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(session.CurrentBootstrapVersion - 1)
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+	revertVersionAndVariables(t, se, int(session.CurrentBootstrapVersion-1))
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	ver, err := session.GetBootstrapVersion(se)
+	require.NoError(t, err)
+	require.Equal(t, session.CurrentBootstrapVersion-1, ver)
+
+	dom.Close()
+	newDom, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	defer newDom.Close()
+
+	tk = testkit.NewTestKit(t, store)
+	ver, err = session.GetBootstrapVersion(tk.Session())
+	require.NoError(t, err)
+	require.Equal(t, session.CurrentBootstrapVersion, ver)
+	checkMaterializedViewBootstrapSchema(t, tk)
+}
+
 func TestUpgradeWithAnalyzeColumnOptions(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")

--- a/pkg/session/test/meta/session_test.go
+++ b/pkg/session/test/meta/session_test.go
@@ -276,5 +276,5 @@ func TestNextgenBootstrap(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, reservedSchemaCnt)
-	require.EqualValues(t, 60, reservedTableCnt)
+	require.EqualValues(t, 65, reservedTableCnt)
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -524,6 +524,9 @@ const (
 
 	// version284 migrate tidb_disable_txn_file (from TiDB-CSE) to tidb_enable_txn_file and inverts its value.
 	version284 = 284
+
+	// version285 creates materialized view maintenance system tables.
+	version285 = 285
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -2321,4 +2324,10 @@ func upgradeToVer284(s sessionapi.Session, _ int64) {
 	failpoint.Inject("mockUpgradeToVer284Error", func() {
 		err = context.Canceled
 	})
+}
+
+func upgradeToVer285(s sessionapi.Session, _ int64) {
+	for _, tbl := range systemTablesOfMaterializedViewNextGenVersion {
+		doReentrantDDL(s, tbl.SQL)
+	}
 }

--- a/pkg/session/upgrade_def.go
+++ b/pkg/session/upgrade_def.go
@@ -540,7 +540,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version284
+var currentBootstrapVersion int64 = version285
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -729,6 +729,7 @@ var (
 		{version: version282, fn: upgradeToVer282},
 		{version: version283, fn: upgradeToVer283},
 		{version: version284, fn: upgradeToVer284},
+		{version: version285, fn: upgradeToVer285},
 	}
 )
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #18023

Problem Summary:

This PR ports the bootstrap-only prerequisites for materialized view maintenance metadata to master. It does not add materialized view SQL syntax, DDL execution, refresh logic, service logic, or materialized view privilege support.

### What changed and how does it work?

This PR adds the bootstrap schema required by later materialized view ports:

- Add MV/MLog maintenance system table definitions and reserved table IDs for:
  - `mysql.tidb_mview_refresh_info`
  - `mysql.tidb_mlog_purge_info`
  - `mysql.tidb_mview_refresh_hist`
  - `mysql.tidb_mview_refresh_alert`
  - `mysql.tidb_mlog_purge_hist`
- Add these tables to the next-gen bootstrap schema version.
- Add classic bootstrap upgrade version 285 to create these system tables on existing clusters.
- Mark the new MV/MLog maintenance tables as unrecoverable during BR system-table restore because their IDs and TSOs are cluster-local maintenance metadata.
- Update bootstrap/upgrade and affected system-table tests.

The materialized view privilege schema/runtime changes are intentionally left out of this PR and will be handled by a separate PR with a closed privilege feature set.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
make failpoint-enable
GOCACHE=/tmp/tidb-gocache go test ./pkg/session/test/bootstraptest -run "TestBootstrapMaterializedViewSystemTables|TestUpgradeVersion284MaterializedViewBootstrap" -tags=intest,deadlock -count=1
make failpoint-disable

GOCACHE=/tmp/tidb-gocache go test ./br/pkg/restore/snap_client -run "TestMonitorTheSystemTableIncremental" -tags=intest,deadlock -count=1

git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added system metadata tables for materialized-view refresh scheduling, log purging, refresh history, alerts, and purge history.
  - Existing installations are upgraded automatically to create the new tables.

- **Bug Fixes**
  - Materialized-view maintenance tables are excluded from system-table restoration to prevent unsupported recovery behavior.

- **Tests**
  - Added coverage for initial creation and upgrade of the new metadata tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->