### PR TITLE
importinto: add conflict-row cleanup package

### DIFF
--- a/pkg/dxf/framework/storage/history.go
+++ b/pkg/dxf/framework/storage/history.go
@@ -135,6 +135,14 @@ type HistoryTaskPage struct {
 	ApproxTotalCount int64
 }
 
+// TaskCleanupInfo contains task metadata needed to clean up external files.
+type TaskCleanupInfo struct {
+	ID      int64
+	Type    proto.TaskType
+	State   proto.TaskState
+	EndTime *time.Time
+}
+
 // ValidateHistoryTaskPageSize validates page size for history task listing.
 func ValidateHistoryTaskPageSize(pageSize int) error {
 	if pageSize < MinHistoryTaskPageSize || pageSize > MaxHistoryTaskPageSize {

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/dxf/framework/taskexecutor",
         "//pkg/dxf/framework/taskexecutor/execute",
         "//pkg/dxf/importinto/conflictedkv",
+        "//pkg/dxf/importinto/conflictrows",
         "//pkg/dxf/importinto/taskkey",
         "//pkg/dxf/operator",
         "//pkg/executor/importer",

--- a/pkg/dxf/importinto/collect_conflicts.go
+++ b/pkg/dxf/importinto/collect_conflicts.go
@@ -17,14 +17,11 @@ package importinto
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"hash/crc32"
-	"path"
 	"sync"
 	"sync/atomic"
 
 	"github.com/docker/go-units"
-	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	dxfhandle "github.com/pingcap/tidb/pkg/dxf/framework/handle"
@@ -32,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
 	"github.com/pingcap/tidb/pkg/dxf/importinto/conflictedkv"
+	"github.com/pingcap/tidb/pkg/dxf/importinto/conflictrows"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	"github.com/pingcap/tidb/pkg/ingestor/globalsort"
@@ -197,8 +195,7 @@ func (e *collectConflictsStepExecutor) collectConflictsOfKVGroup(
 	for i := range concurrency {
 		collectorCh := collectorChs[i]
 		encoder := encoders[i]
-		uid := uuid.New().String()
-		filenamePrefix := getConflictRowFilenamePrefix(e.task.ID, e.currSubtaskID, uid)
+		filenamePrefix := conflictrows.NewFileNamePrefix(e.task.ID, e.currSubtaskID)
 		localSet := conflictedkv.NewBoundedKeySet(e.logger, &e.sizeOfRowKeysFromIndex, e.sizeLimitOfRowKeysFromIndex)
 		collector := conflictedkv.NewCollector(
 			e.tableImporter.Table,
@@ -357,13 +354,4 @@ func (*collectConflictsStepExecutor) Accepted(_ int64) {}
 // Processed implements Collector.Processed interface.
 func (e *collectConflictsStepExecutor) Processed(processedConflictKVs, _ int64) {
 	e.summary.Processed.Add(processedConflictKVs)
-}
-
-// getConflictRowFilenamePrefix returns the file name prefix to store the conflict
-// rows for the given task and subtask.
-func getConflictRowFilenamePrefix(taskID, subtaskID int64, uuid string) string {
-	// we need to keep this file for the user to check the conflict rows, so we
-	// don't put it under '<task-id>/' directory to avoid it being deleted by the
-	// cleanup process.
-	return path.Join("conflicted-rows", fmt.Sprintf("%d", taskID), fmt.Sprintf("%d-%s", subtaskID, uuid))
 }

--- a/pkg/dxf/importinto/conflictrows/BUILD.bazel
+++ b/pkg/dxf/importinto/conflictrows/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "conflictrows",
+    srcs = [
+        "cleanup.go",
+        "path.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/dxf/importinto/conflictrows",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/dxf/framework/proto",
+        "//pkg/dxf/framework/storage",
+        "//pkg/executor/importer",
+        "//pkg/objstore/storeapi",
+        "//pkg/util/logutil",
+        "@com_github_google_uuid//:uuid",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "conflictrows_test",
+    timeout = "short",
+    srcs = ["cleanup_test.go"],
+    embed = [":conflictrows"],
+    flaky = True,
+    shard_count = 4,
+    deps = [
+        "//pkg/dxf/framework/proto",
+        "//pkg/dxf/framework/storage",
+        "//pkg/objstore",
+        "//pkg/objstore/storeapi",
+        "@com_github_pingcap_log//:log",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
+    ],
+)

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -83,9 +83,6 @@ func mergeCountWithSamples(cs **countWithSamples, completed *countWithSamples) {
 
 // cleanupStats uses exported fields so zap.Any can encode them using their JSON tags.
 type cleanupStats struct {
-	CandidateTasks         int64             `json:"candidate-tasks,omitempty"`
-	RetainedTasks          int64             `json:"retained-tasks,omitempty"`
-	DeletedTasks           int64             `json:"deleted-tasks,omitempty"`
 	DeletedFiles           int64             `json:"deleted-files,omitempty"`
 	MissingTasks           *countWithSamples `json:"missing-tasks,omitempty"`
 	MissingTaskFiles       *countWithSamples `json:"missing-task-files,omitempty"`
@@ -98,13 +95,11 @@ func (stats *cleanupStats) recordUnparsedTaskIDFiles(files []string) {
 	recordCountWithSamples(&stats.UnparsedTaskIDFiles, files...)
 }
 
-func (stats *cleanupStats) recordTask(
+func (stats *cleanupStats) recordTaskDiagnostics(
 	taskID int64,
 	files []string,
 	info *storage.TaskCleanupInfo,
-	shouldDeleteFiles bool,
 ) {
-	stats.CandidateTasks++
 	switch {
 	case info == nil:
 		// Conflict-row files should not outlive their task metadata. This is
@@ -114,28 +109,19 @@ func (stats *cleanupStats) recordTask(
 		// A task ID collision with another task type should also be rare. These
 		// files cannot belong to IMPORT INTO, so record samples before deletion.
 		stats.recordNonImportIntoTask(files)
-	case shouldDeleteFiles:
-		stats.DeletedTasks++
-	default:
-		stats.RetainedTasks++
 	}
 }
 
 func (stats *cleanupStats) recordMissingTask(taskID int64, files []string) {
 	recordCountWithSamples(&stats.MissingTasks, strconv.FormatInt(taskID, 10))
 	recordCountWithSamples(&stats.MissingTaskFiles, files...)
-	stats.DeletedTasks++
 }
 
 func (stats *cleanupStats) recordNonImportIntoTask(files []string) {
 	recordCountWithSamples(&stats.NonImportIntoTaskFiles, files...)
-	stats.DeletedTasks++
 }
 
 func (stats *cleanupStats) mergeCompletedFlush(completed cleanupStats) {
-	stats.CandidateTasks += completed.CandidateTasks
-	stats.RetainedTasks += completed.RetainedTasks
-	stats.DeletedTasks += completed.DeletedTasks
 	stats.DeletedFiles += completed.DeletedFiles
 	mergeCountWithSamples(&stats.MissingTasks, completed.MissingTasks)
 	mergeCountWithSamples(&stats.MissingTaskFiles, completed.MissingTaskFiles)
@@ -222,7 +208,7 @@ func cleanFiles(
 			files := taskFiles[taskID]
 			info := infosByTaskID[taskID]
 			shouldDeleteFiles := info == nil || info.Type != proto.ImportInto || shouldDelete(*info, now)
-			flushStats.recordTask(taskID, files, info, shouldDeleteFiles)
+			flushStats.recordTaskDiagnostics(taskID, files, info)
 			if shouldDeleteFiles {
 				filesToDelete = append(filesToDelete, files...)
 			}

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -83,9 +83,11 @@ func mergeCountWithSamples(cs **countWithSamples, completed *countWithSamples) {
 
 // cleanupStats uses exported fields so zap.Any can encode them using their JSON tags.
 type cleanupStats struct {
-	DeletedFiles           int64             `json:"deleted-files,omitempty"`
-	MissingTasks           *countWithSamples `json:"missing-tasks,omitempty"`
-	MissingTaskFiles       *countWithSamples `json:"missing-task-files,omitempty"`
+	DeletedFiles     int64             `json:"deleted-files,omitempty"`
+	MissingTasks     *countWithSamples `json:"missing-tasks,omitempty"`
+	MissingTaskFiles *countWithSamples `json:"missing-task-files,omitempty"`
+	// These two cases should be very rare. Keep bounded path samples in the
+	// cleanup log so operators can identify any unexpected files.
 	NonImportIntoTaskFiles *countWithSamples `json:"non-import-into-task-files,omitempty"`
 	UnparsedTaskIDFiles    *countWithSamples `json:"unparsed-task-id-files,omitempty"`
 	Failures               int64             `json:"failures,omitempty"`

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -1,0 +1,306 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conflictrows
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
+)
+
+const (
+	// Conflict-row files are retained for one week. Keep this hardcoded until
+	// customer feedback shows that a configurable retention period is needed.
+	retention                = 7 * 24 * time.Hour
+	maxTaskIDsPerFlush       = 128
+	maxObjectsPerFlush       = 1000
+	maxLoggedMissingTaskIDs  = 16
+	maxLoggedUnexpectedFiles = 16
+)
+
+// TaskInfoGetter provides task metadata needed to decide conflict-row retention.
+type TaskInfoGetter interface {
+	GetTaskCleanupInfoByIDs(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error)
+}
+
+type cleanupStats struct {
+	candidateTasks              int64
+	retainedTasks               int64
+	deletedTasks                int64
+	deletedFiles                int64
+	missingTasks                int64
+	missingTaskFiles            int64
+	nonImportIntoTaskFiles      int64
+	unparsedTaskIDFiles         int64
+	failures                    int64
+	firstMissingTaskIDs         []int64
+	firstMissingTaskFiles       []string
+	firstNonImportIntoTaskFiles []string
+	firstUnparsedTaskIDFiles    []string
+}
+
+func (stats *cleanupStats) recordUnparsedTaskIDFiles(files []string) {
+	stats.unparsedTaskIDFiles += int64(len(files))
+	stats.firstUnparsedTaskIDFiles = appendFirstFiles(stats.firstUnparsedTaskIDFiles, files)
+}
+
+func (stats *cleanupStats) recordTask(
+	taskID int64,
+	files []string,
+	info *storage.TaskCleanupInfo,
+	shouldDeleteFiles bool,
+) {
+	stats.candidateTasks++
+	switch {
+	case info == nil:
+		// Conflict-row files should not outlive their task metadata. This is
+		// rare, so retain bounded file samples to make the cleanup observable.
+		stats.recordMissingTask(taskID, files)
+	case info.Type != proto.ImportInto:
+		// A task ID collision with another task type should also be rare. These
+		// files cannot belong to IMPORT INTO, so record samples before deletion.
+		stats.recordNonImportIntoTask(files)
+	case shouldDeleteFiles:
+		stats.deletedTasks++
+	default:
+		stats.retainedTasks++
+	}
+}
+
+func (stats *cleanupStats) recordMissingTask(taskID int64, files []string) {
+	stats.missingTasks++
+	stats.missingTaskFiles += int64(len(files))
+	stats.deletedTasks++
+	if len(stats.firstMissingTaskIDs) < maxLoggedMissingTaskIDs {
+		stats.firstMissingTaskIDs = append(stats.firstMissingTaskIDs, taskID)
+	}
+	stats.firstMissingTaskFiles = appendFirstFiles(stats.firstMissingTaskFiles, files)
+}
+
+func (stats *cleanupStats) recordNonImportIntoTask(files []string) {
+	stats.nonImportIntoTaskFiles += int64(len(files))
+	stats.deletedTasks++
+	stats.firstNonImportIntoTaskFiles = appendFirstFiles(stats.firstNonImportIntoTaskFiles, files)
+}
+
+func (stats *cleanupStats) mergeCompletedFlush(completed cleanupStats) {
+	stats.candidateTasks += completed.candidateTasks
+	stats.retainedTasks += completed.retainedTasks
+	stats.deletedTasks += completed.deletedTasks
+	stats.deletedFiles += completed.deletedFiles
+	stats.missingTasks += completed.missingTasks
+	stats.missingTaskFiles += completed.missingTaskFiles
+	stats.nonImportIntoTaskFiles += completed.nonImportIntoTaskFiles
+	stats.unparsedTaskIDFiles += completed.unparsedTaskIDFiles
+	missingIDCapacity := maxLoggedMissingTaskIDs - len(stats.firstMissingTaskIDs)
+	stats.firstMissingTaskIDs = append(
+		stats.firstMissingTaskIDs,
+		completed.firstMissingTaskIDs[:min(missingIDCapacity, len(completed.firstMissingTaskIDs))]...,
+	)
+	stats.firstMissingTaskFiles = appendFirstFiles(
+		stats.firstMissingTaskFiles, completed.firstMissingTaskFiles)
+	stats.firstNonImportIntoTaskFiles = appendFirstFiles(
+		stats.firstNonImportIntoTaskFiles, completed.firstNonImportIntoTaskFiles)
+	stats.firstUnparsedTaskIDFiles = appendFirstFiles(
+		stats.firstUnparsedTaskIDFiles, completed.firstUnparsedTaskIDFiles)
+}
+
+func parseTaskID(name string) (int64, bool) {
+	relativeName, ok := strings.CutPrefix(name, storagePrefix)
+	if !ok {
+		return 0, false
+	}
+	taskIDComponent, descendant, ok := strings.Cut(relativeName, "/")
+	if !ok || strings.Trim(descendant, "/") == "" || taskIDComponent == "" {
+		return 0, false
+	}
+	for _, char := range taskIDComponent {
+		if char < '0' || char > '9' {
+			return 0, false
+		}
+	}
+	taskID, err := strconv.ParseInt(taskIDComponent, 10, 64)
+	if err != nil || taskID <= 0 {
+		return 0, false
+	}
+	return taskID, true
+}
+
+func shouldDelete(info storage.TaskCleanupInfo, now time.Time) bool {
+	if info.Type != proto.ImportInto {
+		return false
+	}
+	switch info.State {
+	case proto.TaskStateFailed, proto.TaskStateReverted:
+		return true
+	case proto.TaskStateSucceed:
+		return info.EndTime != nil && !now.Before(info.EndTime.Add(retention))
+	default:
+		return false
+	}
+}
+
+func cleanFiles(
+	ctx context.Context,
+	store storeapi.Storage,
+	infoGetter TaskInfoGetter,
+	now time.Time,
+) (stats cleanupStats, err error) {
+	defer func() {
+		if err != nil {
+			stats.failures++
+		}
+		logCleanupResult(stats)
+	}()
+
+	taskFiles := make(map[int64][]string, maxTaskIDsPerFlush)
+	unparsedTaskIDFiles := make([]string, 0)
+	fileCount := 0
+	flush := func() error {
+		if fileCount == 0 {
+			return nil
+		}
+		taskIDs := make([]int64, 0, len(taskFiles))
+		for taskID := range taskFiles {
+			taskIDs = append(taskIDs, taskID)
+		}
+		sort.Slice(taskIDs, func(i, j int) bool { return taskIDs[i] < taskIDs[j] })
+
+		infosByTaskID := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
+		if len(taskIDs) > 0 {
+			infos, err := infoGetter.GetTaskCleanupInfoByIDs(ctx, taskIDs)
+			if err != nil {
+				return err
+			}
+			for taskID := range infos {
+				info := infos[taskID]
+				infosByTaskID[taskID] = &info
+			}
+		}
+		flushStats := cleanupStats{}
+		flushStats.recordUnparsedTaskIDFiles(unparsedTaskIDFiles)
+		filesToDelete := make([]string, 0, fileCount)
+		filesToDelete = append(filesToDelete, unparsedTaskIDFiles...)
+		for _, taskID := range taskIDs {
+			files := taskFiles[taskID]
+			info := infosByTaskID[taskID]
+			shouldDeleteFiles := info == nil || info.Type != proto.ImportInto || shouldDelete(*info, now)
+			flushStats.recordTask(taskID, files, info, shouldDeleteFiles)
+			if shouldDeleteFiles {
+				filesToDelete = append(filesToDelete, files...)
+			}
+		}
+		if len(filesToDelete) > 0 {
+			if err := store.DeleteFiles(ctx, filesToDelete); err != nil {
+				return err
+			}
+			flushStats.deletedFiles = int64(len(filesToDelete))
+		}
+		stats.mergeCompletedFlush(flushStats)
+
+		clear(taskFiles)
+		unparsedTaskIDFiles = unparsedTaskIDFiles[:0]
+		fileCount = 0
+		return nil
+	}
+
+	err = store.WalkDir(ctx, &storeapi.WalkOption{SubDir: storagePrefix}, func(name string, _ int64) error {
+		taskID, ok := parseTaskID(name)
+		if !ok {
+			// IMPORT INTO always writes a positive task ID in this path. Malformed
+			// entries are unexpected and rare, so delete them and retain samples.
+			unparsedTaskIDFiles = append(unparsedTaskIDFiles, name)
+		} else {
+			taskFiles[taskID] = append(taskFiles[taskID], name)
+		}
+		fileCount++
+		// Checking after insertion keeps one flush path and lets a batch exceed
+		// either limit by at most one object or task.
+		if fileCount > maxObjectsPerFlush || len(taskFiles) > maxTaskIDsPerFlush {
+			return flush()
+		}
+		return nil
+	})
+	if err != nil {
+		return stats, err
+	}
+	if err = flush(); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+func appendFirstFiles(firstFiles, files []string) []string {
+	remaining := maxLoggedUnexpectedFiles - len(firstFiles)
+	if remaining <= 0 {
+		return firstFiles
+	}
+	return append(firstFiles, files[:min(remaining, len(files))]...)
+}
+
+func logCleanupResult(stats cleanupStats) {
+	logger := logutil.BgLogger()
+	if stats.missingTasks > 0 {
+		logger.Warn("conflict-row cleanup deleted objects without task metadata",
+			zap.Int64("missing-tasks", stats.missingTasks),
+			zap.Int64("file-count", stats.missingTaskFiles),
+			zap.Int64s("task-ids", stats.firstMissingTaskIDs),
+			zap.Strings("file-samples", stats.firstMissingTaskFiles))
+	}
+	if stats.nonImportIntoTaskFiles > 0 {
+		logger.Warn("conflict-row cleanup deleted objects for non-import-into tasks",
+			zap.Int64("file-count", stats.nonImportIntoTaskFiles),
+			zap.Strings("file-samples", stats.firstNonImportIntoTaskFiles))
+	}
+	if stats.unparsedTaskIDFiles > 0 {
+		logger.Warn("conflict-row cleanup deleted objects with unparsed task IDs",
+			zap.Int64("file-count", stats.unparsedTaskIDFiles),
+			zap.Strings("file-samples", stats.firstUnparsedTaskIDFiles))
+	}
+	logger.Info("finished conflict-row file cleanup",
+		zap.Int64("candidate-tasks", stats.candidateTasks),
+		zap.Int64("retained-tasks", stats.retainedTasks),
+		zap.Int64("deleted-tasks", stats.deletedTasks),
+		zap.Int64("deleted-files", stats.deletedFiles),
+		zap.Int64("missing-tasks", stats.missingTasks),
+		zap.Int64("missing-task-files", stats.missingTaskFiles),
+		zap.Int64("non-import-into-task-files", stats.nonImportIntoTaskFiles),
+		zap.Int64("unparsed-task-id-files", stats.unparsedTaskIDFiles),
+		zap.Int64("failures", stats.failures))
+}
+
+// CleanExpiredFiles cleans conflict-row files based on task metadata and the retention policy.
+func CleanExpiredFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStorageURI string) error {
+	if cloudStorageURI == "" {
+		return nil
+	}
+	sortStore, err := importer.GetSortStore(ctx, cloudStorageURI)
+	if err != nil {
+		logCleanupResult(cleanupStats{failures: 1})
+		return err
+	}
+	defer sortStore.Close()
+	_, err = cleanFiles(ctx, sortStore, infoGetter, time.Now())
+	return err
+}

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -41,7 +41,7 @@ const (
 
 // TaskInfoGetter provides task metadata needed to decide conflict-row retention.
 type TaskInfoGetter interface {
-	GetTaskCleanupInfoByIDs(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error)
+	GetTaskCleanupInfoByIDs(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error)
 }
 
 type cleanupStats struct {
@@ -187,15 +187,11 @@ func cleanFiles(
 		}
 		sort.Slice(taskIDs, func(i, j int) bool { return taskIDs[i] < taskIDs[j] })
 
-		infosByTaskID := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
+		var infosByTaskID map[int64]*storage.TaskCleanupInfo
 		if len(taskIDs) > 0 {
-			infos, err := infoGetter.GetTaskCleanupInfoByIDs(ctx, taskIDs)
+			infosByTaskID, err = infoGetter.GetTaskCleanupInfoByIDs(ctx, taskIDs)
 			if err != nil {
 				return err
-			}
-			for taskID := range infos {
-				info := infos[taskID]
-				infosByTaskID[taskID] = &info
 			}
 		}
 		flushStats := cleanupStats{}

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	// Conflict-row files are retained for one week. Keep this hardcoded until
-	// customer feedback shows that a configurable retention period is needed.
+	// Conflict-row output from successful tasks is retained for one week. Output
+	// from failed or reverted tasks, files without matching IMPORT INTO task
+	// metadata, and invalid file names are deleted immediately. Keep the retention
+	// period hardcoded until customer feedback shows that it should be configurable.
 	retention          = 7 * 24 * time.Hour
 	maxTaskIDsPerFlush = 128
 	maxObjectsPerFlush = 1000
@@ -265,8 +267,11 @@ func cleanFiles(
 	return stats, nil
 }
 
-// CleanExpiredFiles cleans conflict-row files based on task metadata and the retention policy.
-func CleanExpiredFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStorageURI string) error {
+// CleanConflictRowFiles applies the conflict-row cleanup policy. Files for failed
+// or reverted tasks, files without matching IMPORT INTO task metadata, and file
+// names without a valid positive task ID are deleted immediately. Files for
+// successful tasks are deleted after the retention period; other states are retained.
+func CleanConflictRowFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStorageURI string) error {
 	if cloudStorageURI == "" {
 		return nil
 	}

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -32,11 +32,10 @@ import (
 const (
 	// Conflict-row files are retained for one week. Keep this hardcoded until
 	// customer feedback shows that a configurable retention period is needed.
-	retention                = 7 * 24 * time.Hour
-	maxTaskIDsPerFlush       = 128
-	maxObjectsPerFlush       = 1000
-	maxLoggedMissingTaskIDs  = 16
-	maxLoggedUnexpectedFiles = 16
+	retention          = 7 * 24 * time.Hour
+	maxTaskIDsPerFlush = 128
+	maxObjectsPerFlush = 1000
+	maxLoggedSamples   = 16
 )
 
 // TaskInfoGetter provides task metadata needed to decide conflict-row retention.
@@ -44,25 +43,57 @@ type TaskInfoGetter interface {
 	GetTaskCleanupInfoByIDs(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error)
 }
 
+// countWithSamples uses exported fields so zap.Any can encode them using their JSON tags.
+type countWithSamples struct {
+	Count   int64    `json:"count,omitempty"`
+	Samples []string `json:"samples,omitempty"`
+}
+
+func (cs *countWithSamples) appendSamples(samples []string) {
+	remaining := maxLoggedSamples - len(cs.Samples)
+	if remaining <= 0 {
+		return
+	}
+	cs.Samples = append(cs.Samples, samples[:min(remaining, len(samples))]...)
+}
+
+func recordCountWithSamples(cs **countWithSamples, samples ...string) {
+	if len(samples) == 0 {
+		return
+	}
+	if *cs == nil {
+		*cs = &countWithSamples{}
+	}
+	(*cs).Count += int64(len(samples))
+	(*cs).appendSamples(samples)
+}
+
+func mergeCountWithSamples(cs **countWithSamples, completed *countWithSamples) {
+	if completed == nil {
+		return
+	}
+	if *cs == nil {
+		*cs = &countWithSamples{}
+	}
+	(*cs).Count += completed.Count
+	(*cs).appendSamples(completed.Samples)
+}
+
+// cleanupStats uses exported fields so zap.Any can encode them using their JSON tags.
 type cleanupStats struct {
-	candidateTasks              int64
-	retainedTasks               int64
-	deletedTasks                int64
-	deletedFiles                int64
-	missingTasks                int64
-	missingTaskFiles            int64
-	nonImportIntoTaskFiles      int64
-	unparsedTaskIDFiles         int64
-	failures                    int64
-	firstMissingTaskIDs         []int64
-	firstMissingTaskFiles       []string
-	firstNonImportIntoTaskFiles []string
-	firstUnparsedTaskIDFiles    []string
+	CandidateTasks         int64             `json:"candidate-tasks,omitempty"`
+	RetainedTasks          int64             `json:"retained-tasks,omitempty"`
+	DeletedTasks           int64             `json:"deleted-tasks,omitempty"`
+	DeletedFiles           int64             `json:"deleted-files,omitempty"`
+	MissingTasks           *countWithSamples `json:"missing-tasks,omitempty"`
+	MissingTaskFiles       *countWithSamples `json:"missing-task-files,omitempty"`
+	NonImportIntoTaskFiles *countWithSamples `json:"non-import-into-task-files,omitempty"`
+	UnparsedTaskIDFiles    *countWithSamples `json:"unparsed-task-id-files,omitempty"`
+	Failures               int64             `json:"failures,omitempty"`
 }
 
 func (stats *cleanupStats) recordUnparsedTaskIDFiles(files []string) {
-	stats.unparsedTaskIDFiles += int64(len(files))
-	stats.firstUnparsedTaskIDFiles = appendFirstFiles(stats.firstUnparsedTaskIDFiles, files)
+	recordCountWithSamples(&stats.UnparsedTaskIDFiles, files...)
 }
 
 func (stats *cleanupStats) recordTask(
@@ -71,7 +102,7 @@ func (stats *cleanupStats) recordTask(
 	info *storage.TaskCleanupInfo,
 	shouldDeleteFiles bool,
 ) {
-	stats.candidateTasks++
+	stats.CandidateTasks++
 	switch {
 	case info == nil:
 		// Conflict-row files should not outlive their task metadata. This is
@@ -82,48 +113,32 @@ func (stats *cleanupStats) recordTask(
 		// files cannot belong to IMPORT INTO, so record samples before deletion.
 		stats.recordNonImportIntoTask(files)
 	case shouldDeleteFiles:
-		stats.deletedTasks++
+		stats.DeletedTasks++
 	default:
-		stats.retainedTasks++
+		stats.RetainedTasks++
 	}
 }
 
 func (stats *cleanupStats) recordMissingTask(taskID int64, files []string) {
-	stats.missingTasks++
-	stats.missingTaskFiles += int64(len(files))
-	stats.deletedTasks++
-	if len(stats.firstMissingTaskIDs) < maxLoggedMissingTaskIDs {
-		stats.firstMissingTaskIDs = append(stats.firstMissingTaskIDs, taskID)
-	}
-	stats.firstMissingTaskFiles = appendFirstFiles(stats.firstMissingTaskFiles, files)
+	recordCountWithSamples(&stats.MissingTasks, strconv.FormatInt(taskID, 10))
+	recordCountWithSamples(&stats.MissingTaskFiles, files...)
+	stats.DeletedTasks++
 }
 
 func (stats *cleanupStats) recordNonImportIntoTask(files []string) {
-	stats.nonImportIntoTaskFiles += int64(len(files))
-	stats.deletedTasks++
-	stats.firstNonImportIntoTaskFiles = appendFirstFiles(stats.firstNonImportIntoTaskFiles, files)
+	recordCountWithSamples(&stats.NonImportIntoTaskFiles, files...)
+	stats.DeletedTasks++
 }
 
 func (stats *cleanupStats) mergeCompletedFlush(completed cleanupStats) {
-	stats.candidateTasks += completed.candidateTasks
-	stats.retainedTasks += completed.retainedTasks
-	stats.deletedTasks += completed.deletedTasks
-	stats.deletedFiles += completed.deletedFiles
-	stats.missingTasks += completed.missingTasks
-	stats.missingTaskFiles += completed.missingTaskFiles
-	stats.nonImportIntoTaskFiles += completed.nonImportIntoTaskFiles
-	stats.unparsedTaskIDFiles += completed.unparsedTaskIDFiles
-	missingIDCapacity := maxLoggedMissingTaskIDs - len(stats.firstMissingTaskIDs)
-	stats.firstMissingTaskIDs = append(
-		stats.firstMissingTaskIDs,
-		completed.firstMissingTaskIDs[:min(missingIDCapacity, len(completed.firstMissingTaskIDs))]...,
-	)
-	stats.firstMissingTaskFiles = appendFirstFiles(
-		stats.firstMissingTaskFiles, completed.firstMissingTaskFiles)
-	stats.firstNonImportIntoTaskFiles = appendFirstFiles(
-		stats.firstNonImportIntoTaskFiles, completed.firstNonImportIntoTaskFiles)
-	stats.firstUnparsedTaskIDFiles = appendFirstFiles(
-		stats.firstUnparsedTaskIDFiles, completed.firstUnparsedTaskIDFiles)
+	stats.CandidateTasks += completed.CandidateTasks
+	stats.RetainedTasks += completed.RetainedTasks
+	stats.DeletedTasks += completed.DeletedTasks
+	stats.DeletedFiles += completed.DeletedFiles
+	mergeCountWithSamples(&stats.MissingTasks, completed.MissingTasks)
+	mergeCountWithSamples(&stats.MissingTaskFiles, completed.MissingTaskFiles)
+	mergeCountWithSamples(&stats.NonImportIntoTaskFiles, completed.NonImportIntoTaskFiles)
+	mergeCountWithSamples(&stats.UnparsedTaskIDFiles, completed.UnparsedTaskIDFiles)
 }
 
 func parseTaskID(name string) (int64, bool) {
@@ -169,9 +184,9 @@ func cleanFiles(
 ) (stats cleanupStats, err error) {
 	defer func() {
 		if err != nil {
-			stats.failures++
+			stats.Failures++
 		}
-		logCleanupResult(stats)
+		logutil.BgLogger().Info("finished conflict-row file cleanup", zap.Any("stats", stats))
 	}()
 
 	taskFiles := make(map[int64][]string, maxTaskIDsPerFlush)
@@ -211,7 +226,7 @@ func cleanFiles(
 			if err := store.DeleteFiles(ctx, filesToDelete); err != nil {
 				return err
 			}
-			flushStats.deletedFiles = int64(len(filesToDelete))
+			flushStats.DeletedFiles = int64(len(filesToDelete))
 		}
 		stats.mergeCompletedFlush(flushStats)
 
@@ -247,45 +262,6 @@ func cleanFiles(
 	return stats, nil
 }
 
-func appendFirstFiles(firstFiles, files []string) []string {
-	remaining := maxLoggedUnexpectedFiles - len(firstFiles)
-	if remaining <= 0 {
-		return firstFiles
-	}
-	return append(firstFiles, files[:min(remaining, len(files))]...)
-}
-
-func logCleanupResult(stats cleanupStats) {
-	logger := logutil.BgLogger()
-	if stats.missingTasks > 0 {
-		logger.Warn("conflict-row cleanup deleted objects without task metadata",
-			zap.Int64("missing-tasks", stats.missingTasks),
-			zap.Int64("file-count", stats.missingTaskFiles),
-			zap.Int64s("task-ids", stats.firstMissingTaskIDs),
-			zap.Strings("file-samples", stats.firstMissingTaskFiles))
-	}
-	if stats.nonImportIntoTaskFiles > 0 {
-		logger.Warn("conflict-row cleanup deleted objects for non-import-into tasks",
-			zap.Int64("file-count", stats.nonImportIntoTaskFiles),
-			zap.Strings("file-samples", stats.firstNonImportIntoTaskFiles))
-	}
-	if stats.unparsedTaskIDFiles > 0 {
-		logger.Warn("conflict-row cleanup deleted objects with unparsed task IDs",
-			zap.Int64("file-count", stats.unparsedTaskIDFiles),
-			zap.Strings("file-samples", stats.firstUnparsedTaskIDFiles))
-	}
-	logger.Info("finished conflict-row file cleanup",
-		zap.Int64("candidate-tasks", stats.candidateTasks),
-		zap.Int64("retained-tasks", stats.retainedTasks),
-		zap.Int64("deleted-tasks", stats.deletedTasks),
-		zap.Int64("deleted-files", stats.deletedFiles),
-		zap.Int64("missing-tasks", stats.missingTasks),
-		zap.Int64("missing-task-files", stats.missingTaskFiles),
-		zap.Int64("non-import-into-task-files", stats.nonImportIntoTaskFiles),
-		zap.Int64("unparsed-task-id-files", stats.unparsedTaskIDFiles),
-		zap.Int64("failures", stats.failures))
-}
-
 // CleanExpiredFiles cleans conflict-row files based on task metadata and the retention policy.
 func CleanExpiredFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStorageURI string) error {
 	if cloudStorageURI == "" {
@@ -293,7 +269,6 @@ func CleanExpiredFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStor
 	}
 	sortStore, err := importer.GetSortStore(ctx, cloudStorageURI)
 	if err != nil {
-		logCleanupResult(cleanupStats{failures: 1})
 		return err
 	}
 	defer sortStore.Close()

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -59,38 +59,29 @@ func (cs *countWithSamples) appendSamples(samples []string) {
 	cs.Samples = append(cs.Samples, samples[:min(remaining, len(samples))]...)
 }
 
-func recordCountWithSamples(cs **countWithSamples, samples ...string) {
+func recordCountWithSamples(cs *countWithSamples, samples ...string) {
 	if len(samples) == 0 {
 		return
 	}
-	if *cs == nil {
-		*cs = &countWithSamples{}
-	}
-	(*cs).Count += int64(len(samples))
-	(*cs).appendSamples(samples)
+	cs.Count += int64(len(samples))
+	cs.appendSamples(samples)
 }
 
-func mergeCountWithSamples(cs **countWithSamples, completed *countWithSamples) {
-	if completed == nil {
-		return
-	}
-	if *cs == nil {
-		*cs = &countWithSamples{}
-	}
-	(*cs).Count += completed.Count
-	(*cs).appendSamples(completed.Samples)
+func mergeCountWithSamples(cs *countWithSamples, completed countWithSamples) {
+	cs.Count += completed.Count
+	cs.appendSamples(completed.Samples)
 }
 
 // cleanupStats uses exported fields so zap.Any can encode them using their JSON tags.
 type cleanupStats struct {
-	DeletedFiles     int64             `json:"deleted-files,omitempty"`
-	MissingTasks     *countWithSamples `json:"missing-tasks,omitempty"`
-	MissingTaskFiles *countWithSamples `json:"missing-task-files,omitempty"`
+	DeletedFiles     int64            `json:"deleted-files,omitempty"`
+	MissingTasks     countWithSamples `json:"missing-tasks,omitzero"`
+	MissingTaskFiles countWithSamples `json:"missing-task-files,omitzero"`
 	// These two cases should be very rare. Keep bounded path samples in the
 	// cleanup log so operators can identify any unexpected files.
-	NonImportIntoTaskFiles *countWithSamples `json:"non-import-into-task-files,omitempty"`
-	UnparsedTaskIDFiles    *countWithSamples `json:"unparsed-task-id-files,omitempty"`
-	Failures               int64             `json:"failures,omitempty"`
+	NonImportIntoTaskFiles countWithSamples `json:"non-import-into-task-files,omitzero"`
+	UnparsedTaskIDFiles    countWithSamples `json:"unparsed-task-id-files,omitzero"`
+	Failures               int64            `json:"failures,omitempty"`
 }
 
 func (stats *cleanupStats) recordUnparsedTaskIDFiles(files []string) {
@@ -259,6 +250,10 @@ func cleanFiles(
 // or reverted tasks, files without matching IMPORT INTO task metadata, and file
 // names without a valid positive task ID are deleted immediately. Files for
 // successful tasks are deleted after the retention period; other states are retained.
+// The initial design used cloud bucket lifecycle policies to manage these files,
+// but that would split ownership between the kernel and control plane, making
+// future changes and maintenance more complex. The policy is simple enough to
+// keep entirely in the kernel.
 func CleanConflictRowFiles(ctx context.Context, infoGetter TaskInfoGetter, cloudStorageURI string) error {
 	if cloudStorageURI == "" {
 		return nil

--- a/pkg/dxf/importinto/conflictrows/cleanup.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup.go
@@ -16,7 +16,7 @@ package conflictrows
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -168,6 +168,9 @@ func shouldDelete(info storage.TaskCleanupInfo, now time.Time) bool {
 	}
 	switch info.State {
 	case proto.TaskStateFailed, proto.TaskStateReverted:
+		// Only successful task output is retained for user inspection. Failed or
+		// reverted tasks may leave incomplete conflict-row files, so remove them
+		// immediately with the task's other external artifacts.
 		return true
 	case proto.TaskStateSucceed:
 		return info.EndTime != nil && !now.Before(info.EndTime.Add(retention))
@@ -200,7 +203,7 @@ func cleanFiles(
 		for taskID := range taskFiles {
 			taskIDs = append(taskIDs, taskID)
 		}
-		sort.Slice(taskIDs, func(i, j int) bool { return taskIDs[i] < taskIDs[j] })
+		slices.Sort(taskIDs)
 
 		var infosByTaskID map[int64]*storage.TaskCleanupInfo
 		if len(taskIDs) > 0 {

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -181,49 +181,25 @@ func TestShouldDelete(t *testing.T) {
 func TestCleanFiles(t *testing.T) {
 	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
 
-	t.Run("record task decisions", func(t *testing.T) {
+	t.Run("record task diagnostics", func(t *testing.T) {
 		files := []string{"conflicted-rows/1/a", "conflicted-rows/1/b"}
 		testCases := []struct {
-			name              string
-			info              *storage.TaskCleanupInfo
-			shouldDeleteFiles bool
-			wantStats         cleanupStats
+			name      string
+			info      *storage.TaskCleanupInfo
+			wantStats cleanupStats
 		}{
 			{
-				name:              "missing task",
-				shouldDeleteFiles: true,
+				name: "missing task",
 				wantStats: cleanupStats{
-					CandidateTasks:   1,
-					DeletedTasks:     1,
 					MissingTasks:     &countWithSamples{Count: 1, Samples: []string{"1"}},
 					MissingTaskFiles: &countWithSamples{Count: 2, Samples: files},
 				},
 			},
 			{
-				name:              "non import into task",
-				info:              &storage.TaskCleanupInfo{Type: proto.TaskTypeExample},
-				shouldDeleteFiles: true,
+				name: "non import into task",
+				info: &storage.TaskCleanupInfo{Type: proto.TaskTypeExample},
 				wantStats: cleanupStats{
-					CandidateTasks:         1,
-					DeletedTasks:           1,
 					NonImportIntoTaskFiles: &countWithSamples{Count: 2, Samples: files},
-				},
-			},
-			{
-				name:              "delete import task files",
-				info:              &storage.TaskCleanupInfo{Type: proto.ImportInto},
-				shouldDeleteFiles: true,
-				wantStats: cleanupStats{
-					CandidateTasks: 1,
-					DeletedTasks:   1,
-				},
-			},
-			{
-				name: "retain task",
-				info: &storage.TaskCleanupInfo{Type: proto.ImportInto},
-				wantStats: cleanupStats{
-					CandidateTasks: 1,
-					RetainedTasks:  1,
 				},
 			},
 		}
@@ -231,7 +207,7 @@ func TestCleanFiles(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
 				stats := cleanupStats{}
-				stats.recordTask(1, files, testCase.info, testCase.shouldDeleteFiles)
+				stats.recordTaskDiagnostics(1, files, testCase.info)
 				require.Equal(t, testCase.wantStats, stats)
 			})
 		}
@@ -285,9 +261,6 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Equal(t, int64(4), stats.CandidateTasks)
-		require.Equal(t, int64(1), stats.RetainedTasks)
-		require.Equal(t, int64(3), stats.DeletedTasks)
 		require.Equal(t, int64(4), stats.DeletedFiles)
 		require.Nil(t, stats.MissingTasks)
 		require.Equal(t, int64(1), stats.NonImportIntoTaskFiles.Count)
@@ -408,9 +381,6 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.ErrorIs(t, err, deleteErr)
-		require.Equal(t, int64(1), stats.CandidateTasks)
-		require.Zero(t, stats.RetainedTasks)
-		require.Equal(t, int64(1), stats.DeletedTasks)
 		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
 		require.Nil(t, stats.MissingTasks)
 		require.Equal(t, int64(1), stats.Failures)
@@ -437,9 +407,6 @@ func TestCleanFiles(t *testing.T) {
 				return map[int64]*storage.TaskCleanupInfo{}, nil
 			}), now)
 		require.NoError(t, err)
-		require.Equal(t, int64(20), stats.CandidateTasks)
-		require.Zero(t, stats.RetainedTasks)
-		require.Equal(t, int64(20), stats.DeletedTasks)
 		require.Equal(t, int64(20), stats.DeletedFiles)
 		require.Equal(t, int64(20), stats.MissingTasks.Count)
 		require.Equal(t, int64(20), stats.MissingTaskFiles.Count)
@@ -456,12 +423,12 @@ func TestCleanFiles(t *testing.T) {
 		fields := entries[0].ContextMap()
 		require.Len(t, fields, 1)
 		loggedStats, loggedFields := requireLoggedCleanupStats(t, fields["stats"])
-		require.Equal(t, int64(20), loggedStats.CandidateTasks)
-		require.Equal(t, int64(20), loggedStats.DeletedTasks)
 		require.Equal(t, int64(20), loggedStats.DeletedFiles)
 		requireLoggedCountWithSamples(t, loggedFields["missing-tasks"], stats.MissingTasks)
 		requireLoggedCountWithSamples(t, loggedFields["missing-task-files"], stats.MissingTaskFiles)
+		require.NotContains(t, loggedFields, "candidate-tasks")
 		require.NotContains(t, loggedFields, "retained-tasks")
+		require.NotContains(t, loggedFields, "deleted-tasks")
 		require.NotContains(t, loggedFields, "non-import-into-task-files")
 		require.NotContains(t, loggedFields, "unparsed-task-id-files")
 		require.NotContains(t, loggedFields, "failures")
@@ -487,8 +454,6 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), stats.CandidateTasks)
-		require.Equal(t, int64(1), stats.DeletedTasks)
 		require.Equal(t, int64(40), stats.DeletedFiles)
 		require.Equal(t, int64(20), stats.NonImportIntoTaskFiles.Count)
 		require.Equal(t, int64(20), stats.UnparsedTaskIDFiles.Count)
@@ -502,8 +467,6 @@ func TestCleanFiles(t *testing.T) {
 		fields := entries[0].ContextMap()
 		require.Len(t, fields, 1)
 		loggedStats, loggedFields := requireLoggedCleanupStats(t, fields["stats"])
-		require.Equal(t, int64(1), loggedStats.CandidateTasks)
-		require.Equal(t, int64(1), loggedStats.DeletedTasks)
 		require.Equal(t, int64(40), loggedStats.DeletedFiles)
 		requireLoggedCountWithSamples(t,
 			loggedFields["non-import-into-task-files"], stats.NonImportIntoTaskFiles)
@@ -527,7 +490,6 @@ func TestCleanFiles(t *testing.T) {
 				return nil, nil
 			}), now)
 		require.NoError(t, err)
-		require.Zero(t, stats.CandidateTasks)
 		require.Equal(t, int64(maxObjectsPerFlush+1), stats.UnparsedTaskIDFiles.Count)
 		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
 		require.Len(t, store.deleteCalls, 1)

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -97,11 +97,11 @@ func requireLoggedCleanupStats(t *testing.T, value any) (cleanupStats, map[strin
 	return logged, fields
 }
 
-func requireLoggedCountWithSamples(t *testing.T, value json.RawMessage, want *countWithSamples) {
+func requireLoggedCountWithSamples(t *testing.T, value json.RawMessage, want countWithSamples) {
 	t.Helper()
 	var logged countWithSamples
 	require.NoError(t, json.Unmarshal(value, &logged))
-	require.Equal(t, want, &logged)
+	require.Equal(t, want, logged)
 	var fields map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(value, &fields))
 	require.Len(t, fields, 2)
@@ -191,15 +191,15 @@ func TestCleanFiles(t *testing.T) {
 			{
 				name: "missing task",
 				wantStats: cleanupStats{
-					MissingTasks:     &countWithSamples{Count: 1, Samples: []string{"1"}},
-					MissingTaskFiles: &countWithSamples{Count: 2, Samples: files},
+					MissingTasks:     countWithSamples{Count: 1, Samples: []string{"1"}},
+					MissingTaskFiles: countWithSamples{Count: 2, Samples: files},
 				},
 			},
 			{
 				name: "non import into task",
 				info: &storage.TaskCleanupInfo{Type: proto.TaskTypeExample},
 				wantStats: cleanupStats{
-					NonImportIntoTaskFiles: &countWithSamples{Count: 2, Samples: files},
+					NonImportIntoTaskFiles: countWithSamples{Count: 2, Samples: files},
 				},
 			},
 		}
@@ -262,7 +262,7 @@ func TestCleanFiles(t *testing.T) {
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
 		require.Equal(t, int64(4), stats.DeletedFiles)
-		require.Nil(t, stats.MissingTasks)
+		require.Zero(t, stats.MissingTasks)
 		require.Equal(t, int64(1), stats.NonImportIntoTaskFiles.Count)
 		require.Equal(t, int64(1), stats.UnparsedTaskIDFiles.Count)
 		require.Zero(t, stats.Failures)
@@ -382,7 +382,7 @@ func TestCleanFiles(t *testing.T) {
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.ErrorIs(t, err, deleteErr)
 		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
-		require.Nil(t, stats.MissingTasks)
+		require.Zero(t, stats.MissingTasks)
 		require.Equal(t, int64(1), stats.Failures)
 
 		store.failDeleteAt = 0

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -549,9 +549,9 @@ func TestCleanFiles(t *testing.T) {
 	})
 }
 
-func TestCleanExpiredFiles(t *testing.T) {
+func TestCleanConflictRowFiles(t *testing.T) {
 	t.Run("empty URI", func(t *testing.T) {
-		require.NoError(t, CleanExpiredFiles(context.Background(), nil, ""))
+		require.NoError(t, CleanConflictRowFiles(context.Background(), nil, ""))
 	})
 
 	t.Run("open error does not log URI", func(t *testing.T) {
@@ -560,7 +560,7 @@ func TestCleanExpiredFiles(t *testing.T) {
 		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
 		t.Cleanup(restoreLog)
 
-		err := CleanExpiredFiles(context.Background(), nil, credentialURI)
+		err := CleanConflictRowFiles(context.Background(), nil, credentialURI)
 		require.Error(t, err)
 		require.Empty(t, logs.All())
 	})

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -32,12 +32,12 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-type taskInfoGetterFunc func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error)
+type taskInfoGetterFunc func(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error)
 
 func (f taskInfoGetterFunc) GetTaskCleanupInfoByIDs(
 	ctx context.Context,
 	taskIDs []int64,
-) (map[int64]storage.TaskCleanupInfo, error) {
+) (map[int64]*storage.TaskCleanupInfo, error) {
 	return f(ctx, taskIDs)
 }
 
@@ -85,8 +85,8 @@ func requireTestFileExists(t *testing.T, store storeapi.Storage, name string, wa
 	require.Equal(t, want, exists, name)
 }
 
-func failedImportInfo(taskID int64) storage.TaskCleanupInfo {
-	return storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateFailed}
+func failedImportInfo(taskID int64) *storage.TaskCleanupInfo {
+	return &storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateFailed}
 }
 
 func TestParseTaskID(t *testing.T) {
@@ -229,9 +229,9 @@ func TestCleanFiles(t *testing.T) {
 		}
 		writeTestFiles(t, store, files...)
 		old := now.Add(-retention)
-		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			require.ElementsMatch(t, []int64{1, 2, 3, 4}, taskIDs)
-			return map[int64]storage.TaskCleanupInfo{
+			return map[int64]*storage.TaskCleanupInfo{
 				1: failedImportInfo(1),
 				2: {ID: 2, Type: proto.ImportInto, State: proto.TaskStateRunning},
 				3: {ID: 3, Type: proto.TaskTypeExample, State: proto.TaskStateFailed},
@@ -262,9 +262,9 @@ func TestCleanFiles(t *testing.T) {
 	t.Run("task ID bound", func(t *testing.T) {
 		store := &testStorage{Storage: objstore.NewMemStorage()}
 		lookupSizes := make([]int, 0, 2)
-		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			lookupSizes = append(lookupSizes, len(taskIDs))
-			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+			result := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
 			for _, taskID := range taskIDs {
 				result[taskID] = failedImportInfo(taskID)
 			}
@@ -285,9 +285,9 @@ func TestCleanFiles(t *testing.T) {
 	t.Run("object bound keeps current callback", func(t *testing.T) {
 		store := &testStorage{Storage: objstore.NewMemStorage()}
 		lookupSizes := make([]int, 0, 2)
-		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			lookupSizes = append(lookupSizes, len(taskIDs))
-			return map[int64]storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
+			return map[int64]*storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
 		})
 		for i := range maxObjectsPerFlush + 1 {
 			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/1/data-%04d", i))
@@ -309,17 +309,17 @@ func TestCleanFiles(t *testing.T) {
 		writeTestFiles(t, store, "conflicted-rows/999/retain")
 		lookupErr := errors.New("lookup failed")
 		lookupCount := 0
-		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			lookupCount++
 			if lookupCount == 2 {
 				return nil, lookupErr
 			}
-			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+			result := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
 			for _, taskID := range taskIDs {
 				if taskID != 999 {
 					result[taskID] = failedImportInfo(taskID)
 				} else {
-					result[taskID] = storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
+					result[taskID] = &storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
 				}
 			}
 			return result, nil
@@ -330,11 +330,11 @@ func TestCleanFiles(t *testing.T) {
 		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.deletedFiles)
 		require.Equal(t, int64(1), stats.failures)
 
-		getter = func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
-			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+		getter = func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
+			result := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
 			for _, taskID := range taskIDs {
 				if taskID == 999 {
-					result[taskID] = storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
+					result[taskID] = &storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
 				} else {
 					result[taskID] = failedImportInfo(taskID)
 				}
@@ -358,8 +358,8 @@ func TestCleanFiles(t *testing.T) {
 			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/1/data-%04d", i))
 		}
 		writeTestFiles(t, store, "conflicted-rows/2/missing-metadata")
-		getter := taskInfoGetterFunc(func(_ context.Context, _ []int64) (map[int64]storage.TaskCleanupInfo, error) {
-			return map[int64]storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
+		getter := taskInfoGetterFunc(func(_ context.Context, _ []int64) (map[int64]*storage.TaskCleanupInfo, error) {
+			return map[int64]*storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
 		})
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
@@ -390,8 +390,8 @@ func TestCleanFiles(t *testing.T) {
 		}
 
 		stats, err := cleanFiles(context.Background(), store, taskInfoGetterFunc(
-			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
-				return map[int64]storage.TaskCleanupInfo{}, nil
+			func(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error) {
+				return map[int64]*storage.TaskCleanupInfo{}, nil
 			}), now)
 		require.NoError(t, err)
 		require.Equal(t, int64(20), stats.candidateTasks)
@@ -426,9 +426,9 @@ func TestCleanFiles(t *testing.T) {
 				fmt.Sprintf("conflicted-rows/not-a-task-%02d/data", i),
 			)
 		}
-		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			require.Equal(t, []int64{1}, taskIDs)
-			return map[int64]storage.TaskCleanupInfo{
+			return map[int64]*storage.TaskCleanupInfo{
 				1: {ID: 1, Type: proto.TaskTypeExample, State: proto.TaskStateFailed},
 			}, nil
 		})
@@ -458,7 +458,7 @@ func TestCleanFiles(t *testing.T) {
 		}
 
 		stats, err := cleanFiles(context.Background(), store, taskInfoGetterFunc(
-			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			func(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 				require.FailNow(t, "metadata lookup should not run")
 				return nil, nil
 			}), now)
@@ -476,7 +476,7 @@ func TestCleanFiles(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		stats, err := cleanFiles(ctx, store, taskInfoGetterFunc(
-			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			func(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 				require.FailNow(t, "metadata lookup should not run")
 				return nil, nil
 			}), now)

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -1,0 +1,509 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conflictrows
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/objstore"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type taskInfoGetterFunc func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error)
+
+func (f taskInfoGetterFunc) GetTaskCleanupInfoByIDs(
+	ctx context.Context,
+	taskIDs []int64,
+) (map[int64]storage.TaskCleanupInfo, error) {
+	return f(ctx, taskIDs)
+}
+
+type testStorage struct {
+	storeapi.Storage
+	walkOptions   []*storeapi.WalkOption
+	failWalkErr   error
+	deleteCalls   [][]string
+	failDeleteAt  int
+	failDeleteErr error
+}
+
+func (s *testStorage) WalkDir(
+	ctx context.Context,
+	opt *storeapi.WalkOption,
+	fn func(string, int64) error,
+) error {
+	optionCopy := *opt
+	s.walkOptions = append(s.walkOptions, &optionCopy)
+	if s.failWalkErr != nil {
+		return s.failWalkErr
+	}
+	return s.Storage.WalkDir(ctx, opt, fn)
+}
+
+func (s *testStorage) DeleteFiles(ctx context.Context, names []string) error {
+	s.deleteCalls = append(s.deleteCalls, slices.Clone(names))
+	if s.failDeleteAt > 0 && len(s.deleteCalls) == s.failDeleteAt {
+		return s.failDeleteErr
+	}
+	return s.Storage.DeleteFiles(ctx, names)
+}
+
+func writeTestFiles(t *testing.T, store storeapi.Storage, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.NoError(t, store.WriteFile(context.Background(), name, []byte("row")))
+	}
+}
+
+func requireTestFileExists(t *testing.T, store storeapi.Storage, name string, want bool) {
+	t.Helper()
+	exists, err := store.FileExists(context.Background(), name)
+	require.NoError(t, err)
+	require.Equal(t, want, exists, name)
+}
+
+func failedImportInfo(taskID int64) storage.TaskCleanupInfo {
+	return storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateFailed}
+}
+
+func TestParseTaskID(t *testing.T) {
+	testCases := []struct {
+		name   string
+		path   string
+		wantID int64
+		ok     bool
+	}{
+		{name: "valid", path: "conflicted-rows/42/data-0001.txt", wantID: 42, ok: true},
+		{name: "nested descendant", path: "conflicted-rows/9223372036854775807/subtask/data", wantID: 9223372036854775807, ok: true},
+		{name: "leading zero is decimal", path: "conflicted-rows/007/data", wantID: 7, ok: true},
+		{name: "unrelated", path: "other/42/data"},
+		{name: "lexical sibling", path: "conflicted-rows-old/42/data"},
+		{name: "empty task", path: "conflicted-rows//data"},
+		{name: "zero", path: "conflicted-rows/0/data"},
+		{name: "negative", path: "conflicted-rows/-1/data"},
+		{name: "explicit positive sign", path: "conflicted-rows/+1/data"},
+		{name: "nondigit", path: "conflicted-rows/1a/data"},
+		{name: "overflow", path: "conflicted-rows/9223372036854775808/data"},
+		{name: "prefix only", path: "conflicted-rows/"},
+		{name: "no descendant", path: "conflicted-rows/42"},
+		{name: "empty descendant", path: "conflicted-rows/42/"},
+		{name: "slash only descendant", path: "conflicted-rows/42//"},
+		{name: "multiple slash only descendants", path: "conflicted-rows/42///"},
+		{name: "deeper nonempty descendant", path: "conflicted-rows/42//data", wantID: 42, ok: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			gotID, ok := parseTaskID(testCase.path)
+			require.Equal(t, testCase.ok, ok)
+			require.Equal(t, testCase.wantID, gotID)
+		})
+	}
+}
+
+func TestShouldDelete(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	justTooYoung := now.Add(-retention + time.Nanosecond)
+	exactlyExpired := now.Add(-retention)
+	old := now.Add(-200 * time.Hour)
+	info := func(taskType proto.TaskType, state proto.TaskState, endTime *time.Time) storage.TaskCleanupInfo {
+		return storage.TaskCleanupInfo{ID: 1, Type: taskType, State: state, EndTime: endTime}
+	}
+
+	testCases := []struct {
+		name string
+		info storage.TaskCleanupInfo
+		want bool
+	}{
+		{name: "one nanosecond before expiry", info: info(proto.ImportInto, proto.TaskStateSucceed, &justTooYoung)},
+		{name: "exact expiry", info: info(proto.ImportInto, proto.TaskStateSucceed, &exactlyExpired), want: true},
+		{name: "success without end time", info: info(proto.ImportInto, proto.TaskStateSucceed, nil)},
+		{name: "failed", info: info(proto.ImportInto, proto.TaskStateFailed, nil), want: true},
+		{name: "reverted", info: info(proto.ImportInto, proto.TaskStateReverted, nil), want: true},
+		{name: "active", info: info(proto.ImportInto, proto.TaskStateRunning, &old)},
+		{name: "wrong type", info: info(proto.TaskTypeExample, proto.TaskStateFailed, &old)},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.want, shouldDelete(testCase.info, now))
+		})
+	}
+}
+
+func TestCleanFiles(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+
+	t.Run("record task decisions", func(t *testing.T) {
+		files := []string{"conflicted-rows/1/a", "conflicted-rows/1/b"}
+		testCases := []struct {
+			name              string
+			info              *storage.TaskCleanupInfo
+			shouldDeleteFiles bool
+			wantStats         cleanupStats
+		}{
+			{
+				name:              "missing task",
+				shouldDeleteFiles: true,
+				wantStats: cleanupStats{
+					candidateTasks:        1,
+					deletedTasks:          1,
+					missingTasks:          1,
+					missingTaskFiles:      2,
+					firstMissingTaskIDs:   []int64{1},
+					firstMissingTaskFiles: files,
+				},
+			},
+			{
+				name:              "non import into task",
+				info:              &storage.TaskCleanupInfo{Type: proto.TaskTypeExample},
+				shouldDeleteFiles: true,
+				wantStats: cleanupStats{
+					candidateTasks:              1,
+					deletedTasks:                1,
+					nonImportIntoTaskFiles:      2,
+					firstNonImportIntoTaskFiles: files,
+				},
+			},
+			{
+				name:              "delete import task files",
+				info:              &storage.TaskCleanupInfo{Type: proto.ImportInto},
+				shouldDeleteFiles: true,
+				wantStats: cleanupStats{
+					candidateTasks: 1,
+					deletedTasks:   1,
+				},
+			},
+			{
+				name: "retain task",
+				info: &storage.TaskCleanupInfo{Type: proto.ImportInto},
+				wantStats: cleanupStats{
+					candidateTasks: 1,
+					retainedTasks:  1,
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				stats := cleanupStats{}
+				stats.recordTask(1, files, testCase.info, testCase.shouldDeleteFiles)
+				require.Equal(t, testCase.wantStats, stats)
+			})
+		}
+	})
+
+	t.Run("mixed decisions", func(t *testing.T) {
+		store := &testStorage{Storage: objstore.NewMemStorage()}
+		files := []string{
+			"conflicted-rows/1/a/data",
+			"conflicted-rows/2/b/data",
+			"conflicted-rows/3/c/data",
+			"conflicted-rows/4/d/data",
+			"conflicted-rows/bad/data",
+			"conflicted-rows-old/1/data",
+			"other/data",
+		}
+		writeTestFiles(t, store, files...)
+		old := now.Add(-retention)
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			require.ElementsMatch(t, []int64{1, 2, 3, 4}, taskIDs)
+			return map[int64]storage.TaskCleanupInfo{
+				1: failedImportInfo(1),
+				2: {ID: 2, Type: proto.ImportInto, State: proto.TaskStateRunning},
+				3: {ID: 3, Type: proto.TaskTypeExample, State: proto.TaskStateFailed},
+				4: {ID: 4, Type: proto.ImportInto, State: proto.TaskStateSucceed, EndTime: &old},
+			}, nil
+		})
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Equal(t, int64(4), stats.candidateTasks)
+		require.Equal(t, int64(1), stats.retainedTasks)
+		require.Equal(t, int64(3), stats.deletedTasks)
+		require.Equal(t, int64(4), stats.deletedFiles)
+		require.Zero(t, stats.missingTasks)
+		require.Equal(t, int64(1), stats.nonImportIntoTaskFiles)
+		require.Equal(t, int64(1), stats.unparsedTaskIDFiles)
+		require.Zero(t, stats.failures)
+		require.Equal(t, storagePrefix, store.walkOptions[0].SubDir)
+		requireTestFileExists(t, store, files[0], false)
+		requireTestFileExists(t, store, files[1], true)
+		requireTestFileExists(t, store, files[2], false)
+		requireTestFileExists(t, store, files[3], false)
+		requireTestFileExists(t, store, files[4], false)
+		requireTestFileExists(t, store, files[5], true)
+		requireTestFileExists(t, store, files[6], true)
+	})
+
+	t.Run("task ID bound", func(t *testing.T) {
+		store := &testStorage{Storage: objstore.NewMemStorage()}
+		lookupSizes := make([]int, 0, 2)
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			lookupSizes = append(lookupSizes, len(taskIDs))
+			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+			for _, taskID := range taskIDs {
+				result[taskID] = failedImportInfo(taskID)
+			}
+			return result, nil
+		})
+		for taskID := int64(1); taskID <= maxTaskIDsPerFlush+1; taskID++ {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/%03d/data", taskID))
+		}
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Equal(t, []int{maxTaskIDsPerFlush + 1}, lookupSizes)
+		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.deletedFiles)
+		require.Len(t, store.deleteCalls, 1)
+		require.Len(t, store.deleteCalls[0], maxTaskIDsPerFlush+1)
+	})
+
+	t.Run("object bound keeps current callback", func(t *testing.T) {
+		store := &testStorage{Storage: objstore.NewMemStorage()}
+		lookupSizes := make([]int, 0, 2)
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			lookupSizes = append(lookupSizes, len(taskIDs))
+			return map[int64]storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
+		})
+		for i := range maxObjectsPerFlush + 1 {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/1/data-%04d", i))
+		}
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Equal(t, []int{1}, lookupSizes)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
+		require.Len(t, store.deleteCalls, 1)
+		require.Len(t, store.deleteCalls[0], maxObjectsPerFlush+1)
+	})
+
+	t.Run("later lookup failure and retry", func(t *testing.T) {
+		store := &testStorage{Storage: objstore.NewMemStorage()}
+		for taskID := int64(1); taskID <= maxTaskIDsPerFlush+1; taskID++ {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/%03d/data", taskID))
+		}
+		writeTestFiles(t, store, "conflicted-rows/999/retain")
+		lookupErr := errors.New("lookup failed")
+		lookupCount := 0
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			lookupCount++
+			if lookupCount == 2 {
+				return nil, lookupErr
+			}
+			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+			for _, taskID := range taskIDs {
+				if taskID != 999 {
+					result[taskID] = failedImportInfo(taskID)
+				} else {
+					result[taskID] = storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
+				}
+			}
+			return result, nil
+		})
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.ErrorIs(t, err, lookupErr)
+		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.deletedFiles)
+		require.Equal(t, int64(1), stats.failures)
+
+		getter = func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			result := make(map[int64]storage.TaskCleanupInfo, len(taskIDs))
+			for _, taskID := range taskIDs {
+				if taskID == 999 {
+					result[taskID] = storage.TaskCleanupInfo{ID: taskID, Type: proto.ImportInto, State: proto.TaskStateRunning}
+				} else {
+					result[taskID] = failedImportInfo(taskID)
+				}
+			}
+			return result, nil
+		}
+		stats, err = cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Zero(t, stats.deletedFiles)
+		requireTestFileExists(t, store, "conflicted-rows/999/retain", true)
+	})
+
+	t.Run("later delete failure and retry", func(t *testing.T) {
+		deleteErr := errors.New("delete failed")
+		store := &testStorage{
+			Storage:       objstore.NewMemStorage(),
+			failDeleteAt:  2,
+			failDeleteErr: deleteErr,
+		}
+		for i := range maxObjectsPerFlush + 1 {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/1/data-%04d", i))
+		}
+		writeTestFiles(t, store, "conflicted-rows/2/missing-metadata")
+		getter := taskInfoGetterFunc(func(_ context.Context, _ []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			return map[int64]storage.TaskCleanupInfo{1: failedImportInfo(1)}, nil
+		})
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.ErrorIs(t, err, deleteErr)
+		require.Equal(t, int64(1), stats.candidateTasks)
+		require.Zero(t, stats.retainedTasks)
+		require.Equal(t, int64(1), stats.deletedTasks)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
+		require.Zero(t, stats.missingTasks)
+		require.Empty(t, stats.firstMissingTaskIDs)
+		require.Equal(t, int64(1), stats.failures)
+
+		store.failDeleteAt = 0
+		stats, err = cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stats.deletedFiles)
+		require.Equal(t, int64(1), stats.missingTasks)
+		require.Equal(t, int64(1), stats.missingTaskFiles)
+	})
+
+	t.Run("missing metadata warning is bounded", func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
+		t.Cleanup(restoreLog)
+		store := objstore.NewMemStorage()
+		for taskID := int64(1); taskID <= 20; taskID++ {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/%d/data", taskID))
+		}
+
+		stats, err := cleanFiles(context.Background(), store, taskInfoGetterFunc(
+			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
+				return map[int64]storage.TaskCleanupInfo{}, nil
+			}), now)
+		require.NoError(t, err)
+		require.Equal(t, int64(20), stats.candidateTasks)
+		require.Zero(t, stats.retainedTasks)
+		require.Equal(t, int64(20), stats.deletedTasks)
+		require.Equal(t, int64(20), stats.deletedFiles)
+		require.Equal(t, int64(20), stats.missingTasks)
+		require.Equal(t, int64(20), stats.missingTaskFiles)
+		require.Len(t, stats.firstMissingTaskIDs, maxLoggedMissingTaskIDs)
+		require.Equal(t, []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, stats.firstMissingTaskIDs)
+		require.Len(t, stats.firstMissingTaskFiles, maxLoggedUnexpectedFiles)
+
+		warningLogs := logs.FilterMessage("conflict-row cleanup deleted objects without task metadata").All()
+		require.Len(t, warningLogs, 1)
+		require.Equal(t, int64(20), warningLogs[0].ContextMap()["missing-tasks"])
+		require.Len(t, warningLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
+		summaryLogs := logs.FilterMessage("finished conflict-row file cleanup").All()
+		require.Len(t, summaryLogs, 1)
+		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["candidate-tasks"])
+		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["missing-tasks"])
+		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["missing-task-files"])
+	})
+
+	t.Run("unexpected file diagnostics are bounded", func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
+		t.Cleanup(restoreLog)
+		store := objstore.NewMemStorage()
+		for i := range 20 {
+			writeTestFiles(t, store,
+				fmt.Sprintf("conflicted-rows/1/data-%02d", i),
+				fmt.Sprintf("conflicted-rows/not-a-task-%02d/data", i),
+			)
+		}
+		getter := taskInfoGetterFunc(func(_ context.Context, taskIDs []int64) (map[int64]storage.TaskCleanupInfo, error) {
+			require.Equal(t, []int64{1}, taskIDs)
+			return map[int64]storage.TaskCleanupInfo{
+				1: {ID: 1, Type: proto.TaskTypeExample, State: proto.TaskStateFailed},
+			}, nil
+		})
+
+		stats, err := cleanFiles(context.Background(), store, getter, now)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stats.candidateTasks)
+		require.Equal(t, int64(1), stats.deletedTasks)
+		require.Equal(t, int64(40), stats.deletedFiles)
+		require.Equal(t, int64(20), stats.nonImportIntoTaskFiles)
+		require.Equal(t, int64(20), stats.unparsedTaskIDFiles)
+		require.Len(t, stats.firstNonImportIntoTaskFiles, maxLoggedUnexpectedFiles)
+		require.Len(t, stats.firstUnparsedTaskIDFiles, maxLoggedUnexpectedFiles)
+
+		nonImportLogs := logs.FilterMessage("conflict-row cleanup deleted objects for non-import-into tasks").All()
+		require.Len(t, nonImportLogs, 1)
+		require.Len(t, nonImportLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
+		unparsedLogs := logs.FilterMessage("conflict-row cleanup deleted objects with unparsed task IDs").All()
+		require.Len(t, unparsedLogs, 1)
+		require.Len(t, unparsedLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
+	})
+
+	t.Run("unparsed files respect the object bound", func(t *testing.T) {
+		store := &testStorage{Storage: objstore.NewMemStorage()}
+		for i := range maxObjectsPerFlush + 1 {
+			writeTestFiles(t, store, fmt.Sprintf("conflicted-rows/not-a-task/data-%04d", i))
+		}
+
+		stats, err := cleanFiles(context.Background(), store, taskInfoGetterFunc(
+			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
+				require.FailNow(t, "metadata lookup should not run")
+				return nil, nil
+			}), now)
+		require.NoError(t, err)
+		require.Zero(t, stats.candidateTasks)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.unparsedTaskIDFiles)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
+		require.Len(t, store.deleteCalls, 1)
+		require.Len(t, store.deleteCalls[0], maxObjectsPerFlush+1)
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		store := objstore.NewMemStorage()
+		writeTestFiles(t, store, "conflicted-rows/1/data")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		stats, err := cleanFiles(ctx, store, taskInfoGetterFunc(
+			func(context.Context, []int64) (map[int64]storage.TaskCleanupInfo, error) {
+				require.FailNow(t, "metadata lookup should not run")
+				return nil, nil
+			}), now)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, int64(1), stats.failures)
+	})
+}
+
+func TestCleanExpiredFiles(t *testing.T) {
+	t.Run("empty URI", func(t *testing.T) {
+		require.NoError(t, CleanExpiredFiles(context.Background(), nil, ""))
+	})
+
+	t.Run("open error does not log URI", func(t *testing.T) {
+		const credentialURI = "unsupported://access:secret@example/bucket"
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
+		t.Cleanup(restoreLog)
+
+		err := CleanExpiredFiles(context.Background(), nil, credentialURI)
+		require.Error(t, err)
+		for _, entry := range logs.All() {
+			require.NotContains(t, entry.Message+fmt.Sprint(entry.ContextMap()), credentialURI)
+			require.NotContains(t, entry.Message+fmt.Sprint(entry.ContextMap()), "secret")
+		}
+		summaryLogs := logs.FilterMessage("finished conflict-row file cleanup").All()
+		require.Len(t, summaryLogs, 1)
+		require.Equal(t, int64(1), summaryLogs[0].ContextMap()["failures"])
+	})
+}

--- a/pkg/dxf/importinto/conflictrows/cleanup_test.go
+++ b/pkg/dxf/importinto/conflictrows/cleanup_test.go
@@ -16,6 +16,7 @@ package conflictrows
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -83,6 +84,29 @@ func requireTestFileExists(t *testing.T, store storeapi.Storage, name string, wa
 	exists, err := store.FileExists(context.Background(), name)
 	require.NoError(t, err)
 	require.Equal(t, want, exists, name)
+}
+
+func requireLoggedCleanupStats(t *testing.T, value any) (cleanupStats, map[string]json.RawMessage) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	var logged cleanupStats
+	require.NoError(t, json.Unmarshal(encoded, &logged))
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &fields))
+	return logged, fields
+}
+
+func requireLoggedCountWithSamples(t *testing.T, value json.RawMessage, want *countWithSamples) {
+	t.Helper()
+	var logged countWithSamples
+	require.NoError(t, json.Unmarshal(value, &logged))
+	require.Equal(t, want, &logged)
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(value, &fields))
+	require.Len(t, fields, 2)
+	require.Contains(t, fields, "count")
+	require.Contains(t, fields, "samples")
 }
 
 func failedImportInfo(taskID int64) *storage.TaskCleanupInfo {
@@ -169,12 +193,10 @@ func TestCleanFiles(t *testing.T) {
 				name:              "missing task",
 				shouldDeleteFiles: true,
 				wantStats: cleanupStats{
-					candidateTasks:        1,
-					deletedTasks:          1,
-					missingTasks:          1,
-					missingTaskFiles:      2,
-					firstMissingTaskIDs:   []int64{1},
-					firstMissingTaskFiles: files,
+					CandidateTasks:   1,
+					DeletedTasks:     1,
+					MissingTasks:     &countWithSamples{Count: 1, Samples: []string{"1"}},
+					MissingTaskFiles: &countWithSamples{Count: 2, Samples: files},
 				},
 			},
 			{
@@ -182,10 +204,9 @@ func TestCleanFiles(t *testing.T) {
 				info:              &storage.TaskCleanupInfo{Type: proto.TaskTypeExample},
 				shouldDeleteFiles: true,
 				wantStats: cleanupStats{
-					candidateTasks:              1,
-					deletedTasks:                1,
-					nonImportIntoTaskFiles:      2,
-					firstNonImportIntoTaskFiles: files,
+					CandidateTasks:         1,
+					DeletedTasks:           1,
+					NonImportIntoTaskFiles: &countWithSamples{Count: 2, Samples: files},
 				},
 			},
 			{
@@ -193,16 +214,16 @@ func TestCleanFiles(t *testing.T) {
 				info:              &storage.TaskCleanupInfo{Type: proto.ImportInto},
 				shouldDeleteFiles: true,
 				wantStats: cleanupStats{
-					candidateTasks: 1,
-					deletedTasks:   1,
+					CandidateTasks: 1,
+					DeletedTasks:   1,
 				},
 			},
 			{
 				name: "retain task",
 				info: &storage.TaskCleanupInfo{Type: proto.ImportInto},
 				wantStats: cleanupStats{
-					candidateTasks: 1,
-					retainedTasks:  1,
+					CandidateTasks: 1,
+					RetainedTasks:  1,
 				},
 			},
 		}
@@ -214,6 +235,29 @@ func TestCleanFiles(t *testing.T) {
 				require.Equal(t, testCase.wantStats, stats)
 			})
 		}
+	})
+
+	t.Run("empty stats are logged as an empty object", func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
+		t.Cleanup(restoreLog)
+
+		stats, err := cleanFiles(context.Background(), objstore.NewMemStorage(), taskInfoGetterFunc(
+			func(context.Context, []int64) (map[int64]*storage.TaskCleanupInfo, error) {
+				require.FailNow(t, "metadata lookup should not run")
+				return nil, nil
+			}), now)
+		require.NoError(t, err)
+		require.Equal(t, cleanupStats{}, stats)
+
+		entries := logs.All()
+		require.Len(t, entries, 1)
+		require.Equal(t, "finished conflict-row file cleanup", entries[0].Message)
+		fields := entries[0].ContextMap()
+		require.Len(t, fields, 1)
+		require.Contains(t, fields, "stats")
+		_, loggedFields := requireLoggedCleanupStats(t, fields["stats"])
+		require.Empty(t, loggedFields)
 	})
 
 	t.Run("mixed decisions", func(t *testing.T) {
@@ -241,14 +285,14 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Equal(t, int64(4), stats.candidateTasks)
-		require.Equal(t, int64(1), stats.retainedTasks)
-		require.Equal(t, int64(3), stats.deletedTasks)
-		require.Equal(t, int64(4), stats.deletedFiles)
-		require.Zero(t, stats.missingTasks)
-		require.Equal(t, int64(1), stats.nonImportIntoTaskFiles)
-		require.Equal(t, int64(1), stats.unparsedTaskIDFiles)
-		require.Zero(t, stats.failures)
+		require.Equal(t, int64(4), stats.CandidateTasks)
+		require.Equal(t, int64(1), stats.RetainedTasks)
+		require.Equal(t, int64(3), stats.DeletedTasks)
+		require.Equal(t, int64(4), stats.DeletedFiles)
+		require.Nil(t, stats.MissingTasks)
+		require.Equal(t, int64(1), stats.NonImportIntoTaskFiles.Count)
+		require.Equal(t, int64(1), stats.UnparsedTaskIDFiles.Count)
+		require.Zero(t, stats.Failures)
 		require.Equal(t, storagePrefix, store.walkOptions[0].SubDir)
 		requireTestFileExists(t, store, files[0], false)
 		requireTestFileExists(t, store, files[1], true)
@@ -277,7 +321,7 @@ func TestCleanFiles(t *testing.T) {
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
 		require.Equal(t, []int{maxTaskIDsPerFlush + 1}, lookupSizes)
-		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.deletedFiles)
+		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.DeletedFiles)
 		require.Len(t, store.deleteCalls, 1)
 		require.Len(t, store.deleteCalls[0], maxTaskIDsPerFlush+1)
 	})
@@ -296,7 +340,7 @@ func TestCleanFiles(t *testing.T) {
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
 		require.Equal(t, []int{1}, lookupSizes)
-		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
 		require.Len(t, store.deleteCalls, 1)
 		require.Len(t, store.deleteCalls[0], maxObjectsPerFlush+1)
 	})
@@ -327,8 +371,8 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.ErrorIs(t, err, lookupErr)
-		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.deletedFiles)
-		require.Equal(t, int64(1), stats.failures)
+		require.Equal(t, int64(maxTaskIDsPerFlush+1), stats.DeletedFiles)
+		require.Equal(t, int64(1), stats.Failures)
 
 		getter = func(_ context.Context, taskIDs []int64) (map[int64]*storage.TaskCleanupInfo, error) {
 			result := make(map[int64]*storage.TaskCleanupInfo, len(taskIDs))
@@ -343,7 +387,7 @@ func TestCleanFiles(t *testing.T) {
 		}
 		stats, err = cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Zero(t, stats.deletedFiles)
+		require.Zero(t, stats.DeletedFiles)
 		requireTestFileExists(t, store, "conflicted-rows/999/retain", true)
 	})
 
@@ -364,23 +408,22 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.ErrorIs(t, err, deleteErr)
-		require.Equal(t, int64(1), stats.candidateTasks)
-		require.Zero(t, stats.retainedTasks)
-		require.Equal(t, int64(1), stats.deletedTasks)
-		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
-		require.Zero(t, stats.missingTasks)
-		require.Empty(t, stats.firstMissingTaskIDs)
-		require.Equal(t, int64(1), stats.failures)
+		require.Equal(t, int64(1), stats.CandidateTasks)
+		require.Zero(t, stats.RetainedTasks)
+		require.Equal(t, int64(1), stats.DeletedTasks)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
+		require.Nil(t, stats.MissingTasks)
+		require.Equal(t, int64(1), stats.Failures)
 
 		store.failDeleteAt = 0
 		stats, err = cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), stats.deletedFiles)
-		require.Equal(t, int64(1), stats.missingTasks)
-		require.Equal(t, int64(1), stats.missingTaskFiles)
+		require.Equal(t, int64(1), stats.DeletedFiles)
+		require.Equal(t, int64(1), stats.MissingTasks.Count)
+		require.Equal(t, int64(1), stats.MissingTaskFiles.Count)
 	})
 
-	t.Run("missing metadata warning is bounded", func(t *testing.T) {
+	t.Run("missing metadata diagnostics are bounded", func(t *testing.T) {
 		core, logs := observer.New(zap.InfoLevel)
 		restoreLog := log.ReplaceGlobals(zap.New(core), &log.ZapProperties{Level: zap.NewAtomicLevelAt(zap.InfoLevel)})
 		t.Cleanup(restoreLog)
@@ -394,25 +437,34 @@ func TestCleanFiles(t *testing.T) {
 				return map[int64]*storage.TaskCleanupInfo{}, nil
 			}), now)
 		require.NoError(t, err)
-		require.Equal(t, int64(20), stats.candidateTasks)
-		require.Zero(t, stats.retainedTasks)
-		require.Equal(t, int64(20), stats.deletedTasks)
-		require.Equal(t, int64(20), stats.deletedFiles)
-		require.Equal(t, int64(20), stats.missingTasks)
-		require.Equal(t, int64(20), stats.missingTaskFiles)
-		require.Len(t, stats.firstMissingTaskIDs, maxLoggedMissingTaskIDs)
-		require.Equal(t, []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, stats.firstMissingTaskIDs)
-		require.Len(t, stats.firstMissingTaskFiles, maxLoggedUnexpectedFiles)
+		require.Equal(t, int64(20), stats.CandidateTasks)
+		require.Zero(t, stats.RetainedTasks)
+		require.Equal(t, int64(20), stats.DeletedTasks)
+		require.Equal(t, int64(20), stats.DeletedFiles)
+		require.Equal(t, int64(20), stats.MissingTasks.Count)
+		require.Equal(t, int64(20), stats.MissingTaskFiles.Count)
+		require.Len(t, stats.MissingTasks.Samples, maxLoggedSamples)
+		require.Equal(t,
+			[]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"},
+			stats.MissingTasks.Samples)
+		require.Len(t, stats.MissingTaskFiles.Samples, maxLoggedSamples)
 
-		warningLogs := logs.FilterMessage("conflict-row cleanup deleted objects without task metadata").All()
-		require.Len(t, warningLogs, 1)
-		require.Equal(t, int64(20), warningLogs[0].ContextMap()["missing-tasks"])
-		require.Len(t, warningLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
-		summaryLogs := logs.FilterMessage("finished conflict-row file cleanup").All()
-		require.Len(t, summaryLogs, 1)
-		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["candidate-tasks"])
-		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["missing-tasks"])
-		require.Equal(t, int64(20), summaryLogs[0].ContextMap()["missing-task-files"])
+		entries := logs.All()
+		require.Len(t, entries, 1)
+		require.Equal(t, zap.InfoLevel, entries[0].Level)
+		require.Equal(t, "finished conflict-row file cleanup", entries[0].Message)
+		fields := entries[0].ContextMap()
+		require.Len(t, fields, 1)
+		loggedStats, loggedFields := requireLoggedCleanupStats(t, fields["stats"])
+		require.Equal(t, int64(20), loggedStats.CandidateTasks)
+		require.Equal(t, int64(20), loggedStats.DeletedTasks)
+		require.Equal(t, int64(20), loggedStats.DeletedFiles)
+		requireLoggedCountWithSamples(t, loggedFields["missing-tasks"], stats.MissingTasks)
+		requireLoggedCountWithSamples(t, loggedFields["missing-task-files"], stats.MissingTaskFiles)
+		require.NotContains(t, loggedFields, "retained-tasks")
+		require.NotContains(t, loggedFields, "non-import-into-task-files")
+		require.NotContains(t, loggedFields, "unparsed-task-id-files")
+		require.NotContains(t, loggedFields, "failures")
 	})
 
 	t.Run("unexpected file diagnostics are bounded", func(t *testing.T) {
@@ -435,20 +487,32 @@ func TestCleanFiles(t *testing.T) {
 
 		stats, err := cleanFiles(context.Background(), store, getter, now)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), stats.candidateTasks)
-		require.Equal(t, int64(1), stats.deletedTasks)
-		require.Equal(t, int64(40), stats.deletedFiles)
-		require.Equal(t, int64(20), stats.nonImportIntoTaskFiles)
-		require.Equal(t, int64(20), stats.unparsedTaskIDFiles)
-		require.Len(t, stats.firstNonImportIntoTaskFiles, maxLoggedUnexpectedFiles)
-		require.Len(t, stats.firstUnparsedTaskIDFiles, maxLoggedUnexpectedFiles)
+		require.Equal(t, int64(1), stats.CandidateTasks)
+		require.Equal(t, int64(1), stats.DeletedTasks)
+		require.Equal(t, int64(40), stats.DeletedFiles)
+		require.Equal(t, int64(20), stats.NonImportIntoTaskFiles.Count)
+		require.Equal(t, int64(20), stats.UnparsedTaskIDFiles.Count)
+		require.Len(t, stats.NonImportIntoTaskFiles.Samples, maxLoggedSamples)
+		require.Len(t, stats.UnparsedTaskIDFiles.Samples, maxLoggedSamples)
 
-		nonImportLogs := logs.FilterMessage("conflict-row cleanup deleted objects for non-import-into tasks").All()
-		require.Len(t, nonImportLogs, 1)
-		require.Len(t, nonImportLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
-		unparsedLogs := logs.FilterMessage("conflict-row cleanup deleted objects with unparsed task IDs").All()
-		require.Len(t, unparsedLogs, 1)
-		require.Len(t, unparsedLogs[0].ContextMap()["file-samples"], maxLoggedUnexpectedFiles)
+		entries := logs.All()
+		require.Len(t, entries, 1)
+		require.Equal(t, zap.InfoLevel, entries[0].Level)
+		require.Equal(t, "finished conflict-row file cleanup", entries[0].Message)
+		fields := entries[0].ContextMap()
+		require.Len(t, fields, 1)
+		loggedStats, loggedFields := requireLoggedCleanupStats(t, fields["stats"])
+		require.Equal(t, int64(1), loggedStats.CandidateTasks)
+		require.Equal(t, int64(1), loggedStats.DeletedTasks)
+		require.Equal(t, int64(40), loggedStats.DeletedFiles)
+		requireLoggedCountWithSamples(t,
+			loggedFields["non-import-into-task-files"], stats.NonImportIntoTaskFiles)
+		requireLoggedCountWithSamples(t,
+			loggedFields["unparsed-task-id-files"], stats.UnparsedTaskIDFiles)
+		require.NotContains(t, loggedFields, "retained-tasks")
+		require.NotContains(t, loggedFields, "missing-tasks")
+		require.NotContains(t, loggedFields, "missing-task-files")
+		require.NotContains(t, loggedFields, "failures")
 	})
 
 	t.Run("unparsed files respect the object bound", func(t *testing.T) {
@@ -463,9 +527,9 @@ func TestCleanFiles(t *testing.T) {
 				return nil, nil
 			}), now)
 		require.NoError(t, err)
-		require.Zero(t, stats.candidateTasks)
-		require.Equal(t, int64(maxObjectsPerFlush+1), stats.unparsedTaskIDFiles)
-		require.Equal(t, int64(maxObjectsPerFlush+1), stats.deletedFiles)
+		require.Zero(t, stats.CandidateTasks)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.UnparsedTaskIDFiles.Count)
+		require.Equal(t, int64(maxObjectsPerFlush+1), stats.DeletedFiles)
 		require.Len(t, store.deleteCalls, 1)
 		require.Len(t, store.deleteCalls[0], maxObjectsPerFlush+1)
 	})
@@ -481,7 +545,7 @@ func TestCleanFiles(t *testing.T) {
 				return nil, nil
 			}), now)
 		require.ErrorIs(t, err, context.Canceled)
-		require.Equal(t, int64(1), stats.failures)
+		require.Equal(t, int64(1), stats.Failures)
 	})
 }
 
@@ -498,12 +562,6 @@ func TestCleanExpiredFiles(t *testing.T) {
 
 		err := CleanExpiredFiles(context.Background(), nil, credentialURI)
 		require.Error(t, err)
-		for _, entry := range logs.All() {
-			require.NotContains(t, entry.Message+fmt.Sprint(entry.ContextMap()), credentialURI)
-			require.NotContains(t, entry.Message+fmt.Sprint(entry.ContextMap()), "secret")
-		}
-		summaryLogs := logs.FilterMessage("finished conflict-row file cleanup").All()
-		require.Len(t, summaryLogs, 1)
-		require.Equal(t, int64(1), summaryLogs[0].ContextMap()["failures"])
+		require.Empty(t, logs.All())
 	})
 }

--- a/pkg/dxf/importinto/conflictrows/path.go
+++ b/pkg/dxf/importinto/conflictrows/path.go
@@ -26,7 +26,9 @@ const (
 )
 
 // NewFileNamePrefix returns a new file name prefix used to store the conflict
-// rows for the given task and subtask.
+// rows for the given task and subtask. All files under storagePrefix must use a
+// prefix returned by this function; CleanConflictRowFiles treats malformed paths
+// in that namespace as invalid files and deletes them.
 func NewFileNamePrefix(taskID, subtaskID int64) string {
 	// Keep these files available for user inspection. They must not live directly
 	// under '<task-id>/', where global-sort cleanup would delete them with temp data.

--- a/pkg/dxf/importinto/conflictrows/path.go
+++ b/pkg/dxf/importinto/conflictrows/path.go
@@ -1,0 +1,34 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conflictrows
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const (
+	storageDir    = "conflicted-rows"
+	storagePrefix = storageDir + "/"
+)
+
+// NewFileNamePrefix returns a new file name prefix used to store the conflict
+// rows for the given task and subtask.
+func NewFileNamePrefix(taskID, subtaskID int64) string {
+	// Keep these files available for user inspection. They must not live directly
+	// under '<task-id>/', where global-sort cleanup would delete them with temp data.
+	return fmt.Sprintf("%s/%d/%d-%s", storageDir, taskID, subtaskID, uuid.NewString())
+}


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #66019

Problem Summary:

Next-generation `IMPORT INTO` conflict resolution needs a dedicated lifecycle for conflict-row objects. The files must remain available long enough for inspection without being retained indefinitely or being removed with temporary global-sort data.

### What changed and how does it work?

- Add unique conflict-row filename prefixes under `conflicted-rows/<task-id>/`, outside the task's temporary global-sort directory.
- Add bounded object scanning, task metadata lookup, and batch deletion for conflict-row cleanup.
- Retain rows from successful import tasks for seven days, delete rows from failed or reverted tasks immediately, and remove orphaned, non-import, or malformed entries with bounded diagnostics.
- Expose the task cleanup metadata value type required by the cleanup package. Scheduler integration will follow separately.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```text
make bazel_prepare
go test ./pkg/dxf/importinto/conflictrows -run 'Test(ParseTaskID|ShouldDelete|CleanFiles|CleanExpiredFiles)$' -tags=intest,deadlock -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for stored conflict-row files.
  * Removes malformed, incomplete, failed, reverted, missing-task, and expired files while retaining eligible files.
  * Added standardized conflict-row file naming for improved storage management.
  * Cleanup supports batched task-metadata lookups and configurable retention handling.
* **Bug Fixes**
  * Handles storage and metadata errors safely, including retries and canceled operations.
  * Limits diagnostic output and redacts sensitive storage credentials.
  * Improved cleanup reporting with consolidated, structured statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->