### PR TITLE
executor: track window memory usage

### DIFF
--- a/pkg/executor/explain_test.go
+++ b/pkg/executor/explain_test.go
@@ -52,11 +52,15 @@ func TestExplainAnalyzeMemory(t *testing.T) {
 	checkMemoryInfo(t, tk, "explain analyze select k from t use index(k)")
 	checkMemoryInfo(t, tk, "explain analyze select * from t use index(k)")
 	checkMemoryInfo(t, tk, "explain analyze select v+k from t")
+	for _, pipelined := range []string{"0", "1"} {
+		tk.MustExec("set @@tidb_enable_pipelined_window_function=" + pipelined)
+		checkMemoryInfo(t, tk, "explain analyze select sum(v) over () from t")
+	}
 }
 
 func checkMemoryInfo(t *testing.T, tk *testkit.TestKit, sql string) {
-	memCol := 6
-	ops := []string{"Join", "Reader", "Top", "Sort", "LookUp", "Projection", "Selection", "Agg"}
+	memCol := 7
+	ops := []string{"Join", "Reader", "Top", "Sort", "LookUp", "Projection", "Selection", "Agg", "Window"}
 	rows := tk.MustQuery(sql).Rows()
 	for _, row := range rows {
 		strs := make([]string, len(row))
@@ -77,6 +81,9 @@ func checkMemoryInfo(t *testing.T, tk *testkit.TestKit, sql string) {
 
 		if shouldHasMem {
 			require.NotEqual(t, "N/A", strs[memCol])
+			if strings.Contains(strs[0], "Window") {
+				require.NotEqual(t, "0 Bytes", strs[memCol])
+			}
 		} else {
 			require.Equal(t, "N/A", strs[memCol])
 		}
@@ -114,6 +121,13 @@ func TestMemoryAndDiskUsageAfterClose(t *testing.T) {
 	}
 	for _, sql := range SQLs {
 		tk.MustQuery(sql)
+		require.Equal(t, int64(0), tk.Session().GetSessionVars().StmtCtx.MemTracker.BytesConsumed())
+		require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0))
+		require.Equal(t, int64(0), tk.Session().GetSessionVars().StmtCtx.DiskTracker.BytesConsumed())
+	}
+	for _, pipelined := range []string{"0", "1"} {
+		tk.MustExec("set @@tidb_enable_pipelined_window_function=" + pipelined)
+		tk.MustQuery("select rank() over (order by v) from t")
 		require.Equal(t, int64(0), tk.Session().GetSessionVars().StmtCtx.MemTracker.BytesConsumed())
 		require.Greater(t, tk.Session().GetSessionVars().StmtCtx.MemTracker.MaxConsumed(), int64(0))
 		require.Equal(t, int64(0), tk.Session().GetSessionVars().StmtCtx.DiskTracker.BytesConsumed())

--- a/pkg/executor/windows/BUILD.bazel
+++ b/pkg/executor/windows/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/planner/core/operator/physicalop",
         "//pkg/sessionctx",
         "//pkg/util/chunk",
+        "//pkg/util/memory",
         "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/pkg/executor/windows/builder.go
+++ b/pkg/executor/windows/builder.go
@@ -54,6 +54,7 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 	}
 	windowFuncs := make([]aggfuncs.AggFunc, 0, len(v.WindowFuncDescs))
 	partialResults := make([]aggfuncs.PartialResult, 0, len(v.WindowFuncDescs))
+	initialPartialResultMemUsage := int64(0)
 	resultColIdx := v.Schema().Len() - len(v.WindowFuncDescs)
 	exprCtx := sctx.GetExprCtx()
 	for _, desc := range v.WindowFuncDescs {
@@ -63,10 +64,12 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 		}
 		agg := aggfuncs.BuildWindowFunctions(exprCtx, aggDesc, resultColIdx, orderByCols)
 		windowFuncs = append(windowFuncs, agg)
-		partialResult, _ := agg.AllocPartialResult()
+		partialResult, memDelta := agg.AllocPartialResult()
 		partialResults = append(partialResults, partialResult)
+		initialPartialResultMemUsage += memDelta
 		resultColIdx++
 	}
+	memTracker := newWindowMemoryTracker(initialPartialResultMemUsage, len(windowFuncs))
 
 	if forcePipelined || sctx.GetSessionVars().EnablePipelinedWindowExec {
 		exec := &PipelinedWindowExec{
@@ -75,6 +78,7 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 			numWindowFuncs: len(v.WindowFuncDescs),
 			windowFuncs:    windowFuncs,
 			partialResults: partialResults,
+			memTracker:     memTracker,
 		}
 		exec.slidingWindowFuncs = make([]aggfuncs.SlidingWindowAggFunc, len(exec.windowFuncs))
 		for i, windowFunc := range exec.windowFuncs {
@@ -112,6 +116,7 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 		processor = &aggWindowProcessor{
 			windowFuncs:    windowFuncs,
 			partialResults: partialResults,
+			memTracker:     memTracker,
 		}
 	} else if v.Frame.Type == ast.Rows {
 		processor = &rowFrameWindowProcessor{
@@ -119,6 +124,7 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 			partialResults: partialResults,
 			start:          v.Frame.Start,
 			end:            v.Frame.End,
+			memTracker:     memTracker,
 		}
 	} else {
 		cmpResult := int64(-1)
@@ -132,6 +138,7 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 			end:               v.Frame.End,
 			orderByCols:       orderByCols,
 			expectedCmpResult: cmpResult,
+			memTracker:        memTracker,
 		}
 		if err := tmpProcessor.start.UpdateCompareCols(sctx, orderByCols); err != nil {
 			return nil, err
@@ -146,5 +153,6 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 		processor:      processor,
 		groupChecker:   vecgroupchecker.NewVecGroupChecker(sctx.GetExprCtx().GetEvalCtx(), sctx.GetSessionVars().EnableVectorizedExpression, groupByItems),
 		numWindowFuncs: len(v.WindowFuncDescs),
+		memTracker:     memTracker,
 	}, nil
 }

--- a/pkg/executor/windows/builder.go
+++ b/pkg/executor/windows/builder.go
@@ -69,7 +69,10 @@ func Build(sctx sessionctx.Context, v *physicalop.PhysicalWindow, childExec exec
 		initialPartialResultMemUsage += memDelta
 		resultColIdx++
 	}
-	memTracker := newWindowMemoryTracker(initialPartialResultMemUsage, len(windowFuncs))
+	memTracker := newWindowMemoryTracker(
+		initialPartialResultMemUsage,
+		len(windowFuncs),
+	)
 
 	if forcePipelined || sctx.GetSessionVars().EnablePipelinedWindowExec {
 		exec := &PipelinedWindowExec{

--- a/pkg/executor/windows/pipelined_window.go
+++ b/pkg/executor/windows/pipelined_window.go
@@ -16,6 +16,7 @@ package windows
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
@@ -34,6 +35,8 @@ type dataInfo struct {
 	accumulated uint64
 }
 
+const dataInfoSize = int64(unsafe.Sizeof(dataInfo{}))
+
 // PipelinedWindowExec is the executor for window functions.
 type PipelinedWindowExec struct {
 	exec.BaseExecutor
@@ -41,14 +44,16 @@ type PipelinedWindowExec struct {
 	windowFuncs        []aggfuncs.AggFunc
 	slidingWindowFuncs []aggfuncs.SlidingWindowAggFunc
 	partialResults     []aggfuncs.PartialResult
+	memTracker         *windowMemoryTracker
 	start              *logicalop.FrameBound
 	end                *logicalop.FrameBound
 	groupChecker       *vecgroupchecker.VecGroupChecker
 
 	// childResult stores the child chunk. Note that even if remaining is 0, e.rows might still references rows in data[0].chk after returned it to upper executor, since there is no guarantee what the upper executor will do to the returned chunk, it might destroy the data (as in the benchmark test, it reused the chunk to pull data, and it will be chk.Reset(), causing panicking). So dataIdx, accumulated and dropped are added to ensure that chunk will only be returned if there is no row reference.
-	childResult *chunk.Chunk
-	data        []dataInfo
-	dataIdx     int
+	childResult  *chunk.Chunk
+	data         []dataInfo
+	dataIdx      int
+	dataMemUsage int64
 
 	// done indicates the child executor is drained or something unexpected happened.
 	done         bool
@@ -70,6 +75,7 @@ type PipelinedWindowExec struct {
 
 	// rows keeps rows starting from curStartRow
 	rows                     []chunk.Row
+	rowsMemUsage             int64
 	rowCnt                   uint64
 	whole                    bool
 	isRangeFrame             bool
@@ -85,6 +91,14 @@ type OrderedWindowExec struct {
 
 // Close implements the Executor Close interface.
 func (e *PipelinedWindowExec) Close() error {
+	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
+	e.childResult = nil
+	e.data = nil
+	e.rows = nil
+	e.dataMemUsage = 0
+	e.rowsMemUsage = 0
+	e.groupChecker.Reset()
+	e.memTracker.close()
 	return errors.Trace(e.BaseExecutor.Close())
 }
 
@@ -98,10 +112,15 @@ func (e *PipelinedWindowExec) Open(ctx context.Context) (err error) {
 
 // OpenSelf initializes the executor state without opening children.
 func (e *PipelinedWindowExec) OpenSelf() error {
+	e.memTracker.open(e.ID(), e.Ctx().GetSessionVars().StmtCtx.MemTracker)
 	e.done, e.newPartition, e.whole, e.initializedSlidingWindow = false, false, false, false
 	e.dataIdx, e.curRowIdx, e.dropped, e.rowToConsume, e.accumulated = 0, 0, 0, 0, 0
 	e.lastStartRow, e.lastEndRow, e.stagedStartRow, e.stagedEndRow, e.rowStart, e.rowCnt = 0, 0, 0, 0, 0, 0
-	e.rows, e.data = make([]chunk.Row, 0), make([]dataInfo, 0)
+	e.rows, e.data = nil, nil
+	e.rowsMemUsage, e.dataMemUsage = 0, 0
+	e.childResult = nil
+	e.groupChecker.Reset()
+	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
 	return nil
 }
 
@@ -156,7 +175,10 @@ func (e *PipelinedWindowExec) Next(ctx context.Context, chk *chunk.Chunk) (err e
 
 		// e.p is ready to produce data
 		if len(e.data) > e.dataIdx && e.data[e.dataIdx].remaining != 0 {
-			produced, err := e.produce(e.Ctx(), e.data[e.dataIdx].chk, e.data[e.dataIdx].remaining)
+			resultChk := e.data[e.dataIdx].chk
+			oldMemUsage := resultChk.MemoryUsage()
+			produced, err := e.produce(e.Ctx(), resultChk, e.data[e.dataIdx].remaining)
+			e.memTracker.consume(resultChk.MemoryUsage() - oldMemUsage)
 			if err != nil {
 				return err
 			}
@@ -167,9 +189,19 @@ func (e *PipelinedWindowExec) Next(ctx context.Context, chk *chunk.Chunk) (err e
 		}
 	}
 	if len(e.data) > 0 {
-		chk.SwapColumns(e.data[0].chk)
+		resultChk := e.data[0].chk
+		// The output chunk takes ownership of the referenced input columns here.
+		// Stop charging them to Window before swapping the column pointers.
+		e.memTracker.consume(-resultChk.MemoryUsage())
+		chk.SwapColumns(resultChk)
+		e.data[0] = dataInfo{}
 		e.data = e.data[1:]
 		e.dataIdx--
+		if len(e.data) == 0 {
+			e.data = nil
+			e.memTracker.consume(-e.dataMemUsage)
+			e.dataMemUsage = 0
+		}
 	}
 	return nil
 }
@@ -203,8 +235,14 @@ func (e *PipelinedWindowExec) getRowsInPartition(ctx context.Context) (err error
 	}
 	begin, end := e.groupChecker.GetNextGroup()
 	e.rowToConsume += uint64(end - begin)
+	oldRowsCap := cap(e.rows)
 	for i := begin; i < end; i++ {
 		e.rows = append(e.rows, e.childResult.GetRow(i))
+	}
+	if cap(e.rows) != oldRowsCap {
+		newMemUsage := int64(cap(e.rows)) * aggfuncs.DefRowSize
+		e.memTracker.consume(newMemUsage - e.rowsMemUsage)
+		e.rowsMemUsage = newMemUsage
 	}
 	return
 }
@@ -229,7 +267,16 @@ func (e *PipelinedWindowExec) fetchChild(ctx context.Context) (eof bool, err err
 		return false, err
 	}
 	e.accumulated += uint64(numRows)
+	oldDataCap := cap(e.data)
 	e.data = append(e.data, dataInfo{chk: resultChk, remaining: uint64(numRows), accumulated: e.accumulated})
+	// resultChk references the input columns in childResult. Charge only the
+	// retained result chunk so shared column buffers are not counted twice.
+	e.memTracker.consume(resultChk.MemoryUsage())
+	if cap(e.data) != oldDataCap {
+		newMemUsage := int64(cap(e.data)) * dataInfoSize
+		e.memTracker.consume(newMemUsage - e.dataMemUsage)
+		e.dataMemUsage = newMemUsage
+	}
 
 	e.childResult = childResult
 	return false, nil
@@ -372,7 +419,7 @@ func (e *PipelinedWindowExec) produce(ctx sessionctx.Context, chk *chunk.Chunk, 
 		if start >= end {
 			for i, wf := range e.windowFuncs {
 				if !e.emptyFrame {
-					wf.ResetPartialResult(e.partialResults[i])
+					e.memTracker.resetPartialResult(i, wf, e.partialResults[i])
 				}
 				err = wf.AppendFinalResult2Chunk(ctx.GetExprCtx().GetEvalCtx(), e.partialResults[i], chk)
 				if err != nil {
@@ -397,9 +444,8 @@ func (e *PipelinedWindowExec) produce(ctx sessionctx.Context, chk *chunk.Chunk, 
 							// Store start inside MaxMinSlidingWindowAggFunc.windowInfo
 							minMaxSlidingWindowAggFunc.SetWindowStart(start)
 						}
-						// TODO(zhifeng): track memory usage here
-						wf.ResetPartialResult(e.partialResults[i])
-						_, err = wf.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), e.getRows(start, end), e.partialResults[i])
+						e.memTracker.resetPartialResult(i, wf, e.partialResults[i])
+						err = e.memTracker.updatePartialResult(i, wf, ctx, e.getRows(start, end), e.partialResults[i])
 					}
 				}
 				if err != nil {
@@ -461,7 +507,5 @@ func (e *PipelinedWindowExec) reset() {
 	e.rowStart = 0
 	e.rowCnt = 0
 	e.initializedSlidingWindow = false
-	for i, windowFunc := range e.windowFuncs {
-		windowFunc.ResetPartialResult(e.partialResults[i])
-	}
+	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
 }

--- a/pkg/executor/windows/pipelined_window.go
+++ b/pkg/executor/windows/pipelined_window.go
@@ -91,7 +91,6 @@ type OrderedWindowExec struct {
 
 // Close implements the Executor Close interface.
 func (e *PipelinedWindowExec) Close() error {
-	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
 	e.childResult = nil
 	e.data = nil
 	e.rows = nil
@@ -120,7 +119,6 @@ func (e *PipelinedWindowExec) OpenSelf() error {
 	e.rowsMemUsage, e.dataMemUsage = 0, 0
 	e.childResult = nil
 	e.groupChecker.Reset()
-	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
 	return nil
 }
 
@@ -419,7 +417,7 @@ func (e *PipelinedWindowExec) produce(ctx sessionctx.Context, chk *chunk.Chunk, 
 		if start >= end {
 			for i, wf := range e.windowFuncs {
 				if !e.emptyFrame {
-					e.memTracker.resetPartialResult(i, wf, e.partialResults[i])
+					resetPartialResultAndReleaseMemory(e.memTracker, i, wf, e.partialResults[i])
 				}
 				err = wf.AppendFinalResult2Chunk(ctx.GetExprCtx().GetEvalCtx(), e.partialResults[i], chk)
 				if err != nil {
@@ -444,8 +442,8 @@ func (e *PipelinedWindowExec) produce(ctx sessionctx.Context, chk *chunk.Chunk, 
 							// Store start inside MaxMinSlidingWindowAggFunc.windowInfo
 							minMaxSlidingWindowAggFunc.SetWindowStart(start)
 						}
-						e.memTracker.resetPartialResult(i, wf, e.partialResults[i])
-						err = e.memTracker.updatePartialResult(i, wf, ctx, e.getRows(start, end), e.partialResults[i])
+						resetPartialResultAndReleaseMemory(e.memTracker, i, wf, e.partialResults[i])
+						err = updatePartialResultAndTrackMemory(e.memTracker, i, wf, ctx, e.getRows(start, end), e.partialResults[i])
 					}
 				}
 				if err != nil {
@@ -507,5 +505,5 @@ func (e *PipelinedWindowExec) reset() {
 	e.rowStart = 0
 	e.rowCnt = 0
 	e.initializedSlidingWindow = false
-	e.memTracker.resetAllPartialResults(e.windowFuncs, e.partialResults)
+	resetPartialResultsAndReleaseMemory(e.memTracker, e.windowFuncs, e.partialResults)
 }

--- a/pkg/executor/windows/window.go
+++ b/pkg/executor/windows/window.go
@@ -16,6 +16,7 @@ package windows
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/executor/aggfuncs"
@@ -26,7 +27,76 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/memory"
 )
+
+const (
+	chunkPointerSize = int64(unsafe.Sizeof((*chunk.Chunk)(nil)))
+	intSize          = int64(unsafe.Sizeof(int(0)))
+)
+
+type windowMemoryTracker struct {
+	tracker                      *memory.Tracker
+	initialPartialResultMemUsage int64
+	partialResultMemUsage        []int64
+}
+
+func newWindowMemoryTracker(initialPartialResultMemUsage int64, numWindowFuncs int) *windowMemoryTracker {
+	return &windowMemoryTracker{
+		initialPartialResultMemUsage: initialPartialResultMemUsage,
+		partialResultMemUsage:        make([]int64, numWindowFuncs),
+	}
+}
+
+func (t *windowMemoryTracker) open(label int, stmtTracker *memory.Tracker) {
+	if t.tracker == nil {
+		t.tracker = memory.NewTracker(label, -1)
+	} else {
+		t.tracker.Reset()
+	}
+	clear(t.partialResultMemUsage)
+	t.tracker.AttachTo(stmtTracker)
+	t.tracker.Consume(t.initialPartialResultMemUsage)
+}
+
+func (t *windowMemoryTracker) consume(bytes int64) {
+	if t == nil || t.tracker == nil || bytes == 0 {
+		return
+	}
+	t.tracker.Consume(bytes)
+}
+
+func (t *windowMemoryTracker) updatePartialResult(
+	idx int,
+	windowFunc aggfuncs.AggFunc,
+	ctx sessionctx.Context,
+	rows []chunk.Row,
+	partialResult aggfuncs.PartialResult,
+) error {
+	memDelta, err := windowFunc.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), rows, partialResult)
+	t.partialResultMemUsage[idx] += memDelta
+	t.consume(memDelta)
+	return err
+}
+
+func (t *windowMemoryTracker) resetPartialResult(idx int, windowFunc aggfuncs.AggFunc, partialResult aggfuncs.PartialResult) {
+	windowFunc.ResetPartialResult(partialResult)
+	t.consume(-t.partialResultMemUsage[idx])
+	t.partialResultMemUsage[idx] = 0
+}
+
+func (t *windowMemoryTracker) resetAllPartialResults(windowFuncs []aggfuncs.AggFunc, partialResults []aggfuncs.PartialResult) {
+	for i, windowFunc := range windowFuncs {
+		t.resetPartialResult(i, windowFunc, partialResults[i])
+	}
+}
+
+func (t *windowMemoryTracker) close() {
+	if t == nil || t.tracker == nil {
+		return
+	}
+	t.tracker.ReplaceBytesUsed(0)
+}
 
 // WindowExec is the executor for window functions.
 type WindowExec struct {
@@ -40,14 +110,42 @@ type WindowExec struct {
 	// resultChunks stores the chunks to return
 	resultChunks []*chunk.Chunk
 	// remainingRowsInChunk indicates how many rows the resultChunks[i] is not prepared.
-	remainingRowsInChunk []int
+	remainingRowsInChunk  []int
+	resultChunksMemUsage  int64
+	remainingRowsMemUsage int64
 
 	numWindowFuncs int
 	processor      windowProcessor
+	memTracker     *windowMemoryTracker
+}
+
+// Open implements the Executor Open interface.
+func (e *WindowExec) Open(ctx context.Context) error {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
+		return err
+	}
+	e.executed = false
+	e.childResult = nil
+	e.resultChunks = nil
+	e.remainingRowsInChunk = nil
+	e.resultChunksMemUsage = 0
+	e.remainingRowsMemUsage = 0
+	e.groupChecker.Reset()
+	e.memTracker.open(e.ID(), e.Ctx().GetSessionVars().StmtCtx.MemTracker)
+	e.processor.resetPartialResult()
+	return nil
 }
 
 // Close implements the Executor Close interface.
 func (e *WindowExec) Close() error {
+	e.processor.resetPartialResult()
+	e.childResult = nil
+	e.resultChunks = nil
+	e.remainingRowsInChunk = nil
+	e.resultChunksMemUsage = 0
+	e.remainingRowsMemUsage = 0
+	e.groupChecker.Reset()
+	e.memTracker.close()
 	return errors.Trace(e.BaseExecutor.Close())
 }
 
@@ -62,10 +160,21 @@ func (e *WindowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		}
 	}
 	if len(e.resultChunks) > 0 {
-		chk.SwapColumns(e.resultChunks[0])
+		resultChk := e.resultChunks[0]
+		// The output chunk takes ownership of the referenced input columns here.
+		// Stop charging them to Window before swapping the column pointers.
+		e.memTracker.consume(-resultChk.MemoryUsage())
+		chk.SwapColumns(resultChk)
 		e.resultChunks[0] = nil // GC it. TODO: Reuse it.
 		e.resultChunks = e.resultChunks[1:]
 		e.remainingRowsInChunk = e.remainingRowsInChunk[1:]
+		if len(e.resultChunks) == 0 {
+			e.resultChunks = nil
+			e.remainingRowsInChunk = nil
+			e.memTracker.consume(-e.resultChunksMemUsage - e.remainingRowsMemUsage)
+			e.resultChunksMemUsage = 0
+			e.remainingRowsMemUsage = 0
+		}
 	}
 	return nil
 }
@@ -76,6 +185,21 @@ func (e *WindowExec) preparedChunkAvailable() bool {
 
 func (e *WindowExec) consumeOneGroup(ctx context.Context) error {
 	var groupRows []chunk.Row
+	groupRowsMemUsage := int64(0)
+	defer func() {
+		e.memTracker.consume(-groupRowsMemUsage)
+	}()
+	appendGroupRows := func(begin, end int) {
+		oldCap := cap(groupRows)
+		for i := begin; i < end; i++ {
+			groupRows = append(groupRows, e.childResult.GetRow(i))
+		}
+		if cap(groupRows) != oldCap {
+			newMemUsage := int64(cap(groupRows)) * aggfuncs.DefRowSize
+			e.memTracker.consume(newMemUsage - groupRowsMemUsage)
+			groupRowsMemUsage = newMemUsage
+		}
+	}
 	if e.groupChecker.IsExhausted() {
 		eof, err := e.fetchChild(ctx)
 		if err != nil {
@@ -91,9 +215,7 @@ func (e *WindowExec) consumeOneGroup(ctx context.Context) error {
 		}
 	}
 	begin, end := e.groupChecker.GetNextGroup()
-	for i := begin; i < end; i++ {
-		groupRows = append(groupRows, e.childResult.GetRow(i))
-	}
+	appendGroupRows(begin, end)
 
 	for meetLastGroup := end == e.childResult.NumRows(); meetLastGroup; {
 		meetLastGroup = false
@@ -113,9 +235,7 @@ func (e *WindowExec) consumeOneGroup(ctx context.Context) error {
 
 		if isFirstGroupSameAsPrev {
 			begin, end = e.groupChecker.GetNextGroup()
-			for i := begin; i < end; i++ {
-				groupRows = append(groupRows, e.childResult.GetRow(i))
-			}
+			appendGroupRows(begin, end)
 			meetLastGroup = end == e.childResult.NumRows()
 		}
 	}
@@ -131,6 +251,8 @@ func (e *WindowExec) consumeGroupRows(groupRows []chunk.Row) (err error) {
 		remained := min(e.remainingRowsInChunk[i], remainingRowsInGroup)
 		e.remainingRowsInChunk[i] -= remained
 		remainingRowsInGroup -= remained
+		resultChk := e.resultChunks[i]
+		oldMemUsage := resultChk.MemoryUsage()
 
 		// TODO: Combine these three methods.
 		// The old implementation needs the processor has these three methods
@@ -139,7 +261,8 @@ func (e *WindowExec) consumeGroupRows(groupRows []chunk.Row) (err error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		_, err = e.processor.appendResult2Chunk(e.Ctx(), groupRows, e.resultChunks[i], remained)
+		_, err = e.processor.appendResult2Chunk(e.Ctx(), groupRows, resultChk, remained)
+		e.memTracker.consume(resultChk.MemoryUsage() - oldMemUsage)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -168,8 +291,23 @@ func (e *WindowExec) fetchChild(ctx context.Context) (eof bool, err error) {
 	if err != nil {
 		return false, err
 	}
+	oldResultChunksCap := cap(e.resultChunks)
+	oldRemainingRowsCap := cap(e.remainingRowsInChunk)
 	e.resultChunks = append(e.resultChunks, resultChk)
 	e.remainingRowsInChunk = append(e.remainingRowsInChunk, numRows)
+	// resultChk references the input columns in childResult. Charge only the
+	// retained result chunk so shared column buffers are not counted twice.
+	e.memTracker.consume(resultChk.MemoryUsage())
+	if cap(e.resultChunks) != oldResultChunksCap {
+		newMemUsage := int64(cap(e.resultChunks)) * chunkPointerSize
+		e.memTracker.consume(newMemUsage - e.resultChunksMemUsage)
+		e.resultChunksMemUsage = newMemUsage
+	}
+	if cap(e.remainingRowsInChunk) != oldRemainingRowsCap {
+		newMemUsage := int64(cap(e.remainingRowsInChunk)) * intSize
+		e.memTracker.consume(newMemUsage - e.remainingRowsMemUsage)
+		e.remainingRowsMemUsage = newMemUsage
+	}
 
 	e.childResult = childResult
 	return false, nil
@@ -200,13 +338,12 @@ type windowProcessor interface {
 type aggWindowProcessor struct {
 	windowFuncs    []aggfuncs.AggFunc
 	partialResults []aggfuncs.PartialResult
+	memTracker     *windowMemoryTracker
 }
 
 func (p *aggWindowProcessor) consumeGroupRows(ctx sessionctx.Context, rows []chunk.Row) ([]chunk.Row, error) {
 	for i, windowFunc := range p.windowFuncs {
-		// @todo Add memory trace
-		_, err := windowFunc.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), rows, p.partialResults[i])
-		if err != nil {
+		if err := p.memTracker.updatePartialResult(i, windowFunc, ctx, rows, p.partialResults[i]); err != nil {
 			return nil, err
 		}
 	}
@@ -229,9 +366,7 @@ func (p *aggWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, rows []c
 }
 
 func (p *aggWindowProcessor) resetPartialResult() {
-	for i, windowFunc := range p.windowFuncs {
-		windowFunc.ResetPartialResult(p.partialResults[i])
-	}
+	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
 }
 
 type rowFrameWindowProcessor struct {
@@ -240,6 +375,7 @@ type rowFrameWindowProcessor struct {
 	start          *logicalop.FrameBound
 	end            *logicalop.FrameBound
 	curRowIdx      uint64
+	memTracker     *windowMemoryTracker
 }
 
 func (p *rowFrameWindowProcessor) getStartOffset(numRows uint64) uint64 {
@@ -349,7 +485,7 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 					// Store start inside MaxMinSlidingWindowAggFunc.windowInfo
 					minMaxSlidingWindowAggFunc.SetWindowStart(start)
 				}
-				_, err = windowFunc.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), rows[start:end], p.partialResults[i])
+				err = p.memTracker.updatePartialResult(i, windowFunc, ctx, rows[start:end], p.partialResults[i])
 			}
 			if err != nil {
 				return nil, err
@@ -359,21 +495,24 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 				return nil, err
 			}
 			if slidingWindowAggFunc == nil {
-				windowFunc.ResetPartialResult(p.partialResults[i])
+				p.memTracker.resetPartialResult(i, windowFunc, p.partialResults[i])
 			}
 		}
 		if !initializedSlidingWindow {
 			initializedSlidingWindow = true
 		}
 	}
-	for i, windowFunc := range p.windowFuncs {
-		windowFunc.ResetPartialResult(p.partialResults[i])
+	for i, slidingWindowAggFunc := range slidingWindowAggFuncs {
+		if slidingWindowAggFunc != nil {
+			p.memTracker.resetPartialResult(i, p.windowFuncs[i], p.partialResults[i])
+		}
 	}
 	return rows, nil
 }
 
 func (p *rowFrameWindowProcessor) resetPartialResult() {
 	p.curRowIdx = 0
+	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
 }
 
 type rangeFrameWindowProcessor struct {
@@ -387,6 +526,7 @@ type rangeFrameWindowProcessor struct {
 	orderByCols     []*expression.Column
 	// expectedCmpResult is used to decide if one value is included in the frame.
 	expectedCmpResult int64
+	memTracker        *windowMemoryTracker
 }
 
 func (p *rangeFrameWindowProcessor) getStartOffset(ctx sessionctx.Context, rows []chunk.Row) (uint64, error) {
@@ -500,7 +640,7 @@ func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, r
 				if minMaxSlidingWindowAggFunc, ok := windowFunc.(aggfuncs.MaxMinSlidingWindowAggFunc); ok {
 					minMaxSlidingWindowAggFunc.SetWindowStart(start)
 				}
-				_, err = windowFunc.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), rows[start:end], p.partialResults[i])
+				err = p.memTracker.updatePartialResult(i, windowFunc, ctx, rows[start:end], p.partialResults[i])
 			}
 			if err != nil {
 				return nil, err
@@ -510,15 +650,17 @@ func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, r
 				return nil, err
 			}
 			if slidingWindowAggFunc == nil {
-				windowFunc.ResetPartialResult(p.partialResults[i])
+				p.memTracker.resetPartialResult(i, windowFunc, p.partialResults[i])
 			}
 		}
 		if !initializedSlidingWindow {
 			initializedSlidingWindow = true
 		}
 	}
-	for i, windowFunc := range p.windowFuncs {
-		windowFunc.ResetPartialResult(p.partialResults[i])
+	for i, slidingWindowAggFunc := range slidingWindowAggFuncs {
+		if slidingWindowAggFunc != nil {
+			p.memTracker.resetPartialResult(i, p.windowFuncs[i], p.partialResults[i])
+		}
 	}
 	return rows, nil
 }
@@ -531,4 +673,5 @@ func (p *rangeFrameWindowProcessor) resetPartialResult() {
 	p.curRowIdx = 0
 	p.lastStartOffset = 0
 	p.lastEndOffset = 0
+	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
 }

--- a/pkg/executor/windows/window.go
+++ b/pkg/executor/windows/window.go
@@ -66,7 +66,18 @@ func (t *windowMemoryTracker) consume(bytes int64) {
 	t.tracker.Consume(bytes)
 }
 
-func (t *windowMemoryTracker) updatePartialResult(
+func (t *windowMemoryTracker) consumePartialResultMemDelta(idx int, memDelta int64) {
+	t.partialResultMemUsage[idx] += memDelta
+	t.consume(memDelta)
+}
+
+func (t *windowMemoryTracker) releasePartialResultMemUsage(idx int) {
+	t.consume(-t.partialResultMemUsage[idx])
+	t.partialResultMemUsage[idx] = 0
+}
+
+func updatePartialResultAndTrackMemory(
+	t *windowMemoryTracker,
 	idx int,
 	windowFunc aggfuncs.AggFunc,
 	ctx sessionctx.Context,
@@ -74,20 +85,19 @@ func (t *windowMemoryTracker) updatePartialResult(
 	partialResult aggfuncs.PartialResult,
 ) error {
 	memDelta, err := windowFunc.UpdatePartialResult(ctx.GetExprCtx().GetEvalCtx(), rows, partialResult)
-	t.partialResultMemUsage[idx] += memDelta
-	t.consume(memDelta)
+	t.consumePartialResultMemDelta(idx, memDelta)
 	return err
 }
 
-func (t *windowMemoryTracker) resetPartialResult(idx int, windowFunc aggfuncs.AggFunc, partialResult aggfuncs.PartialResult) {
+func resetPartialResultAndReleaseMemory(t *windowMemoryTracker, idx int, windowFunc aggfuncs.AggFunc, partialResult aggfuncs.PartialResult) {
 	windowFunc.ResetPartialResult(partialResult)
-	t.consume(-t.partialResultMemUsage[idx])
-	t.partialResultMemUsage[idx] = 0
+	t.releasePartialResultMemUsage(idx)
 }
 
-func (t *windowMemoryTracker) resetAllPartialResults(windowFuncs []aggfuncs.AggFunc, partialResults []aggfuncs.PartialResult) {
+// resetPartialResultsAndReleaseMemory resets each window function's corresponding partial result and releases its tracked memory.
+func resetPartialResultsAndReleaseMemory(t *windowMemoryTracker, windowFuncs []aggfuncs.AggFunc, partialResults []aggfuncs.PartialResult) {
 	for i, windowFunc := range windowFuncs {
-		t.resetPartialResult(i, windowFunc, partialResults[i])
+		resetPartialResultAndReleaseMemory(t, i, windowFunc, partialResults[i])
 	}
 }
 
@@ -132,13 +142,11 @@ func (e *WindowExec) Open(ctx context.Context) error {
 	e.remainingRowsMemUsage = 0
 	e.groupChecker.Reset()
 	e.memTracker.open(e.ID(), e.Ctx().GetSessionVars().StmtCtx.MemTracker)
-	e.processor.resetPartialResult()
 	return nil
 }
 
 // Close implements the Executor Close interface.
 func (e *WindowExec) Close() error {
-	e.processor.resetPartialResult()
 	e.childResult = nil
 	e.resultChunks = nil
 	e.remainingRowsInChunk = nil
@@ -343,7 +351,7 @@ type aggWindowProcessor struct {
 
 func (p *aggWindowProcessor) consumeGroupRows(ctx sessionctx.Context, rows []chunk.Row) ([]chunk.Row, error) {
 	for i, windowFunc := range p.windowFuncs {
-		if err := p.memTracker.updatePartialResult(i, windowFunc, ctx, rows, p.partialResults[i]); err != nil {
+		if err := updatePartialResultAndTrackMemory(p.memTracker, i, windowFunc, ctx, rows, p.partialResults[i]); err != nil {
 			return nil, err
 		}
 	}
@@ -366,7 +374,7 @@ func (p *aggWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, rows []c
 }
 
 func (p *aggWindowProcessor) resetPartialResult() {
-	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
+	resetPartialResultsAndReleaseMemory(p.memTracker, p.windowFuncs, p.partialResults)
 }
 
 type rowFrameWindowProcessor struct {
@@ -485,7 +493,7 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 					// Store start inside MaxMinSlidingWindowAggFunc.windowInfo
 					minMaxSlidingWindowAggFunc.SetWindowStart(start)
 				}
-				err = p.memTracker.updatePartialResult(i, windowFunc, ctx, rows[start:end], p.partialResults[i])
+				err = updatePartialResultAndTrackMemory(p.memTracker, i, windowFunc, ctx, rows[start:end], p.partialResults[i])
 			}
 			if err != nil {
 				return nil, err
@@ -495,7 +503,7 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 				return nil, err
 			}
 			if slidingWindowAggFunc == nil {
-				p.memTracker.resetPartialResult(i, windowFunc, p.partialResults[i])
+				resetPartialResultAndReleaseMemory(p.memTracker, i, windowFunc, p.partialResults[i])
 			}
 		}
 		if !initializedSlidingWindow {
@@ -504,7 +512,7 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 	}
 	for i, slidingWindowAggFunc := range slidingWindowAggFuncs {
 		if slidingWindowAggFunc != nil {
-			p.memTracker.resetPartialResult(i, p.windowFuncs[i], p.partialResults[i])
+			resetPartialResultAndReleaseMemory(p.memTracker, i, p.windowFuncs[i], p.partialResults[i])
 		}
 	}
 	return rows, nil
@@ -512,7 +520,7 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 
 func (p *rowFrameWindowProcessor) resetPartialResult() {
 	p.curRowIdx = 0
-	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
+	resetPartialResultsAndReleaseMemory(p.memTracker, p.windowFuncs, p.partialResults)
 }
 
 type rangeFrameWindowProcessor struct {
@@ -640,7 +648,7 @@ func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, r
 				if minMaxSlidingWindowAggFunc, ok := windowFunc.(aggfuncs.MaxMinSlidingWindowAggFunc); ok {
 					minMaxSlidingWindowAggFunc.SetWindowStart(start)
 				}
-				err = p.memTracker.updatePartialResult(i, windowFunc, ctx, rows[start:end], p.partialResults[i])
+				err = updatePartialResultAndTrackMemory(p.memTracker, i, windowFunc, ctx, rows[start:end], p.partialResults[i])
 			}
 			if err != nil {
 				return nil, err
@@ -650,7 +658,7 @@ func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, r
 				return nil, err
 			}
 			if slidingWindowAggFunc == nil {
-				p.memTracker.resetPartialResult(i, windowFunc, p.partialResults[i])
+				resetPartialResultAndReleaseMemory(p.memTracker, i, windowFunc, p.partialResults[i])
 			}
 		}
 		if !initializedSlidingWindow {
@@ -659,7 +667,7 @@ func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, r
 	}
 	for i, slidingWindowAggFunc := range slidingWindowAggFuncs {
 		if slidingWindowAggFunc != nil {
-			p.memTracker.resetPartialResult(i, p.windowFuncs[i], p.partialResults[i])
+			resetPartialResultAndReleaseMemory(p.memTracker, i, p.windowFuncs[i], p.partialResults[i])
 		}
 	}
 	return rows, nil
@@ -673,5 +681,5 @@ func (p *rangeFrameWindowProcessor) resetPartialResult() {
 	p.curRowIdx = 0
 	p.lastStartOffset = 0
 	p.lastEndOffset = 0
-	p.memTracker.resetAllPartialResults(p.windowFuncs, p.partialResults)
+	resetPartialResultsAndReleaseMemory(p.memTracker, p.windowFuncs, p.partialResults)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70629 

Problem Summary:

Window executors did not fully track memory allocated for partial results, partition rows, intermediate chunks, and internal buffers. As a result, EXPLAIN ANALYZE could report incomplete Window memory usage, while tidb_mem_quota_query could underestimate the query’s actual memory consumption and fail to trigger timely cancellation for memory-intensive Window queries, increasing OOM risk.

### What changed and how does it work?

Introduce a shared windowMemoryTracker for regular and pipelined Window executors. The tracker accounts for partial-result initialization and update deltas, retained rows, internal slice capacities, result chunks, and chunk memory growth. It is attached to the statement memory tracker, and memory is deducted when partial results are reset or result ownership is transferred to the parent executor. Executor lifecycle handling is also integrated with the tracker so Window memory is cleaned up correctly. This improves Window memory visibility and query memory-limit enforcement without changing SQL semantics or result correctness.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory tracking for window-function queries across pipelined and non-pipelined execution.
  * Ensured memory used by buffered rows, intermediate results, and output data is accurately accounted for and released.
  * Enhanced cleanup of memory and disk resources during window query execution.
  * Improved memory reporting for window operators.
* **Tests**
  * Added coverage for `rank()` queries and memory tracking across different execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->