### PR TITLE
br: only support restore base tables

### DIFF
--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -116,7 +116,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 39,
+    shard_count = 40,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -9,9 +9,12 @@ import (
 	backup "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
 	kvconfig "github.com/pingcap/tidb/br/pkg/config"
+	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
@@ -29,6 +32,14 @@ func (f fakeValue) Set(string) error {
 
 func (f fakeValue) Type() string {
 	panic("implement me")
+}
+
+type fakeRestoreFileClient struct {
+	dbs []*metautil.Database
+}
+
+func (c fakeRestoreFileClient) GetDatabases() []*metautil.Database {
+	return c.dbs
 }
 
 func TestUrlNoQuery(t *testing.T) {
@@ -95,6 +106,56 @@ func TestUrlNoQuery(t *testing.T) {
 		}
 		require.Equal(t, tc.expectedValue, field.String, `test-case [%s="%s"]`, tc.expectedName, tc.expectedValue)
 	}
+}
+
+func TestFilterRestoreFilesSkipsMaterializedObjects(t *testing.T) {
+	dbInfo := &model.DBInfo{ID: 1, Name: pmodel.NewCIStr("test")}
+	baseTable := &metautil.Table{
+		DB: dbInfo,
+		Info: &model.TableInfo{
+			ID:   11,
+			Name: pmodel.NewCIStr("base_table"),
+			MaterializedViewBase: &model.MaterializedViewBaseInfo{
+				MLogID:   12,
+				MViewIDs: []int64{13},
+			},
+		},
+		Files: []*backup.File{{Name: "base_table_write.sst"}},
+	}
+	database := &metautil.Database{
+		Info: dbInfo,
+		Tables: []*metautil.Table{
+			baseTable,
+			{
+				DB:    dbInfo,
+				Info:  &model.TableInfo{ID: 12, Name: pmodel.NewCIStr("$mlog$base_table"), MaterializedViewLog: &model.MaterializedViewLogInfo{BaseTableID: 11}},
+				Files: []*backup.File{{Name: "mlog_write.sst"}},
+			},
+			{
+				DB:    dbInfo,
+				Info:  &model.TableInfo{ID: 13, Name: pmodel.NewCIStr("mv_table"), MaterializedView: &model.MaterializedViewInfo{BaseTableIDs: []int64{11}}},
+				Files: []*backup.File{{Name: "mv_write.sst"}},
+			},
+			{
+				DB:    dbInfo,
+				Info:  &model.TableInfo{ID: 14, Name: pmodel.NewCIStr("_mv_shadow"), MaterializedViewShadow: &model.MaterializedViewShadowInfo{SourceMViewID: 13}},
+				Files: []*backup.File{{Name: "shadow_write.sst"}},
+			},
+		},
+	}
+	cfg := &RestoreConfig{
+		Config: Config{
+			TableFilter: filter.CaseInsensitive(must(filter.Parse([]string{"*.*"}))),
+		},
+	}
+
+	files, tables, dbs := filterRestoreFiles(fakeRestoreFileClient{dbs: []*metautil.Database{database}}, cfg)
+
+	require.Len(t, dbs, 1)
+	require.Len(t, tables, 1)
+	require.Same(t, baseTable, tables[0])
+	require.Nil(t, baseTable.Info.MaterializedViewBase)
+	require.Equal(t, []*backup.File{{Name: "base_table_write.sst"}}, files)
 }
 
 func TestTiDBConfigUnchanged(t *testing.T) {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1383,7 +1383,7 @@ func dropToBlackhole(
 // filterRestoreFiles filters tables that can't be processed after applying cfg.TableFilter.MatchTable.
 // if the db has no table that can be processed, the db will be filtered too.
 func filterRestoreFiles(
-	client *snapclient.SnapClient,
+	client restoreFileClient,
 	cfg *RestoreConfig,
 ) (files []*backuppb.File, tables []*metautil.Table, dbs []*metautil.Database) {
 	for _, db := range client.GetDatabases() {
@@ -1402,11 +1402,23 @@ func filterRestoreFiles(
 			if table.Info == nil || !cfg.TableFilter.MatchTable(dbName, table.Info.Name.O) {
 				continue
 			}
+			if table.Info.MaterializedView != nil ||
+				table.Info.MaterializedViewLog != nil ||
+				table.Info.MaterializedViewShadow != nil {
+				continue
+			}
+			if table.Info.MaterializedViewBase != nil {
+				table.Info.MaterializedViewBase = nil
+			}
 			files = append(files, table.Files...)
 			tables = append(tables, table)
 		}
 	}
 	return
+}
+
+type restoreFileClient interface {
+	GetDatabases() []*metautil.Database
 }
 
 // tweakLocalConfForRestore tweaks some of configs of TiDB to make the restore progress go well.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70606

Problem Summary:
Currently backup and restore doesn't support materialized views.
### What changed and how does it work?
only support restore base tables at first
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore processing to exclude materialized views, their logs, and shadow tables.
  * Preserved eligible base tables while clearing materialized-view metadata and limiting restored files appropriately.

* **Tests**
  * Added coverage for filtering restore files involving materialized views and related objects.
  * Increased test execution sharding for improved distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->