### PR TITLE
executor: fix auto ID reuse during transaction retry

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1074,7 +1074,6 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, lockErr error
 	// Rollback the statement change before retry it.
 	a.Ctx.StmtRollback()
 	a.Ctx.GetSessionVars().StmtCtx.ResetForRetry()
-	a.Ctx.GetSessionVars().RetryInfo.ResetOffset()
 
 	failpoint.Inject("assertTxnManagerAfterPessimisticLockErrorRetry", func() {
 		sessiontxn.RecordAssert(a.Ctx, "assertTxnManagerAfterPessimisticLockErrorRetry", true)

--- a/executor/autoidtest/autoid_test.go
+++ b/executor/autoidtest/autoid_test.go
@@ -573,9 +573,11 @@ func testInsertWithAutoidSchema(t *testing.T, tk *testkit.TestKit) {
 	for _, tt := range tests {
 		if strings.HasPrefix(tt.insert, "retry : ") {
 			// it's the last retry insert case, change the sessionVars.
+			tableID, err := strconv.ParseInt(tk.MustQuery(`select tidb_table_id from information_schema.tables where table_schema = "test" and table_name = "t8"`).Rows()[0][0].(string), 10, 64)
+			require.NoError(t, err)
 			retryInfo := &variable.RetryInfo{Retrying: true}
-			retryInfo.AddAutoIncrementID(1000)
-			retryInfo.AddAutoIncrementID(1001)
+			retryInfo.AddAutoIncrementID(tableID, 1000)
+			retryInfo.AddAutoIncrementID(tableID, 1001)
 			tk.Session().GetSessionVars().RetryInfo = retryInfo
 			tk.MustExec(tt.insert[8:])
 			tk.Session().GetSessionVars().RetryInfo = &variable.RetryInfo{}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -788,10 +788,12 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		// Change NULL to auto id.
 		// Change value 0 to auto id, if NoAutoValueOnZero SQL mode is not set.
 		if autoDatum.IsNull() || e.ctx.GetSessionVars().SQLMode&mysql.ModeNoAutoValueOnZero == 0 {
+			// Consume the auto IDs in RetryInfo first.
 			if retryInfo.Retrying {
-				cachedID, ok := retryInfo.GetCurrAutoIncrementID()
+				nextID, ok := retryInfo.GetCurrAutoIncrementID()
 				if ok {
-					if err = setDatumAutoIDAndCast(e.ctx, &rows[processedIdx][idx], cachedID, col); err != nil {
+					err = setDatumAutoIDAndCast(e.ctx, &rows[processedIdx][idx], nextID, col)
+					if err != nil {
 						return nil, err
 					}
 					continue
@@ -840,9 +842,10 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
 	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
 	if retryInfo.Retrying && needsAutoID {
-		cachedID, ok := retryInfo.GetCurrAutoIncrementID()
+		id, ok := retryInfo.GetCurrAutoIncrementID()
 		if ok {
-			if err := setDatumAutoIDAndCast(e.ctx, &d, cachedID, c); err != nil {
+			err := setDatumAutoIDAndCast(e.ctx, &d, id, c)
+			if err != nil {
 				return types.Datum{}, err
 			}
 			return d, nil
@@ -917,9 +920,10 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
 	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
 	if retryInfo.Retrying && needsAutoID {
-		cachedID, ok := retryInfo.GetCurrAutoRandomID()
+		autoRandomID, ok := retryInfo.GetCurrAutoRandomID()
 		if ok {
-			if err := setDatumAutoIDAndCast(e.ctx, &d, cachedID, c); err != nil {
+			err := setDatumAutoIDAndCast(e.ctx, &d, autoRandomID, c)
+			if err != nil {
 				return types.Datum{}, err
 			}
 			return d, nil

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -825,7 +825,9 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				if err != nil {
 					return nil, err
 				}
-				retryInfo.AddAutoIncrementID(id)
+				if !retryInfo.Retrying {
+					retryInfo.AddAutoIncrementID(id)
+				}
 			}
 			continue
 		}
@@ -891,7 +893,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	if err != nil {
 		return types.Datum{}, err
 	}
-	if needsAutoID {
+	if needsAutoID && !retryInfo.Retrying {
 		retryInfo.AddAutoIncrementID(recordID)
 	}
 	return d, nil
@@ -976,7 +978,7 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 	if err != nil {
 		return types.Datum{}, err
 	}
-	if needsAutoID {
+	if needsAutoID && !retryInfo.Retrying {
 		retryInfo.AddAutoRandomID(recordID)
 	}
 	return d, nil

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -782,26 +782,19 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				return nil, err
 			}
 			e.ctx.GetSessionVars().StmtCtx.InsertID = uint64(recordID)
-			retryInfo.AddAutoIncrementID(recordID)
 			continue
 		}
 
 		// Change NULL to auto id.
 		// Change value 0 to auto id, if NoAutoValueOnZero SQL mode is not set.
 		if autoDatum.IsNull() || e.ctx.GetSessionVars().SQLMode&mysql.ModeNoAutoValueOnZero == 0 {
-			// Consume the auto IDs in RetryInfo first.
-			for retryInfo.Retrying && processedIdx < rowCount {
-				nextID, ok := retryInfo.GetCurrAutoIncrementID()
-				if !ok {
-					break
-				}
-				err = setDatumAutoIDAndCast(e.ctx, &rows[processedIdx][idx], nextID, col)
-				if err != nil {
-					return nil, err
-				}
-				processedIdx++
-				if processedIdx == rowCount {
-					return rows, nil
+			if retryInfo.Retrying {
+				cachedID, ok := retryInfo.GetCurrAutoIncrementID()
+				if ok {
+					if err = setDatumAutoIDAndCast(e.ctx, &rows[processedIdx][idx], cachedID, col); err != nil {
+						return nil, err
+					}
+					continue
 				}
 			}
 			// Find consecutive num.
@@ -839,18 +832,17 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		if err != nil {
 			return nil, err
 		}
-		retryInfo.AddAutoIncrementID(recordID)
 	}
 	return rows, nil
 }
 
 func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Datum, hasValue bool, c *table.Column) (types.Datum, error) {
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
-	if retryInfo.Retrying {
-		id, ok := retryInfo.GetCurrAutoIncrementID()
+	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
+	if retryInfo.Retrying && needsAutoID {
+		cachedID, ok := retryInfo.GetCurrAutoIncrementID()
 		if ok {
-			err := setDatumAutoIDAndCast(e.ctx, &d, id, c)
-			if err != nil {
+			if err := setDatumAutoIDAndCast(e.ctx, &d, cachedID, c); err != nil {
 				return types.Datum{}, err
 			}
 			return d, nil
@@ -875,7 +867,6 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 			return types.Datum{}, err
 		}
 		e.ctx.GetSessionVars().StmtCtx.InsertID = uint64(recordID)
-		retryInfo.AddAutoIncrementID(recordID)
 		return d, nil
 	}
 
@@ -897,7 +888,9 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	if err != nil {
 		return types.Datum{}, err
 	}
-	retryInfo.AddAutoIncrementID(recordID)
+	if needsAutoID {
+		retryInfo.AddAutoIncrementID(recordID)
+	}
 	return d, nil
 }
 
@@ -922,11 +915,11 @@ func getAutoRecordID(d types.Datum, target *types.FieldType, isInsert bool) (int
 
 func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum, hasValue bool, c *table.Column) (types.Datum, error) {
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
-	if retryInfo.Retrying {
-		autoRandomID, ok := retryInfo.GetCurrAutoRandomID()
+	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
+	if retryInfo.Retrying && needsAutoID {
+		cachedID, ok := retryInfo.GetCurrAutoRandomID()
 		if ok {
-			err := setDatumAutoIDAndCast(e.ctx, &d, autoRandomID, c)
-			if err != nil {
+			if err := setDatumAutoIDAndCast(e.ctx, &d, cachedID, c); err != nil {
 				return types.Datum{}, err
 			}
 			return d, nil
@@ -958,7 +951,6 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 		if err != nil {
 			return types.Datum{}, err
 		}
-		retryInfo.AddAutoRandomID(recordID)
 		return d, nil
 	}
 
@@ -980,7 +972,9 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 	if err != nil {
 		return types.Datum{}, err
 	}
-	retryInfo.AddAutoRandomID(recordID)
+	if needsAutoID {
+		retryInfo.AddAutoRandomID(recordID)
+	}
 	return d, nil
 }
 

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -762,6 +762,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		return rows, nil
 	}
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
+	tableID := e.Table.Meta().ID
 	rowCount := len(rows)
 	for processedIdx := 0; processedIdx < rowCount; processedIdx++ {
 		autoDatum := rows[processedIdx][idx]
@@ -790,7 +791,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		if autoDatum.IsNull() || e.ctx.GetSessionVars().SQLMode&mysql.ModeNoAutoValueOnZero == 0 {
 			// Consume the auto IDs in RetryInfo first.
 			if retryInfo.Retrying {
-				nextID, ok := retryInfo.GetCurrAutoIncrementID()
+				nextID, ok := retryInfo.GetCurrAutoIncrementID(tableID)
 				if ok {
 					err = setDatumAutoIDAndCast(e.ctx, &rows[processedIdx][idx], nextID, col)
 					if err != nil {
@@ -826,7 +827,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 					return nil, err
 				}
 				if !retryInfo.Retrying {
-					retryInfo.AddAutoIncrementID(id)
+					retryInfo.AddAutoIncrementID(tableID, id)
 				}
 			}
 			continue
@@ -842,9 +843,10 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 
 func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Datum, hasValue bool, c *table.Column) (types.Datum, error) {
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
+	tableID := e.Table.Meta().ID
 	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
 	if retryInfo.Retrying && needsAutoID {
-		id, ok := retryInfo.GetCurrAutoIncrementID()
+		id, ok := retryInfo.GetCurrAutoIncrementID(tableID)
 		if ok {
 			err := setDatumAutoIDAndCast(e.ctx, &d, id, c)
 			if err != nil {
@@ -894,7 +896,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 		return types.Datum{}, err
 	}
 	if needsAutoID && !retryInfo.Retrying {
-		retryInfo.AddAutoIncrementID(recordID)
+		retryInfo.AddAutoIncrementID(tableID, recordID)
 	}
 	return d, nil
 }
@@ -920,9 +922,10 @@ func getAutoRecordID(d types.Datum, target *types.FieldType, isInsert bool) (int
 
 func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum, hasValue bool, c *table.Column) (types.Datum, error) {
 	retryInfo := e.ctx.GetSessionVars().RetryInfo
+	tableID := e.Table.Meta().ID
 	needsAutoID := !hasValue || e.isAutoNull(ctx, d, c)
 	if retryInfo.Retrying && needsAutoID {
-		autoRandomID, ok := retryInfo.GetCurrAutoRandomID()
+		autoRandomID, ok := retryInfo.GetCurrAutoRandomID(tableID)
 		if ok {
 			err := setDatumAutoIDAndCast(e.ctx, &d, autoRandomID, c)
 			if err != nil {
@@ -979,7 +982,7 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 		return types.Datum{}, err
 	}
 	if needsAutoID && !retryInfo.Retrying {
-		retryInfo.AddAutoRandomID(recordID)
+		retryInfo.AddAutoRandomID(tableID, recordID)
 	}
 	return d, nil
 }

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -1471,6 +1471,33 @@ func TestAutoIncrementIDRetryWhenStatementRowCountChanges(t *testing.T) {
 	tk.MustQuery("select id from t where u = 3").Check(testkit.Rows("100"))
 }
 
+func TestAutoIncrementIDRetryWhenStatementRowCountGrows(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table src (k int primary key, u int, v int)")
+	tk.MustExec("create table t (id int auto_increment primary key, u int unique key)")
+	tk.MustExec("insert into src values (1, 1, 0)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into t (u) select u from src order by k")
+	tk.MustExec("update src set v = 1 where k = 1")
+
+	// The retry sees more rows than the original execution. IDs allocated after
+	// the retry cache is exhausted must not be consumed again by later rows.
+	tk2.MustExec("update src set v = 2 where k = 1")
+	tk2.MustExec("insert into src values (2, 2, 0), (3, 3, 0)")
+
+	tk.MustExec("commit")
+	tk.MustQuery("select id, u from t order by id").Check(testkit.Rows(
+		"1 1",
+		"2 2",
+		"3 3",
+	))
+}
+
 func TestAutoRandomIDRetryUsesCurrentExplicitID(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -1498,6 +1498,34 @@ func TestAutoIncrementIDRetryWhenStatementRowCountGrows(t *testing.T) {
 	))
 }
 
+func TestAutoIncrementIDRetryAcrossTables(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table src (k int primary key, u int, v int)")
+	tk.MustExec("create table a (id int auto_increment primary key, u int unique key)")
+	tk.MustExec("create table b (id int auto_increment primary key, u int unique key)")
+	tk.MustExec("insert into src values (1, 1, 0)")
+	tk.MustExec("insert into b values (1, 1)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into a (u) select u from src")
+	tk.MustExec("insert into b (u) values (2)")
+	tk.MustExec("update src set v = 1 where k = 1")
+
+	// The first insert produces no rows during retry. The insert into b must
+	// reuse b's cached ID instead of consuming the cached ID allocated for a.
+	tk2.MustExec("delete from src where k = 1")
+
+	tk.MustExec("commit")
+	tk.MustQuery("select id, u from b order by id").Check(testkit.Rows(
+		"1 1",
+		"2 2",
+	))
+}
+
 func TestAutoRandomIDRetryUsesCurrentExplicitID(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -1386,6 +1386,93 @@ func TestAutoRandIDRetry(t *testing.T) {
 	require.Equal(t, []int64{1, 2, 3, 4, 5, 7}, maskedHandles)
 }
 
+func TestAutoRandomIDRetryAfterPessimisticStatementRetry(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id bigint primary key clustered auto_random, u int unique key, v int)")
+	tk.MustExec("set @@tidb_txn_mode = 'optimistic'")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+
+	// Use autocommit=0 to start an explicit transaction without replaying an
+	// explicit BEGIN. Replaying BEGIN restores the original optimistic mode
+	// and does not reach the pessimistic statement retry path.
+	tk.MustExec("set @@autocommit = 0")
+
+	// S1 and S2 allocate two different AUTO_RANDOM IDs. The commit failpoint
+	// below makes the whole transaction replay in pessimistic mode.
+	tk.MustExec("insert into t (u, v) values (1, 1)")
+	tk.MustExec("insert into t (u, v) values (2, 2) on duplicate key update v = values(v)")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/session/mockCommitRetryForAutoRandID", "return(true)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/session/mockCommitRetryForAutoRandID"))
+		session.ResetMockAutoRandIDRetryCount(0)
+	}()
+	session.ResetMockAutoRandIDRetryCount(1)
+	lockConflictFailpoint := "github.com/pingcap/tidb/store/mockstore/unistore/tikv/pessimisticLockReturnWriteConflict"
+	require.NoError(t, failpoint.Enable(lockConflictFailpoint, "1*return(false)->1*return(true)->return(false)"))
+	defer func() {
+		require.NoError(t, failpoint.Disable(lockConflictFailpoint))
+	}()
+
+	// S2 must not reuse an AUTO_RANDOM ID already consumed during replay.
+	tk.MustExec("commit")
+	tk.MustQuery("select u, v from t order by u").Check(testkit.Rows("1 1", "2 2"))
+}
+
+func TestAutoRandomIDRetryUsesCurrentExplicitID(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table src (id bigint primary key, u int)")
+	tk.MustExec("create table t (id bigint primary key clustered auto_random, u int)")
+	tk.MustExec("insert into src values (200, 2), (300, 3)")
+	tk.MustExec("set @@allow_auto_random_explicit_insert = 1")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into t select id, u from src")
+	tk.MustExec("insert into t (id, u) values (null, 10), (400, 20), (null, 30)")
+	tk.MustExec("update src set u = 4 where id = 200")
+
+	// The retry sees one fewer source row. Explicit IDs must remain
+	// authoritative and must not consume generated-ID cache entries.
+	tk2.MustExec("delete from src where id = 200")
+
+	tk.MustExec("commit")
+	tk.MustQuery("select id, u from t where u in (3, 20) order by u").Check(testkit.Rows(
+		"300 3",
+		"400 20",
+	))
+	tk.MustQuery("select count(*) from t").Check(testkit.Rows("4"))
+}
+
+func TestAutoIncrementIDRetryWithMixedValues(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table src (u int primary key, v int)")
+	tk.MustExec("create table t (id int auto_increment primary key, u int unique key)")
+	tk.MustExec("insert into src values (1, 0)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into t (u) select u from src")
+	tk.MustExec("insert into t values (null, 2), (100, 3), (null, 4)")
+	tk.MustExec("update src set v = 1 where u = 1")
+
+	// The first statement produces no rows during retry. The next statement
+	// must preserve its explicit ID and use distinct generated IDs. Generated
+	// IDs do not need to remain associated with the same statement.
+	tk2.MustExec("delete from src where u = 1")
+	tk.MustExec("commit")
+	tk.MustQuery("select u from t order by u").Check(testkit.Rows("2", "3", "4"))
+	tk.MustQuery("select id from t where u = 3").Check(testkit.Rows("100"))
+}
+
 func TestAutoRandRecoverTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -1421,6 +1421,56 @@ func TestAutoRandomIDRetryAfterPessimisticStatementRetry(t *testing.T) {
 	tk.MustQuery("select u, v from t order by u").Check(testkit.Rows("1 1", "2 2"))
 }
 
+func TestAutoIncrementIDRetryDoesNotDuplicate(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table t (id int not null auto_increment primary key, idx int unique key, c int)")
+	tk.MustExec("insert into t values (1, 1, 1)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into t (id, idx, c) values (10, 11, 12)")
+	tk.MustExec("update t set c = 15 where idx = 1")
+	tk.MustExec("insert into t (idx, c) values (13, 14)")
+
+	// The explicit ID must not enter the generated-ID retry buffer. Otherwise
+	// the generated row reuses ID 10 during replay and fails with a duplicate.
+	tk2.MustExec("update t set c = 100 where idx = 1")
+	tk.MustExec("commit")
+	tk.MustQuery("select id, idx, c from t order by id").Check(testkit.Rows(
+		"1 1 15",
+		"10 11 12",
+		"11 13 14",
+	))
+}
+
+func TestAutoIncrementIDRetryWhenStatementRowCountChanges(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk2.MustExec("use test")
+	tk.MustExec("create table src (k int primary key, id int, u int, v int)")
+	tk.MustExec("create table t (id int auto_increment primary key, u int unique key)")
+	tk.MustExec("insert into src values (1, null, 1, 0), (2, null, 2, 0), (3, 100, 3, 0), (4, null, 4, 0)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
+	tk.MustExec("begin optimistic")
+	tk.MustExec("insert into t (u) select u from src where k = 1")
+	tk.MustExec("insert into t select id, u from src where k > 1 order by k")
+	tk.MustExec("update src set v = 1 where k = 1")
+
+	// The first statement produces no rows during retry. The next INSERT ...
+	// SELECT must preserve its explicit ID and use distinct generated IDs.
+	// Generated IDs do not need to remain associated with the same statement.
+	tk2.MustExec("delete from src where k = 1")
+
+	tk.MustExec("commit")
+	tk.MustQuery("select u from t order by u").Check(testkit.Rows("2", "3", "4"))
+	tk.MustQuery("select id from t where u = 3").Check(testkit.Rows("100"))
+}
+
 func TestAutoRandomIDRetryUsesCurrentExplicitID(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -119,47 +119,63 @@ func (r *RetryInfo) ResetOffset() {
 }
 
 // AddAutoIncrementID adds id to autoIncrementIDs.
-func (r *RetryInfo) AddAutoIncrementID(id int64) {
-	r.autoIncrementIDs.autoIDs = append(r.autoIncrementIDs.autoIDs, id)
+func (r *RetryInfo) AddAutoIncrementID(tableID, id int64) {
+	r.autoIncrementIDs.add(tableID, id)
 }
 
 // GetCurrAutoIncrementID gets current autoIncrementID.
-func (r *RetryInfo) GetCurrAutoIncrementID() (int64, bool) {
-	return r.autoIncrementIDs.getCurrent()
+func (r *RetryInfo) GetCurrAutoIncrementID(tableID int64) (int64, bool) {
+	return r.autoIncrementIDs.getCurrent(tableID)
 }
 
 // AddAutoRandomID adds id to autoRandomIDs.
-func (r *RetryInfo) AddAutoRandomID(id int64) {
-	r.autoRandomIDs.autoIDs = append(r.autoRandomIDs.autoIDs, id)
+func (r *RetryInfo) AddAutoRandomID(tableID, id int64) {
+	r.autoRandomIDs.add(tableID, id)
 }
 
 // GetCurrAutoRandomID gets current AutoRandomID.
-func (r *RetryInfo) GetCurrAutoRandomID() (int64, bool) {
-	return r.autoRandomIDs.getCurrent()
+func (r *RetryInfo) GetCurrAutoRandomID(tableID int64) (int64, bool) {
+	return r.autoRandomIDs.getCurrent(tableID)
 }
 
 type retryInfoAutoIDs struct {
+	byTable map[int64]*retryInfoAutoID
+}
+
+type retryInfoAutoID struct {
 	currentOffset int
 	autoIDs       []int64
 }
 
 func (r *retryInfoAutoIDs) resetOffset() {
-	r.currentOffset = 0
+	for _, ids := range r.byTable {
+		ids.currentOffset = 0
+	}
 }
 
 func (r *retryInfoAutoIDs) clean() {
-	r.currentOffset = 0
-	if len(r.autoIDs) > 0 {
-		r.autoIDs = r.autoIDs[:0]
-	}
+	r.byTable = nil
 }
 
-func (r *retryInfoAutoIDs) getCurrent() (int64, bool) {
-	if r.currentOffset >= len(r.autoIDs) {
+func (r *retryInfoAutoIDs) add(tableID, id int64) {
+	if r.byTable == nil {
+		r.byTable = make(map[int64]*retryInfoAutoID)
+	}
+	ids := r.byTable[tableID]
+	if ids == nil {
+		ids = &retryInfoAutoID{}
+		r.byTable[tableID] = ids
+	}
+	ids.autoIDs = append(ids.autoIDs, id)
+}
+
+func (r *retryInfoAutoIDs) getCurrent(tableID int64) (int64, bool) {
+	ids := r.byTable[tableID]
+	if ids == nil || ids.currentOffset >= len(ids.autoIDs) {
 		return 0, false
 	}
-	id := r.autoIDs[r.currentOffset]
-	r.currentOffset++
+	id := ids.autoIDs[ids.currentOffset]
+	ids.currentOffset++
 	return id, true
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #42613

Problem Summary:

PR [#20659](https://github.com/pingcap/tidb/pull/20659) changed the AUTO_INCREMENT and AUTO_RANDOM ID lists in `RetryInfo` into flat buffers so a transaction replay can reuse cached IDs and allocate new IDs after the buffer is exhausted. Two paths violate that buffer model:

- Insert execution caches and consumes explicit or otherwise non-generated IDs. During replay, this can shift the buffer, overwrite an explicit ID, or add the same explicit ID again, leading to a duplicate key or an `ON DUPLICATE KEY UPDATE` against the wrong row.
- A pessimistic statement retry nested inside an optimistic whole-transaction replay resets the transaction-wide buffer offset. IDs already consumed by earlier replayed statements can then be reused.

### What is changed and how it works?

- Consume a cached AUTO_INCREMENT or AUTO_RANDOM ID only when the current row needs an automatically generated ID.
- Add only generated IDs to `RetryInfo`; explicit IDs still follow the existing rebase path but do not enter the retry buffer.
- Do not reset the transaction-wide retry offset during a nested pessimistic statement retry. `session.retry` still resets the offset once at the beginning of every whole-transaction replay attempt.

This keeps the existing flat-buffer structure and transaction retry behavior. It does not introduce statement-scoped caches or disable retry. This PR supersedes the statement-cache approach in #70619 with a smaller fix scoped to the two buffer invariant violations.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Added regression coverage for:

- The #42613 AUTO_INCREMENT duplicate-key path with explicit and generated IDs in the same transaction.
- Non-lazy AUTO_INCREMENT allocation through `INSERT ... SELECT` when replay observes a different source row count.
- Lazy AUTO_INCREMENT allocation with mixed generated and explicit values when replay observes a different source row count.
- Explicit AUTO_RANDOM IDs when replay observes a different source row count.
- AUTO_RANDOM ID reuse after a nested pessimistic statement retry.

All five new tests fail on `release-6.5` before the fix and pass after the fix. They also pass for three consecutive runs. Existing AUTO_INCREMENT, AUTO_RANDOM, pessimistic-conflict, and `INSERT ... SELECT` retry tests pass.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix potential duplicate keys and incorrect row updates caused by reusing AUTO_INCREMENT or AUTO_RANDOM IDs during transaction retry.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction retry handling so lock conflicts preserve consistent retry state.
  * Fixed automatic ID allocation during single-row and batch insert retries.
  * Prevented duplicate or incorrect generated IDs when retrying statements across tables or with changing row counts.
  * Preserved explicit IDs and handled mixed explicit and automatically generated values correctly during replay.

* **Tests**
  * Added regression coverage for auto-increment and auto-random ID behavior across transaction retry scenarios, including cross-table allocations and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->