### PR TITLE
autoid: prevent ID reuse after cross-database table rename

### DIFF
--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -910,6 +910,7 @@ func TestRenameTableWithReload(t *testing.T) {
 
 	tk.MustExec("create table rename1.t(id int primary key auto_increment, v varchar(20)) AUTO_ID_CACHE=1")
 	tk.MustExec("insert into rename1.t(v) values ('row1'), ('row2')")
+	forceFullReload(t, store, dom)
 	tk.MustExec("rename table rename1.t to rename2.t")
 	tk.MustExec("drop database rename1")
 	forceFullReload(t, store, dom)

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -908,6 +908,16 @@ func TestRenameTableWithReload(t *testing.T) {
 	tk.MustQuery("select * from rename2.t").Check(testkit.Rows("1", "2"))
 	tk.MustExec("drop table rename2.t")
 
+	tk.MustExec("create table rename1.t(id int primary key auto_increment, v varchar(20)) AUTO_ID_CACHE=1")
+	tk.MustExec("insert into rename1.t(v) values ('row1'), ('row2')")
+	tk.MustExec("rename table rename1.t to rename2.t")
+	tk.MustExec("drop database rename1")
+	forceFullReload(t, store, dom)
+	tk.MustExec("replace into rename2.t(v) values ('replacement')")
+	tk.MustQuery("select * from rename2.t").Check(testkit.Rows("1 row1", "2 row2", "3 replacement"))
+	tk.MustExec("drop table rename2.t")
+	tk.MustExec("create database rename1")
+
 	tk.MustExec("create table rename1.t(id int primary key auto_increment) AUTO_ID_CACHE=1")
 	tk.MustExec("insert into rename1.t values (), ()")
 	tk.MustExec("rename table rename1.t to rename2.t")

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -908,6 +908,7 @@ func TestRenameTableWithReload(t *testing.T) {
 	tk.MustQuery("select * from rename2.t").Check(testkit.Rows("1", "2"))
 	tk.MustExec("drop table rename2.t")
 
+	// Issue #70582: keep the allocated upper bound across a cold reload and cross-database rename.
 	tk.MustExec("create table rename1.t(id int primary key auto_increment, v varchar(20)) AUTO_ID_CACHE=1")
 	tk.MustExec("insert into rename1.t(v) values ('row1'), ('row2')")
 	forceFullReload(t, store, dom)

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -908,7 +908,6 @@ func TestRenameTableWithReload(t *testing.T) {
 	tk.MustQuery("select * from rename2.t").Check(testkit.Rows("1", "2"))
 	tk.MustExec("drop table rename2.t")
 
-	// Issue #70582: keep the allocated upper bound across a cold reload and cross-database rename.
 	tk.MustExec("create table rename1.t(id int primary key auto_increment, v varchar(20)) AUTO_ID_CACHE=1")
 	tk.MustExec("insert into rename1.t(v) values ('row1'), ('row2')")
 	forceFullReload(t, store, dom)

--- a/pkg/meta/autoid/BUILD.bazel
+++ b/pkg/meta/autoid/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
     ],
     embed = [":autoid"],
     flaky = True,
-    shard_count = 16,
+    shard_count = 17,
     deps = [
         "//pkg/kv",
         "//pkg/meta",

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -39,9 +39,12 @@ import (
 var _ Allocator = &singlePointAlloc{}
 
 type singlePointAlloc struct {
-	dbID          int64
-	tblID         int64
-	lastAllocated int64
+	dbID  int64
+	tblID int64
+	// stateMu keeps owner transfer exclusive while allowing concurrent allocation RPCs.
+	stateMu sync.RWMutex
+	// lastAllocated is updated independently because concurrent RPCs can return out of order.
+	lastAllocated atomic.Int64
 	isUnsigned    bool
 	*ClientDiscover
 	keyspaceID     uint32
@@ -348,6 +351,12 @@ retry:
 // case increment=1 & offset=1: you can derive the ids like min+1, min+2... max.
 // case increment=x & offset=y: you firstly need to seek to firstID by `SeekToFirstAutoIDXXX`, then derive the IDs like firstID, firstID + increment * 2... in the caller.
 func (sp *singlePointAlloc) Alloc(ctx context.Context, n uint64, increment, offset int64) (minv, maxv int64, retErr error) {
+	sp.stateMu.RLock()
+	defer sp.stateMu.RUnlock()
+	return sp.alloc(ctx, n, increment, offset)
+}
+
+func (sp *singlePointAlloc) alloc(ctx context.Context, n uint64, increment, offset int64) (minv, maxv int64, retErr error) {
 	r, ctx := tracing.StartRegionEx(ctx, "autoid.Alloc")
 	defer r.End()
 
@@ -400,8 +409,24 @@ retry:
 
 	du := time.Since(start)
 	metrics.AutoIDReqDuration.Observe(du.Seconds())
-	sp.lastAllocated = resp.Max
+	sp.updateLastAllocated(resp.Max)
 	return resp.Min, resp.Max, err
+}
+
+func (sp *singlePointAlloc) updateLastAllocated(newBase int64) {
+	for {
+		current := sp.lastAllocated.Load()
+		if sp.isUnsigned {
+			if uint64(newBase) <= uint64(current) {
+				return
+			}
+		} else if newBase <= current {
+			return
+		}
+		if sp.lastAllocated.CompareAndSwap(current, newBase) {
+			return
+		}
+	}
 }
 
 const backoffMin = 5 * time.Millisecond
@@ -477,12 +502,24 @@ func (d *ClientDiscover) ResetConn(reason error) {
 }
 
 func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
+	sp.stateMu.Lock()
+	defer sp.stateMu.Unlock()
 	if sp.dbID == databaseID && sp.tblID == tableID {
 		return nil
 	}
+	_, sourceBase, err := sp.alloc(context.Background(), 0, 1, 1)
+	if err != nil {
+		return err
+	}
+	sourceDBID, sourceTableID := sp.dbID, sp.tblID
 	sp.dbID = databaseID
 	sp.tblID = tableID
-	return sp.Rebase(context.Background(), sp.lastAllocated, false)
+	if err := sp.rebase(context.Background(), sourceBase, false); err != nil {
+		sp.dbID = sourceDBID
+		sp.tblID = sourceTableID
+		return err
+	}
+	return nil
 }
 
 // AllocSeqCache allocs sequence batch value cached in table level（rather than in alloc), the returned range covering
@@ -496,16 +533,22 @@ func (*singlePointAlloc) AllocSeqCache() (a int64, b int64, c int64, err error) 
 // If allocIDs is true, it will allocate some IDs and save to the cache.
 // If allocIDs is false, it will not allocate IDs.
 func (sp *singlePointAlloc) Rebase(ctx context.Context, newBase int64, _ bool) error {
+	sp.stateMu.RLock()
+	defer sp.stateMu.RUnlock()
+	return sp.rebase(ctx, newBase, false)
+}
+
+func (sp *singlePointAlloc) rebase(ctx context.Context, newBase int64, force bool) error {
 	r, ctx := tracing.StartRegionEx(ctx, "autoid.Rebase")
 	defer r.End()
 
 	start := time.Now()
-	err := sp.rebase(ctx, newBase, false)
+	err := sp.rebaseRPC(ctx, newBase, force)
 	metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDRebase, metrics.RetLabel(err)).Observe(time.Since(start).Seconds())
 	return err
 }
 
-func (sp *singlePointAlloc) rebase(ctx context.Context, newBase int64, force bool) (retErr error) {
+func (sp *singlePointAlloc) rebaseRPC(ctx context.Context, newBase int64, force bool) (retErr error) {
 	var bo backoffer
 	start := time.Now()
 	requestLog := newRPCRetryLogState("rebase", sp.keyspaceID, sp.dbID, sp.tblID, start)
@@ -542,7 +585,11 @@ retry:
 	if len(resp.Errmsg) != 0 {
 		return errors.Trace(errors.New(string(resp.Errmsg)))
 	}
-	sp.lastAllocated = newBase
+	if force {
+		sp.lastAllocated.Store(newBase)
+	} else {
+		sp.updateLastAllocated(newBase)
+	}
 	return nil
 }
 
@@ -551,6 +598,8 @@ func (sp *singlePointAlloc) ForceRebase(newBase int64) error {
 	if newBase == -1 {
 		return ErrAutoincReadFailed.GenWithStack("Cannot force rebase the next global ID to '0'")
 	}
+	sp.stateMu.Lock()
+	defer sp.stateMu.Unlock()
 	return sp.rebase(context.Background(), newBase, true)
 }
 
@@ -561,12 +610,12 @@ func (*singlePointAlloc) RebaseSeq(_ int64) (int64, bool, error) {
 
 // Base return the current base of Allocator.
 func (sp *singlePointAlloc) Base() int64 {
-	return sp.lastAllocated
+	return sp.lastAllocated.Load()
 }
 
 // End is only used for test.
 func (sp *singlePointAlloc) End() int64 {
-	return sp.lastAllocated
+	return sp.lastAllocated.Load()
 }
 
 // NextGlobalAutoID returns the next global autoID.

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -400,7 +400,7 @@ retry:
 
 	du := time.Since(start)
 	metrics.AutoIDReqDuration.Observe(du.Seconds())
-	sp.lastAllocated = resp.Min
+	sp.lastAllocated = resp.Max
 	return resp.Min, resp.Max, err
 }
 
@@ -482,7 +482,7 @@ func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
 	}
 	sp.dbID = databaseID
 	sp.tblID = tableID
-	return sp.Rebase(context.Background(), sp.lastAllocated+1, false)
+	return sp.Rebase(context.Background(), sp.lastAllocated, false)
 }
 
 // AllocSeqCache allocs sequence batch value cached in table level（rather than in alloc), the returned range covering

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -41,7 +41,7 @@ var _ Allocator = &singlePointAlloc{}
 type singlePointAlloc struct {
 	dbID  int64
 	tblID int64
-	// stateMu keeps owner transfer exclusive while allowing concurrent allocation RPCs.
+	// stateMu lets Alloc and Rebase run concurrently while making Transfer and ForceRebase exclusive.
 	stateMu sync.RWMutex
 	// lastAllocated is updated independently because concurrent RPCs can return out of order.
 	lastAllocated atomic.Int64
@@ -507,14 +507,17 @@ func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
 	if sp.dbID == databaseID && sp.tblID == tableID {
 		return nil
 	}
-	_, sourceBase, err := sp.alloc(context.Background(), 0, 1, 1)
+	// Re-fetch the authoritative source base because a cold allocator may not have observed IDs allocated by other TiDBs.
+	// updateLastAllocated keeps the greater of that value and the local bound in case the source metadata is already gone.
+	_, _, err := sp.alloc(context.Background(), 0, 1, 1)
 	if err != nil {
 		return err
 	}
+	transferBase := sp.lastAllocated.Load()
 	sourceDBID, sourceTableID := sp.dbID, sp.tblID
 	sp.dbID = databaseID
 	sp.tblID = tableID
-	if err := sp.rebase(context.Background(), sourceBase, false); err != nil {
+	if err := sp.rebase(context.Background(), transferBase, false); err != nil {
 		sp.dbID = sourceDBID
 		sp.tblID = sourceTableID
 		return err

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -508,7 +508,6 @@ func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
 		return nil
 	}
 	// Re-fetch the authoritative source base because a cold allocator may not have observed IDs allocated by other TiDBs.
-	// updateLastAllocated keeps the greater of that value and the local bound in case the source metadata is already gone.
 	_, _, err := sp.alloc(context.Background(), 0, 1, 1)
 	if err != nil {
 		return err

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -73,9 +73,10 @@ const (
 	// AutoIDLeaderPath is etcd key of auto id service leader, exported for test.
 	AutoIDLeaderPath = "tidb/autoid/leader"
 
-	defaultRPCRetryMinErrors   = 10
-	defaultRPCRetryMinDuration = 15 * time.Second
-	rpcRetryAction             = "check AutoID service availability and connectivity, then retry the statement"
+	defaultRPCRetryMinErrors         = 10
+	defaultRPCRetryMinDuration       = 15 * time.Second
+	singlePointWriteOperationTimeout = 2 * defaultRPCRetryMinDuration
+	rpcRetryAction                   = "check AutoID service availability and connectivity, then retry the statement"
 )
 
 type rpcRetryPolicy struct {
@@ -502,13 +503,19 @@ func (d *ClientDiscover) ResetConn(reason error) {
 }
 
 func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), singlePointWriteOperationTimeout)
+	defer cancel()
+	return sp.transfer(ctx, databaseID, tableID)
+}
+
+func (sp *singlePointAlloc) transfer(ctx context.Context, databaseID, tableID int64) error {
 	sp.stateMu.Lock()
 	defer sp.stateMu.Unlock()
 	if sp.dbID == databaseID && sp.tblID == tableID {
 		return nil
 	}
 	// Re-fetch the authoritative source base because a cold allocator may not have observed IDs allocated by other TiDBs.
-	_, _, err := sp.alloc(context.Background(), 0, 1, 1)
+	_, _, err := sp.alloc(ctx, 0, 1, 1)
 	if err != nil {
 		return err
 	}
@@ -516,7 +523,7 @@ func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
 	sourceDBID, sourceTableID := sp.dbID, sp.tblID
 	sp.dbID = databaseID
 	sp.tblID = tableID
-	if err := sp.rebase(context.Background(), transferBase, false); err != nil {
+	if err := sp.rebase(ctx, transferBase, false); err != nil {
 		sp.dbID = sourceDBID
 		sp.tblID = sourceTableID
 		return err
@@ -600,9 +607,15 @@ func (sp *singlePointAlloc) ForceRebase(newBase int64) error {
 	if newBase == -1 {
 		return ErrAutoincReadFailed.GenWithStack("Cannot force rebase the next global ID to '0'")
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), singlePointWriteOperationTimeout)
+	defer cancel()
+	return sp.forceRebase(ctx, newBase)
+}
+
+func (sp *singlePointAlloc) forceRebase(ctx context.Context, newBase int64) error {
 	sp.stateMu.Lock()
 	defer sp.stateMu.Unlock()
-	return sp.rebase(context.Background(), newBase, true)
+	return sp.rebase(ctx, newBase, true)
 }
 
 // RebaseSeq rebases the sequence value in number axis with tableID and the new base value.

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -44,13 +44,19 @@ type mockAutoIDClient struct {
 	rebaseCallCount          atomic.Int64
 	allocResp                *autoid.AutoIDResponse
 	rebaseResp               *autoid.RebaseResponse
+	allocReq                 *autoid.AutoIDRequest
 	rebaseReq                *autoid.RebaseRequest
+	alloc                    func(int64, *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error)
 	allocErr                 error
 	rebaseErr                error
 }
 
-func (m *mockAutoIDClient) AllocAutoID(_ context.Context, _ *autoid.AutoIDRequest, _ ...grpc.CallOption) (*autoid.AutoIDResponse, error) {
-	m.allocCallCount.Add(1)
+func (m *mockAutoIDClient) AllocAutoID(_ context.Context, req *autoid.AutoIDRequest, _ ...grpc.CallOption) (*autoid.AutoIDResponse, error) {
+	call := m.allocCallCount.Add(1)
+	if m.alloc != nil {
+		return m.alloc(call, req)
+	}
+	m.allocReq = req
 	return m.allocResp, m.allocErr
 }
 
@@ -159,7 +165,7 @@ func runOperation(ctx context.Context, operation string, allocator *singlePointA
 		_, _, err := allocator.Alloc(ctx, 1, 1, 1)
 		return err
 	}
-	return allocator.rebase(ctx, 100, false)
+	return allocator.Rebase(ctx, 100, false)
 }
 
 func operationCallCount(operation string, service *scriptedServer) int64 {
@@ -231,7 +237,7 @@ func TestRebaseCanceledRPCReturnsQuickly(t *testing.T) {
 	cancel()
 
 	start := time.Now()
-	err := sp.rebase(ctx, 100, false)
+	err := sp.Rebase(ctx, 100, false)
 	elapsed := time.Since(start)
 
 	require.Error(t, err)
@@ -307,22 +313,78 @@ func TestAutoIDRPCRetryPolicy(t *testing.T) {
 }
 
 func TestSinglePointAllocTransfer(t *testing.T) {
-	mockCli := &mockAutoIDClient{
-		allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 2},
-		rebaseResp: &autoid.RebaseResponse{},
-	}
-	allocator := newTestSinglePointAlloc(mockCli)
+	t.Run("uses authoritative source base", func(t *testing.T) {
+		mockCli := &mockAutoIDClient{
+			allocResp:  &autoid.AutoIDResponse{Min: 2, Max: 2},
+			rebaseResp: &autoid.RebaseResponse{},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
 
-	minID, maxID, err := allocator.Alloc(context.Background(), 2, 1, 1)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), minID)
-	require.Equal(t, int64(2), maxID)
-	require.Equal(t, maxID, allocator.Base())
+		require.NoError(t, allocator.Transfer(2, 1))
+		require.Equal(t, int64(2), allocator.dbID)
+		require.Equal(t, int64(1), mockCli.allocCallCount.Load())
+		require.NotNil(t, mockCli.allocReq)
+		require.Equal(t, int64(1), mockCli.allocReq.DbID)
+		require.Equal(t, uint64(0), mockCli.allocReq.N)
+		require.NotNil(t, mockCli.rebaseReq)
+		require.Equal(t, int64(2), mockCli.rebaseReq.Base)
+	})
 
-	require.NoError(t, allocator.Transfer(2, 1))
-	require.Equal(t, int64(2), allocator.dbID)
-	require.NotNil(t, mockCli.rebaseReq)
-	require.Equal(t, maxID, mockCli.rebaseReq.Base)
+	t.Run("keeps source owner when destination rebase fails", func(t *testing.T) {
+		rebaseErr := errors.New("rebase failed")
+		mockCli := &mockAutoIDClient{
+			allocResp: &autoid.AutoIDResponse{Min: 2, Max: 2},
+			rebaseErr: rebaseErr,
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+
+		require.ErrorIs(t, allocator.Transfer(2, 1), rebaseErr)
+		require.Equal(t, int64(1), allocator.dbID)
+		require.Equal(t, int64(1), allocator.tblID)
+	})
+
+	t.Run("does not regress after a lower rebase", func(t *testing.T) {
+		mockCli := &mockAutoIDClient{
+			allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 2},
+			rebaseResp: &autoid.RebaseResponse{},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+
+		_, _, err := allocator.Alloc(context.Background(), 2, 1, 1)
+		require.NoError(t, err)
+		require.NoError(t, allocator.Rebase(context.Background(), 1, false))
+		require.Equal(t, int64(2), allocator.Base())
+		require.NoError(t, allocator.ForceRebase(1))
+		require.Equal(t, int64(1), allocator.Base())
+	})
+
+	t.Run("keeps the greatest out-of-order allocation response", func(t *testing.T) {
+		firstRequestStarted := make(chan struct{})
+		releaseFirstRequest := make(chan struct{})
+		mockCli := &mockAutoIDClient{
+			alloc: func(call int64, _ *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+				if call == 1 {
+					close(firstRequestStarted)
+					<-releaseFirstRequest
+					return &autoid.AutoIDResponse{Min: 0, Max: 1}, nil
+				}
+				return &autoid.AutoIDResponse{Min: 1, Max: 2}, nil
+			},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+		firstErr := make(chan error, 1)
+		go func() {
+			_, _, err := allocator.Alloc(context.Background(), 1, 1, 1)
+			firstErr <- err
+		}()
+
+		<-firstRequestStarted
+		_, _, err := allocator.Alloc(context.Background(), 1, 1, 1)
+		require.NoError(t, err)
+		close(releaseFirstRequest)
+		require.NoError(t, <-firstErr)
+		require.Equal(t, int64(2), allocator.Base())
+	})
 }
 
 func TestAutoIDRPCRetry(t *testing.T) {

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -42,18 +42,22 @@ type mockAutoIDClient struct {
 	autoid.AutoIDAllocClient // embed to satisfy interface without implementing all methods
 	allocCallCount           atomic.Int64
 	rebaseCallCount          atomic.Int64
+	allocResp                *autoid.AutoIDResponse
+	rebaseResp               *autoid.RebaseResponse
+	rebaseReq                *autoid.RebaseRequest
 	allocErr                 error
 	rebaseErr                error
 }
 
 func (m *mockAutoIDClient) AllocAutoID(_ context.Context, _ *autoid.AutoIDRequest, _ ...grpc.CallOption) (*autoid.AutoIDResponse, error) {
 	m.allocCallCount.Add(1)
-	return nil, m.allocErr
+	return m.allocResp, m.allocErr
 }
 
-func (m *mockAutoIDClient) Rebase(_ context.Context, _ *autoid.RebaseRequest, _ ...grpc.CallOption) (*autoid.RebaseResponse, error) {
+func (m *mockAutoIDClient) Rebase(_ context.Context, req *autoid.RebaseRequest, _ ...grpc.CallOption) (*autoid.RebaseResponse, error) {
 	m.rebaseCallCount.Add(1)
-	return nil, m.rebaseErr
+	m.rebaseReq = req
+	return m.rebaseResp, m.rebaseErr
 }
 
 type scriptedServer struct {
@@ -300,6 +304,25 @@ func TestAutoIDRPCRetryPolicy(t *testing.T) {
 		require.False(t, durationOnly.observe(start, policy))
 		require.False(t, durationOnly.observe(start.Add(3*time.Second), policy))
 	})
+}
+
+func TestSinglePointAllocTransfer(t *testing.T) {
+	mockCli := &mockAutoIDClient{
+		allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 2},
+		rebaseResp: &autoid.RebaseResponse{},
+	}
+	allocator := newTestSinglePointAlloc(mockCli)
+
+	minID, maxID, err := allocator.Alloc(context.Background(), 2, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), minID)
+	require.Equal(t, int64(2), maxID)
+	require.Equal(t, maxID, allocator.Base())
+
+	require.NoError(t, allocator.Transfer(2, 1))
+	require.Equal(t, int64(2), allocator.dbID)
+	require.NotNil(t, mockCli.rebaseReq)
+	require.Equal(t, maxID, mockCli.rebaseReq.Base)
 }
 
 func TestAutoIDRPCRetry(t *testing.T) {

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -417,63 +417,116 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(3), allocator.Base())
 	})
 
-	t.Run("in-flight allocation holds the transfer barrier", func(t *testing.T) {
+	t.Run("transfers after an in-flight allocation", func(t *testing.T) {
 		allocationStarted := make(chan struct{})
 		releaseAllocation := make(chan struct{})
-		allocRequests := make(chan *autoid.AutoIDRequest, 2)
+		allocRequests := make(chan *autoid.AutoIDRequest, 3)
+		rebaseRequests := make(chan *autoid.RebaseRequest, 1)
+		var sourceBase atomic.Int64
+		var destinationBase atomic.Int64
 		mockCli := &mockAutoIDClient{
 			alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
 				allocRequests <- req
-				if req.N == 0 {
-					return &autoid.AutoIDResponse{Min: 2, Max: 2}, nil
+				switch {
+				case req.DbID == 1 && req.N == 2:
+					close(allocationStarted)
+					<-releaseAllocation
+					sourceBase.Store(2)
+					return &autoid.AutoIDResponse{Min: 0, Max: 2}, nil
+				case req.DbID == 1 && req.N == 0:
+					base := sourceBase.Load()
+					return &autoid.AutoIDResponse{Min: base, Max: base}, nil
+				case req.DbID == 2 && req.N == 1:
+					minBase := destinationBase.Load()
+					maxBase := minBase + 1
+					destinationBase.Store(maxBase)
+					return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
+				default:
+					return nil, errors.New("unexpected allocation request")
 				}
-				close(allocationStarted)
-				<-releaseAllocation
-				return &autoid.AutoIDResponse{Min: 0, Max: 2}, nil
 			},
-			rebaseResp: &autoid.RebaseResponse{},
+			rebase: func(_ int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+				rebaseRequests <- req
+				destinationBase.Store(req.Base)
+				return &autoid.RebaseResponse{}, nil
+			},
 		}
 		allocator := newTestSinglePointAlloc(mockCli)
-		allocationErr := make(chan error, 1)
+		allocationDone := make(chan error, 1)
+		var allocatedMin, allocatedMax int64
 		go func() {
-			_, _, err := allocator.Alloc(context.Background(), 2, 1, 1)
-			allocationErr <- err
+			var err error
+			allocatedMin, allocatedMax, err = allocator.Alloc(context.Background(), 2, 1, 1)
+			allocationDone <- err
 		}()
 
 		<-allocationStarted
-		if allocator.stateMu.TryLock() {
-			allocator.stateMu.Unlock()
-			close(releaseAllocation)
-			t.Fatal("Transfer lock acquired while allocation RPC was in flight")
-		}
-		allocCallCount := mockCli.allocCallCount.Load()
+		transferStarted := make(chan struct{})
+		transferDone := make(chan error, 1)
+		go func() {
+			close(transferStarted)
+			transferDone <- allocator.Transfer(2, 1)
+		}()
+		<-transferStarted
 		close(releaseAllocation)
-		require.Equal(t, int64(1), allocCallCount)
-		require.NoError(t, <-allocationErr)
-		require.True(t, allocator.stateMu.TryLock())
-		allocator.stateMu.Unlock()
-		require.NoError(t, allocator.Transfer(2, 1))
+
+		require.NoError(t, <-allocationDone)
+		require.NoError(t, <-transferDone)
+		require.Equal(t, int64(0), allocatedMin)
+		require.Equal(t, int64(2), allocatedMax)
+		minBase, maxBase, err := allocator.Alloc(context.Background(), 1, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), minBase)
+		require.Equal(t, int64(3), maxBase)
+		require.Equal(t, int64(3), allocator.Base())
 
 		allocationReq := <-allocRequests
 		sourceBaseReq := <-allocRequests
+		destinationAllocationReq := <-allocRequests
+		destinationRebaseReq := <-rebaseRequests
 		require.Equal(t, int64(1), allocationReq.DbID)
+		require.Equal(t, int64(1), allocationReq.TblID)
 		require.Equal(t, int64(1), sourceBaseReq.DbID)
+		require.Equal(t, int64(1), sourceBaseReq.TblID)
 		require.Equal(t, uint64(0), sourceBaseReq.N)
-		require.Equal(t, int64(2), mockCli.rebaseReq.DbID)
-		require.Equal(t, int64(2), mockCli.rebaseReq.Base)
+		require.Equal(t, int64(2), destinationRebaseReq.DbID)
+		require.Equal(t, int64(1), destinationRebaseReq.TblID)
+		require.Equal(t, int64(2), destinationRebaseReq.Base)
+		require.Equal(t, int64(2), destinationAllocationReq.DbID)
+		require.Equal(t, int64(1), destinationAllocationReq.TblID)
 	})
 
-	t.Run("in-flight rebase holds the transfer barrier", func(t *testing.T) {
+	t.Run("transfers after an in-flight rebase", func(t *testing.T) {
 		rebaseStarted := make(chan struct{})
 		releaseRebase := make(chan struct{})
+		allocRequests := make(chan *autoid.AutoIDRequest, 2)
 		rebaseRequests := make(chan *autoid.RebaseRequest, 2)
+		var sourceBase atomic.Int64
+		var destinationBase atomic.Int64
 		mockCli := &mockAutoIDClient{
-			allocResp: &autoid.AutoIDResponse{Min: 2, Max: 2},
+			alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+				allocRequests <- req
+				switch {
+				case req.DbID == 1 && req.N == 0:
+					base := sourceBase.Load()
+					return &autoid.AutoIDResponse{Min: base, Max: base}, nil
+				case req.DbID == 2 && req.N == 1:
+					minBase := destinationBase.Load()
+					maxBase := minBase + 1
+					destinationBase.Store(maxBase)
+					return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
+				default:
+					return nil, errors.New("unexpected allocation request")
+				}
+			},
 			rebase: func(call int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
 				rebaseRequests <- req
 				if call == 1 {
 					close(rebaseStarted)
 					<-releaseRebase
+					sourceBase.Store(req.Base)
+				} else {
+					destinationBase.Store(req.Base)
 				}
 				return &autoid.RebaseResponse{}, nil
 			},
@@ -481,28 +534,42 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		allocator := newTestSinglePointAlloc(mockCli)
 		rebaseErr := make(chan error, 1)
 		go func() {
-			rebaseErr <- allocator.Rebase(context.Background(), 2, false)
+			rebaseErr <- allocator.Rebase(context.Background(), 4, false)
 		}()
 
 		<-rebaseStarted
-		if allocator.stateMu.TryLock() {
-			allocator.stateMu.Unlock()
-			close(releaseRebase)
-			t.Fatal("Transfer lock acquired while rebase RPC was in flight")
-		}
-		rebaseCallCount := mockCli.rebaseCallCount.Load()
+		transferStarted := make(chan struct{})
+		transferDone := make(chan error, 1)
+		go func() {
+			close(transferStarted)
+			transferDone <- allocator.Transfer(2, 1)
+		}()
+		<-transferStarted
 		close(releaseRebase)
-		require.Equal(t, int64(1), rebaseCallCount)
+
 		require.NoError(t, <-rebaseErr)
-		require.True(t, allocator.stateMu.TryLock())
-		allocator.stateMu.Unlock()
-		require.NoError(t, allocator.Transfer(2, 1))
+		require.NoError(t, <-transferDone)
+		minBase, maxBase, err := allocator.Alloc(context.Background(), 1, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, int64(4), minBase)
+		require.Equal(t, int64(5), maxBase)
+		require.Equal(t, int64(5), allocator.Base())
 
 		sourceRebaseReq := <-rebaseRequests
 		destinationRebaseReq := <-rebaseRequests
+		sourceBaseReq := <-allocRequests
+		destinationAllocationReq := <-allocRequests
 		require.Equal(t, int64(1), sourceRebaseReq.DbID)
+		require.Equal(t, int64(1), sourceRebaseReq.TblID)
+		require.Equal(t, int64(4), sourceRebaseReq.Base)
+		require.Equal(t, int64(1), sourceBaseReq.DbID)
+		require.Equal(t, int64(1), sourceBaseReq.TblID)
+		require.Equal(t, uint64(0), sourceBaseReq.N)
 		require.Equal(t, int64(2), destinationRebaseReq.DbID)
-		require.Equal(t, int64(2), destinationRebaseReq.Base)
+		require.Equal(t, int64(1), destinationRebaseReq.TblID)
+		require.Equal(t, int64(4), destinationRebaseReq.Base)
+		require.Equal(t, int64(2), destinationAllocationReq.DbID)
+		require.Equal(t, int64(1), destinationAllocationReq.TblID)
 	})
 }
 

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -47,6 +47,7 @@ type mockAutoIDClient struct {
 	allocReq                 *autoid.AutoIDRequest
 	rebaseReq                *autoid.RebaseRequest
 	alloc                    func(int64, *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error)
+	rebase                   func(int64, *autoid.RebaseRequest) (*autoid.RebaseResponse, error)
 	allocErr                 error
 	rebaseErr                error
 }
@@ -61,7 +62,10 @@ func (m *mockAutoIDClient) AllocAutoID(_ context.Context, req *autoid.AutoIDRequ
 }
 
 func (m *mockAutoIDClient) Rebase(_ context.Context, req *autoid.RebaseRequest, _ ...grpc.CallOption) (*autoid.RebaseResponse, error) {
-	m.rebaseCallCount.Add(1)
+	call := m.rebaseCallCount.Add(1)
+	if m.rebase != nil {
+		return m.rebase(call, req)
+	}
 	m.rebaseReq = req
 	return m.rebaseResp, m.rebaseErr
 }
@@ -343,6 +347,19 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(1), allocator.tblID)
 	})
 
+	t.Run("uses local bound when the source base is stale", func(t *testing.T) {
+		mockCli := &mockAutoIDClient{
+			allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 0},
+			rebaseResp: &autoid.RebaseResponse{},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+		allocator.lastAllocated.Store(4)
+
+		require.NoError(t, allocator.Transfer(2, 1))
+		require.NotNil(t, mockCli.rebaseReq)
+		require.Equal(t, int64(4), mockCli.rebaseReq.Base)
+	})
+
 	t.Run("does not regress after a lower rebase", func(t *testing.T) {
 		mockCli := &mockAutoIDClient{
 			allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 2},
@@ -384,6 +401,108 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		close(releaseFirstRequest)
 		require.NoError(t, <-firstErr)
 		require.Equal(t, int64(2), allocator.Base())
+	})
+
+	t.Run("keeps unsigned allocation order", func(t *testing.T) {
+		mockCli := &mockAutoIDClient{rebaseResp: &autoid.RebaseResponse{}}
+		allocator := newTestSinglePointAlloc(mockCli)
+		allocator.isUnsigned = true
+		allocator.updateLastAllocated(2)
+		allocator.updateLastAllocated(-2) // -2 represents MaxUint64-1.
+
+		require.Equal(t, int64(-2), allocator.Base())
+		require.NoError(t, allocator.Rebase(context.Background(), 3, false))
+		require.Equal(t, int64(-2), allocator.Base())
+		require.NoError(t, allocator.ForceRebase(3))
+		require.Equal(t, int64(3), allocator.Base())
+	})
+
+	t.Run("in-flight allocation holds the transfer barrier", func(t *testing.T) {
+		allocationStarted := make(chan struct{})
+		releaseAllocation := make(chan struct{})
+		allocRequests := make(chan *autoid.AutoIDRequest, 2)
+		mockCli := &mockAutoIDClient{
+			alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+				allocRequests <- req
+				if req.N == 0 {
+					return &autoid.AutoIDResponse{Min: 2, Max: 2}, nil
+				}
+				close(allocationStarted)
+				<-releaseAllocation
+				return &autoid.AutoIDResponse{Min: 0, Max: 2}, nil
+			},
+			rebaseResp: &autoid.RebaseResponse{},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+		allocationErr := make(chan error, 1)
+		go func() {
+			_, _, err := allocator.Alloc(context.Background(), 2, 1, 1)
+			allocationErr <- err
+		}()
+
+		<-allocationStarted
+		if allocator.stateMu.TryLock() {
+			allocator.stateMu.Unlock()
+			close(releaseAllocation)
+			t.Fatal("Transfer lock acquired while allocation RPC was in flight")
+		}
+		allocCallCount := mockCli.allocCallCount.Load()
+		close(releaseAllocation)
+		require.Equal(t, int64(1), allocCallCount)
+		require.NoError(t, <-allocationErr)
+		require.True(t, allocator.stateMu.TryLock())
+		allocator.stateMu.Unlock()
+		require.NoError(t, allocator.Transfer(2, 1))
+
+		allocationReq := <-allocRequests
+		sourceBaseReq := <-allocRequests
+		require.Equal(t, int64(1), allocationReq.DbID)
+		require.Equal(t, int64(1), sourceBaseReq.DbID)
+		require.Equal(t, uint64(0), sourceBaseReq.N)
+		require.Equal(t, int64(2), mockCli.rebaseReq.DbID)
+		require.Equal(t, int64(2), mockCli.rebaseReq.Base)
+	})
+
+	t.Run("in-flight rebase holds the transfer barrier", func(t *testing.T) {
+		rebaseStarted := make(chan struct{})
+		releaseRebase := make(chan struct{})
+		rebaseRequests := make(chan *autoid.RebaseRequest, 2)
+		mockCli := &mockAutoIDClient{
+			allocResp: &autoid.AutoIDResponse{Min: 2, Max: 2},
+			rebase: func(call int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+				rebaseRequests <- req
+				if call == 1 {
+					close(rebaseStarted)
+					<-releaseRebase
+				}
+				return &autoid.RebaseResponse{}, nil
+			},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+		rebaseErr := make(chan error, 1)
+		go func() {
+			rebaseErr <- allocator.Rebase(context.Background(), 2, false)
+		}()
+
+		<-rebaseStarted
+		if allocator.stateMu.TryLock() {
+			allocator.stateMu.Unlock()
+			close(releaseRebase)
+			t.Fatal("Transfer lock acquired while rebase RPC was in flight")
+		}
+		rebaseCallCount := mockCli.rebaseCallCount.Load()
+		close(releaseRebase)
+		require.Equal(t, int64(1), rebaseCallCount)
+		require.NoError(t, <-rebaseErr)
+		require.True(t, allocator.stateMu.TryLock())
+		allocator.stateMu.Unlock()
+		require.NoError(t, allocator.Transfer(2, 1))
+
+		sourceRebaseReq := <-rebaseRequests
+		destinationRebaseReq := <-rebaseRequests
+		require.Equal(t, int64(1), sourceRebaseReq.DbID)
+		require.Equal(t, int64(2), destinationRebaseReq.DbID)
+		require.Equal(t, int64(2), destinationRebaseReq.Base)
 	})
 }
 

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -70,6 +70,89 @@ func (m *mockAutoIDClient) Rebase(_ context.Context, req *autoid.RebaseRequest, 
 	return m.rebaseResp, m.rebaseErr
 }
 
+type transferMockState struct {
+	sourceBase      atomic.Int64
+	destinationBase atomic.Int64
+	allocRequests   chan *autoid.AutoIDRequest
+	rebaseRequests  chan *autoid.RebaseRequest
+	beforeAlloc     func(*autoid.AutoIDRequest)
+	beforeRebase    func(*autoid.RebaseRequest)
+}
+
+func newTransferMockState() *transferMockState {
+	return &transferMockState{
+		allocRequests:  make(chan *autoid.AutoIDRequest, 3),
+		rebaseRequests: make(chan *autoid.RebaseRequest, 2),
+	}
+}
+
+func (s *transferMockState) client() *mockAutoIDClient {
+	return &mockAutoIDClient{
+		alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+			s.allocRequests <- req
+			if s.beforeAlloc != nil {
+				s.beforeAlloc(req)
+			}
+			base, err := s.base(req.DbID)
+			if err != nil {
+				return nil, err
+			}
+			minBase := base.Load()
+			maxBase := minBase + int64(req.N)
+			base.Store(maxBase)
+			return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
+		},
+		rebase: func(_ int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+			s.rebaseRequests <- req
+			if s.beforeRebase != nil {
+				s.beforeRebase(req)
+			}
+			base, err := s.base(req.DbID)
+			if err != nil {
+				return nil, err
+			}
+			base.Store(req.Base)
+			return &autoid.RebaseResponse{}, nil
+		},
+	}
+}
+
+func (s *transferMockState) base(dbID int64) (*atomic.Int64, error) {
+	switch dbID {
+	case 1:
+		return &s.sourceBase, nil
+	case 2:
+		return &s.destinationBase, nil
+	default:
+		return nil, errors.New("unexpected database ID")
+	}
+}
+
+func requireAllocRequest(t *testing.T, req *autoid.AutoIDRequest, dbID int64, n uint64) {
+	t.Helper()
+	require.Equal(t, dbID, req.DbID)
+	require.Equal(t, int64(1), req.TblID)
+	require.Equal(t, n, req.N)
+}
+
+func requireRebaseRequest(t *testing.T, req *autoid.RebaseRequest, dbID, base int64) {
+	t.Helper()
+	require.Equal(t, dbID, req.DbID)
+	require.Equal(t, int64(1), req.TblID)
+	require.Equal(t, base, req.Base)
+}
+
+func startTransfer(allocator *singlePointAlloc, dbID, tableID int64) <-chan error {
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- allocator.Transfer(dbID, tableID)
+	}()
+	<-started
+	return done
+}
+
 type scriptedServer struct {
 	autoid.UnimplementedAutoIDAllocServer
 	allocCallCount  atomic.Int64
@@ -420,38 +503,14 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 	t.Run("transfers after an in-flight allocation", func(t *testing.T) {
 		allocationStarted := make(chan struct{})
 		releaseAllocation := make(chan struct{})
-		allocRequests := make(chan *autoid.AutoIDRequest, 3)
-		rebaseRequests := make(chan *autoid.RebaseRequest, 1)
-		var sourceBase atomic.Int64
-		var destinationBase atomic.Int64
-		mockCli := &mockAutoIDClient{
-			alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
-				allocRequests <- req
-				switch {
-				case req.DbID == 1 && req.N == 2:
-					close(allocationStarted)
-					<-releaseAllocation
-					sourceBase.Store(2)
-					return &autoid.AutoIDResponse{Min: 0, Max: 2}, nil
-				case req.DbID == 1 && req.N == 0:
-					base := sourceBase.Load()
-					return &autoid.AutoIDResponse{Min: base, Max: base}, nil
-				case req.DbID == 2 && req.N == 1:
-					minBase := destinationBase.Load()
-					maxBase := minBase + 1
-					destinationBase.Store(maxBase)
-					return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
-				default:
-					return nil, errors.New("unexpected allocation request")
-				}
-			},
-			rebase: func(_ int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
-				rebaseRequests <- req
-				destinationBase.Store(req.Base)
-				return &autoid.RebaseResponse{}, nil
-			},
+		state := newTransferMockState()
+		state.beforeAlloc = func(req *autoid.AutoIDRequest) {
+			if req.DbID == 1 && req.N == 2 {
+				close(allocationStarted)
+				<-releaseAllocation
+			}
 		}
-		allocator := newTestSinglePointAlloc(mockCli)
+		allocator := newTestSinglePointAlloc(state.client())
 		allocationDone := make(chan error, 1)
 		var allocatedMin, allocatedMax int64
 		go func() {
@@ -461,13 +520,7 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		}()
 
 		<-allocationStarted
-		transferStarted := make(chan struct{})
-		transferDone := make(chan error, 1)
-		go func() {
-			close(transferStarted)
-			transferDone <- allocator.Transfer(2, 1)
-		}()
-		<-transferStarted
+		transferDone := startTransfer(allocator, 2, 1)
 		close(releaseAllocation)
 
 		require.NoError(t, <-allocationDone)
@@ -480,71 +533,30 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(3), maxBase)
 		require.Equal(t, int64(3), allocator.Base())
 
-		allocationReq := <-allocRequests
-		sourceBaseReq := <-allocRequests
-		destinationAllocationReq := <-allocRequests
-		destinationRebaseReq := <-rebaseRequests
-		require.Equal(t, int64(1), allocationReq.DbID)
-		require.Equal(t, int64(1), allocationReq.TblID)
-		require.Equal(t, int64(1), sourceBaseReq.DbID)
-		require.Equal(t, int64(1), sourceBaseReq.TblID)
-		require.Equal(t, uint64(0), sourceBaseReq.N)
-		require.Equal(t, int64(2), destinationRebaseReq.DbID)
-		require.Equal(t, int64(1), destinationRebaseReq.TblID)
-		require.Equal(t, int64(2), destinationRebaseReq.Base)
-		require.Equal(t, int64(2), destinationAllocationReq.DbID)
-		require.Equal(t, int64(1), destinationAllocationReq.TblID)
+		requireAllocRequest(t, <-state.allocRequests, 1, 2)
+		requireAllocRequest(t, <-state.allocRequests, 1, 0)
+		requireRebaseRequest(t, <-state.rebaseRequests, 2, 2)
+		requireAllocRequest(t, <-state.allocRequests, 2, 1)
 	})
 
 	t.Run("transfers after an in-flight rebase", func(t *testing.T) {
 		rebaseStarted := make(chan struct{})
 		releaseRebase := make(chan struct{})
-		allocRequests := make(chan *autoid.AutoIDRequest, 2)
-		rebaseRequests := make(chan *autoid.RebaseRequest, 2)
-		var sourceBase atomic.Int64
-		var destinationBase atomic.Int64
-		mockCli := &mockAutoIDClient{
-			alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
-				allocRequests <- req
-				switch {
-				case req.DbID == 1 && req.N == 0:
-					base := sourceBase.Load()
-					return &autoid.AutoIDResponse{Min: base, Max: base}, nil
-				case req.DbID == 2 && req.N == 1:
-					minBase := destinationBase.Load()
-					maxBase := minBase + 1
-					destinationBase.Store(maxBase)
-					return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
-				default:
-					return nil, errors.New("unexpected allocation request")
-				}
-			},
-			rebase: func(call int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
-				rebaseRequests <- req
-				if call == 1 {
-					close(rebaseStarted)
-					<-releaseRebase
-					sourceBase.Store(req.Base)
-				} else {
-					destinationBase.Store(req.Base)
-				}
-				return &autoid.RebaseResponse{}, nil
-			},
+		state := newTransferMockState()
+		state.beforeRebase = func(req *autoid.RebaseRequest) {
+			if req.DbID == 1 {
+				close(rebaseStarted)
+				<-releaseRebase
+			}
 		}
-		allocator := newTestSinglePointAlloc(mockCli)
+		allocator := newTestSinglePointAlloc(state.client())
 		rebaseErr := make(chan error, 1)
 		go func() {
 			rebaseErr <- allocator.Rebase(context.Background(), 4, false)
 		}()
 
 		<-rebaseStarted
-		transferStarted := make(chan struct{})
-		transferDone := make(chan error, 1)
-		go func() {
-			close(transferStarted)
-			transferDone <- allocator.Transfer(2, 1)
-		}()
-		<-transferStarted
+		transferDone := startTransfer(allocator, 2, 1)
 		close(releaseRebase)
 
 		require.NoError(t, <-rebaseErr)
@@ -555,21 +567,10 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(5), maxBase)
 		require.Equal(t, int64(5), allocator.Base())
 
-		sourceRebaseReq := <-rebaseRequests
-		destinationRebaseReq := <-rebaseRequests
-		sourceBaseReq := <-allocRequests
-		destinationAllocationReq := <-allocRequests
-		require.Equal(t, int64(1), sourceRebaseReq.DbID)
-		require.Equal(t, int64(1), sourceRebaseReq.TblID)
-		require.Equal(t, int64(4), sourceRebaseReq.Base)
-		require.Equal(t, int64(1), sourceBaseReq.DbID)
-		require.Equal(t, int64(1), sourceBaseReq.TblID)
-		require.Equal(t, uint64(0), sourceBaseReq.N)
-		require.Equal(t, int64(2), destinationRebaseReq.DbID)
-		require.Equal(t, int64(1), destinationRebaseReq.TblID)
-		require.Equal(t, int64(4), destinationRebaseReq.Base)
-		require.Equal(t, int64(2), destinationAllocationReq.DbID)
-		require.Equal(t, int64(1), destinationAllocationReq.TblID)
+		requireRebaseRequest(t, <-state.rebaseRequests, 1, 4)
+		requireAllocRequest(t, <-state.allocRequests, 1, 0)
+		requireRebaseRequest(t, <-state.rebaseRequests, 2, 4)
+		requireAllocRequest(t, <-state.allocRequests, 2, 1)
 	})
 }
 

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -143,13 +143,14 @@ func requireRebaseRequest(t *testing.T, req *autoid.RebaseRequest, dbID, base in
 }
 
 func startTransfer(allocator *singlePointAlloc, dbID, tableID int64) <-chan error {
-	started := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
-		close(started)
 		done <- allocator.Transfer(dbID, tableID)
 	}()
-	<-started
+	for allocator.stateMu.TryRLock() {
+		allocator.stateMu.RUnlock()
+		runtime.Gosched()
+	}
 	return done
 }
 

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -46,25 +46,25 @@ type mockAutoIDClient struct {
 	rebaseResp               *autoid.RebaseResponse
 	allocReq                 *autoid.AutoIDRequest
 	rebaseReq                *autoid.RebaseRequest
-	alloc                    func(int64, *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error)
-	rebase                   func(int64, *autoid.RebaseRequest) (*autoid.RebaseResponse, error)
+	alloc                    func(context.Context, int64, *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error)
+	rebase                   func(context.Context, int64, *autoid.RebaseRequest) (*autoid.RebaseResponse, error)
 	allocErr                 error
 	rebaseErr                error
 }
 
-func (m *mockAutoIDClient) AllocAutoID(_ context.Context, req *autoid.AutoIDRequest, _ ...grpc.CallOption) (*autoid.AutoIDResponse, error) {
+func (m *mockAutoIDClient) AllocAutoID(ctx context.Context, req *autoid.AutoIDRequest, _ ...grpc.CallOption) (*autoid.AutoIDResponse, error) {
 	call := m.allocCallCount.Add(1)
 	if m.alloc != nil {
-		return m.alloc(call, req)
+		return m.alloc(ctx, call, req)
 	}
 	m.allocReq = req
 	return m.allocResp, m.allocErr
 }
 
-func (m *mockAutoIDClient) Rebase(_ context.Context, req *autoid.RebaseRequest, _ ...grpc.CallOption) (*autoid.RebaseResponse, error) {
+func (m *mockAutoIDClient) Rebase(ctx context.Context, req *autoid.RebaseRequest, _ ...grpc.CallOption) (*autoid.RebaseResponse, error) {
 	call := m.rebaseCallCount.Add(1)
 	if m.rebase != nil {
-		return m.rebase(call, req)
+		return m.rebase(ctx, call, req)
 	}
 	m.rebaseReq = req
 	return m.rebaseResp, m.rebaseErr
@@ -88,7 +88,7 @@ func newTransferMockState() *transferMockState {
 
 func (s *transferMockState) client() *mockAutoIDClient {
 	return &mockAutoIDClient{
-		alloc: func(_ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+		alloc: func(_ context.Context, _ int64, req *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
 			s.allocRequests <- req
 			if s.beforeAlloc != nil {
 				s.beforeAlloc(req)
@@ -102,7 +102,7 @@ func (s *transferMockState) client() *mockAutoIDClient {
 			base.Store(maxBase)
 			return &autoid.AutoIDResponse{Min: minBase, Max: maxBase}, nil
 		},
-		rebase: func(_ int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+		rebase: func(_ context.Context, _ int64, req *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
 			s.rebaseRequests <- req
 			if s.beforeRebase != nil {
 				s.beforeRebase(req)
@@ -418,6 +418,48 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(2), mockCli.rebaseReq.Base)
 	})
 
+	t.Run("uses one deadline for transfer RPCs", func(t *testing.T) {
+		missingDeadlineErr := errors.New("missing transfer deadline")
+		var sourceDeadline, destinationDeadline time.Time
+		mockCli := &mockAutoIDClient{
+			alloc: func(ctx context.Context, _ int64, _ *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+				var ok bool
+				sourceDeadline, ok = ctx.Deadline()
+				if !ok {
+					return nil, missingDeadlineErr
+				}
+				return &autoid.AutoIDResponse{Min: 2, Max: 2}, nil
+			},
+			rebase: func(ctx context.Context, _ int64, _ *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+				var ok bool
+				destinationDeadline, ok = ctx.Deadline()
+				if !ok {
+					return nil, missingDeadlineErr
+				}
+				return &autoid.RebaseResponse{}, nil
+			},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+
+		require.NoError(t, allocator.Transfer(2, 1))
+		require.Equal(t, sourceDeadline, destinationDeadline)
+	})
+
+	t.Run("uses a deadline for force rebase", func(t *testing.T) {
+		missingDeadlineErr := errors.New("missing force-rebase deadline")
+		mockCli := &mockAutoIDClient{
+			rebase: func(ctx context.Context, _ int64, _ *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
+				if _, ok := ctx.Deadline(); !ok {
+					return nil, missingDeadlineErr
+				}
+				return &autoid.RebaseResponse{}, nil
+			},
+		}
+		allocator := newTestSinglePointAlloc(mockCli)
+
+		require.NoError(t, allocator.ForceRebase(2))
+	})
+
 	t.Run("keeps source owner when destination rebase fails", func(t *testing.T) {
 		rebaseErr := errors.New("rebase failed")
 		mockCli := &mockAutoIDClient{
@@ -463,7 +505,7 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		firstRequestStarted := make(chan struct{})
 		releaseFirstRequest := make(chan struct{})
 		mockCli := &mockAutoIDClient{
-			alloc: func(call int64, _ *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
+			alloc: func(_ context.Context, call int64, _ *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
 				if call == 1 {
 					close(firstRequestStarted)
 					<-releaseFirstRequest
@@ -740,5 +782,47 @@ func TestAutoIDRPCRetry(t *testing.T) {
 		require.Empty(t, logs.FilterMessage("autoid request entered RPC retry").All())
 		require.Empty(t, logs.FilterMessage("autoid request completed after RPC retry").All())
 		require.Empty(t, logs.FilterMessage("autoid request stopped after reaching RPC retry limit").All())
+	})
+
+	t.Run("write operations release locks when leader discovery times out", func(t *testing.T) {
+		tests := []struct {
+			name string
+			run  func(context.Context, *singlePointAlloc) error
+		}{
+			{
+				name: "transfer",
+				run: func(ctx context.Context, allocator *singlePointAlloc) error {
+					return allocator.transfer(ctx, 33, 44)
+				},
+			},
+			{
+				name: "force rebase",
+				run: func(ctx context.Context, allocator *singlePointAlloc) error {
+					return allocator.forceRebase(ctx, 100)
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				allocator := newRPCRetryTestAllocator(t, newTestEtcdClient(t))
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
+
+				err := test.run(ctx, allocator)
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.Equal(t, int64(11), allocator.dbID)
+				require.Equal(t, int64(22), allocator.tblID)
+
+				allocator.mu.Lock()
+				allocator.mu.AutoIDAllocClient = &mockAutoIDClient{
+					allocResp: &autoid.AutoIDResponse{Min: 100, Max: 101},
+				}
+				allocator.mu.Unlock()
+				_, maxID, err := allocator.Alloc(testContext(t), 1, 1, 1)
+				require.NoError(t, err)
+				require.Equal(t, int64(101), maxID)
+			})
+		}
 	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70582

Problem Summary:

For an `AUTO_ID_CACHE=1` table, cross-database rename transferred the allocator using a TiDB process-local `lastAllocated` value. That value could be below the authoritative auto ID service base after a multi-row allocation, a cold InfoSchema reload, a lower no-op rebase, or out-of-order concurrent RPC responses. Rebasing the destination owner to that stale value could reuse an existing auto-increment ID; `REPLACE` could then silently overwrite the existing row.

### What changed and how does it work?

- Re-fetch the source owner with `AllocAutoID(N=0)` during transfer, then rebase the destination to the unsigned-aware maximum of the service base and the locally known bound.
- Keep allocation RPCs concurrent with a read lock while making owner transfer and force-rebase exclusive.
- Track successful non-force allocations/rebases with a signed/unsigned-aware atomic maximum, while preserving force-rebase semantics.
- Restore the source owner if rebasing the destination fails.
- Add focused coverage for cold/stale source state, transfer failure, lower and unsigned rebases, out-of-order responses, deterministic allocation/rebase transfer barriers, and a SQL regression with full reload before and after cross-database rename.

#### Correctness validation

Using local TCP gRPC with the source service base at `4`:

- Baseline `c8cc767e9f`: destination base became `1` (RED).
- Current `d3bd8e0c08`: destination base became `4` (GREEN).
- The channel-synchronized transfer-barrier test passed 100 consecutive runs and the race detector; it has no sleep or timing-window assertion.

#### Allocation RPC performance

Environment: Apple M3, local TCP gRPC, `GOMAXPROCS=2`, five 2-second runs per case.

| Concurrent requests | Baseline | Current | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 34.938 µs/op | 35.156 µs/op | +0.62% |
| 2 | 20.607 µs/op | 20.763 µs/op | +0.76% |
| 8 | 10.360 µs/op | 10.492 µs/op | +1.27% |
| 32 | 7.503 µs/op | 7.571 µs/op | +0.91% |

Bytes and allocations per operation were unchanged.

- Included: loopback TCP, HTTP/2 gRPC, protobuf, client/server scheduling, service mutex, and in-memory base updates.
- Excluded: SQL execution, KV encoding, uniqueness checks, TiDB-to-TiKV networking, Raft/transaction commit, and periodic TiKV range refill.

The measured `0.6%-1.3%` applies to the allocation RPC subpath, not end-to-end INSERT/UPDATE QPS. Overall SQL impact should be lower unless auto-ID allocation is the workload bottleneck. The extra `N=0` RPC occurs only during cross-database rename.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `GOMAXPROCS=2 ./tools/check/failpoint-go-test.sh pkg/meta/autoid -run '^(TestSinglePointAllocTransfer|TestAllocCanceledRPCReturnsQuickly|TestRebaseCanceledRPCReturnsQuickly|TestAutoIDRPCRetry|TestAutoIDRPCRetryPolicy)$' -count=1 -p=2`
  - `GOMAXPROCS=2 ./tools/check/failpoint-go-test.sh pkg/meta/autoid -run '^TestSinglePointAllocTransfer$' -count=1 -race -p=2`
  - `GOMAXPROCS=2 ./tools/check/failpoint-go-test.sh pkg/executor/test/ddl -run '^TestRenameTableWithReload$' -count=1 -p=2`
  - `make bazel_prepare`
  - `GOMAXPROCS=2 GOFLAGS='-p=2' make lint`
  - Real TiKV with two TiDB nodes: after allocating IDs `1,2`, cross-database rename, and cold-node reload, `REPLACE` generated ID `3`, affected one row, and preserved rows `1,2`.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential auto-increment ID reuse and silent row overwrite after cross-database table rename with `AUTO_ID_CACHE=1` and cold InfoSchema reload.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved auto-increment value allocation during concurrent operations, schema reloads, and state transfers.
  - Prevented stale or out-of-order allocation results from replacing the highest known value.
  - Improved recovery when transferring allocation state encounters an error.
  - Ensured `REPLACE` assigns the correct next auto-increment value after database reloads while preserving existing rows.
  - Improved consistency when renaming tables across databases and removing the original database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
