### PR TITLE
ddl, importinto: reject stale IMPORT INTO plans when schema changes concurrently #70580

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -1426,6 +1426,11 @@ error = '''
 `%s` is unsupported on temporary tables.
 '''
 
+["ddl:8028"]
+error = '''
+Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`
+'''
+
 ["ddl:8148"]
 error = '''
 Field '%-.192s' is of a not supported type for TTL config, expect DATETIME, DATE or TIMESTAMP

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5918,12 +5918,13 @@ func (e *executor) AlterTableMode(sctx sessionctx.Context, args *model.AlterTabl
 	}
 
 	job, jobArgs, noop, err := jobsubmit.BuildAlterTableModeJob(sctx, model.AlterTableModeTarget{
-		SchemaID:    args.SchemaID,
-		SchemaName:  schema.Name,
-		TableID:     args.TableID,
-		TableName:   table.Meta().Name,
-		CurrentMode: table.Meta().Mode,
-		TargetMode:  args.TableMode,
+		SchemaID:         args.SchemaID,
+		SchemaName:       schema.Name,
+		TableID:          args.TableID,
+		TableName:        table.Meta().Name,
+		CurrentMode:      table.Meta().Mode,
+		TargetMode:       args.TableMode,
+		ExpectedRevision: args.ExpectedRevision,
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/ddl/jobsubmit/BUILD.bazel
+++ b/pkg/ddl/jobsubmit/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
         "table_mode_test.go",
     ],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         ":jobsubmit",
         "//pkg/ddl/serverstate",

--- a/pkg/ddl/jobsubmit/table_mode.go
+++ b/pkg/ddl/jobsubmit/table_mode.go
@@ -31,7 +31,13 @@ func BuildAlterTableModeJob(
 		return nil, nil, false, infoschema.ErrInvalidTableModeSet.GenWithStackByArgs(
 			target.CurrentMode, target.TargetMode, target.TableName.O)
 	}
-	if target.CurrentMode == target.TargetMode {
+	// A caller with ExpectedRevision set must always go through a real job:
+	// CurrentMode here is only a cache-freshness read (via infoschema), so
+	// skipping the job just because the mode already matches would let a
+	// stale caller (e.g. IMPORT INTO racing a concurrent schema change)
+	// slip through without ever having its Revision checked atomically in
+	// onAlterTableMode.
+	if target.CurrentMode == target.TargetMode && target.ExpectedRevision == nil {
 		return nil, nil, true, nil
 	}
 

--- a/pkg/ddl/jobsubmit/table_mode.go
+++ b/pkg/ddl/jobsubmit/table_mode.go
@@ -36,9 +36,10 @@ func BuildAlterTableModeJob(
 	}
 
 	args := &model.AlterTableModeArgs{
-		TableMode: target.TargetMode,
-		SchemaID:  target.SchemaID,
-		TableID:   target.TableID,
+		TableMode:        target.TargetMode,
+		SchemaID:         target.SchemaID,
+		TableID:          target.TableID,
+		ExpectedRevision: target.ExpectedRevision,
 	}
 	job := &model.Job{
 		Version:    model.JobVersion2,

--- a/pkg/ddl/jobsubmit/table_mode_test.go
+++ b/pkg/ddl/jobsubmit/table_mode_test.go
@@ -93,3 +93,34 @@ func TestBuildAlterTableModeJobNoopAndInvalidMode(t *testing.T) {
 	require.Nil(t, job)
 	require.Nil(t, args)
 }
+
+// TestBuildAlterTableModeJobExpectedRevisionSkipsNoop is a regression test:
+// when CurrentMode already equals TargetMode but the caller supplied
+// ExpectedRevision (e.g. IMPORT INTO racing a concurrent schema change that
+// itself set the table to TableModeImport), the noop shortcut must not skip
+// job creation, or the Revision would never be checked atomically in
+// onAlterTableMode.
+func TestBuildAlterTableModeJobExpectedRevisionSkipsNoop(t *testing.T) {
+	sctx := newAlterTableModeSession()
+	expectedRevision := uint64(5)
+	target := model.AlterTableModeTarget{
+		SchemaID:         101,
+		SchemaName:       ast.NewCIStr("test"),
+		TableID:          202,
+		TableName:        ast.NewCIStr("t"),
+		CurrentMode:      model.TableModeImport,
+		TargetMode:       model.TableModeImport,
+		ExpectedRevision: &expectedRevision,
+	}
+
+	job, args, noop, err := jobsubmit.BuildAlterTableModeJob(sctx, target)
+	require.NoError(t, err)
+	require.False(t, noop)
+	require.NotNil(t, job)
+	require.Equal(t, &model.AlterTableModeArgs{
+		TableMode:        model.TableModeImport,
+		SchemaID:         101,
+		TableID:          202,
+		ExpectedRevision: &expectedRevision,
+	}, args)
+}

--- a/pkg/ddl/table_mode.go
+++ b/pkg/ddl/table_mode.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 )
 
 // onAlterTableMode should only be called by alterTableMode, will call updateVersionAndTableInfo
@@ -33,6 +34,17 @@ func onAlterTableMode(jobCtx *jobContext, job *model.Job) (ver int64, err error)
 	tbInfo, err = GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, err
+	}
+
+	// tbInfo is read fresh from the job's own metadata mutator, so this
+	// read is atomic with respect to any other concurrent DDL job on the
+	// same table (the job scheduler serializes them). Rejecting here, rather
+	// than relying only on a caller-side pre-check, closes the race where a
+	// concurrent schema change lands after the caller's own check but before
+	// this job actually runs.
+	if args.ExpectedRevision != nil && tbInfo.Revision != *args.ExpectedRevision {
+		job.State = model.JobStateCancelled
+		return ver, dbterror.ErrInfoSchemaChanged.GenWithStackByArgs()
 	}
 
 	switch tbInfo.Mode {
@@ -76,11 +88,24 @@ func alterTableMode(tbInfo *model.TableInfo, args *model.AlterTableModeArgs) err
 }
 
 // AlterTableMode creates a DDL job for alter table mode.
-func AlterTableMode(de Executor, sctx sessionctx.Context, mode model.TableMode, schemaID, tableID int64) error {
+//
+// expectedRevision is optional (pass none, or a single value): when given,
+// the job is rejected with dbterror.ErrInfoSchemaChanged unless the table's
+// Revision, read atomically at job-execution time, still matches. Callers
+// that captured a table schema snapshot earlier and only later request the
+// mode switch should pass the snapshot's Revision to detect and reject a
+// schema change that raced ahead of them.
+func AlterTableMode(de Executor, sctx sessionctx.Context, mode model.TableMode, schemaID, tableID int64, expectedRevision ...uint64) error {
+	if len(expectedRevision) > 1 {
+		return errors.Errorf("AlterTableMode: at most one expectedRevision is allowed, got %d", len(expectedRevision))
+	}
 	args := &model.AlterTableModeArgs{
 		TableMode: mode,
 		SchemaID:  schemaID,
 		TableID:   tableID,
+	}
+	if len(expectedRevision) == 1 {
+		args.ExpectedRevision = &expectedRevision[0]
 	}
 	return de.AlterTableMode(sctx, args)
 }

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -116,7 +116,7 @@ go_test(
     ],
     embed = [":importinto"],
     flaky = True,
-    shard_count = 38,
+    shard_count = 39,
     deps = [
         "//pkg/config",
         "//pkg/config/configtypes",

--- a/pkg/dxf/importinto/BUILD.bazel
+++ b/pkg/dxf/importinto/BUILD.bazel
@@ -169,6 +169,7 @@ go_test(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/codec",
+        "//pkg/util/dbterror",
         "//pkg/util/dbterror/exeerrors",
         "//pkg/util/etcd",
         "//pkg/util/mock",

--- a/pkg/dxf/importinto/job.go
+++ b/pkg/dxf/importinto/job.go
@@ -123,7 +123,18 @@ func doSubmitTask(ctx context.Context, plan *importer.Plan, stmt string, instanc
 			return err2
 		}
 		if kerneltype.IsClassic() {
-			err2 = ddl.AlterTableMode(domain.GetDomain(se).DDLExecutor(), se, model.TableModeImport, plan.DBID, plan.TableInfo.ID)
+			// plan.TableInfo was captured before this transaction, during an
+			// unguarded prepare phase (file discovery, prechecks, size
+			// estimation). A concurrent DDL (e.g. ADD INDEX) may have changed
+			// the table's schema since then; TableModeImport only blocks
+			// *future* DDL, so we pass the captured Revision through and let
+			// AlterTableMode's own DDL job reject a stale plan atomically
+			// (the job reads the table fresh from its metadata mutator,
+			// which is serialized against other concurrent DDL on the same
+			// table), rather than let import silently finish against an
+			// outdated schema.
+			err2 = ddl.AlterTableMode(domain.GetDomain(se).DDLExecutor(), se, model.TableModeImport, plan.DBID, plan.TableInfo.ID,
+				plan.TableInfo.Revision)
 			if err2 != nil {
 				return err2
 			}

--- a/pkg/dxf/importinto/job_testkit_test.go
+++ b/pkg/dxf/importinto/job_testkit_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/config/configtypes"
 	"github.com/pingcap/tidb/pkg/config/deploymode"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
@@ -37,12 +38,14 @@ import (
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	kvstore "github.com/pingcap/tidb/pkg/store"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/etcd"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/tikv"
@@ -101,6 +104,82 @@ func TestShouldUseAsyncPrepare(t *testing.T) {
 			require.Equal(t, tt.want, importinto.ShouldUseAsyncPrepare(globalSortPlan))
 		})
 	}
+}
+
+// TestSubmitTaskRejectsStalePlanSchema is a regression test for
+// https://github.com/pingcap/tidb/issues/70580: if the table's schema
+// changes (e.g. a concurrent ADD UNIQUE INDEX) between when IMPORT INTO
+// captures its Plan.TableInfo snapshot and when doSubmitTask acquires the
+// TableModeImport guard, submission must be rejected instead of silently
+// proceeding against a stale schema. The rejection happens inside the
+// AlterTableMode DDL job itself (see onAlterTableMode's ExpectedRevision
+// check), which reads the table atomically w.r.t. other concurrent DDL, so
+// this also covers the narrower window where the concurrent ADD INDEX lands
+// after doSubmitTask's own checks but before the AlterTableMode job runs.
+func TestSubmitTaskRejectsStalePlanSchema(t *testing.T) {
+	if !kerneltype.IsClassic() {
+		t.Skip("table mode is only set in classic kernel")
+	}
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int, v int)")
+
+	dom := domain.GetDomain(tk.Session())
+	is := dom.InfoSchema()
+	dbInfo, ok := is.SchemaByName(ast.NewCIStr("test"))
+	require.True(t, ok)
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	// staleTableInfo mimics the schema snapshot IMPORT INTO captures during
+	// its unguarded prepare phase, before this test performs a concurrent DDL.
+	staleTableInfo := tbl.Meta().Clone()
+
+	pool := pools.NewResourcePool(func() (pools.Resource, error) {
+		return tk.Session(), nil
+	}, 1, 1, time.Second)
+	defer pool.Close()
+	ctx := util.WithInternalSourceType(context.Background(), kv.InternalDistTask)
+	manager := storage.NewTaskManager(pool)
+	storage.SetTaskManager(manager)
+	require.NoError(t, manager.InitMeta(ctx, ":4000", ""))
+
+	// concurrent ALTER TABLE ... ADD UNIQUE INDEX bumps the table's Revision,
+	// simulating the race window described in the issue.
+	tk.MustExec("alter table t add unique index kv(v)")
+
+	_, _, err = importinto.SubmitTask(ctx, &importer.Plan{
+		DBName:     "test",
+		DBID:       dbInfo.ID,
+		TableInfo:  staleTableInfo,
+		Parameters: &importer.ImportParameters{},
+	}, "import into t from '/path/to/file'")
+	require.True(t, dbterror.ErrInfoSchemaChanged.Equal(err), "expected ErrInfoSchemaChanged, got: %v", err)
+
+	// the job/task rollback must leave no residue behind for the rejected submission.
+	tk.MustQuery("select count(1) from mysql.tidb_import_jobs").Check(testkit.Rows("0"))
+	tk.MustQuery("select count(1) from mysql.tidb_global_task").Check(testkit.Rows("0"))
+
+	// table mode must remain Normal since the guard rejected before AlterTableMode.
+	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, model.TableModeNormal, tbl.Meta().Mode)
+
+	// sanity: submitting with the current (fresh) schema still succeeds.
+	freshTbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	jobID, task, err := importinto.SubmitTask(ctx, &importer.Plan{
+		DBName:     "test",
+		DBID:       dbInfo.ID,
+		TableInfo:  freshTbl.Meta(),
+		Parameters: &importer.ImportParameters{},
+	}, "import into t from '/path/to/file'")
+	require.NoError(t, err)
+	require.NotZero(t, jobID)
+	require.NotNil(t, task)
 }
 
 func TestSubmitTaskNextgen(t *testing.T) {

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -525,6 +525,7 @@ go_test(
         "//pkg/util/chunk",
         "//pkg/util/codec",
         "//pkg/util/collate",
+        "//pkg/util/dbterror",
         "//pkg/util/dbterror/exeerrors",
         "//pkg/util/dbterror/plannererrors",
         "//pkg/util/deadlockhistory",

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -18,16 +18,21 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
 	"github.com/pingcap/tidb/pkg/dxf/importinto"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -36,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	semv1 "github.com/pingcap/tidb/pkg/util/sem"
@@ -142,6 +148,61 @@ func TestClassicS3ExternalID(t *testing.T) {
 		tk.MustExec("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'")
 		tk.MustQuery("select * from test.t").Check(testkit.Rows())
 	})
+}
+
+// TestImportIntoRejectsConcurrentAddIndex is a regression test for
+// https://github.com/pingcap/tidb/issues/70580: a concurrent
+// ALTER TABLE ... ADD UNIQUE INDEX that lands between IMPORT INTO's planning
+// (NewImportPlan, which snapshots the table schema) and task submission must
+// cause the IMPORT INTO statement to fail, instead of silently succeeding
+// against a schema that no longer matches the table (which would leave the
+// new index un-backfilled for the imported rows).
+func TestImportIntoRejectsConcurrentAddIndex(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("import from server disk is not supported in nextgen")
+	}
+	username, err := user.Current()
+	require.NoError(t, err)
+	if username.Name == "root" {
+		t.Skip("it cannot run as root")
+	}
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int, v int)")
+
+	tempDir := t.TempDir()
+	csvPath := filepath.Join(tempDir, "data.csv")
+	require.NoError(t, os.WriteFile(csvPath, []byte("1,1\n2,2\n"), 0o644))
+
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan",
+		func(*plannercore.ImportInto) {
+			// runs on a second session, simulating a concurrent client racing
+			// the IMPORT INTO statement right after it captured the table's
+			// schema snapshot but before it reaches task submission.
+			ddlTK := testkit.NewTestKit(t, store)
+			ddlTK.MustExec("use test")
+			ddlTK.MustExec("alter table t add unique index kv(v)")
+		})
+
+	// disable_precheck: the CDC/PiTR precheck needs a real etcd client, which
+	// this mock-store test environment doesn't provide; unrelated to the
+	// schema-race guard under test.
+	err = tk.QueryToErr(fmt.Sprintf("IMPORT INTO t FROM '%s' WITH disable_precheck", csvPath))
+	require.True(t, dbterror.ErrInfoSchemaChanged.Equal(err), "expected ErrInfoSchemaChanged, got: %v", err)
+
+	// the table must not be left stuck in import mode by the rejected statement.
+	tbl, err := domain.GetDomain(tk.Session()).InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, model.TableModeNormal, tbl.Meta().Mode)
+	// the new index must be usable and empty; nothing was silently imported
+	// past it.
+	tk.MustExec("insert into t values (1, 1)")
+	err = tk.ExecToErr("insert into t values (2, 1)")
+	require.Error(t, err, "unique index kv should reject the duplicate value")
 }
 
 func TestNextGenS3ExternalID(t *testing.T) {

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -1097,6 +1097,9 @@ type AlterTableModeArgs struct {
 	TableMode TableMode `json:"table_mode,omitempty"`
 	SchemaID  int64     `json:"schema_id,omitempty"`
 	TableID   int64     `json:"table_id,omitempty"`
+	// ExpectedRevision, when non-nil, is checked against the table's current
+	// Revision at job-execution time; see AlterTableModeTarget.ExpectedRevision.
+	ExpectedRevision *uint64 `json:"expected_revision,omitempty"`
 }
 
 func (a *AlterTableModeArgs) getArgsV1(*Job) []any {

--- a/pkg/meta/model/table_mode.go
+++ b/pkg/meta/model/table_mode.go
@@ -86,4 +86,15 @@ type AlterTableModeTarget struct {
 	// TargetMode is required input for AlterTableMode requests. It is the table
 	// mode requested by the caller.
 	TargetMode TableMode
+	// ExpectedRevision is optional input for AlterTableMode requests. When
+	// non-nil, the job is rejected with ErrInfoSchemaChanged unless the
+	// table's current Revision (read from the DDL job's own metadata
+	// mutator, so it is atomic with respect to other concurrent DDL on the
+	// same table) still matches. Callers that captured a table schema
+	// snapshot earlier and only later request the mode switch (e.g. IMPORT
+	// INTO, which prepares against a snapshot before acquiring
+	// TableModeImport) use this to detect and reject a schema change that
+	// raced ahead of them, rather than silently proceeding against a stale
+	// snapshot.
+	ExpectedRevision *uint64
 }

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -37,6 +37,10 @@ var (
 	ErrPausedDDLJob = ClassDDL.NewStd(mysql.ErrPausedDDLJob)
 	// ErrBDRRestrictedDDL means the DDL is restricted in BDR mode.
 	ErrBDRRestrictedDDL = ClassDDL.NewStd(mysql.ErrBDRRestrictedDDL)
+	// ErrInfoSchemaChanged means the table's schema changed concurrently with
+	// a DDL job that expected a specific schema revision (e.g. AlterTableMode
+	// requested by IMPORT INTO after capturing a schema snapshot).
+	ErrInfoSchemaChanged = ClassDDL.NewStd(mysql.ErrInfoSchemaChanged)
 	// ErrDDLAutoPausedByKVDiskFull means TiDB paused the DDL job because a storage node disk is full.
 	ErrDDLAutoPausedByKVDiskFull = ClassDDL.NewStd(mysql.ErrDDLAutoPausedByKVDiskFull)
 	// ErrRunMultiSchemaChanges means we run multi schema changes.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70580

Problem Summary:

Classic `IMPORT INTO` captures a snapshot of the target table's schema
during planning, then performs an unguarded prepare phase (file discovery,
prechecks, size estimation) before acquiring the `TableModeImport` guard.
If a concurrent `ALTER TABLE ... ADD UNIQUE INDEX` completes during that
window, the import proceeds using the stale schema snapshot while
`TableModeImport` only blocks *future* DDL — so the import can finish
successfully while the newly added unique index is left silently empty
for the imported rows, and `ADMIN CHECK TABLE` later fails.

### What changed and how does it work?

- `pkg/meta/model`: added an optional `ExpectedRevision *uint64` field to
  `AlterTableModeTarget` / `AlterTableModeArgs`.
- `pkg/ddl/table_mode.go`: `onAlterTableMode` (the DDL job's own execution
  function) now rejects the job with `ErrInfoSchemaChanged` when the
  table's current `Revision` (read fresh from the job's metadata mutator)
  no longer matches the caller's `ExpectedRevision`. This check runs
  inside the DDL job itself, which the job scheduler serializes against
  any other concurrent DDL on the same table for the job's entire
  lifetime — so this closes the race rather than merely narrowing it.
- `pkg/ddl/executor.go`, `pkg/ddl/jobsubmit/table_mode.go`: thread
  `ExpectedRevision` through job construction. The no-op shortcut in
  `BuildAlterTableModeJob` now only applies when `ExpectedRevision` is
  nil, so a caller with a captured revision always goes through the
  atomic check even if the table is already in the target mode.
- `pkg/ddl/table_mode.go`: `AlterTableMode(...)` gains an optional
  variadic `expectedRevision` argument; all existing call sites are
  unaffected when it's omitted.
- `pkg/util/dbterror`: added `ErrInfoSchemaChanged` (mirrors
  `domain.ErrInfoSchemaChanged`, which `pkg/ddl` cannot import directly
  due to an existing import cycle).
- `pkg/dxf/importinto/job.go`: `doSubmitTask` now passes the captured
  `plan.TableInfo.Revision` into `AlterTableMode`, so a stale plan is
  rejected atomically at the point `TableModeImport` would otherwise take
  effect.
- `errors.toml`: regenerated to add the `ddl:8028` entry for the new
  error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Added regression tests:
- `pkg/dxf/importinto/job_testkit_test.go`:
  `TestSubmitTaskRejectsStalePlanSchema` — verifies `SubmitTask` rejects a
  stale plan and leaves no orphaned job/task rows.
- `pkg/executor/import_into_test.go`:
  `TestImportIntoRejectsConcurrentAddIndex` — drives a real `IMPORT INTO`
  statement, injects a genuine concurrent `ALTER TABLE ... ADD UNIQUE
  INDEX` via the `NewImportPlan` failpoint, and asserts the statement is
  rejected and the new index stays correctly enforced.
- `pkg/ddl/jobsubmit/table_mode_test.go`:
  `TestBuildAlterTableModeJobExpectedRevisionSkipsNoop` — verifies the
  no-op shortcut doesn't bypass the revision check when the table is
  already in the target mode.

All tests were verified to fail without the fix and pass with it.

`tests/integrationtest` is not used here: that suite's `IMPORT INTO`
coverage (`tests/integrationtest/t/executor/import_into.test`) is
single-session and only exercises option-parsing/precheck errors that
return before this fix's code path is ever reached. Reproducing this bug
requires two concurrent sessions racing a DDL against an in-flight
import, which that format can't express — the tests above already
exercise the real fix path end-to-end, including a full SQL-level
`IMPORT INTO` statement via `pkg/executor/import_into_test.go`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
fix a race between `IMPORT INTO` and concurrent `ADD INDEX`/`ADD UNIQUE INDEX` DDL that could leave the new index missing imported rows
