### PR TITLE
planner: add unified cacheability checks for non-prepared plan cache

### DIFF
--- a/docs/design/2026-08-11-non-prepared-plan-cache-cacheability-check-implementation.md
+++ b/docs/design/2026-08-11-non-prepared-plan-cache-cacheability-check-implementation.md
@@ -1,0 +1,1007 @@
+# Non-Prepared Plan Cache 支持范围改造实现说明
+
+相关设计和调研：
+
+- [组内设计文档](2026-08-11-non-prepared-plan-cache-cacheability-check.md)
+- [其他数据库实现调研](2026-08-11-non-prepared-plan-cache-other-databases.md)
+- [OceanBase 实现专项调研](2026-08-11-non-prepared-plan-cache-oceanbase.md)
+
+## 文档目的
+
+本文是《Non-Prepared Plan Cache 支持范围与 cacheability 检查改造》的配套实现文档，面向实际写代码和 review 的同学，重点回答：
+
+- 当前调用链具体在哪里；
+- 要新增哪些类型、函数和检查；
+- 每个文件具体改什么、哪些旧代码可以删除；
+- LRU hit/miss、错误、warning 和 metric 分别怎么处理；
+- 测试应该落在哪些文件、覆盖哪些分支。
+
+本文描述两个实现 PR：先独立修复 AST 恢复，再在灰度开关保护下接入参数化安全规则并复用公共 AST 规则。TiDB 当前通过参数化后调用 `IsASTCacheable` 落地规则复用，这是一项实现选择，不是改造目标本身。原始 literal 总数、`LIMIT` 和 `SELECT ... INTO` 等阶段性策略继续保留；特殊 literal 第一阶段采用 preserve-first，不要求立即把它们转换成 typed parameter，也不实现 OceanBase 风格的 not-param constraint matcher。
+
+新流程由 `tidb_enable_non_prepared_plan_cache_unified_cacheability_check` 控制，默认关闭。关闭时继续使用原有 `NonPreparedPlanCacheableWithCtx`、原有参数化规则、原有支持范围以及原有 reason/metric 行为；打开后才使用本文描述的 parameterization precheck、context-aware parameterize/preserve 和公共 `IsASTCacheable` 流程。独立的 original AST 恢复修复不受开关控制。两条路径继续使用现有 statement LRU，本文不修改其 key 组成。
+
+## 当前代码路径
+
+入口在 `pkg/planner/optimize.go` 的 `getPlanFromNonPreparedPlanCache`。当前执行顺序是：
+
+```text
+getPlanFromNonPreparedPlanCache
+    |
+    |-- 检查总开关、trace、restricted SQL 等入口条件
+    |
+    |-- core.NonPreparedPlanCacheableWithCtx(original AST, InfoSchema)
+    |       - DML / locking read 开关
+    |       - Non-Prepared AST allowlist
+    |       - 特殊 literal 和 literal 总数
+    |       - 表、列类型和 LIMIT 等限制
+    |
+    |-- core.GetParamSQLFromAST(original AST)
+    |       - ParameterizeAST 临时替换 ValueExpr
+    |       - restore 参数化 SQL
+    |       - RestoreASTWithParams 恢复 original AST
+    |
+    |-- SessionVars.GetNonPreparedPlanCacheStmt(paramSQL)
+    |       |
+    |       |-- miss: ParseParameterizedSQL
+    |       |         SetParameterValuesIntoSCtx
+    |       |         GeneratePlanCacheStmtWithAST(..., false, ...)
+    |       |         AddNonPreparedPlanCacheStmt
+    |       |
+    |       `-- hit: 复用 PlanCacheStmt
+    |
+    `-- core.GetPlanFromPlanCache(..., isNonPrepared=true, ...)
+```
+
+实现时需要注意当前路径的几个细节：
+
+1. `GeneratePlanCacheStmtWithAST` 的 `isPrepStmt=false` 分支直接设置 `cacheable=true`，注释假设 Non-Prepared 已经在调用前完成检查；
+2. statement LRU miss 后不检查 `cachedStmt.StmtCacheable`，当前会无条件写入 LRU；
+3. `GetParamSQLFromAST` 只有在 `ParameterizeAST` 成功后才恢复 AST，SQL restore 报错时 original AST 可能残留参数标记；
+4. `NonPreparedPlanCacheableWithCtx` 的 unsupported counter 只在 visitor 执行结束后计数，fast check 的早退没有计数；
+5. 后端 `GetPlanFromPlanCache` 已经负责参数写入、schema/MDL、权限、物理 plan key、类型匹配、range rebuild 和物理计划检查，本次不重复实现这些能力。
+
+## 灰度开关
+
+### 定义
+
+新增 Boolean 系统变量：
+
+```text
+tidb_enable_non_prepared_plan_cache_unified_cacheability_check
+```
+
+定义如下：
+
+| 属性 | 取值 |
+| --- | --- |
+| Scope | GLOBAL、SESSION |
+| 默认值 | `OFF` |
+| 动态修改 | 支持 |
+| `OFF` | 使用改造前的 Non-Prepared checker、参数化规则和支持范围 |
+| `ON` | 使用本文描述的新参数化和统一 cacheability 检查流程 |
+
+这个变量只在 `tidb_enable_non_prepared_plan_cache=ON` 时有实际效果。它不替代 Non-Prepared Plan Cache 总开关，也不改变 `tidb_enable_non_prepared_plan_cache_for_dml`、`tidb_enable_plan_cache_for_param_limit` 等已有开关的产品语义。
+
+变量命名使用 `unified_cacheability_check` 而不是 `new` 或版本号，表达它控制的是“Non-Prepared 参数化安全规则与公共 cacheability 规则收敛”这一稳定语义。
+
+灰度和回滚示例：
+
+```sql
+-- 只为当前 session 打开新流程。
+SET SESSION tidb_enable_non_prepared_plan_cache_unified_cacheability_check = ON;
+
+-- 为之后新建的 session 设置默认值；不改变已经存在的 session。
+SET GLOBAL tidb_enable_non_prepared_plan_cache_unified_cacheability_check = ON;
+
+-- 发现问题时立即让当前 session 回到旧流程。
+SET SESSION tidb_enable_non_prepared_plan_cache_unified_cacheability_check = OFF;
+```
+
+切换开关本身不产生 warning，也不增加 unsupported counter。是否 bypass、使用哪个 reason 和如何计数，由所选中的完整 legacy/unified 路径决定。
+
+### 分流原则
+
+`getPlanFromNonPreparedPlanCache` 先执行现有总开关、trace、restricted SQL、retry 和 multi-statement 等通用入口排除，再读取一次 session 开关值并选择整条调用链：
+
+```text
+getPlanFromNonPreparedPlanCache
+    |
+    |-- 通用入口排除项
+    |
+    |-- unified cacheability check = OFF
+    |       `-- legacyNonPreparedPlanCachePath
+    |               - NonPreparedPlanCacheableWithCtx
+    |               - 原有参数化和 statement LRU 流程
+    |               - 原有 reason、warning 和 unsupported metric 边界
+    |
+    `-- unified cacheability check = ON
+            `-- unifiedNonPreparedPlanCachePath
+                    - DML / locking read 入口 gate
+                    - parameterization precheck
+                    - context-aware parameterize/preserve
+                    - LRU hit/miss 均执行 IsASTCacheable
+                    - StmtCacheable admission check
+```
+
+不能只在某个 checker 调用点局部判断开关，否则关闭开关时仍可能使用新 parameterizer、新 reason 或新 metric，形成无法可靠回滚的混合路径。建议把旧路径和新路径拆成两个私有 helper，入口只负责共同 gate 和一次性分流。
+
+### 与正确性修复的边界
+
+下面一项属于独立正确性修复，对 `OFF` 和 `ON` 都生效：
+
+- 所有退出路径都安全恢复 original AST；
+
+因此“关闭时与原本一样”指 SQL 支持范围、cacheability 决策、bypass reason、warning 和 unsupported metric 保持旧行为，而不是重新启用已知的 AST 污染问题。
+
+### 动态切换和现有 LRU
+
+开关切换不修改 statement LRU key，也不要求为了切换开关清空整个 LRU。统一流程取得 carrier 后仍会重新运行 `IsASTCacheable`；如果新参数化规则生成了不同的 ParamSQL，则沿用现有 SQL 文本自然形成不同的 LRU entry。本文不承诺为 legacy/unified 两种模式分别保留 carrier。
+
+后端物理 Plan Cache key 和现有失效机制保持不变。开关只控制前端调用流程；后端继续使用现有 backend key、参数类型、schema/MDL 和物理 checker 保护计划复用。
+
+## 目标调用链
+
+开关打开时，`getPlanFromNonPreparedPlanCache` 的新分支按下面的顺序执行：
+
+```text
+1. Non-Prepared 通用入口排除项
+2. DML / locking read 开关
+3. Non-Prepared parameterization precheck
+4. 参数化，并恢复 original AST
+5. 按 paramSQL 查现有 statement LRU
+6. 获取 parameterized AST
+   - hit: cachedStmt.PreparedAst.Stmt
+   - miss: ParseParameterizedSQL
+7. 每次调用 IsASTCacheable(parameterized AST, current InfoSchema)
+8. miss 时构造 PlanCacheStmt
+9. 只有 StmtCacheable=true 才写 statement LRU
+10. 调用共用的 GetPlanFromPlanCache
+```
+
+关键顺序不能调换：
+
+- precheck 必须在参数化之前，否则看不到原始 literal 的类型和数量；
+- `IsASTCacheable` 必须在参数化之后，否则无法按参数标记的位置做公共检查；
+- `IsASTCacheable` 必须在 LRU hit 和 miss 两条路径都执行，因为结果依赖当前 session 和 InfoSchema；
+- miss 时必须先通过公共 checker，再构造和写入 carrier。
+
+## 新增的参数化接口
+
+### 返回结构
+
+在 `pkg/planner/core/plan_cache_param.go` 增加：
+
+```go
+// NonPreparedPlanCacheParamResult is the result of parameterizing a normal SQL
+// statement for the non-prepared plan cache.
+type NonPreparedPlanCacheParamResult struct {
+	ParamSQL    string
+	ParamValues []types.Datum
+}
+```
+
+字段只保留调用方真正需要的内容：
+
+- `ParamSQL` 用于 parse、statement LRU 和后端 plan cache；
+- `ParamValues` 用于本次执行的参数表达式；
+- literal 数量、是否包含 `LIMIT` 等只属于 precheck 内部状态，不暴露给 planner。
+
+### 主入口
+
+同一文件增加：
+
+```go
+// ParameterizeForNonPreparedPlanCache validates and parameterizes stmt for the
+// non-prepared plan cache. supported=false means the whole statement should
+// bypass the non-prepared plan cache and use normal planning.
+func ParameterizeForNonPreparedPlanCache(
+	sctx base.PlanContext,
+	stmt ast.StmtNode,
+) (result NonPreparedPlanCacheParamResult, supported bool, reason string, err error)
+```
+
+返回值约定：
+
+| 返回值 | 含义 | `getPlanFromNonPreparedPlanCache` 的处理 |
+| --- | --- | --- |
+| `supported=true, err=nil` | 整条语句参数化成功 | 继续 statement LRU 和公共 checker |
+| `supported=false, err=nil` | 不满足 Non-Prepared 策略，或无法构造语义可靠的 ParamSQL | 记录 bypass reason，整条语句走普通优化 |
+| `err!=nil` | original AST 恢复失败或其他不能安全继续的内部错误 | 返回错误，不使用可能已被修改的 AST |
+
+这里的 `supported` 是整条参数化流程的结果，不是 literal 的第三种决策。不要用 `err` 表示“不支持缓存”；只要 original AST 已经安全恢复，这类情况就应当让整条语句正常 bypass。只有无法保证 original AST 可继续使用时才返回错误。
+
+原 `GetParamSQLFromAST` 在灰度期必须保留给开关关闭的旧路径使用。新入口可以复用它的 AST 安全恢复基础设施，但不能改变旧入口选择 literal 的规则。只有开关默认打开并经过完整灰度、确认不再需要回滚后，才能另行决定是否删除或降为内部函数。
+
+## 参数化 precheck 的实现
+
+### 新 visitor
+
+在 `plan_cache_param.go` 增加私有 visitor，例如：
+
+```go
+type nonPreparedPlanCachePrechecker struct {
+	sctx         base.PlanContext
+	supported    bool
+	reason       string
+	literalCount int
+	maxLiteral   int
+}
+```
+
+初始化时：
+
+```go
+checker := nonPreparedPlanCachePrechecker{
+	sctx:       sctx,
+	supported:  true,
+	maxLiteral: getMaxParamLimit(sctx),
+}
+```
+
+visitor 必须遍历 original AST 的全部子树，不能复用 `paramReplacer` 的 `skipChildren` 规则。
+
+### `ValueExpr` 检查
+
+遇到每个 `*driver.ValueExpr` 时都执行 `literalCount++`，超过 `getMaxParamLimit` 时返回 `query has too many constants`。计数针对 original AST 中的全部 literal，不是最终生成的参数数量。
+
+precheck 不再因为 `UnderScoreCharsetFlag`、`KindBinaryLiteral` 或 `IsNull()` 统一拒绝整条 SQL。这些信息由后续 literal 处理逻辑使用：能够忠实保留原 AST 节点和完整 token 时采用 preserve；如果完成整棵 AST 的处理后仍无法保证 restore、重新解析或参数映射正确，则整条语句 bypass。
+
+original AST 中已经存在的 `ParamMarkerExpr` 不属于本次 parameterization 生成的 marker。为避免恢复校验把原始 `?` 与新生成的 marker 混淆，precheck 发现任意原始 marker 时直接按 statement-level bypass 处理，reason 固定为 `query has parameter markers`，并保留原 AST 交给普通优化路径。
+
+因此旧的三个特殊 literal reason 不再作为第一阶段的固定结果。只有整条语句实际需要 bypass 时才返回与具体限制对应的 reason，避免把“这个 literal 不应参数化”和“整条语句不能进入 Non-Prepared Plan Cache”混为一谈。
+
+即使 literal 位于下面这些最终不会参数化的位置，precheck 也必须计数，后续处理逻辑也必须访问并明确选择 parameterize 或 preserve：
+
+- `SELECT` field；
+- `GROUP BY`、`ORDER BY`；
+- `LIMIT/OFFSET`；
+- 日期/时间函数的 format 参数；
+- window frame。
+
+### `LIMIT` 检查
+
+遇到任意 `*ast.Limit`，如果 `EnablePlanCacheForParamLimit=false`，返回当前 reason：
+
+```text
+query has 'limit ?' is un-cacheable
+```
+
+这里保留的是产品开关语义，不是因为 literal 本身无法 preserve。开关关闭时继续让整条语句 bypass；开关打开时，第一阶段保留 literal `LIMIT/OFFSET`，后续再单独评估是否参数化。原因是 `IsASTCacheable` 只在看到 `ParamMarkerExpr` 时检查该开关，而 `NewPlanCacheKey` 又会对所有记录到的 `Limit` 检查开关；不显式处理会改变当前执行路径和 warning。
+
+### `SELECT ... INTO`
+
+遇到 `*ast.SelectStmt` 且 `SelectIntoOpt != nil` 时，将整条语句标记为 bypass。
+
+旧 checker 会提前拒绝这类 statement。公共 `IsASTCacheable` 只看到 `SelectStmt`，不会检查 Prepared 协议限制；继续执行可能在 `GeneratePlanCacheStmtWithAST` 中返回 `ErrUnsupportedPs`，把原来的普通优化变成 SQL 错误。
+
+这个规则属于 Non-Prepared carrier 构造前的兼容策略，先放在 precheck 中。后续如果要支持，应单独验证每种 `SELECT INTO` 类型，而不是随 checker 统一一起放开。
+
+### DML 和 locking read
+
+DML 开关不放进 visitor。在 `optimize.go` 入口保留一个私有检查：
+
+```go
+func nonPreparedPlanCacheDMLAllowed(
+	vars *variable.SessionVars,
+	stmt ast.StmtNode,
+) (bool, string) {
+	if vars.EnableNonPreparedPlanCacheForDML {
+		return true, ""
+	}
+	switch stmt := stmt.(type) {
+	case *ast.SelectStmt:
+		if !containsLockingRead(stmt) {
+			return true, ""
+		}
+	case *ast.SetOprStmt:
+		if !containsLockingRead(stmt) {
+			return true, ""
+		}
+	}
+	return false, "not a SELECT statement"
+}
+
+type lockingReadFinder struct {
+	found bool
+}
+
+func (finder *lockingReadFinder) Enter(in ast.Node) (ast.Node, bool) {
+	if stmt, ok := in.(*ast.SelectStmt); ok && stmt.LockInfo != nil {
+		finder.found = true
+		return in, true
+	}
+	return in, false
+}
+
+func (*lockingReadFinder) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+func containsLockingRead(node ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	finder := lockingReadFinder{}
+	node.Accept(&finder)
+	return finder.found
+}
+```
+
+开关关闭时 bypass 并走普通优化，不计 unsupported metric，保持它作为功能入口条件的语义；但 Explain Plan Cache 仍然要显示 `not a SELECT statement`，与当前行为一致。
+
+## parameterize / preserve 规则
+
+### 默认规则
+
+开关打开、不再使用旧 allowlist 后，不能继续使用“没有特殊处理就参数化”的默认行为。实现必须保证：
+
+```text
+明确标记为 parameterize → 替换成参数标记
+明确标记为 preserve     → literal 留在参数化 SQL 中
+```
+
+未知 AST 上下文第一阶段默认 preserve。实现上由表达式 selector 对已确认安全的表达式容器显式递归，未列入白名单的表达式节点直接跳过子树；因此新 AST 节点不会因为包含 `ValueExpr` 就被自动参数化。`fallback` 不是第三种 literal 决策：只有在所有 literal 处理完成后，发现某个 preserve 结构无法通过 restore 稳定进入 statement identity，或者完整 token 无法在相同解析上下文中重建，整条参数化流程才返回 `supported=false`。公共 `IsASTCacheable` 在参数化之后运行，不能代替这层判断。
+
+建议在替换前增加一次 context-aware 遍历。它只用私有 set/map 记录需要 parameterize 的 `ValueExpr`；未被记录的 literal 默认 preserve。新流程使用单独的私有 replacer，或让底层 replacer 显式接收选择结果，只替换 set/map 中明确标记的节点。旧 `GetParamSQLFromAST` 仍使用 legacy selection，不能因为共用 `paramReplacer` 而被间接切换到新规则。遍历过程中如果发现 ParamSQL 无法忠实表达某个 preserve 结构，则在 statement 级记录 `supported=false` 和 reason，不需要定义 literal 级的 `fallback` action 或三态枚举。
+
+第一阶段 preserve 的 literal 直接保留在 `ParamSQL` 中，因此 `ORDER BY 1` 和 `ORDER BY 2` 会形成不同的 LRU entry 和后端 `StmtText`。本次不实现额外的 not-param constraint matcher。
+
+preserve 不能只理解为“visitor 跳过替换”。必须验证 restore 后完整 token 仍然存在。例如当前参数化 restore 使用 `RestoreStringWithoutCharset`，会省略字符串 charset；charset introducer 要么使用能够保留 introducer 的 restore 方式，要么让整条语句 bypass。
+
+### Context matrix
+
+第一阶段需要得到下面的矩阵：
+
+| AST 上下文 | 处理 | 原因/实现 |
+| --- | --- | --- |
+| `WHERE`、join `ON` | parameterize | 典型运行时 filter value |
+| `IN`、`BETWEEN` | parameterize | 后端已有 range rebuild 和参数类型保护 |
+| HAVING | parameterize | 与普通 filter 相同；新增端到端测试 |
+| `INSERT ... VALUES`、UPDATE assignment | parameterize | 本次参数值写入 `PlanCacheParams` |
+| `SELECT` field 子树 | preserve | 保持输出列名和 metadata；沿用现有 skip |
+| `GROUP BY`、`ORDER BY` 子树 | preserve | 避免位置引用、alias 和 `ONLY_FULL_GROUP_BY` 语义变化 |
+| `LIMIT/OFFSET` | preserve | 不同 literal 保留在 `ParamSQL` 和 `StmtText`；沿用现有 skip |
+| `NULL` | preserve | 避免丢失无类型 `NULL` 的原始语义 |
+| BIT/HEX literal | preserve | 保留原 AST 节点和原始 token，不转换成普通整数或字符串参数 |
+| charset introducer literal | preserve | introducer 与后面的字符串作为整体保留；不能拆开参数化 |
+| `DATE_FORMAT` 等 format 参数 | 只参数化第一个参数 | 沿用现有特殊处理 |
+| `WEIGHT_STRING(... AS CHAR/BINARY(n))` 的语法参数 | 只参数化第一个表达式，保留 `CHAR`/`BINARY` 和长度 | 后两个 AST 参数参与语法恢复，不能替换为 `?` |
+| 构建期类型依赖参数：`CHAR ... USING` charset、`LPAD/RPAD` length、`CONVERT_TZ`/`UNIX_TIMESTAMP` datetime、`FROM_UNIXTIME` timestamp | preserve 影响签名或返回类型推导的参数 | 保证不同 charset、长度或时间精度不会复用首次构建的函数类型 |
+| 时间精度和构建期类型参数：`TIME`、`TIMEDIFF`、`TIMESTAMP`、`NOW`/`CURRENT_TIMESTAMP`/`CURRENT_TIME`/`LOCALTIME`/`LOCALTIMESTAMP`/`UTC_TIMESTAMP`/`UTC_TIME`/`SYSDATE` | preserve 函数参数 | FSP 和首参数类型参与函数签名构建，不能在后续执行中只替换运行时参数 |
+| `ROUND`/`TRUNCATE` 的值和 scale 参数 | preserve 函数参数 | 返回类型的 decimal scale 在构建期确定 |
+| `RAND(seed)` 的 seed 参数 | preserve | 常量 seed 在构建期初始化 RNG，避免不同 seed 复用同一随机状态 |
+| `ADDTIME`/`SUBTIME` 的参数 | preserve 整个函数参数列表 | 返回 FSP/Flen 在构建期由两个参数共同确定，不能复用不同精度的函数签名 |
+| `BENCHMARK` 的 loop count 参数 | preserve 第一个参数，第二个表达式按常规规则递归处理 | 正数 loop count 会缓存到函数签名，避免不同循环次数复用首次构建状态 |
+| window frame bound | preserve | 在新流程的 context selector/replacer 中处理；不改变 legacy replacer 行为 |
+| CTE、derived table、set operation 内的 filter | parameterize | 不在 preserve 子树下时递归使用相同规则 |
+| multi-table DML 的 filter/assignment | parameterize | 参数化规则先实现，端到端放开单独评审 |
+| 未识别的 literal 上下文 | preserve | 不能自动参数化；如果最终无法稳定生成 ParamSQL，则整条语句 bypass |
+
+需要为新进入的顶层 AST 结构增加 table-driven parameterizer 测试，至少覆盖：
+
+- CTE 内外各有 literal；
+- `UNION/INTERSECT/EXCEPT` 各分支有 literal；
+- named/inline window spec 和 frame bound；
+- derived table 和 correlated/uncorrelated subquery；
+- multi-table UPDATE/DELETE；
+- HAVING；
+- 含 hint 的 statement。
+
+测试要同时断言：
+
+- 参数化 SQL 的形状；
+- `ParamValues` 的数量和顺序；
+- preserve 位置仍保留 literal；
+- original AST restore 后与参数化前 restore 的 SQL 一致。
+
+如果某个新上下文中的 literal 会影响语法结构或 metadata，应明确采用 preserve；如果现有 restore 无法忠实保留，则参数化接口返回 `supported=false`，让整条语句 bypass。切换到公共 checker 前必须完成这张矩阵，不能依赖“公共 checker 可能会拒绝”。
+
+## original AST 的恢复
+
+### 当前问题
+
+当前 `GetParamSQLFromAST` 的逻辑是：
+
+```go
+paramSQL, params, err = ParameterizeAST(stmt)
+if err != nil {
+	return "", nil, err
+}
+// copy values
+err = RestoreASTWithParams(stmt, params)
+```
+
+`ParameterizeAST` 先修改 AST，再调用 `stmt.Restore`。如果 `stmt.Restore` 失败，它返回的 `params` 为空，调用方无法恢复已经替换的节点。
+
+### 建议改法
+
+把“执行替换并持有原 ValueExpr”的主体抽成私有函数：
+
+```go
+func parameterizeAST(
+	stmt ast.StmtNode,
+) (paramSQL string, params []*driver.ValueExpr, err error)
+```
+
+它在 `stmt.Accept(paramReplacer)` 后立刻保存 `params`，然后再 restore SQL。即使 SQL restore 失败，也把已经替换的原节点列表返回给内部调用方。
+
+`GetParamSQLFromAST` 使用该私有函数，并保证：
+
+1. 只要发生过替换，就在退出前调用 `RestoreASTWithParams`；
+2. 在恢复前复制每个参数的 `Datum`；
+3. ParamSQL restore 失败时仍先恢复 AST；高层 `ParameterizeForNonPreparedPlanCache` 在恢复成功后返回 `supported=false`，让整条语句 bypass；
+4. AST restore 失败时返回错误；如果 ParamSQL restore 也失败，在错误中同时保留两个原因；
+5. 只有 marker 已经从 AST 中替换掉后，才能放回 `paramMakerPool`。
+
+为了避免 `RestoreASTWithParams` 修改到一半才发现非法 offset，可以先做一次只读校验：所有待恢复 marker 的 offset 必须在 `[0, len(params))` 内。校验通过后第二次 visitor 才执行替换和对象归池。
+
+`ParameterizeAST` 是低层 API，注释已经说明它可能修改输入。可以继续保留当前对外语义；Non-Prepared 生产路径必须只调用能够保证恢复的高层接口。
+
+### 必须增加的失败路径测试
+
+在 `plan_cache_param_test.go` 增加可注入 restore 错误的 AST 节点或测试 hook，验证：
+
+- ParamSQL restore 失败但 AST 恢复成功时，返回 `supported=false, err=nil`；
+- 上述 bypass 路径的 original AST 中不存在新增的 `ParamMarkerExpr`，仍可以正常 restore 和进入普通 optimizer；
+- AST restore 失败时返回错误，不进入普通 optimizer；
+- 连续再次参数化不会复用仍挂在 AST 上的池化 marker。
+
+## `getPlanFromNonPreparedPlanCache` 的具体改造
+
+### PR 2 的最终控制流
+
+`pkg/planner/optimize.go` 中先保留共同入口 gate，然后一次性选择 legacy 或 unified 分支：
+
+```go
+func getPlanFromNonPreparedPlanCache(...) (...) {
+	vars := sctx.GetSessionVars()
+
+	// Keep the existing common switch, trace, restricted SQL, retry and
+	// multi-statement entry exclusions unchanged.
+	if !vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck {
+		return getPlanFromNonPreparedPlanCacheLegacy(ctx, sctx, stmt, is)
+	}
+	return getPlanFromNonPreparedPlanCacheUnified(ctx, sctx, stmt, is)
+}
+```
+
+`getPlanFromNonPreparedPlanCacheLegacy` 从当前实现机械抽取，除 PR 1 的 AST 恢复修复外不改变控制流。新分支按下面的伪代码实现。伪代码省略了当前已有的 test hook，但实现时必须保留 hook 的相对位置。
+
+```go
+func getPlanFromNonPreparedPlanCacheUnified(...) (...) {
+	stmtCtx := sctx.GetSessionVars().StmtCtx
+	vars := sctx.GetSessionVars()
+
+	if allowed, reason := nonPreparedPlanCacheDMLAllowed(vars, stmt); !allowed {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, false)
+		return nil, nil, false, nil
+	}
+
+	result, supported, reason, err := core.ParameterizeForNonPreparedPlanCache(
+		sctx.GetPlanCtx(), stmt,
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if !supported {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, true)
+		return nil, nil, false, nil
+	}
+
+	paramExprs := core.Params2Expressions(result.ParamValues)
+	value := vars.GetNonPreparedPlanCacheStmt(result.ParamSQL)
+
+	var cachedStmt *core.PlanCacheStmt
+	var paramStmt ast.StmtNode
+	if value == nil {
+		paramStmt, err = core.ParseParameterizedSQL(sctx, result.ParamSQL)
+		if err != nil {
+			// Treat a malformed parameterized SQL as a statement-level bypass.
+			// Ordinary execution must keep the original AST path warning-free;
+			// EXPLAIN FORMAT='plan_cache' reports this stable reason.
+			recordNonPreparedPlanCacheBypass(stmtCtx, "failed to parse parameterized SQL", true)
+			return nil, nil, false, nil
+		}
+	} else {
+		cachedStmt = value.(*core.PlanCacheStmt)
+		paramStmt = cachedStmt.PreparedAst.Stmt
+	}
+
+	cacheable, reason := core.IsASTCacheable(ctx, sctx.GetPlanCtx(), paramStmt, is)
+	if !cacheable {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, true)
+		return nil, nil, false, nil
+	}
+
+	if cachedStmt == nil {
+		if err := core.SetParameterValuesIntoSCtx(
+			sctx.GetPlanCtx(), true, nil, paramExprs,
+		); err != nil {
+			return nil, nil, false, err
+		}
+
+		cachedStmt, _, _, err = core.GeneratePlanCacheStmtWithAST(
+			ctx, sctx, false, result.ParamSQL, paramStmt, is,
+		)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if !cachedStmt.StmtCacheable {
+			recordNonPreparedPlanCacheBypass(
+				stmtCtx, cachedStmt.UncacheableReason, true,
+			)
+			return nil, nil, false, nil
+		}
+		vars.AddNonPreparedPlanCacheStmt(result.ParamSQL, cachedStmt)
+	}
+
+	plan, names, err := core.GetPlanFromPlanCache(
+		ctx, sctx, true, is, cachedStmt, paramExprs,
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return plan, names, true, nil
+}
+```
+
+### LRU hit 路径
+
+hit 后必须从 `cachedStmt.PreparedAst.Stmt` 取得 parameterized AST，并对它重新运行 `IsASTCacheable`。
+
+如果本次因为动态开关或当前 InfoSchema 被拒绝：
+
+- 不调用 `GetPlanFromPlanCache`；
+- 不删除 statement LRU entry，因为开关恢复后它可能再次可用；
+- 本次返回 `ok=false`，让外层使用 original AST 普通优化。
+
+### LRU miss 路径
+
+miss 时顺序必须是：
+
+1. parse parameterized SQL；
+2. `IsASTCacheable`；
+3. 把本次参数写入 session context；
+4. `GeneratePlanCacheStmtWithAST(..., false, ...)`；
+5. 检查 `StmtCacheable`；
+6. 写入 statement LRU。
+
+不能在第 2 步之前构造 carrier，否则公共 checker 拒绝的 statement 可能产生 Prepared warning、受到 `Fix49736` 强制放开的影响，或者进入 LRU。
+
+如果第 5 步发现不可缓存，第一阶段让整条语句 bypass，回到 original AST 普通优化，不缓存 carrier。这个分支可能多做一次 PlanBuilder 工作，但只发生在 AST checker 通过、构造阶段又发现不可缓存的情况，优先保证语义清楚。后续如需优化，可以研究安全复用 `GeneratePlanCacheStmtWithAST` 返回的 plan。
+
+### 保留现有 test hook
+
+以下 hook 的位置不能在重构时丢失：
+
+- `PlanCacheKeyTestIssue43667`：保持在参数化完成、statement LRU 查找前；
+- `PlanCacheKeyTestIssue47133`：保持在 `GetPlanFromPlanCache` 返回 names 后。
+
+先把现有函数机械抽取成 legacy helper 并用旧路径回归测试锁定行为，再实现 unified helper，比较容易确认 hook 和错误路径没有遗漏。两个 helper 都必须保留相应 hook；不要为了共享 hook 而重新合并两条流程。
+
+## bypass reason、warning 和 metric
+
+### Reason 选择
+
+开关打开的新流程不保证具体 reason 文本与旧 checker 完全一致。实现必须保证同一个 session/InfoSchema 状态下选择结果确定，并按调用链采用第一个失败原因：
+
+1. 入口策略，例如 DML/locking read 功能开关；
+2. 参数化流程，例如 literal 上限或无法忠实构造 ParamSQL；
+3. 公共 `IsASTCacheable`；
+4. carrier 构造结果；
+5. 物理计划检查。
+
+普通执行不增加 warning；`EXPLAIN FORMAT='plan_cache'` 继续使用 `skip non-prepared plan-cache: <reason>` 的前缀。新路径测试应验证 reason 类别和优先级，不要求复制旧 checker 的检查顺序。开关关闭时继续使用旧路径原有 reason 和 warning，相关 golden 测试保持不变。
+
+### 新 helper
+
+在 `optimize.go` 增加私有 helper，例如：
+
+```go
+func recordNonPreparedPlanCacheBypass(
+	stmtCtx *stmtctx.StatementContext,
+	reason string,
+	countUnsupported bool,
+) {
+	if countUnsupported {
+		core_metrics.GetNonPrepPlanCacheUnsupportedCounter().Inc()
+	}
+	if stmtCtx.InExplainStmt &&
+		stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
+		stmtCtx.AppendWarning(errors.NewNoStackErrorf(
+			"skip non-prepared plan-cache: %s", reason,
+		))
+	}
+}
+```
+
+需要在 `optimize.go` 增加 `pkg/planner/core/metrics` 的别名 import。`pkg/planner/core/metrics/metrics.go` 中已有 counter 和 accessor，不需要修改指标定义。
+
+### 计数边界
+
+开关打开时建议统一成：
+
+| 场景 | unsupported counter | warning |
+| --- | --- | --- |
+| Non-Prepared 总开关、trace、restricted SQL 等入口排除 | 不计 | 无 |
+| DML/locking read 功能开关关闭 | 不计 | 仅 Explain Plan Cache |
+| parameterization precheck 拒绝或 ParamSQL 无法忠实构造 | 计一次 | 仅 Explain Plan Cache |
+| `IsASTCacheable` 拒绝 | 计一次 | 仅 Explain Plan Cache |
+| carrier 构造后 `StmtCacheable=false` | 计一次 | 仅 Explain Plan Cache |
+| 物理计划 checker 拒绝 | 沿用后端 metric | 沿用后端行为 |
+
+这会让 unified 路径的 unsupported counter 覆盖范围比旧路径更完整：当前旧 checker 的 fast-check early return 没有计数。本设计接受打开开关后的可观测行为变化；开关关闭时继续保留旧 fast-check 的历史计数边界。灰度期间 dashboard 必须按开关启用范围解释数据，开启前后的 counter 绝对值不能直接比较。
+
+`ParseParameterizedSQL` 在 statement-LRU miss 上失败时也属于参数化阶段的 statement-level bypass：普通执行不追加 parser 原始 warning，unsupported counter 增加一次；`EXPLAIN FORMAT='plan_cache'` 使用稳定 reason `failed to parse parameterized SQL`。这样解析失败不会把原始 AST fallback 与缓存前端的内部 parser 错误混在一起。
+
+不要给 metric 增加 reason label。
+
+## Statement LRU admission
+
+本次沿用现有 statement LRU 的 key、容量和淘汰行为，不在 `SessionVars` 中新增 key builder，也不把 unified/legacy 模式编码进 key。参数化 SQL 仍通过现有 `AddNonPreparedPlanCacheStmt` / `GetNonPreparedPlanCacheStmt` 查找 statement carrier。
+
+unified 路径需要遵守以下 admission 规则：
+
+- hit 后重新执行 `IsASTCacheable`，不能直接复用 carrier 创建时的检查结论；
+- miss 时只有通过公共 checker 且 `StmtCacheable=true` 的 carrier 才能写入现有 LRU；
+- checker 拒绝或 carrier 不可缓存时直接走普通优化，不写入 LRU；
+- 动态开关切换不依赖 LRU key 隔离，实际使用哪条前端流程由当前 session 开关决定。
+
+现有 LRU 的参数化 SQL identity 和后端计划 key 不属于本次改造范围。若后续发现需要扩大 key 覆盖范围，应作为独立 correctness 变更评审，不能与本次 cacheability 职责调整混在一起。
+
+## `GeneratePlanCacheStmtWithAST` 的处理
+
+第一阶段不修改函数签名，也不增加新的公共 wrapper，减少对 Prepared 和 stored procedure 调用点的影响。
+
+修改 `pkg/planner/core/plan_cache_utils.go` 中 Non-Prepared 分支的注释：
+
+```go
+if isPrepStmt {
+	cacheable, reason = IsASTCacheable(...)
+} else {
+	// The non-prepared caller checks cacheability before building the
+	// PlanCacheStmt.
+	cacheable = true
+}
+```
+
+不要改成两条路径都在这里调用 `IsASTCacheable`，原因有两个：
+
+1. `Fix49736` 位于这个函数内部，会把 checker 的 false 强制改成 true；当前它不会覆盖 Non-Prepared 入口拒绝；
+2. 不可缓存时这里使用 `skip prepared plan-cache` warning，文案不适合 Non-Prepared。
+
+开关打开的 Non-Prepared 调用方在构造完成后仍需检查 `StmtCacheable`，因为 PlanBuilder 可能根据 partition processor 等信息把 statement 标记为不可缓存。开关关闭时保留旧调用方行为。
+
+当 unified Non-Prepared 调用触发上述 partition processor 拒绝时，不在 `GeneratePlanCacheStmtWithAST` 内追加 `skip prepared plan-cache` warning；由调用方统一通过 `recordNonPreparedPlanCacheBypass` 处理，只在 `EXPLAIN FORMAT='plan_cache'` 下输出 Non-Prepared 前缀的 warning。Prepared 调用和开关关闭的 legacy Non-Prepared warning 行为保持不变。
+
+## 灰度期保留旧 checker
+
+为了保证开关关闭时回到原有行为，PR 2 不能删除 `pkg/planner/core/plan_cacheable_checker.go` 中的 legacy 实现，包括：
+
+- `NonPreparedPlanCacheableWithCtx`；
+- `nonPreparedPlanCacheableChecker`；
+- `nonPrepCacheCheckerPool`；
+- `isSelectStmtNonPrepCacheableFastCheck`；
+- `nonPreparedPlanCacheableTableHints`；
+- `extractTableNames`；
+- `getColType`；
+- 只服务这些符号的字段、方法和 import。
+
+现有 `TestNonPreparedPlanCacheable` 和 `BenchmarkNonPreparedPlanCacheableChecker` 继续覆盖开关关闭的路径；同时新增：
+
+- AST 公共规则由 `IsASTCacheable` 的单元测试承接；
+- Non-Prepared 特有规则迁到 `plan_cache_param_test.go`；
+- 新放开的 SQL 迁到 `plan_cache_test.go` 做端到端测试；
+- benchmark 改成覆盖“precheck + parameterize + IsASTCacheable”的新热路径。
+
+### `checkTableCacheable`
+
+当前签名：
+
+```go
+func checkTableCacheable(
+	ctx context.Context,
+	sctx base.PlanContext,
+	schema infoschema.InfoSchema,
+	node *ast.TableName,
+	isNonPrep bool,
+) (bool, string)
+```
+
+灰度期保留 `isNonPrep` 参数和 legacy 专属的 view、非 normal table 拒绝分支。开关关闭的路径继续传 `true`；开关打开的路径通过公共 `IsASTCacheable` 使用 `false` 对应的公共 table 规则。最终仍有物理计划检查，例如 `PhysicalMemTable` 会被拒绝；但 view、system table 等必须用端到端测试确认实际落点，不能只依赖 checker 单测。
+
+如果测试发现某类表只能在 Non-Prepared 拒绝，应在 parameterization precheck 中增加名字明确的策略函数，不要重新给公共 table checker 加 `isNonPrep` 布尔分支。
+
+只有在后续版本将 unified 开关默认打开、完成灰度并正式移除 legacy 回滚能力后，才能在独立清理 PR 中删除上述 checker、测试和 `checkTableCacheable` 的 `isNonPrep` 参数。该清理不属于本文两个实现 PR。
+
+保留以下公共/后端逻辑不变：
+
+- `IsASTCacheable` 和 `cacheableChecker`；
+- `getMaxParamLimit`；
+- `isPlanCacheable`；
+- `isPhysicalPlanCacheable`；
+- generated column、partition、temporary table 等公共 table 检查。
+
+## 各文件最终改动清单
+
+### `pkg/planner/optimize.go`
+
+新增：
+
+- `getPlanFromNonPreparedPlanCacheLegacy`；
+- `getPlanFromNonPreparedPlanCacheUnified`；
+- `nonPreparedPlanCacheDMLAllowed`；
+- `recordNonPreparedPlanCacheBypass`；
+- `core_metrics` import。
+
+修改：
+
+- `getPlanFromNonPreparedPlanCache` 在共同入口 gate 后读取新开关并选择完整的 legacy/unified 分支；
+- legacy 分支继续调用 `NonPreparedPlanCacheableWithCtx` 和 `GetParamSQLFromAST`；
+- unified 分支调用 `ParameterizeForNonPreparedPlanCache`；
+- unified 分支在 LRU hit/miss 都调用 `IsASTCacheable`；
+- unified miss 时检查 `StmtCacheable` 后再写 LRU；
+- 两个分支都保留两个现有 test hook。
+
+### `pkg/planner/core/plan_cache_param.go`
+
+新增：
+
+- `NonPreparedPlanCacheParamResult`；
+- `ParameterizeForNonPreparedPlanCache`；
+- `nonPreparedPlanCachePrechecker`；
+- context-aware literal 遍历和待参数化节点 set/map；
+- 参数化内部 helper；
+- restore 前的 marker 校验；
+- `FrameBound` preserve 规则。
+
+修改：
+
+- `GetParamSQLFromAST` 所有路径恢复 original AST；
+- 新流程的 replacer 只替换 set/map 中明确选择 parameterize 的 literal，legacy replacer 的选择规则不变；
+- pool 对象只在 AST 不再引用后归还。
+
+暂不修改：
+
+- `Params2Expressions` 继续从 `Datum` 推导参数类型；
+- `ParseParameterizedSQL` 的 parser 配置来源。
+
+### `pkg/planner/core/plan_cacheable_checker.go`
+
+灰度期保留旧 Non-Prepared checker、allowlist、辅助代码和 `checkTableCacheable` 的 `isNonPrep` 分支，作为开关关闭时的完整回滚路径。公共 `IsASTCacheable` 需要按 AST 作用域识别 CTE 名称，避免把 CTE 引用当作物理表查询 InfoSchema；CTE 定义内部访问的真实表仍必须执行原有 table cacheability 检查。
+
+### `pkg/planner/core/plan_cache_utils.go`
+
+更新 Non-Prepared 已由调用方检查的注释；unified Non-Prepared carrier 拒绝时抑制 prepared 前缀的 partition warning，由 unified 调用方输出正确 warning。Prepared checker、Prepared warning 和 `Fix49736` 流程不变。
+
+### `pkg/sessionctx/variable/session.go`
+
+新增 `EnableNonPreparedPlanCacheUnifiedCacheabilityCheck` session 字段。`AddNonPreparedPlanCacheStmt` / `GetNonPreparedPlanCacheStmt` 继续使用现有实现和 key，不新增 key builder，不把 unified/legacy 模式写入 key；只需确认 unified 路径遵守新的 LRU admission 规则。
+
+### `pkg/sessionctx/variable/tidb_vars.go`
+
+新增 `TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck` 常量和默认值 `DefTiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck=false`。
+
+### `pkg/sessionctx/variable/sysvar.go`
+
+注册 `tidb_enable_non_prepared_plan_cache_unified_cacheability_check`，类型为 Boolean，scope 为 GLOBAL 和 SESSION，默认 `OFF`；`SetSession` 写入对应 SessionVars 字段。不把它声明为 `SET_VAR` hint 可修改，避免单条 statement 在 planner 流程中途改变前端模式。
+
+### 测试文件
+
+- `pkg/planner/core/plan_cache_param_test.go`：precheck、参数化矩阵、AST restore 和 benchmark；
+- `pkg/planner/core/plan_cacheable_checker_test.go`：保留旧 checker 专属测试，补公共 checker 必要用例；
+- `pkg/planner/core/plan_cache_test.go`：分别覆盖开关关闭的兼容行为，以及开关打开后的支持范围、warning/reason 和不同参数顺序；
+- `pkg/sessionctx/variable/session_test.go`：保留现有 statement LRU 行为测试；新增或扩展 unified 路径的 hit/miss、`StmtCacheable=false` 不写入 LRU 和容量/淘汰行为测试；
+- 相应 sysvar 测试：默认 `OFF`、GLOBAL/SESSION 设置和新 session 继承；
+- 必要时扩展 `pkg/planner/core/plan_cache_partition_table_test.go`：partition mode 动态切换。
+
+### `pkg/planner/MAINTAINER_GUIDE.md`
+
+更新：
+
+- 改造目标是 Non-Prepared 支持范围和公共 cacheability 规则收敛；
+- unified cacheability 开关默认关闭，关闭时走 legacy 前端路径，正确性修复由两条路径共享；
+- TiDB 当前通过 Prepared/Non-Prepared 调用 `IsASTCacheable` 复用公共 AST 规则；
+- Non-Prepared parameterization precheck 的职责；
+- statement LRU 沿用现有 key，本次只调整 carrier admission；
+- statement LRU 只接收通过公共 checker 且 `StmtCacheable=true` 的 carrier；
+- 为什么第一阶段每次执行公共 checker。
+
+## 端到端测试设计
+
+### 开关兼容和切换用例
+
+所有已有 Non-Prepared Plan Cache 回归用例在不设置新变量时继续以默认 `OFF` 运行，锁定旧 checker 的支持范围、reason、warning 和 metric。对本文新增或改变支持范围的用例显式执行：
+
+```sql
+SET tidb_enable_non_prepared_plan_cache = ON;
+SET tidb_enable_non_prepared_plan_cache_unified_cacheability_check = ON;
+```
+
+至少增加以下对照：
+
+- 默认值以及新建 session 继承的值为 `OFF`；
+- 同一条 HAVING、window、CTE 或三表 join SQL 在 `OFF` 时保持旧路径 bypass，在 `ON` 时进入新流程并按行为矩阵验证最终落点；
+- 同一条包含多个拒绝条件的 SQL 在 `OFF` 时保持旧 reason/metric，在 `ON` 时使用新优先级；
+- 在 statement LRU entry 已存在时执行 `OFF -> ON -> OFF` 和 `ON -> OFF -> ON`，验证每次执行都按当前开关选择对应前端流程；不要求通过 LRU key 隔离 legacy/unified carrier；
+- 在两种模式下分别验证 original AST 恢复和统一 admission 规则；
+- 总开关为 `OFF` 时，新开关无效果，仍完全跳过 Non-Prepared Plan Cache。
+
+测试不能只断言 `@@last_plan_from_cache`。还要验证 statement LRU hit/miss（通过现有 hook 或可观察测试点）、Explain reason、unsupported counter 增量和 SQL 结果，证明切换的是完整前端流程。
+
+### 兼容用例
+
+开关打开时，以下场景执行两次后 `@@last_plan_from_cache` 仍应为 0：
+
+- DML 开关关闭时的 INSERT/UPDATE/DELETE；
+- DML 开关关闭时的 `SELECT ... FOR UPDATE`；
+- literal 总数超过 Fix44823 对应上限；
+- param-limit 开关关闭时的 `LIMIT/OFFSET`；
+- `SELECT ... INTO`；
+- `ignore_plan_cache()`、用户变量、不可缓存函数；
+- 公共 checker 或物理 checker 明确拒绝的 statement。
+
+`NULL`、BIT、HEX 和 charset introducer 不再因为“不能参数化”而统一让整条语句 bypass。参数化单测需要断言能够 preserve 的类别完整保留在 `ParamSQL` 中、不进入 `ParamValues`，并验证 ordinary literal 与这些 preserve literal 混合时的参数顺序。charset introducer 还要覆盖当前 `RestoreStringWithoutCharset` 的问题：修正 restore 后验证完整 token；如果第一阶段不能修正，则明确断言整条语句 bypass。端到端测试再根据公共 AST 和物理计划结果断言最终落点；至少选择一组普通 SELECT 用例验证相同 SQL 的第二次执行可以命中。
+
+同时验证普通执行没有新增 warning；`EXPLAIN FORMAT='plan_cache'` 包含 `skip non-prepared plan-cache: <reason>`。
+
+增加包含多个拒绝条件的用例，确认 reason 优先级：入口策略 → 参数化安全 → 公共 AST → carrier → 物理计划。unsupported counter 用测试确认入口 gate 不计数、precheck/公共 AST/carrier 各计一次，物理计划拒绝不重复计数。
+
+### 行为矩阵和分阶段用例
+
+开关打开、不再使用旧 allowlist，只表示 SQL 可以进入后续检查，不表示每一类都必须命中物理 Plan Cache。测试按下面的矩阵分别断言最终落点：
+
+| SQL 类别 | parameterizer 预期 | AST checker 预期 | 最终预期 | 第一阶段 |
+| --- | --- | --- | --- | --- |
+| HAVING | filter value parameterize | 按公共规则 | 普通计划可命中 | 放开 |
+| window | frame 等结构值 preserve | 按公共规则 | 视物理计划 | 放开已确认位置 |
+| subquery | 内外 literal 分别分类 | 受开关控制 | 视 subquery plan | 开关打开时验证 |
+| CTE、set operation | 各分支按相同规则分类 | 按公共规则 | 视物理计划 | 分类放开 |
+| 三表以上 join | filter value parameterize | 按公共规则 | 普通 join 可命中 | 放开 |
+| multi-table UPDATE/DELETE | filter/assignment parameterize | 可能通过 | 写入正确性需要单独验证 | 后续阶段 |
+| view | 按表达式位置分类 | 可能通过 | 验证 schema 依赖 | 验证后决定 |
+| system table | 按表达式位置分类 | 可能通过 | `PhysicalMemTable` 通常拒绝 | 不要求命中 |
+| JSON/ENUM/SET/BIT 类型列的 filter | literal 按形式和上下文分类 | 可能通过 | 验证类型和 range 保护 | 单独验证 |
+
+“按表达式位置分类”表示表类型本身不是 parameterize/preserve 决策；决策针对 SQL 中的 literal。表和最终计划由 AST/physical checker 处理。
+
+预期可命中的类别每类至少准备两个参数值，按 `A -> B` 和 `B -> A` 两种顺序执行。预期物理阶段拒绝的类别需要断言：
+
+- 参数化和公共 checker 的落点符合矩阵；
+- `@@last_plan_from_cache` 保持为 0；
+- Explain Plan Cache 显示物理阶段 reason；
+- SQL 结果与关闭 Plan Cache 时一致。
+
+每类都比较：
+
+1. 关闭 Plan Cache 的结果；
+2. Prepared Plan Cache 的结果；
+3. Non-Prepared miss 的结果；
+4. Non-Prepared hit 或预期 bypass 的结果；
+5. output field metadata、warning、affected rows 和表中最终数据。
+
+### 动态状态用例
+
+在 statement LRU entry 已存在时切换：
+
+- `EnableNonPreparedPlanCacheUnifiedCacheabilityCheck`，并验证当前执行按开关选择对应前端流程，不依赖 key 隔离；
+- `EnablePlanCacheForSubquery`；
+- `EnablePlanCacheForParamLimit`；
+- partition prune mode；
+- Fix44823、Fix33031、Fix45798 等相关 fix-control；
+- schema：普通表和 view/temporary table 等属性变化。
+
+确认当前执行重新运行公共 checker，而不是沿用 carrier 创建时的结论。
+
+## 建议实现顺序
+
+### PR 1：独立正确性修复
+
+1. 修复 `GetParamSQLFromAST` 的 original AST 恢复；
+2. 增加失败路径和 AST 恢复单元测试。
+
+这个 PR 不引入新 precheck，不改变 checker、支持范围、reason 或 metric，便于独立 backport 和排查。
+
+### PR 2：完成新流程切换
+
+1. 注册默认 `OFF` 的 unified cacheability 系统变量并加入 SessionVars；
+2. 把当前实现机械抽取为 legacy helper，用现有测试锁定关闭时的行为；
+3. 增加 parameterization precheck 和新返回接口；
+4. 增加 context-aware literal 遍历、新流程专用的节点选择/replacer，以及特殊 literal、window frame 等 preserve 规则；
+5. 增加 unified helper，把 DML/locking read 开关放到该分支入口；
+6. unified 分支参数化后在 LRU hit/miss 都调用 `IsASTCacheable`；
+7. unified 分支增加 bypass helper、固定 reason 优先级和 `StmtCacheable` LRU admission 检查；
+8. 接受并记录 unified 分支 unsupported metric 的新计数语义；
+9. 保留 `NonPreparedPlanCacheableWithCtx`、旧 allowlist 及其测试作为回滚路径；
+10. 补齐开关切换、参数化矩阵、端到端差分测试和 benchmark；
+11. 更新 `MAINTAINER_GUIDE.md`，运行 targeted tests、benchmark、`make fmt` 和 `make check`。
+
+为了便于 review，这个 PR 内部按 commit 分层：先提交 sysvar 和 legacy helper 抽取，再提交 precheck、literal 处理规则和单元测试，然后接入 unified 分支，最后补 reason、metric、端到端测试、benchmark 和文档。生产代码不串联旧 checker 与新 precheck，而是在入口选择完整路径。
+
+### 后续清理 PR：移除 legacy 路径
+
+这不是本文实现 PR 的一部分。只有在 unified 路径经过灰度、默认值已经切换为 `ON`、兼容性和性能观测达到要求，并且产品决定不再保留即时回滚能力后，才能：
+
+1. 删除 legacy helper 和 `NonPreparedPlanCacheableWithCtx`；
+2. 删除旧 allowlist、辅助代码、测试和 benchmark；
+3. 简化 `checkTableCacheable`；
+4. 决定删除系统变量，或保留为仅兼容读取且不再改变行为的 deprecated 变量。
+
+## 实现阶段待确认事项
+
+下面这些事项是 PR 2 完成前必须关闭的实现和验证项，不能仅以 parameterizer 或 AST checker 返回通过作为完成标准。
+
+### charset introducer 的完整恢复
+
+当前参数化 restore 使用 `RestoreStringWithoutCharset`，会丢失 charset introducer。第一阶段采用 statement-level bypass：precheck 发现 introducer 后返回 `supported=false, err=nil`，保证不会生成语义不完整的 `ParamSQL`，并且 original AST 保持不变。
+
+测试至少覆盖 introducer 与普通 filter literal 混合的语句，断言 `ParameterizeForNonPreparedPlanCache` 返回 `supported=false, err=nil`，普通执行不新增 warning，`EXPLAIN FORMAT='plan_cache'` 显示稳定的 bypass reason。后续只有在 restore 能完整保留 token 后，才能把该策略改成 literal-level preserve。
+
+### 未识别上下文默认 preserve 的缓存碎片
+
+未知 literal 上下文默认 preserve 是第一阶段的正确性边界，但不同 literal 会形成不同的参数化 SQL identity 和后端 `StmtText`，从而降低归一化比例并增加缓存碎片。现有 statement LRU 会按这些 SQL identity 查找 entry，本次不调整其 key 组成。
+
+新增 benchmark 时需要包含 literal 值持续变化的未识别上下文，除参数化本身的 `ns/op` 和 allocation 外，还要记录生成的 ParamSQL identity 数量以及 statement/plan cache 的命中情况，并与已明确 parameterize 的 filter 场景对照。第一阶段不以命中率下降为由放宽默认规则；后续只在补齐语义测试后，逐类把上下文从 preserve 改为 parameterize。
+
+### 分阶段验证最终缓存落点
+
+CTE、set operation、window、subquery、view 和 system table 等结构通过 parameterization 和 `IsASTCacheable`，只表示可以进入下一阶段，不表示最终一定能够写入或命中物理 Plan Cache。测试必须分别断言 parameterizer、公共 AST checker、carrier 和物理 checker 的落点，避免把物理阶段 bypass 误判为支持范围改造失败，也避免把 AST checker 通过误判为已经支持缓存。
+
+对于预期物理阶段拒绝的类别，仍需验证 SQL 结果、field metadata、warning 和动态 schema/session 状态与关闭 Plan Cache 时一致，并确认 statement LRU 中不存在 `StmtCacheable=false` 的 carrier。
+
+### multi-table DML 的放开边界
+
+第一阶段可以实现 multi-table UPDATE/DELETE 中 filter 和 assignment 的参数化规则，但在写入正确性、affected rows、warning、trigger/constraint 等行为完成独立评审和端到端差分测试前，不正式允许它们进入 Non-Prepared Plan Cache。
+
+如果这些验证不属于当前 PR，入口或 parameterization precheck 必须保留明确的 statement-level bypass gate，并提供稳定 reason；不能依赖公共 AST checker 或物理 checker 偶然拒绝。正式移除 gate 时，应单独提交行为变更和测试，至少比较关闭 Plan Cache、Prepared miss/hit、Non-Prepared miss/hit，以及不同参数执行顺序下的最终数据。
+
+### LRU hit 重跑公共 checker 的性能
+
+每次 statement LRU hit 都运行 `IsASTCacheable` 是动态 session 和 InfoSchema 正确性的要求，第一阶段不能通过缓存 checker 结论来规避。实现完成后需要增加或扩展 Non-Prepared hit-path benchmark，分别覆盖公共 checker 通过和因动态状态拒绝的路径，记录 `ns/op`、allocation 和相对改造前的变化。
+
+如果开销明显，需要先用 profile 确认热点，再评估 checker 内部无状态、无语义变化的优化；不能把依赖 session、InfoSchema 或 fix-control 的检查结果存入 `PlanCacheStmt` 长期复用。
+
+## 本地验证命令
+
+按仓库测试规范启用 failpoint 后执行 targeted tests：
+
+```bash
+make failpoint-enable
+
+pushd pkg/planner/core
+go test -run 'Test(NonPreparedPlanCache|.*UnifiedCacheability.*|.*ParamSQL.*|.*Parameteriz.*)' -tags=intest,deadlock
+go test -run '^$' -bench '^(BenchmarkNonPrepared|BenchmarkUnifiedNonPrepared|BenchmarkParameterize|BenchmarkGetParamSQL)' -tags=intest,deadlock
+popd
+
+pushd pkg/sessionctx/variable
+go test -run 'Test(NonPreparedPlanCacheStmt|.*NonPreparedPlanCacheUnifiedCacheability.*)' -tags=intest,deadlock
+popd
+
+make failpoint-disable
+make fmt
+make check
+```
+
+如果修改了 partition 相关用例，再单独运行对应测试名，不运行整个 workspace。
+
+## Review 时重点检查
+
+- 新开关是否为 GLOBAL/SESSION Boolean 且默认 `OFF`，总开关关闭时是否无效果；
+- 开关关闭时是否完整走 legacy checker、参数化、reason、warning 和 metric 路径；
+- 开关打开时是否完整走 unified 路径，而不是与 legacy checker 串联；
+- 动态切换时是否按当前开关选择 legacy 或 unified 前端，而不是依赖 LRU key 隔离；
+- PR 1 的 AST 恢复正确性修复是否在两个模式下都生效；
+- original AST 在所有 return path 上是否保持不变；
+- precheck 是否遍历了 preserve 位置的 literal；
+- LRU hit 是否也运行 `IsASTCacheable`；
+- checker false 是否在构造 carrier 和进入后端之前返回；
+- `StmtCacheable=false` 的 carrier 是否没有写入 LRU；
+- statement LRU 是否只接收通过公共 checker 且 `StmtCacheable=true` 的 carrier；
+- 未识别的 literal 上下文是否默认 preserve；无法忠实生成 ParamSQL 时是否在 statement 级 bypass；
+- 普通执行是否没有新增 Prepared warning；
+- `Fix49736` 是否仍不能覆盖 Non-Prepared 入口拒绝；
+- unified 路径绕过旧 allowlist 后，每类新增行为是否有端到端测试；
+- bypass reason 是否遵守入口策略、参数化流程、公共 AST、carrier、物理计划的优先级；
+- unsupported metric 是否按文档中的新计数边界实现。
+
+完成以上改动后，代码中的职责应当是清楚的：新开关决定选择 legacy 还是 unified 前端；legacy helper 保留旧支持范围和可观测行为；unified 路径中的 `plan_cache_param.go` 决定 literal 应当 parameterize 还是 preserve，并给出整条语句能否安全生成 ParamSQL 的结果；`IsASTCacheable` 决定参数化 AST 是否满足公共 plan cache 规则；unified helper 负责两者的编排和 statement 级 bypass；`GetPlanFromPlanCache` 继续负责两条路径共用的后端。

--- a/docs/design/2026-08-11-non-prepared-plan-cache-cacheability-check.md
+++ b/docs/design/2026-08-11-non-prepared-plan-cache-cacheability-check.md
@@ -1,0 +1,314 @@
+# Non-Prepared Plan Cache 支持范围与 cacheability 检查改造
+
+配套材料：
+
+- [代码实现说明](2026-08-11-non-prepared-plan-cache-cacheability-check-implementation.md)
+- [其他数据库实现调研](2026-08-11-non-prepared-plan-cache-other-databases.md)
+- [OceanBase 实现专项调研](2026-08-11-non-prepared-plan-cache-oceanbase.md)
+
+## 背景
+
+Plan Cache 不能只根据参数化 SQL 判断计划是否可以复用。同一种 SQL 结构可能因为参数位置、表类型、schema 或 session 状态不同而不适合缓存。TiDB 会在不同阶段检查：
+
+- AST 结构和表达式是否适合复用；
+- 参数类型和取值是否与缓存计划兼容；
+- schema、MDL、权限和会话环境是否变化；
+- 优化后的物理计划是否安全。
+
+本设计主要调整优化前的前端职责：Non-Prepared 如何处理普通 SQL literal，以及如何判断参数化后的 statement 能否进入公共 Plan Cache 流程。后端已有的 schema、权限、参数类型、range rebuild 和物理计划检查继续保留。
+
+## 当前两条路径
+
+### Prepared Plan Cache
+
+Prepared SQL 在进入 Plan Cache 前已经有参数标记：
+
+```sql
+PREPARE stmt FROM 'SELECT * FROM t WHERE a = ?';
+```
+
+TiDB 可以直接对带参数标记的 AST 调用 `IsASTCacheable`，检查 statement 类型、hint、函数、参数位置、相关开关、表属性和结构大小。通过后构造已经 parse/preprocess 的 statement carrier，再进入共用后端。
+
+### Non-Prepared Plan Cache
+
+普通 SQL 中没有客户端参数：
+
+```sql
+SELECT * FROM t WHERE a = 1;
+SELECT * FROM t WHERE a = 2;
+```
+
+Non-Prepared 需要先判断 literal 是否能安全转换，再得到统一的参数化 SQL：
+
+```sql
+SELECT * FROM t WHERE a = ?;
+```
+
+当前流程先调用 `NonPreparedPlanCacheableWithCtx`。这个 checker 同时承担：
+
+1. DML/locking read 等入口策略；
+2. 特殊 literal、literal 数量和 `LIMIT` 等参数化策略；
+3. statement 结构、表类型和表达式等 AST cacheability。
+
+第 3 类职责与 `IsASTCacheable` 重复，但两边长期演进不一致。当前 Non-Prepared checker 采用较窄的 AST allowlist，因此 HAVING、window、CTE、三表以上 join 等 Prepared 已支持的结构仍可能被提前拒绝。
+
+## 问题和目标
+
+本次首先要解决的是支持范围和规则漂移问题：Non-Prepared 不应仅因为独立 AST allowlist 没有覆盖某个结构，就拒绝 Prepared 已经能够安全处理的 SQL。改造后，Non-Prepared 只保留普通 SQL 自动参数化特有的判断；与参数来源无关的 AST、schema 和物理计划安全规则复用公共逻辑。
+
+基于 TiDB 当前代码结构，本次选择删除重复 AST allowlist，并在 Non-Prepared 参数化后调用现有 `IsASTCacheable`。这是实现规则复用的方式，不是为了共用某个函数而设定的目标，也不表示可以简单改成：
+
+```text
+参数化 → IsASTCacheable(parameterized AST)
+```
+
+参数化后，公共 checker 已经看不到原 literal 的写法、类型和所在上下文。旧 checker 中属于 Non-Prepared 参数化安全的规则必须在原始信息仍然可见时完成；实现上可以与 literal 处理合并为一次遍历，但职责上仍要与公共 AST cacheability 检查分开。新进入 parameterizer 的 AST 位置也必须逐类确认。
+
+本次改造目标：
+
+- 扩大并稳定 Non-Prepared Plan Cache 的 SQL 结构支持范围；
+- 删除容易与 Prepared 规则漂移的 Non-Prepared AST allowlist；
+- 让 Non-Prepared 只保留职责明确的参数化安全检查；
+- 复用与参数来源无关的公共 AST 和后端安全规则；
+- 在 TiDB 当前实现中，通过参数化后调用 `IsASTCacheable` 落地公共 AST 规则复用；
+- 修复参数化过程中 original AST 恢复的正确性问题；
+- 保持后端缓存和物理计划保护不变。
+
+第一阶段继续保留：
+
+- 特殊 literal 的保守处理：能够忠实保留原 token 时进入 statement identity，当前实现无法安全保留时整条语句 bypass；
+- 原始 literal 默认 200 的上限；
+- DML/locking read 和 `LIMIT` 的产品开关；
+- `SELECT ... INTO` 的提前回退；
+- 每次执行公共 checker。
+
+本次不修改 statement LRU key 的组成。现有 statement LRU 仍用于保存和查找已经 parse/preprocess 的 carrier；key 完整性和解析上下文隔离问题另行处理。
+
+特殊 literal 的进一步参数化、OceanBase 风格的 not-param constraint matcher，以及只在 statement LRU miss 时运行公共 checker，不属于第一阶段。
+
+## 目标流程
+
+```text
+普通 SQL / original AST
+    ↓
+检查入口 gate
+    - 总开关和通用排除项
+    - DML / locking read 开关
+    ↓
+参数化前检查
+    - 原始 literal 总数
+    - 参数化流程的基本前提
+    - LIMIT 产品策略
+    - SELECT ... INTO
+    ↓
+按上下文处理 literal，并选择性参数化
+    - 普通数据值 parameterize
+    - 结构或解释敏感的值 preserve
+    - 所有路径恢复 original AST
+    ↓
+检查 ParamSQL 构造结果
+    - success：得到可靠的 ParamSQL 和 ParamValues
+    - bypass：无法保证 restore 或参数映射正确，走普通优化
+    - error：original AST 无法安全恢复，返回错误
+    ↓
+按参数化 SQL 查现有 statement LRU
+    - hit：取得缓存的 parameterized AST / carrier
+    - miss：重新 parse 参数化 SQL；失败时整条语句 bypass
+    ↓
+每次执行 IsASTCacheable
+    - false：记录 bypass reason，走普通优化
+    - true：继续构造或复用 carrier
+    ↓
+共用 Plan Cache 后端和物理计划检查
+```
+
+## 参数化规则
+
+### Literal 的两种处理方式
+
+每个 literal 按所在 AST 上下文选择两种处理方式之一：
+
+- **parameterize**：可以自由变化，例如 `WHERE`、`ON`、`IN`、`BETWEEN`、HAVING 和 DML values 中的普通运行时数据；
+- **preserve**：会影响语法结构、输出列名、metadata 或表达式解释，需要保留原值。
+
+同一条 SQL 可以同时包含 parameterize 和 preserve。例如：
+
+```sql
+SELECT * FROM t WHERE a = 10 ORDER BY 1 LIMIT 100;
+```
+
+第一阶段得到 `SELECT * FROM t WHERE a = ? ORDER BY 1 LIMIT 100`：`10` 被参数化，`ORDER BY 1` 和 `LIMIT 100` 保留。
+
+第一阶段的 preserve 采用简单实现：literal 继续留在 parameterized SQL 中，因此自然进入 statement identity。`ORDER BY 1` 和 `ORDER BY 2` 会形成不同 key，不需要额外实现 OceanBase 风格的 not-param matcher。
+
+第一阶段按下面的原则处理常见 literal：
+
+| literal 场景 | 处理 |
+| --- | --- |
+| 普通过滤值、join 条件、HAVING、DML values/assignment | parameterize |
+| `ORDER BY`/`GROUP BY` 位置序号、window frame、影响输出 metadata 的值 | preserve |
+| `NULL`、BIT/HEX literal | preserve 原 AST 节点和原 token |
+| charset introducer literal | introducer 与字符串整体 preserve |
+| `WEIGHT_STRING(... AS CHAR/BINARY(n))` 的语法参数 | 只参数化第一个表达式，保留 `CHAR`/`BINARY` 和长度 |
+| 构建期类型依赖参数（`CHAR ... USING` charset、`LPAD/RPAD` length、`CONVERT_TZ`/`UNIX_TIMESTAMP` datetime、`FROM_UNIXTIME` timestamp） | preserve，避免函数签名或返回类型按首次执行固化 |
+| 时间精度或构建期类型依赖参数（`TIME`、`TIMEDIFF`、`TIMESTAMP`、显式 FSP 的当前时间函数） | preserve，避免 FSP 或首参数类型按首次执行固化 |
+| `ROUND`/`TRUNCATE` 的值和 scale 参数 | preserve，避免返回 decimal scale 按首次执行固化 |
+| `RAND(seed)` 的 seed 参数 | preserve，避免不同 seed 复用首次构建的 RNG 状态 |
+| `ADDTIME`/`SUBTIME` 的参数 | preserve 整个函数参数列表，避免返回 FSP/Flen 按首次执行固化 |
+| `BENCHMARK` 的 loop count 参数 | preserve loop count，第二个表达式按常规上下文处理，避免循环次数按首次执行固化 |
+| 未识别的 literal 上下文 | 默认 preserve |
+
+`fallback` 不是第三种 literal 决策，而是整条语句的控制流。所有 literal 处理完成后，如果 ParamSQL restore 或参数数量/顺序无法保证正确，本次参数化结果为 bypass，整条 SQL 回到普通优化；statement LRU miss 后在同一上下文中重新解析 ParamSQL 失败，也按 statement 级 bypass 处理。如果 original AST 本身无法安全恢复，则返回错误，不能继续使用可能已经被修改的 AST。
+
+### 默认必须保守
+
+删除旧 allowlist 后，CTE、set operation、window、subquery 和 multi-table DML 等结构会首次进入 parameterizer。参数化器必须按上下文显式决定 literal 的处理方式：
+
+> 未确认安全的位置不能默认参数化；第一阶段优先 preserve。如果 preserve 机制本身无法忠实生成 ParamSQL，则整条语句 bypass，而不是给该 literal 增加第三种决策。
+
+context matrix 必须落实为代码中的上下文规则，而不仅是一张测试表。公共 checker 运行在参数化之后，不能替代这层判断。
+
+### 参数化前检查
+
+参数化前需要完整遍历 original AST，包括最终会被 preserve 的子树。这一步只判断参数化流程能否安全启动，不承担特殊 literal 的通用拒绝，也不重新引入 statement 结构 allowlist。
+
+- 所有 original literal 都计入默认 200 上限；
+- `LIMIT` 产品开关关闭时，含 literal `LIMIT/OFFSET` 的 SQL 按现有策略 bypass；开关打开时，第一阶段可以 preserve，后续再单独评估参数化；
+- `SELECT ... INTO` 在 carrier 构造前 bypass。
+
+`NULL`、BIT/HEX 和 charset introducer 交给 literal 处理逻辑：第一阶段优先保留原 AST 节点及完整 token。charset introducer 必须与后面的字符串整体保留。仅仅跳过参数替换并不一定等于忠实 preserve；例如当前参数化 restore 使用的配置会省略字符串 charset，实施时必须修正 restore 方式。某类 token 仍无法忠实进入 ParamSQL 时，参数化流程将整条语句标记为 bypass。
+
+这些拒绝都表示“不使用 Non-Prepared Plan Cache”，不是 SQL 执行错误。
+
+parameterizer 会临时替换 original AST 中的 literal，再 restore 出参数化 SQL。无论 SQL restore 成功还是失败，都必须在退出前恢复 original AST，避免普通优化路径看到残留的参数标记或已经归池的对象。
+
+## 公共 checker 的调用方式
+
+参数化完成后，对 parameterized AST 调用 `IsASTCacheable`。第一阶段在 statement LRU hit 和 miss 时都调用，因为结果仍依赖 subquery/limit 开关、partition prune mode、fix-control、当前表属性等 session 和 InfoSchema 状态。
+
+只有在这些动态输入已经被现有的缓存隔离、metadata 或可靠失效机制覆盖后，才可以考虑只在 LRU miss 时检查。
+
+公共 checker 由 Non-Prepared 入口显式调用，不修改 Prepared carrier 构造函数的检查和 warning 行为，避免 Prepared 专用 fix-control 意外覆盖 Non-Prepared 的拒绝结果。
+
+## Statement LRU admission
+
+statement LRU 仍然保存已经 parse/preprocess 的 carrier。只有同时满足下面两个条件的 carrier 才能写入现有 statement LRU：
+
+- parameterized AST 通过 `IsASTCacheable`；
+- carrier 构造完成后仍标记为可缓存。
+
+如果某次执行因为动态开关或当前 InfoSchema 被公共 checker 拒绝，已有 LRU entry 可以保留，但本次不能进入 Plan Cache 后端。下一次仍需根据当时状态重新检查。
+
+## Bypass reason、warning 和 metric
+
+### Reason 优先级
+
+本次不保证 `EXPLAIN FORMAT='plan_cache'` 的具体 reason 文本与旧 checker 完全一致。支持范围和检查顺序都会变化，强行保留旧文本会继续暴露旧 checker 的实现结构。
+
+需要保证同一状态下结果确定，并按下面的优先级选择第一个 reason：
+
+1. 入口策略；
+2. 参数化安全；
+3. 公共 AST cacheability；
+4. statement carrier；
+5. 物理计划。
+
+普通执行不新增 warning；Explain Plan Cache 继续使用 Non-Prepared 的 warning 前缀。
+
+### Metric 语义
+
+旧 checker 只有进入完整 AST visitor 后被拒绝才增加 unsupported counter，fast-check early return 不计数。新流程统一计数后，指标范围会扩大。
+
+本设计接受这个可观测变化，并定义新的计数边界：
+
+| 场景 | unsupported counter |
+| --- | --- |
+| 总开关、trace、restricted SQL 等入口排除 | 不计 |
+| DML/locking read 功能开关关闭 | 不计 |
+| 参数化 precheck 或上下文安全规则拒绝 | 计一次 |
+| `IsASTCacheable` 拒绝 | 计一次 |
+| carrier 构造后不可缓存 | 计一次 |
+| 物理计划 checker 拒绝 | 沿用后端 metric，不重复计 |
+
+升级后 unsupported counter 不能与升级前的绝对值直接比较，dashboard 可能出现台阶变化。metric 不增加 reason label，避免高基数和指标兼容问题。
+
+## 行为变化矩阵
+
+删除通用 AST allowlist 不等于下面所有 SQL 都保证命中。每一类需要分别经过 parameterizer、公共 AST 和物理计划检查。
+
+| SQL 类别 | literal 处理 | 公共 AST | 最终预期 | 第一阶段 |
+| --- | --- | --- | --- | --- |
+| HAVING | 普通过滤值 parameterize | 按公共规则检查 | 普通计划预期可命中 | 放开 |
+| window | frame 等结构值 preserve | 按公共规则检查 | 视物理计划而定 | 放开已确认位置 |
+| subquery | 内部 literal 按上下文分类 | 受 subquery 开关控制 | 视 subquery 计划而定 | 开关打开时验证 |
+| CTE、set operation | 各分支按相同规则分类 | 按公共规则检查 | 视物理计划而定 | 分类放开 |
+| 三表以上 join | filter literal parameterize | 按公共规则检查 | 普通 join 预期可命中 | 放开 |
+| multi-table DML | filter/assignment parameterize | 可能通过 | 写入正确性风险较高 | 单独阶段 |
+| view | 按表达式位置分类 | 可能通过 | 依赖 schema 保护验证 | 验证后决定 |
+| system table | 按表达式位置分类 | 可能通过 | `PhysicalMemTable` 通常使整条语句 bypass | 不承诺命中 |
+| JSON/ENUM/SET/BIT 类型列的 filter | literal 按形式和上下文分类 | 可能通过 | 依赖类型和 range 保护 | 单独验证 |
+
+对于尚未确认的类别，允许增加范围具体、命名明确的临时策略；不能重新引入“未知 AST 默认拒绝”的通用 statement allowlist。
+
+## 正确性和兼容性决策
+
+- 原始 literal 默认 200 上限第一阶段保留，后续再讨论改成实际参数数量；
+- view、system table 和特殊列类型不一次性承诺命中，按行为矩阵分阶段验证；
+- 每次执行 `IsASTCacheable` 是第一阶段的正确性要求，性能成本通过 benchmark 量化后再优化；
+- 被参数化的普通 literal 第一阶段继续使用 `Datum` 和现有类型推导；特殊 literal 先 preserve，不要求为了本次改造立即把它们转换成 typed parameter；
+- schema、MDL、权限、参数类型和物理计划等后端检查保持不变；
+- Prepared 和 Non-Prepared 不要求共享 statement carrier、cache entry 或物理计划。
+
+## 风险和验证重点
+
+| 风险 | 处理方式 |
+| --- | --- |
+| 未知 AST 位置被自动参数化 | context-aware 规则，未知位置默认 preserve；无法忠实生成 ParamSQL 时整条语句 bypass |
+| 特殊 literal 信息丢失 | literal 处理逻辑保留原 AST 节点和完整 token，restore/重新解析不可靠时整条语句 bypass |
+| literal 上限被 preserve 绕过 | precheck 遍历全部 original literal |
+| 动态开关变化后沿用旧结论 | 每次执行公共 checker |
+| 参数化失败污染 original AST | 所有退出路径原子恢复 |
+| reason 和 metric 无意变化 | 固定 reason 优先级，明确 metric 新语义 |
+| AST 通过但物理计划仍拒绝 | 行为矩阵区分各阶段结果 |
+
+端到端测试需要比较 cache disabled、Prepared、Non-Prepared miss 和 Non-Prepared hit 的结果，并对不同参数值执行 `A → B`、`B → A` 两种顺序。除查询结果外，还要比较 output metadata、warning、affected rows 和最终数据。
+
+## 实施阶段
+
+### PR 1：参数化正确性修复
+
+- 修复所有错误路径上的 original AST 恢复；
+- 增加对应单元测试。
+
+这个 PR 不改变 checker、支持范围、reason 和 metric。
+
+### PR 2：完成新流程切换
+
+- 增加 parameterization precheck，以及区分参数化成功、整条语句 bypass 和内部错误的返回接口；
+- 实现 context-aware literal 处理，literal 层只区分 parameterize 和 preserve，未知位置默认 preserve；
+- 让普通 literal parameterize，特殊 literal preserve-first；
+- 把 DML/locking read 开关移到入口 gate；
+- 参数化后在 statement LRU hit/miss 都调用 `IsASTCacheable`；
+- 统一 statement LRU admission、bypass reason 和 metric；
+- 删除旧 checker 及其 AST allowlist；
+- 先放开行为矩阵中风险较低且验证完成的类别；
+- 对高风险类别保留命名明确的临时策略；
+- 增加参数化矩阵、端到端差分测试和性能 benchmark。
+
+这个 PR 可以按内部 commit 分层实现：先落 precheck、literal 处理规则和单元测试，再切换调用链并删除旧 checker，最后补齐 reason、metric、端到端测试和 benchmark。生产代码不引入“旧 checker 和新 precheck 长期串联”的临时状态。
+
+详细的函数、文件改动、伪代码和测试命令见[代码实现说明](2026-08-11-non-prepared-plan-cache-cacheability-check-implementation.md)。
+
+## 最终状态
+
+改造后，HAVING、window、CTE、多表 join 等结构不再仅因 Non-Prepared 独立 allowlist 未覆盖而回退。Non-Prepared parameterizer 判断普通 SQL literal 如何安全转换或保留，并在无法构造可靠 ParamSQL 时让整条语句 bypass；公共 AST 规则判断参数化后的 statement 是否适合复用，Non-Prepared 入口负责 LRU 和 bypass 编排，公共后端继续负责 schema、权限、参数类型和物理计划安全。
+
+TiDB 当前通过调用 `IsASTCacheable` 复用公共 AST 规则；真正需要长期保持一致的是规则职责和支持范围，而不是某个具体函数的调用形式。
+
+
+
+
+
+# future work
+
+特殊 literal 的进一步参数化、OceanBase 风格的 not-param constraint matcher，以及只在 statement LRU miss 时运行公共 checker

--- a/docs/design/2026-08-11-non-prepared-plan-cache-oceanbase.md
+++ b/docs/design/2026-08-11-non-prepared-plan-cache-oceanbase.md
@@ -1,0 +1,537 @@
+# OceanBase Non-Prepared Plan Cache 实现调研
+
+本文是 [其他数据库的 Non-Prepared Plan Cache 调研](2026-08-11-non-prepared-plan-cache-other-databases.md) 的补充，重点回答下面几个问题：
+
+- OceanBase 的 Prepared 和 Non-Prepared 是否共用 cacheability checker；
+- 普通文本 SQL 是怎样参数化、查找和写入 Plan Cache 的；
+- Prepared 和 Non-Prepared 的参数化有哪些差异；
+- 这些设计对 TiDB 本次改造有什么参考价值。
+
+调研基于 OceanBase `master` 的提交 `f05b2af69729379eae4612d1d5c2ce310ae093f0`，提交日期为 2026-08-13。文中的代码结构可能随版本变化。
+
+## 结论
+
+OceanBase 没有一个类似 TiDB `IsASTCacheable` 的单体 AST checker，由 Prepared 和 Non-Prepared 以完全相同的方式调用。
+
+它的设计更接近：
+
+```text
+不同协议分别准备 SQL 和参数
+        ↓
+共用一套带 mode 的参数化和约束记录规则
+        ↓
+完整解析和优化后判断计划能否写入缓存
+        ↓
+命中时共用 schema、参数类型、权限和计划约束匹配
+```
+
+其中：
+
+- 普通文本 SQL 和 Prepared 的入口不同，参数来源也不同；
+- 两者共用大部分“某个 literal 能否自由变化”的语义规则；
+- 不适合参数化的 literal 通常被保留下来，后续命中时要求其保持一致，而不是直接拒绝整条 SQL；
+- schema、参数类型、权限、会话环境和物理计划等检查主要由后端共用；
+- Text 和 Prepared 的 cache key 包含不同 mode，因此当前不会共享同一个 cache entry 或物理计划。
+
+因此，如果把 checker 理解为一个返回 `true/false` 的函数，OceanBase 没有 Prepared/Text 共用的统一 checker；如果把它理解为完整的可缓存性判断，那么 OceanBase 采用的是“入口分开、参数化规则核心共用、后端匹配共用”。
+
+## 先区分两类 mode
+
+OceanBase 源码中存在两组容易混淆的 mode。
+
+第一组是参数化阶段使用的执行模式：
+
+| 参数化 mode | 含义 |
+| --- | --- |
+| `TEXT_MODE` | 普通文本 SQL，也就是本文所说的 Non-Prepared |
+| `PS_PREPARE_MODE` | 处理 `COM_STMT_PREPARE`，分析参数位置并保存 Prepared metadata |
+| `PS_EXECUTE_MODE` | 处理 `COM_STMT_EXECUTE`，将真实参数与 Prepare metadata 组合起来 |
+
+此外还有 PL 对应的 Prepare/Execute mode，与本文关系不大，不再展开。
+
+第二组是 Plan Cache key 中的模式：
+
+| Plan Cache mode | 含义 |
+| --- | --- |
+| `PC_TEXT_MODE` | Text SQL 的缓存项 |
+| `PC_PS_MODE` | Prepared Execute 的缓存项 |
+
+即使两条路径最终都得到下面的参数化 SQL：
+
+```sql
+SELECT * FROM t WHERE a = ?;
+```
+
+它们也会因为 cache mode 不同而进入不同的缓存项。目前 OceanBase 共用代码框架和后端匹配逻辑，但不共用 Text/Prepared 的实际计划。
+
+## Fast Parser 是什么
+
+Fast Parser 是普通文本 SQL 查 Plan Cache 前使用的轻量级扫描器。它不构造完整 AST，主要完成下面几件事：
+
+1. 找出 SQL 文本中的 literal；
+2. 生成参数化 SQL；
+3. 收集 literal 的值、位置和原始 token；
+4. 尽早使用参数化 SQL 查 Plan Cache。
+
+例如：
+
+```sql
+SELECT * FROM t WHERE a = 10 AND b = 'abc';
+```
+
+Fast Parser 大致得到：
+
+```text
+参数化 SQL：SELECT * FROM t WHERE a = ? AND b = ?
+参数值：[10, 'abc']
+原始 token：["10", "'abc'"]
+```
+
+它的目标是减少 cache hit 路径的开销。如果每次都先构造完整 AST、做名字解析，再查 Plan Cache，即使命中也已经付出了较高的前端成本。
+
+Fast Parser 不负责完整理解 SQL 语义，例如：
+
+- 不解析表和列对应的 schema 对象；
+- 不负责完整的类型推导和权限检查；
+- 不知道所有函数参数和特殊语法位置是否可以自由参数化；
+- 不判断最终物理计划是否适合缓存。
+
+所以第一次 cache miss 时仍然需要完整 Parser。完整 Parser 和参数化规则会确认 Fast Parser 的结果是否可靠，并把后续命中需要的约束保存下来。
+
+Prepared Execute 已经从协议和 Prepare metadata 中知道参数的位置、值和类型，因此不需要 Fast Parser 再从 SQL 文本中寻找参数。
+
+## Non-Prepared SQL 的完整执行流程
+
+下面以普通文本 SQL 为例，说明一次执行从收到 SQL 到执行计划的完整过程。
+
+```text
+普通 Text SQL
+    ↓
+Fast Parser 快速提取 literal，生成参数化 SQL
+    ↓
+使用 Text mode、参数化 SQL 和会话环境查 Plan Cache
+    ├─ 命中：匹配参数和依赖后执行缓存计划
+    └─ 未命中：完整解析、参数化、优化并生成新计划
+                    ↓
+                 判断是否写入缓存
+                    ↓
+                 执行新计划
+```
+
+### 1. 快速提取参数
+
+收到普通 SQL 后，OceanBase 首先进入 Text 模式。Fast Parser 扫描 SQL，生成参数化 SQL 和本次 literal 列表。
+
+这一步只为快速查缓存准备输入，不代表已经确认每个 literal 都可以自由变化。某些特殊位置需要等完整解析后才能判断。
+
+### 2. 定位候选缓存项
+
+OceanBase 使用下面的信息定位候选缓存项：
+
+- 参数化 SQL；
+- Text cache mode；
+- 当前 database；
+- 会话和配置环境；
+- connection collation 等影响 SQL 语义的信息。
+
+找到相同的参数化 SQL 仍然不等于可以直接复用物理计划。一个 key 下可以有多组不同的 schema 依赖、参数约束和计划形态，后面还要继续匹配。
+
+### 3. Cache hit 时验证能否复用
+
+命中候选项后，OceanBase 依次确认：
+
+- Fast Parser 提取的 literal 数量是否与首次完整解析一致；
+- 不能自由参数化的位置是否仍然保持相同 token；
+- schema、临时表和相关依赖是否变化；
+- 参数类型、signed/unsigned、charset/collation 是否兼容；
+- decimal precision/scale 和其他参数约束是否满足；
+- 用户变量、权限和当前执行环境是否匹配；
+- 当前应当选择哪一种物理计划。
+
+全部匹配后，将本次参数填入缓存计划并执行。这个路径通常不需要再次构造完整 AST，也不需要重新优化。
+
+任意一层不匹配时，不会错误复用当前计划，而是继续寻找其他 plan variant；仍然找不到时按 cache miss 处理。
+
+### 4. Cache miss 时完整解析
+
+cache miss 后进入正常的 hard parse 流程：
+
+1. 使用完整 Parser 构造 AST，并确认 statement type；
+2. 根据 AST 上下文判断每个 literal 是可以参数化，还是必须保持不变；
+3. 对比 Fast Parser 与完整 Parser 识别的 literal 数量和顺序；
+4. 完成名字解析、类型处理和权限相关信息收集；
+5. 进入优化器生成物理计划。
+
+Fast Parser 与完整 Parser 必须保持一致。如果两边识别出的 literal 数量、顺序或位置无法对齐，本次 SQL 仍然可以使用新生成的计划正常执行，但不会写入 Text Plan Cache。
+
+### 5. 记录不能自由变化的 literal
+
+某个 literal 不适合自由参数化时，OceanBase 通常不会直接拒绝整条 SQL，而是把这个位置记录为 not-param。
+
+例如：
+
+```sql
+SELECT * FROM t ORDER BY 1;
+```
+
+`ORDER BY 1` 中的 `1` 可能表示输出列的位置，不能像 `WHERE a = 1` 中的过滤值一样自由替换。Text 模式会记录它的原始 token，后续命中时要求这个位置保持一致。
+
+类似的特殊位置还包括：
+
+- `GROUP BY`、`ORDER BY` 中的位置引用；
+- hint、collation、cast 的部分参数；
+- named window 和部分 window 定义；
+- 日期格式字符串；
+- `SUBSTR`、JSON 等函数中影响解释方式的参数；
+- 影响返回类型、precision 或执行语义的位置。
+
+这样可以让 SQL 的其他普通过滤值继续共享计划，同时避免特殊 literal 被错误复用。
+
+### 6. 判断是否写入缓存
+
+生成物理计划后，还要判断当前计划是否适合加入 Plan Cache，主要包括：
+
+- Plan Cache 和当前 statement 的缓存开关是否允许；
+- SQL 是否显式要求不使用 Plan Cache；
+- 是否涉及当前不支持缓存的 dblink、hybrid search 等能力；
+- 生成的计划是否可以安全复制和保存；
+- schema、资源和计划形态是否满足缓存要求。
+
+通过后，参数化 SQL、not-param 信息、参数约束、schema/权限依赖和物理计划一起写入 Text Plan Cache。没有通过也只是不写缓存，本次新计划仍然正常执行。
+
+## Prepared SQL 的执行流程
+
+Prepared 路径分为 Prepare 和 Execute 两个阶段。
+
+### Prepare 阶段
+
+Prepare 阶段主要做下面几件事：
+
+1. 完整解析和名字解析；
+2. 检查 statement 是否支持 Prepared 协议；
+3. 检查 `?` 的数量是否超过限制；
+4. 记录参数数量、位置、字段和 statement type 等 metadata；
+5. 在开启 Prepared 自动参数化时，继续分析 SQL 中的固定 literal；
+6. 保存 Execute 阶段组合参数和查找计划需要的信息。
+
+Prepare metadata 和物理 Plan Cache 是两层不同的缓存。Prepare 成功不表示已经生成物理计划；物理计划通常在第一次 Execute 时生成。
+
+### Execute 阶段
+
+Execute 阶段主要做下面几件事：
+
+1. 根据 statement ID 取得 Prepare metadata；
+2. 检查客户端传入的参数数量并解码真实值和类型；
+3. 合并客户端 `?` 参数和 Prepare 阶段提取的固定 literal；
+4. 使用 Prepared cache mode 查找物理计划；
+5. 匹配参数类型、collation、precision/scale、schema 和权限等约束；
+6. 命中时执行缓存计划，未命中时重新生成并按条件写入 Prepared Plan Cache。
+
+## 三种参数化模式分别做什么
+
+### `TEXT_MODE`
+
+处理完整的普通 SQL 文本。
+
+主要职责是：
+
+- 从 SQL 文本中提取 literal；
+- 将完整 Parser 的结果和 Fast Parser 结果对齐；
+- 判断哪些 literal 可以自由变化；
+- 对不能参数化的位置保存原始 token；
+- 为 Text Plan Cache 生成参数和匹配信息。
+
+### `PS_PREPARE_MODE`
+
+处理 Prepared SQL 的结构，此时客户端 `?` 还没有真实值。
+
+主要职责是：
+
+- 识别已有 `?` 的数量和位置；
+- 判断 Prepared SQL 中的固定 literal 是否可以继续参数化；
+- 记录两类参数的顺序和对应关系；
+- 保存 Execute 时需要的参数化模板和特殊 literal 信息。
+
+### `PS_EXECUTE_MODE`
+
+处理本次 Execute 的真实参数。
+
+主要职责是：
+
+- 取得客户端传入的值和类型；
+- 与 Prepare 阶段提取的固定 literal 组成完整参数列表；
+- 根据真实值生成类型、collation 和参数约束；
+- 为本次执行匹配或生成合适的 Prepared 计划。
+
+三种模式共用参数化和 AST 遍历框架，但输入、生成的 metadata 和失败后的处理不同，并不是无差别地执行同一组逻辑。
+
+## Prepared 也会参数化固定 literal
+
+OceanBase 的 Prepared SQL 除了客户端 `?`，还可以包含固定 literal：
+
+```sql
+SELECT * FROM t WHERE c1 = 1 AND c2 = ?;
+```
+
+在 Prepared 自动参数化开启且语义安全时，Prepare 阶段可以继续提取 `c1 = 1` 中的 `1`。这样下面几条 Prepared SQL 有机会使用相同的参数化模板：
+
+```sql
+SELECT * FROM t WHERE c1 = 1 AND c2 = ?;
+SELECT * FROM t WHERE c1 = 2 AND c2 = ?;
+SELECT * FROM t WHERE c1 = ? AND c2 = ?;
+```
+
+这时需要保存：
+
+- 哪些参数来自客户端 `?`；
+- 哪些参数来自 Prepared SQL 的固定 literal；
+- 两类参数在 Execute 时如何组成完整列表；
+- 哪些固定 literal 不能继续参数化。
+
+如果固定 literal 不适合继续参数化，通常只是缩小 Prepared SQL 之间的共享范围，并不表示 Prepared Plan Cache 整体不可用。原有客户端 `?` 仍然可以正常参与 PS 计划缓存。
+
+## Prepared 和 Non-Prepared 参数化的主要区别
+
+两条路径的语法安全规则大体共用，主要区别在参数来源、处理时机和匹配信息。
+
+| 维度 | Non-Prepared / Text | Prepared |
+| --- | --- | --- |
+| 参数来源 | SQL 文本中的 literal | 客户端 `?`，以及可选的固定 literal |
+| 参数化时机 | 每次执行 Text SQL 时 | Prepare 时分析结构，Execute 时填入真实参数 |
+| Fast Parser | 需要，并与完整 Parser 对齐 | 不需要 |
+| `?` 的含义 | 没有 Prepared 协议提供的参数值 | 客户端参数，值在 Execute 时提供 |
+| 固定 literal | 主要参数来源 | 开启自动参数化时才继续提取 |
+| 类型信息 | SQL literal 在解析时已有类型 | 客户端 `?` 的真实类型通常到 Execute 才知道 |
+| not-param 表达 | 保存原 SQL token | 保存参数值、类型或 collation 等约束 |
+| 无法继续参数化 | 通常缩小共享范围；无法表达时不写 Text 缓存 | 通常保留固定 literal，PS Plan Cache 仍可工作 |
+
+例如：
+
+```sql
+-- Non-Prepared
+SELECT * FROM t WHERE a = 1 AND b = 'x';
+
+-- Prepared
+SELECT * FROM t WHERE a = 1 AND b = ?;
+```
+
+Non-Prepared 的参数都来自当前 SQL 文本。Prepared 则同时存在固定 literal `1` 和客户端参数 `?`，需要先在 Prepare 阶段记录位置，再在 Execute 阶段与真实参数合并。
+
+因此可以概括为：
+
+> Non-Prepared 是从每条 SQL 文本中发现参数；Prepared 是在已有 `?` 的基础上，可选地继续抽取固定 literal，并在 Execute 时组合真实参数。
+
+## 各入口自己的检查
+
+### Text 入口
+
+Text 路径特有的检查主要包括：
+
+- 当前 statement type 是否进入 Text Plan Cache 主流程；
+- Fast Parser 能否稳定生成参数化 SQL 和 literal 列表；
+- Fast Parser 与完整 Parser 识别的常量数量和顺序是否一致；
+- not-param 位置能否与本次原始 token 对应；
+- Text literal 是否能用当前参数化和约束机制安全表达。
+
+Text 路径主要覆盖核心 DML，另外对 `SHOW VARIABLES` 有单独支持。解析或执行本身合法，但不满足 Text Plan Cache 条件的 SQL，仍然正常执行，只是不写缓存。
+
+### Prepare 入口
+
+Prepare 阶段特有的检查主要包括：
+
+- statement 是否支持 Prepared 协议；
+- `?` 的数量是否超过上限；
+- 参数字段和 returning 参数等协议 metadata 是否能正确构造；
+- Prepared SQL 中的固定 literal 是否可以继续自动参数化；
+- 原始 Prepared SQL 与参数化模板如何关联。
+
+协议不合法或参数数量错误可能直接导致 Prepare 报错；固定 literal 不能继续参数化通常只会缩小共享范围。
+
+### Execute 入口
+
+Execute 阶段特有的检查主要包括：
+
+- statement ID 和 Prepare metadata 是否存在；
+- 客户端参数数量是否匹配；
+- 参数值和类型能否正确解码；
+- 客户端参数与固定 literal 能否组成完整参数列表；
+- 当前 statement 是否进入 Prepared Plan Cache 主流程。
+
+Prepared 的 statement type 范围略宽，特别是部分 `EXPLAIN` 和 SHOW family；核心 SELECT/DML 与 Text 路径重合。
+
+### 两条路径共用的后端检查
+
+进入计划生成或缓存匹配后，两条路径共用大量检查：
+
+- Plan Cache 开关和 SQL hint；
+- schema、临时表和依赖对象；
+- 参数类型、signed/unsigned、charset/collation；
+- decimal precision/scale 和其他参数约束；
+- 用户变量、权限和会话环境；
+- 当前物理计划是否适合缓存和复用。
+
+这些检查不是集中在一个 AST checker 中，而是分布在计划生成、缓存写入和命中匹配阶段。
+
+## Prepared 和 Non-Prepared 的支持范围
+
+### 先区分协议支持和 Plan Cache 支持
+
+Prepared 协议支持某条 SQL，不表示它的物理计划一定进入 Plan Cache。类似地，Text SQL 能正常执行，也不表示一定能写入 Text Plan Cache。
+
+从 statement type 看：
+
+| 路径 | 进入 Plan Cache 主流程的 statement |
+| --- | --- |
+| Text/Non-Prepared | 核心 DML，另外单独支持 `SHOW VARIABLES` |
+| Prepared Execute | 核心 DML，以及部分 `EXPLAIN` 和 SHOW family |
+
+Prepared 的入口范围略宽，但核心 SELECT/DML 是重合的。
+
+### 查询结构上没有明显的两套 allowlist 断层
+
+OceanBase 没有看到类似 TiDB 当前这样的情况：Prepared 使用较完整的 AST checker，而 Non-Prepared 再维护一份很窄的 AST allowlist，导致 HAVING、window、CTE 或多表 join 仅因为 checker 未覆盖而整体回退。
+
+对核心 DML 来说，两条路径共用完整解析、参数化规则以及 not-param/参数约束的记录机制。某个结构能否最终复用计划，主要取决于：
+
+- 特殊 literal 是否能通过 not-param 约束表达；
+- schema、参数类型和权限能否匹配；
+- 最终生成的物理计划是否适合缓存。
+
+这不表示 HAVING、window、CTE、subquery 或多表 join 无条件都能命中，只表示它们不会因为 Text 路径额外维护的一份总 allowlist 而统一失败。
+
+### 差异主要体现在共享粒度
+
+当一个 literal 不能自由变化时：
+
+- Text 模式通常保存原 token，要求下次仍然一致；
+- Prepared 模式通常保存对应的值、类型或 collation 约束；
+- Prepared 固定 literal 无法继续自动参数化时，可以继续使用原始 Prepared 模板。
+
+所以很多差异表现为“哪些值可以共享同一计划”，而不是“整条 SQL 能不能使用 Plan Cache”。
+
+## OceanBase 为什么不需要每次运行完整 AST checker
+
+Text SQL 第一次 cache miss 时会把后续命中需要的信息保存下来，包括：
+
+- 完整 Parser 识别出的 literal 数量；
+- 不能参数化的位置和对应 token；
+- 参数类型、charset/collation；
+- 参数约束；
+- schema、用户变量和权限依赖。
+
+后续执行只需要用 Fast Parser 得到本次参数，然后逐项匹配这些信息。如果任意条件不满足，就查找其他 plan variant 或重新 hard parse。
+
+关键不是“第一次检查通过后永远相信”，而是把检查结论转换成可缓存、可在 hit 路径重新验证的 metadata。
+
+相比之下，TiDB 当前 Non-Prepared statement LRU 没有保存这么完整的约束和依赖。因此本次设计在 statement LRU hit 后继续运行 `IsASTCacheable`，是合理的保守选择。
+
+## 与 TiDB 当前实现的主要差异
+
+| 维度 | OceanBase | TiDB 当前实现 |
+| --- | --- | --- |
+| Text 参数化入口 | Fast Parser 提前生成 key，miss 后用完整 Parser 校验 | 基于已经构造的完整 AST 参数化 |
+| 参数化规则 | 共用 mode-aware 的参数化框架，按上下文记录 not-param 和其他约束 | Prepared 和 Non-Prepared 前端逻辑分开 |
+| 特殊 literal | 优先记录 not-param，缩小共享范围 | 很多情况直接让整条 Non-Prepared SQL bypass Plan Cache |
+| AST 支持范围 | 没有明显的 Text 独立窄 allowlist | Non-Prepared checker 比 Prepared 明显更窄 |
+| hit 时验证 | 匹配结构化 metadata 和依赖 | statement LRU 层保存的信息较少 |
+| Text/Prepared 计划 | mode 隔离，不直接共享 | 本次改造也不要求共享实际计划 |
+
+## 对 TiDB 方案的启发
+
+### 1. 共用公共规则，但保留 Non-Prepared 前置逻辑
+
+TiDB 可以让 Prepared 和 Non-Prepared 共用 `IsASTCacheable`，但不能把 Non-Prepared 原始 literal 的处理伪装成 Prepared 协议参数。
+
+合理的职责边界是：
+
+```text
+Non-Prepared 前置逻辑
+  → 判断普通 SQL literal 能否安全转换
+  → 生成参数化 SQL 和参数
+        ↓
+公共 AST cacheability 检查
+        ↓
+公共 schema、参数类型和物理计划后端
+```
+
+### 2. Literal 处理和整条语句退出是两个层级
+
+OceanBase 没有为每个 literal 定义 `parameterize`、`preserve`、`fallback` 三态枚举。更准确的理解是：
+
+- Fast Parser 先抽取 literal 并生成参数化 key；
+- 完整 Parser 根据 AST 上下文记录哪些位置属于 not-param，以及 `must_be_positive` 等额外约束；
+- 后续无法建立安全参数映射或约束不匹配时，整条 Text SQL 查找其他 plan variant 或重新 hard parse。
+
+因此，not-param 是 literal/参数位置上的属性，而退出当前缓存流程是 statement 级控制流，两者不应合并成 literal 的三个并列决策。
+
+TiDB 第一阶段可以采用类似的职责划分，但实现方式更简单：literal 层只选择 `parameterize` 或 `preserve`；完成整棵 AST 的处理后，如果 restore、重新解析或参数映射仍无法保证正确，参数化接口再让整条语句 bypass Non-Prepared Plan Cache。不能仅因为公共 checker 没有拒绝，就默认某个 literal 可以参数化。
+
+### 3. 当前不需要照搬三个 mode
+
+TiDB Prepared 当前没有继续参数化 Prepared SQL 固定 literal 的需求，因此本次改造不必为了形式统一引入完整的 `TEXT/PS_PREPARE/PS_EXECUTE` mode 系统。
+
+当前更重要的是：
+
+- 把 Non-Prepared literal 的 parameterize/preserve 规则做完整；
+- 保留 Prepared 和 Non-Prepared 不同的参数来源；
+- 共用真正等价的 AST 和后端检查；
+- 不要求两种协议立即共享 statement carrier 或物理计划。
+
+如果未来 TiDB 也支持 Prepared SQL 固定 literal 的自动参数化，再引入类似 mode 会更有价值。
+
+### 4. 如果未来引入 Fast Parser，必须设计一致性保护
+
+TiDB 当前基于完整 AST 参数化，没有 OceanBase 的双 Parser 对齐问题。如果未来为了性能改成词法级快速参数化，需要同时设计：
+
+- Fast Parser 和完整 Parser 的 literal 数量、顺序校验；
+- 特殊 token 的原文保存；
+- 失败后无副作用地回到完整解析；
+- Parser 或参数化规则变化后的缓存失效机制。
+
+### 5. 长期可以把检查结论结构化
+
+TiDB 后续如果希望 statement LRU hit 时不再遍历完整 AST，需要先让 carrier 保存足够的信息，并在 hit 时重新验证：
+
+- parser 和 session 语义上下文；
+- 参数类型和特殊 literal 约束；
+- schema、系统变量和权限依赖；
+- 会影响 cacheability 的动态开关。
+
+不能仅因为第一次检查通过，就永久复用这个结论。
+
+## 源码索引
+
+正文只描述职责和流程。下面集中列出关键源码入口，方便需要进一步核对实现的读者查阅：
+
+- [普通 Text SQL 入口](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/ob_sql.cpp#L3010-L3120)
+- [Text Plan Cache 查找和 Fast Parser](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_plan_cache.cpp#L575-L795)
+- [Prepared Prepare 阶段](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/ob_sql.cpp#L1238-L1510)
+- [Prepared Execute 阶段](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/ob_sql.cpp#L2583-L2710)
+- [三种参数化 mode 和完整参数化流程](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_sql_parameterization.cpp#L387-L415)
+- [参数化主流程](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_sql_parameterization.cpp#L1130-L1365)
+- [特殊 literal 和 not-param 规则](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_sql_parameterization.cpp#L2251-L2505)
+- [hard parse 后的缓存准入流程](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/ob_sql.cpp#L4796-L5148)
+- [参数类型、collation 和约束匹配](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_plan_set.cpp#L69-L205)
+- [not-param 和 schema 匹配](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_plan_cache_value.cpp#L1958-L2055)
+- [Text/Prepared cache mode 隔离](https://github.com/oceanbase/oceanbase/blob/f05b2af69729379eae4612d1d5c2ce310ae093f0/src/sql/plan_cache/ob_plan_cache_struct.h#L39-L180)
+
+## 最终判断
+
+OceanBase 的设计不能概括为“Prepared checker 直接复用于 Non-Prepared”。更准确的描述是：
+
+```text
+Text：Fast Parser + Text 特有一致性检查 --------+
+                                             |
+Prepared：协议参数和 Prepare metadata --------+--> 共用参数化和约束规则
+                                                   → 共用缓存准入骨架
+                                                   → mode 隔离的 cache entry
+                                                   → 共用参数、schema、权限和计划匹配
+```
+
+对 TiDB 最有价值的参考不是某个具体函数，而是这套职责边界：
+
+- 共用语义规则和后端匹配；
+- 保留 Non-Prepared 参数化前置逻辑；
+- literal 层明确区分 parameterize 和 preserve，无法安全构造参数化语句时在 statement 层退出；
+- 不要求两种协议立即共享 cache entry 或 physical plan；
+- 长期把检查结论转换成 hit 路径可以重新验证的 metadata。

--- a/docs/design/2026-08-11-non-prepared-plan-cache-other-databases.md
+++ b/docs/design/2026-08-11-non-prepared-plan-cache-other-databases.md
@@ -1,0 +1,419 @@
+# 其他数据库的 Non-Prepared Plan Cache 调研
+
+本文是 [Non-Prepared Plan Cache 统一 cacheability 检查](2026-08-11-non-prepared-plan-cache-cacheability-check.md) 的配套调研。具体代码改动见 [实现说明](2026-08-11-non-prepared-plan-cache-cacheability-check-implementation.md)，OceanBase 的源码调用链见 [专项调研](2026-08-11-non-prepared-plan-cache-oceanbase.md)。
+
+## 调研范围
+
+`Non-Prepared Plan Cache` 是 TiDB 使用的名字。其他数据库中，与它最接近的能力通常叫：
+
+- automatic/simple/forced parameterization；
+- cursor sharing；
+- statement concentrator；
+- fast parameterization。
+
+它们要解决的问题基本相同：应用发送的是带字面量的普通 SQL，而不是带参数的 prepared statement；数据库希望把其中可以安全替换的字面量提取成参数，让多条结构相同的 SQL 复用解析结果或执行计划。
+
+本文关注的是“普通 SQL 如何归一化并复用计划”，不讨论客户端 prepared statement 的协议细节，也不讨论 result cache。
+
+## 结论先行
+
+几种实现虽然名字不同，但大体都可以拆成下面几层：
+
+1. 识别并提取可以参数化的字面量，得到归一化 SQL 和参数值。
+2. 根据字面量所在的语法位置、类型和语义，决定参数化、保留原值，或者整条 SQL 不缓存。
+3. 用归一化 SQL 加数据库、会话语义和优化器环境组成缓存键。
+4. 在同一个归一化 SQL 下，根据参数类型或参数分布选择一个或多个计划。
+5. 在 schema、统计信息或相关会话状态变化后，使已有结果失效或重新优化。
+6. 控制只执行一次的 SQL 对缓存空间的污染，并提供原始 SQL、归一化 SQL、命中情况和不缓存原因等诊断信息。
+
+对 TiDB 当前方案最直接的启发是：
+
+- “先参数化，再调用公共 `IsASTCacheable`”的方向是合理的，但参数化之前仍然需要保留 Non-Prepared 特有的语法位置和类型检查。
+- 不能把现有 parameterizer 原样当成完整的 cacheability checker。其他数据库也都存在“这个位置保留原值”或“这个语句不共享”的规则。
+- statement LRU 的 key 不能只有归一化 SQL。数据库、SQL mode、字符集、时区等可能改变解析或语义的状态也要进入 key，或者能够使缓存失效。
+- 一个归一化 SQL 永远只对应一个计划并不是成熟系统的最终形态。SQL Server、Oracle、PostgreSQL 和 Db2 都以不同方式处理参数敏感问题。
+- 参数的类型信息很重要。长期看只保存 `Datum`，依靠值反推类型，不足以覆盖所有兼容性要求。
+
+## 整体对比
+
+| 数据库 | 普通字面量 SQL 自动归一化 | 参数化策略 | 同一 SQL 的计划选择 | 主要特点 |
+| --- | --- | --- | --- | --- |
+| SQL Server | 支持 | Simple 或 Forced Parameterization | 普通缓存；新版本支持 Parameter Sensitive Plan | 语法位置规则详细，生成参数有明确类型，缓存键包含大量会话环境 |
+| Oracle | 支持 | `CURSOR_SHARING=FORCE` | 一个 parent cursor 下可以有多个 child cursor；Adaptive Cursor Sharing 按值域选计划 | 把归一化 SQL 和具体可共享计划分开管理 |
+| Db2 | 支持 | Statement Concentrator | 可结合 `REOPT` 在首次或每次执行时重新优化 | 很强调参数类型、长度和使用上下文对结果及计划的影响 |
+| OceanBase | 支持 | Fast Parser 做快速参数化 | plan cache 中查找可用计划 | 与 TiDB 场景最接近；归一化结果显式保存参数和不参数化信息 |
+| PostgreSQL | 普通 Simple Query 不自动做这一层 | Prepared Statement 内使用参数 | 在 generic plan 和 custom plan 之间选择 | 重点是 prepared statement 内的计划复用和参数敏感性 |
+| MySQL | 官方能力主要围绕 prepared statement | 客户端或 SQL PREPARE 显式提供参数 | prepared statement 的内部结构复用 | 可作为兼容性对照，不是 TiDB Non-Prepared 方案的直接参考实现 |
+
+## SQL Server
+
+### 基本设计
+
+SQL Server 把普通 SQL 的自动参数化分成两档：
+
+- Simple Parameterization：只参数化一小部分形态简单、风险较低的语句。
+- Forced Parameterization：在数据库级别尽量参数化普通的 `SELECT`、`INSERT`、`UPDATE`、`DELETE`，但仍然有明确的排除条件。
+
+参数化后的语句进入 plan cache。SQL Server 的缓存中会区分 ad hoc、自动参数化、动态 SQL 和 prepared SQL 等对象，但它们会共享一套与编译环境相关的缓存管理机制。
+
+[SQL Server Query Processing Architecture Guide](https://learn.microsoft.com/en-us/sql/relational-databases/query-processing-architecture-guide?view=sql-server-ver17)
+
+### 不是所有字面量都直接替换
+
+Forced Parameterization 也不是遍历 AST 后把所有常量替换成参数。例如下面这些位置有专门规则，可能保留原值，或者让语句不能使用 forced parameterization：
+
+- `TOP`、`TABLESAMPLE`、`HAVING`、`GROUP BY`、`ORDER BY` 等子句；
+- `LIKE` pattern、`CONVERT` style、部分内建函数参数；
+- 可以在编译期折叠的算术表达式；
+- query hint 参数；
+- 已经 prepared 的语句、游标、特定 `SET` 环境、`RECOMPILE`；
+- 参数数量过多的语句。
+
+这里最值得 TiDB 参考的不是具体规则，而是规则的分层：某个字面量不能替换，不一定意味着整条语句不能缓存；只有当前机制无法保留语义时，整条语句才需要 bypass Plan Cache。
+
+### 参数带有明确类型
+
+SQL Server 会根据原始字面量生成有具体类型的参数，例如整数、带 precision/scale 的 decimal、不同长度范围的 varchar/nvarchar 和 varbinary。官方文档也明确提醒，常量表达式在参数化前后可能因为类型推导、算术和转换规则产生不同结果。
+
+这说明参数化结果不应该只表达“这里有一个值”，还需要可靠地保留“这个值在原始 SQL 中是什么类型”。
+
+### 缓存键不只是归一化 SQL
+
+SQL Server 暴露的 plan attributes 中，可能参与缓存键的内容包括：
+
+- database id；
+- 影响语义的 `SET` options；
+- language、date format、date first；
+- compatibility level；
+- name resolution 依赖的 user；
+- cursor options；
+- 临时表相关的 session 信息。
+
+[SQL Server `sys.dm_exec_plan_attributes`](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-objects/sys-dm-exec-plan-attributes-transact-sql?view=sql-server-ver17)
+
+这和 TiDB statement LRU 面临的问题相同：即使归一化 SQL 文本一样，只要解析、名字解析或表达式语义可能不同，就不能直接复用同一个 statement carrier。
+
+### 参数敏感和缓存污染
+
+自动参数化会引入参数敏感问题：第一次编译时适合某个值的计划，可能不适合其他值。SQL Server 2022 以后提供 Parameter Sensitive Plan Optimization，可以为同一条参数化语句保留多个 plan variant，并根据参数落入的基数区间选择计划。
+
+[SQL Server Parameter Sensitive Plan Optimization](https://learn.microsoft.com/en-us/sql/relational-databases/performance/parameter-sensitive-plan-optimization?view=sql-server-ver17)
+
+SQL Server 还支持 `optimize for ad hoc workloads`：某条 ad hoc SQL 第一次出现时只保存较小的 plan stub，第二次出现才保存完整计划，用来减少大量 single-use SQL 污染 plan cache。
+
+[SQL Server optimize for ad hoc workloads](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/optimize-for-ad-hoc-workloads-server-configuration-option?view=sql-server-ver17)
+
+## Oracle
+
+### Cursor Sharing
+
+Oracle 默认使用 `CURSOR_SHARING=EXACT`，只有 SQL 文本一致时才共享 parent cursor。配置为 `FORCE` 后，Oracle 会把普通 SQL 中的字面量替换成系统生成的 bind variable，再按转换后的 SQL 在 shared pool 中查找 cursor。
+
+一次执行大致是：
+
+1. 保存原始字面量并生成系统 bind；
+2. 用归一化后的 SQL 查找 parent cursor；
+3. 找不到时 hard parse，找到可共享的 child cursor 时 soft parse；
+4. 使用本次的 bind 值执行。
+
+`FORCE` 减少的是 hard parse，不会让每次提交 SQL 的 parse 动作本身消失。
+
+[Oracle Improving Real-World Performance Through Cursor Sharing](https://docs.oracle.com/en/database/oracle/oracle-database/23/tgsql/improving-rwp-cursor-sharing.html)
+
+### Parent cursor 和 child cursor
+
+Oracle 的设计比较清楚地分开了两类对象：
+
+- parent cursor：代表归一化 SQL；
+- child cursor：保存可以在特定环境下执行的计划、bind 和依赖对象等信息。
+
+即使 parent cursor 相同，下面这些差异也可能要求新的 child cursor：
+
+- SQL 解析到的 schema object 不同；
+- optimizer mode 或 optimizer environment 不同；
+- NLS 等会话语义不同；
+- bind metadata 不兼容；
+- 原有 child cursor 因 schema 或统计信息变化而失效。
+
+这与 TiDB 中 `PlanCacheStmt` 和 `PlanCacheValue` 的职责划分很接近：前者是参数化语句的载体，后者才是具体计划。
+
+### 仍然需要语法位置规则
+
+Oracle 的文档举了 `ORDER BY` 数字常量的例子。数字在这里可能表示 select list 的序号，值变化会改变语义；即使系统做了 bind 替换，也不能简单认为两条语句一定可以共享 cursor。
+
+这说明“字面量节点看起来相同”不等于“处在任何位置都可以参数化”。参数化逻辑必须知道父节点和使用上下文。
+
+### Adaptive Cursor Sharing
+
+Oracle 会观察不同 bind 值对应的 selectivity 和执行统计：
+
+- 先把 cursor 标记为 bind-sensitive；
+- 如果发现不同值的执行特征差异明显，再变成 bind-aware；
+- 为不同 selectivity 范围生成或选择不同 child cursor；
+- 等价计划可以合并，最终通常稳定为少量计划，而不是每个参数值一个计划。
+
+这个方案说明，扩大自动参数化范围后，参数敏感性应该作为独立问题处理，而不应通过永久拒绝所有可能敏感的语句来回避。
+
+### 产品定位上的提醒
+
+Oracle 官方把 `CURSOR_SHARING=FORCE` 更多看作无法及时修改应用时的缓解方案，仍然更推荐应用使用 bind variables。这是因为自动替换发生在 SQL 已经送到数据库并完成解析之后，也无法替代应用层的 SQL 注入防护。
+
+## Db2
+
+### Statement Concentrator
+
+Db2 可以通过 statement concentrator 把动态 SQL 中的字面量替换成类似 `:L0` 的参数，使结构相同的语句共享 package cache entry。该能力默认关闭，也可以选择在归一化时移除不影响语义的 comment。
+
+Db2 的诊断和 explain 信息能够同时保留原始语句和集中后的语句，便于判断是否发生了归一化以及实际复用了哪个 cache entry。
+
+[Db2 Statement Concentrator](https://www.ibm.com/docs/en/db2/11.5.x?topic=plans-statement-concentrator)
+
+### 类型和长度会影响结果
+
+Db2 文档特别强调了参数 marker 的类型和长度：它们由使用上下文决定，必要时需要通过 `CAST` 明确类型。Statement Concentrator 也可能因为归一化后的参数长度推导方式不同，改变字符串表达式的结果类型或长度。
+
+[Db2 Parameter Markers](https://www.ibm.com/docs/en/db2/11.5.x?topic=ess-providing-variable-input-dynamically-executed-sql-statements-by-using-parameter-markers)
+
+因此 Db2 要求常量复用时考虑：
+
+- 使用位置是否相同；
+- data type 是否一致；
+- 字符串等类型的长度是否兼容；
+- 某些要求 immediate value 的上下文中，常量值是否完全一致。
+
+这个案例对 TiDB 很重要：如果参数化只返回 `[]Datum`，后续再从运行时值推断类型，有可能丢掉原始 literal 的类型、长度或写法信息。第一阶段可以对有风险的 literal 采用 preserve；如果当前机制仍无法忠实构造参数化 SQL，再让整条语句 bypass Non-Prepared Plan Cache。长期更合理的是参数化结果携带原始 `FieldType` 或等价元数据。
+
+### REOPT
+
+Db2 允许使用 `REOPT` 调整参数化语句的优化时机：
+
+- `REOPT ONCE`：第一次执行时使用实际参数值优化，之后复用；
+- `REOPT ALWAYS`：每次执行时都使用当前参数重新优化，并且不再使用 statement concentrator 的普通复用方式。
+
+[Db2 REOPT](https://www.ibm.com/docs/en/db2/11.5.x?topic=bespdbc-performance-improvements-when-using-reopt-option-bind-command)
+
+它和 Oracle/SQL Server 的实现不同，但解决的是同一个问题：归一化 SQL 可以共享，并不代表所有参数值都适合共享同一个计划。
+
+## OceanBase
+
+本节只概括产品设计；Prepared/Text 两条源码调用链、共用和不共用的检查见 [OceanBase 专项调研](2026-08-11-non-prepared-plan-cache-oceanbase.md)。
+
+### Fast Parameterization
+
+OceanBase 与 TiDB Non-Prepared Plan Cache 的场景最接近。普通 SQL 到达后，Fast Parser 先通过词法分析快速得到：
+
+- 参数化 SQL；
+- 原始参数值；
+- 用于 plan cache 查找的 key。
+
+命中后直接取得可用计划；未命中时再经过完整解析和优化，并将生成的计划写入缓存。
+
+[OceanBase Fast Parameterization](https://en.oceanbase.com/docs/common-oceanbase-database-10000000001717237)
+
+[OceanBase Plan Cache](https://en.oceanbase.com/docs/common-oceanbase-database-10000000001123504)
+
+### 参数化上下文不只有 SQL 和值
+
+OceanBase 的开源实现中，`ObFastParserResult` 保存 parameterized SQL、原始参数、question mark 上下文、`INSERT ... VALUES` token 位置和 array binding 参数等信息。完整 Parser 再把下面这些信息补充到 `ObPlanCacheCtx`：
+
+- 哪些 token 不应参数化及其原始文本；
+- select item 中参数的位置及表达形式；
+- 参数的 charset、正负号和必须为正等约束；
+- Prepared 模式下不能自由变化的参数值。
+
+这些信息说明，快速参数化也需要显式表达“替换了什么”和“为什么这个位置不能按普通参数处理”，而不是只输出一段带 `?` 的文本。
+
+[OceanBase `ObFastParserResult` 等数据结构](https://github.com/oceanbase/oceanbase/blob/master/src/sql/plan_cache/ob_plan_cache_struct.h)
+
+### Plan cache key
+
+OceanBase 开源代码中的 plan cache key 还包含 database id、session id、plan cache mode、系统变量、配置、namespace 和 connection collation 等信息。具体字段会随版本变化，但总体原则稳定：参数化 SQL 只是 key 的主要部分，不是完整 key。
+
+查找流程的源码注释也明确分成：fast parser 生成参数化 SQL 和参数、按参数化 SQL 找 plan cache value、检查权限和可用性等步骤。
+
+[OceanBase `ObPlanCache::get_plan`](https://github.com/oceanbase/oceanbase/blob/master/src/sql/plan_cache/ob_plan_cache.cpp)
+
+### 控制和可观测性
+
+OceanBase 支持通过 session/global `cursor_sharing` 控制是否自动替换字面量，也支持 statement hint：
+
+- `CURSOR_SHARING_EXACT`：本条语句不做 literal replacement；
+- `USE_PLAN_CACHE(NONE)`：本条语句不使用 plan cache。
+
+系统视图中可以查看归一化 SQL、SQL ID 和 cursor sharing 状态；outline/plan binding 也使用参数化 SQL 或其 SQL ID 关联。这让参数化不仅服务于 plan cache，也成为诊断和计划管理时的稳定语句身份。
+
+[OceanBase Cursor Sharing](https://en.oceanbase.com/docs/common-oceanbase-database-10000000000931135)
+
+[OceanBase Query Hints](https://en.oceanbase.com/docs/common-oceanbase-database-10000000001108045)
+
+## PostgreSQL 和 MySQL：作为对照
+
+### PostgreSQL
+
+PostgreSQL 的内建计划复用主要围绕 prepared statement。Simple Query Protocol 接收完整 SQL 文本；Extended Query Protocol 则明确分成 Parse、Bind、Execute，参数值在 Bind 阶段提供。
+
+[PostgreSQL Frontend/Backend Protocol](https://www.postgresql.org/docs/current/protocol-flow.html)
+
+在 prepared statement 内，PostgreSQL 不会始终固定使用一个计划：
+
+- custom plan 使用本次参数值优化；
+- generic plan 不依赖具体参数值，编译成本较低；
+- 默认先执行若干次 custom plan，再比较平均代价和 generic plan 代价，决定后续使用哪一种；
+- 也可以通过 `plan_cache_mode` 强制使用 custom 或 generic plan。
+
+[PostgreSQL PREPARE](https://www.postgresql.org/docs/current/sql-prepare.html)
+
+[PostgreSQL `plan_cache_mode`](https://www.postgresql.org/docs/current/runtime-config-query.html)
+
+PostgreSQL 还会在 schema、`search_path`、role/RLS 等相关环境变化后重新分析或使 cached plan 失效。它的源码把 cached query source 和 generic/custom plan 分开管理，这也说明“参数化语句载体”和“具体执行计划”适合成为两个生命周期不同的对象。
+
+[PostgreSQL `plancache.c`](https://doxygen.postgresql.org/plancache_8c_source.html)
+
+从官方协议和 PREPARE 文档可以推断，PostgreSQL 没有把普通 Simple Query 中的不同字面量自动集中成同一条 prepared statement；它的主要借鉴价值是 generic/custom plan 选择和严格的失效管理。
+
+### MySQL
+
+MySQL 官方文档描述的 statement cache 主要用于 prepared statement 和 stored program。prepared statement 的解析结果及内部结构可以复用，并在依赖对象 metadata 变化后自动 reprepare。
+
+[MySQL Caching of Prepared Statements and Stored Programs](https://dev.mysql.com/doc/refman/8.4/en/statement-caching.html)
+
+[MySQL Prepared Statements](https://dev.mysql.com/doc/refman/8.4/en/sql-prepared-statements.html)
+
+从官方文档覆盖的能力看，MySQL 没有提供和 SQL Server Forced Parameterization、Db2 Statement Concentrator 对等的普通文本 SQL 自动归一化接口。因此 TiDB 的 Non-Prepared Plan Cache 不是简单复刻 MySQL 行为，而是在 MySQL 协议兼容之外提供的服务端优化。
+
+## 对 TiDB 当前设计的具体启发
+
+### 1. 当前总体方向是合理的
+
+当前设计准备把流程调整为：
+
+```text
+Non-Prepared 特有 precheck
+    -> 参数化，并保留参数值/上下文
+    -> 对参数化 AST 调用公共 IsASTCacheable
+    -> 生成或复用 PlanCacheStmt
+    -> 后端选择 PlanCacheValue
+```
+
+这与其他数据库的总体分层一致。公共 checker 负责回答“这个参数化后的语句能否进入 plan cache”，Non-Prepared precheck 负责回答“能否安全地把这条普通 SQL 转成这种参数化形式”。两者不能合并成一次不区分阶段的 AST 扫描。
+
+### 2. 不建议直接复用现有 parameterizer 而不加约束
+
+其他数据库都证明了参数化规则与语法上下文相关：
+
+- SQL Server 会按 clause 或函数参数位置保留常量；
+- Oracle 的 `ORDER BY` 数字可能是 ordinal，值本身参与语义；
+- Db2 要求比较使用上下文、类型和长度；
+- OceanBase 的参数化结果专门记录 not-param token 和位置元数据。
+
+因此 TiDB 当前设计中的三种处理结果是必要的：
+
+1. parameterize：替换成参数；
+2. preserve：保留原值，但语句仍可继续检查；
+3. reject：整条语句不走 Non-Prepared Plan Cache。
+
+`LIMIT`、`ORDER BY` ordinal、内建函数特殊参数、字符集 introducer、bit/hex literal、`NULL` 等，都应先明确属于哪一种，而不是由通用 `ValueExpr` visitor 统一替换。
+
+### 3. 第一阶段应保守保留原始类型语义
+
+SQL Server 和 Db2 都把参数类型作为参数化协议的一部分。TiDB 第一阶段如果还没有完整的 typed parameter result，应继续拒绝或保留那些参数化后可能改变类型推导、结果 metadata 或表达式语义的 literal。
+
+后续可以把参数化结果从：
+
+```text
+parameterized AST + []Datum
+```
+
+扩展为：
+
+```text
+parameterized AST
++ parameter value
++ original FieldType / charset / collation
++ source location and parameterization kind
+```
+
+这样才能逐步、安全地扩大支持范围，而不需要把所有特殊情况永久放在 deny list 中。
+
+### 4. statement LRU 必须使用复合 key
+
+当前设计准备给 statement LRU 补充 database、SQL mode、charset/collation 等信息，这一点有充分的外部实现依据：
+
+- SQL Server 把 database、`SET` options、language/date 等作为 cache-key attributes；
+- Oracle child cursor 受 schema resolution、optimizer 和 NLS 环境影响；
+- OceanBase key 包含 database、session、sys vars、config 和 collation；
+- PostgreSQL 会因 `search_path`、role/RLS 等变化重新分析。
+
+原则上，所有可能改变 parser 输出、name resolution、返回类型或优化语义的状态都需要满足以下二选一：进入 key，或者在变化时可靠地使对应 carrier 失效。
+
+### 5. 公共 checker 每次执行仍有必要
+
+当前 TiDB statement LRU 还没有完整覆盖所有动态状态和失效条件。在这个前提下，即使命中 `PlanCacheStmt`，仍然每次对本次参数化 AST 调用 `IsASTCacheable`，是合理的保守设计。
+
+未来只有在下面两个条件都满足后，才适合把完整 cacheability 检查移到 LRU miss：
+
+- key 已包含所有影响检查结果的语义环境；
+- schema、table 属性、系统变量等变化能够准确使 carrier 失效。
+
+### 6. 参数敏感计划应作为后续独立议题
+
+TiDB 后端已经会按参数类型等维度区分部分 plan cache entry，但这不等价于按 selectivity 选择计划。扩大 Non-Prepared 支持范围后，可能更容易遇到同一归一化 SQL 在不同参数值上最优计划差异很大的情况。
+
+其他数据库提供了几种不同思路：
+
+- SQL Server：一个 dispatcher 加多个 parameter-sensitive variants；
+- Oracle：根据运行时统计逐步形成 bind-aware child cursors；
+- PostgreSQL：比较 generic 和 custom plan 的成本；
+- Db2：通过 `REOPT` 选择首次或每次重新优化。
+
+本次 cacheability 统一不需要同时解决这个问题，但设计上不要假设“一个归一化 SQL 必须永久对应一个计划”。
+
+### 7. 需要补齐可观测性
+
+至少需要能够区分下面几类状态：
+
+- 原始 SQL 和参数化 SQL；
+- 参数化 precheck 被拒绝及其原因；
+- 公共 `IsASTCacheable` 被拒绝及其原因；
+- statement LRU hit/miss；
+- backend plan cache hit/miss；
+- 因 schema 或会话环境变化导致的失效。
+
+这既方便验证新实现，也能避免用户看到 `last_plan_from_cache=0` 时无法判断是参数化失败、cacheability 失败，还是后端没有合适计划。
+
+## 对本次实现范围的建议
+
+### 本次应做
+
+- 增加 Non-Prepared 参数化 precheck，明确 parameterize/preserve/reject。
+- 参数化后统一调用 `IsASTCacheable`。
+- 保守处理可能改变类型、metadata 或语义的 literal。
+- statement LRU 使用复合 key，并且只缓存已经通过完整检查的 carrier。
+- 保持 statement 级 bypass 行为，不让 cacheability 优化改变 SQL 本身能否正常执行。
+- 增加 A 值后执行 B 值、B 值后执行 A 值的双向测试，避免首个 literal 决定后续行为。
+- 测试结果值以外，再校验 result field type、charset/collation 和 warning/error 行为。
+
+### 本次不建议一起做
+
+- 把 AST parameterizer 重写成 OceanBase 式 lexical fast parser。
+- 实现 parameter-sensitive 多计划选择。
+- 把 session statement LRU 扩成全局 statement cache。
+- 引入“第二次出现才缓存”的 admission policy。
+- 一次性支持所有 bit/hex、introducer、特殊函数参数等 typed literal。
+
+这些方向有价值，但与统一 cacheability checker 的正确性边界不同，放到同一个改动中会显著增加 review 和回归范围。
+
+## 建议的后续演进顺序
+
+1. 当前：完成 precheck、参数化、公共 checker 和复合 LRU key，优先保证行为兼容。
+2. Typed parameter：让参数化结果携带原始类型、charset/collation 和来源位置，逐步缩小保守 reject 范围。
+3. 可观测性：统一记录 raw SQL、normalized SQL、bypass stage/reason 和两层 cache hit。
+4. 性能：在 key 和失效机制完备后，评估 checker 只在 LRU miss 执行，并评估 second-hit admission。
+5. 计划质量：根据实际 workload 评估 generic/custom 或 parameter-sensitive 多计划机制。
+
+## 调研限制
+
+- SQL Server、Oracle 和 Db2 的实现细节主要依据官方行为文档、系统视图和公开概念模型，无法像开源项目一样检查完整实现。
+- OceanBase 和 PostgreSQL 同时参考了官方文档与公开源码；源码链接指向当前主分支，只用于理解结构，不应依赖具体字段名作为稳定接口。
+- PostgreSQL 和 MySQL 关于“普通文本 SQL 不自动集中”的描述是根据官方公开的协议、PREPARE 和 statement caching 能力作出的判断，不代表数据库内部完全不存在任何解析或元数据缓存。
+- 本文调研时间为 2026-08-14。数据库新版本可能继续调整参数化范围、缓存键或参数敏感计划机制。

--- a/pkg/planner/MAINTAINER_GUIDE.md
+++ b/pkg/planner/MAINTAINER_GUIDE.md
@@ -1,0 +1,449 @@
+# Planner Maintainer Guide
+
+This doc records non-obvious design choices, invariants, and maintainer workflows
+for TiDB's planner/optimizer.
+
+It intentionally:
+- prioritizes relatively complex logic and explains why it is designed this way
+- skips content that is easiest to learn by reading the code
+- stays concise and action-oriented for maintainers/reviewers/oncall
+
+Status: describes current behavior as implemented in `pkg/planner/` and its
+boundary modules (`pkg/executor/compiler.go`, `pkg/planner/optimize.go`,
+`pkg/planner/core/preprocess.go`, `pkg/planner/core/plan_cache.go`,
+`pkg/planner/core/optimizer.go`). If you change a correctness fence (plan cache,
+schema snapshot rules, binding/hint behavior), update this doc in the same patch.
+
+Hard rule:
+- Use this guide as a map, but confirm conclusions against code/tests.
+
+## Contents
+1. Scope And Non-Negotiable Invariants
+2. Responsibility Boundaries (Where Changes Belong)
+3. Planning Mental Model (Statement Scope + Hidden State)
+4. Plan Cache Invariants (Prepared / Non-Prepared / Instance)
+5. Optimizer Engine Invariants (Volcano vs Cascades)
+6. Debugging Anchors And Common Failure Modes
+7. Maintainer Playbooks (Common Change Types)
+8. Glossary
+
+## 1. Scope And Non-Negotiable Invariants
+
+This guide covers:
+- statement planning policy and wiring: `pkg/planner/optimize.go`
+- preprocess (name resolution + schema snapshot selection): `pkg/planner/core/preprocess.go`
+- plan cache safety boundary (fences, keying, reuse/adjust): `pkg/planner/core/plan_cache.go`
+- optimizer engines and shared finalization: `pkg/planner/core/optimizer.go`
+
+It intentionally skips:
+- parser and AST shapes (`pkg/parser/*`)
+- executor/runtime semantics (`pkg/executor/*`, `pkg/expression/*`)
+- statistics collection lifecycle (owned by `pkg/statistics/*` / `pkg/domain/*`)
+
+Top invariants a planner maintainer must not break:
+1. A statement MUST be planned against exactly one InfoSchema snapshot.
+2. Plan cache reuse MUST be fenced by schema/version checks, MDL, and per-exec
+   adjustment (param typing + range rebuild).
+3. Plan cache key/caching rules MUST treat "plan meaning" as the boundary: any
+   plan-affecting input must be reflected in the key or ruled non-cacheable.
+4. Cached plans MUST NOT leak mutable state across sessions; instance plan cache
+   requires cloning and "read-only cached value" semantics.
+5. Volcano vs Cascades MUST be semantically equivalent (shape may differ; result
+   set must not).
+
+Other planner sharp edges (easy to break accidentally):
+- Preprocess MUST be safe to re-run; plan-cache reuse may trigger re-preprocess
+  when schema fences fail.
+- Planner code that mutates an AST MUST restore it (or operate on a copy);
+  leaking mutations changes later planning steps and can corrupt plan-cache
+  reuse/binding match behavior.
+
+Maintainer preflight (write these down before touching plan cache behavior):
+- Which axis are you changing: prepared / non-prepared / instance plan cache?
+- Are you changing plan meaning? (cache key inputs, cacheability rules, per-exec
+  adjustment, bindings/hints, schema snapshot selection)
+- What are the correctness fences you rely on (schema meta version, per-table
+  revision, MDL, privilege/table-lock checks)?
+- Does your change introduce mutable state inside cached values? If yes, how is
+  it isolated (session-only) or cloned (instance cache)?
+- What is the minimal regression test: execute twice with different parameters,
+  execute across DDL, and (for instance cache) cross-session coverage.
+
+## 2. Responsibility Boundaries (Where Changes Belong)
+
+Keep these boundaries sharp; it makes correctness reviewable.
+
+- `pkg/executor/compiler.go`: statement boundary orchestration; MUST NOT grow
+  planner logic.
+- `pkg/planner/core/preprocess.go`: resolve + validation that depends on schema
+  snapshot/staleness/session variables; produces the InfoSchema used for the
+  statement.
+- `pkg/planner/optimize.go`: statement-level planning policy:
+  - picking cache frontend (prepared vs non-prepared)
+  - hint parsing + binding selection
+  - fast-plan attempts
+- `pkg/planner/core/plan_cache.go`: plan-cache backend and safety fences:
+  - schema/MDL fencing
+  - cache key construction + lookup
+  - hit adjustment / miss generation
+- `pkg/planner/core/plan_cache_utils.go`: cache key/value encoding utilities,
+  param-type extraction, clone helpers (treat as correctness-critical).
+- `pkg/planner/core/plan_cacheable_checker.go`: cacheability rules (AST-level and
+  plan-shape-level). Keep conservative.
+
+Rule of thumb:
+- If an input can change plan meaning, it MUST appear in preprocess, cache key,
+  or cacheability rules. Do not hide it in incidental globals or mutable fields.
+
+## 3. Planning Mental Model (Statement Scope + Hidden State)
+
+Planner execution is statement-scoped, but several "hidden" cross-statement
+mechanisms exist:
+- plan cache (prepared/non-prepared/instance) introduces correctness-sensitive
+  reuse across executions.
+- bindings/hints can make plan selection depend on persisted metadata.
+- schema can change concurrently (DDL), so reuse must be fenced.
+
+One-minute flow (ignoring details):
+1. `pkg/executor/compiler.go` picks a schema snapshot and calls planner.
+2. `pkg/planner/optimize.go` applies hints/bindings, and then either:
+   - goes through plan cache (EXECUTE or eligible non-prepared), or
+   - builds/optimizes a fresh plan.
+3. On a plan-cache hit, planner MUST still validate fences and rebuild
+   param-dependent pieces; reuse is never a blind memoization.
+
+### 3.1 Alternative Logical-Plan Rounds Are Isolated Transactions
+
+When alternative logical plans are enabled, each build/optimization round is a
+speculative transaction over statement-scoped planner state. A losing round
+MUST NOT leave metadata that is observable from the winning plan.
+
+Maintenance rules:
+- Add per-round initialization to `resetLogicalPlanBuildRoundState`; do not add
+  one-off resets at individual round call sites.
+- Keep resets introduced solely for candidate isolation behind
+  `EnableAlternativeLogicalPlans`; changing how state accumulates on the
+  feature-off path is a separate behavior change and requires dedicated tests.
+- If a new field's winning value must survive the round, snapshot and restore it
+  in `logicalPlanBuildCtx` or `stmtctx.LogicalPlanBuildState`, as appropriate.
+- Mutable pointer-backed values must either be freshly allocated after every
+  reset or deeply cloned. Saving and restoring an aliased pointer is not enough.
+- `OptimizerDebugTrace` starts recording before the individual build rounds, so
+  preserve its outer context and clone its context tree in the round snapshot.
+  Do not clear it in the per-round reset; that would discard command/binding
+  trace entries recorded before candidate optimization starts.
+- Extend `TestLogicalPlanBuildRoundStateResetAndRestore` when adding new
+  round-local planner state.
+
+## 4. Plan Cache Invariants (Prepared / Non-Prepared / Instance)
+
+The plan cache is a correctness boundary. The common failure mode is treating it
+as a pure performance layer and missing a "plan meaning" input or fence.
+
+### 4.0 Jump Table (Start Here When Debugging/Reviewing)
+
+Plan cache is intentionally layered:
+- Frontend: prepares the statement carrier (`PlanCacheStmt`) and inputs for lookup
+  (AST, parameter markers/values, resolve context).
+- Backend: applies correctness fences, does lookup, hit adjustment, and miss handling.
+
+Frontend entrypoints:
+- Prepared statements:
+  - PREPARE builds `PlanCacheStmt` (AST + resolve/visit infos + schema fences)
+  - EXECUTE routes to the backend with the `PlanCacheStmt` and current params
+- Non-prepared statements:
+  - parameterize + restore AST to get parameterized SQL
+  - build/reuse a per-session `PlanCacheStmt` for that parameterized SQL
+  - route to the same backend
+
+- Backend entrypoint (shared): `pkg/planner/core/plan_cache.go` (`GetPlanFromPlanCache`)
+- Preprocess fences on reuse: `pkg/planner/core/plan_cache.go` (`planCachePreprocess`)
+- Cache key: `pkg/planner/core/plan_cache_utils.go` (`NewPlanCacheKey`)
+- Cacheability rules:
+  - prepared AST: `pkg/planner/core/plan_cacheable_checker.go` (`IsASTCacheable`)
+  - non-prepared legacy path: `pkg/planner/core/plan_cacheable_checker.go` (`NonPreparedPlanCacheableWithCtx`)
+  - non-prepared unified path: context-aware parameterization followed by
+    `IsASTCacheable`; it is guarded by
+    `tidb_enable_non_prepared_plan_cache_unified_cacheability_check`
+  - plan-shape: `pkg/planner/core/plan_cacheable_checker.go` (`isPlanCacheable`)
+- Hit adjustment (ranges): `pkg/planner/core/plan_cache_rebuild.go` (`RebuildPlan4CachedPlan`)
+- Non-prepared parameterization: `pkg/planner/core/plan_cache_param.go`
+  (`GetParamSQLFromAST` for the legacy path and
+  `ParameterizeForNonPreparedPlanCache` for the unified path)
+- Cache implementations:
+  - session cache (LRU): `pkg/planner/core/plan_cache_lru.go`
+  - instance cache (node-level): `pkg/planner/core/plan_cache_instance.go`
+
+### 4.1 Two Cached Objects: `PlanCacheStmt` vs `PlanCacheValue`
+
+There are two different "cached things". Conflating them causes subtle bugs.
+
+- `PlanCacheStmt` (statement carrier; reused across executions):
+  - owns the prepared AST, resolve context, visit infos (privilege/table-lock
+    checks), parameter markers, and schema fences (schema version + per-table
+    revisions).
+  - may include short-path caches (e.g. PointGet executor reuse) that MUST be
+    cleared when schema changes.
+- `PlanCacheValue` (plan carrier; stored in the plan cache):
+  - owns the physical plan and its metadata for a particular `(cacheKey,
+    paramTypes)` match.
+
+Non-obvious mutability rule:
+- Session plan cache: cached plan is session-owned; it may contain mutable state
+  as long as it cannot escape the session.
+- Instance plan cache: cached value MUST be treated as read-only and MUST be a
+  clone; every execution clones again before using it.
+
+Why this exists:
+- Session cache optimizes for simplicity and speed inside a single goroutine-ish
+  session context.
+- Instance cache is shared across sessions; any mutable state becomes a data
+  race or cross-session correctness leak.
+
+### 4.2 Reuse Fences: What MUST Be Validated On Every Hit
+
+On a hit, planner MUST validate (and may need to refresh) these fences before
+returning the plan:
+
+- Schema fencing:
+  - InfoSchema meta version matches.
+  - Per-table revision fencing matches (single-table changes must invalidate).
+  - In some cases (e.g. `READ COMMITTED` / `FOR UPDATE`), reuse must be sensitive
+    to the latest domain schema version, not only the prepare-time one.
+- MDL fencing:
+  - required metadata locks for referenced tables are acquired/validated.
+- Authorization fencing:
+  - privilege checks and table-lock checks must still be enforced per execution
+    (with a known PointGet-executor reuse exception; see 4.6).
+
+Workflow invariant:
+- If schema fencing fails, plan cache preprocess can re-run `Preprocess` to
+  refresh resolve context and schema fences. Any new preprocess behavior must
+  remain idempotent under retries.
+
+Why this exists:
+- Plan reuse without these fences can produce wrong results, panic (schema
+  mismatch), or privilege bypass.
+
+### 4.3 Cache Key Design: "Plan Meaning" MUST Be In The Key
+
+Rule: all information that can change plan meaning MUST be represented in the
+cache key, or caching MUST be disabled for statements affected by that input.
+
+High-signal groups that are intentionally part of the key (non-exhaustive):
+- identity: user/host (do not share plans across users), current DB, statement
+  text (parameterized text for both prepared and non-prepared)
+- effective hints/bindings: matched binding SQL must be reflected
+- schema fences: schema meta version + per-table revision map; partition prune
+  mode is part of the key
+- session environment: SQL mode, time zone/offset, connection collation/charset,
+  isolation read engines, `sql_select_limit`, restricted SQL marker, foreign-key
+  checks, and other knobs that can alter plan selection/semantics
+- runtime semantics state: "dirty table" markers (union scan) and transaction
+  flags that change locking/reads
+- optional freshness invalidation: when enabled, a stats-version hash is
+  included so fresh stats naturally force a miss
+
+Design intent:
+- "key completeness" is the safety net; cacheability rules are the coarse filter.
+- If you add a new plan-affecting session var / hint / binding behavior, you
+  must explicitly decide: key it, or forbid reuse (and test that decision).
+
+### 4.4 Per-Execution Adjustment: Param Types + Range Rebuild
+
+Plan cache lookup matches by `(cacheKey, paramTypes)`:
+- the same `cacheKey` can hold multiple `PlanCacheValue`s for different
+  parameter type vectors.
+- param type extraction differs by protocol (binary vs text-protocol user vars);
+  be careful when changing typing rules.
+
+Even on a hit, planner MUST rebuild param-dependent ranges for current values
+before executing:
+- scan ranges (table/index), point-get/batch-point-get ranges, index-join ranges
+  must be regenerated.
+- wrapper plans such as `SelectInto` must be unwrapped to their target plan for
+  cacheability checks, plan digest, and range rebuild; the executor still
+  receives the wrapper plan so statement semantics are preserved.
+- hidden stored-routine prepared templates may need statement-visible warnings
+  produced while building the cached plan (for example constant-fold side
+  effects) to be replayed on cache hits so warning handlers observe the same
+  warnings on hit and miss paths. Plain prepared statements currently preserve
+  their historical behavior and do not replay those warnings on hits.
+- if rebuild fails or hits a safety fallback, the cached plan is treated as
+  unusable and the execution falls back to "miss" behavior.
+
+Why this exists:
+- the cached plan is a template; ranges are execution-specific and must not be
+  reused blindly.
+
+### 4.5 Non-Prepared Plan Cache: Parameterization Must Be Reversible
+
+Non-prepared plan cache is a text-protocol optimization that reuses the same
+backend (`GetPlanFromPlanCache`) after turning constants into parameters.
+
+Invariants:
+- Parameterization MUST NOT leave mutations on the original AST. If you need to
+  mutate, you must restore (or operate on a copied AST). Validate every marker
+  before restoration so a malformed marker cannot leave a partially restored
+  AST.
+- `tidb_enable_non_prepared_plan_cache_unified_cacheability_check=OFF` MUST run
+  the complete legacy checker and parameterizer flow. When it is `ON`, the
+  frontend applies parameterization safety checks and reruns `IsASTCacheable`
+  on both statement-carrier LRU hits and misses.
+- The statement-carrier LRU MUST admit only carriers that passed the selected
+  frontend checks and have `StmtCacheable=true`.
+- The stored-routine-specific rules below apply only when
+  `tidb_enable_sp_plan_cache=ON`; with the switch OFF, routine internal SQL
+  stays on the plain execution path.
+- Stored routine parameterization MUST respect SQL name-resolution boundaries;
+  for example, alias-sensitive `GROUP BY` / `HAVING` / `ORDER BY` references
+  should fall back rather than being rewritten before the planner can
+  disambiguate aliases and routine vars.
+- Stored routine `LIMIT` routine variables MUST fall back; prepared-parameter
+  semantics reject values like `-1` and bypass the routine-only mutability
+  checks that plain procedure execution applies.
+- Stored routine `ENUM` / `SET` variables MUST fall back for now; the hidden
+  prepared `EXECUTE` path can lose scalar-result metadata for those parameter
+  types, so the uncached routine execution path is the current correctness
+  boundary.
+- Hidden stored-routine prepared templates MUST isolate statement-scoped table
+  tracking such as `StmtCtx.RelatedTableIDs`; otherwise one internal SQL can
+  inherit another statement's schema fences and fail after unrelated DDL.
+- Hidden stored-routine prepared-template generation can run while the outer
+  statement still has active cache state; seed and restore temporary
+  `PlanCacheParams` slots during probing so parameter markers do not read the
+  outer execution's runtime arguments.
+- Hidden stored-routine prepared-template probes MUST isolate warnings; an
+  unsupported probe should fall back without changing `SHOW WARNINGS` output or
+  stored-routine warning-handler behavior. Hidden `EXECUTE` paths may replace
+  `SessionVars.StmtCtx`, so warning filtering must be applied to the final
+  active statement context, not only to the pre-execution pointer.
+- Non-prepared cacheability rules MUST remain conservative; widen only with
+  dedicated semantic coverage.
+- The per-session `PlanCacheStmt` for non-prepared cache is keyed by the
+  parameterized SQL plus every parse/name-resolution input (connection and
+  client charset/collation, current database, SQL mode, parser feature flags)
+  and the legacy/unified mode bit. It is a different object from the cached
+  plan values. When parser configuration gains another semantic input, extend
+  this key at the same time.
+
+Why this exists:
+- Mutating the original AST leaks state across retries/other code paths and
+  breaks plan digest / hint matching / later planning phases.
+
+### 4.6 PointGet Fast Paths: Executor Reuse Has Special Privilege Semantics
+
+Prepared statements can reuse a cached PointGet executor for an autocommit
+point-get fast path.
+
+Sharp edge:
+- In the PointGet-executor reuse path, `GetPlanFromPlanCache` can skip the usual
+  per-execution privilege check.
+
+Maintainer rule:
+- If you touch privilege semantics, point-get executor reuse, or the fencing
+  conditions, add/extend a regression test for this specific path.
+
+### 4.7 Instance Plan Cache: Clone Discipline And Memory/Eviction
+
+Instance plan cache is node-level and shared across sessions.
+
+Non-negotiable rules:
+- Values stored in the instance cache MUST be clones and treated as read-only.
+- On hit, the cached value MUST be cloned again for the current execution.
+- Cached values MUST NOT reference session-specific pointers (StmtCtx, session
+  vars, allocators, mutable global slices, etc).
+
+Operational notes:
+- Instance cache eviction is memory-driven (soft/hard limits) and coordinated by
+  a domain-owned background goroutine. Be cautious when adding per-plan memory.
+- `admin flush instance plan_cache` uses a domain-level invalidation timestamp;
+  sessions observe it lazily during preprocess and clear their local cache.
+
+## 5. Optimizer Engine Invariants (Volcano vs Cascades)
+
+TiDB has two planning engines behind a switch (`EnableCascadesPlanner`):
+- Volcano: rule-based logical optimize + cost-based physical selection.
+- Cascades: memo-based normalize/explore/implement.
+
+Invariants:
+- Both engines MUST preserve SQL semantics. Treat divergences as correctness
+  regressions even if they "only" show up under a flag.
+- Shared finalization steps (post-optimization fixups) must stay consistent; if a
+  new physical operator requires finalization, wire it in the shared path.
+
+Workflow tip:
+- When adding a new logical rewrite, decide explicitly whether it belongs in:
+  - Volcano logical rule batches
+  - Cascades normalization
+  - Cascades exploration rules
+  and ensure the other engine has an equivalent semantic behavior (or is gated
+  with explicit justification + tests).
+
+## 6. Debugging Anchors And Common Failure Modes
+
+Where to look first (planner-specific):
+- Only fails on 2nd execution / after "hit": start at `pkg/planner/core/plan_cache.go`
+  (fences, param types, rebuild, clone).
+- Only fails across DDL: inspect schema fencing + re-preprocess behavior.
+- Only fails cross-session (instance cache): suspect missing clone/read-only
+  discipline or session-pointer leakage.
+- "ignored hint" / binding unexpected: start at `pkg/planner/optimize.go` and
+  binding match logic; validate AST restore.
+- Volcano vs Cascades divergence: search for engine-specific code paths under
+  `pkg/planner/core/optimizer.go`.
+
+Test surfaces that should catch most regressions:
+- prepared/non-prepared plan cache: `pkg/planner/core/casetest/plancache/`
+- instance plan cache: `pkg/planner/core/casetest/instanceplancache/`
+- SQL integration tests for planner behavior: `tests/integrationtest/t/planner/`
+- sysvar surface coverage: `tests/integrationtest/t/sessionctx/setvar.test`
+
+## 7. Maintainer Playbooks (Common Change Types)
+
+### 7.1 Changing Cache Key Inputs
+
+Checklist:
+- Decide whether the input changes plan meaning; if yes, key it or ban caching.
+- Add a test that executes twice and proves "old key would be wrong".
+- For schema-related keying, add coverage with "execute -> DDL -> execute".
+
+### 7.2 Changing Cacheability Rules
+
+Checklist:
+- Keep the rules conservative; widen only with targeted coverage.
+- Ensure both prepared and non-prepared checkers are updated when applicable.
+- Add at least one semantic test, not only plan-shape tests.
+
+### 7.3 Changing Hit Adjustment / Range Rebuild
+
+Checklist:
+- Verify param typing extraction for both protocols (binary and text-protocol).
+- Add a test that hits the cache with different param values and validates
+  ranges are rebuilt (or validate via result set difference).
+
+### 7.4 Changing Instance Cache Behavior
+
+Checklist:
+- Audit clone paths: on miss (store) and on hit (execute).
+- Add cross-session coverage.
+- Watch for any newly stored per-plan data that could carry session pointers or
+  mutable slices.
+
+### 7.5 Changing Privilege / Table-Lock Semantics Around Cached Plans
+
+Checklist:
+- Validate normal hit path and PointGet-executor reuse path explicitly.
+- Add a regression test that changes privileges between executes.
+
+## 8. Glossary
+
+- InfoSchema: the per-statement schema snapshot used for name resolution and planning.
+- MDL: metadata lock used to fence schema changes vs plan reuse.
+- PlanCacheStmt: statement carrier reused across executions (AST/resolve/visit infos/schema fences).
+- PlanCacheValue: cached physical plan value stored for a specific key + param types match.
+- Prepared plan cache: plan cache for `PREPARE` / `EXECUTE`.
+- Non-prepared plan cache: plan cache for parameterized text-protocol statements.
+- Instance plan cache: node-level plan cache shared across sessions; requires cloning.
+- Volcano: rule-based optimizer pipeline with cost-based physical selection.
+- Cascades: memo-based optimizer pipeline (normalize -> explore -> implement).

--- a/pkg/planner/MAINTAINER_GUIDE.md
+++ b/pkg/planner/MAINTAINER_GUIDE.md
@@ -321,11 +321,7 @@ Invariants:
 - Non-prepared cacheability rules MUST remain conservative; widen only with
   dedicated semantic coverage.
 - The per-session `PlanCacheStmt` for non-prepared cache is keyed by the
-  parameterized SQL plus every parse/name-resolution input (connection and
-  client charset/collation, current database, SQL mode, parser feature flags)
-  and the legacy/unified mode bit. It is a different object from the cached
-  plan values. When parser configuration gains another semantic input, extend
-  this key at the same time.
+  parameterized SQL. It is a different object from the cached plan values.
 
 Why this exists:
 - Mutating the original AST leaks state across retries/other code paths and

--- a/pkg/planner/core/casetest/plancache/plan_cache_param_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_param_test.go
@@ -17,13 +17,17 @@ package plancache
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/format"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,6 +155,373 @@ func TestGetParamSQLFromASTConcurrently(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func restorePlanCacheParamTestStmt(t *testing.T, stmt ast.StmtNode) string {
+	var builder strings.Builder
+	ctx := format.NewRestoreCtx(format.DefaultRestoreFlags, &builder)
+	require.NoError(t, stmt.Restore(ctx))
+	return builder.String()
+}
+
+func TestParameterizeForNonPreparedPlanCache(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = true
+
+	testCases := []struct {
+		name     string
+		sql      string
+		paramSQL string
+		params   []any
+	}{
+		{
+			name:     "filter and preserved clauses",
+			sql:      "select 1 from t where a=2 group by 3 having sum(a)>4 order by 5 limit 6",
+			paramSQL: "SELECT 1 FROM `t` WHERE `a`=? GROUP BY 3 HAVING sum(`a`)>? ORDER BY 5 LIMIT 6",
+			params:   []any{int64(2), int64(4)},
+		},
+		{
+			name:     "literal-list IN",
+			sql:      "select * from t where a in (1, 2, 3) and b=4",
+			paramSQL: "SELECT * FROM `t` WHERE `a` IN (?,?,?) AND `b`=?",
+			params:   []any{int64(1), int64(2), int64(3), int64(4)},
+		},
+		{
+			name:     "BETWEEN",
+			sql:      "select * from t where a between 1 and 2 and b=3",
+			paramSQL: "SELECT * FROM `t` WHERE `a` BETWEEN ? AND ? AND `b`=?",
+			params:   []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:     "join and derived table",
+			sql:      "select x.a from (select a from t where b=1) x join t2 on x.a=t2.a and t2.b=2 where x.a=3",
+			paramSQL: "SELECT x.a FROM (SELECT a FROM `t` WHERE `b`=?) AS `x` JOIN `t2` ON `x`.`a`=`t2`.`a` AND `t2`.`b`=? WHERE `x`.`a`=?",
+			params:   []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:     "cte",
+			sql:      "with cte as (select a from t where b=1) select a from cte where a=2",
+			paramSQL: "WITH `cte` AS (SELECT a FROM `t` WHERE `b`=?) SELECT a FROM `cte` WHERE `a`=?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "set operation",
+			sql:      "select a from t where b=1 union select a from t where b=2 order by 1 limit 3",
+			paramSQL: "SELECT a FROM `t` WHERE `b`=? UNION SELECT a FROM `t` WHERE `b`=? ORDER BY 1 LIMIT 3",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "intersect",
+			sql:      "select a from t where b=1 intersect select a from t where b=2",
+			paramSQL: "SELECT a FROM `t` WHERE `b`=? INTERSECT SELECT a FROM `t` WHERE `b`=?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "except",
+			sql:      "select a from t where b=1 except select a from t where b=2",
+			paramSQL: "SELECT a FROM `t` WHERE `b`=? EXCEPT SELECT a FROM `t` WHERE `b`=?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "special literals",
+			sql:      "select * from t where a=null or b=b'1' or c=x'0a' or d=4",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=NULL OR `b`=b'1' OR `c`=x'0a' OR `d`=?",
+			params:   []any{int64(4)},
+		},
+		{
+			name:     "binary literal token spelling",
+			sql:      "select * from t where a=b'0001' or b=B'0001' or c=0b0001 or d=X'0A' or e=x'0A' or f=0x0A or g=4",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=b'0001' OR `b`=B'0001' OR `c`=0b0001 OR `d`=X'0A' OR `e`=x'0A' OR `f`=0x0A OR `g`=?",
+			params:   []any{int64(4)},
+		},
+		{
+			name:     "date format",
+			sql:      "select * from t where a=date_format('2020-02-02', '%Y-%m-%d')",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=date_format(?, '%Y-%m-%d')",
+			params:   []any{"2020-02-02"},
+		},
+		{
+			name:     "generic function",
+			sql:      "select * from t where coalesce(a, 1)=2",
+			paramSQL: "SELECT * FROM `t` WHERE coalesce(`a`, ?)=?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "date format without arguments",
+			sql:      "select * from t where date_format()",
+			paramSQL: "SELECT * FROM `t` WHERE date_format()",
+		},
+		{
+			name:     "window frame",
+			sql:      "select sum(a) over (order by a rows 1 preceding) from t where b=2",
+			paramSQL: "SELECT sum(a) over (order by a rows 1 preceding) FROM `t` WHERE `b`=?",
+			params:   []any{int64(2)},
+		},
+		{
+			name:     "named window",
+			sql:      "select sum(a) over w from t where b=2 window w as (partition by a order by b)",
+			paramSQL: "SELECT sum(a) over w FROM `t` WHERE `b`=? WINDOW `w` AS (PARTITION BY `a` ORDER BY `b`)",
+			params:   []any{int64(2)},
+		},
+		{
+			name:     "uncorrelated subquery",
+			sql:      "select a from t where a in (select a from t2 where b=1) and a>2",
+			paramSQL: "SELECT a FROM `t` WHERE `a` IN (SELECT a FROM `t2` WHERE `b`=?) AND `a`>?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "correlated subquery",
+			sql:      "select a from t where a > (select max(a) from t2 where t2.b > t.b and t2.a > 1) and b=2",
+			paramSQL: "SELECT a FROM `t` WHERE `a`>(SELECT max(a) FROM `t2` WHERE `t2`.`b`>`t`.`b` AND `t2`.`a`>?) AND `b`=?",
+			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "hint",
+			sql:      "select /*+ use_index(t, idx_a) */ * from t where a=1",
+			paramSQL: "SELECT /*+ use_index(`t` `idx_a`)*/ * FROM `t` WHERE `a`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "insert values",
+			sql:      "insert into t values (1, null, x'0a')",
+			paramSQL: "INSERT INTO `t` VALUES (?,NULL,x'0a')",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "insert on duplicate key update",
+			sql:      "insert into t (a, b) values (1, 2) on duplicate key update b=b+3",
+			paramSQL: "INSERT INTO `t` (`a`,`b`) VALUES (?,?) ON DUPLICATE KEY UPDATE `b`=`b`+?",
+			params:   []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:     "update assignment",
+			sql:      "update t set a=1 where b=2 order by c+3 limit 4",
+			paramSQL: "UPDATE `t` SET `a`=? WHERE `b`=? ORDER BY `c`+3 LIMIT 4",
+			params:   []any{int64(1), int64(2)},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			originalSQL := restorePlanCacheParamTestStmt(t, stmt)
+
+			result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+			require.NoError(t, err)
+			require.True(t, supported, reason)
+			require.Empty(t, reason)
+			require.Equal(t, testCase.paramSQL, result.ParamSQL)
+			require.Len(t, result.ParamValues, len(testCase.params))
+			for i, param := range result.ParamValues {
+				require.Equal(t, testCase.params[i], param.GetValue())
+			}
+			require.Equal(t, originalSQL, restorePlanCacheParamTestStmt(t, stmt))
+		})
+	}
+}
+
+func TestParameterizeForNonPreparedPlanCacheBypass(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = true
+
+	testCases := []struct {
+		sql    string
+		reason string
+	}{
+		{"select _utf8mb4'a' from t where a=1", "under-score charset"},
+		{"select * from t into outfile '/tmp/a'", "SELECT INTO"},
+		{"update t1 join t2 on t1.a=t2.a set t1.b=1", "multiple-table UPDATE"},
+		{"delete t1 from t1 join t2 on t1.a=t2.a where t1.b=1", "multiple-table DELETE"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.reason, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			originalSQL := restorePlanCacheParamTestStmt(t, stmt)
+			_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+			require.NoError(t, err)
+			require.False(t, supported, "sql: %s, reason: %s", testCase.sql, reason)
+			require.Contains(t, reason, testCase.reason)
+			require.Equal(t, originalSQL, restorePlanCacheParamTestStmt(t, stmt))
+		})
+	}
+
+	stmt, err := parser.New().ParseOneStmt("select * from t where a = ?", "", "")
+	require.NoError(t, err)
+	_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.False(t, supported)
+	require.Equal(t, "query has parameter markers", reason)
+
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = false
+	stmt, err = parser.New().ParseOneStmt("select * from t limit 1", "", "")
+	require.NoError(t, err)
+	_, supported, reason, err = plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.False(t, supported)
+	require.Equal(t, "query has 'limit ?' is un-cacheable", reason)
+}
+
+func TestParameterizeForNonPreparedPlanCacheDumpfileBypass(t *testing.T) {
+	sctx := mock.NewContext()
+	stmt, err := parser.New().ParseOneStmt("select * from t into outfile '/tmp/a'", "", "")
+	require.NoError(t, err)
+	selectStmt := stmt.(*ast.SelectStmt)
+	// The current parser does not expose INTO DUMPFILE syntax, but the AST
+	// supports the type. Keep the unified gate conservative for it as well.
+	selectStmt.SelectIntoOpt.Tp = ast.SelectIntoDumpfile
+
+	_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.False(t, supported)
+	require.Equal(t, "SELECT INTO is not supported", reason)
+}
+
+// unknownPlanCacheExpr deliberately wraps a literal in an expression type that
+// the selector does not know. It verifies the selector's preserve-by-default
+// behavior for future AST nodes.
+type unknownPlanCacheExpr struct {
+	*ast.ParenthesesExpr
+}
+
+func (n *unknownPlanCacheExpr) Accept(v ast.Visitor) (ast.Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*unknownPlanCacheExpr)
+	node, ok := n.Expr.Accept(v)
+	if !ok {
+		return n, false
+	}
+	n.Expr = node.(ast.ExprNode)
+	return v.Leave(n)
+}
+
+func TestNonPreparedPlanCacheSelectorPreservesUnknownExpressionChildren(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = true
+	stmt, err := parser.New().ParseOneStmt("select * from t where a=1 and b=2", "", "")
+	require.NoError(t, err)
+	where := stmt.(*ast.SelectStmt).Where.(*ast.BinaryOperationExpr)
+	where.R = &unknownPlanCacheExpr{ParenthesesExpr: &ast.ParenthesesExpr{Expr: ast.NewValueExpr(int64(2), "", "")}}
+	originalSQL := restorePlanCacheParamTestStmt(t, stmt)
+
+	result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.True(t, supported, reason)
+	require.Equal(t, "SELECT * FROM `t` WHERE `a`=? AND (2)", result.ParamSQL)
+	require.Len(t, result.ParamValues, 1)
+	require.Equal(t, int64(1), result.ParamValues[0].GetValue())
+	require.Equal(t, originalSQL, restorePlanCacheParamTestStmt(t, stmt))
+}
+
+func TestNonPreparedPlanCacheParameterizerSelectsMultiTableDML(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sql      string
+		paramSQL string
+		params   []any
+	}{
+		{
+			name:     "update",
+			sql:      "update t1 join t2 on t1.a=t2.a and t2.b=2 set t1.b=1 where t1.a=3",
+			paramSQL: "UPDATE `t1` JOIN `t2` ON `t1`.`a`=`t2`.`a` AND `t2`.`b`=? SET `t1`.`b`=? WHERE `t1`.`a`=?",
+			params:   []any{int64(2), int64(1), int64(3)},
+		},
+		{
+			name:     "delete",
+			sql:      "delete t1 from t1 join t2 on t1.a=t2.a and t2.b=2 where t1.a=3",
+			paramSQL: "DELETE `t1` FROM `t1` JOIN `t2` ON `t1`.`a`=`t2`.`a` AND `t2`.`b`=? WHERE `t1`.`a`=?",
+			params:   []any{int64(2), int64(3)},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			originalSQL := restorePlanCacheParamTestStmt(t, stmt)
+			result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(mock.NewContext().GetPlanCtx(), stmt)
+			require.NoError(t, err)
+			require.True(t, supported, reason)
+			require.Equal(t, testCase.paramSQL, result.ParamSQL)
+			require.Len(t, result.ParamValues, len(testCase.params))
+			for i, value := range result.ParamValues {
+				require.Equal(t, testCase.params[i], value.GetValue())
+			}
+			require.Equal(t, originalSQL, restorePlanCacheParamTestStmt(t, stmt))
+		})
+	}
+}
+
+func TestGetParamSQLFromASTRestoresAfterParamSQLRestoreFailure(t *testing.T) {
+	stmt, err := parser.New().ParseOneStmt("select 1 from t where a=2", "", "")
+	require.NoError(t, err)
+	selectStmt := stmt.(*ast.SelectStmt)
+	selectStmt.Fields.Fields[0].Expr = ast.NewValueExpr(struct{}{}, "", "")
+	selectStmt.Fields.Fields[0].SetText(nil, "")
+
+	_, _, err = plannercore.GetParamSQLFromAST(stmt)
+	require.Error(t, err)
+	binaryExpr := selectStmt.Where.(*ast.BinaryOperationExpr)
+	require.IsType(t, &driver.ValueExpr{}, binaryExpr.R)
+
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = true
+	for i := 0; i < 8; i++ {
+		_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+		require.NoError(t, err)
+		require.False(t, supported)
+		require.Equal(t, "failed to restore parameterized SQL", reason)
+		require.IsType(t, &driver.ValueExpr{}, binaryExpr.R)
+	}
+}
+
+func TestRestoreASTWithParamsValidatesBeforeMutation(t *testing.T) {
+	stmt, err := parser.New().ParseOneStmt("select * from t where a=1 and b=2", "", "")
+	require.NoError(t, err)
+	_, params, err := plannercore.ParameterizeAST(stmt)
+	require.NoError(t, err)
+	require.Len(t, params, 2)
+	parameterizedSQL := restorePlanCacheParamTestStmt(t, stmt)
+
+	where := stmt.(*ast.SelectStmt).Where.(*ast.BinaryOperationExpr)
+	leftMarker := where.L.(*ast.BinaryOperationExpr).R.(*driver.ParamMarkerExpr)
+	rightMarker := where.R.(*ast.BinaryOperationExpr).R.(*driver.ParamMarkerExpr)
+	leftMarker.Offset = -1
+	require.Error(t, plannercore.RestoreASTWithParams(stmt, params))
+	require.Same(t, leftMarker, where.L.(*ast.BinaryOperationExpr).R)
+	require.Same(t, rightMarker, where.R.(*ast.BinaryOperationExpr).R)
+	require.Equal(t, parameterizedSQL, restorePlanCacheParamTestStmt(t, stmt))
+
+	leftMarker.Offset = 0
+	rightMarker.Offset = len(params)
+	require.Error(t, plannercore.RestoreASTWithParams(stmt, params))
+	require.Same(t, leftMarker, where.L.(*ast.BinaryOperationExpr).R)
+	require.Same(t, rightMarker, where.R.(*ast.BinaryOperationExpr).R)
+	require.Equal(t, parameterizedSQL, restorePlanCacheParamTestStmt(t, stmt))
+
+	rightMarker.Offset = 1
+	require.NoError(t, plannercore.RestoreASTWithParams(stmt, params))
+	require.Equal(t, int64(1), where.L.(*ast.BinaryOperationExpr).R.(*driver.ValueExpr).GetInt64())
+	require.Equal(t, int64(2), where.R.(*ast.BinaryOperationExpr).R.(*driver.ValueExpr).GetInt64())
+}
+
+func TestParameterizeForNonPreparedPlanCacheLiteralLimit(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().EnablePlanCacheForParamLimit = true
+	values := make([]string, 201)
+	for i := range values {
+		values[i] = fmt.Sprintf("%d", i)
+	}
+	stmt, err := parser.New().ParseOneStmt("select * from t where a in ("+strings.Join(values, ",")+")", "", "")
+	require.NoError(t, err)
+	_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.False(t, supported)
+	require.Equal(t, "query has too many constants", reason)
 }
 
 func BenchmarkParameterizeSelect(b *testing.B) {

--- a/pkg/planner/core/casetest/plancache/plan_cache_param_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_param_test.go
@@ -241,10 +241,124 @@ func TestParameterizeForNonPreparedPlanCache(t *testing.T) {
 			params:   []any{"2020-02-02"},
 		},
 		{
+			name:     "weight string char syntax",
+			sql:      "select * from t where a=weight_string(b as char(5)) and c=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=weight_string(`b` AS CHAR(5)) AND `c`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "weight string binary syntax",
+			sql:      "select * from t where a=weight_string(b as binary(5)) and c=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=weight_string(`b` AS BINARY(5)) AND `c`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "char charset",
+			sql:      "select * from t where a=char(228 using utf8mb4) and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=char_func(?, 'utf8mb4') AND `b`=?",
+			params:   []any{int64(228), int64(1)},
+		},
+		{
+			name:     "lpad length",
+			sql:      "select * from t where a=lpad('x', 2, '0') and b=3",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=lpad(?, 2, ?) AND `b`=?",
+			params:   []any{"x", "0", int64(3)},
+		},
+		{
+			name:     "rpad length",
+			sql:      "select * from t where a=rpad('x', 2, '0') and b=3",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=rpad(?, 2, ?) AND `b`=?",
+			params:   []any{"x", "0", int64(3)},
+		},
+		{
+			name:     "convert tz precision",
+			sql:      "select * from t where a=convert_tz('2020-01-01 00:00:00.123','+00:00','+00:00') and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=convert_tz('2020-01-01 00:00:00.123', ?, ?) AND `b`=?",
+			params:   []any{"+00:00", "+00:00", int64(1)},
+		},
+		{
+			name:     "unix timestamp precision",
+			sql:      "select * from t where a=unix_timestamp('2020-01-01 00:00:00.123') and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=unix_timestamp('2020-01-01 00:00:00.123') AND `b`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "from unix time precision",
+			sql:      "select * from t where a=from_unixtime(0.123456) and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=from_unixtime(0.123456) AND `b`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "approx percentile preserves percentage",
+			sql:      "select a from t group by a having approx_percentile(a, 50)>1",
+			paramSQL: "SELECT a FROM `t` GROUP BY `a` HAVING approx_percentile(`a`, 50)>?",
+			params:   []any{int64(1)},
+		},
+		{
 			name:     "generic function",
 			sql:      "select * from t where coalesce(a, 1)=2",
 			paramSQL: "SELECT * FROM `t` WHERE coalesce(`a`, ?)=?",
 			params:   []any{int64(1), int64(2)},
+		},
+		{
+			name:     "time precision",
+			sql:      "select * from t where time('00:00:01.123456') > time('00:00:00') and a=1",
+			paramSQL: "SELECT * FROM `t` WHERE time('00:00:01.123456')>time('00:00:00') AND `a`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "timediff precision",
+			sql:      "select * from t where timediff('2020-01-01 00:00:00.123456', '2020-01-01 00:00:00') > 1",
+			paramSQL: "SELECT * FROM `t` WHERE timediff('2020-01-01 00:00:00.123456', '2020-01-01 00:00:00')>?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "timestamp precision",
+			sql:      "select * from t where timestamp('2020-01-01 00:00:00.123456') > '2020-01-01' and a=1",
+			paramSQL: "SELECT * FROM `t` WHERE timestamp('2020-01-01 00:00:00.123456')>? AND `a`=?",
+			params:   []any{"2020-01-01", int64(1)},
+		},
+		{
+			name:     "now precision",
+			sql:      "select * from t where now(6) is not null and a=1",
+			paramSQL: "SELECT * FROM `t` WHERE now(6) IS NOT NULL AND `a`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "round scale",
+			sql:      "select * from t where round(a, 2)=3",
+			paramSQL: "SELECT * FROM `t` WHERE round(`a`, 2)=?",
+			params:   []any{int64(3)},
+		},
+		{
+			name:     "truncate scale",
+			sql:      "select * from t where truncate(a, 2)=3",
+			paramSQL: "SELECT * FROM `t` WHERE truncate(`a`, 2)=?",
+			params:   []any{int64(3)},
+		},
+		{
+			name:     "rand seed",
+			sql:      "select * from t where rand(1)>0",
+			paramSQL: "SELECT * FROM `t` WHERE rand(1)>?",
+			params:   []any{int64(0)},
+		},
+		{
+			name:     "addtime precision",
+			sql:      "select * from t where a=addtime('2020-01-01 00:00:00', '00:00:00.123456') and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=addtime('2020-01-01 00:00:00', '00:00:00.123456') AND `b`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "subtime precision",
+			sql:      "select * from t where a=subtime('2020-01-01 00:00:00', '00:00:00.123456') and b=1",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=subtime('2020-01-01 00:00:00', '00:00:00.123456') AND `b`=?",
+			params:   []any{int64(1)},
+		},
+		{
+			name:     "benchmark loop count",
+			sql:      "select * from t where a=benchmark(1, coalesce(2, 3)) and b=4",
+			paramSQL: "SELECT * FROM `t` WHERE `a`=benchmark(1, coalesce(?, ?)) AND `b`=?",
+			params:   []any{int64(2), int64(3), int64(4)},
 		},
 		{
 			name:     "date format without arguments",
@@ -419,22 +533,19 @@ func TestNonPreparedPlanCacheSelectorPreservesUnknownExpressionChildren(t *testi
 
 func TestNonPreparedPlanCacheParameterizerSelectsMultiTableDML(t *testing.T) {
 	testCases := []struct {
-		name     string
-		sql      string
-		paramSQL string
-		params   []any
+		name   string
+		sql    string
+		reason string
 	}{
 		{
-			name:     "update",
-			sql:      "update t1 join t2 on t1.a=t2.a and t2.b=2 set t1.b=1 where t1.a=3",
-			paramSQL: "UPDATE `t1` JOIN `t2` ON `t1`.`a`=`t2`.`a` AND `t2`.`b`=? SET `t1`.`b`=? WHERE `t1`.`a`=?",
-			params:   []any{int64(2), int64(1), int64(3)},
+			name:   "update",
+			sql:    "update t1 join t2 on t1.a=t2.a and t2.b=2 set t1.b=1 where t1.a=3",
+			reason: "multiple-table UPDATE is not supported",
 		},
 		{
-			name:     "delete",
-			sql:      "delete t1 from t1 join t2 on t1.a=t2.a and t2.b=2 where t1.a=3",
-			paramSQL: "DELETE `t1` FROM `t1` JOIN `t2` ON `t1`.`a`=`t2`.`a` AND `t2`.`b`=? WHERE `t1`.`a`=?",
-			params:   []any{int64(2), int64(3)},
+			name:   "delete",
+			sql:    "delete t1 from t1 join t2 on t1.a=t2.a and t2.b=2 where t1.a=3",
+			reason: "multiple-table DELETE is not supported",
 		},
 	}
 
@@ -445,12 +556,10 @@ func TestNonPreparedPlanCacheParameterizerSelectsMultiTableDML(t *testing.T) {
 			originalSQL := restorePlanCacheParamTestStmt(t, stmt)
 			result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(mock.NewContext().GetPlanCtx(), stmt)
 			require.NoError(t, err)
-			require.True(t, supported, reason)
-			require.Equal(t, testCase.paramSQL, result.ParamSQL)
-			require.Len(t, result.ParamValues, len(testCase.params))
-			for i, value := range result.ParamValues {
-				require.Equal(t, testCase.params[i], value.GetValue())
-			}
+			require.False(t, supported)
+			require.Equal(t, testCase.reason, reason)
+			require.Empty(t, result.ParamSQL)
+			require.Empty(t, result.ParamValues)
 			require.Equal(t, originalSQL, restorePlanCacheParamTestStmt(t, stmt))
 		})
 	}

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -875,52 +875,6 @@ func TestNonPreparedPlanCacheUnifiedOriginalParamMarkerBypass(t *testing.T) {
 	require.False(t, postParameterizationCalled)
 }
 
-func TestNonPreparedPlanCacheUnifiedLegacyCarrierIsolationE2E(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table unified_carrier_isolation(a int, key(a))")
-	tk.MustExec("insert into unified_carrier_isolation values (1), (2), (3)")
-	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
-	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
-
-	query := "select a from unified_carrier_isolation where a > 0 order by a"
-	lookup := func(sql string) (unifiedPlanCacheQueryObservation, []bool) {
-		lookups := make([]bool, 0, 1)
-		ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
-			lookups = append(lookups, found)
-		})
-		return observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql), lookups
-	}
-
-	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
-	before := promtestutils.ToFloat64(unsupported)
-	legacyMiss, legacyMissLookup := lookup(query)
-	require.Equal(t, []bool{false}, legacyMissLookup)
-	require.False(t, legacyMiss.cacheHit)
-	legacyHit, legacyHitLookup := lookup(query)
-	require.Equal(t, []bool{true}, legacyHitLookup)
-	require.True(t, legacyHit.cacheHit)
-	require.Equal(t, legacyMiss.rows, legacyHit.rows)
-	require.Empty(t, legacyHit.warnings)
-
-	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
-	unifiedMiss, unifiedMissLookup := lookup(query)
-	require.Equal(t, []bool{false}, unifiedMissLookup, "ON must not reuse the legacy carrier")
-	require.Equal(t, legacyMiss.rows, unifiedMiss.rows)
-	unifiedHit, unifiedHitLookup := lookup(query)
-	require.Equal(t, []bool{true}, unifiedHitLookup)
-	require.True(t, unifiedHit.cacheHit)
-	require.Equal(t, legacyMiss.rows, unifiedHit.rows)
-
-	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
-	legacyAgain, legacyAgainLookup := lookup(query)
-	require.Equal(t, []bool{true}, legacyAgainLookup, "OFF must recover the legacy carrier")
-	require.True(t, legacyAgain.cacheHit)
-	require.Equal(t, legacyMiss.rows, legacyAgain.rows)
-	require.Equal(t, before, promtestutils.ToFloat64(unsupported), "valid carrier transitions must not bypass")
-}
-
 func TestNonPreparedPlanCacheUnifiedParamSQLParseFailureBypass(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -1826,55 +1780,6 @@ func TestNonPreparedPlanCacheUnifiedLegacyBehaviorMatrix(t *testing.T) {
 			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: "+testCase.reason)
 		})
 	}
-}
-
-func TestNonPreparedPlanCacheUnifiedCharacterSetClientCarrierKey(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	setupTK := testkit.NewTestKit(t, store)
-	setupTK.MustExec("use test")
-	setupTK.MustExec("create table charset_t(a int, key(a))")
-	setupTK.MustExec("insert into charset_t values (1), (2)")
-	queryA := "select 'preserved' as literal_value, a from charset_t where a = 1"
-	queryB := "select 'preserved' as literal_value, a from charset_t where a = 2"
-
-	baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
-	baselineTK.MustExec("set character_set_client=utf8mb4")
-	utf8BaselineA := observeUnifiedPlanCacheQuery(t, baselineTK, queryA)
-	utf8BaselineB := observeUnifiedPlanCacheQuery(t, baselineTK, queryB)
-	baselineTK.MustExec("set character_set_client=latin1")
-	latin1BaselineA := observeUnifiedPlanCacheQuery(t, baselineTK, queryA)
-	latin1BaselineB := observeUnifiedPlanCacheQuery(t, baselineTK, queryB)
-
-	tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
-	tk.MustExec("set character_set_client=utf8mb4")
-	utf8Miss, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, queryA)
-	require.Contains(t, paramSQL, "'preserved'")
-
-	require.False(t, utf8Miss.cacheHit)
-	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineA, utf8Miss, "utf8mb4 cache miss")
-	utf8Carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
-	require.NotNil(t, utf8Carrier)
-
-	utf8Hit := observeUnifiedPlanCacheQuery(t, tk, queryB)
-	require.True(t, utf8Hit.cacheHit)
-	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineB, utf8Hit, "utf8mb4 cache hit")
-
-	tk.MustExec("set character_set_client=latin1")
-	require.Nil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
-	latin1First := observeUnifiedPlanCacheQuery(t, tk, queryB)
-	requireUnifiedPlanCacheQueryEqual(t, latin1BaselineB, latin1First, "latin1 first execution")
-	latin1Carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
-	require.NotNil(t, latin1Carrier)
-	require.NotSame(t, utf8Carrier, latin1Carrier)
-	latin1Hit := observeUnifiedPlanCacheQuery(t, tk, queryA)
-	require.True(t, latin1Hit.cacheHit)
-	requireUnifiedPlanCacheQueryEqual(t, latin1BaselineA, latin1Hit, "latin1 cache hit")
-
-	tk.MustExec("set character_set_client=utf8mb4")
-	require.Same(t, utf8Carrier, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
-	restored := observeUnifiedPlanCacheQuery(t, tk, queryB)
-	require.True(t, restored.cacheHit)
-	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineB, restored, "restored utf8mb4 cache hit")
 }
 
 func TestNonPreparedPlanCacheUnifiedViewSystemTemporaryTables(t *testing.T) {

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -31,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	core_metrics "github.com/pingcap/tidb/pkg/planner/core/metrics"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
 	"github.com/pingcap/tidb/pkg/session"
@@ -40,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
+	promtestutils "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -326,6 +329,1836 @@ func TestNonPreparedPlanCacheBasically(t *testing.T) {
 		tk.MustQuery(query).Sort().Check(resultNormal.Rows())                  // equal to the result without plan-cache
 		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // this plan is from plan-cache
 	}
+}
+
+type unifiedPlanCacheFieldMetadata struct {
+	columnName   string
+	columnAsName string
+	tableAsName  string
+	dbName       string
+	fieldType    byte
+	flen         int
+	decimal      int
+	charset      string
+	collation    string
+	flag         uint
+}
+
+type unifiedPlanCacheQueryObservation struct {
+	rows         [][]string
+	fields       []unifiedPlanCacheFieldMetadata
+	warnings     [][]any
+	affectedRows uint64
+	cacheHit     bool
+}
+
+func observeUnifiedPlanCacheQuery(t *testing.T, tk *testkit.TestKit, sql string) unifiedPlanCacheQueryObservation {
+	return observeUnifiedPlanCacheQueryWithContext(context.Background(), t, tk, sql)
+}
+
+func observeUnifiedPlanCacheQueryWithContext(
+	ctx context.Context,
+	t *testing.T,
+	tk *testkit.TestKit,
+	sql string,
+) unifiedPlanCacheQueryObservation {
+	rs, err := tk.ExecWithContext(ctx, sql)
+	require.NoError(t, err, sql)
+	require.NotNil(t, rs, sql)
+
+	fields := make([]unifiedPlanCacheFieldMetadata, 0, len(rs.Fields()))
+	for _, field := range rs.Fields() {
+		require.NotNil(t, field.Column, sql)
+		fieldType := &field.Column.FieldType
+		fields = append(fields, unifiedPlanCacheFieldMetadata{
+			columnName:   field.Column.Name.O,
+			columnAsName: field.ColumnAsName.O,
+			tableAsName:  field.TableAsName.O,
+			dbName:       field.DBName.O,
+			fieldType:    fieldType.GetType(),
+			flen:         fieldType.GetFlen(),
+			decimal:      fieldType.GetDecimal(),
+			charset:      fieldType.GetCharset(),
+			collation:    fieldType.GetCollate(),
+			flag:         fieldType.GetFlag(),
+		})
+	}
+
+	rows, err := session.ResultSetToStringSlice(context.Background(), tk.Session(), rs)
+	require.NoError(t, err, sql)
+	observation := unifiedPlanCacheQueryObservation{
+		rows:         rows,
+		fields:       fields,
+		affectedRows: tk.Session().AffectedRows(),
+		cacheHit:     tk.Session().GetSessionVars().FoundInPlanCache,
+	}
+	observation.warnings = tk.MustQuery("show warnings").Rows()
+	return observation
+}
+
+func requireUnifiedPlanCacheQueryEqual(t *testing.T, expected, actual unifiedPlanCacheQueryObservation, message string) {
+	require.Equal(t, expected.rows, actual.rows, message+": rows")
+	require.Equal(t, expected.fields, actual.fields, message+": fields")
+	require.Equal(t, expected.warnings, actual.warnings, message+": warnings")
+	require.Equal(t, expected.affectedRows, actual.affectedRows, message+": affected rows")
+}
+
+func observeUnifiedPlanCacheQueryAndParamSQL(
+	t *testing.T,
+	tk *testkit.TestKit,
+	sql string,
+) (unifiedPlanCacheQueryObservation, string) {
+	var paramSQL string
+	captureParamSQL := func(stmt ast.StmtNode) {
+		result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(tk.Session().GetPlanCtx(), stmt)
+		require.NoError(t, err)
+		require.True(t, supported, reason)
+		paramSQL = result.ParamSQL
+	}
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestIssue43667{}, captureParamSQL)
+	observation := observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql)
+	require.NotEmpty(t, paramSQL)
+	return observation, paramSQL
+}
+
+func newUnifiedPlanCacheMatrixTestKit(t *testing.T, store kv.Storage, mode string) *testkit.TestKit {
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_plan_cache_for_subquery=on")
+	tk.MustExec("set tidb_enable_plan_cache_for_param_limit=on")
+	switch mode {
+	case "cache-off":
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+		tk.MustExec("set tidb_enable_prepared_plan_cache=off")
+	case "prepared":
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+		tk.MustExec("set tidb_enable_prepared_plan_cache=on")
+	case "non-prepared":
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	default:
+		require.FailNow(t, "unknown plan cache matrix mode", mode)
+	}
+	return tk
+}
+
+func setUnifiedPlanCachePreparedArgs(tk *testkit.TestKit, args []string) string {
+	assignments := make([]string, 0, len(args))
+	using := make([]string, 0, len(args))
+	for i, value := range args {
+		name := fmt.Sprintf("@unified_matrix_arg_%d", i)
+		assignments = append(assignments, name+"="+value)
+		using = append(using, name)
+	}
+	tk.MustExec("set " + strings.Join(assignments, ", "))
+	return strings.Join(using, ", ")
+}
+
+type unifiedPlanCacheMatrixCase struct {
+	name        string
+	preparedSQL string
+	sql         [2]string
+	args        [2][]string
+}
+
+func runUnifiedPlanCacheQueryMatrix(t *testing.T, store kv.Storage, testCases []unifiedPlanCacheMatrixCase) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baseline := [2]unifiedPlanCacheQueryObservation{
+				observeUnifiedPlanCacheQuery(t, baselineTK, testCase.sql[0]),
+				observeUnifiedPlanCacheQuery(t, baselineTK, testCase.sql[1]),
+			}
+			for i := range baseline {
+				require.False(t, baseline[i].cacheHit)
+				require.Empty(t, baseline[i].warnings)
+			}
+
+			orders := []struct {
+				name    string
+				indexes [2]int
+			}{
+				{name: "a_to_b", indexes: [2]int{0, 1}},
+				{name: "b_to_a", indexes: [2]int{1, 0}},
+			}
+			for _, order := range orders {
+				t.Run(order.name, func(t *testing.T) {
+					preparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "prepared")
+					preparedTK.MustExec(fmt.Sprintf("prepare unified_matrix_stmt from %q", testCase.preparedSQL))
+					for execution, index := range order.indexes {
+						using := setUnifiedPlanCachePreparedArgs(preparedTK, testCase.args[index])
+						actual := observeUnifiedPlanCacheQuery(t, preparedTK, "execute unified_matrix_stmt using "+using)
+						require.Equal(t, execution == 1, actual.cacheHit, "prepared execution %d", execution)
+						requireUnifiedPlanCacheQueryEqual(t, baseline[index], actual, fmt.Sprintf("prepared execution %d", execution))
+					}
+
+					nonPreparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+					for execution, index := range order.indexes {
+						actual := observeUnifiedPlanCacheQuery(t, nonPreparedTK, testCase.sql[index])
+						require.Equal(t, execution == 1, actual.cacheHit, "non-prepared execution %d", execution)
+						requireUnifiedPlanCacheQueryEqual(t, baseline[index], actual, fmt.Sprintf("non-prepared execution %d", execution))
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedBehaviorMatrix(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	tk.MustExec("create table t2(a int, b int, key(a))")
+	tk.MustExec("create table t3(a int, b int, key(a))")
+	tk.MustExec(`create table t_special(
+		id int, j json, e enum('a', 'b'), s set('x', 'y'), bit_col bit(4), key(id))`)
+	tk.MustExec("insert into t values (1, 1), (1, 2), (2, 3), (3, 1)")
+	tk.MustExec("insert into t2 select * from t")
+	tk.MustExec("insert into t3 select * from t")
+	tk.MustExec(`insert into t_special values
+		(1, '{"k": 1}', 'a', 'x', b'0001'),
+		(2, '{"k": 2}', 'b', 'x,y', b'0010'),
+		(3, '{"k": 3}', 'a', 'y', b'0011')`)
+
+	runUnifiedPlanCacheQueryMatrix(t, store, []unifiedPlanCacheMatrixCase{
+		{
+			name:        "having",
+			preparedSQL: "select a, sum(b) as total from t where a > ? group by a having sum(b) > ? order by a",
+			sql: [2]string{
+				"select a, sum(b) as total from t where a > 0 group by a having sum(b) > 2 order by a",
+				"select a, sum(b) as total from t where a > 1 group by a having sum(b) > 1 order by a",
+			},
+			args: [2][]string{{"0", "2"}, {"1", "1"}},
+		},
+		{
+			name:        "window",
+			preparedSQL: "select a, b, sum(b) over (order by a, b rows 1 preceding) as running_sum from t where b > ? order by a, b",
+			sql: [2]string{
+				"select a, b, sum(b) over (order by a, b rows 1 preceding) as running_sum from t where b > 1 order by a, b",
+				"select a, b, sum(b) over (order by a, b rows 1 preceding) as running_sum from t where b > 2 order by a, b",
+			},
+			args: [2][]string{{"1"}, {"2"}},
+		},
+		{
+			name:        "cte",
+			preparedSQL: "with cte as (select a from t where b > ?) select a from cte where a > ? order by a",
+			sql: [2]string{
+				"with cte as (select a from t where b > 1) select a from cte where a > 0 order by a",
+				"with cte as (select a from t where b > 2) select a from cte where a > 1 order by a",
+			},
+			args: [2][]string{{"1", "0"}, {"2", "1"}},
+		},
+		{
+			name:        "set_operation",
+			preparedSQL: "select a from t where b > ? union select a from t where b < ? order by 1",
+			sql: [2]string{
+				"select a from t where b > 1 union select a from t where b < 3 order by 1",
+				"select a from t where b > 2 union select a from t where b < 2 order by 1",
+			},
+			args: [2][]string{{"1", "3"}, {"2", "2"}},
+		},
+		{
+			name:        "intersect",
+			preparedSQL: "select a from t where b > ? intersect select a from t where b < ? order by 1",
+			sql: [2]string{
+				"select a from t where b > 1 intersect select a from t where b < 3 order by 1",
+				"select a from t where b > 2 intersect select a from t where b < 2 order by 1",
+			},
+			args: [2][]string{{"1", "3"}, {"2", "2"}},
+		},
+		{
+			name:        "except",
+			preparedSQL: "select a from t where b > ? except select a from t where b < ? order by 1",
+			sql: [2]string{
+				"select a from t where b > 0 except select a from t where b < 2 order by 1",
+				"select a from t where b > 2 except select a from t where b < 4 order by 1",
+			},
+			args: [2][]string{{"0", "2"}, {"2", "4"}},
+		},
+		{
+			name:        "three_table_join",
+			preparedSQL: "select t.a, t.b, t2.b, t3.b from t join t2 on t.a=t2.a join t3 on t2.a=t3.a where t.b > ? order by t.a, t.b, t2.b, t3.b",
+			sql: [2]string{
+				"select t.a, t.b, t2.b, t3.b from t join t2 on t.a=t2.a join t3 on t2.a=t3.a where t.b > 1 order by t.a, t.b, t2.b, t3.b",
+				"select t.a, t.b, t2.b, t3.b from t join t2 on t.a=t2.a join t3 on t2.a=t3.a where t.b > 2 order by t.a, t.b, t2.b, t3.b",
+			},
+			args: [2][]string{{"1"}, {"2"}},
+		},
+		{
+			name:        "subquery",
+			preparedSQL: "select a, b from t where b > ? and a in (select a from t2 where b > ?) order by a, b",
+			sql: [2]string{
+				"select a, b from t where b > 0 and a in (select a from t2 where b > 1) order by a, b",
+				"select a, b from t where b > 1 and a in (select a from t2 where b > 2) order by a, b",
+			},
+			args: [2][]string{{"0", "1"}, {"1", "2"}},
+		},
+		{
+			name:        "limit",
+			preparedSQL: "select a, b from t where a > ? order by a, b limit 2",
+			sql: [2]string{
+				"select a, b from t where a > 0 order by a, b limit 2",
+				"select a, b from t where a > 1 order by a, b limit 2",
+			},
+			args: [2][]string{{"0"}, {"1"}},
+		},
+		{
+			name:        "preserved_null_bit_hex_literals",
+			preparedSQL: "select a, null as null_literal, b'1' as bit_literal, x'0a' as hex_literal from t where a > ? order by a",
+			sql: [2]string{
+				"select a, null as null_literal, b'1' as bit_literal, x'0a' as hex_literal from t where a > 0 order by a",
+				"select a, null as null_literal, b'1' as bit_literal, x'0a' as hex_literal from t where a > 1 order by a",
+			},
+			args: [2][]string{{"0"}, {"1"}},
+		},
+		{
+			name: "json_enum_set_bit_columns",
+			preparedSQL: "select id, j, e, s, bit_col from t_special " +
+				"where id > ? and j = ? and e = ? and s = ? and bit_col >= ? order by id",
+			sql: [2]string{
+				"select id, j, e, s, bit_col from t_special " +
+					"where id > 0 and j = '{\"k\": 1}' and e = 'a' and s = 'x' and bit_col >= 1 order by id",
+				"select id, j, e, s, bit_col from t_special " +
+					"where id > 1 and j = '{\"k\": 3}' and e = 'a' and s = 'y' and bit_col >= 3 order by id",
+			},
+			args: [2][]string{
+				{"0", "'{\"k\": 1}'", "'a'", "'x'", "1"},
+				{"1", "'{\"k\": 3}'", "'a'", "'y'", "3"},
+			},
+		},
+	})
+}
+
+func TestNonPreparedPlanCacheUnifiedPreservedLiteralsInFilters(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table preserved_filter_literals(a int, key(a))")
+	setupTK.MustExec("insert into preserved_filter_literals values (1), (2), (3)")
+
+	cases := []struct {
+		name string
+		sql  string
+		rows [][]string
+	}{
+		{
+			name: "null",
+			sql:  "select a from preserved_filter_literals where a = null order by a",
+			rows: [][]string{},
+		},
+		{
+			name: "bit",
+			sql:  "select a from preserved_filter_literals where a > b'0' order by a",
+			rows: [][]string{{"1"}, {"2"}, {"3"}},
+		},
+		{
+			name: "hex",
+			sql:  "select a from preserved_filter_literals where a > x'00' order by a",
+			rows: [][]string{{"1"}, {"2"}, {"3"}},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baseline := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.sql)
+			require.False(t, baseline.cacheHit)
+			require.Equal(t, testCase.rows, baseline.rows)
+
+			nonPreparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			miss := observeUnifiedPlanCacheQuery(t, nonPreparedTK, testCase.sql)
+			require.False(t, miss.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baseline, miss, "non-prepared miss")
+
+			hit := observeUnifiedPlanCacheQuery(t, nonPreparedTK, testCase.sql)
+			require.True(t, hit.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baseline, hit, "non-prepared hit")
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedPreservedLiteralStatementLRUIdentity(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table preserved_literal_lru_identity(a int, b int, key(a))")
+	setupTK.MustExec("insert into preserved_literal_lru_identity values (1, 30), (2, 10), (3, 20)")
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "order by positional literal",
+			a:    "select a, b from preserved_literal_lru_identity order by 1",
+			b:    "select a, b from preserved_literal_lru_identity order by 2",
+		},
+		{
+			name: "limit literal",
+			a:    "select a, b from preserved_literal_lru_identity order by a limit 1",
+			b:    "select a, b from preserved_literal_lru_identity order by a limit 2",
+		},
+		{
+			name: "null projection literal",
+			a:    "select null as preserved_literal, a from preserved_literal_lru_identity order by a",
+			b:    "select 0 as preserved_literal, a from preserved_literal_lru_identity order by a",
+		},
+		{
+			name: "bit range literal",
+			a:    "select a from preserved_literal_lru_identity where a > b'0' order by a",
+			b:    "select a from preserved_literal_lru_identity where a > b'1' order by a",
+		},
+		{
+			name: "hex range literal",
+			a:    "select a from preserved_literal_lru_identity where a > x'00' order by a",
+			b:    "select a from preserved_literal_lru_identity where a > x'02' order by a",
+		},
+		{
+			name: "binary token spelling",
+			a:    "select a from preserved_literal_lru_identity where a > b'0001' and a < X'04' order by a",
+			b:    "select a from preserved_literal_lru_identity where a > b'1' and a < 0x04 order by a",
+		},
+		{
+			name: "window frame literal",
+			a:    "select a, sum(b) over (order by a rows 1 preceding) as running_sum from preserved_literal_lru_identity where a > 0 order by a",
+			b:    "select a, sum(b) over (order by a rows 2 preceding) as running_sum from preserved_literal_lru_identity where a > 0 order by a",
+		},
+		{
+			name: "named window frame literal",
+			a:    "select a, sum(b) over named_window as running_sum from preserved_literal_lru_identity where a > 0 window named_window as (order by a rows 1 preceding) order by a",
+			b:    "select a, sum(b) over named_window as running_sum from preserved_literal_lru_identity where a > 0 window named_window as (order by a rows 2 preceding) order by a",
+		},
+		{
+			name: "date format literal",
+			a:    "select a, date_format('2020-01-02', '%Y-%m-%d') as formatted from preserved_literal_lru_identity where a > 0 order by a",
+			b:    "select a, date_format('2020-01-02', '%d/%m/%Y') as formatted from preserved_literal_lru_identity where a > 0 order by a",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineA := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.a)
+			baselineB := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.b)
+			require.False(t, baselineA.cacheHit)
+			require.False(t, baselineB.cacheHit)
+
+			executeWithLookup := func(tk *testkit.TestKit, sql string) (unifiedPlanCacheQueryObservation, bool) {
+				lookups := make([]bool, 0, 1)
+				ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(hit bool) {
+					lookups = append(lookups, hit)
+				})
+				observation := observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql)
+				require.Len(t, lookups, 1, "statement carrier lookup count")
+				return observation, lookups[0]
+			}
+
+			orders := []struct {
+				name           string
+				first          string
+				second         string
+				firstBaseline  unifiedPlanCacheQueryObservation
+				secondBaseline unifiedPlanCacheQueryObservation
+			}{
+				{name: "a_to_b", first: testCase.a, second: testCase.b, firstBaseline: baselineA, secondBaseline: baselineB},
+				{name: "b_to_a", first: testCase.b, second: testCase.a, firstBaseline: baselineB, secondBaseline: baselineA},
+			}
+			for _, order := range orders {
+				t.Run(order.name, func(t *testing.T) {
+					tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+
+					first, firstLookup := executeWithLookup(tk, order.first)
+					require.False(t, firstLookup, "first statement carrier lookup must miss")
+					require.False(t, first.cacheHit)
+					requireUnifiedPlanCacheQueryEqual(t, order.firstBaseline, first, "first execution")
+
+					second, secondLookup := executeWithLookup(tk, order.second)
+					require.False(t, secondLookup, "changed preserve literal must use a different statement carrier")
+					require.False(t, second.cacheHit)
+					requireUnifiedPlanCacheQueryEqual(t, order.secondBaseline, second, "changed literal execution")
+
+					firstAgain, firstAgainLookup := executeWithLookup(tk, order.first)
+					require.True(t, firstAgainLookup, "original statement carrier must be reusable")
+					require.True(t, firstAgain.cacheHit)
+					requireUnifiedPlanCacheQueryEqual(t, order.firstBaseline, firstAgain, "original literal execution")
+				})
+			}
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedParamSQLRestoreFallback(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table param_restore_fallback(a int)")
+	tk.MustExec("insert into param_restore_fallback values (1), (2)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	paramSQLRestoreFailed := false
+	injectFailure := func(stmt ast.StmtNode) {
+		paramSQLRestoreFailed = true
+		selectStmt := stmt.(*ast.SelectStmt)
+		badLiteral := ast.NewValueExpr(struct{}{}, "", "")
+		badLiteral.SetText(nil, "")
+		selectStmt.Fields.Fields[0].Expr = badLiteral
+	}
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedParam{}, injectFailure)
+
+	tk.MustQueryWithContext(ctx, "select 1 from param_restore_fallback where a = 1").Check(testkit.Rows("1"))
+	require.True(t, paramSQLRestoreFailed)
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+}
+
+func TestNonPreparedPlanCacheUnifiedASTRestoreFailure(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table ast_restore_failure(a int)")
+	tk.MustExec("insert into ast_restore_failure values (1), (2)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	const failpointName = "github.com/pingcap/tidb/pkg/planner/core/mockNonPreparedPlanCacheASTRestoreError"
+	require.NoError(t, failpoint.Enable(failpointName, `return(true)`))
+	defer func() { _ = failpoint.Disable(failpointName) }()
+
+	var parameterizedStmt ast.StmtNode
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedParam{}, func(stmt ast.StmtNode) {
+		parameterizedStmt = stmt
+	})
+	_, err := tk.ExecWithContext(ctx, "select a from ast_restore_failure where a = 1")
+	require.ErrorContains(t, err, "failed to restore ast.Node")
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.NotNil(t, parameterizedStmt)
+
+	// The restore error must not leave generated markers attached to the AST.
+	require.NoError(t, failpoint.Disable(failpointName))
+	result, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(
+		tk.Session().GetPlanCtx(), parameterizedStmt,
+	)
+	require.NoError(t, err)
+	require.True(t, supported, reason)
+	require.Equal(t, "SELECT a FROM `test`.`ast_restore_failure` WHERE `a`=?", result.ParamSQL)
+	require.Equal(t, int64(1), result.ParamValues[0].GetValue())
+}
+
+func TestNonPreparedPlanCacheUnifiedOriginalParamMarkerBypass(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table original_param_marker(a int)")
+	tk.MustExec("insert into original_param_marker values (1)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	postParameterizationCalled := false
+	injectFailure := func(stmt ast.StmtNode) {
+		where := stmt.(*ast.SelectStmt).Where.(*ast.BinaryOperationExpr)
+		where.R = ast.NewParamMarkerExpr(-1)
+	}
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedParam{}, injectFailure)
+	ctx = context.WithValue(ctx, plannercore.PlanCacheKeyTestIssue43667{}, func(ast.StmtNode) {
+		postParameterizationCalled = true
+	})
+
+	rs, err := tk.ExecWithContext(ctx, "select 1 from original_param_marker where a = 1")
+	require.NoError(t, err)
+	if rs != nil {
+		require.NoError(t, rs.Close())
+	}
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.False(t, postParameterizationCalled)
+}
+
+func TestNonPreparedPlanCacheUnifiedLegacyCarrierIsolationE2E(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table unified_carrier_isolation(a int, key(a))")
+	tk.MustExec("insert into unified_carrier_isolation values (1), (2), (3)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+
+	query := "select a from unified_carrier_isolation where a > 0 order by a"
+	lookup := func(sql string) (unifiedPlanCacheQueryObservation, []bool) {
+		lookups := make([]bool, 0, 1)
+		ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+			lookups = append(lookups, found)
+		})
+		return observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql), lookups
+	}
+
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	before := promtestutils.ToFloat64(unsupported)
+	legacyMiss, legacyMissLookup := lookup(query)
+	require.Equal(t, []bool{false}, legacyMissLookup)
+	require.False(t, legacyMiss.cacheHit)
+	legacyHit, legacyHitLookup := lookup(query)
+	require.Equal(t, []bool{true}, legacyHitLookup)
+	require.True(t, legacyHit.cacheHit)
+	require.Equal(t, legacyMiss.rows, legacyHit.rows)
+	require.Empty(t, legacyHit.warnings)
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	unifiedMiss, unifiedMissLookup := lookup(query)
+	require.Equal(t, []bool{false}, unifiedMissLookup, "ON must not reuse the legacy carrier")
+	require.Equal(t, legacyMiss.rows, unifiedMiss.rows)
+	unifiedHit, unifiedHitLookup := lookup(query)
+	require.Equal(t, []bool{true}, unifiedHitLookup)
+	require.True(t, unifiedHit.cacheHit)
+	require.Equal(t, legacyMiss.rows, unifiedHit.rows)
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+	legacyAgain, legacyAgainLookup := lookup(query)
+	require.Equal(t, []bool{true}, legacyAgainLookup, "OFF must recover the legacy carrier")
+	require.True(t, legacyAgain.cacheHit)
+	require.Equal(t, legacyMiss.rows, legacyAgain.rows)
+	require.Equal(t, before, promtestutils.ToFloat64(unsupported), "valid carrier transitions must not bypass")
+}
+
+func TestNonPreparedPlanCacheUnifiedParamSQLParseFailureBypass(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table param_sql_parse_failure(a int)")
+	tk.MustExec("insert into param_sql_parse_failure values (1), (2)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	corruptParamSQL := func(paramSQL *string) {
+		*paramSQL = "select !!!"
+	}
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedParamSQL{}, corruptParamSQL)
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	before := promtestutils.ToFloat64(unsupported)
+
+	tk.MustQueryWithContext(ctx, "select a from param_sql_parse_failure where a = 1").Check(testkit.Rows("1"))
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
+
+	beforeExplain := promtestutils.ToFloat64(unsupported)
+	tk.MustExecWithContext(ctx, "explain format='plan_cache' select a from param_sql_parse_failure where a = 1")
+	warnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: failed to parse parameterized SQL")
+	require.Equal(t, beforeExplain+1, promtestutils.ToFloat64(unsupported))
+}
+
+type unifiedPlanCacheDMLObservation struct {
+	warnings     [][]any
+	affectedRows uint64
+	cacheHit     bool
+}
+
+func observeUnifiedPlanCacheDML(t *testing.T, tk *testkit.TestKit, sql string) unifiedPlanCacheDMLObservation {
+	rs, err := tk.Exec(sql)
+	require.NoError(t, err, sql)
+	if rs != nil {
+		require.NoError(t, rs.Close(), sql)
+	}
+	affectedRows := tk.Session().AffectedRows()
+	cacheHit := tk.Session().GetSessionVars().FoundInPlanCache
+	return unifiedPlanCacheDMLObservation{
+		warnings:     tk.MustQuery("show warnings").Rows(),
+		affectedRows: affectedRows,
+		cacheHit:     cacheHit,
+	}
+}
+
+func resetUnifiedPlanCacheDMLTable(t *testing.T, tk *testkit.TestKit, rows string) {
+	tk.MustExec("drop table if exists unified_dml_matrix")
+	tk.MustExec("create table unified_dml_matrix(a int, b int, key(a))")
+	tk.MustExec("insert into unified_dml_matrix values " + rows)
+}
+
+type unifiedPlanCacheDMLCase struct {
+	name        string
+	preparedSQL string
+	sql         [2]string
+	args        [2][]string
+	initialRows string
+	setupTables func(*testkit.TestKit)
+	finalQuery  string
+	finalRows   [][]any
+}
+
+func (testCase unifiedPlanCacheDMLCase) resetTables(t *testing.T, tk *testkit.TestKit) {
+	if testCase.setupTables != nil {
+		testCase.setupTables(tk)
+		return
+	}
+	resetUnifiedPlanCacheDMLTable(t, tk, testCase.initialRows)
+}
+
+func (testCase unifiedPlanCacheDMLCase) checkFinalRows(tk *testkit.TestKit) {
+	query := testCase.finalQuery
+	if query == "" {
+		query = "select a, b from unified_dml_matrix order by a"
+	}
+	tk.MustQuery(query).Check(testCase.finalRows)
+}
+
+func runUnifiedPlanCacheDMLMatrix(t *testing.T, store kv.Storage, testCases []unifiedPlanCacheDMLCase) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineTK.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+			testCase.resetTables(t, baselineTK)
+			baseline := [2]unifiedPlanCacheDMLObservation{
+				observeUnifiedPlanCacheDML(t, baselineTK, testCase.sql[0]),
+				observeUnifiedPlanCacheDML(t, baselineTK, testCase.sql[1]),
+			}
+			for i := range baseline {
+				require.False(t, baseline[i].cacheHit)
+				require.Empty(t, baseline[i].warnings)
+			}
+			testCase.checkFinalRows(baselineTK)
+
+			orders := []struct {
+				name    string
+				indexes [2]int
+			}{
+				{name: "a_to_b", indexes: [2]int{0, 1}},
+				{name: "b_to_a", indexes: [2]int{1, 0}},
+			}
+			for _, order := range orders {
+				t.Run(order.name, func(t *testing.T) {
+					preparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "prepared")
+					preparedTK.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+					testCase.resetTables(t, preparedTK)
+					preparedTK.MustExec(fmt.Sprintf("prepare unified_dml_matrix_stmt from %q", testCase.preparedSQL))
+					for execution, index := range order.indexes {
+						using := setUnifiedPlanCachePreparedArgs(preparedTK, testCase.args[index])
+						actual := observeUnifiedPlanCacheDML(t, preparedTK, "execute unified_dml_matrix_stmt using "+using)
+						require.Equal(t, execution == 1, actual.cacheHit, "prepared execution %d", execution)
+						require.Equal(t, baseline[index].affectedRows, actual.affectedRows, "prepared affected rows %d", execution)
+						require.Equal(t, baseline[index].warnings, actual.warnings, "prepared warnings %d", execution)
+					}
+					testCase.checkFinalRows(preparedTK)
+
+					nonPreparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+					nonPreparedTK.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+					nonPreparedTK.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+					testCase.resetTables(t, nonPreparedTK)
+					nonPreparedTK.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+					nonPreparedTK.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+					for execution, index := range order.indexes {
+						actual := observeUnifiedPlanCacheDML(t, nonPreparedTK, testCase.sql[index])
+						require.Equal(t, execution == 1, actual.cacheHit, "non-prepared execution %d", execution)
+						require.Equal(t, baseline[index].affectedRows, actual.affectedRows, "non-prepared affected rows %d", execution)
+						require.Equal(t, baseline[index].warnings, actual.warnings, "non-prepared warnings %d", execution)
+					}
+					testCase.checkFinalRows(nonPreparedTK)
+				})
+			}
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedDMLBehaviorMatrix(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	setupInsertSelect := func(tk *testkit.TestKit) {
+		tk.MustExec("drop table if exists unified_insert_select_source")
+		tk.MustExec("drop table if exists unified_insert_select_target")
+		tk.MustExec("create table unified_insert_select_source(a int, b int)")
+		tk.MustExec("create table unified_insert_select_target(a int, b int, primary key (a, b))")
+		tk.MustExec("insert into unified_insert_select_source values (1, 1), (2, 2), (3, 3)")
+	}
+	setupDuplicate := func(tk *testkit.TestKit) {
+		tk.MustExec("drop table if exists unified_duplicate_target")
+		tk.MustExec("create table unified_duplicate_target(a int primary key, b int)")
+		tk.MustExec("insert into unified_duplicate_target values (1, 0)")
+	}
+
+	runUnifiedPlanCacheDMLMatrix(t, store, []unifiedPlanCacheDMLCase{
+		{
+			name:        "insert",
+			preparedSQL: "insert into unified_dml_matrix values (?, ?)",
+			sql: [2]string{
+				"insert into unified_dml_matrix values (1, 10)",
+				"insert into unified_dml_matrix values (2, 20)",
+			},
+			args:        [2][]string{{"1", "10"}, {"2", "20"}},
+			initialRows: "(9, 90)",
+			finalRows:   testkit.Rows("1 10", "2 20", "9 90"),
+		},
+		{
+			name:        "update",
+			preparedSQL: "update unified_dml_matrix set b = ? where a = ?",
+			sql: [2]string{
+				"update unified_dml_matrix set b = 11 where a = 1",
+				"update unified_dml_matrix set b = 22 where a = 2",
+			},
+			args:        [2][]string{{"11", "1"}, {"22", "2"}},
+			initialRows: "(1, 10), (2, 20)",
+			finalRows:   testkit.Rows("1 11", "2 22"),
+		},
+		{
+			name:        "delete",
+			preparedSQL: "delete from unified_dml_matrix where a = ?",
+			sql: [2]string{
+				"delete from unified_dml_matrix where a = 1",
+				"delete from unified_dml_matrix where a = 2",
+			},
+			args:        [2][]string{{"1"}, {"2"}},
+			initialRows: "(1, 10), (2, 20)",
+			finalRows:   testkit.Rows(),
+		},
+		{
+			name:        "insert select",
+			preparedSQL: "insert into unified_insert_select_target(a, b) select a, b from unified_insert_select_source where a > ? and b < ?",
+			sql: [2]string{
+				"insert into unified_insert_select_target(a, b) select a, b from unified_insert_select_source where a > 1 and b < 3",
+				"insert into unified_insert_select_target(a, b) select a, b from unified_insert_select_source where a > 2 and b < 4",
+			},
+			args:        [2][]string{{"1", "3"}, {"2", "4"}},
+			setupTables: setupInsertSelect,
+			finalQuery:  "select a, b from unified_insert_select_target order by a, b",
+			finalRows:   testkit.Rows("2 2", "3 3"),
+		},
+		{
+			name:        "on duplicate key update",
+			preparedSQL: "insert into unified_duplicate_target(a, b) values (?, ?) on duplicate key update b = b + ?",
+			sql: [2]string{
+				"insert into unified_duplicate_target(a, b) values (1, 10) on duplicate key update b = b + 2",
+				"insert into unified_duplicate_target(a, b) values (2, 20) on duplicate key update b = b + 3",
+			},
+			args:        [2][]string{{"1", "10", "2"}, {"2", "20", "3"}},
+			setupTables: setupDuplicate,
+			finalQuery:  "select a, b from unified_duplicate_target order by a",
+			finalRows:   testkit.Rows("1 2", "2 20"),
+		},
+	})
+}
+
+func TestNonPreparedPlanCacheUnifiedMultiTableDMLGateE2E(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+
+	type dmlCase struct {
+		name       string
+		first      string
+		second     string
+		explain    string
+		reason     string
+		finalQuery string
+		finalRows  [][]any
+	}
+	cases := []dmlCase{
+		{
+			name:       "update",
+			first:      "update multi_gate_left l join multi_gate_right r on l.a=r.a set l.b=11 where l.a=1",
+			second:     "update multi_gate_left l join multi_gate_right r on l.a=r.a set l.b=12 where l.a=2",
+			explain:    "update multi_gate_left l join multi_gate_right r on l.a=r.a set l.b=11 where l.a=1",
+			reason:     "multiple-table UPDATE is not supported",
+			finalQuery: "select a, b from multi_gate_left order by a",
+			finalRows:  testkit.Rows("1 11", "2 12"),
+		},
+		{
+			name:       "delete",
+			first:      "delete l from multi_gate_left l join multi_gate_right r on l.a=r.a where l.a=1",
+			second:     "delete l from multi_gate_left l join multi_gate_right r on l.a=r.a where l.a=2",
+			explain:    "delete l from multi_gate_left l join multi_gate_right r on l.a=r.a where l.a=1",
+			reason:     "multiple-table DELETE is not supported",
+			finalQuery: "select a, b from multi_gate_left order by a",
+			finalRows:  testkit.Rows(),
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tk.MustExec("drop table if exists multi_gate_left")
+			tk.MustExec("drop table if exists multi_gate_right")
+			tk.MustExec("create table multi_gate_left(a int primary key, b int)")
+			tk.MustExec("create table multi_gate_right(a int primary key)")
+			tk.MustExec("insert into multi_gate_left values (1, 10), (2, 20)")
+			tk.MustExec("insert into multi_gate_right values (1), (2)")
+
+			execute := func(sql string) (uint64, bool, []bool, [][]any) {
+				lookups := make([]bool, 0, 1)
+				ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+					lookups = append(lookups, found)
+				})
+				rs, err := tk.ExecWithContext(ctx, sql)
+				require.NoError(t, err, sql)
+				if rs != nil {
+					require.NoError(t, rs.Close(), sql)
+				}
+				return tk.Session().AffectedRows(), tk.Session().GetSessionVars().FoundInPlanCache, lookups, tk.MustQuery("show warnings").Rows()
+			}
+
+			unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+			before := promtestutils.ToFloat64(unsupported)
+			firstAffected, firstHit, firstLookups, firstWarnings := execute(testCase.first)
+			secondAffected, secondHit, secondLookups, secondWarnings := execute(testCase.second)
+			require.Equal(t, uint64(1), firstAffected)
+			require.Equal(t, uint64(1), secondAffected)
+			require.False(t, firstHit)
+			require.False(t, secondHit)
+			require.Empty(t, firstLookups)
+			require.Empty(t, secondLookups)
+			require.Empty(t, firstWarnings)
+			require.Empty(t, secondWarnings)
+			require.Greater(t, promtestutils.ToFloat64(unsupported), before, "multi-table DML precheck must increment unsupported metric")
+			tk.MustQuery(testCase.finalQuery).Check(testCase.finalRows)
+
+			beforeExplain := promtestutils.ToFloat64(unsupported)
+			tk.MustExec("explain format='plan_cache' " + testCase.explain)
+			warnings := tk.MustQuery("show warnings").Rows()
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: "+testCase.reason)
+			require.Greater(t, promtestutils.ToFloat64(unsupported), beforeExplain, "Explain must count the multi-table DML bypass")
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheck(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	tk.MustExec("create table t2(a int, b int, key(a))")
+	tk.MustExec("create table t3(a int, b int, key(a))")
+	tk.MustExec("insert into t values (1, 1), (1, 2), (2, 3), (3, 1)")
+	tk.MustExec("insert into t2 select * from t")
+	tk.MustExec("insert into t3 select * from t")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustQuery("select @@tidb_enable_non_prepared_plan_cache_unified_cacheability_check").Check(testkit.Rows("0"))
+
+	legacyHaving := "select a, sum(b) from t where a > 0 group by a having sum(b) > 2 order by a"
+	tk.MustQuery(legacyHaving).Check(testkit.Rows("1 3", "2 3"))
+	tk.MustQuery(legacyHaving).Check(testkit.Rows("1 3", "2 3"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustQuery(legacyHaving).Check(testkit.Rows("1 3", "2 3"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select a, sum(b) from t where a > 0 group by a having sum(b) > 3 order by a").Check(testkit.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	testCases := []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{
+			name:   "window",
+			first:  "select a, sum(b) over (order by a rows 1 preceding) from t where b > 1",
+			second: "select a, sum(b) over (order by a rows 1 preceding) from t where b > 2",
+		},
+		{
+			name:   "cte",
+			first:  "with cte as (select a from t where b > 1) select a from cte where a > 0 order by a",
+			second: "with cte as (select a from t where b > 2) select a from cte where a > 0 order by a",
+		},
+		{
+			name:   "set operation",
+			first:  "select a from t where b > 1 union select a from t where b < 3 order by 1",
+			second: "select a from t where b > 2 union select a from t where b < 2 order by 1",
+		},
+		{
+			name:   "three table join",
+			first:  "select t.a from t join t2 on t.a=t2.a join t3 on t2.a=t3.a where t.b > 1",
+			second: "select t.a from t join t2 on t.a=t2.a join t3 on t2.a=t3.a where t.b > 2",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Logf("unified non-prepared plan cache case: %s", testCase.name)
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+		firstBaseline := tk.MustQuery(testCase.first).Sort()
+		secondBaseline := tk.MustQuery(testCase.second).Sort()
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+		tk.MustQuery(testCase.first).Sort().Check(firstBaseline.Rows())
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+		tk.MustQuery(testCase.second).Sort().Check(secondBaseline.Rows())
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	}
+
+	tk.MustExec("set tidb_enable_plan_cache_for_subquery=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+	subqueryFirstBaseline := tk.MustQuery("select a from t where b > 0 and a in (select a from t2 where b > 1)").Sort()
+	subquerySecondBaseline := tk.MustQuery("select a from t where b > 1 and a in (select a from t2 where b > 2)").Sort()
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustQuery("select a from t where b > 0 and a in (select a from t2 where b > 1)").Sort().Check(subqueryFirstBaseline.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select a from t where b > 1 and a in (select a from t2 where b > 2)").Sort().Check(subquerySecondBaseline.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec("set tidb_enable_plan_cache_for_subquery=off")
+	tk.MustQuery("select a from t where b > 2 and a in (select a from t2 where b > 3)")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("set tidb_enable_plan_cache_for_subquery=on")
+	tk.MustQuery("select a from t where b > 3 and a in (select a from t2 where b > 4)")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tk.MustExec("set tidb_enable_plan_cache_for_param_limit=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+	limitFirstBaseline := tk.MustQuery("select a from t where a > 0 order by a limit 2").Sort()
+	limitSecondBaseline := tk.MustQuery("select a from t where a > 1 order by a limit 2").Sort()
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustQuery("select a from t where a > 0 order by a limit 2").Sort().Check(limitFirstBaseline.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select a from t where a > 1 order by a limit 2").Sort().Check(limitSecondBaseline.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec("set tidb_enable_plan_cache_for_param_limit=off")
+	tk.MustQuery("select a from t where a > 2 order by a limit 2")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("set tidb_enable_plan_cache_for_param_limit=on")
+	tk.MustQuery("select a from t where a > 3 order by a limit 2")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+	tk.MustQuery(legacyHaving).Check(testkit.Rows("1 3", "2 3"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustQuery(legacyHaving).Check(testkit.Rows("1 3", "2 3"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+	tk.MustExec("insert into t values (4, 4)")
+	tk.MustExec("insert into t values (5, 5)")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+	tk.MustExec("insert into t values (6, 6)")
+	tk.MustExec("insert into t values (7, 7)")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec("update t set b=16 where a=6")
+	tk.MustExec("update t set b=17 where a=7")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustExec("delete from t where a=6")
+	tk.MustExec("delete from t where a=7")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustQuery("select count(*) from t where a in (6, 7)").Check(testkit.Rows("0"))
+	tk.MustQuery("select * from t order by a").Check(testkit.Rows("1 1", "1 2", "2 3", "3 1", "4 4", "5 5"))
+
+	tk.MustQuery("select _utf8mb4'a' from t where a=1").Check(testkit.Rows("a", "a"))
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustExec("explain format='plan_cache' select _utf8mb4'a' from t where a=1")
+	warnings := tk.MustQuery("show warnings").Rows()
+	require.NotEmpty(t, warnings)
+	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query has values with under-score charset")
+}
+
+func TestNonPreparedPlanCacheUnifiedLimitOffset(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table unified_limit_offset(a int, key(a))")
+	setupTK.MustExec("insert into unified_limit_offset values (1), (2), (3), (4)")
+
+	cases := []struct {
+		name   string
+		first  string
+		second string
+	}{
+		{
+			name:   "offset_count",
+			first:  "select a from unified_limit_offset where a > 0 order by a limit 1, 2",
+			second: "select a from unified_limit_offset where a > 1 order by a limit 1, 2",
+		},
+		{
+			name:   "limit_offset",
+			first:  "select a from unified_limit_offset where a > 0 order by a limit 2 offset 1",
+			second: "select a from unified_limit_offset where a > 1 order by a limit 2 offset 1",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineFirst := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.first)
+			baselineSecond := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.second)
+
+			nonPreparedTK := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			miss := observeUnifiedPlanCacheQuery(t, nonPreparedTK, testCase.first)
+			require.False(t, miss.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baselineFirst, miss, "param-limit enabled miss")
+			hit := observeUnifiedPlanCacheQuery(t, nonPreparedTK, testCase.second)
+			require.True(t, hit.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baselineSecond, hit, "param-limit enabled hit")
+
+			bypassTK := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			bypassTK.MustExec("set tidb_enable_plan_cache_for_param_limit=off")
+			unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+			beforeBypass := promtestutils.ToFloat64(unsupported)
+			bypassFirst := observeUnifiedPlanCacheQuery(t, bypassTK, testCase.first)
+			require.False(t, bypassFirst.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baselineFirst, bypassFirst, "param-limit disabled first")
+			bypassSecond := observeUnifiedPlanCacheQuery(t, bypassTK, testCase.second)
+			require.False(t, bypassSecond.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baselineSecond, bypassSecond, "param-limit disabled second")
+			require.Equal(t, beforeBypass+2, promtestutils.ToFloat64(unsupported), "parameterization bypass must count once per execution")
+
+			beforeExplain := promtestutils.ToFloat64(unsupported)
+			bypassTK.MustExec("explain format='plan_cache' " + testCase.first)
+			warnings := bypassTK.MustQuery("show warnings").Rows()
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query has 'limit ?' is un-cacheable")
+			require.Equal(t, beforeExplain+1, promtestutils.ToFloat64(unsupported))
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheckGlobalVar(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache_unified_cacheability_check").Check(testkit.Rows("0"))
+	tk.MustExec("set global tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache_unified_cacheability_check").Check(testkit.Rows("0"))
+
+	newSession := testkit.NewTestKit(t, store)
+	newSession.MustQuery("select @@session.tidb_enable_non_prepared_plan_cache_unified_cacheability_check").Check(testkit.Rows("1"))
+}
+
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheckMetric(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	before := promtestutils.ToFloat64(unsupported)
+	tk.MustExec("insert into t values (1)")
+	require.Equal(t, before, promtestutils.ToFloat64(unsupported))
+
+	tk.MustQuery("select _utf8mb4'a'").Check(testkit.Rows("a"))
+	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
+
+	tk.MustExec("set @a=1")
+	before = promtestutils.ToFloat64(unsupported)
+	tk.MustQuery("select * from t where a=@a").Check(testkit.Rows("1"))
+	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
+}
+
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheckRejects(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	tk.MustExec("insert into t values (1, 1), (2, 2)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	// SELECT INTO is rejected before carrier construction and must continue with
+	// ordinary planning on every execution.
+	for i := 0; i < 2; i++ {
+		tk.MustExec("select a into @a from t where a=1")
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	}
+	// Locking reads are controlled by the DML gate even though they are SELECTs.
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+	for i := 0; i < 2; i++ {
+		tk.MustQuery("select * from t where a=1 for update").Check(testkit.Rows("1 1"))
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	}
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+
+	// Explicit ignore_plan_cache() and an uncacheable function are checked by the
+	// unified AST cacheability path.
+	for i := 0; i < 2; i++ {
+		tk.MustQuery("select /*+ ignore_plan_cache() */ * from t where a=1").Check(testkit.Rows("1 1"))
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+		tk.MustQuery("select connection_id() from t where a=1")
+		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	}
+
+	// The unified switch must have no effect when the main non-prepared cache
+	// switch is disabled.
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
+	tk.MustQuery("select * from t where a=1").Check(testkit.Rows("1 1"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
+func TestNonPreparedPlanCacheUnifiedLockingReadWithDMLEnabled(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table unified_locking_read(a int, b int, key(a))")
+	setupTK.MustExec("insert into unified_locking_read values (1, 10), (2, 20)")
+
+	for _, lockClause := range []string{"for update", "for share"} {
+		t.Run(lockClause, func(t *testing.T) {
+			query := "select a, b from unified_locking_read where a > 0 order by a " + lockClause
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineTK.MustExec("set tidb_enable_noop_functions=on")
+			baseline := observeUnifiedPlanCacheQuery(t, baselineTK, query)
+			require.False(t, baseline.cacheHit)
+
+			tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+			tk.MustExec("set tidb_enable_noop_functions=on")
+			executeWithLookup := func(sql string) (unifiedPlanCacheQueryObservation, bool) {
+				lookups := make([]bool, 0, 1)
+				ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+					lookups = append(lookups, found)
+				})
+				observation := observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql)
+				require.Len(t, lookups, 1, "locking read statement carrier lookup count")
+				return observation, lookups[0]
+			}
+
+			first, firstLookup := executeWithLookup(query)
+			require.False(t, firstLookup, "first locking read must miss the statement carrier")
+			require.False(t, first.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baseline, first, "locking read miss")
+
+			second, secondLookup := executeWithLookup(query)
+			require.True(t, secondLookup, "second locking read must hit the statement carrier")
+			require.True(t, second.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, baseline, second, "locking read hit")
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedDMLCTE(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+
+	updateQuery := "with cte(a) as (select 1) update t set b = b + 1 where a in (select a from cte)"
+	tk.MustExec(updateQuery)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("with cte(a) as (select 1) update t set b = b + 2 where a in (select a from cte)")
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustQuery("select * from t order by a").Check(testkit.Rows("1 13", "2 20"))
+
+	deleteQuery := "with cte(a) as (select 1) delete from t where a in (select a from cte)"
+	tk.MustExec("insert into t values (1, 30)")
+	tk.MustExec(deleteQuery)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustExec("insert into t values (1, 40)")
+	tk.MustExec(deleteQuery)
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
+	tk.MustQuery("select * from t order by a").Check(testkit.Rows("2 20"))
+}
+
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheckStateChanges(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table tp (a int, b int, key(a)) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than (20),
+		partition p2 values less than maxvalue)`)
+	tk.MustExec("insert into tp values (1, 10), (11, 20), (21, 30)")
+	tk.MustExec("analyze table tp")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+
+	first := tk.MustQuery("select b from tp where a > 0").Sort()
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	second := tk.MustQuery("select b from tp where a > 10").Sort()
+	require.Equal(t, testkit.Rows("20", "30"), second.Rows())
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
+
+	// The carrier remains in the statement LRU, but the current partition mode
+	// makes the same parameterized AST uncacheable.
+	tk.MustExec("set tidb_partition_prune_mode=static")
+	tk.MustQuery("select b from tp where a > 20").Sort().Check(testkit.Rows("30"))
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.Equal(t, testkit.Rows("10", "20", "30"), first.Rows())
+
+	// A schema change must invalidate the plan value associated with the
+	// statement carrier before the next execution.
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+	tk.MustExec("alter table tp add column c int")
+	tk.MustQuery("select b from tp where a > 10").Sort().Check(testkit.Rows("20", "30"))
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+}
+
+func TestNonPreparedPlanCacheUnifiedFixControlStateChanges(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table fix_plain(a int, key(a))")
+	setupTK.MustExec("insert into fix_plain values (1), (2), (3), (4)")
+	setupTK.MustExec(`create table fix_partition(a int, b int, key(a)) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than (20),
+		partition p2 values less than maxvalue)`)
+	setupTK.MustExec("insert into fix_partition values (1, 10), (11, 20), (21, 30)")
+	setupTK.MustExec("analyze table fix_partition")
+	setupTK.MustExec("create table fix_generated(a int, b int as (a + 1), key(a))")
+	setupTK.MustExec("insert into fix_generated(a) values (1), (2), (3)")
+
+	testCases := []struct {
+		name        string
+		fixControl  string
+		reason      string
+		firstSQL    string
+		hitSQL      string
+		rejectedSQL string
+		restoredSQL string
+	}{
+		{
+			name:        "Fix44823",
+			fixControl:  "44823:1",
+			reason:      "query has too many constants",
+			firstSQL:    "select a from fix_plain where a > 0 and a < 4 order by a",
+			hitSQL:      "select a from fix_plain where a > 1 and a < 5 order by a",
+			rejectedSQL: "select a from fix_plain where a > 2 and a < 5 order by a",
+			restoredSQL: "select a from fix_plain where a > 0 and a < 3 order by a",
+		},
+		{
+			name:        "Fix33031",
+			fixControl:  "33031:ON",
+			reason:      "Fix33031 fix-control set and partitioned table",
+			firstSQL:    "select b from fix_partition where a > 0 order by b",
+			hitSQL:      "select b from fix_partition where a > 10 order by b",
+			rejectedSQL: "select b from fix_partition where a > 20 order by b",
+			restoredSQL: "select b from fix_partition where a > 1 order by b",
+		},
+		{
+			name:        "Fix45798",
+			fixControl:  "45798:OFF",
+			reason:      "query accesses generated columns is un-cacheable",
+			firstSQL:    "select b from fix_generated where a > 0 order by b",
+			hitSQL:      "select b from fix_generated where a > 1 order by b",
+			rejectedSQL: "select b from fix_generated where a > 2 order by b",
+			restoredSQL: "select b from fix_generated where a > 0 order by b",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineTK.MustExec("set tidb_partition_prune_mode=dynamic")
+			firstBaseline := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.firstSQL)
+			hitBaseline := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.hitSQL)
+			rejectedBaseline := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.rejectedSQL)
+			restoredBaseline := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.restoredSQL)
+
+			tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			tk.MustExec("set tidb_partition_prune_mode=dynamic")
+			first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, testCase.firstSQL)
+			require.False(t, first.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, firstBaseline, first, "initial cache miss")
+			carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
+			require.NotNil(t, carrier)
+
+			hit := observeUnifiedPlanCacheQuery(t, tk, testCase.hitSQL)
+			require.True(t, hit.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, hitBaseline, hit, "initial cache hit")
+
+			tk.MustExec("set tidb_opt_fix_control='" + testCase.fixControl + "'")
+			require.Same(t, carrier, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+			unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+			before := promtestutils.ToFloat64(unsupported)
+			rejected := observeUnifiedPlanCacheQuery(t, tk, testCase.rejectedSQL)
+			require.False(t, rejected.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, rejectedBaseline, rejected, "fix-control rejection")
+			require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
+
+			beforeExplain := promtestutils.ToFloat64(unsupported)
+			tk.MustExec("explain format='plan_cache' " + testCase.rejectedSQL)
+			require.Equal(t, beforeExplain+1, promtestutils.ToFloat64(unsupported))
+			warnings := tk.MustQuery("show warnings").Rows()
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: "+testCase.reason)
+
+			tk.MustExec("set tidb_opt_fix_control=''")
+			require.Same(t, carrier, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+			restored := observeUnifiedPlanCacheQuery(t, tk, testCase.restoredSQL)
+			require.True(t, restored.cacheHit)
+			requireUnifiedPlanCacheQueryEqual(t, restoredBaseline, restored, "restored fix-control cache hit")
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedStatementLRUHitAndCheckerReject(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table lru_generated(a int, b int as (a + 1), key(a))")
+	tk.MustExec("insert into lru_generated(a) values (1), (2), (3)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	queries := []string{
+		"with source as (select a, b from lru_generated) select b from source where a > 0 order by b",
+		"with source as (select a, b from lru_generated) select b from source where a > 1 order by b",
+		"with source as (select a, b from lru_generated) select b from source where a > 2 order by b",
+	}
+	executeWithLookup := func(sql string) (unifiedPlanCacheQueryObservation, []bool) {
+		lookups := make([]bool, 0, 1)
+		ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+			lookups = append(lookups, found)
+		})
+		observation := observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql)
+		require.Len(t, lookups, 1, "statement carrier lookup count")
+		return observation, lookups
+	}
+
+	first, firstLookups := executeWithLookup(queries[0])
+	require.Equal(t, []bool{false}, firstLookups)
+	require.False(t, first.cacheHit)
+	require.Equal(t, [][]string{{"2"}, {"3"}, {"4"}}, first.rows)
+
+	hit, hitLookups := executeWithLookup(queries[1])
+	require.Equal(t, []bool{true}, hitLookups)
+	require.True(t, hit.cacheHit)
+	require.Equal(t, [][]string{{"3"}, {"4"}}, hit.rows)
+
+	tk.MustExec("set tidb_opt_fix_control='45798:OFF'")
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	before := promtestutils.ToFloat64(unsupported)
+	rejected, rejectedLookups := executeWithLookup(queries[2])
+	require.Equal(t, []bool{true}, rejectedLookups)
+	require.False(t, rejected.cacheHit)
+	require.Equal(t, [][]string{{"4"}}, rejected.rows)
+	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
+
+	tk.MustExec("explain format='plan_cache' " + queries[2])
+	warnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query accesses generated columns is un-cacheable")
+
+	tk.MustExec("set tidb_opt_fix_control=''")
+	restored, restoredLookups := executeWithLookup(queries[1])
+	require.Equal(t, []bool{true}, restoredLookups)
+	require.True(t, restored.cacheHit)
+	require.Equal(t, hit.rows, restored.rows)
+}
+
+func TestNonPreparedPlanCacheUnifiedLegacyBehaviorMatrix(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table legacy_matrix_t(a int, b int, key(a))")
+	setupTK.MustExec("create table legacy_matrix_t2(a int, b int, key(a))")
+	setupTK.MustExec("create table legacy_matrix_t3(a int, b int, key(a))")
+	setupTK.MustExec("insert into legacy_matrix_t values (1, 1), (2, 2), (3, 3)")
+	setupTK.MustExec("insert into legacy_matrix_t2 select * from legacy_matrix_t")
+	setupTK.MustExec("insert into legacy_matrix_t3 select * from legacy_matrix_t")
+
+	testCases := []struct {
+		name        string
+		first       string
+		second      string
+		reason      string
+		metricDelta float64
+	}{
+		{
+			name:        "window",
+			first:       "select a, sum(b) over (order by a rows 1 preceding) from legacy_matrix_t where b > 1",
+			second:      "select a, sum(b) over (order by a rows 1 preceding) from legacy_matrix_t where b > 2",
+			reason:      "query has some unsupported Node",
+			metricDelta: 2,
+		},
+		{
+			name:        "cte",
+			first:       "with source as (select a from legacy_matrix_t where b > 1) select a from source where a > 0 order by a",
+			second:      "with source as (select a from legacy_matrix_t where b > 2) select a from source where a > 0 order by a",
+			reason:      "query has some unsupported Node",
+			metricDelta: 2,
+		},
+		{
+			name:        "set operation",
+			first:       "select a from legacy_matrix_t where b > 1 union select a from legacy_matrix_t where b < 3 order by 1",
+			second:      "select a from legacy_matrix_t where b > 2 union select a from legacy_matrix_t where b < 2 order by 1",
+			reason:      "not a SELECT statement",
+			metricDelta: 0,
+		},
+		{
+			name:        "three table join",
+			first:       "select legacy_matrix_t.a from legacy_matrix_t join legacy_matrix_t2 on legacy_matrix_t.a=legacy_matrix_t2.a join legacy_matrix_t3 on legacy_matrix_t2.a=legacy_matrix_t3.a where legacy_matrix_t.b > 1",
+			second:      "select legacy_matrix_t.a from legacy_matrix_t join legacy_matrix_t2 on legacy_matrix_t.a=legacy_matrix_t2.a join legacy_matrix_t3 on legacy_matrix_t2.a=legacy_matrix_t3.a where legacy_matrix_t.b > 2",
+			reason:      "queries that have more than 2 tables are not supported",
+			metricDelta: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineFirst := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.first)
+			baselineSecond := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.second)
+
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+			tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+			tk.MustExec("set tidb_enable_plan_cache_for_subquery=on")
+			tk.MustExec("set tidb_enable_plan_cache_for_param_limit=on")
+
+			unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+			before := promtestutils.ToFloat64(unsupported)
+			lookupEvents := make([]bool, 0, 2)
+			lookupCtx := func() context.Context {
+				return context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+					lookupEvents = append(lookupEvents, found)
+				})
+			}
+			first := tk.MustQueryWithContext(lookupCtx(), testCase.first)
+			require.Equal(t, fmt.Sprint(baselineFirst.rows), fmt.Sprint(first.Rows()))
+			require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+			require.Empty(t, tk.MustQuery("show warnings").Rows())
+			second := tk.MustQueryWithContext(lookupCtx(), testCase.second)
+			require.Equal(t, fmt.Sprint(baselineSecond.rows), fmt.Sprint(second.Rows()))
+			require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+			require.Empty(t, tk.MustQuery("show warnings").Rows())
+			require.Empty(t, lookupEvents, "legacy bypass must not perform unified statement-LRU lookup")
+			require.Equal(t, before+testCase.metricDelta, promtestutils.ToFloat64(unsupported), "legacy metric boundary")
+
+			tk.MustExec("explain format='plan_cache' " + testCase.first)
+			warnings := tk.MustQuery("show warnings").Rows()
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: "+testCase.reason)
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedCharacterSetClientCarrierKey(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table charset_t(a int, key(a))")
+	setupTK.MustExec("insert into charset_t values (1), (2)")
+	queryA := "select 'preserved' as literal_value, a from charset_t where a = 1"
+	queryB := "select 'preserved' as literal_value, a from charset_t where a = 2"
+
+	baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+	baselineTK.MustExec("set character_set_client=utf8mb4")
+	utf8BaselineA := observeUnifiedPlanCacheQuery(t, baselineTK, queryA)
+	utf8BaselineB := observeUnifiedPlanCacheQuery(t, baselineTK, queryB)
+	baselineTK.MustExec("set character_set_client=latin1")
+	latin1BaselineA := observeUnifiedPlanCacheQuery(t, baselineTK, queryA)
+	latin1BaselineB := observeUnifiedPlanCacheQuery(t, baselineTK, queryB)
+
+	tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+	tk.MustExec("set character_set_client=utf8mb4")
+	utf8Miss, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, queryA)
+	require.Contains(t, paramSQL, "'preserved'")
+
+	require.False(t, utf8Miss.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineA, utf8Miss, "utf8mb4 cache miss")
+	utf8Carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
+	require.NotNil(t, utf8Carrier)
+
+	utf8Hit := observeUnifiedPlanCacheQuery(t, tk, queryB)
+	require.True(t, utf8Hit.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineB, utf8Hit, "utf8mb4 cache hit")
+
+	tk.MustExec("set character_set_client=latin1")
+	require.Nil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+	latin1First := observeUnifiedPlanCacheQuery(t, tk, queryB)
+	requireUnifiedPlanCacheQueryEqual(t, latin1BaselineB, latin1First, "latin1 first execution")
+	latin1Carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
+	require.NotNil(t, latin1Carrier)
+	require.NotSame(t, utf8Carrier, latin1Carrier)
+	latin1Hit := observeUnifiedPlanCacheQuery(t, tk, queryA)
+	require.True(t, latin1Hit.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, latin1BaselineA, latin1Hit, "latin1 cache hit")
+
+	tk.MustExec("set character_set_client=utf8mb4")
+	require.Same(t, utf8Carrier, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+	restored := observeUnifiedPlanCacheQuery(t, tk, queryB)
+	require.True(t, restored.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, utf8BaselineB, restored, "restored utf8mb4 cache hit")
+}
+
+func TestNonPreparedPlanCacheUnifiedViewSystemTemporaryTables(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table view_base(a int, b int, key(a))")
+	setupTK.MustExec("insert into view_base values (1, 10), (2, 20), (3, 30)")
+	setupTK.MustExec("create view unified_view as select a, b from view_base")
+	setupTK.MustExec("create table system_base(a int)")
+
+	t.Run("view caches and invalidates on schema change", func(t *testing.T) {
+		query := [3]string{
+			"select a, b from unified_view where a > 0 order by a",
+			"select a, b from unified_view where a > 1 order by a",
+			"select a, b from unified_view where a > 2 order by a",
+		}
+		baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+		baseline := [3]unifiedPlanCacheQueryObservation{
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[0]),
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[1]),
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[2]),
+		}
+
+		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, query[0])
+		require.False(t, first.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[0], first, "view initial miss")
+		carrier := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
+		require.NotNil(t, carrier)
+
+		hit := observeUnifiedPlanCacheQuery(t, tk, query[1])
+		require.True(t, hit.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[1], hit, "view cache hit")
+
+		tk.MustExec("alter table view_base add column c int")
+		schemaMiss := observeUnifiedPlanCacheQuery(t, tk, query[2])
+		require.False(t, schemaMiss.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[2], schemaMiss, "view schema-change miss")
+		require.NotNil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+
+		postSchemaHit := observeUnifiedPlanCacheQuery(t, tk, query[1])
+		require.True(t, postSchemaHit.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[1], postSchemaHit, "view post-schema cache hit")
+	})
+
+	t.Run("system table is rejected by physical checker", func(t *testing.T) {
+		query := [2]string{
+			"select table_name from information_schema.columns where table_schema = 'test' and table_name = 'system_base'",
+			"select table_name from information_schema.columns where table_schema = 'test' and table_name = 'missing_base'",
+		}
+		baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+		baseline := [2]unifiedPlanCacheQueryObservation{
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[0]),
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[1]),
+		}
+
+		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		before := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
+		first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, query[0])
+		require.False(t, first.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[0], first, "system table initial execution")
+		carrier, ok := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL).(*plannercore.PlanCacheStmt)
+		require.True(t, ok)
+		// Physical-plan rejection must not turn the reusable statement carrier
+		// into an uncacheable carrier; the physical checker runs again per use.
+		require.True(t, carrier.StmtCacheable)
+		require.Equal(t, before, promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter()))
+
+		second := observeUnifiedPlanCacheQuery(t, tk, query[1])
+		require.False(t, second.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[1], second, "system table second execution")
+		require.Equal(t, before, promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter()))
+
+		tk.MustExec("explain format='plan_cache' " + query[0])
+		warnings := tk.MustQuery("show warnings").Rows()
+		require.Len(t, warnings, 1)
+		require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: PhysicalMemTable plan is un-cacheable")
+	})
+
+	t.Run("temporary table is rejected by AST checker", func(t *testing.T) {
+		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		tk.MustExec("create temporary table unified_tmp(a int, key(a))")
+		tk.MustExec("insert into unified_tmp values (1), (2)")
+		query := [2]string{
+			"select a from unified_tmp where a = 1",
+			"select a from unified_tmp where a = 2",
+		}
+		baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+		baselineTK.MustExec("create temporary table unified_tmp(a int, key(a))")
+		baselineTK.MustExec("insert into unified_tmp values (1), (2)")
+		baseline := [2]unifiedPlanCacheQueryObservation{
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[0]),
+			observeUnifiedPlanCacheQuery(t, baselineTK, query[1]),
+		}
+		before := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
+		first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, query[0])
+		require.False(t, first.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[0], first, "temporary table initial execution")
+		require.Nil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL))
+		require.Equal(t, before+1, promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter()))
+
+		second := observeUnifiedPlanCacheQuery(t, tk, query[1])
+		require.False(t, second.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[1], second, "temporary table second execution")
+		require.Equal(t, before+2, promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter()))
+
+		tk.MustExec("explain format='plan_cache' " + query[0])
+		warnings := tk.MustQuery("show warnings").Rows()
+		require.Len(t, warnings, 1)
+		require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query accesses temporary tables is un-cacheable")
+	})
+}
+
+func TestNonPreparedPlanCacheUnifiedDoesNotCacheUncacheableCarrier(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table tp (a int, b int) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than maxvalue)`)
+	tk.MustExec("insert into tp values (1, 10), (11, 20)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
+
+	stmt, err := parser.New().ParseOneStmt("select b from tp where a > 0", "", "")
+	require.NoError(t, err)
+	paramResult, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(tk.Session().GetPlanCtx(), stmt)
+	require.NoError(t, err)
+	require.True(t, supported, reason)
+
+	carrierBefore := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
+	tk.MustQuery("select b from tp where a > 0").Sort().Check(testkit.Rows("10", "20"))
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.Nil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramResult.ParamSQL))
+	carrierRejected := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
+	require.Equal(t, carrierBefore+1, carrierRejected)
+
+	tk.MustExec("explain format='plan_cache' select b from tp where a > 1")
+	warnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: static partition prune mode used")
+}
+
+func TestNonPreparedPlanCacheUnifiedUnsupportedMetricBoundaries(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int, key(a))")
+	tk.MustExec("create table t2(a int, b int, key(a))")
+	tk.MustExec("insert into t values (1, 1), (2, 2)")
+	tk.MustExec("insert into t2 select * from t")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
+
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	before := promtestutils.ToFloat64(unsupported)
+	tk.MustExec("insert into t values (3, 3)")
+	require.Equal(t, before, promtestutils.ToFloat64(unsupported), "DML gate must not count")
+
+	tk.MustQuery("select _utf8mb4'a' from t where a=1").Check(testkit.Rows("a"))
+	precheckRejected := promtestutils.ToFloat64(unsupported)
+	require.Equal(t, before+1, precheckRejected, "parameterization precheck must count once")
+
+	tk.MustQuery("select /*+ ignore_plan_cache() */ a from t where a=1").Check(testkit.Rows("1"))
+	astRejected := promtestutils.ToFloat64(unsupported)
+	require.Equal(t, precheckRejected+1, astRejected, "public AST checker must count once")
+
+	tk.MustExec(`create table tp_metric (a int, b int) partition by range (a) (
+		partition p0 values less than (10), partition p1 values less than maxvalue)`)
+	tk.MustExec("insert into tp_metric values (1, 1), (11, 11)")
+	tk.MustExec("set tidb_partition_prune_mode=static")
+	tk.MustQuery("select b from tp_metric where a > 0").Sort().Check(testkit.Rows("1", "11"))
+	carrierRejected := promtestutils.ToFloat64(unsupported)
+	require.Equal(t, astRejected+1, carrierRejected, "carrier rejection must count once")
+
+	tk.MustExec("set tidb_enable_plan_cache_for_subquery=on")
+	physicalQuery := "select * from t t1 where t1.a > (select max(t2.a) from t t2 where t2.b < t1.b and t2.b < 2)"
+	physicalBefore := promtestutils.ToFloat64(unsupported)
+	tk.MustQuery(physicalQuery)
+	require.Equal(t, physicalBefore, promtestutils.ToFloat64(unsupported), "physical rejection must not duplicate unsupported count")
+
+	tk.MustExec("explain format='plan_cache' " + physicalQuery)
+	warnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache:")
+	require.Contains(t, warnings[0][2], "PhysicalApply plan is un-cacheable")
+}
+
+func TestNonPreparedPlanCacheUnifiedReasonPriority(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_reason(a int)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+	query := "select _utf8mb4'a' into @reason_value from t_reason where a=1"
+
+	// Legacy mode remains the compatibility path; its reason is intentionally
+	// different from the unified parameterization-priority reason.
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+	tk.MustExec("explain format='plan_cache' " + query)
+	legacyWarnings := tk.MustQuery("show warnings").Rows()
+	require.NotEmpty(t, legacyWarnings)
+	for _, warning := range legacyWarnings {
+		require.Contains(t, warning[2], "skip non-prepared plan-cache:")
+	}
+
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("explain format='plan_cache' " + query)
+	unifiedWarnings := tk.MustQuery("show warnings").Rows()
+	require.NotEmpty(t, unifiedWarnings)
+	require.Contains(t, unifiedWarnings[0][2], "skip non-prepared plan-cache: SELECT INTO is not supported")
+
+	tk.MustExec("set tidb_enable_plan_cache_for_param_limit=off")
+	precheckCases := []struct {
+		name           string
+		sql            string
+		expectedReason string
+	}{
+		{
+			name:           "charset beats limit",
+			sql:            "select _utf8mb4'a' from t_reason limit 1",
+			expectedReason: "query has values with under-score charset that cannot be preserved safely",
+		},
+	}
+	values := make([]string, 201)
+	for i := range values {
+		values[i] = fmt.Sprintf("%d", i)
+	}
+	precheckCases = append(precheckCases, struct {
+		name           string
+		sql            string
+		expectedReason string
+	}{
+		name:           "literal limit beats charset and limit clause",
+		sql:            "select _utf8mb4'a', " + strings.Join(values, ", ") + " from t_reason limit 1",
+		expectedReason: "query has too many constants",
+	})
+	for _, testCase := range precheckCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			_, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(tk.Session().GetPlanCtx(), stmt)
+			require.NoError(t, err)
+			require.False(t, supported)
+			require.Equal(t, testCase.expectedReason, reason)
+		})
+	}
+
+	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+	before := promtestutils.ToFloat64(unsupported)
+	tk.MustExec("explain format='plan_cache' select _utf8mb4'a' from t_reason where a=1 for update")
+	dmlWarnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, dmlWarnings, 1)
+	require.Contains(t, dmlWarnings[0][2], "skip non-prepared plan-cache: not a SELECT statement")
+	require.Equal(t, before, promtestutils.ToFloat64(unsupported), "DML entry gate must not increment unsupported metric")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
+
+	before = promtestutils.ToFloat64(unsupported)
+	tk.MustQuery("select /*+ ignore_plan_cache() */ a from t_reason where a=1")
+	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported), "AST checker rejection must increment unsupported metric")
+	tk.MustExec("explain format='plan_cache' select /*+ ignore_plan_cache() */ a from t_reason where a=1")
+	hintWarnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, hintWarnings, 1)
+	require.Contains(t, hintWarnings[0][2], "skip non-prepared plan-cache: ignore plan cache by hint")
+	require.GreaterOrEqual(t, promtestutils.ToFloat64(unsupported), before+2, "AST checker rejection must increment unsupported metric")
+
+	tk.MustExec(`create table priority_partition (a int) partition by range (a) (
+		partition p0 values less than (10), partition p1 values less than maxvalue)`)
+	tk.MustExec("insert into priority_partition values (1), (11)")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
+	before = promtestutils.ToFloat64(unsupported)
+	tk.MustExec("explain format='plan_cache' select a from priority_partition where a > 0")
+	physicalWarnings := tk.MustQuery("show warnings").Rows()
+	require.Len(t, physicalWarnings, 1)
+	require.Contains(t, physicalWarnings[0][2], "skip non-prepared plan-cache: static partition prune mode used")
+	require.GreaterOrEqual(t, promtestutils.ToFloat64(unsupported), before+1, "carrier rejection must increment unsupported metric")
 }
 
 func TestNonPreparedPlanCacheInternalSQL(t *testing.T) {
@@ -1869,6 +3702,7 @@ func BenchmarkNonPreparedPlanCacheDML(b *testing.B) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int)")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=1")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/planner"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	core_metrics "github.com/pingcap/tidb/pkg/planner/core/metrics"
@@ -38,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/types"
@@ -356,6 +359,35 @@ func observeUnifiedPlanCacheQuery(t *testing.T, tk *testkit.TestKit, sql string)
 	return observeUnifiedPlanCacheQueryWithContext(context.Background(), t, tk, sql)
 }
 
+func assertSingleNonPreparedPlanCacheWarning(t *testing.T, warnings [][]any, reason string) {
+	want := "skip non-prepared plan-cache: " + reason
+	matches := 0
+	for _, warning := range warnings {
+		if len(warning) > 2 && strings.Contains(fmt.Sprint(warning[2]), want) {
+			matches++
+		}
+	}
+	require.Equal(t, 1, matches, "expected exactly one %q warning, got %v", want, warnings)
+}
+
+func statementWarningsToRows(warnings []stmtctx.SQLWarn) [][]any {
+	rows := make([][]any, 0, len(warnings))
+	for _, warning := range warnings {
+		var sqlErr *terror.Error
+		if errors.As(warning.Err, &sqlErr) {
+			converted := terror.ToSQLError(sqlErr)
+			rows = append(rows, []any{warning.Level, int64(converted.Code), converted.Message})
+			continue
+		}
+		message := ""
+		if warning.Err != nil {
+			message = warning.Err.Error()
+		}
+		rows = append(rows, []any{warning.Level, int64(mysql.ErrUnknown), message})
+	}
+	return rows
+}
+
 func observeUnifiedPlanCacheQueryWithContext(
 	ctx context.Context,
 	t *testing.T,
@@ -392,7 +424,7 @@ func observeUnifiedPlanCacheQueryWithContext(
 		affectedRows: tk.Session().AffectedRows(),
 		cacheHit:     tk.Session().GetSessionVars().FoundInPlanCache,
 	}
-	observation.warnings = tk.MustQuery("show warnings").Rows()
+	observation.warnings = statementWarningsToRows(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
 	return observation
 }
 
@@ -735,6 +767,26 @@ func TestNonPreparedPlanCacheUnifiedPreservedLiteralStatementLRUIdentity(t *test
 			a:    "select a, date_format('2020-01-02', '%Y-%m-%d') as formatted from preserved_literal_lru_identity where a > 0 order by a",
 			b:    "select a, date_format('2020-01-02', '%d/%m/%Y') as formatted from preserved_literal_lru_identity where a > 0 order by a",
 		},
+		{
+			name: "char charset literal in filter",
+			a:    "select a from preserved_literal_lru_identity where char(a using utf8mb4) is not null order by a",
+			b:    "select a from preserved_literal_lru_identity where char(a using latin1) is not null order by a",
+		},
+		{
+			name: "lpad length literal in filter",
+			a:    "select a from preserved_literal_lru_identity where cast(lpad(cast(a as char), 1, '0') as unsigned) = 1 order by a",
+			b:    "select a from preserved_literal_lru_identity where cast(lpad(cast(a as char), 2, '0') as unsigned) = 1 order by a",
+		},
+		{
+			name: "rpad length literal in filter",
+			a:    "select a from preserved_literal_lru_identity where cast(rpad(cast(a as char), 1, '0') as unsigned) = 1 order by a",
+			b:    "select a from preserved_literal_lru_identity where cast(rpad(cast(a as char), 2, '0') as unsigned) = 1 order by a",
+		},
+		{
+			name: "convert tz datetime precision in filter",
+			a:    "select a from preserved_literal_lru_identity where a > 0 and convert_tz('2020-01-01 00:00:00.1', '+00:00', '+00:00') is not null order by a",
+			b:    "select a from preserved_literal_lru_identity where a > 0 and convert_tz('2020-01-01 00:00:00.123456', '+00:00', '+00:00') is not null order by a",
+		},
 	}
 
 	for _, testCase := range cases {
@@ -787,6 +839,7 @@ func TestNonPreparedPlanCacheUnifiedPreservedLiteralStatementLRUIdentity(t *test
 			}
 		})
 	}
+
 }
 
 func TestNonPreparedPlanCacheUnifiedParamSQLRestoreFallback(t *testing.T) {
@@ -893,12 +946,12 @@ func TestNonPreparedPlanCacheUnifiedParamSQLParseFailureBypass(t *testing.T) {
 
 	tk.MustQueryWithContext(ctx, "select a from param_sql_parse_failure where a = 1").Check(testkit.Rows("1"))
 	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
-	tk.MustQuery("show warnings").Check(testkit.Rows())
+	require.Empty(t, statementWarningsToRows(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
 	require.Equal(t, before+1, promtestutils.ToFloat64(unsupported))
 
 	beforeExplain := promtestutils.ToFloat64(unsupported)
 	tk.MustExecWithContext(ctx, "explain format='plan_cache' select a from param_sql_parse_failure where a = 1")
-	warnings := tk.MustQuery("show warnings").Rows()
+	warnings := statementWarningsToRows(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
 	require.Len(t, warnings, 1)
 	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: failed to parse parameterized SQL")
 	require.Equal(t, beforeExplain+1, promtestutils.ToFloat64(unsupported))
@@ -919,7 +972,7 @@ func observeUnifiedPlanCacheDML(t *testing.T, tk *testkit.TestKit, sql string) u
 	affectedRows := tk.Session().AffectedRows()
 	cacheHit := tk.Session().GetSessionVars().FoundInPlanCache
 	return unifiedPlanCacheDMLObservation{
-		warnings:     tk.MustQuery("show warnings").Rows(),
+		warnings:     statementWarningsToRows(tk.Session().GetSessionVars().StmtCtx.GetWarnings()),
 		affectedRows: affectedRows,
 		cacheHit:     cacheHit,
 	}
@@ -1150,7 +1203,7 @@ func TestNonPreparedPlanCacheUnifiedMultiTableDMLGateE2E(t *testing.T) {
 				if rs != nil {
 					require.NoError(t, rs.Close(), sql)
 				}
-				return tk.Session().AffectedRows(), tk.Session().GetSessionVars().FoundInPlanCache, lookups, tk.MustQuery("show warnings").Rows()
+				return tk.Session().AffectedRows(), tk.Session().GetSessionVars().FoundInPlanCache, lookups, statementWarningsToRows(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
 			}
 
 			unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
@@ -1304,6 +1357,265 @@ func TestNonPreparedPlanCacheUnifiedCacheabilityCheck(t *testing.T) {
 	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query has values with under-score charset")
 }
 
+func TestNonPreparedPlanCacheUnifiedApproxPercentile(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table approx_percentile_plan_cache(a int)")
+	setupTK.MustExec("insert into approx_percentile_plan_cache values (1), (2), (3)")
+
+	query := "select a from approx_percentile_plan_cache group by a having approx_percentile(a, 50) > 1 order by a"
+	baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+	baseline := observeUnifiedPlanCacheQuery(t, baselineTK, query)
+	require.False(t, baseline.cacheHit)
+
+	tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+	firstLookup := false
+	firstLookupCount := 0
+	firstCtx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+		firstLookup = found
+		firstLookupCount++
+	})
+	first := observeUnifiedPlanCacheQueryWithContext(firstCtx, t, tk, query)
+	require.Equal(t, 1, firstLookupCount)
+	require.False(t, firstLookup)
+	require.False(t, first.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, baseline, first, "approx_percentile first execution")
+
+	secondLookup := false
+	secondLookupCount := 0
+	secondCtx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+		secondLookup = found
+		secondLookupCount++
+	})
+	second := observeUnifiedPlanCacheQueryWithContext(secondCtx, t, tk, query)
+	require.Equal(t, 1, secondLookupCount)
+	require.True(t, secondLookup)
+	require.True(t, second.cacheHit)
+	requireUnifiedPlanCacheQueryEqual(t, baseline, second, "approx_percentile cached execution")
+}
+
+func TestNonPreparedPlanCacheUnifiedFunctionTypeStability(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table function_type_plan_cache(a int)")
+	setupTK.MustExec("insert into function_type_plan_cache values (1), (2)")
+
+	queries := [2]string{
+		"select a from function_type_plan_cache group by a having length(char(195,164 using utf8mb4)) = 1 order by a",
+		"select a from function_type_plan_cache group by a having length(char(228,164 using latin1)) = 1 order by a",
+	}
+	baseline := [2]unifiedPlanCacheQueryObservation{}
+	baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+	for i := range queries {
+		baseline[i] = observeUnifiedPlanCacheQuery(t, baselineTK, queries[i])
+		require.False(t, baseline[i].cacheHit)
+	}
+
+	for _, order := range [][2]int{{0, 1}, {1, 0}} {
+		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		lookup := func(sql string) (unifiedPlanCacheQueryObservation, bool) {
+			found := false
+			ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(hit bool) {
+				found = hit
+			})
+			return observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql), found
+		}
+
+		first, firstFound := lookup(queries[order[0]])
+		require.False(t, firstFound)
+		require.False(t, first.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[order[0]], first, "first charset execution")
+
+		second, secondFound := lookup(queries[order[1]])
+		require.False(t, secondFound, "changing CHAR charset must use a different statement carrier")
+		require.False(t, second.cacheHit)
+		requireUnifiedPlanCacheQueryEqual(t, baseline[order[1]], second, "second charset execution")
+
+		firstAgain, firstAgainFound := lookup(queries[order[0]])
+		require.True(t, firstAgainFound)
+		// CHAR's constant predicate may be folded away, so the physical plan
+		// cache is not guaranteed to hit even though the statement carrier is.
+		requireUnifiedPlanCacheQueryEqual(t, baseline[order[0]], firstAgain, "cached charset execution")
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedFunctionBuildTimeArguments(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table function_build_time_plan_cache(a decimal(10, 2), key(a))")
+	setupTK.MustExec("insert into function_build_time_plan_cache values (1.00), (1.23), (2.34)")
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "time fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(time('00:00:01') as char)) = 8 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(time('00:00:01.123456') as char)) = 15 order by a",
+		},
+		{
+			name: "timediff fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(timediff('2020-01-01 00:00:01', '2020-01-01 00:00:00') as char)) = 8 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(timediff('2020-01-01 00:00:01.123456', '2020-01-01 00:00:00') as char)) = 15 order by a",
+		},
+		{
+			name: "timestamp fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(timestamp('2020-01-01 00:00:01') as char)) = 19 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(timestamp('2020-01-01 00:00:01.123456') as char)) = 26 order by a",
+		},
+		{
+			name: "now fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(now(0) as char)) = 19 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(now(6) as char)) = 26 order by a",
+		},
+		{
+			name: "round scale",
+			a:    "select a from function_build_time_plan_cache where a > 0 and round(a, 0) = 1.00 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and round(a, 2) = 1.23 order by a",
+		},
+		{
+			name: "truncate scale",
+			a:    "select a from function_build_time_plan_cache where a > 0 and truncate(a, 0) = 1.00 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and truncate(a, 2) = 1.23 order by a",
+		},
+		{
+			name: "from unix time fsp",
+			a:    "select a from function_build_time_plan_cache where a = 1 and length(cast(from_unixtime(0.123456) as char)) = 26",
+			b:    "select a from function_build_time_plan_cache where a = 1 and length(cast(from_unixtime(0.1) as char)) = 21",
+		},
+		{
+			name: "rand seed",
+			a:    "select count(*) from function_build_time_plan_cache where a > 0 having rand(1) < 0.8",
+			b:    "select count(*) from function_build_time_plan_cache where a > 0 having rand(2) < 0.8",
+		},
+		{
+			name: "addtime fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(addtime(cast('2020-01-01 00:00:00' as datetime), '00:00:00') as char)) = 19 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(addtime(cast('2020-01-01 00:00:00' as datetime), '00:00:00.123456') as char)) = 26 order by a",
+		},
+		{
+			name: "subtime fsp",
+			a:    "select a from function_build_time_plan_cache where a > 0 and length(cast(subtime(cast('2020-01-01 00:00:00' as datetime), '00:00:00') as char)) = 19 order by a",
+			b:    "select a from function_build_time_plan_cache where a > 0 and length(cast(subtime(cast('2020-01-01 00:00:00' as datetime), '00:00:00.123456') as char)) = 26 order by a",
+		},
+		{
+			name: "benchmark loop count",
+			a:    "select a from function_build_time_plan_cache where a > 0 having benchmark(1, json_extract('{}', concat('$.a', cast(a as signed)))) = 0",
+			b:    "select a from function_build_time_plan_cache where a > 0 having benchmark(0, json_extract('{}', concat('$[x', cast(a as signed)))) = 0",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineA := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.a)
+			baselineB := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.b)
+
+			for _, order := range [][2]string{{testCase.a, testCase.b}, {testCase.b, testCase.a}} {
+				tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+				lookup := func(sql string) (unifiedPlanCacheQueryObservation, bool) {
+					found := false
+					ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(hit bool) {
+						found = hit
+					})
+					return observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql), found
+				}
+
+				first, firstFound := lookup(order[0])
+				require.False(t, firstFound)
+				require.False(t, first.cacheHit)
+				if order[0] == testCase.a {
+					requireUnifiedPlanCacheQueryEqual(t, baselineA, first, "first execution")
+				} else {
+					requireUnifiedPlanCacheQueryEqual(t, baselineB, first, "first execution")
+				}
+
+				second, secondFound := lookup(order[1])
+				require.False(t, secondFound, "changing a build-time function argument must use a different statement carrier")
+				require.False(t, second.cacheHit)
+				if order[1] == testCase.a {
+					requireUnifiedPlanCacheQueryEqual(t, baselineA, second, "second execution")
+				} else {
+					requireUnifiedPlanCacheQueryEqual(t, baselineB, second, "second execution")
+				}
+
+				_, firstAgainFound := lookup(order[0])
+				require.True(t, firstAgainFound, "the original build-time function argument must reuse its carrier")
+			}
+		})
+	}
+}
+
+func TestNonPreparedPlanCacheUnifiedWeightStringSyntax(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("create table weight_string_plan_cache(a varchar(20), key(a))")
+	setupTK.MustExec("insert into weight_string_plan_cache values ('alpha'), ('beta')")
+
+	cases := []struct {
+		name        string
+		first       string
+		second      string
+		expectedSQL string
+	}{
+		{
+			name:        "char",
+			first:       "select a from weight_string_plan_cache where weight_string(a as char(5)) = weight_string('alpha' as char(5)) order by a",
+			second:      "select a from weight_string_plan_cache where weight_string(a as char(5)) = weight_string('beta' as char(5)) order by a",
+			expectedSQL: "SELECT a FROM `test`.`weight_string_plan_cache` WHERE weight_string(`a` AS CHAR(5))=weight_string(? AS CHAR(5)) ORDER BY `a`",
+		},
+		{
+			name:        "binary",
+			first:       "select a from weight_string_plan_cache where weight_string(a as binary(5)) = weight_string('alpha' as binary(5)) order by a",
+			second:      "select a from weight_string_plan_cache where weight_string(a as binary(5)) = weight_string('beta' as binary(5)) order by a",
+			expectedSQL: "SELECT a FROM `test`.`weight_string_plan_cache` WHERE weight_string(`a` AS BINARY(5))=weight_string(? AS BINARY(5)) ORDER BY `a`",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineTK := newUnifiedPlanCacheMatrixTestKit(t, store, "cache-off")
+			baselineFirst := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.first)
+			baselineSecond := observeUnifiedPlanCacheQuery(t, baselineTK, testCase.second)
+
+			tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+			lookup := func(sql string) (unifiedPlanCacheQueryObservation, bool, string) {
+				found := false
+				paramSQL := ""
+				ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(hit bool) {
+					found = hit
+				})
+				ctx = context.WithValue(ctx, plannercore.PlanCacheKeyTestNonPreparedParamSQL{}, func(sql *string) {
+					paramSQL = *sql
+				})
+				return observeUnifiedPlanCacheQueryWithContext(ctx, t, tk, sql), found, paramSQL
+			}
+
+			first, firstFound, paramSQL := lookup(testCase.first)
+			require.False(t, firstFound)
+			require.False(t, first.cacheHit)
+			require.Equal(t, testCase.expectedSQL, paramSQL)
+			requireUnifiedPlanCacheQueryEqual(t, baselineFirst, first, "WEIGHT_STRING first execution")
+
+			second, secondFound, secondParamSQL := lookup(testCase.second)
+			require.True(t, secondFound, "the WEIGHT_STRING value expression should reuse its statement carrier")
+			require.True(t, second.cacheHit)
+			require.Equal(t, testCase.expectedSQL, secondParamSQL)
+			requireUnifiedPlanCacheQueryEqual(t, baselineSecond, second, "WEIGHT_STRING second execution")
+
+			firstAgain, firstAgainFound, _ := lookup(testCase.first)
+			require.True(t, firstAgainFound)
+			requireUnifiedPlanCacheQueryEqual(t, baselineFirst, firstAgain, "WEIGHT_STRING cached execution")
+		})
+	}
+}
+
 func TestNonPreparedPlanCacheUnifiedLimitOffset(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	setupTK := testkit.NewTestKit(t, store)
@@ -1356,7 +1668,7 @@ func TestNonPreparedPlanCacheUnifiedLimitOffset(t *testing.T) {
 
 			beforeExplain := promtestutils.ToFloat64(unsupported)
 			bypassTK.MustExec("explain format='plan_cache' " + testCase.first)
-			warnings := bypassTK.MustQuery("show warnings").Rows()
+			warnings := statementWarningsToRows(bypassTK.Session().GetSessionVars().StmtCtx.GetWarnings())
 			require.Len(t, warnings, 1)
 			require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: query has 'limit ?' is un-cacheable")
 			require.Equal(t, beforeExplain+1, promtestutils.ToFloat64(unsupported))
@@ -1410,7 +1722,8 @@ func TestNonPreparedPlanCacheUnifiedCacheabilityCheckRejects(t *testing.T) {
 	// SELECT INTO is rejected before carrier construction and must continue with
 	// ordinary planning on every execution.
 	for i := 0; i < 2; i++ {
-		tk.MustExec("select a into @a from t where a=1")
+		query := fmt.Sprintf("select a from t where a=1 into outfile '%s/result'", t.TempDir())
+		tk.MustExec(query)
 		tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 	}
 	// Locking reads are controlled by the DML gate even though they are SELECTs.
@@ -1435,6 +1748,46 @@ func TestNonPreparedPlanCacheUnifiedCacheabilityCheckRejects(t *testing.T) {
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=off")
 	tk.MustQuery("select * from t where a=1").Check(testkit.Rows("1 1"))
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+}
+
+func TestNonPreparedPlanCacheUnifiedSetOperationLockingReadGate(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table set_locking_read(a int, key(a))")
+	tk.MustExec("insert into set_locking_read values (1), (2)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
+	tk.MustExec("set tidb_enable_noop_functions=on")
+
+	for _, lockClause := range []string{"for update", "for share"} {
+		t.Run(lockClause, func(t *testing.T) {
+			query := "select a from set_locking_read where a=1 " + lockClause + " union all select a from set_locking_read where a=2"
+			for i := 0; i < 2; i++ {
+				lookupCount := 0
+				ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(bool) {
+					lookupCount++
+				})
+				tk.MustQueryWithContext(ctx, query).Sort().Check(testkit.Rows("1", "2"))
+				require.Equal(t, 0, lookupCount, "locking set operation must bypass statement-LRU lookup")
+				require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+			}
+		})
+	}
+
+	t.Run("nested subquery", func(t *testing.T) {
+		query := "select a from set_locking_read where a in (select a from set_locking_read for update)"
+		for i := 0; i < 2; i++ {
+			lookupCount := 0
+			ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(bool) {
+				lookupCount++
+			})
+			tk.MustQueryWithContext(ctx, query).Sort().Check(testkit.Rows("1", "2"))
+			require.Equal(t, 0, lookupCount, "nested locking read must bypass statement-LRU lookup")
+			require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+		}
+	})
 }
 
 func TestNonPreparedPlanCacheUnifiedLockingReadWithDMLEnabled(t *testing.T) {
@@ -1730,7 +2083,7 @@ func TestNonPreparedPlanCacheUnifiedLegacyBehaviorMatrix(t *testing.T) {
 			name:        "set operation",
 			first:       "select a from legacy_matrix_t where b > 1 union select a from legacy_matrix_t where b < 3 order by 1",
 			second:      "select a from legacy_matrix_t where b > 2 union select a from legacy_matrix_t where b < 2 order by 1",
-			reason:      "not a SELECT statement",
+			reason:      "not a SELECT/UPDATE/INSERT/DELETE statement",
 			metricDelta: 0,
 		},
 		{
@@ -1805,6 +2158,7 @@ func TestNonPreparedPlanCacheUnifiedViewSystemTemporaryTables(t *testing.T) {
 		}
 
 		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
 		first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, query[0])
 		require.False(t, first.cacheHit)
 		requireUnifiedPlanCacheQueryEqual(t, baseline[0], first, "view initial miss")
@@ -1838,6 +2192,7 @@ func TestNonPreparedPlanCacheUnifiedViewSystemTemporaryTables(t *testing.T) {
 		}
 
 		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
 		before := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
 		first, paramSQL := observeUnifiedPlanCacheQueryAndParamSQL(t, tk, query[0])
 		require.False(t, first.cacheHit)
@@ -1862,6 +2217,7 @@ func TestNonPreparedPlanCacheUnifiedViewSystemTemporaryTables(t *testing.T) {
 
 	t.Run("temporary table is rejected by AST checker", func(t *testing.T) {
 		tk := newUnifiedPlanCacheMatrixTestKit(t, store, "non-prepared")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
 		tk.MustExec("create temporary table unified_tmp(a int, key(a))")
 		tk.MustExec("insert into unified_tmp values (1), (2)")
 		query := [2]string{
@@ -1905,16 +2261,17 @@ func TestNonPreparedPlanCacheUnifiedDoesNotCacheUncacheableCarrier(t *testing.T)
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
 	tk.MustExec("set tidb_partition_prune_mode=dynamic")
-	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
+	tk.MustExec("set tidb_skip_missing_partition_stats=off")
 
-	stmt, err := parser.New().ParseOneStmt("select b from tp where a > 0", "", "")
+	query := "select b from tp where a > 0"
+	stmt, err := parser.New().ParseOneStmt(query, "", "")
 	require.NoError(t, err)
 	paramResult, supported, reason, err := plannercore.ParameterizeForNonPreparedPlanCache(tk.Session().GetPlanCtx(), stmt)
 	require.NoError(t, err)
 	require.True(t, supported, reason)
 
 	carrierBefore := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
-	tk.MustQuery("select b from tp where a > 0").Sort().Check(testkit.Rows("10", "20"))
+	tk.MustQuery(query).Sort().Check(testkit.Rows("10", "20"))
 	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
 	require.Nil(t, tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramResult.ParamSQL))
 	carrierRejected := promtestutils.ToFloat64(core_metrics.GetNonPrepPlanCacheUnsupportedCounter())
@@ -1922,8 +2279,53 @@ func TestNonPreparedPlanCacheUnifiedDoesNotCacheUncacheableCarrier(t *testing.T)
 
 	tk.MustExec("explain format='plan_cache' select b from tp where a > 1")
 	warnings := tk.MustQuery("show warnings").Rows()
-	require.Len(t, warnings, 1)
-	require.Contains(t, warnings[0][2], "skip non-prepared plan-cache: static partition prune mode used")
+	assertSingleNonPreparedPlanCacheWarning(t, warnings, "static partition prune mode used")
+}
+
+func TestNonPreparedPlanCacheUnifiedRecoversLegacyUncacheableCarrier(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table tp_recover (a int, b int) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than maxvalue)`)
+	tk.MustExec("insert into tp_recover values (1, 10), (11, 20)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+	tk.MustExec("set tidb_skip_missing_partition_stats=off")
+
+	query := "select b from tp_recover where a > 0"
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=off")
+	legacyParamSQL := ""
+	legacyCtx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestIssue43667{}, func(stmt ast.StmtNode) {
+		var err error
+		legacyParamSQL, _, err = plannercore.GetParamSQLFromAST(stmt)
+		require.NoError(t, err)
+	})
+	tk.MustQueryWithContext(legacyCtx, query).Sort().Check(testkit.Rows("10", "20"))
+	require.NotEmpty(t, legacyParamSQL)
+	paramSQL := legacyParamSQL
+	legacyCarrier, ok := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL).(*plannercore.PlanCacheStmt)
+	require.True(t, ok)
+	require.False(t, legacyCarrier.StmtCacheable)
+
+	tk.MustExec("analyze table tp_recover")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	lookupCount := 0
+	ctx := context.WithValue(context.Background(), plannercore.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+		require.True(t, found)
+		lookupCount++
+	})
+	tk.MustQueryWithContext(ctx, "select b from tp_recover where a > 1").Sort().Check(testkit.Rows("20"))
+	require.Equal(t, 1, lookupCount)
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+
+	tk.MustQuery("select b from tp_recover where a > 2").Sort().Check(testkit.Rows("20"))
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	recoveredCarrier, ok := tk.Session().GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL).(*plannercore.PlanCacheStmt)
+	require.True(t, ok)
+	require.True(t, recoveredCarrier.StmtCacheable)
 }
 
 func TestNonPreparedPlanCacheUnifiedUnsupportedMetricBoundaries(t *testing.T) {
@@ -1937,7 +2339,6 @@ func TestNonPreparedPlanCacheUnifiedUnsupportedMetricBoundaries(t *testing.T) {
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=off")
-	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
 
 	unsupported := core_metrics.GetNonPrepPlanCacheUnsupportedCounter()
 	before := promtestutils.ToFloat64(unsupported)
@@ -1955,7 +2356,8 @@ func TestNonPreparedPlanCacheUnifiedUnsupportedMetricBoundaries(t *testing.T) {
 	tk.MustExec(`create table tp_metric (a int, b int) partition by range (a) (
 		partition p0 values less than (10), partition p1 values less than maxvalue)`)
 	tk.MustExec("insert into tp_metric values (1, 1), (11, 11)")
-	tk.MustExec("set tidb_partition_prune_mode=static")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+	tk.MustExec("set tidb_skip_missing_partition_stats=off")
 	tk.MustQuery("select b from tp_metric where a > 0").Sort().Check(testkit.Rows("1", "11"))
 	carrierRejected := promtestutils.ToFloat64(unsupported)
 	require.Equal(t, astRejected+1, carrierRejected, "carrier rejection must count once")
@@ -1980,7 +2382,7 @@ func TestNonPreparedPlanCacheUnifiedReasonPriority(t *testing.T) {
 	tk.MustExec("create table t_reason(a int)")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
 	tk.MustExec("set tidb_enable_non_prepared_plan_cache_for_dml=on")
-	query := "select _utf8mb4'a' into @reason_value from t_reason where a=1"
+	query := "select _utf8mb4'a' from t_reason where a=1 into outfile '/tmp/reason_value'"
 
 	// Legacy mode remains the compatibility path; its reason is intentionally
 	// different from the unified parameterization-priority reason.
@@ -2056,13 +2458,14 @@ func TestNonPreparedPlanCacheUnifiedReasonPriority(t *testing.T) {
 	tk.MustExec(`create table priority_partition (a int) partition by range (a) (
 		partition p0 values less than (10), partition p1 values less than maxvalue)`)
 	tk.MustExec("insert into priority_partition values (1), (11)")
+	// Missing global partition stats force the plan builder to use the static
+	// partition processor while the session remains in dynamic pruning mode.
 	tk.MustExec("set tidb_partition_prune_mode=dynamic")
-	tk.MustExec("set tidb_opt_enable_selected_partition_stats=on")
+	tk.MustExec("set tidb_skip_missing_partition_stats=off")
 	before = promtestutils.ToFloat64(unsupported)
 	tk.MustExec("explain format='plan_cache' select a from priority_partition where a > 0")
 	physicalWarnings := tk.MustQuery("show warnings").Rows()
-	require.Len(t, physicalWarnings, 1)
-	require.Contains(t, physicalWarnings[0][2], "skip non-prepared plan-cache: static partition prune mode used")
+	assertSingleNonPreparedPlanCacheWarning(t, physicalWarnings, "static partition prune mode used")
 	require.GreaterOrEqual(t, promtestutils.ToFloat64(unsupported), before+1, "carrier rejection must increment unsupported metric")
 }
 

--- a/pkg/planner/core/casetest/plancache/plan_cacheable_checker_test.go
+++ b/pkg/planner/core/casetest/plancache/plan_cacheable_checker_test.go
@@ -365,6 +365,81 @@ func TestCacheable(t *testing.T) {
 		},
 	}
 	require.True(t, core.Cacheable(stmt, is))
+
+	// A CTE reference is not a physical table, but physical tables referenced by
+	// the CTE definition must still be checked. A non-recursive CTE is not visible
+	// inside its own definition.
+	cteStmt, err := parser.New().ParseOneStmt("with cte as (select * from test.t3) select * from cte", "", "")
+	require.NoError(t, err)
+	cacheable, reason := core.CacheableWithCtx(tk.Session().GetPlanCtx(), cteStmt, is)
+	require.True(t, cacheable, reason)
+
+	cteStmt, err = parser.New().ParseOneStmt("with missing as (select * from missing) select * from missing", "", "")
+	require.NoError(t, err)
+	cacheable, _ = core.CacheableWithCtx(tk.Session().GetPlanCtx(), cteStmt, is)
+	require.False(t, cacheable)
+
+	tk.MustExec("create temporary table nested_shadow(a int)")
+	cteCases := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "recursive self reference",
+			sql:  "with recursive cte(n) as (select 1 union all select n + 1 from cte where n < 3) select n from cte",
+		},
+		{
+			name: "sibling reference",
+			sql:  "with first_cte as (select * from test.t3), second_cte as (select * from first_cte) select * from second_cte",
+		},
+		{
+			name: "nested scope",
+			sql:  "with outer_cte as (select * from test.t3) select * from (with inner_cte as (select 1 as a) select * from inner_cte) as nested_result",
+		},
+		{
+			name: "nested same-name shadowing",
+			sql:  "with shadow_cte as (select * from test.t3) select * from (with shadow_cte as (select 1 as a) select * from shadow_cte) as nested_result",
+		},
+		{
+			name: "nested cte shadows temporary table",
+			sql:  "with outer_cte as (select * from test.t3) select * from (with nested_shadow as (select 1 as a) select * from nested_shadow) as nested_result",
+		},
+	}
+	for _, testCase := range cteCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			cacheable, reason := core.IsASTCacheable(context.Background(), tk.Session().GetPlanCtx(), stmt, is)
+			require.True(t, cacheable, "query: %s, reason: %s", testCase.sql, reason)
+		})
+	}
+}
+
+func TestIssue49166(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (c int)`)
+	tk.MustContainErrMsg(`prepare stmt from "select c from t limit 1 into outfile 'text'"`, "This command is not supported in the prepared statement protocol yet")
+}
+
+func TestCacheableDMLCTE(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int)")
+	is := tk.Session().GetInfoSchema().(infoschema.InfoSchema)
+
+	queries := []string{
+		"with cte(a) as (select 36) update t set a = 1 where a in (select a from cte)",
+		"with cte(a) as (select 36) delete from t where a in (select a from cte)",
+	}
+	for _, query := range queries {
+		stmt, err := parser.New().ParseOneStmt(query, "", "")
+		require.NoError(t, err)
+		cacheable, reason := core.IsASTCacheable(context.Background(), tk.Session().GetPlanCtx(), stmt, is)
+		require.True(t, cacheable, "query: %s, reason: %s", query, reason)
+	}
 }
 
 func TestNonPreparedPlanCacheable(t *testing.T) {
@@ -576,4 +651,153 @@ func BenchmarkNonPreparedPlanCacheableChecker(b *testing.B) {
 			b.Fatal()
 		}
 	}
+}
+
+func BenchmarkUnifiedNonPreparedPlanCacheabilityCheck(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int, key(a))")
+
+	stmt, err := parser.New().ParseOneStmt("select a, count(*) from t where a>1 and b<2 group by a having count(*)>3", "", "")
+	require.NoError(b, err)
+	sctx := tk.Session()
+	result, supported, reason, err := core.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	require.NoError(b, err)
+	require.True(b, supported, reason)
+	paramStmt, err := core.ParseParameterizedSQL(sctx, result.ParamSQL)
+	require.NoError(b, err)
+	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, supported, _, err = core.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+		if err != nil || !supported {
+			b.Fatal(err)
+		}
+		cacheable, _ := core.IsASTCacheable(context.Background(), sctx.GetPlanCtx(), paramStmt, is)
+		if !cacheable {
+			b.Fatal("parameterized statement is not cacheable")
+		}
+	}
+}
+
+func BenchmarkUnifiedNonPreparedPlanCacheabilityCheckStatementLRUHit(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int, key(a))")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+	// Warm the statement carrier and the plan cache. The second execution must
+	// be a real statement-LRU hit, which also reruns the unified AST checker.
+	tk.MustQuery("select count(*) from t where a > 0")
+	if tk.Session().GetSessionVars().FoundInPlanCache {
+		b.Fatal("first execution unexpectedly hit the plan cache")
+	}
+	tk.MustQuery("select count(*) from t where a > 1")
+	if !tk.Session().GetSessionVars().FoundInPlanCache {
+		b.Fatal("second execution did not hit the plan cache")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		tk.MustQuery("select count(*) from t where a > 2")
+	}
+}
+
+func BenchmarkUnifiedNonPreparedPlanCacheabilityCheckStatementLRUHitReject(b *testing.B) {
+	store := testkit.CreateMockStore(b)
+	tk := testkit.NewTestKit(b, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table tp (a int, b int, key(a)) partition by range (a) (
+		partition p0 values less than (10), partition p1 values less than maxvalue)`)
+	tk.MustExec("insert into tp values (1, 1), (11, 11)")
+	tk.MustExec("analyze table tp")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+	tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+	tk.MustExec("set tidb_partition_prune_mode=dynamic")
+
+	tk.MustQuery("select b from tp where a > 0")
+	if tk.Session().GetSessionVars().FoundInPlanCache {
+		b.Fatal("first execution unexpectedly hit the plan cache")
+	}
+	tk.MustQuery("select b from tp where a > 1")
+	if !tk.Session().GetSessionVars().FoundInPlanCache {
+		b.Fatal("second execution did not hit the plan cache")
+	}
+
+	// Keep the statement carrier, but make the current InfoSchema/session state
+	// reject it in the public checker on every statement-LRU lookup.
+	tk.MustExec("set tidb_partition_prune_mode=static")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		tk.MustQuery("select b from tp where a > 2")
+		if tk.Session().GetSessionVars().FoundInPlanCache {
+			b.Fatal("static partition pruning unexpectedly hit the plan cache")
+		}
+	}
+}
+
+func BenchmarkUnifiedNonPreparedPlanCacheabilityCheckUnknownLiteralContext(b *testing.B) {
+	bench := func(b *testing.B, unknownContext bool) {
+		store := testkit.CreateMockStore(b)
+		tk := testkit.NewTestKit(b, store)
+		tk.MustExec("use test")
+		tk.MustExec("create table t (a int, key(a))")
+		tk.MustExec("insert into t values (1), (2), (3)")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache=on")
+		tk.MustExec("set tidb_enable_non_prepared_plan_cache_unified_cacheability_check=on")
+
+		identities := make(map[string]struct{})
+		statementLRUHits := 0
+		planCacheHits := 0
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var sql string
+			if unknownContext {
+				// Literals in the projection are not selected by the context-aware
+				// parameterizer and therefore remain part of ParamSQL identity.
+				sql = fmt.Sprintf("select %d as preserved_literal, a from t where a > 0 order by a", i)
+			} else {
+				sql = fmt.Sprintf("select a from t where a > %d order by a", i)
+			}
+
+			stmt, err := parser.New().ParseOneStmt(sql, "", "")
+			if err != nil {
+				b.Fatal(err)
+			}
+			result, supported, reason, err := core.ParameterizeForNonPreparedPlanCache(tk.Session().GetPlanCtx(), stmt)
+			if err != nil || !supported {
+				b.Fatalf("parameterize failed: supported=%v reason=%s err=%v", supported, reason, err)
+			}
+			identities[result.ParamSQL] = struct{}{}
+			lookupCtx := context.WithValue(context.Background(), core.PlanCacheKeyTestNonPreparedStmtLookup{}, func(found bool) {
+				if found {
+					statementLRUHits++
+				}
+			})
+			tk.MustQueryWithContext(lookupCtx, sql)
+			if tk.Session().GetSessionVars().FoundInPlanCache {
+				planCacheHits++
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(len(identities)), "paramsql_identities")
+		b.ReportMetric(float64(statementLRUHits)/float64(b.N), "statement_lru_hits/op")
+		b.ReportMetric(float64(planCacheHits)/float64(b.N), "plan_cache_hits/op")
+	}
+
+	b.Run("unknown_context_preserve", func(b *testing.B) {
+		bench(b, true)
+	})
+	b.Run("filter_parameterize", func(b *testing.B) {
+		bench(b, false)
+	})
 }

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -55,6 +55,15 @@ type PlanCacheKeyTestIssue46760 struct{}
 // PlanCacheKeyTestIssue47133 is only for test.
 type PlanCacheKeyTestIssue47133 struct{}
 
+// PlanCacheKeyTestNonPreparedStmtLookup is only for test.
+type PlanCacheKeyTestNonPreparedStmtLookup struct{}
+
+// PlanCacheKeyTestNonPreparedParam is only for test.
+type PlanCacheKeyTestNonPreparedParam struct{}
+
+// PlanCacheKeyTestNonPreparedParamSQL is only for test.
+type PlanCacheKeyTestNonPreparedParamSQL struct{}
+
 // PlanCacheKeyTestClone is only for test.
 type PlanCacheKeyTestClone struct{}
 

--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -19,9 +19,12 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
@@ -51,7 +54,8 @@ var (
 
 // paramReplacer is an ast.Visitor that replaces all values with `?` and collects them.
 type paramReplacer struct {
-	params []*driver.ValueExpr
+	params       []*driver.ValueExpr
+	parameterize map[*driver.ValueExpr]struct{}
 }
 
 func (pr *paramReplacer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
@@ -78,6 +82,11 @@ func (pr *paramReplacer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 			return in, false
 		}
 	case *driver.ValueExpr:
+		if pr.parameterize != nil {
+			if _, ok := pr.parameterize[n]; !ok {
+				return in, true
+			}
+		}
 		pr.params = append(pr.params, n)
 		param := paramMakerPool.Get().(*driver.ParamMarkerExpr)
 		param.Offset = len(pr.params) - 1 // offset is used as order in non-prepared plan cache.
@@ -93,30 +102,28 @@ func (*paramReplacer) Leave(in ast.Node) (out ast.Node, ok bool) {
 
 func (pr *paramReplacer) Reset() {
 	pr.params = make([]*driver.ValueExpr, 0, 4)
+	pr.parameterize = nil
 }
 
 // GetParamSQLFromAST returns the parameterized SQL of this AST.
 // NOTICE: this function does not modify the original AST.
 // paramVals are copied from this AST.
 func GetParamSQLFromAST(stmt ast.StmtNode) (paramSQL string, paramVals []types.Datum, err error) {
-	var params []*driver.ValueExpr
-	paramSQL, params, err = ParameterizeAST(stmt)
-	if err != nil {
+	paramSQL, paramVals, paramSQLErr, restoreErr := parameterizeAndRestoreAST(stmt, nil)
+	if err := errors.Join(paramSQLErr, restoreErr); err != nil {
 		return "", nil, err
 	}
-	paramVals = make([]types.Datum, len(params))
-	for i, p := range params {
-		p.Datum.Copy(&paramVals[i])
-	}
-
-	err = RestoreASTWithParams(stmt, params)
-	return
+	return paramSQL, paramVals, nil
 }
 
 // ParameterizeAST parameterizes this StmtNode.
 // e.g. `select * from t where a<10 and b<23` --> `select * from t where a<? and b<?`, [10, 23].
 // NOTICE: this function may modify the input stmt.
 func ParameterizeAST(stmt ast.StmtNode) (paramSQL string, params []*driver.ValueExpr, err error) {
+	return parameterizeAST(stmt, nil)
+}
+
+func parameterizeAST(stmt ast.StmtNode, selected map[*driver.ValueExpr]struct{}) (paramSQL string, params []*driver.ValueExpr, err error) {
 	pr := paramReplacerPool.Get().(*paramReplacer)
 	pCtx := paramCtxPool.Get().(*format.RestoreCtx)
 	defer func() {
@@ -125,17 +132,52 @@ func ParameterizeAST(stmt ast.StmtNode) (paramSQL string, params []*driver.Value
 		pCtx.In.(*bytes.Buffer).Reset()
 		paramCtxPool.Put(pCtx)
 	}()
+	pr.parameterize = selected
 	stmt.Accept(pr)
+	params = append(params, pr.params...)
 	if err := stmt.Restore(pCtx); err != nil {
-		return "", nil, err
+		return "", params, err
 	}
-	paramSQL, params = pCtx.In.(*bytes.Buffer).String(), pr.params
+	paramSQL = pCtx.In.(*bytes.Buffer).String()
+	return
+}
+
+func parameterizeAndRestoreAST(stmt ast.StmtNode, selected map[*driver.ValueExpr]struct{}) (
+	paramSQL string,
+	paramVals []types.Datum,
+	paramSQLErr error,
+	restoreErr error,
+) {
+	var params []*driver.ValueExpr
+	paramSQL, params, paramSQLErr = parameterizeAST(stmt, selected)
+	paramVals = make([]types.Datum, len(params))
+	for i, param := range params {
+		param.Datum.Copy(&paramVals[i])
+	}
+	restoreErr = RestoreASTWithParams(stmt, params)
 	return
 }
 
 type paramRestorer struct {
 	params []*driver.ValueExpr
 	err    error
+}
+
+type paramMarkerValidator struct {
+	paramCount int
+	err        error
+}
+
+func (v *paramMarkerValidator) Enter(in ast.Node) (ast.Node, bool) {
+	if marker, ok := in.(*driver.ParamMarkerExpr); ok && (marker.Offset < 0 || marker.Offset >= v.paramCount) {
+		v.err = errors.New("failed to restore ast.Node")
+		return in, true
+	}
+	return in, v.err != nil
+}
+
+func (v *paramMarkerValidator) Leave(in ast.Node) (ast.Node, bool) {
+	return in, v.err == nil
 }
 
 func (pr *paramRestorer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
@@ -166,6 +208,12 @@ func (pr *paramRestorer) Reset() {
 // RestoreASTWithParams restore this parameterized AST with specific parameters.
 // e.g. `select * from t where a<? and b<?`, [10, 23] --> `select * from t where a<10 and b<23`.
 func RestoreASTWithParams(stmt ast.StmtNode, params []*driver.ValueExpr) error {
+	validator := paramMarkerValidator{paramCount: len(params)}
+	stmt.Accept(&validator)
+	if validator.err != nil {
+		return validator.err
+	}
+
 	pr := paramRestorerPool.Get().(*paramRestorer)
 	defer func() {
 		pr.Reset()
@@ -173,7 +221,304 @@ func RestoreASTWithParams(stmt ast.StmtNode, params []*driver.ValueExpr) error {
 	}()
 	pr.params = params
 	stmt.Accept(pr)
+	failpoint.Inject("mockNonPreparedPlanCacheASTRestoreError", func(val failpoint.Value) {
+		// Keep the AST fully restored, but let tests verify that callers propagate
+		// an AST restore error instead of falling back to ordinary optimization.
+		_ = val
+		pr.err = errors.New("failed to restore ast.Node")
+	})
 	return pr.err
+}
+
+// NonPreparedPlanCacheParamResult is the result of parameterizing a normal SQL
+// statement for the non-prepared plan cache.
+type NonPreparedPlanCacheParamResult struct {
+	ParamSQL    string
+	ParamValues []types.Datum
+}
+
+// ParameterizeForNonPreparedPlanCache validates and parameterizes stmt for the
+// non-prepared plan cache. supported=false means the statement should use normal
+// planning instead. An error means the original AST could not be restored safely.
+func ParameterizeForNonPreparedPlanCache(
+	sctx base.PlanContext,
+	stmt ast.StmtNode,
+) (result NonPreparedPlanCacheParamResult, supported bool, reason string, err error) {
+	checker := nonPreparedPlanCachePrechecker{
+		sctx:       sctx,
+		supported:  true,
+		maxLiteral: getMaxParamLimit(sctx),
+	}
+	stmt.Accept(&checker)
+	checker.finalize()
+	if !checker.supported {
+		return result, false, checker.reason, nil
+	}
+
+	selector := nonPreparedPlanCacheParamSelector{
+		selected: make(map[*driver.ValueExpr]struct{}),
+	}
+	if !selector.selectStatement(stmt) {
+		return result, false, "not a SELECT/UPDATE/INSERT/DELETE/SET statement", nil
+	}
+
+	paramSQL, paramValues, paramSQLErr, restoreErr := parameterizeAndRestoreAST(stmt, selector.selected)
+	if restoreErr != nil {
+		return result, false, "", errors.Join(paramSQLErr, restoreErr)
+	}
+	if paramSQLErr != nil {
+		return result, false, "failed to restore parameterized SQL", nil
+	}
+	return NonPreparedPlanCacheParamResult{
+		ParamSQL:    paramSQL,
+		ParamValues: paramValues,
+	}, true, "", nil
+}
+
+type nonPreparedPlanCachePrechecker struct {
+	sctx                 base.PlanContext
+	supported            bool
+	reason               string
+	literalCount         int
+	maxLiteral           int
+	tooManyLiterals      bool
+	hasCharsetIntroducer bool
+	hasLimit             bool
+	hasSelectInto        bool
+	hasMultiTableUpdate  bool
+	hasMultiTableDelete  bool
+	hasParamMarker       bool
+}
+
+func (c *nonPreparedPlanCachePrechecker) Enter(in ast.Node) (ast.Node, bool) {
+	switch node := in.(type) {
+	case *driver.ValueExpr:
+		c.literalCount++
+		if c.maxLiteral > 0 && c.literalCount > c.maxLiteral {
+			c.tooManyLiterals = true
+		}
+		if node.GetType().GetFlag()&mysql.UnderScoreCharsetFlag != 0 {
+			c.hasCharsetIntroducer = true
+		}
+	case *driver.ParamMarkerExpr:
+		// A marker in the original non-prepared statement is not one of the
+		// markers generated by this parameterization pass. Keeping it in the
+		// AST would make RestoreASTWithParams unable to distinguish the two
+		// kinds of markers safely, so bypass the unified path for the whole
+		// statement.
+		c.hasParamMarker = true
+	case *ast.Limit:
+		if !c.sctx.GetSessionVars().EnablePlanCacheForParamLimit {
+			c.hasLimit = true
+		}
+	case *ast.SelectStmt:
+		if node.SelectIntoOpt != nil {
+			c.hasSelectInto = true
+		}
+	case *ast.UpdateStmt:
+		if node.MultipleTable || (node.TableRefs != nil && node.TableRefs.TableRefs != nil && node.TableRefs.TableRefs.Right != nil) {
+			c.hasMultiTableUpdate = true
+		}
+	case *ast.DeleteStmt:
+		if node.IsMultiTable {
+			c.hasMultiTableDelete = true
+		}
+	}
+	return in, false
+}
+
+func (c *nonPreparedPlanCachePrechecker) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+func (c *nonPreparedPlanCachePrechecker) finalize() {
+	// Keep statement-level gates ahead of literal-level gates. The order is
+	// explicit so the reported bypass reason does not depend on AST traversal.
+	switch {
+	case c.hasSelectInto:
+		c.reason = "SELECT INTO is not supported"
+	case c.hasMultiTableUpdate:
+		c.reason = "multiple-table UPDATE is not supported"
+	case c.hasMultiTableDelete:
+		c.reason = "multiple-table DELETE is not supported"
+	case c.hasParamMarker:
+		c.reason = "query has parameter markers"
+	case c.tooManyLiterals:
+		c.reason = "query has too many constants"
+	case c.hasCharsetIntroducer:
+		c.reason = "query has values with under-score charset that cannot be preserved safely"
+	case c.hasLimit:
+		c.reason = "query has 'limit ?' is un-cacheable"
+	}
+	c.supported = c.reason == ""
+}
+
+type nonPreparedPlanCacheParamSelector struct {
+	selected map[*driver.ValueExpr]struct{}
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectStatement(stmt ast.StmtNode) bool {
+	switch node := stmt.(type) {
+	case *ast.SelectStmt:
+		s.selectSelect(node)
+	case *ast.SetOprStmt:
+		s.selectSetOperation(node)
+	case *ast.InsertStmt:
+		s.selectResultSet(node.Table.TableRefs)
+		for _, row := range node.Lists {
+			for _, expr := range row {
+				s.selectExpression(expr)
+			}
+		}
+		for _, assignment := range node.OnDuplicate {
+			s.selectExpression(assignment.Expr)
+		}
+		if node.Select != nil {
+			s.selectResultSet(node.Select)
+		}
+	case *ast.UpdateStmt:
+		s.selectWith(node.With)
+		s.selectResultSet(node.TableRefs.TableRefs)
+		for _, assignment := range node.List {
+			s.selectExpression(assignment.Expr)
+		}
+		s.selectExpression(node.Where)
+	case *ast.DeleteStmt:
+		s.selectWith(node.With)
+		s.selectResultSet(node.TableRefs.TableRefs)
+		s.selectExpression(node.Where)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectSelect(stmt *ast.SelectStmt) {
+	s.selectWith(stmt.With)
+	if stmt.From != nil {
+		s.selectResultSet(stmt.From.TableRefs)
+	}
+	s.selectExpression(stmt.Where)
+	if stmt.Having != nil {
+		s.selectExpression(stmt.Having.Expr)
+	}
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectSetOperation(stmt *ast.SetOprStmt) {
+	s.selectWith(stmt.With)
+	s.selectSetOperationList(stmt.SelectList)
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectSetOperationList(list *ast.SetOprSelectList) {
+	if list == nil {
+		return
+	}
+	s.selectWith(list.With)
+	for _, node := range list.Selects {
+		switch selectNode := node.(type) {
+		case *ast.SelectStmt:
+			s.selectSelect(selectNode)
+		case *ast.SetOprSelectList:
+			s.selectSetOperationList(selectNode)
+		}
+	}
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectWith(with *ast.WithClause) {
+	if with == nil {
+		return
+	}
+	for _, cte := range with.CTEs {
+		if cte != nil && cte.Query != nil {
+			s.selectResultSet(cte.Query.Query)
+		}
+	}
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectResultSet(resultSet ast.ResultSetNode) {
+	switch node := resultSet.(type) {
+	case *ast.Join:
+		s.selectResultSet(node.Left)
+		s.selectResultSet(node.Right)
+		if node.On != nil {
+			s.selectExpression(node.On.Expr)
+		}
+	case *ast.TableSource:
+		s.selectResultSet(node.Source)
+	case *ast.SelectStmt:
+		s.selectSelect(node)
+	case *ast.SetOprStmt:
+		s.selectSetOperation(node)
+	case *ast.SubqueryExpr:
+		s.selectResultSet(node.Query)
+	}
+}
+
+func (s *nonPreparedPlanCacheParamSelector) selectExpression(expr ast.ExprNode) {
+	if expr == nil {
+		return
+	}
+	expr.Accept(&nonPreparedPlanCacheExprSelector{selector: s})
+}
+
+type nonPreparedPlanCacheExprSelector struct {
+	selector *nonPreparedPlanCacheParamSelector
+}
+
+func (s *nonPreparedPlanCacheExprSelector) Enter(in ast.Node) (ast.Node, bool) {
+	switch node := in.(type) {
+	case *driver.ValueExpr:
+		if node.IsNull() || node.Kind() == types.KindBinaryLiteral || node.GetType().GetFlag()&mysql.UnderScoreCharsetFlag != 0 {
+			return in, true
+		}
+		s.selector.selected[node] = struct{}{}
+		return in, true
+	case *ast.SubqueryExpr:
+		s.selector.selectResultSet(node.Query)
+		return in, true
+	case *ast.FuncCallExpr:
+		switch node.FnName.L {
+		case ast.DateFormat, ast.StrToDate, ast.TimeFormat, ast.FromUnixTime:
+			if len(node.Args) > 0 {
+				s.selector.selectExpression(node.Args[0])
+			}
+			return in, true
+		default:
+			return in, false
+		}
+	case *ast.FrameBound:
+		return in, true
+	case *ast.WhenClause, *ast.WindowSpec, *ast.FrameClause:
+		// These are structural nodes whose expression children are safe to
+		// inspect. FrameBound itself is handled above because frame literals
+		// must remain preserved.
+		return in, false
+	case *ast.SelectField, *ast.GroupByClause, *ast.OrderByClause, *ast.Limit,
+		*ast.ByItem, *ast.ColumnName, *ast.TableName:
+		// Projection, grouping, ordering, limits, and identifier nodes are
+		// preserve-first contexts. Do not descend into a future child added to
+		// one of these nodes accidentally.
+		return in, true
+	case *ast.BetweenExpr, *ast.BinaryOperationExpr, *ast.CaseExpr,
+		*ast.CompareSubqueryExpr, *ast.ExistsSubqueryExpr, *ast.IsNullExpr,
+		*ast.IsTruthExpr, *ast.ParenthesesExpr, *ast.PatternInExpr,
+		*ast.PatternLikeOrIlikeExpr, *ast.PatternRegexpExpr, *ast.PositionExpr,
+		*ast.RowExpr, *ast.UnaryOperationExpr, *ast.ValuesExpr,
+		*ast.VariableExpr, *ast.MatchAgainst, *ast.SetCollationExpr,
+		*ast.TableNameExpr, *ast.ColumnNameExpr, *ast.DefaultExpr,
+		*ast.MaxValueExpr, *ast.FuncCastExpr, *ast.TrimDirectionExpr,
+		*ast.AggregateFuncExpr, *ast.WindowFuncExpr, *ast.TimeUnitExpr,
+		*ast.GetFormatSelectorExpr:
+		return in, false
+	}
+	// Unknown expression and structural nodes default to preserve. This is a
+	// forward-compatibility fence: a new AST node must opt into parameterization
+	// explicitly after its literal semantics are reviewed.
+	return in, true
+}
+
+func (*nonPreparedPlanCacheExprSelector) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
 }
 
 // Params2Expressions converts these parameters to an expression list.

--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -478,13 +478,103 @@ func (s *nonPreparedPlanCacheExprSelector) Enter(in ast.Node) (ast.Node, bool) {
 		return in, true
 	case *ast.FuncCallExpr:
 		switch node.FnName.L {
-		case ast.DateFormat, ast.StrToDate, ast.TimeFormat, ast.FromUnixTime:
+		case ast.DateFormat, ast.StrToDate, ast.TimeFormat:
 			if len(node.Args) > 0 {
 				s.selector.selectExpression(node.Args[0])
 			}
 			return in, true
+		case ast.WeightString:
+			// WEIGHT_STRING's AS CHAR/BINARY and length arguments are syntax
+			// parameters, not expressions. Preserve them so the restored
+			// parameterized SQL remains valid and the built-in keeps its padding
+			// mode and length.
+			if len(node.Args) > 0 {
+				s.selector.selectExpression(node.Args[0])
+			}
+			return in, true
+		case ast.FromUnixTime:
+			// FROM_UNIXTIME derives the one-argument result FSP from the first
+			// timestamp argument while building the function signature. Preserve
+			// all arguments so a different timestamp precision gets a new carrier.
+			return in, true
+		case ast.CharFunc:
+			// CHAR's last argument is the charset selected by USING. It is
+			// evaluated while building the function signature, so it must stay
+			// a constant in the parameterized AST.
+			for i, arg := range node.Args {
+				if i == len(node.Args)-1 {
+					continue
+				}
+				s.selector.selectExpression(arg)
+			}
+			return in, true
+		case ast.Lpad, ast.Rpad:
+			// LPAD/RPAD derive the result Flen from the length argument at
+			// build time. Preserve that argument while parameterizing the
+			// string and padding expressions.
+			if len(node.Args) > 0 {
+				s.selector.selectExpression(node.Args[0])
+			}
+			if len(node.Args) > 2 {
+				s.selector.selectExpression(node.Args[2])
+			}
+			return in, true
+		case ast.ConvertTz, ast.UnixTimestamp:
+			// These functions derive their result precision from the first
+			// argument's value/type while the plan is built. Preserve that
+			// argument so a later execution cannot reuse a signature with a
+			// different temporal precision.
+			for i, arg := range node.Args {
+				if i == 0 {
+					continue
+				}
+				s.selector.selectExpression(arg)
+			}
+			return in, true
+		case ast.Time, ast.CurrentTime, ast.Curtime, ast.LocalTime,
+			ast.Now, ast.CurrentTimestamp, ast.LocalTimestamp, ast.UTCTime,
+			ast.UTCTimestamp, ast.Sysdate:
+			// These functions derive their result FSP from a constant argument
+			// while building the function signature. Keep the argument in the
+			// statement identity instead of replacing it with a marker.
+			return in, true
+		case ast.TimeDiff, ast.Timestamp:
+			// Both arguments contribute to the temporal result type (FSP, and for
+			// TIMESTAMP the first argument's numeric-vs-string type).
+			return in, true
+		case ast.AddTime, ast.SubTime:
+			// ADDTIME and SUBTIME derive the result FSP and Flen from both
+			// arguments while building the function signature.
+			return in, true
+		case ast.Round, ast.Truncate:
+			// The value type and the requested scale are both used to construct
+			// the result type. Preserve the whole argument list so neither can be
+			// changed while reusing a cached signature.
+			return in, true
+		case ast.Rand:
+			// A constant RAND seed initializes the RNG when the signature is
+			// built. Preserve it so a different seed cannot reuse that state.
+			return in, true
+		case ast.Benchmark:
+			// BENCHMARK caches a positive constant loop count in its signature.
+			// Preserve that argument, but still select literals in the expression
+			// being benchmarked using the regular expression rules.
+			if len(node.Args) > 1 {
+				s.selector.selectExpression(node.Args[1])
+			}
+			return in, true
 		default:
 			return in, false
+		}
+	case *ast.AggregateFuncExpr:
+		if node.F == ast.AggFuncApproxPercentile {
+			// The percentage argument must remain a constant because the
+			// aggregate descriptor evaluates it while the plan is built.
+			// Parameterize only the data expression and preserve the percentage.
+			if len(node.Args) > 0 {
+				s.selector.selectExpression(node.Args[0])
+			}
+			return in, true
 		}
 	case *ast.FrameBound:
 		return in, true
@@ -507,7 +597,7 @@ func (s *nonPreparedPlanCacheExprSelector) Enter(in ast.Node) (ast.Node, bool) {
 		*ast.VariableExpr, *ast.MatchAgainst, *ast.SetCollationExpr,
 		*ast.TableNameExpr, *ast.ColumnNameExpr, *ast.DefaultExpr,
 		*ast.MaxValueExpr, *ast.FuncCastExpr, *ast.TrimDirectionExpr,
-		*ast.AggregateFuncExpr, *ast.WindowFuncExpr, *ast.TimeUnitExpr,
+		*ast.WindowFuncExpr, *ast.TimeUnitExpr,
 		*ast.GetFormatSelectorExpr:
 		return in, false
 	}

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -158,7 +158,8 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 		if isPrepStmt {
 			cacheable, reason = IsASTCacheable(ctx, sctx.GetPlanCtx(), paramStmt, ret.InfoSchema)
 		} else {
-			cacheable = true // it is already checked here
+			// The non-prepared caller checks cacheability before building the PlanCacheStmt.
+			cacheable = true
 		}
 
 		if !cacheable && fixcontrol.GetBoolWithDefault(vars.OptimizerFixControl, fixcontrol.Fix49736, false) {
@@ -194,7 +195,9 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 		// dynamic prune mode is not used, could be that global statistics not yet available!
 		cacheable = false
 		reason = "static partition prune mode used"
-		sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("skip prepared plan-cache: " + reason))
+		if isPrepStmt || !vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck {
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("skip prepared plan-cache: " + reason))
+		}
 	}
 
 	// Collect information for metadata lock.

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/filter"
+	h "github.com/pingcap/tidb/pkg/util/hint"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
@@ -96,9 +97,35 @@ type cacheableChecker struct {
 func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.SelectStmt:
-		if node.With != nil {
-			// Record the CTE visibility boundary for this query block.
-			checker.withScopeOffset = append(checker.withScopeOffset, len(checker.cteCanUsed))
+		checker.enterWithScope(node.With)
+		for _, hints := range node.TableHints {
+			if hints.HintName.L == h.HintIgnorePlanCache {
+				checker.cacheable = false
+				checker.reason = "ignore plan cache by hint"
+				return in, true
+			}
+		}
+	case *ast.SetOprStmt:
+		checker.enterWithScope(node.With)
+	case *ast.SetOprSelectList:
+		checker.enterWithScope(node.With)
+	case *ast.DeleteStmt:
+		checker.enterWithScope(node.With)
+		for _, hints := range node.TableHints {
+			if hints.HintName.L == h.HintIgnorePlanCache {
+				checker.cacheable = false
+				checker.reason = "ignore plan cache by hint"
+				return in, true
+			}
+		}
+	case *ast.UpdateStmt:
+		checker.enterWithScope(node.With)
+		for _, hints := range node.TableHints {
+			if hints.HintName.L == h.HintIgnorePlanCache {
+				checker.cacheable = false
+				checker.reason = "ignore plan cache by hint"
+				return in, true
+			}
 		}
 	case *ast.InsertStmt:
 		if node.Select == nil {
@@ -110,6 +137,13 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 			if nRows*nCols > checker.maxNumParam { // to save memory
 				checker.cacheable = false
 				checker.reason = "too many values in the insert statement"
+				return in, true
+			}
+		}
+		for _, hints := range node.TableHints {
+			if hints.HintName.L == h.HintIgnorePlanCache {
+				checker.cacheable = false
+				checker.reason = "ignore plan cache by hint"
 				return in, true
 			}
 		}
@@ -206,16 +240,38 @@ func (checker *cacheableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
 	switch node := in.(type) {
 	case *ast.CommonTableExpression:
 		if !node.IsRecursive {
-			// Non-recursive CTE becomes visible only after its definition has been fully traversed.
+			// Non-recursive CTE becomes visible only after its definition is fully traversed.
 			checker.cteCanUsed = append(checker.cteCanUsed, node.Name.L)
 		}
 	case *ast.SelectStmt:
 		if node.With != nil {
-			// Leave query-block WITH scope and restore CTE visibility from outer context.
+			checker.leaveWithScope()
+		}
+	case *ast.SetOprStmt:
+		if node.With != nil {
+			checker.leaveWithScope()
+		}
+	case *ast.SetOprSelectList:
+		if node.With != nil {
+			checker.leaveWithScope()
+		}
+	case *ast.DeleteStmt:
+		if node.With != nil {
+			checker.leaveWithScope()
+		}
+	case *ast.UpdateStmt:
+		if node.With != nil {
 			checker.leaveWithScope()
 		}
 	}
 	return in, checker.cacheable
+}
+
+func (checker *cacheableChecker) enterWithScope(with *ast.WithClause) {
+	if with != nil {
+		// Record the CTE visibility boundary for this query block.
+		checker.withScopeOffset = append(checker.withScopeOffset, len(checker.cteCanUsed))
+	}
 }
 
 func (checker *cacheableChecker) leaveWithScope() {

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	core_metrics "github.com/pingcap/tidb/pkg/planner/core/metrics"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/planner/core/rule"
 	"github.com/pingcap/tidb/pkg/planner/indexadvisor"
@@ -66,28 +67,38 @@ func containUsePlanCacheHintInSQLOrBinding(sctx sessionctx.Context, stmt ast.Stm
 
 // getPlanFromNonPreparedPlanCache tries to get an available cached plan from the NonPrepared Plan Cache for this stmt.
 func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW, is infoschema.InfoSchema) (p base.Plan, ns types.NameSlice, ok bool, err error) {
-	stmtCtx := sctx.GetSessionVars().StmtCtx
+	vars := sctx.GetSessionVars()
+	stmtCtx := vars.StmtCtx
 	stmt, isStmtNode := node.Node.(ast.StmtNode)
 	_, isExplain := stmt.(*ast.ExplainStmt)
-	if !sctx.GetSessionVars().EnableNonPreparedPlanCache || // disabled
+	if !vars.EnableNonPreparedPlanCache || // disabled
 		!isStmtNode ||
+		stmtCtx.EnableOptimizerCETrace || stmtCtx.EnableOptimizeTrace || // in trace
 		stmtCtx.InRestrictedSQL || // is internal SQL
 		isExplain || // explain external
-		!sctx.GetSessionVars().DisableTxnAutoRetry || // txn-auto-retry
-		sctx.GetSessionVars().InMultiStmts { // in multi-stmt
+		!vars.DisableTxnAutoRetry || // txn-auto-retry
+		vars.InMultiStmts || // in multi-stmt
+		(stmtCtx.InExplainStmt && stmtCtx.ExplainFormat != types.ExplainFormatPlanCache) { // in explain internal
 		return nil, nil, false, nil
 	}
-	if sctx.GetSessionVars().PlanCacheStrategy == vardef.TiDBPlanCacheStrategyHintOnly &&
+	if vars.PlanCacheStrategy == vardef.TiDBPlanCacheStrategyHintOnly &&
 		!containUsePlanCacheHintInSQLOrBinding(sctx, stmt) {
 		if !isExplain && stmtCtx.InExplainStmt && stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
 			stmtCtx.AppendWarning(errors.NewNoStackErrorf("skip non-prepared plan-cache: %s", nonPreparedPlanCacheHintOnlyNoHintReason))
 		}
 		return nil, nil, false, nil
 	}
+	if vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck {
+		return getPlanFromNonPreparedPlanCacheUnified(ctx, sctx, stmt, is)
+	}
+	return getPlanFromNonPreparedPlanCacheLegacy(ctx, sctx, stmt, is)
+}
 
+func getPlanFromNonPreparedPlanCacheLegacy(ctx context.Context, sctx sessionctx.Context, stmt ast.StmtNode, is infoschema.InfoSchema) (p base.Plan, ns types.NameSlice, ok bool, err error) {
+	stmtCtx := sctx.GetSessionVars().StmtCtx
 	ok, reason := core.NonPreparedPlanCacheableWithCtx(sctx.GetPlanCtx(), stmt, is)
 	if !ok {
-		if !isExplain && stmtCtx.InExplainStmt && stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
+		if stmtCtx.InExplainStmt && stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
 			stmtCtx.AppendWarning(errors.NewNoStackErrorf("skip non-prepared plan-cache: %s", reason))
 		}
 		return nil, nil, false, nil
@@ -101,6 +112,9 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 		ctx.Value(core.PlanCacheKeyTestIssue43667{}).(func(stmt ast.StmtNode))(stmt)
 	}
 	val := sctx.GetSessionVars().GetNonPreparedPlanCacheStmt(paramSQL)
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestNonPreparedStmtLookup{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestNonPreparedStmtLookup{}).(func(bool))(val != nil)
+	}
 	paramExprs := core.Params2Expressions(paramsVals)
 
 	if val == nil {
@@ -135,6 +149,105 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 	}
 
 	return cachedPlan, names, true, nil
+}
+
+func getPlanFromNonPreparedPlanCacheUnified(ctx context.Context, sctx sessionctx.Context, stmt ast.StmtNode, is infoschema.InfoSchema) (p base.Plan, ns types.NameSlice, ok bool, err error) {
+	vars := sctx.GetSessionVars()
+	stmtCtx := vars.StmtCtx
+	if allowed, reason := nonPreparedPlanCacheDMLAllowed(vars, stmt); !allowed {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, false)
+		return nil, nil, false, nil
+	}
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestNonPreparedParam{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestNonPreparedParam{}).(func(ast.StmtNode))(stmt)
+	}
+
+	result, supported, reason, err := core.ParameterizeForNonPreparedPlanCache(sctx.GetPlanCtx(), stmt)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if !supported {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, true)
+		return nil, nil, false, nil
+	}
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestNonPreparedParamSQL{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestNonPreparedParamSQL{}).(func(*string))(&result.ParamSQL)
+	}
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestIssue43667{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestIssue43667{}).(func(stmt ast.StmtNode))(stmt)
+	}
+
+	paramExprs := core.Params2Expressions(result.ParamValues)
+	value := vars.GetNonPreparedPlanCacheStmt(result.ParamSQL)
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestNonPreparedStmtLookup{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestNonPreparedStmtLookup{}).(func(bool))(value != nil)
+	}
+	var cachedStmt *core.PlanCacheStmt
+	var paramStmt ast.StmtNode
+	if value == nil {
+		paramStmt, err = core.ParseParameterizedSQL(sctx, result.ParamSQL)
+		if err != nil {
+			recordNonPreparedPlanCacheBypass(stmtCtx, "failed to parse parameterized SQL", true)
+			return nil, nil, false, nil
+		}
+	} else {
+		cachedStmt = value.(*core.PlanCacheStmt)
+		paramStmt = cachedStmt.PreparedAst.Stmt
+	}
+
+	cacheable, reason := core.IsASTCacheable(ctx, sctx.GetPlanCtx(), paramStmt, is)
+	if !cacheable {
+		recordNonPreparedPlanCacheBypass(stmtCtx, reason, true)
+		return nil, nil, false, nil
+	}
+
+	if cachedStmt == nil {
+		if err := core.SetParameterValuesIntoSCtx(sctx.GetPlanCtx(), true, nil, paramExprs); err != nil {
+			return nil, nil, false, err
+		}
+		cachedStmt, _, _, err = core.GeneratePlanCacheStmtWithAST(ctx, sctx, false, result.ParamSQL, paramStmt, is)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if !cachedStmt.StmtCacheable {
+			recordNonPreparedPlanCacheBypass(stmtCtx, cachedStmt.UncacheableReason, true)
+			return nil, nil, false, nil
+		}
+		vars.AddNonPreparedPlanCacheStmt(result.ParamSQL, cachedStmt)
+	}
+
+	cachedPlan, names, err := core.GetPlanFromPlanCache(ctx, sctx, true, is, cachedStmt, paramExprs)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if intest.InTest && ctx.Value(core.PlanCacheKeyTestIssue47133{}) != nil {
+		ctx.Value(core.PlanCacheKeyTestIssue47133{}).(func(names []*types.FieldName))(names)
+	}
+	return cachedPlan, names, true, nil
+}
+
+func nonPreparedPlanCacheDMLAllowed(vars *variable.SessionVars, stmt ast.StmtNode) (bool, string) {
+	if vars.EnableNonPreparedPlanCacheForDML {
+		return true, ""
+	}
+	switch stmt := stmt.(type) {
+	case *ast.SelectStmt:
+		if stmt.LockInfo == nil {
+			return true, ""
+		}
+	case *ast.SetOprStmt:
+		return true, ""
+	}
+	return false, "not a SELECT statement"
+}
+
+func recordNonPreparedPlanCacheBypass(stmtCtx *stmtctx.StatementContext, reason string, countUnsupported bool) {
+	if countUnsupported {
+		core_metrics.GetNonPrepPlanCacheUnsupportedCounter().Inc()
+	}
+	if stmtCtx.InExplainStmt && stmtCtx.ExplainFormat == types.ExplainFormatPlanCache {
+		stmtCtx.AppendWarning(errors.NewNoStackErrorf("skip non-prepared plan-cache: %s", reason))
+	}
 }
 
 // Optimize does optimization and creates a Plan.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -200,7 +200,17 @@ func getPlanFromNonPreparedPlanCacheUnified(ctx context.Context, sctx sessionctx
 		recordNonPreparedPlanCacheBypass(stmtCtx, reason, true)
 		return nil, nil, false, nil
 	}
-
+	// A legacy execution may leave a non-cacheable carrier in the statement LRU
+	// before the unified checker is enabled. Rebuild it after the current AST
+	// check succeeds so a later physical-cacheable execution can recover.
+	if cachedStmt != nil && !cachedStmt.StmtCacheable {
+		cachedStmt = nil
+		paramStmt, err = core.ParseParameterizedSQL(sctx, result.ParamSQL)
+		if err != nil {
+			recordNonPreparedPlanCacheBypass(stmtCtx, "failed to parse parameterized SQL", true)
+			return nil, nil, false, nil
+		}
+	}
 	if cachedStmt == nil {
 		if err := core.SetParameterValuesIntoSCtx(sctx.GetPlanCtx(), true, nil, paramExprs); err != nil {
 			return nil, nil, false, err
@@ -232,13 +242,40 @@ func nonPreparedPlanCacheDMLAllowed(vars *variable.SessionVars, stmt ast.StmtNod
 	}
 	switch stmt := stmt.(type) {
 	case *ast.SelectStmt:
-		if stmt.LockInfo == nil {
+		if !containsLockingRead(stmt) {
 			return true, ""
 		}
 	case *ast.SetOprStmt:
-		return true, ""
+		if !containsLockingRead(stmt) {
+			return true, ""
+		}
 	}
 	return false, "not a SELECT statement"
+}
+
+type lockingReadFinder struct {
+	found bool
+}
+
+func (finder *lockingReadFinder) Enter(in ast.Node) (ast.Node, bool) {
+	if stmt, ok := in.(*ast.SelectStmt); ok && stmt.LockInfo != nil {
+		finder.found = true
+		return in, true
+	}
+	return in, false
+}
+
+func (*lockingReadFinder) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
+}
+
+func containsLockingRead(node ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	finder := lockingReadFinder{}
+	node.Accept(&finder)
+	return finder.found
 }
 
 func recordNonPreparedPlanCacheBypass(stmtCtx *stmtctx.StatementContext, reason string, countUnsupported bool) {

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -978,6 +978,8 @@ const (
 
 	// TiDBEnableNonPreparedPlanCache indicates whether to enable non-prepared plan cache.
 	TiDBEnableNonPreparedPlanCache = "tidb_enable_non_prepared_plan_cache"
+	// TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck controls whether the non-prepared plan cache uses the unified cacheability checks.
+	TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck = "tidb_enable_non_prepared_plan_cache_unified_cacheability_check"
 	// TiDBEnableNonPreparedPlanCacheForDML indicates whether to enable non-prepared plan cache for DML statements.
 	TiDBEnableNonPreparedPlanCacheForDML = "tidb_enable_non_prepared_plan_cache_for_dml"
 	// TiDBPlanCacheStrategy controls plan cache strategy.
@@ -1884,6 +1886,9 @@ const (
 	DefConnectAttrsSize             int64 = 4096
 	DefTiDBEnableConnectionEventLog       = false
 )
+
+// DefTiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck is the default value for the unified non-prepared plan cache cacheability check.
+const DefTiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck = false
 
 const (
 	// MaxTiDBAnalyzeStoreBatchSize is the upper bound for child Region tasks in one Analyze store batch.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1651,6 +1651,9 @@ type SessionVars struct {
 	// EnableNonPreparedPlanCache indicates whether to enable non-prepared plan cache.
 	EnableNonPreparedPlanCache bool
 
+	// EnableNonPreparedPlanCacheUnifiedCacheabilityCheck indicates whether to use the unified non-prepared plan cache checks.
+	EnableNonPreparedPlanCacheUnifiedCacheabilityCheck bool
+
 	// EnableNonPreparedPlanCacheForDML indicates whether to enable non-prepared plan cache for DML statements.
 	EnableNonPreparedPlanCacheForDML bool
 
@@ -2507,6 +2510,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		OptPartialOrderedIndexForTopN:    vardef.DefTiDBOptPartialOrderedIndexForTopN,
 		EnableCachePrepareStmt:           vardef.DefEnableCachePrepareStmt,
 	}
+	vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = vardef.DefTiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck
 	vars.TiFlashFineGrainedShuffleBatchSize = vardef.DefTiFlashFineGrainedShuffleBatchSize
 	vars.status.Store(uint32(mysql.ServerStatusAutocommit))
 	vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName
@@ -2918,12 +2922,61 @@ func (k planCacheStmtKey) Hash() []byte {
 	return []byte(k)
 }
 
+func writePlanCacheStmtKeyString(builder *strings.Builder, value string) {
+	var length [8]byte
+	binary.LittleEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = builder.Write(length[:])
+	_, _ = builder.WriteString(value)
+}
+
+func (s *SessionVars) nonPreparedPlanCacheStmtKey(sql string) planCacheStmtKey {
+	charset, collation := s.GetCharsetInfo()
+	characterSetClient, ok := s.systems[vardef.CharacterSetClient]
+	if !ok && s.GlobalVarsAccessor != nil {
+		var err error
+		characterSetClient, err = s.GetSessionOrGlobalSystemVar(context.Background(), vardef.CharacterSetClient)
+		ok = err == nil
+	}
+	if !ok {
+		characterSetClient = GetSysVar(vardef.CharacterSetClient).Value
+	}
+	parserConfig := s.BuildParserConfig()
+
+	var builder strings.Builder
+	builder.Grow(len(sql) + len(charset) + len(collation) + len(characterSetClient) + len(s.CurrentDB) + 64)
+	writePlanCacheStmtKeyString(&builder, sql)
+	writePlanCacheStmtKeyString(&builder, charset)
+	writePlanCacheStmtKeyString(&builder, collation)
+	writePlanCacheStmtKeyString(&builder, characterSetClient)
+	writePlanCacheStmtKeyString(&builder, s.CurrentDB)
+
+	var sqlMode [8]byte
+	binary.LittleEndian.PutUint64(sqlMode[:], uint64(s.SQLMode))
+	_, _ = builder.Write(sqlMode[:])
+	if parserConfig.EnableWindowFunction {
+		_ = builder.WriteByte(1)
+	} else {
+		_ = builder.WriteByte(0)
+	}
+	if parserConfig.EnableStrictDoubleTypeCheck {
+		_ = builder.WriteByte(1)
+	} else {
+		_ = builder.WriteByte(0)
+	}
+	if s.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck {
+		_ = builder.WriteByte(1)
+	} else {
+		_ = builder.WriteByte(0)
+	}
+	return planCacheStmtKey(builder.String())
+}
+
 // AddNonPreparedPlanCacheStmt adds this PlanCacheStmt into non-preapred plan-cache stmt cache
 func (s *SessionVars) AddNonPreparedPlanCacheStmt(sql string, stmt any) {
 	if s.nonPreparedPlanCacheStmts == nil {
 		s.nonPreparedPlanCacheStmts = kvcache.NewSimpleLRUCache(uint(s.SessionPlanCacheSize), 0, 0)
 	}
-	s.nonPreparedPlanCacheStmts.Put(planCacheStmtKey(sql), stmt)
+	s.nonPreparedPlanCacheStmts.Put(s.nonPreparedPlanCacheStmtKey(sql), stmt)
 }
 
 // GetNonPreparedPlanCacheStmt gets the PlanCacheStmt.
@@ -2931,7 +2984,7 @@ func (s *SessionVars) GetNonPreparedPlanCacheStmt(sql string) any {
 	if s.nonPreparedPlanCacheStmts == nil {
 		return nil
 	}
-	stmt, _ := s.nonPreparedPlanCacheStmts.Get(planCacheStmtKey(sql))
+	stmt, _ := s.nonPreparedPlanCacheStmts.Get(s.nonPreparedPlanCacheStmtKey(sql))
 	return stmt
 }
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2922,61 +2922,12 @@ func (k planCacheStmtKey) Hash() []byte {
 	return []byte(k)
 }
 
-func writePlanCacheStmtKeyString(builder *strings.Builder, value string) {
-	var length [8]byte
-	binary.LittleEndian.PutUint64(length[:], uint64(len(value)))
-	_, _ = builder.Write(length[:])
-	_, _ = builder.WriteString(value)
-}
-
-func (s *SessionVars) nonPreparedPlanCacheStmtKey(sql string) planCacheStmtKey {
-	charset, collation := s.GetCharsetInfo()
-	characterSetClient, ok := s.systems[vardef.CharacterSetClient]
-	if !ok && s.GlobalVarsAccessor != nil {
-		var err error
-		characterSetClient, err = s.GetSessionOrGlobalSystemVar(context.Background(), vardef.CharacterSetClient)
-		ok = err == nil
-	}
-	if !ok {
-		characterSetClient = GetSysVar(vardef.CharacterSetClient).Value
-	}
-	parserConfig := s.BuildParserConfig()
-
-	var builder strings.Builder
-	builder.Grow(len(sql) + len(charset) + len(collation) + len(characterSetClient) + len(s.CurrentDB) + 64)
-	writePlanCacheStmtKeyString(&builder, sql)
-	writePlanCacheStmtKeyString(&builder, charset)
-	writePlanCacheStmtKeyString(&builder, collation)
-	writePlanCacheStmtKeyString(&builder, characterSetClient)
-	writePlanCacheStmtKeyString(&builder, s.CurrentDB)
-
-	var sqlMode [8]byte
-	binary.LittleEndian.PutUint64(sqlMode[:], uint64(s.SQLMode))
-	_, _ = builder.Write(sqlMode[:])
-	if parserConfig.EnableWindowFunction {
-		_ = builder.WriteByte(1)
-	} else {
-		_ = builder.WriteByte(0)
-	}
-	if parserConfig.EnableStrictDoubleTypeCheck {
-		_ = builder.WriteByte(1)
-	} else {
-		_ = builder.WriteByte(0)
-	}
-	if s.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck {
-		_ = builder.WriteByte(1)
-	} else {
-		_ = builder.WriteByte(0)
-	}
-	return planCacheStmtKey(builder.String())
-}
-
 // AddNonPreparedPlanCacheStmt adds this PlanCacheStmt into non-preapred plan-cache stmt cache
 func (s *SessionVars) AddNonPreparedPlanCacheStmt(sql string, stmt any) {
 	if s.nonPreparedPlanCacheStmts == nil {
 		s.nonPreparedPlanCacheStmts = kvcache.NewSimpleLRUCache(uint(s.SessionPlanCacheSize), 0, 0)
 	}
-	s.nonPreparedPlanCacheStmts.Put(s.nonPreparedPlanCacheStmtKey(sql), stmt)
+	s.nonPreparedPlanCacheStmts.Put(planCacheStmtKey(sql), stmt)
 }
 
 // GetNonPreparedPlanCacheStmt gets the PlanCacheStmt.
@@ -2984,7 +2935,7 @@ func (s *SessionVars) GetNonPreparedPlanCacheStmt(sql string) any {
 	if s.nonPreparedPlanCacheStmts == nil {
 		return nil
 	}
-	stmt, _ := s.nonPreparedPlanCacheStmts.Get(s.nonPreparedPlanCacheStmtKey(sql))
+	stmt, _ := s.nonPreparedPlanCacheStmts.Get(planCacheStmtKey(sql))
 	return stmt
 }
 

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1659,6 +1659,10 @@ var defaultSysVars = []*SysVar{
 		s.EnableNonPreparedPlanCache = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck, Value: BoolToOnOff(vardef.DefTiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBEnableNonPreparedPlanCacheForDML, Value: BoolToOnOff(vardef.DefTiDBEnableNonPreparedPlanCacheForDML), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.EnableNonPreparedPlanCacheForDML = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1793,6 +1793,26 @@ func TestTiDBOptTxnAutoRetry(t *testing.T) {
 	}
 }
 
+func TestNonPreparedPlanCacheUnifiedCacheabilityCheckSysVar(t *testing.T) {
+	sv := GetSysVar(vardef.TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck)
+	require.NotNil(t, sv)
+	require.True(t, sv.HasGlobalScope())
+	require.True(t, sv.HasSessionScope())
+	require.Equal(t, vardef.Off, sv.Value)
+	require.False(t, sv.IsHintUpdatableVerified)
+
+	vars := NewSessionVars(nil)
+	require.False(t, vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck)
+	value, err := sv.Validate(vars, "ON", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, vardef.On, value)
+	require.NoError(t, sv.SetSessionFromHook(vars, value))
+	require.True(t, vars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck)
+	value, ok := vars.GetSystemVar(vardef.TiDBEnableNonPreparedPlanCacheUnifiedCacheabilityCheck)
+	require.True(t, ok)
+	require.Equal(t, vardef.On, value)
+}
+
 func TestTiDBLowResTSOUpdateInterval(t *testing.T) {
 	sv := GetSysVar(vardef.TiDBLowResolutionTSOUpdateInterval)
 	vars := NewSessionVars(nil)

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -660,6 +660,89 @@ func TestNonPreparedPlanCacheStmt(t *testing.T) {
 	sessVars.AddNonPreparedPlanCacheStmt(sql2, new(plannercore.PlanCacheStmt))
 	require.NotNil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
 	require.NotNil(t, sessVars.GetNonPreparedPlanCacheStmt(sql2))
+
+	legacyStmt := new(plannercore.PlanCacheStmt)
+	sessVars.AddNonPreparedPlanCacheStmt(sql1, legacyStmt)
+	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	testContextChange := func(change, restore func()) {
+		change()
+		require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+		restore()
+		require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	}
+
+	originalDB := sessVars.CurrentDB
+	testContextChange(func() { sessVars.CurrentDB = "another_db" }, func() { sessVars.CurrentDB = originalDB })
+
+	originalSQLMode := sessVars.SQLMode
+	testContextChange(func() { sessVars.SQLMode = mysql.ModeANSIQuotes }, func() { sessVars.SQLMode = originalSQLMode })
+
+	originalCharset, originalCollation := sessVars.GetCharsetInfo()
+	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetConnection, "latin1"))
+	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetConnection, originalCharset))
+	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, originalCollation))
+	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, "utf8mb4_general_ci"))
+	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, originalCollation))
+	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetClient, "latin1"))
+	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetClient, mysql.DefaultCharset))
+	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	originalWindowFunction := sessVars.EnableWindowFunction
+	testContextChange(func() { sessVars.EnableWindowFunction = !originalWindowFunction }, func() { sessVars.EnableWindowFunction = originalWindowFunction })
+
+	originalStrictDoubleCheck := sessVars.EnableStrictDoubleTypeCheck
+	testContextChange(func() { sessVars.EnableStrictDoubleTypeCheck = !originalStrictDoubleCheck }, func() { sessVars.EnableStrictDoubleTypeCheck = originalStrictDoubleCheck })
+
+	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
+	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	unifiedStmt := new(plannercore.PlanCacheStmt)
+	sessVars.AddNonPreparedPlanCacheStmt(sql1, unifiedStmt)
+	require.Same(t, unifiedStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = false
+	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
+	require.Same(t, unifiedStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+}
+
+func TestNonPreparedPlanCacheStmtLRUCapacityAndKeyIsolation(t *testing.T) {
+	sessVars := variable.NewSessionVars(nil)
+	sessVars.SessionPlanCacheSize = 2
+	stmt1, stmt2, stmt3 := new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt)
+	sql1 := "select * from t where a>?"
+	sql2 := "select * from t where a<?"
+	sql3 := "select * from t where a=?"
+
+	sessVars.AddNonPreparedPlanCacheStmt(sql1, stmt1)
+	sessVars.AddNonPreparedPlanCacheStmt(sql2, stmt2)
+	// Touch sql1 so sql2 is the least recently used entry.
+	require.Same(t, stmt1, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	sessVars.AddNonPreparedPlanCacheStmt(sql3, stmt3)
+	require.Same(t, stmt1, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql2))
+	require.Same(t, stmt3, sessVars.GetNonPreparedPlanCacheStmt(sql3))
+
+	keyIsolationVars := variable.NewSessionVars(nil)
+	keyIsolationVars.SessionPlanCacheSize = 2
+	legacyStmt := new(plannercore.PlanCacheStmt)
+	keyIsolationVars.AddNonPreparedPlanCacheStmt(sql1, legacyStmt)
+	require.Same(t, legacyStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	keyIsolationVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
+	require.Nil(t, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
+	unifiedStmt := new(plannercore.PlanCacheStmt)
+	keyIsolationVars.AddNonPreparedPlanCacheStmt(sql1, unifiedStmt)
+	require.Same(t, unifiedStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
+
+	keyIsolationVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = false
+	require.Same(t, legacyStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
 }
 
 func TestHookContext(t *testing.T) {

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -661,88 +661,23 @@ func TestNonPreparedPlanCacheStmt(t *testing.T) {
 	require.NotNil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
 	require.NotNil(t, sessVars.GetNonPreparedPlanCacheStmt(sql2))
 
-	legacyStmt := new(plannercore.PlanCacheStmt)
-	sessVars.AddNonPreparedPlanCacheStmt(sql1, legacyStmt)
-	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
+	t.Run("LRU capacity", func(t *testing.T) {
+		lruVars := variable.NewSessionVars(nil)
+		lruVars.SessionPlanCacheSize = 2
+		stmt1, stmt2, stmt3 := new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt)
+		lruSQL1 := "select * from t where a>?"
+		lruSQL2 := "select * from t where a<?"
+		lruSQL3 := "select * from t where a=?"
 
-	testContextChange := func(change, restore func()) {
-		change()
-		require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-		restore()
-		require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	}
-
-	originalDB := sessVars.CurrentDB
-	testContextChange(func() { sessVars.CurrentDB = "another_db" }, func() { sessVars.CurrentDB = originalDB })
-
-	originalSQLMode := sessVars.SQLMode
-	testContextChange(func() { sessVars.SQLMode = mysql.ModeANSIQuotes }, func() { sessVars.SQLMode = originalSQLMode })
-
-	originalCharset, originalCollation := sessVars.GetCharsetInfo()
-	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetConnection, "latin1"))
-	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetConnection, originalCharset))
-	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, originalCollation))
-	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-
-	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, "utf8mb4_general_ci"))
-	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	require.NoError(t, sessVars.SetSystemVar(vardef.CollationConnection, originalCollation))
-	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-
-	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetClient, "latin1"))
-	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	require.NoError(t, sessVars.SetSystemVar(vardef.CharacterSetClient, mysql.DefaultCharset))
-	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-
-	originalWindowFunction := sessVars.EnableWindowFunction
-	testContextChange(func() { sessVars.EnableWindowFunction = !originalWindowFunction }, func() { sessVars.EnableWindowFunction = originalWindowFunction })
-
-	originalStrictDoubleCheck := sessVars.EnableStrictDoubleTypeCheck
-	testContextChange(func() { sessVars.EnableStrictDoubleTypeCheck = !originalStrictDoubleCheck }, func() { sessVars.EnableStrictDoubleTypeCheck = originalStrictDoubleCheck })
-
-	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
-	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	unifiedStmt := new(plannercore.PlanCacheStmt)
-	sessVars.AddNonPreparedPlanCacheStmt(sql1, unifiedStmt)
-	require.Same(t, unifiedStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = false
-	require.Same(t, legacyStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	sessVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
-	require.Same(t, unifiedStmt, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-}
-
-func TestNonPreparedPlanCacheStmtLRUCapacityAndKeyIsolation(t *testing.T) {
-	sessVars := variable.NewSessionVars(nil)
-	sessVars.SessionPlanCacheSize = 2
-	stmt1, stmt2, stmt3 := new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt), new(plannercore.PlanCacheStmt)
-	sql1 := "select * from t where a>?"
-	sql2 := "select * from t where a<?"
-	sql3 := "select * from t where a=?"
-
-	sessVars.AddNonPreparedPlanCacheStmt(sql1, stmt1)
-	sessVars.AddNonPreparedPlanCacheStmt(sql2, stmt2)
-	// Touch sql1 so sql2 is the least recently used entry.
-	require.Same(t, stmt1, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	sessVars.AddNonPreparedPlanCacheStmt(sql3, stmt3)
-	require.Same(t, stmt1, sessVars.GetNonPreparedPlanCacheStmt(sql1))
-	require.Nil(t, sessVars.GetNonPreparedPlanCacheStmt(sql2))
-	require.Same(t, stmt3, sessVars.GetNonPreparedPlanCacheStmt(sql3))
-
-	keyIsolationVars := variable.NewSessionVars(nil)
-	keyIsolationVars.SessionPlanCacheSize = 2
-	legacyStmt := new(plannercore.PlanCacheStmt)
-	keyIsolationVars.AddNonPreparedPlanCacheStmt(sql1, legacyStmt)
-	require.Same(t, legacyStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
-
-	keyIsolationVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = true
-	require.Nil(t, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
-	unifiedStmt := new(plannercore.PlanCacheStmt)
-	keyIsolationVars.AddNonPreparedPlanCacheStmt(sql1, unifiedStmt)
-	require.Same(t, unifiedStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
-
-	keyIsolationVars.EnableNonPreparedPlanCacheUnifiedCacheabilityCheck = false
-	require.Same(t, legacyStmt, keyIsolationVars.GetNonPreparedPlanCacheStmt(sql1))
+		lruVars.AddNonPreparedPlanCacheStmt(lruSQL1, stmt1)
+		lruVars.AddNonPreparedPlanCacheStmt(lruSQL2, stmt2)
+		// Touch lruSQL1 so lruSQL2 is the least recently used entry.
+		require.Same(t, stmt1, lruVars.GetNonPreparedPlanCacheStmt(lruSQL1))
+		lruVars.AddNonPreparedPlanCacheStmt(lruSQL3, stmt3)
+		require.Same(t, stmt1, lruVars.GetNonPreparedPlanCacheStmt(lruSQL1))
+		require.Nil(t, lruVars.GetNonPreparedPlanCacheStmt(lruSQL2))
+		require.Same(t, stmt3, lruVars.GetNonPreparedPlanCacheStmt(lruSQL3))
+	})
 }
 
 func TestHookContext(t *testing.T) {

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -20,7 +20,6 @@ import (
 
 	"go.uber.org/atomic"
 )
-
 var (
 	// SetMemQuotaAnalyze is the func registered by global/subglobal tracker to set memory quota.
 	SetMemQuotaAnalyze func(quota int64) = nil

--- a/pkg/types/parser_driver/value_expr.go
+++ b/pkg/types/parser_driver/value_expr.go
@@ -54,17 +54,35 @@ func init() {
 	}
 	ast.NewHexLiteral = func(str string) (any, error) {
 		h, err := types.NewHexLiteral(str)
-		return h, err
+		if err != nil {
+			return nil, err
+		}
+		return rawBinaryLiteral{value: h, text: str}, nil
 	}
 	ast.NewBitLiteral = func(str string) (any, error) {
 		b, err := types.NewBitLiteral(str)
-		return b, err
+		if err != nil {
+			return nil, err
+		}
+		return rawBinaryLiteral{value: b, text: str}, nil
 	}
+}
+
+// rawBinaryLiteral keeps the token spelling while the datum stores its
+// normalized binary value for expression evaluation.
+type rawBinaryLiteral struct {
+	value any
+	text  string
+}
+
+func (r rawBinaryLiteral) ToString() string {
+	return r.value.(interface{ ToString() string }).ToString()
 }
 
 var (
 	_ ast.ParamMarkerExpr = &ParamMarkerExpr{}
 	_ ast.ValueExpr       = &ValueExpr{}
+	_ ast.BinaryLiteral   = rawBinaryLiteral{}
 )
 
 // ValueExpr is the simple value expression.
@@ -116,6 +134,10 @@ func (n *ValueExpr) Restore(ctx *format.RestoreCtx) error {
 	case types.KindMysqlDecimal:
 		ctx.WritePlain(n.GetMysqlDecimal().String())
 	case types.KindBinaryLiteral:
+		if ctx.Flags.HasRestoreForNonPrepPlanCache() && n.OriginalText() != "" {
+			ctx.WritePlain(n.OriginalText())
+			return nil
+		}
 		if n.Type.GetFlag()&mysql.UnsignedFlag != 0 {
 			ctx.WritePlainf("x'%x'", n.GetBytes())
 		} else {
@@ -206,11 +228,19 @@ func newValueExpr(value any, charset string, collate string) ast.ValueExpr {
 	if ve, ok := value.(*ValueExpr); ok {
 		return ve
 	}
+	var originalText string
+	if raw, ok := value.(rawBinaryLiteral); ok {
+		value = raw.value
+		originalText = raw.text
+	}
 	ve := &ValueExpr{}
 	// We need to keep the ve.Type.GetCollate() equals to ve.Datum.collation.
 	types.DefaultTypeForValue(value, &ve.Type, charset, collate)
 	ve.Datum.SetValue(value, &ve.Type)
 	ve.projectionOffset = -1
+	if originalText != "" {
+		ve.SetText(nil, originalText)
+	}
 	return ve
 }
 

--- a/pkg/types/parser_driver/value_expr_test.go
+++ b/pkg/types/parser_driver/value_expr_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,40 @@ func TestValueExprRestore(t *testing.T) {
 			err := expr.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
 			require.NoError(t, err)
 			require.Equalf(t, test.expect, sb.String(), "datum: %#v", test.datum)
+		})
+	}
+}
+
+func TestValueExprRestorePreservesBinaryLiteralToken(t *testing.T) {
+	for _, test := range []struct {
+		token     string
+		canonical string
+	}{
+		{token: "b'0001'", canonical: "b'1'"},
+		{token: "B'0001'", canonical: "b'1'"},
+		{token: "0b0001", canonical: "b'1'"},
+		{token: "X'0A'", canonical: "x'0a'"},
+		{token: "x'0A'", canonical: "x'0a'"},
+		{token: "0x0A", canonical: "x'0a'"},
+	} {
+		t.Run(test.token, func(t *testing.T) {
+			var err error
+			var value any
+			if test.token[0] == 'b' || test.token[0] == 'B' || test.token[:2] == "0b" {
+				value, err = ast.NewBitLiteral(test.token)
+			} else {
+				value, err = ast.NewHexLiteral(test.token)
+			}
+			require.NoError(t, err)
+			expr := ast.NewValueExpr(value, "", "")
+			var sb strings.Builder
+			err = expr.Restore(format.NewRestoreCtx(format.RestoreForNonPrepPlanCache, &sb))
+			require.NoError(t, err)
+			require.Equal(t, test.token, sb.String())
+			sb.Reset()
+			err = expr.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
+			require.NoError(t, err)
+			require.Equal(t, test.canonical, sb.String())
 		})
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close pingcap/tidb#70626

Problem Summary:

The non-prepared plan cache uses a conservative legacy cacheability check, which prevents supported SQL shapes from sharing the same cacheability rules as prepared plan cache.

### What changed and how does it work?

- Introduce `tidb_enable_non_prepared_plan_cache_unified_cacheability_check`, disabled by default. The existing legacy non-prepared plan-cache path remains unchanged when the switch is disabled.

- In unified mode, run a parameterization precheck before the non-prepared statement-LRU lookup. Unsupported statements, such as statements with `SELECT INTO`, original parameter markers, unsupported DML shapes, or unsafe `LIMIT`/charset cases, fall back to normal optimization without constructing a statement carrier.

- For statements that pass the precheck, parameterize the original AST and build the parameterized SQL. Run `IsASTCacheable` both after a statement-LRU miss, using the newly parsed parameterized AST, and after a statement-LRU hit, using the cached carrier AST.

- Restore the original AST after parameterization. Validate parameter-marker positions and return restore errors without leaving a partially modified AST behind.

- Add regression tests and targeted benchmarks for parameterization, AST restore and fallback, statement-LRU admission and hit/miss behavior, cacheability rejection reasons, unsupported-counter boundaries, DML gates, CTE scopes, preserved-literal identity, and dynamic cacheability state changes.

### Check List

Tests

- [x] Unit test
- [x] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains variable changes

### Release note

```release-note
Add an opt-in unified cacheability check for non-prepared plan cache.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an optional unified cacheability check for non-prepared plan caching.
- Expanded plan-cache support for eligible queries and DML, including CTEs and SQL functions.
- Added safeguards that bypass unsupported statements and preserve locking-read behavior.
- Preserved original binary and bit-literal formatting during plan-cache restoration.

## Documentation
- Added planner maintainer guidance covering plan-cache behavior, invariants, troubleshooting, and workflows.
- Added design documentation describing cacheability checks and parameterization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->