### PR TITLE
sessionctx: add sysvar for plan replayer GC retention

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1837,7 +1837,7 @@ func (do *Domain) DumpFileGcCheckerLoop() {
 			case <-do.exit:
 				return
 			case <-gcTicker.C:
-				do.dumpFileGcChecker.GCDumpFiles(do.ctx, time.Hour, time.Hour*24*7)
+				do.dumpFileGcChecker.GCDumpFiles(do.ctx, vardef.GetPlanReplayerFileRetentionTime(), time.Hour*24*7)
 			}
 		}
 	}, "dumpFileGcChecker")

--- a/pkg/sessionctx/vardef/runtime.go
+++ b/pkg/sessionctx/vardef/runtime.go
@@ -31,6 +31,8 @@ var (
 	statsLease = int64(3 * time.Second)
 	// planReplayerGCLease is the time for plan replayer gc.
 	planReplayerGCLease = int64(10 * time.Minute)
+	// planReplayerFileRetentionTime is the retention time for non-capture plan replayer files.
+	planReplayerFileRetentionTime = int64(DefTiDBPlanReplayerFileRetentionTime)
 )
 
 // SetSchemaLease changes the default schema lease time for DDL.
@@ -63,6 +65,16 @@ func SetPlanReplayerGCLease(lease time.Duration) {
 // GetPlanReplayerGCLease returns the plan replayer gc lease time.
 func GetPlanReplayerGCLease() time.Duration {
 	return time.Duration(atomic.LoadInt64(&planReplayerGCLease))
+}
+
+// SetPlanReplayerFileRetentionTime changes the retention time for non-capture plan replayer files.
+func SetPlanReplayerFileRetentionTime(duration time.Duration) {
+	atomic.StoreInt64(&planReplayerFileRetentionTime, int64(duration))
+}
+
+// GetPlanReplayerFileRetentionTime returns the retention time for non-capture plan replayer files.
+func GetPlanReplayerFileRetentionTime() time.Duration {
+	return time.Duration(atomic.LoadInt64(&planReplayerFileRetentionTime))
 }
 
 // IsReadOnlyVarInNextGen checks if the variable is read-only in the nextgen.

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1029,6 +1029,9 @@ const (
 
 	// TiDBEnablePlanReplayerContinuousCapture indicates whether to enable continuous capture
 	TiDBEnablePlanReplayerContinuousCapture = "tidb_enable_plan_replayer_continuous_capture"
+
+	// TiDBPlanReplayerFileRetentionTime indicates how long to retain non-capture plan replayer files.
+	TiDBPlanReplayerFileRetentionTime = "tidb_plan_replayer_file_retention_time"
 	// TiDBEnableReusechunk indicates whether to enable chunk alloc
 	TiDBEnableReusechunk = "tidb_enable_reuse_chunk"
 
@@ -1730,6 +1733,7 @@ const (
 	DefTiDBEnableReusechunk                           = true
 	DefTiDBUseAlloc                                   = false
 	DefTiDBEnablePlanReplayerCapture                  = true
+	DefTiDBPlanReplayerFileRetentionTime              = 7 * 24 * time.Hour
 	DefTiDBIndexMergeIntersectionConcurrency          = ConcurrencyUnset
 	DefTiDBTTLJobEnable                               = true
 	DefTiDBTTLScanBatchSize                           = 500

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1800,6 +1800,17 @@ var defaultSysVars = []*SysVar{
 			vardef.HistoricalStatsDuration.Store(d)
 			return nil
 		}},
+	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBPlanReplayerFileRetentionTime, Value: vardef.DefTiDBPlanReplayerFileRetentionTime.String(), Type: vardef.TypeDuration, MaxValue: uint64(time.Hour * 24 * 365),
+		GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
+			return vardef.GetPlanReplayerFileRetentionTime().String(), nil
+		}, SetGlobal: func(ctx context.Context, vars *SessionVars, s string) error {
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return err
+			}
+			vardef.SetPlanReplayerFileRetentionTime(d)
+			return nil
+		}},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBLowResolutionTSOUpdateInterval, Value: strconv.Itoa(vardef.DefTiDBLowResolutionTSOUpdateInterval), Type: vardef.TypeInt, MinValue: 10, MaxValue: 60000,
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 			vardef.LowResolutionTSOUpdateInterval.Store(uint32(TidbOptInt64(val, vardef.DefTiDBLowResolutionTSOUpdateInterval)))

--- a/pkg/sessionctx/variable/tests/variable_test.go
+++ b/pkg/sessionctx/variable/tests/variable_test.go
@@ -615,6 +615,10 @@ func TestSetSysVar(t *testing.T) {
 	require.Equal(t, "America/New_York", val)
 	variable.SetSysVar(vardef.SystemTimeZone, originalVal) // restore
 	require.Equal(t, originalVal, variable.GetSysVar(vardef.SystemTimeZone).Value)
+
+	planReplayerFileRetentionTimeVar := variable.GetSysVar(vardef.TiDBPlanReplayerFileRetentionTime)
+	require.NotNil(t, planReplayerFileRetentionTimeVar)
+	require.Equal(t, (7 * 24 * time.Hour).String(), planReplayerFileRetentionTimeVar.Value)
 }
 
 func TestSkipSysvarCache(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69100

Problem Summary: sessionctx: add sysvar for plan replayer GC retention

### What changed and how does it work?

Cherry-pick of https://github.com/pingcap/tidb/pull/69969

Add a new global SQL variable, tidb_plan_replayer_gc_duration, to configure the retention duration for non-capture plan replayer files.
The default is 7d (168h0m0s). The dump file GC loop now reads this runtime value instead of using a hard-coded duration, while capture replayer retention remains unchanged.
Also adds unit coverage for the new sysvar default, global setter behavior, and invalid duration handling.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the global `tidb_plan_replayer_file_retention_time` setting.
  * Plan replayer files can now use a configurable retention period, from the default seven days up to one year.
* **Bug Fixes**
  * File cleanup now respects the configured retention period while preserving the existing seven-day maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->