### PR TITLE
planner: fix IN-subquery join+agg rewrite duplication with implicit casted RHS keys (#66897)

### DIFF
--- a/pkg/executor/test/jointest/join_test.go
+++ b/pkg/executor/test/jointest/join_test.go
@@ -991,3 +991,28 @@ func TestSingleTaskIncrementalIndexHashJoin(t *testing.T) {
 	tk.MustQuery("select /*+ inl_hash_join(t2,t1) */ * from t1 where t1.a not in (select t2.b from t2 where t2.b = t1.a)")
 	tk.MustQuery("select /*+ inl_hash_join(t2,t1) */ count(*) from t1 where t1.a not in (select t2.b from t2 where t2.b = t1.a)").Check(testkit.Rows("1"))
 }
+
+// TestIssue70546 verifies that `IN (subquery)` keeps semi-join semantics when the
+// subquery column is implicitly cast to the outer column's type.
+// See https://github.com/pingcap/tidb/issues/70546
+func TestIssue70546(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t0")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t0(c0 TINYINT(1))")
+	tk.MustExec("create table t1(c0 BLOB, KEY i0(c0(79)))")
+	tk.MustExec("insert into t0 values (0),(0)")
+	tk.MustExec("insert into t1 values ('a'),('b'),('c')")
+
+	// Q1: IN is a semi-join; each qualifying t0 row must appear at most once.
+	// 'a'/'b'/'c' all coerce to numeric 0, so before the fix the join+agg rewrite
+	// deduplicated the raw (string) inner values and multiplied outer rows: 2 * 3 = 6.
+	tk.MustQuery("select t0.c0 from t0 where t0.c0 in (select t1.c0 from t1 where t1.c0 is not null) order by t0.c0").
+		Check(testkit.Rows("0", "0"))
+
+	// Q2: relocating the IN predicate to a boolean column must give the same result.
+	tk.MustQuery("select ref0 from (select t0.c0 as ref0, t0.c0 in (select t1.c0 from t1 where t1.c0 is not null) as ref1 from t0) s where ref1 order by ref0").
+		Check(testkit.Rows("0", "0"))
+}

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1280,8 +1280,52 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		planCtx.builder.optFlag |= rule.FlagEliminateAgg
 		planCtx.builder.optFlag |= rule.FlagEliminateProjection
 		planCtx.builder.optFlag |= rule.FlagJoinReOrder
+		distinctChild := np
+		distinctLen := np.Schema().Len()
+		joinCondition := checkCondition
+		// IN-subquery rewrite turns:
+		//   outer_col IN (SELECT inner_col ...)
+		// into:
+		//   outer JOIN DISTINCT(inner_col) ON outer_col = inner_col
+		//
+		// DISTINCT must be applied on the same comparison domain as the join predicate.
+		// If "=" injects an implicit cast on the RHS (e.g. blob/string -> number), deduplicating
+		// raw inner values is insufficient: different raw values may become equal after cast and
+		// multiply outer rows in the rewritten inner join.
+		//
+		// To keep semantics equivalent to IN, we project the RHS comparison expression first,
+		// then distinct on that projected key.
+		if lLen == 1 {
+			if eqCond, ok := checkCondition.(*expression.ScalarFunction); ok && eqCond.FuncName.L == ast.EQ {
+				rhs := eqCond.GetArgs()[1]
+				if expression.ExprFromSchema(rhs, np.Schema()) {
+					if _, isCol := rhs.(*expression.Column); !isCol {
+						// rhs is computed from inner columns (typically with an implicit cast generated
+						// by type coercion rules). Materialize it as an inner projection column so both
+						// DISTINCT and JOIN use exactly this coerced key.
+						proj := logicalop.LogicalProjection{Exprs: []expression.Expression{rhs}}.Init(planCtx.builder.ctx, planCtx.builder.getSelectOffset())
+						projCol := &expression.Column{
+							UniqueID: planCtx.builder.ctx.GetSessionVars().AllocPlanColumnID(),
+							RetType:  rhs.GetType(er.sctx.GetEvalCtx()).Clone(),
+						}
+						proj.SetChildren(np)
+						proj.SetSchema(expression.NewSchema(projCol))
+						proj.SetOutputNames([]*types.FieldName{types.EmptyName})
+						distinctChild = proj
+						distinctLen = 1
+						// Rebuild join condition against the projected key; this preserves
+						// the same coercion behavior while preventing duplicate matches.
+						joinCondition, err = er.constructBinaryOpFunction(lexpr, projCol, ast.EQ)
+						if err != nil {
+							er.err = err
+							return v, true
+						}
+					}
+				}
+			}
+		}
 		// Build distinct for the inner query.
-		agg, err := planCtx.builder.buildDistinct(np, np.Schema().Len())
+		agg, err := planCtx.builder.buildDistinct(distinctChild, distinctLen)
 		if err != nil {
 			er.err = err
 			return v, true
@@ -1293,7 +1337,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		join.SetOutputNames(make([]*types.FieldName, planCtx.plan.Schema().Len()+agg.Schema().Len()))
 		copy(join.OutputNames(), planCtx.plan.OutputNames())
 		copy(join.OutputNames()[planCtx.plan.Schema().Len():], agg.OutputNames())
-		join.AttachOnConds(expression.SplitCNFItems(checkCondition))
+		join.AttachOnConds(expression.SplitCNFItems(joinCondition))
 		// set FullSchema and FullNames for this join
 		if left, ok := planCtx.plan.(*logicalop.LogicalJoin); ok && left.FullSchema != nil {
 			join.FullSchema = left.FullSchema

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -162,6 +162,14 @@ select * from t1 where a not in (select * from t2 where false);
 a
 1
 2
+drop table if exists t0;
+create table t0 (c1 blob);
+insert into t0 values ('gO'), ('W');
+select hex(t0.c1) from t0 where 0 in (select t0.c1 from t0) order by hex(t0.c1);
+hex(t0.c1)
+57
+674F
+drop table if exists t0;
 drop table if exists t1, t2;
 create table t1 (a int, key b (a));
 create table t2 (a int, key b (a));

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -137,6 +137,10 @@ select * from t1 where a in (select * from t2);
 select * from t1 where a in (select * from t2 where false);
 --sorted_result
 select * from t1 where a not in (select * from t2 where false);
+drop table if exists t0;
+create table t0 (c1 blob);
+insert into t0 values ('gO'), ('W');
+select hex(t0.c1) from t0 where 0 in (select t0.c1 from t0) order by hex(t0.c1);
 drop table if exists t1, t2;
 create table t1 (a int, key b (a));
 create table t2 (a int, key b (a));

--- a/tests/integrationtest/t/executor/jointest/join.test
+++ b/tests/integrationtest/t/executor/jointest/join.test
@@ -141,6 +141,7 @@ drop table if exists t0;
 create table t0 (c1 blob);
 insert into t0 values ('gO'), ('W');
 select hex(t0.c1) from t0 where 0 in (select t0.c1 from t0) order by hex(t0.c1);
+drop table if exists t0;
 drop table if exists t1, t2;
 create table t1 (a int, key b (a));
 create table t2 (a int, key b (a));


### PR DESCRIPTION
### What problem does this PR solve?

This is a **backport** of [#66897](https://github.com/pingcap/tidb/pull/66897) to `release-8.5`.

Close #70546

`IN (subquery)` is a semi-join: each qualifying outer row must be returned **at most once**. TiDB's IN-subquery rewrite turns `outer_col IN (SELECT inner_col ...)` into `outer JOIN DISTINCT(inner_col) ON outer_col = inner_col`. When `=` injects an implicit cast on the inner side (e.g. `BLOB`/string compared against a numeric column), the DISTINCT deduplicates by the **raw** inner values while the join equality is evaluated on the **coerced** values. Distinct raw strings that all coerce to the same number are all kept, so each outer row multiplies — the semi-join degrades into an inner join and the result set is spuriously enlarged.

### Reproducer (issue #70546)

```sql
CREATE TABLE t0(c0 TINYINT(1));
CREATE TABLE t1(c0 BLOB, KEY i0(c0(79)));
INSERT INTO t0 VALUES (0),(0);
INSERT INTO t1 VALUES ('a'),('b'),('c');

-- Q1: should return 2 rows (0,0); release-8.5 returns 6 rows (0 repeated 6×)
SELECT t0.c0 FROM t0 WHERE t0.c0 IN (SELECT t1.c0 FROM t1 WHERE t1.c0 IS NOT NULL);
```

Verified locally on `release-8.5` before the fix: **Q1 returns 6 rows**; after this fix it returns 2 rows. The semantically-equivalent relocation (boolean column) returns 2 rows on both.

### What is changed and how it works?

Project the RHS comparison expression (the coerced key) into an inner projection column, then run `DISTINCT` on that projected key so DISTINCT and the join predicate operate on the same comparison domain. This is the exact change from #66897, ported unchanged.

### Checked items

- [x] Code change is not breaking / covered by tests
- [x] Regression test `TestIssue70546` in `pkg/executor/test/jointest` added for the issue's exact scenario
- [x] Original #66897 integrationtest case mirrored into `tests/integrationtest/.../jointest/join.{test,result}`

### Release note

```release-note
Fix `IN (subquery)` returning duplicated rows when the subquery column is implicitly cast to the outer column's type (semi-join semantics violated)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `IN` subqueries with implicit type conversions to preserve correct semi-join behavior.
  * Prevented duplicate or excessive result rows when comparing numeric values with text or BLOB data.

* **Tests**
  * Added regression coverage for numeric-to-BLOB comparisons, type coercion, deduplication, and result ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->