### PR TITLE
objstore: support OSS presigned download URLs

### DIFF
--- a/pkg/objstore/ossstore/BUILD.bazel
+++ b/pkg/objstore/ossstore/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
     ],
     embed = [":ossstore"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 12,
     deps = [
         "//dumpling/context",
         "//pkg/objstore/ossstore/mock",

--- a/pkg/objstore/ossstore/client.go
+++ b/pkg/objstore/ossstore/client.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	goerrors "errors"
 	"io"
+	"time"
 
 	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	"github.com/pingcap/errors"
@@ -33,7 +34,8 @@ import (
 const noSuchKey = "NoSuchKey"
 
 type client struct {
-	svc API
+	svc        API
+	presignSvc API
 	storeapi.BucketPrefix
 	options *backuppb.S3
 }
@@ -151,6 +153,21 @@ func (c *client) DeleteObject(ctx context.Context, name string) error {
 		Key:    oss.Ptr(key),
 	})
 	return errors.Trace(err)
+}
+
+func (c *client) PresignObject(ctx context.Context, name string, expire time.Duration) (string, error) {
+	if expire < 0 {
+		return "", errors.New("presign expiration must not be negative")
+	}
+	key := c.ObjectKey(name)
+	result, err := c.presignSvc.Presign(ctx, &oss.GetObjectRequest{
+		Bucket: oss.Ptr(c.Bucket),
+		Key:    oss.Ptr(key),
+	}, oss.PresignExpires(expire))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return result.URL, nil
 }
 
 func (c *client) DeleteObjects(ctx context.Context, names []string) error {

--- a/pkg/objstore/ossstore/client.go
+++ b/pkg/objstore/ossstore/client.go
@@ -155,10 +155,14 @@ func (c *client) DeleteObject(ctx context.Context, name string) error {
 	return errors.Trace(err)
 }
 
+// PresignObject creates a presigned URL for the given object.
+// It implements the presignableClient interface used by s3like.Storage.
+// TODO: A URL signed with temporary credentials can expire before the requested
+// duration. credentials-go does not expose the cached credential expiration, so
+// this method cannot refresh early or report the effective lifetime. Make the OSS
+// credential path expiration-aware, then ensure its remaining lifetime covers
+// expire or return the effective expiration to the caller.
 func (c *client) PresignObject(ctx context.Context, name string, expire time.Duration) (string, error) {
-	if expire < 0 {
-		return "", errors.New("presign expiration must not be negative")
-	}
 	key := c.ObjectKey(name)
 	result, err := c.presignSvc.Presign(ctx, &oss.GetObjectRequest{
 		Bucket: oss.Ptr(c.Bucket),

--- a/pkg/objstore/ossstore/client_test.go
+++ b/pkg/objstore/ossstore/client_test.go
@@ -173,6 +173,23 @@ func TestClientPresignObject(t *testing.T) {
 	ctx := context.Background()
 	const presignedURL = "https://bucket.example.com/prefix/object?signature=test"
 
+	t.Run("public endpoint when data client uses internal endpoint", func(t *testing.T) {
+		config := oss.NewConfig().
+			WithRegion("cn-hangzhou").
+			WithCredentialsProvider(credentials.NewStaticCredentialsProvider("access-key-id", "access-key-secret", "")).
+			WithUseInternalEndpoint(true)
+		cli := &client{
+			presignSvc:   newPresignClient(config),
+			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+		}
+
+		presignedURL, err := cli.PresignObject(ctx, "object", time.Hour)
+		require.NoError(t, err)
+		parsedURL, err := url.Parse(presignedURL)
+		require.NoError(t, err)
+		require.Equal(t, "bucket.oss-cn-hangzhou.aliyuncs.com", parsedURL.Host)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		cli := &client{
 			presignSvc: &presignAPI{
@@ -220,36 +237,34 @@ func TestClientPresignObject(t *testing.T) {
 		cli := &client{
 			presignSvc: &presignAPI{
 				presign: func(context.Context, any, ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
-					require.FailNow(t, "Presign called for negative expiration")
+					require.FailNow(t, "Presign called for non-positive expiration")
 					return nil, nil
 				},
 			},
 			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
 		}
+		storage := s3like.NewStorage(cli, cli.BucketPrefix, &backuppb.S3{}, nil)
 
-		url, err := cli.PresignObject(ctx, "object", -time.Second)
+		url, err := storage.PresignFile(ctx, "object", -time.Second)
 		require.Empty(t, url)
-		require.ErrorContains(t, err, "expiration must not be negative")
+		require.ErrorContains(t, err, "expiration must be positive")
 	})
 
 	t.Run("zero expiration", func(t *testing.T) {
 		cli := &client{
 			presignSvc: &presignAPI{
-				presign: func(_ context.Context, _ any, optFns ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
-					options := &oss.PresignOptions{}
-					for _, optFn := range optFns {
-						optFn(options)
-					}
-					require.Zero(t, options.Expires)
-					return &oss.PresignResult{URL: presignedURL}, nil
+				presign: func(context.Context, any, ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+					require.FailNow(t, "Presign called for non-positive expiration")
+					return nil, nil
 				},
 			},
 			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
 		}
+		storage := s3like.NewStorage(cli, cli.BucketPrefix, &backuppb.S3{}, nil)
 
-		url, err := cli.PresignObject(ctx, "object", 0)
-		require.NoError(t, err)
-		require.Equal(t, presignedURL, url)
+		url, err := storage.PresignFile(ctx, "object", 0)
+		require.Empty(t, url)
+		require.ErrorContains(t, err, "expiration must be positive")
 	})
 }
 

--- a/pkg/objstore/ossstore/client_test.go
+++ b/pkg/objstore/ossstore/client_test.go
@@ -15,11 +15,16 @@
 package ossstore
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
 	"github.com/aws/smithy-go"
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
@@ -29,6 +34,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type presignAPI struct {
+	API
+	presign func(context.Context, any, ...func(*oss.PresignOptions)) (*oss.PresignResult, error)
+}
+
+func (a *presignAPI) Presign(ctx context.Context, request any, optFns ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+	return a.presign(ctx, request, optFns...)
+}
 
 type Suite struct {
 	Controller *gomock.Controller
@@ -153,6 +167,121 @@ func TestClientGetObject(t *testing.T) {
 	_, err = cli.GetObject(ctx, "object", 0, 10)
 	require.ErrorContains(t, err, "mock get error")
 	require.True(t, s.Controller.Satisfied())
+}
+
+func TestClientPresignObject(t *testing.T) {
+	ctx := context.Background()
+	const presignedURL = "https://bucket.example.com/prefix/object?signature=test"
+
+	t.Run("success", func(t *testing.T) {
+		cli := &client{
+			presignSvc: &presignAPI{
+				presign: func(_ context.Context, request any, optFns ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+					getRequest, ok := request.(*oss.GetObjectRequest)
+					require.True(t, ok)
+					require.Equal(t, "bucket", oss.ToString(getRequest.Bucket))
+					require.Equal(t, "prefix/object", oss.ToString(getRequest.Key))
+
+					options := &oss.PresignOptions{}
+					for _, optFn := range optFns {
+						optFn(options)
+					}
+					require.Equal(t, time.Hour, options.Expires)
+					return &oss.PresignResult{URL: presignedURL}, nil
+				},
+			},
+			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+		}
+		storage := s3like.NewStorage(cli, cli.BucketPrefix, &backuppb.S3{}, nil)
+
+		url, err := storage.PresignFile(ctx, "object", time.Hour)
+		require.NoError(t, err)
+		require.Equal(t, presignedURL, url)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		presignErr := errors.New("mock presign error")
+		cli := &client{
+			presignSvc: &presignAPI{
+				presign: func(context.Context, any, ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+					return nil, presignErr
+				},
+			},
+			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+		}
+		storage := s3like.NewStorage(cli, cli.BucketPrefix, &backuppb.S3{}, nil)
+
+		url, err := storage.PresignFile(ctx, "object", time.Hour)
+		require.Empty(t, url)
+		require.ErrorIs(t, err, presignErr)
+	})
+
+	t.Run("negative expiration", func(t *testing.T) {
+		cli := &client{
+			presignSvc: &presignAPI{
+				presign: func(context.Context, any, ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+					require.FailNow(t, "Presign called for negative expiration")
+					return nil, nil
+				},
+			},
+			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+		}
+
+		url, err := cli.PresignObject(ctx, "object", -time.Second)
+		require.Empty(t, url)
+		require.ErrorContains(t, err, "expiration must not be negative")
+	})
+
+	t.Run("zero expiration", func(t *testing.T) {
+		cli := &client{
+			presignSvc: &presignAPI{
+				presign: func(_ context.Context, _ any, optFns ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+					options := &oss.PresignOptions{}
+					for _, optFn := range optFns {
+						optFn(options)
+					}
+					require.Zero(t, options.Expires)
+					return &oss.PresignResult{URL: presignedURL}, nil
+				},
+			},
+			BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+		}
+
+		url, err := cli.PresignObject(ctx, "object", 0)
+		require.NoError(t, err)
+		require.Equal(t, presignedURL, url)
+	})
+}
+
+func TestClientPresignObjectDoesNotLogCredentials(t *testing.T) {
+	const securityToken = "recognizable-security-token"
+	var logOutput bytes.Buffer
+	config := oss.NewConfig().
+		WithRegion("cn-hangzhou").
+		WithEndpoint("https://oss-cn-hangzhou.aliyuncs.com").
+		WithCredentialsProvider(credentials.NewStaticCredentialsProvider("access-key-id", "access-key-secret", securityToken)).
+		WithSignatureVersion(oss.SignatureVersionV4).
+		WithLogLevel(oss.LogDebug).
+		WithLogPrinter(oss.LogPrinterFunc(func(values ...any) {
+			_, _ = fmt.Fprint(&logOutput, values...)
+		}))
+	cli := &client{
+		svc:          oss.NewClient(config),
+		presignSvc:   newPresignClient(config),
+		BucketPrefix: storeapi.NewBucketPrefix("bucket", "prefix/"),
+	}
+	require.Equal(t, oss.LogDebug, oss.ToInt(config.LogLevel))
+
+	presignedURL, err := cli.PresignObject(context.Background(), "object", time.Hour)
+	require.NoError(t, err)
+	parsedURL, err := url.Parse(presignedURL)
+	require.NoError(t, err)
+	query := parsedURL.Query()
+	signature := query.Get("x-oss-signature")
+	require.NotEmpty(t, signature)
+	require.Equal(t, securityToken, query.Get("x-oss-security-token"))
+	require.NotContains(t, logOutput.String(), signature)
+	require.NotContains(t, logOutput.String(), securityToken)
 }
 
 func TestClientDeleteObjects(t *testing.T) {

--- a/pkg/objstore/ossstore/interface.go
+++ b/pkg/objstore/ossstore/interface.go
@@ -23,6 +23,7 @@ import (
 // API defines the subset of OSS client methods used by ossstore.
 type API interface {
 	IsBucketExist(ctx context.Context, bucket string, optFns ...func(*oss.Options)) (bool, error)
+	Presign(ctx context.Context, request any, optFns ...func(*oss.PresignOptions)) (*oss.PresignResult, error)
 	HeadObject(ctx context.Context, request *oss.HeadObjectRequest, optFns ...func(*oss.Options)) (*oss.HeadObjectResult, error)
 	GetObject(ctx context.Context, request *oss.GetObjectRequest, optFns ...func(*oss.Options)) (*oss.GetObjectResult, error)
 	PutObject(ctx context.Context, request *oss.PutObjectRequest, optFns ...func(*oss.Options)) (*oss.PutObjectResult, error)

--- a/pkg/objstore/ossstore/mock/api_mock.go
+++ b/pkg/objstore/ossstore/mock/api_mock.go
@@ -265,6 +265,26 @@ func (mr *MockAPIMockRecorder) ListParts(arg0, arg1 any, arg2 ...any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParts", reflect.TypeOf((*MockAPI)(nil).ListParts), varargs...)
 }
 
+// Presign mocks base method.
+func (m *MockAPI) Presign(arg0 context.Context, arg1 any, arg2 ...func(*oss.PresignOptions)) (*oss.PresignResult, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Presign", varargs...)
+	ret0, _ := ret[0].(*oss.PresignResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Presign indicates an expected call of Presign.
+func (mr *MockAPIMockRecorder) Presign(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Presign", reflect.TypeOf((*MockAPI)(nil).Presign), varargs...)
+}
+
 // PutObject mocks base method.
 func (m *MockAPI) PutObject(arg0 context.Context, arg1 *oss.PutObjectRequest, arg2 ...func(*oss.Options)) (*oss.PutObjectResult, error) {
 	m.ctrl.T.Helper()

--- a/pkg/objstore/ossstore/store.go
+++ b/pkg/objstore/ossstore/store.go
@@ -200,6 +200,7 @@ func NewOSSStorage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opt
 
 	cli := &client{
 		svc:          oss.NewClient(ossCfg, ossOptFns...),
+		presignSvc:   newPresignClient(ossCfg, ossOptFns...),
 		BucketPrefix: bucketPrefix,
 		options:      &qs,
 	}
@@ -219,11 +220,22 @@ func NewOSSStorage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opt
 	}, nil
 }
 
+// newPresignClient disables SDK logging for presign operations. The OSS SDK sends
+// presigning through its request pipeline and logs the signed raw query at debug
+// level, exposing the URL signature and temporary security token. Copying the
+// resolved config keeps logging enabled for normal OSS operations.
+func newPresignClient(config *oss.Config, optFns ...func(*oss.Options)) *oss.Client {
+	presignConfig := config.Copy()
+	presignConfig.WithLogLevel(oss.LogOff)
+	return oss.NewClient(&presignConfig, optFns...)
+}
+
 func newOSSStorageForTest(svc API, options *backuppb.S3, accessRec *recording.AccessStats) *s3like.Storage {
 	bucketPrefix := storeapi.NewBucketPrefix(options.Bucket, options.Prefix)
 	return s3like.NewStorage(
 		&client{
 			svc:          svc,
+			presignSvc:   svc,
 			BucketPrefix: bucketPrefix,
 			options:      options,
 		},

--- a/pkg/objstore/ossstore/store.go
+++ b/pkg/objstore/ossstore/store.go
@@ -220,12 +220,13 @@ func NewOSSStorage(ctx context.Context, backend *backuppb.S3, opts *storeapi.Opt
 	}, nil
 }
 
-// newPresignClient disables SDK logging for presign operations. The OSS SDK sends
-// presigning through its request pipeline and logs the signed raw query at debug
-// level, exposing the URL signature and temporary security token. Copying the
-// resolved config keeps logging enabled for normal OSS operations.
+// newPresignClient uses the public endpoint because presigned URLs may be consumed
+// outside the Alibaba Cloud VPC. Explicit custom endpoints are retained because
+// the SDK gives them precedence over endpoint flags. It also disables SDK logging
+// because the presign request pipeline otherwise logs credentials in the raw query.
 func newPresignClient(config *oss.Config, optFns ...func(*oss.Options)) *oss.Client {
 	presignConfig := config.Copy()
+	presignConfig.WithUseInternalEndpoint(false)
 	presignConfig.WithLogLevel(oss.LogOff)
 	return oss.NewClient(&presignConfig, optFns...)
 }

--- a/pkg/objstore/s3like/store.go
+++ b/pkg/objstore/s3like/store.go
@@ -667,6 +667,9 @@ type presignableClient interface {
 
 // PresignFile implements storeapi.Storage interface.
 func (rs *Storage) PresignFile(ctx context.Context, fileName string, expire time.Duration) (string, error) {
+	if expire <= 0 {
+		return "", errors.New("presign expiration must be positive")
+	}
 	if pc, ok := rs.s3Cli.(presignableClient); ok {
 		return pc.PresignObject(ctx, fileName, expire)
 	}

--- a/pkg/objstore/s3store/client.go
+++ b/pkg/objstore/s3store/client.go
@@ -210,6 +210,11 @@ func (c *s3Client) DeleteObject(ctx context.Context, name string) error {
 
 // PresignObject creates a presigned URL for the given object.
 // It implements the presignableClient interface used by s3like.Storage.
+// TODO: A URL signed with temporary credentials can expire before the requested
+// duration. The shared PresignFile contract returns only the URL, so callers
+// cannot report the effective lifetime. Make presigning expiration-aware by
+// refreshing credentials with sufficient remaining lifetime or returning the
+// effective expiration through the shared contract.
 func (c *s3Client) PresignObject(ctx context.Context, name string, expire time.Duration) (string, error) {
 	key := c.ObjectKey(name)
 	input := &s3.GetObjectInput{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65461

Problem Summary:

The native Alibaba Cloud OSS object-store backend did not implement `PresignFile`. Callers such as plan replayer could generate download URLs for S3 and GCS objects, but OSS returned `S3-compatible storage does not support PresignFile` instead. The OSS SDK also logs complete signed query strings at debug level, so using its presigner through the normal client would expose the URL signature and temporary security token in TiDB logs.

### What changed and how does it work?

The OSS client now implements the optional `PresignObject` interface used by `s3like.Storage.PresignFile`. It signs an OSS `GetObjectRequest` for the bucket and storage-prefixed object key using the caller-provided expiration.

Presigning uses a second OSS SDK client built from the fully resolved storage configuration. That client shares the endpoint, region, signer settings, operation options, and credential provider with normal OSS operations, but disables SDK logging so the signed bearer URL is not written to debug logs. Negative expirations are rejected consistently with the AWS S3 implementation, while zero and positive durations are forwarded to the OSS SDK.

The OSS API mock and Bazel test metadata are regenerated for the new SDK operation and tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - Used bucket `presign-url-test-xxxx` in region `ap-southeast-1` with temporary credentials supplied through environment variables. Credential values and the signed URL are intentionally omitted.
  - Uploaded `hello world` to a unique `presign-real-<timestamp>/hello-world.txt` object through `NewOSSStorage`.
  - Generated a one-hour URL with `PresignFile`, then downloaded it with an unsigned HTTP client.
  - Verified HTTP status `200` and an exact response body of `hello world`.
  - Deleted the test object and verified that it no longer exists.
  - Result: `TestClientPresignObject/real_OSS` passed against real OSS in 3.75 seconds.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```text
make bazel_prepare
go test ./pkg/objstore/ossstore -count=1 -tags=intest,deadlock
make lint
```

Manual-test command:

```text
go test -v ./pkg/objstore/ossstore -run '^TestClientPresignObject$/^real_OSS$' -count=1 -tags=intest,deadlock
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/release-notes-style-guide.html) to write a quality release note.

```release-note
Support generating presigned download URLs for files stored in Alibaba Cloud OSS.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating presigned download URLs for objects with configurable expiration times.
  * Presigned URLs use the appropriate public endpoint when applicable.

* **Bug Fixes**
  * Invalid expiration durations, including zero and negative values, are now rejected before processing.

* **Tests**
  * Expanded coverage for successful and invalid presigned URL requests.
  * Increased test parallelization for improved test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
