### PR TITLE
planner: detect LATERAL nested inside a derived table or set-op

### DIFF
--- a/pkg/planner/core/lateral_join_test.go
+++ b/pkg/planner/core/lateral_join_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
@@ -846,6 +847,59 @@ func TestLateralJoinMySQLCompatibility(t *testing.T) {
 			} else {
 				require.NoError(t, err, "Unexpected error for: %s\nError: %v", tc.sql, err)
 			}
+		})
+	}
+}
+
+// TestContainsLateralTableSourceNested checks that containsLateralTableSource sees a
+// LATERAL nested inside a derived table or a set-op operand, not just one that is the
+// immediate right operand of the join. buildJoin uses this to decide whether to push the
+// left schema onto outerSchemas and to suppress join reordering, so a false negative
+// silently skips both for the nested shapes below.
+func TestContainsLateralTableSourceNested(t *testing.T) {
+	s := createPlannerSuite()
+	defer s.Close()
+
+	testCases := []struct {
+		name     string
+		sql      string
+		expected bool
+	}{
+		{
+			name:     "LATERAL as the immediate right operand",
+			sql:      "SELECT * FROM t, LATERAL (SELECT t.a) AS dt",
+			expected: true,
+		},
+		{
+			name:     "LATERAL nested inside a derived table",
+			sql:      "SELECT * FROM t JOIN (SELECT * FROM t t2, LATERAL (SELECT t2.a) AS d) AS s ON true",
+			expected: true,
+		},
+		{
+			name:     "LATERAL nested inside a set-op operand",
+			sql:      "SELECT * FROM t JOIN (SELECT 1 UNION ALL SELECT t2.a FROM t t2, LATERAL (SELECT t2.a) AS d) AS s ON true",
+			expected: true,
+		},
+		{
+			name:     "no LATERAL anywhere in the right subtree",
+			sql:      "SELECT * FROM t JOIN (SELECT * FROM t t2) AS s ON true",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := s.GetParser().ParseOneStmt(tc.sql, "", "")
+			require.NoError(t, err, "Failed to parse SQL: %s", tc.sql)
+
+			sel, ok := stmt.(*ast.SelectStmt)
+			require.True(t, ok)
+			require.NotNil(t, sel.From)
+			join := sel.From.TableRefs
+			require.NotNil(t, join.Right, "test case must be a two-operand join")
+
+			require.Equal(t, tc.expected, containsLateralTableSource(join.Right),
+				"containsLateralTableSource mismatch for: %s", tc.sql)
 		})
 	}
 }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -696,6 +696,22 @@ func containsLateralTableSource(node ast.ResultSetNode) bool {
 		}
 		// Check both sides for nested LATERAL
 		return containsLateralTableSource(n.Left) || containsLateralTableSource(n.Right)
+	case *ast.SelectStmt:
+		// Descend into the FROM clause of a derived subquery.
+		if n.From != nil {
+			return containsLateralTableSource(n.From.TableRefs)
+		}
+		return false
+	case *ast.SetOprStmt:
+		// Check each operand in the UNION/INTERSECT/EXCEPT list.
+		if n.SelectList != nil {
+			for _, sel := range n.SelectList.Selects {
+				if rs, ok := sel.(ast.ResultSetNode); ok && containsLateralTableSource(rs) {
+					return true
+				}
+			}
+		}
+		return false
 	default:
 		return false
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #40328

Problem Summary:

`containsLateralTableSource` descends into a `TableSource`'s inner `Source`, but on `release-8.5` there is no `case` for the node types that `Source` actually is (`*ast.SelectStmt` / `*ast.SetOprStmt`). The recursion therefore always falls through to the `default` branch and reports `false`.

The result is that a LATERAL nested inside a derived table or a set-op operand on the right of a join goes undetected:

```sql
SELECT * FROM t JOIN (SELECT * FROM t t2, LATERAL (SELECT t2.a) AS d) AS s ON true
SELECT * FROM t JOIN (SELECT 1 UNION ALL SELECT t2.a FROM t t2, LATERAL (SELECT t2.a) AS d) AS s ON true
```

`buildJoin` uses that predicate to decide whether to push the left schema onto `outerSchemas` and whether to suppress join reordering, so a false negative silently skips both, and also skips the correlated-column safety net that produces a `LogicalApply` when a nested LATERAL does reference the left side.

How the gap arose: the descent into `n.Source` was added on the 8.5 line by 6f886fc8c4 in #67389 (merged 2026-04-01), which developed this set of LATERAL fixes independently of, and a week before, master's equivalent #67482 (merged 2026-04-07). #67482 added both the descent *and* the two cases that terminate it; #67389 added only the descent. #68953 then re-picked #67389's result onto `release-8.5`, carrying the incomplete version forward. So the descent has been unreachable on this branch since March, and the terminating cases have only ever existed on master.

This supersedes the abandoned cherry-pick #68889, whose head commit was left with unresolved conflict markers.

**This is a parity fix, not an observed defect.** No query is known to change plan or error today — patching this hunk into a `release-8.5` build produced byte-identical `EXPLAIN` output for the nested shapes tried. Reviewers should not go looking for a user-visible repro.

### What changed and how does it work?

Added the `*ast.SelectStmt` and `*ast.SetOprStmt` cases so the descent added by #67482 terminates where it was meant to, instead of being unreachable. `containsLateralTableSource` is now byte-for-byte identical to master.

`master` already carries all six hunks and needs no change; this is `release-8.5`-only.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

`TestContainsLateralTableSourceNested` in `pkg/planner/core/lateral_join_test.go` covers the immediate-LATERAL, nested-in-derived-table, nested-in-set-op, and negative cases. Verified it fails before the fix (both nested cases report `false`) and passes after.

```
go test -tags=intest ./pkg/planner/core/ -run 'TestLateral|TestContainsLateral' -count=1
make bazel_prepare   # no BUILD.bazel changes: srcs already listed, shard_count unchanged
make lint
go vet ./pkg/planner/core/
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

The change only adds `switch` cases to a pure AST predicate; no existing case is altered, so it can only turn `false` into `true` for the nested shapes above, restoring master's behavior.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
