### PR TITLE
planner: remove nested locking clauses from views

### DIFF
--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -166,6 +166,7 @@ const (
 	// rename table, alter table add foreign key, alter table in prepare stmt, and BR restore.
 	// TODO need a better name to clarify it's meaning
 	inCreateOrDropTable
+	inCreateView
 	// parentIsJoin is set when visiting node's parent is join.
 	parentIsJoin
 	// inRepairTable is set when visiting a repair table statement.
@@ -264,6 +265,9 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		p.stmtTp = TypeDelete
 	case *ast.SelectStmt:
 		p.stmtTp = TypeSelect
+		if p.flag&inCreateView != 0 && node.LockInfo != nil {
+			node.LockInfo.LockType = ast.SelectLockNone
+		}
 		if node.With != nil {
 			p.preprocessWith.cteStack = append(p.preprocessWith.cteStack, node.With.CTEs)
 		}
@@ -292,7 +296,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		p.checkCreateTableGrammar(node)
 	case *ast.CreateViewStmt:
 		p.stmtTp = TypeCreate
-		p.flag |= inCreateOrDropTable
+		p.flag |= inCreateOrDropTable | inCreateView
 		p.checkCreateViewGrammar(node)
 		p.checkCreateViewWithSelectGrammar(node)
 	case *ast.DropTableStmt:
@@ -638,7 +642,7 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 		p.checkAutoIncrement(x)
 		p.checkContainDotColumn(x)
 	case *ast.CreateViewStmt:
-		p.flag &= ^inCreateOrDropTable
+		p.flag &= ^(inCreateOrDropTable | inCreateView)
 	case *ast.DropTableStmt, *ast.AlterTableStmt, *ast.RenameTableStmt:
 		p.flag &= ^inCreateOrDropTable
 	case *driver.ParamMarkerExpr:

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -353,6 +354,43 @@ func TestValidator(t *testing.T) {
 	is := infoschema.MockInfoSchema([]*model.TableInfo{coretestsdk.MockSignedTable()})
 	for _, tt := range tests {
 		runSQL(t, tk.Session(), is, tt.sql, tt.inPrepare, tt.err)
+	}
+}
+
+func TestCreateViewRemovesNestedSelectLocks(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key)")
+
+	tests := []string{
+		"create view v as select * from (select * from t for update) as nested",
+		"create view v as select (select id from t for update) as id",
+		"create view v as select id from t outer_t where exists " +
+			"(select 1 from t inner_t where inner_t.id = outer_t.id for update)",
+		"create view v as select * from (select * from t lock in share mode) as nested",
+	}
+	for _, sql := range tests {
+		stmt, err := parser.New().ParseOneStmt(sql, "", "")
+		require.NoError(t, err, sql)
+		nodeW := resolve.NewNodeW(stmt)
+		require.NoError(t, core.Preprocess(
+			context.Background(),
+			tk.Session(),
+			nodeW,
+			core.WithPreprocessorReturn(&core.PreprocessorReturn{
+				InfoSchema: tk.Session().GetInfoSchema().(infoschema.InfoSchema),
+			}),
+		), sql)
+
+		createView := stmt.(*ast.CreateViewStmt)
+		var restored strings.Builder
+		require.NoError(t, createView.Select.Restore(format.NewRestoreCtx(
+			format.RestoreStringSingleQuotes|format.RestoreKeyWordUppercase|format.RestoreNameBackQuotes,
+			&restored,
+		)))
+		require.NotContains(t, restored.String(), "FOR UPDATE", sql)
+		require.NotContains(t, restored.String(), "LOCK IN SHARE MODE", sql)
 	}
 }
 

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -369,6 +369,8 @@ func TestCreateViewRemovesNestedSelectLocks(t *testing.T) {
 		"create view v as select id from t outer_t where exists " +
 			"(select 1 from t inner_t where inner_t.id = outer_t.id for update)",
 		"create view v as select * from (select * from t lock in share mode) as nested",
+		"create view v as select * from (" +
+			"(select id from t for update) union all (select id from t)) as nested",
 	}
 	for _, sql := range tests {
 		stmt, err := parser.New().ParseOneStmt(sql, "", "")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26254

Problem Summary:

TiDB removes locking clauses from the top-level query block when creating a view, but keeps them inside derived tables and scalar or correlated subqueries. `SHOW CREATE VIEW` therefore returns `FOR UPDATE` or `LOCK IN SHARE MODE` clauses that MySQL removes.

### What changed and how does it work?

The preprocessor now tracks when it is visiting a view definition and clears the lock type from every nested `SELECT`, not only the top-level query and direct set-operation branches.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

<details>
<summary>Manual test</summary>

Before:

```sql
CREATE TABLE t (id INT PRIMARY KEY);
CREATE VIEW v AS SELECT * FROM (SELECT * FROM t FOR UPDATE) AS nested;
SHOW CREATE VIEW v;
```

```text
... FROM (SELECT `test`.`t`.`id` AS `id` FROM `test`.`t` FOR UPDATE) AS `nested`
```

After:

```sql
CREATE OR REPLACE VIEW v AS
  SELECT * FROM (SELECT * FROM t FOR UPDATE) AS nested;
SHOW CREATE VIEW v;
```

```text
... FROM (SELECT `test`.`t`.`id` AS `id` FROM `test`.`t`) AS `nested`
```

The unit test covers derived tables, scalar and correlated subqueries, and `LOCK IN SHARE MODE`.

```text
go test -tags=intest ./pkg/planner/core/ -run \
  'TestCreateViewRemovesNestedSelectLocks|TestValidator' -count=1
ok  	github.com/pingcap/tidb/pkg/planner/core	2.477s
```

</details>

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Remove locking clauses from nested query blocks in view definitions to match MySQL.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where locking clauses in nested queries could remain when creating a view.
  * View definitions now correctly omit clauses such as `FOR UPDATE` and `LOCK IN SHARE MODE`.

* **Tests**
  * Added regression coverage for removing nested query locking clauses from view definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->