### PR TITLE
executor, expression, chunk: reduce allocations in execution hot paths

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -491,6 +491,16 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 	// Extract trace ID from context to store in recordSet for lazy execution
 	traceID := tikvtrace.TraceIDFromContext(ctx)
 
+	if pointGetExecutor, ok := executor.(*PointGetExecutor); ok {
+		pointGetExecutor.resultSet = recordSet{
+			executor:   executor,
+			schema:     executor.Schema(),
+			stmt:       a,
+			txnStartTS: startTs,
+			traceID:    traceID,
+		}
+		return &pointGetExecutor.resultSet, nil
+	}
 	return &recordSet{
 		executor:   executor,
 		schema:     executor.Schema(),

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -98,7 +98,6 @@ import (
 	clientkv "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv"
-	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 )
 
 // executorBuilder builds an Executor from a Plan.
@@ -5847,11 +5846,8 @@ func (b *executorBuilder) buildBatchPointGet(plan *physicalop.BatchPointGetPlan)
 		e.snapshot.SetOption(kv.ReplicaReadAdjuster, newReplicaReadAdjuster(e.Ctx(), plan.GetAvgRowSize()))
 	}
 	if e.RuntimeStats() != nil {
-		snapshotStats := &txnsnapshot.SnapshotRuntimeStats{}
-		e.stats = &runtimeStatsWithSnapshot{
-			SnapshotRuntimeStats: snapshotStats,
-		}
-		e.snapshot.SetOption(kv.CollectRuntimeStats, snapshotStats)
+		e.stats = &runtimeStatsWithSnapshot{}
+		e.snapshot.SetOption(kv.CollectRuntimeStats, &e.stats.SnapshotRuntimeStats)
 	}
 
 	if plan.IndexInfo != nil {

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -5734,6 +5734,10 @@ func (b *executorBuilder) buildSQLBindExec(v *plannercore.SQLBindPlan) exec.Exec
 
 // NewRowDecoder creates a chunk decoder for new row format row value decode.
 func NewRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model.TableInfo) *rowcodec.ChunkDecoder {
+	return initRowDecoder(nil, ctx, schema, tbl)
+}
+
+func initRowDecoder(decoder *rowcodec.ChunkDecoder, ctx sessionctx.Context, schema *expression.Schema, tbl *model.TableInfo) *rowcodec.ChunkDecoder {
 	getColInfoByID := func(tbl *model.TableInfo, colID int64) *model.ColumnInfo {
 		for _, col := range tbl.Columns {
 			if col.ID == colID {
@@ -5782,7 +5786,11 @@ func NewRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model
 		chk.AppendDatum(i, &d)
 		return nil
 	}
-	return rowcodec.NewChunkDecoder(reqCols, pkCols, defVal, ctx.GetSessionVars().Location())
+	if decoder == nil {
+		return rowcodec.NewChunkDecoder(reqCols, pkCols, defVal, ctx.GetSessionVars().Location())
+	}
+	decoder.Reset(reqCols, pkCols, defVal, ctx.GetSessionVars().Location())
+	return decoder
 }
 
 func (b *executorBuilder) buildBatchPointGet(plan *physicalop.BatchPointGetPlan) exec.Executor {

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"context"
 	"reflect"
+	"sync"
 	stdatomic "sync/atomic"
 	"time"
 
@@ -250,6 +251,18 @@ type Executor interface {
 }
 
 var _ Executor = &BaseExecutor{}
+
+var executorNextTraceNames sync.Map
+
+func nextTraceName(e Executor) string {
+	typ := reflect.TypeOf(e)
+	if name, ok := executorNextTraceNames.Load(typ); ok {
+		return name.(string)
+	}
+	name := typ.String() + ".Next"
+	actual, _ := executorNextTraceNames.LoadOrStore(typ, name)
+	return actual.(string)
+}
 
 // executorChunkAllocator is a helper to implement `Chunk` related methods in `Executor` interface
 type executorChunkAllocator struct {
@@ -657,7 +670,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		recorder = cache.recorder
 	} else {
 		execType := reflect.TypeOf(e).String()
-		regionName = execType + ".Next"
+		regionName = nextTraceName(e)
 		var hasInfo bool
 		if info, hasInfo = ruv2ExecutorMetricByType(execType); hasInfo {
 			if m := execdetails.RUV2MetricsFromContext(ctx); m != nil && !m.Bypass() {

--- a/pkg/executor/internal/exec/executor_bench_test.go
+++ b/pkg/executor/internal/exec/executor_bench_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/stretchr/testify/require"
+)
+
+type nextTraceNameExecutor struct {
+	BaseExecutorV2
+}
+
+func TestNextTraceName(t *testing.T) {
+	vars := variable.NewSessionVars(nil)
+	v2 := NewBaseExecutorV2(vars, nil, 0)
+	embedded := nextTraceNameExecutor{BaseExecutorV2: NewBaseExecutorV2(vars, nil, 0)}
+
+	require.Equal(t, "*exec.BaseExecutorV2.Next", nextTraceName(&v2))
+	require.Equal(t, "*exec.nextTraceNameExecutor.Next", nextTraceName(&embedded))
+
+	const concurrency = 32
+	names := make(chan string, concurrency)
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			names <- nextTraceName(&v2)
+		}()
+	}
+	wg.Wait()
+	close(names)
+	for name := range names {
+		require.Equal(t, "*exec.BaseExecutorV2.Next", name)
+	}
+}
+
+func TestNextTraceNameWithOpenTracing(t *testing.T) {
+	vars := variable.NewSessionVars(nil)
+	executor := nextTraceNameExecutor{BaseExecutorV2: NewBaseExecutorV2(vars, nil, 0)}
+	tracer := mocktracer.New()
+	parent := tracer.StartSpan("parent")
+	ctx := opentracing.ContextWithSpan(context.Background(), parent)
+
+	require.NoError(t, Next(ctx, &executor, chunk.NewChunkWithCapacity(nil, 0)))
+	parent.Finish()
+
+	spans := tracer.FinishedSpans()
+	require.Len(t, spans, 2)
+	require.Equal(t, "*exec.nextTraceNameExecutor.Next", spans[0].OperationName)
+}
+
+func BenchmarkNextWrapper(b *testing.B) {
+	executor := NewBaseExecutorV2(variable.NewSessionVars(nil), nil, 0)
+	req := chunk.NewChunkWithCapacity(nil, 0)
+	ctx := context.Background()
+	if err := Next(ctx, &executor, req); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := Next(ctx, &executor, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/executor/join/concurrent_map.go
+++ b/pkg/executor/join/concurrent_map.go
@@ -25,7 +25,7 @@ const ShardCount = 320
 
 // A "thread" safe map of type string:Anything.
 // To avoid lock bottlenecks this map is dived to several (ShardCount) map shards.
-type concurrentMap []*concurrentMapShared
+type concurrentMap []concurrentMapShared
 
 // A "thread" safe string to anything map.
 type concurrentMapShared struct {
@@ -35,20 +35,12 @@ type concurrentMapShared struct {
 
 // newConcurrentMap creates a new concurrent map.
 func newConcurrentMap() concurrentMap {
-	m := make(concurrentMap, ShardCount)
-	for i := range ShardCount {
-		m[i] = &concurrentMapShared{}
-		m[i].items.Init(make(map[uint64]*entry))
-		if intest.InTest {
-			m[i].items.MockSeedForTest()
-		}
-	}
-	return m
+	return make(concurrentMap, ShardCount)
 }
 
 // getShard returns shard under given key
 func (m concurrentMap) getShard(hashKey uint64) *concurrentMapShared {
-	return m[hashKey%uint64(ShardCount)]
+	return &m[hashKey%uint64(ShardCount)]
 }
 
 // Insert inserts a value in a shard safely
@@ -57,6 +49,12 @@ func (m concurrentMap) Insert(key uint64, value *entry) (memDelta int64) {
 	shard.Lock()
 	oldValue := shard.items.M[key]
 	value.Next = oldValue
+	if shard.items.M == nil {
+		shard.items.Init(make(map[uint64]*entry))
+		if intest.InTest {
+			shard.items.MockSeedForTest()
+		}
+	}
 	memDelta += shard.items.Set(key, value)
 	shard.Unlock()
 	return memDelta
@@ -85,7 +83,7 @@ type IterCb func(key uint64, e *entry)
 // all elements in a map.
 func (m concurrentMap) IterCb(fn IterCb) {
 	for idx := range m {
-		shard := (m)[idx]
+		shard := &m[idx]
 		shard.RLock()
 		for key, value := range shard.items.M {
 			fn(key, value)

--- a/pkg/executor/join/concurrent_map_bench_test.go
+++ b/pkg/executor/join/concurrent_map_bench_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+var benchmarkConcurrentMapSink *concurrentMapHashTable
+
+func BenchmarkNewConcurrentMapInitialization(b *testing.B) {
+	var sink concurrentMap
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		sink = newConcurrentMap()
+	}
+	b.StopTimer()
+	if len(sink) != ShardCount {
+		b.Fatalf("unexpected shard count: %d", len(sink))
+	}
+}
+
+func BenchmarkConcurrentMapHashTableBuild(b *testing.B) {
+	cases := []struct {
+		name      string
+		rows      int
+		sameShard bool
+	}{
+		{name: "empty"},
+		{name: "rows=10/single-shard", rows: 10, sameShard: true},
+		{name: "rows=10/spread", rows: 10},
+		{name: "rows=1000/all-shards", rows: 1000},
+	}
+
+	for _, bc := range cases {
+		b.Run(bc.name, func(b *testing.B) {
+			keys := make([]uint64, bc.rows)
+			rows := make([]chunk.RowPtr, bc.rows)
+			for i := range bc.rows {
+				if bc.sameShard {
+					keys[i] = uint64(i * ShardCount)
+				} else {
+					keys[i] = uint64(i)
+				}
+				rows[i] = chunk.RowPtr{ChkIdx: uint32(i / 32), RowIdx: uint32(i % 32)}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				table := NewConcurrentMapHashTable()
+				for i := range keys {
+					table.Put(keys[i], rows[i])
+				}
+				benchmarkConcurrentMapSink = table
+			}
+			b.StopTimer()
+			if got := benchmarkConcurrentMapSink.Len(); got != uint64(bc.rows) {
+				b.Fatalf("case %s: got %d rows", strconv.Quote(bc.name), got)
+			}
+		})
+	}
+}

--- a/pkg/executor/join/concurrent_map_test.go
+++ b/pkg/executor/join/concurrent_map_test.go
@@ -67,6 +67,22 @@ func TestConcurrentMap(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestConcurrentMapLazyShardInitialization(t *testing.T) {
+	m := newConcurrentMap()
+	for i := range m {
+		require.Nil(t, m[i].items.M)
+	}
+
+	first := &entry{Ptr: chunk.RowPtr{ChkIdx: 1, RowIdx: 2}}
+	m.Insert(0, first)
+	require.NotNil(t, m[0].items.M)
+	require.Nil(t, m[1].items.M)
+
+	got, ok := m.Get(0)
+	require.True(t, ok)
+	require.Same(t, first, got)
+}
+
 func TestConcurrentMapMemoryUsage(t *testing.T) {
 	m := newConcurrentMap()
 	memUsage := int64(0)

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -135,7 +135,7 @@ type PointGetExecutor struct {
 	done             bool
 	lock             bool
 	lockWaitTime     int64
-	rowDecoder       *rowcodec.ChunkDecoder
+	rowDecoder       rowcodec.ChunkDecoder
 
 	columns []*model.ColumnInfo
 	// virtualColumnIndex records all the indices of virtual columns and sort them in definition
@@ -197,7 +197,7 @@ func (e *PointGetExecutor) Recreated(p *physicalop.PointGetPlan, ctx sessionctx.
 // Note: since this function is also used by Recreated function, thus we can't rely on member field's default value
 // for example: we need to explicitly set e.stats to nil when e.RuntimeStats() is nil
 func (e *PointGetExecutor) Init(p *physicalop.PointGetPlan) {
-	decoder := NewRowDecoder(e.Ctx(), p.Schema(), p.TblInfo)
+	initRowDecoder(&e.rowDecoder, e.Ctx(), p.Schema(), p.TblInfo)
 	e.tblInfo = p.TblInfo
 	e.handle = p.Handle
 	e.idxInfo = p.IndexInfo
@@ -211,7 +211,6 @@ func (e *PointGetExecutor) Init(p *physicalop.PointGetPlan) {
 		e.lock = false
 		e.lockWaitTime = 0
 	}
-	e.rowDecoder = decoder
 	e.partitionDefIdx = p.PartitionIdx
 	e.columns = p.Columns
 	e.buildVirtualColumnInfo()
@@ -434,7 +433,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 
 	sctx := e.BaseExecutor.Ctx()
 	schema := e.Schema()
-	err = DecodeRowValToChunk(sctx, schema, e.tblInfo, e.handle, val, req, e.rowDecoder)
+	err = DecodeRowValToChunk(sctx, schema, e.tblInfo, e.handle, val, req, &e.rowDecoder)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -227,11 +227,8 @@ func (e *PointGetExecutor) Init(p *physicalop.PointGetPlan) {
 	})
 
 	if e.RuntimeStats() != nil {
-		snapshotStats := &txnsnapshot.SnapshotRuntimeStats{}
-		e.stats = &runtimeStatsWithSnapshot{
-			SnapshotRuntimeStats: snapshotStats,
-		}
-		e.snapshot.SetOption(kv.CollectRuntimeStats, snapshotStats)
+		e.stats = &runtimeStatsWithSnapshot{}
+		e.snapshot.SetOption(kv.CollectRuntimeStats, &e.stats.SnapshotRuntimeStats)
 	} else {
 		e.stats = nil
 	}
@@ -831,24 +828,19 @@ func getColInfoByID(tbl *model.TableInfo, colID int64) *model.ColumnInfo {
 }
 
 type runtimeStatsWithSnapshot struct {
-	*txnsnapshot.SnapshotRuntimeStats
+	txnsnapshot.SnapshotRuntimeStats
 }
 
 func (e *runtimeStatsWithSnapshot) String() string {
-	if e.SnapshotRuntimeStats != nil {
-		return e.SnapshotRuntimeStats.String()
-	}
-	return ""
+	return e.SnapshotRuntimeStats.String()
 }
 
 // Clone implements the RuntimeStats interface.
 func (e *runtimeStatsWithSnapshot) Clone() execdetails.RuntimeStats {
-	newRs := &runtimeStatsWithSnapshot{}
-	if e.SnapshotRuntimeStats != nil {
-		snapshotStats := e.SnapshotRuntimeStats.Clone()
-		newRs.SnapshotRuntimeStats = snapshotStats
+	snapshotStats := e.SnapshotRuntimeStats.Clone()
+	return &runtimeStatsWithSnapshot{
+		SnapshotRuntimeStats: *snapshotStats,
 	}
-	return newRs
 }
 
 // Merge implements the RuntimeStats interface.
@@ -857,14 +849,7 @@ func (e *runtimeStatsWithSnapshot) Merge(other execdetails.RuntimeStats) {
 	if !ok {
 		return
 	}
-	if tmp.SnapshotRuntimeStats != nil {
-		if e.SnapshotRuntimeStats == nil {
-			snapshotStats := tmp.SnapshotRuntimeStats.Clone()
-			e.SnapshotRuntimeStats = snapshotStats
-			return
-		}
-		e.SnapshotRuntimeStats.Merge(tmp.SnapshotRuntimeStats)
-	}
+	e.SnapshotRuntimeStats.Merge(&tmp.SnapshotRuntimeStats)
 }
 
 // Tp implements the RuntimeStats interface.

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -145,7 +145,8 @@ type PointGetExecutor struct {
 	// virtualColumnRetFieldTypes records the RetFieldTypes of virtual columns.
 	virtualColumnRetFieldTypes []*types.FieldType
 
-	stats *runtimeStatsWithSnapshot
+	stats     *runtimeStatsWithSnapshot
+	resultSet recordSet
 }
 
 // GetPhysID returns the physical id used, either the table's id or a partition's ID

--- a/pkg/executor/runtime_stats_with_snapshot_test.go
+++ b/pkg/executor/runtime_stats_with_snapshot_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeStatsWithSnapshotValue(t *testing.T) {
+	stats := &runtimeStatsWithSnapshot{}
+	require.Equal(t, "", stats.String())
+	require.Equal(t, execdetails.TpRuntimeStatsWithSnapshot, stats.Tp())
+
+	cloned, ok := stats.Clone().(*runtimeStatsWithSnapshot)
+	require.True(t, ok)
+	require.NotSame(t, stats, cloned)
+	require.NotSame(t, &stats.SnapshotRuntimeStats, &cloned.SnapshotRuntimeStats)
+	require.Equal(t, stats.String(), cloned.String())
+
+	stats.Merge(cloned)
+	require.Equal(t, "", stats.String())
+}

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -62,6 +62,7 @@ type UpdateExec struct {
 	tblColPosInfos            physicalop.TblColPosInfoSlice
 	assignFlag                []int
 	evalBuffer                chunk.MutRow
+	newRowData                []types.Datum
 	allAssignmentsAreConstant bool
 	virtualAssignmentsOffset  int
 	drained                   bool
@@ -512,7 +513,7 @@ func handleUpdateError(sctx sessionctx.Context, colName ast.CIStr, colInfo *mmod
 }
 
 func (e *UpdateExec) fastComposeNewRow(rowIdx int, oldRow []types.Datum, cols []*table.Column) ([]types.Datum, error) {
-	newRowData := types.CloneRow(oldRow)
+	newRowData := e.cloneRow(oldRow)
 	for _, assign := range e.OrderedList {
 		var colInfo *mmodel.ColumnInfo
 		if cols[assign.Col.Index] != nil {
@@ -544,7 +545,7 @@ func (e *UpdateExec) fastComposeNewRow(rowIdx int, oldRow []types.Datum, cols []
 }
 
 func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*table.Column) ([]types.Datum, error) {
-	newRowData := types.CloneRow(oldRow)
+	newRowData := e.cloneRow(oldRow)
 	e.evalBuffer.SetDatums(newRowData...)
 	for _, assign := range e.OrderedList[:e.virtualAssignmentsOffset] {
 		tblIdx := e.assignFlag[assign.Col.Index]
@@ -571,9 +572,25 @@ func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*tab
 	return newRowData, nil
 }
 
+func (e *UpdateExec) cloneRow(row []types.Datum) []types.Datum {
+	if cap(e.newRowData) < len(row) {
+		e.newRowData = make([]types.Datum, len(row))
+	} else {
+		if len(e.newRowData) > len(row) {
+			clear(e.newRowData[len(row):])
+		}
+		e.newRowData = e.newRowData[:len(row)]
+	}
+	for i := range row {
+		row[i].Copy(&e.newRowData[i])
+	}
+	return e.newRowData
+}
+
 // Close implements the Executor Close interface.
 func (e *UpdateExec) Close() error {
 	defer e.memTracker.ReplaceBytesUsed(0)
+	e.newRowData = nil
 	e.setMessage()
 	if e.RuntimeStats() != nil && e.stats != nil {
 		txn, err := e.Ctx().Txn(false)

--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -62,6 +62,7 @@ type UpdateExec struct {
 	tblColPosInfos            physicalop.TblColPosInfoSlice
 	assignFlag                []int
 	evalBuffer                chunk.MutRow
+	datumRow                  []types.Datum
 	newRowData                []types.Datum
 	allAssignmentsAreConstant bool
 	virtualAssignmentsOffset  int
@@ -454,7 +455,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, int64, error) {
 		}
 		for rowIdx := range chk.NumRows() {
 			chunkRow := chk.GetRow(rowIdx)
-			datumRow := chunkRow.GetDatumRow(fields)
+			datumRow := e.getDatumRow(chunkRow, fields)
 			// precomputes handles
 			if err := e.prepare(datumRow); err != nil {
 				return 0, 0, err
@@ -572,6 +573,16 @@ func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*tab
 	return newRowData, nil
 }
 
+func (e *UpdateExec) getDatumRow(row chunk.Row, fields []*types.FieldType) []types.Datum {
+	rowLen := row.Len()
+	if e.datumRow == nil || len(e.datumRow) != rowLen {
+		e.datumRow = row.GetDatumRow(fields)
+		return e.datumRow
+	}
+	clear(e.datumRow)
+	return row.GetDatumRowWithBuffer(fields, e.datumRow)
+}
+
 func (e *UpdateExec) cloneRow(row []types.Datum) []types.Datum {
 	if cap(e.newRowData) < len(row) {
 		e.newRowData = make([]types.Datum, len(row))
@@ -590,6 +601,7 @@ func (e *UpdateExec) cloneRow(row []types.Datum) []types.Datum {
 // Close implements the Executor Close interface.
 func (e *UpdateExec) Close() error {
 	defer e.memTracker.ReplaceBytesUsed(0)
+	e.datumRow = nil
 	e.newRowData = nil
 	e.setMessage()
 	if e.RuntimeStats() != nil && e.stats != nil {

--- a/pkg/executor/update_tpcc_bench_test.go
+++ b/pkg/executor/update_tpcc_bench_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/types"
+)
+
+var updateCloneRowBenchmarkSink []types.Datum
+
+func makeTPCCUpdateDatumRow(n int) []types.Datum {
+	row := make([]types.Datum, n)
+	for i := range row {
+		switch i % 5 {
+		case 0:
+			row[i] = types.NewIntDatum(int64(i + 1))
+		case 1:
+			row[i] = types.NewStringDatum("tpcc-string-value")
+		case 2:
+			row[i] = types.NewBytesDatum([]byte("tpcc-bytes-value"))
+		case 3:
+			row[i] = types.NewDecimalDatum(types.NewDecFromStringForTest("12345.67"))
+		case 4:
+			row[i] = types.NewTimeDatum(types.ZeroTime)
+		}
+	}
+	return row
+}
+
+func BenchmarkUpdateExecCloneRowTPCC(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		width int
+	}{
+		{name: "warehouse", width: 9},
+		{name: "district", width: 11},
+		{name: "customer", width: 21},
+		{name: "stock", width: 17},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			e := &UpdateExec{}
+			row := makeTPCCUpdateDatumRow(tc.width)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var err error
+				updateCloneRowBenchmarkSink, err = e.fastComposeNewRow(i, row, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if len(updateCloneRowBenchmarkSink) != tc.width {
+				b.Fatalf("got row width %d, want %d", len(updateCloneRowBenchmarkSink), tc.width)
+			}
+		})
+	}
+}
+
+func TestUpdateExecCloneRowBuffer(t *testing.T) {
+	sourceBytes := []byte("first-row")
+	firstSource := []types.Datum{
+		types.NewIntDatum(1),
+		types.NewBytesDatum(sourceBytes),
+		types.NewDecimalDatum(types.NewDecFromStringForTest("1.25")),
+	}
+	e := &UpdateExec{}
+	first, err := e.fastComposeNewRow(0, firstSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstBacking := &first[0]
+	retained := slices.Clone(first)
+
+	sourceBytes[0] = 'X'
+	if got := string(first[1].GetBytes()); got != "first-row" {
+		t.Fatalf("composed row aliases source bytes: got %q", got)
+	}
+
+	secondSource := []types.Datum{
+		types.NewIntDatum(2),
+		types.NewBytesDatum([]byte("second-row")),
+		types.NewDecimalDatum(types.NewDecFromStringForTest("2.50")),
+	}
+	second, err := e.fastComposeNewRow(1, secondSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBacking != &second[0] {
+		t.Fatal("row buffer was not reused for the same width")
+	}
+	if retained[0].GetInt64() != 1 || string(retained[1].GetBytes()) != "first-row" ||
+		retained[2].GetMysqlDecimal().String() != "1.25" {
+		t.Fatalf("retained shallow clone changed after buffer reuse: %v", retained)
+	}
+
+	larger, err := e.fastComposeNewRow(2, makeTPCCUpdateDatumRow(21), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(larger) != 21 {
+		t.Fatalf("got grown row width %d, want 21", len(larger))
+	}
+	smaller, err := e.fastComposeNewRow(3, makeTPCCUpdateDatumRow(9), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(smaller) != 9 {
+		t.Fatalf("got shrunk row width %d, want 9", len(smaller))
+	}
+	for i, d := range e.newRowData[:cap(e.newRowData)][len(smaller):] {
+		if !d.IsNull() {
+			t.Fatalf("truncated Datum %d was retained", i+len(smaller))
+		}
+	}
+
+	other := &UpdateExec{}
+	otherRow, err := other.fastComposeNewRow(0, secondSource, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if &otherRow[0] == &second[0] {
+		t.Fatal("different UpdateExec instances share row storage")
+	}
+}

--- a/pkg/executor/update_tpcc_bench_test.go
+++ b/pkg/executor/update_tpcc_bench_test.go
@@ -18,10 +18,16 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
-var updateCloneRowBenchmarkSink []types.Datum
+var (
+	updateCloneRowBenchmarkSink []types.Datum
+	updateDatumRowBenchmarkSink []types.Datum
+	updateExecBenchmarkSink     *UpdateExec
+)
 
 func makeTPCCUpdateDatumRow(n int) []types.Datum {
 	row := make([]types.Datum, n)
@@ -70,6 +76,166 @@ func BenchmarkUpdateExecCloneRowTPCC(b *testing.B) {
 			}
 		})
 	}
+}
+
+type updateDatumRowGetter interface {
+	getDatumRow(chunk.Row, []*types.FieldType) []types.Datum
+}
+
+func getUpdateDatumRowForBenchmark(
+	e *UpdateExec, row chunk.Row, fields []*types.FieldType,
+) []types.Datum {
+	if getter, ok := any(e).(updateDatumRowGetter); ok {
+		return getter.getDatumRow(row, fields)
+	}
+	return row.GetDatumRow(fields)
+}
+
+func BenchmarkUpdateExecGetDatumRowTPCC(b *testing.B) {
+	warehouse, district, customer, stock := tpccUpdateFieldTypes()
+	for _, tc := range []struct {
+		name   string
+		fields []*types.FieldType
+	}{
+		{name: "warehouse", fields: warehouse},
+		{name: "district", fields: district},
+		{name: "customer", fields: customer},
+		{name: "stock", fields: stock},
+	} {
+		chk := makeTPCCUpdateChunk(tc.fields, 32)
+		b.Run(tc.name+"/cold", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				e := &UpdateExec{}
+				updateExecBenchmarkSink = e
+				row := chk.GetRow(i % chk.NumRows())
+				updateDatumRowBenchmarkSink = getUpdateDatumRowForBenchmark(e, row, tc.fields)
+				updateCloneRowBenchmarkSink = e.cloneRow(updateDatumRowBenchmarkSink)
+			}
+		})
+		b.Run(tc.name+"/steady", func(b *testing.B) {
+			e := &UpdateExec{}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				row := chk.GetRow(i % chk.NumRows())
+				updateDatumRowBenchmarkSink = getUpdateDatumRowForBenchmark(e, row, tc.fields)
+				updateCloneRowBenchmarkSink = e.cloneRow(updateDatumRowBenchmarkSink)
+			}
+		})
+	}
+}
+
+func BenchmarkUpdateExecGetDatumRowColdPairedTPCC(b *testing.B) {
+	warehouse, district, customer, stock := tpccUpdateFieldTypes()
+	for _, tc := range []struct {
+		name   string
+		fields []*types.FieldType
+	}{
+		{name: "warehouse", fields: warehouse},
+		{name: "district", fields: district},
+		{name: "customer", fields: customer},
+		{name: "stock", fields: stock},
+	} {
+		chk := makeTPCCUpdateChunk(tc.fields, 32)
+		b.Run(tc.name+"/old", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				e := &UpdateExec{}
+				updateExecBenchmarkSink = e
+				row := chk.GetRow(i % chk.NumRows())
+				updateDatumRowBenchmarkSink = row.GetDatumRow(tc.fields)
+				updateCloneRowBenchmarkSink = e.cloneRow(updateDatumRowBenchmarkSink)
+			}
+		})
+		b.Run(tc.name+"/new", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				e := &UpdateExec{}
+				updateExecBenchmarkSink = e
+				row := chk.GetRow(i % chk.NumRows())
+				updateDatumRowBenchmarkSink = e.getDatumRow(row, tc.fields)
+				updateCloneRowBenchmarkSink = e.cloneRow(updateDatumRowBenchmarkSink)
+			}
+		})
+	}
+}
+
+func tpccUpdateFieldTypes() (
+	warehouse, district, customer, stock []*types.FieldType,
+) {
+	const (
+		intType = iota
+		stringType
+		decimalType
+		datetimeType
+	)
+	makeTypes := func(spec ...int) []*types.FieldType {
+		result := make([]*types.FieldType, len(spec))
+		for i, kind := range spec {
+			mysqlType := byte(mysql.TypeLong)
+			switch kind {
+			case stringType:
+				mysqlType = mysql.TypeVarchar
+			case decimalType:
+				mysqlType = mysql.TypeNewDecimal
+			case datetimeType:
+				mysqlType = mysql.TypeDatetime
+			}
+			result[i] = types.NewFieldType(mysqlType)
+		}
+		return result
+	}
+
+	warehouse = makeTypes(
+		intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		decimalType, decimalType,
+	)
+	district = makeTypes(
+		intType, intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		decimalType, decimalType, intType,
+	)
+	customer = makeTypes(
+		intType, intType, intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		stringType, stringType, stringType,
+		datetimeType, stringType,
+		decimalType, decimalType, decimalType, decimalType,
+		intType, intType, stringType,
+	)
+	stock = makeTypes(
+		intType, intType, intType,
+		stringType, stringType, stringType, stringType, stringType,
+		stringType, stringType, stringType, stringType, stringType,
+		intType, intType, intType, stringType,
+	)
+	return warehouse, district, customer, stock
+}
+
+func makeTPCCUpdateChunk(fields []*types.FieldType, rows int) *chunk.Chunk {
+	chk := chunk.NewChunkWithCapacity(fields, rows)
+	for rowIdx := 0; rowIdx < rows; rowIdx++ {
+		for colIdx, field := range fields {
+			if (rowIdx+colIdx)%17 == 0 {
+				chk.AppendNull(colIdx)
+				continue
+			}
+			switch field.GetType() {
+			case mysql.TypeLong:
+				chk.AppendInt64(colIdx, int64(rowIdx+colIdx+1))
+			case mysql.TypeVarchar:
+				chk.AppendString(colIdx, "tpcc-string-value")
+			case mysql.TypeNewDecimal:
+				chk.AppendMyDecimal(colIdx, types.NewDecFromStringForTest("12345.67"))
+			case mysql.TypeDatetime:
+				chk.AppendTime(colIdx, types.ZeroTime)
+			default:
+				panic("unsupported TPCC benchmark field type")
+			}
+		}
+	}
+	return chk
 }
 
 func TestUpdateExecCloneRowBuffer(t *testing.T) {
@@ -136,5 +302,81 @@ func TestUpdateExecCloneRowBuffer(t *testing.T) {
 	}
 	if &otherRow[0] == &second[0] {
 		t.Fatal("different UpdateExec instances share row storage")
+	}
+}
+
+func TestUpdateExecDatumRowBuffers(t *testing.T) {
+	fields := []*types.FieldType{
+		types.NewFieldType(mysql.TypeVarchar),
+		types.NewFieldType(mysql.TypeNewDecimal),
+		types.NewFieldType(mysql.TypeDatetime),
+		types.NewFieldType(mysql.TypeLong),
+	}
+	chk := chunk.NewChunkWithCapacity(fields, 2)
+	chk.AppendString(0, "first-row")
+	chk.AppendMyDecimal(1, types.NewDecFromStringForTest("1.25"))
+	chk.AppendTime(2, types.ZeroTime)
+	chk.AppendInt64(3, 1)
+	for colIdx := range fields {
+		chk.AppendNull(colIdx)
+	}
+
+	e := &UpdateExec{}
+	first := e.getDatumRow(chk.GetRow(0), fields)
+	firstBacking := &first[0]
+	if len(first) != len(fields) || cap(first) != len(fields) {
+		t.Fatalf("input row length/capacity = %d/%d, want %d/%d",
+			len(first), cap(first), len(fields), len(fields))
+	}
+	retainedInput := slices.Clone(first)
+	firstComposed := e.cloneRow(first)
+	firstComposedBacking := &firstComposed[0]
+	retainedComposed := slices.Clone(firstComposed)
+	if cap(firstComposed) != len(fields) {
+		t.Fatalf("composed row capacity = %d, want %d", cap(firstComposed), len(fields))
+	}
+	if firstBacking == firstComposedBacking {
+		t.Fatal("input and composed rows alias")
+	}
+
+	second := e.getDatumRow(chk.GetRow(1), fields)
+	if firstBacking != &second[0] {
+		t.Fatal("input row buffer was not reused")
+	}
+	for i, datum := range second {
+		if !datum.IsNull() || datum.GetValue() != nil || len(datum.GetBytes()) != 0 {
+			t.Fatalf("NULL Datum %d retained previous state: %v", i, datum)
+		}
+	}
+	secondComposed := e.cloneRow(second)
+	if firstComposedBacking != &secondComposed[0] {
+		t.Fatal("composed row buffer was not reused")
+	}
+	if retainedInput[0].GetString() != "first-row" ||
+		retainedInput[1].GetMysqlDecimal().String() != "1.25" {
+		t.Fatalf("retained input changed after buffer reuse: %v", retainedInput)
+	}
+	if retainedComposed[0].GetString() != "first-row" ||
+		retainedComposed[1].GetMysqlDecimal().String() != "1.25" {
+		t.Fatalf("retained composed row changed after buffer reuse: %v", retainedComposed)
+	}
+
+	_, _, customerFields, _ := tpccUpdateFieldTypes()
+	customerChunk := makeTPCCUpdateChunk(customerFields, 1)
+	grown := e.getDatumRow(customerChunk.GetRow(0), customerFields)
+	if len(grown) != len(customerFields) || cap(grown) != len(customerFields) {
+		t.Fatalf("grown input length/capacity = %d/%d, want %d/%d",
+			len(grown), cap(grown), len(customerFields), len(customerFields))
+	}
+	grownComposed := e.cloneRow(grown)
+	if len(grownComposed) != len(customerFields) || cap(grownComposed) != len(customerFields) {
+		t.Fatalf("grown composed length/capacity = %d/%d, want %d/%d",
+			len(grownComposed), cap(grownComposed), len(customerFields), len(customerFields))
+	}
+
+	other := &UpdateExec{}
+	otherInput := other.getDatumRow(chk.GetRow(0), fields)
+	if &otherInput[0] == &second[0] {
+		t.Fatal("different UpdateExec instances share input row storage")
 	}
 }

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -363,12 +363,18 @@ func (c *Constant) EvalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) 
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
+	tp := c.RetType
+	var paramType types.FieldType
+	if c.ParamMarker != nil {
+		types.InferParamTypeFromDatum(&dt, &paramType)
+		tp = &paramType
+	}
+	if tp.GetType() == mysql.TypeNull || dt.IsNull() {
 		return 0, true, nil
 	} else if dt.Kind() == types.KindBinaryLiteral {
 		val, err := dt.GetBinaryLiteral().ToInt(typeCtx(ctx))
 		return int64(val), err != nil, err
-	} else if c.GetType(ctx).Hybrid() || dt.Kind() == types.KindString {
+	} else if tp.Hybrid() || dt.Kind() == types.KindString {
 		res, err := dt.ToInt64(typeCtx(ctx))
 		return res, false, err
 	} else if dt.Kind() == types.KindMysqlBit {

--- a/pkg/expression/constant_param_bench_test.go
+++ b/pkg/expression/constant_param_bench_test.go
@@ -1,0 +1,119 @@
+package expression
+
+import (
+	"math"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/expression/exprstatic"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+var (
+	benchmarkParamInt    int64
+	benchmarkParamNull   bool
+	benchmarkParamResult int64
+)
+
+func benchmarkParamConstant(value types.Datum) (*Constant, EvalContext) {
+	params := variable.NewPlanCacheParamList()
+	params.Append(value)
+	ctx := exprstatic.NewEvalContext(exprstatic.WithParamList(params))
+	con := &Constant{
+		RetType:     types.NewFieldType(mysql.TypeUnspecified),
+		ParamMarker: &ParamMarker{order: 0},
+	}
+	return con, ctx
+}
+
+func TestParamMarkerEvalIntKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		datum    types.Datum
+		expected int64
+		isNull   bool
+	}{
+		{name: "signed", datum: types.NewIntDatum(42), expected: 42},
+		{name: "unsigned", datum: types.NewUintDatum(math.MaxUint64), expected: -1},
+		{name: "numeric-string", datum: types.NewStringDatum("42"), expected: 42},
+		{name: "binary-literal", datum: types.NewBinaryLiteralDatum([]byte{0x2a}), expected: 42},
+		{name: "null", datum: types.NewDatum(nil), isNull: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			con, ctx := benchmarkParamConstant(tt.datum)
+			value, isNull, err := con.EvalInt(ctx, chunk.Row{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if value != tt.expected || isNull != tt.isNull {
+				t.Fatalf("EvalInt() = (%d, %t), want (%d, %t)", value, isNull, tt.expected, tt.isNull)
+			}
+			if con.GetType(ctx) == con.GetType(ctx) {
+				t.Fatal("GetType returned a shared pointer for a prepared parameter")
+			}
+		})
+	}
+}
+
+func BenchmarkParamMarkerIntHotPath(b *testing.B) {
+	b.Run("EvalInt/signed", func(b *testing.B) {
+		con, ctx := benchmarkParamConstant(types.NewIntDatum(42))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			value, isNull, err := con.EvalInt(ctx, chunk.Row{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkParamInt = value
+			benchmarkParamNull = isNull
+		}
+	})
+
+	b.Run("EvalInt/unsigned", func(b *testing.B) {
+		con, ctx := benchmarkParamConstant(types.NewUintDatum(math.MaxUint64))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			value, isNull, err := con.EvalInt(ctx, chunk.Row{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkParamInt = value
+			benchmarkParamNull = isNull
+		}
+	})
+
+	b.Run("CompareInt/param_vs_constant", func(b *testing.B) {
+		con, ctx := benchmarkParamConstant(types.NewIntDatum(42))
+		fixed := NewInt64Const(40)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			result, isNull, err := CompareInt(ctx, con, fixed, chunk.Row{}, chunk.Row{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkParamResult = result
+			benchmarkParamNull = isNull
+		}
+	})
+
+	b.Run("EvalInt/plain_constant", func(b *testing.B) {
+		con := NewInt64Const(42)
+		ctx := exprstatic.NewEvalContext()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			value, isNull, err := con.EvalInt(ctx, chunk.Row{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkParamInt = value
+			benchmarkParamNull = isNull
+		}
+	})
+}

--- a/pkg/expression/exec_binary_param_bench_test.go
+++ b/pkg/expression/exec_binary_param_bench_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/param"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+var benchmarkExecBinaryParamResult []Expression
+
+func binaryParamUint64(tp byte, value uint64, unsigned bool) param.BinaryParam {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, value)
+	return param.BinaryParam{Tp: tp, IsUnsigned: unsigned, Val: buf}
+}
+
+func execBinaryParamBenchmarkCases() []struct {
+	name   string
+	params []param.BinaryParam
+} {
+	signed := binaryParamUint64(mysql.TypeLonglong, 734521, false)
+	unsigned := binaryParamUint64(mysql.TypeLonglong, math.MaxUint64, true)
+	double := binaryParamUint64(mysql.TypeDouble, math.Float64bits(123.5), false)
+	datetime := param.BinaryParam{
+		Tp:  mysql.TypeDatetime,
+		Val: []byte{0xda, 0x07, 0x0a, 0x11, 0x13, 0x1b, 0x1e, 0x01, 0x00, 0x00, 0x00},
+	}
+
+	return []struct {
+		name   string
+		params []param.BinaryParam
+	}{
+		{name: "signed-longlong", params: []param.BinaryParam{signed}},
+		{name: "unsigned-longlong", params: []param.BinaryParam{unsigned}},
+		{name: "null", params: []param.BinaryParam{{Tp: mysql.TypeNull, IsNull: true}}},
+		{name: "varchar", params: []param.BinaryParam{{Tp: mysql.TypeVarchar, Val: []byte("point-select")}}},
+		{name: "datetime", params: []param.BinaryParam{datetime}},
+		{
+			name: "mixed-eight",
+			params: []param.BinaryParam{
+				signed,
+				unsigned,
+				{Tp: mysql.TypeNull, IsNull: true},
+				{Tp: mysql.TypeVarchar, Val: []byte("point-select")},
+				double,
+				datetime,
+				{Tp: mysql.TypeTiny, Val: []byte{0x7f}},
+				{Tp: mysql.TypeBlob, Val: []byte("binary-value")},
+			},
+		},
+	}
+}
+
+func BenchmarkExecBinaryParam(b *testing.B) {
+	for _, testCase := range execBinaryParamBenchmarkCases() {
+		b.Run(testCase.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				result, err := ExecBinaryParam(types.DefaultStmtNoWarningContext, testCase.params)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkExecBinaryParamResult = result
+			}
+		})
+	}
+}
+
+func TestExecBinaryParamValuesAndOrder(t *testing.T) {
+	testCases := execBinaryParamBenchmarkCases()
+	mixed := testCases[len(testCases)-1].params
+	result, err := ExecBinaryParam(types.DefaultStmtNoWarningContext, mixed)
+	require.NoError(t, err)
+	require.Len(t, result, len(mixed))
+
+	expected := []any{
+		int64(734521),
+		uint64(math.MaxUint64),
+		nil,
+		"point-select",
+		float64(123.5),
+		types.NewTime(types.FromDate(2010, 10, 17, 19, 27, 30, 1), mysql.TypeDatetime, types.MaxFsp),
+		int64(127),
+		[]byte("binary-value"),
+	}
+	for i, expression := range result {
+		constant, ok := expression.(*Constant)
+		require.True(t, ok)
+		require.NotNil(t, constant.RetType)
+		require.Equal(t, expected[i], constant.Value.GetValue())
+	}
+
+	empty, err := ExecBinaryParam(types.DefaultStmtNoWarningContext, nil)
+	require.NoError(t, err)
+	require.NotNil(t, empty)
+	require.Empty(t, empty)
+}
+
+func TestExecBinaryParamErrors(t *testing.T) {
+	result, err := ExecBinaryParam(types.DefaultStmtNoWarningContext, []param.BinaryParam{{
+		Tp:  mysql.TypeDatetime,
+		Val: []byte{1},
+	}})
+	require.ErrorIs(t, err, mysql.ErrMalformPacket)
+	require.Len(t, result, 1)
+	require.Nil(t, result[0])
+
+	result, err = ExecBinaryParam(types.DefaultStmtNoWarningContext, []param.BinaryParam{{Tp: 0xaa}})
+	require.Error(t, err)
+	require.Len(t, result, 1)
+	require.Nil(t, result[0])
+}

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -2119,7 +2119,11 @@ func ExecBinaryParam(typectx types.Context, binaryParams []param.BinaryParam) (p
 	)
 
 	params = make([]Expression, len(binaryParams))
-	args := make([]types.Datum, len(binaryParams))
+	var singleArg [1]types.Datum
+	args := singleArg[:]
+	if len(binaryParams) != 1 {
+		args = make([]types.Datum, len(binaryParams))
+	}
 	for i := range args {
 		tp := binaryParams[i].Tp
 		isUnsigned := binaryParams[i].IsUnsigned

--- a/pkg/planner/core/tests/partition/bench_test.go
+++ b/pkg/planner/core/tests/partition/bench_test.go
@@ -83,7 +83,7 @@ func prepareBenchSession() (sessionapi.Session, *domain.Domain, kv.Storage) {
 		logutil.BgLogger().Fatal(err.Error())
 	}
 	// TODO: use environment variable "log_level" if set?
-	log.SetLevel(zapcore.ErrorLevel)
+	log.SetLevel(zapcore.FatalLevel)
 	se, err := session.CreateSession4Test(store)
 	if err != nil {
 		logutil.BgLogger().Fatal(err.Error())

--- a/pkg/util/chunk/codec.go
+++ b/pkg/util/chunk/codec.go
@@ -305,8 +305,10 @@ func (c *Decoder) decodeColumn(chk *Chunk, ordinal int, requiredRows int) {
 		numDataBytes = srcCol.offsets[requiredRows] - srcCol.offsets[0]
 		deltaOffset := destCol.offsets[destCol.length] - srcCol.offsets[0]
 		destCol.offsets = append(destCol.offsets, srcCol.offsets[1:requiredRows+1]...)
-		for i := destCol.length + 1; i <= destCol.length+requiredRows; i++ {
-			destCol.offsets[i] = destCol.offsets[i] + deltaOffset
+		if deltaOffset != 0 {
+			for i := destCol.length + 1; i <= destCol.length+requiredRows; i++ {
+				destCol.offsets[i] = destCol.offsets[i] + deltaOffset
+			}
 		}
 		srcCol.offsets = srcCol.offsets[requiredRows:]
 	}

--- a/pkg/util/chunk/codec_test.go
+++ b/pkg/util/chunk/codec_test.go
@@ -189,3 +189,59 @@ func BenchmarkDecodeToChunkWithVariableType(b *testing.B) {
 		codec.DecodeToChunk(buffer, chk)
 	}
 }
+
+func BenchmarkDecoderWideRowsZeroDelta(b *testing.B) {
+	const rows = 510
+	colTypes := []*types.FieldType{
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeLong),
+		types.NewFieldType(mysql.TypeVarchar),
+		types.NewFieldType(mysql.TypeVarchar),
+	}
+	source := NewChunkWithCapacity(colTypes, rows)
+	c := make([]byte, 119)
+	pad := make([]byte, 59)
+	for i := range rows {
+		source.AppendInt64(0, int64(i))
+		source.AppendInt64(1, int64(i))
+		source.AppendBytes(2, c)
+		source.AppendBytes(3, pad)
+	}
+	codec := NewCodec(colTypes)
+	buffer := codec.Encode(source)
+	intermediate := NewChunkWithCapacity(colTypes, rows)
+	destination := NewChunkWithCapacity(colTypes, rows)
+	decoder := NewDecoder(intermediate, colTypes)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(buffer)))
+	b.ResetTimer()
+	for range b.N {
+		destination.Reset()
+		decoder.Reset(buffer)
+		decoder.Decode(destination)
+	}
+}
+
+func TestDecoderAdjustsNonZeroVarLenOffsets(t *testing.T) {
+	colTypes := []*types.FieldType{types.NewFieldType(mysql.TypeVarchar)}
+	source := NewChunkWithCapacity(colTypes, 4)
+	values := []string{"a", "bb", "ccc", "dddd"}
+	for _, value := range values {
+		source.AppendString(0, value)
+	}
+	codec := NewCodec(colTypes)
+	intermediate := NewChunkWithCapacity(colTypes, 4)
+	decoder := NewDecoder(intermediate, colTypes)
+	decoder.Reset(codec.Encode(source))
+
+	destination := NewChunkWithCapacity(colTypes, 16)
+	destination.AppendString(0, "prefix")
+	decoder.Decode(destination)
+
+	require.Equal(t, 1+len(values), destination.NumRows())
+	require.Equal(t, "prefix", destination.GetRow(0).GetString(0))
+	for i, value := range values {
+		require.Equal(t, value, destination.GetRow(i+1).GetString(0))
+	}
+}

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -123,11 +123,26 @@ func newColumn(ts, capacity int) *Column {
 
 // newFixedLenColumn creates a fixed length Column with elemLen and initial data capacity.
 func newFixedLenColumn(elemLen, capacity int) *Column {
-	return &Column{
-		elemBuf:    make([]byte, elemLen),
-		data:       make([]byte, 0, getInitDataMemCap(capacity, elemLen)),
-		nullBitmap: make([]byte, 0, getInitNullBitmapCap(capacity)),
+	var col *Column
+	if elemLen == sizeInt64 && capacity == InitialCapacity {
+		storage := &fixedLen8ColumnStorage{}
+		storage.col.elemBuf = storage.elemBuf[:]
+		storage.col.nullBitmap = storage.nullBitmap[:0]
+		col = &storage.col
+	} else {
+		col = &Column{
+			elemBuf:    make([]byte, elemLen),
+			nullBitmap: make([]byte, 0, getInitNullBitmapCap(capacity)),
+		}
 	}
+	col.data = make([]byte, 0, getInitDataMemCap(capacity, elemLen))
+	return col
+}
+
+type fixedLen8ColumnStorage struct {
+	col        Column
+	elemBuf    [sizeInt64]byte
+	nullBitmap [InitialCapacity / 8]byte
 }
 
 // newVarLenColumn creates a variable length Column with initial data capacity.

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -147,11 +147,25 @@ type fixedLen8ColumnStorage struct {
 
 // newVarLenColumn creates a variable length Column with initial data capacity.
 func newVarLenColumn(capacity int) *Column {
-	return &Column{
-		offsets:    make([]int64, 1, getInitOffsetsCap(capacity)),
-		data:       make([]byte, 0, getInitDataMemCap(capacity, estimatedElemLen)),
-		nullBitmap: make([]byte, 0, getInitNullBitmapCap(capacity)),
+	if capacity != InitialCapacity {
+		return &Column{
+			offsets:    make([]int64, 1, getInitOffsetsCap(capacity)),
+			data:       make([]byte, 0, getInitDataMemCap(capacity, estimatedElemLen)),
+			nullBitmap: make([]byte, 0, getInitNullBitmapCap(capacity)),
+		}
 	}
+
+	storage := &varLenColumnStorage{}
+	storage.col.offsets = storage.offsets[:1]
+	storage.col.data = make([]byte, 0, getInitDataMemCap(capacity, estimatedElemLen))
+	storage.col.nullBitmap = storage.nullBitmap[:0]
+	return &storage.col
+}
+
+type varLenColumnStorage struct {
+	col        Column
+	offsets    [InitialCapacity + 1]int64
+	nullBitmap [(InitialCapacity + 7) / 8]byte
 }
 
 func getInitDataMemCap(capacity int, elemLen int) int64 {

--- a/pkg/util/chunk/fixed_len_column_bench_test.go
+++ b/pkg/util/chunk/fixed_len_column_bench_test.go
@@ -1,0 +1,105 @@
+package chunk
+
+import (
+	"fmt"
+	"testing"
+)
+
+var benchmarkNewFixedLenColumnSink *Column
+
+func BenchmarkNewFixedLenColumnDominantLegacy(b *testing.B) {
+	benchmarkFixedLenColumnFactory(b, func() *Column {
+		return &Column{
+			elemBuf:    make([]byte, sizeInt64),
+			data:       make([]byte, 0, getDataMemCap(InitialCapacity, sizeInt64)),
+			nullBitmap: make([]byte, 0, getNullBitmapCap(InitialCapacity)),
+		}
+	})
+}
+
+func BenchmarkNewFixedLenColumnDominantCurrent(b *testing.B) {
+	benchmarkFixedLenColumnFactory(b, func() *Column {
+		return newFixedLenColumn(sizeInt64, InitialCapacity)
+	})
+}
+
+func benchmarkFixedLenColumnFactory(b *testing.B, factory func() *Column) {
+	col := factory()
+	validateFixedLenColumnBenchmark(b, col, sizeInt64, InitialCapacity)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		col = factory()
+	}
+	b.StopTimer()
+
+	benchmarkNewFixedLenColumnSink = col
+	validateFixedLenColumnBenchmark(b, col, sizeInt64, InitialCapacity)
+}
+
+func BenchmarkNewFixedLenColumnRandomRanges(b *testing.B) {
+	cases := []struct {
+		elemLen  int
+		capacity int
+	}{
+		{elemLen: 4, capacity: InitialCapacity},
+		{elemLen: 8, capacity: InitialCapacity},
+		{elemLen: 16, capacity: InitialCapacity},
+		{elemLen: 40, capacity: InitialCapacity},
+		{elemLen: 8, capacity: 0},
+		{elemLen: 8, capacity: 1024},
+	}
+
+	for _, tc := range cases {
+		name := fmt.Sprintf("elem=%d/cap=%d", tc.elemLen, tc.capacity)
+		b.Run(name, func(b *testing.B) {
+			col := newFixedLenColumn(tc.elemLen, tc.capacity)
+			validateFixedLenColumnBenchmark(b, col, tc.elemLen, tc.capacity)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				col = newFixedLenColumn(tc.elemLen, tc.capacity)
+			}
+			b.StopTimer()
+
+			benchmarkNewFixedLenColumnSink = col
+			validateFixedLenColumnBenchmark(b, col, tc.elemLen, tc.capacity)
+		})
+	}
+}
+
+func validateFixedLenColumnBenchmark(
+	b *testing.B,
+	col *Column,
+	elemLen int,
+	capacity int,
+) {
+	b.Helper()
+	if len(col.elemBuf) != elemLen || cap(col.elemBuf) != elemLen {
+		b.Fatalf("unexpected element buffer: len=%d cap=%d", len(col.elemBuf), cap(col.elemBuf))
+	}
+	if len(col.data) != 0 || int64(cap(col.data)) != getDataMemCap(capacity, elemLen) {
+		b.Fatalf("unexpected data buffer: len=%d cap=%d", len(col.data), cap(col.data))
+	}
+	if len(col.nullBitmap) != 0 || int64(cap(col.nullBitmap)) != getNullBitmapCap(capacity) {
+		b.Fatalf("unexpected null bitmap: len=%d cap=%d", len(col.nullBitmap), cap(col.nullBitmap))
+	}
+}
+
+func TestFixedLen8ColumnStorageIndependence(t *testing.T) {
+	first := newFixedLenColumn(sizeInt64, InitialCapacity)
+	second := newFixedLenColumn(sizeInt64, InitialCapacity)
+
+	first.elemBuf[0] = 1
+	first.data = append(first.data, 2)
+	first.nullBitmap = append(first.nullBitmap, 3)
+
+	if second.elemBuf[0] != 0 || len(second.data) != 0 || len(second.nullBitmap) != 0 {
+		t.Fatal("fixed-length columns alias")
+	}
+	if first.elemBuf[0] != 1 {
+		t.Fatal("data or null-bitmap mutation changed the element buffer")
+	}
+}

--- a/pkg/util/chunk/fixed_len_column_bench_test.go
+++ b/pkg/util/chunk/fixed_len_column_bench_test.go
@@ -11,8 +11,8 @@ func BenchmarkNewFixedLenColumnDominantLegacy(b *testing.B) {
 	benchmarkFixedLenColumnFactory(b, func() *Column {
 		return &Column{
 			elemBuf:    make([]byte, sizeInt64),
-			data:       make([]byte, 0, getDataMemCap(InitialCapacity, sizeInt64)),
-			nullBitmap: make([]byte, 0, getNullBitmapCap(InitialCapacity)),
+			data:       make([]byte, 0, getInitDataMemCap(InitialCapacity, sizeInt64)),
+			nullBitmap: make([]byte, 0, getInitNullBitmapCap(InitialCapacity)),
 		}
 	})
 }
@@ -80,10 +80,10 @@ func validateFixedLenColumnBenchmark(
 	if len(col.elemBuf) != elemLen || cap(col.elemBuf) != elemLen {
 		b.Fatalf("unexpected element buffer: len=%d cap=%d", len(col.elemBuf), cap(col.elemBuf))
 	}
-	if len(col.data) != 0 || int64(cap(col.data)) != getDataMemCap(capacity, elemLen) {
+	if len(col.data) != 0 || int64(cap(col.data)) != getInitDataMemCap(capacity, elemLen) {
 		b.Fatalf("unexpected data buffer: len=%d cap=%d", len(col.data), cap(col.data))
 	}
-	if len(col.nullBitmap) != 0 || int64(cap(col.nullBitmap)) != getNullBitmapCap(capacity) {
+	if len(col.nullBitmap) != 0 || int64(cap(col.nullBitmap)) != getInitNullBitmapCap(capacity) {
 		b.Fatalf("unexpected null bitmap: len=%d cap=%d", len(col.nullBitmap), cap(col.nullBitmap))
 	}
 }

--- a/pkg/util/chunk/mutrow.go
+++ b/pkg/util/chunk/mutrow.go
@@ -182,6 +182,18 @@ func makeMutRowColumn(in any) *Column {
 }
 
 func newMutRowFixedLenColumn(elemSize int) *Column {
+	if elemSize == sizeInt64 {
+		storage := &mutRowFixedLen8ColumnStorage{}
+		storage.nullBitmap[0] = 1
+		storage.col = Column{
+			length:     1,
+			elemBuf:    storage.data[:],
+			data:       storage.data[:],
+			nullBitmap: storage.nullBitmap[:],
+		}
+		return &storage.col
+	}
+
 	buf := make([]byte, elemSize)
 	col := &Column{
 		length:     1,
@@ -191,6 +203,12 @@ func newMutRowFixedLenColumn(elemSize int) *Column {
 	}
 	col.nullBitmap[0] = 1
 	return col
+}
+
+type mutRowFixedLen8ColumnStorage struct {
+	col        Column
+	data       [sizeInt64]byte
+	nullBitmap [1]byte
 }
 
 func newMutRowVarLenColumn(valSize int) *Column {

--- a/pkg/util/chunk/mutrow.go
+++ b/pkg/util/chunk/mutrow.go
@@ -139,6 +139,9 @@ func makeMutRowColumn(in any) *Column {
 		*(*uint32)(unsafe.Pointer(&col.data[0])) = math.Float32bits(x)
 		return col
 	case string:
+		if len(x) == 0 {
+			return newMutRowEmptyVarLenColumn()
+		}
 		return makeMutRowBytesColumn(hack.Slice(x))
 	case []byte:
 		return makeMutRowBytesColumn(x)
@@ -200,6 +203,24 @@ func newMutRowVarLenColumn(valSize int) *Column {
 	}
 	col.nullBitmap[0] = 1
 	return col
+}
+
+func newMutRowEmptyVarLenColumn() *Column {
+	storage := &mutRowVarLenColumnStorage{}
+	storage.nullBitmap[0] = 1
+	storage.col = Column{
+		length:     1,
+		offsets:    storage.offsets[:],
+		data:       storage.nullBitmap[:0],
+		nullBitmap: storage.nullBitmap[:],
+	}
+	return &storage.col
+}
+
+type mutRowVarLenColumnStorage struct {
+	col        Column
+	offsets    [2]int64
+	nullBitmap [1]byte
 }
 
 func makeMutRowUint64Column(val uint64) *Column {

--- a/pkg/util/chunk/mutrow_tpcc_bench_test.go
+++ b/pkg/util/chunk/mutrow_tpcc_bench_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mutRowVarLenColumnTPCCSink *Column
+	mutRowTPCCSink             MutRow
+)
+
+func BenchmarkNewMutRowVarLenColumnTPCC(b *testing.B) {
+	for _, size := range []int{0, 2, 24, 50, 500} {
+		b.Run(fmt.Sprintf("value-size=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				mutRowVarLenColumnTPCCSink = newMutRowVarLenColumn(size)
+			}
+			require.Len(b, mutRowVarLenColumnTPCCSink.data, size)
+			require.Equal(b, []int64{0, int64(size)}, mutRowVarLenColumnTPCCSink.offsets)
+			require.Equal(b, byte(1), mutRowVarLenColumnTPCCSink.nullBitmap[0])
+		})
+	}
+}
+
+func BenchmarkMutRowFromTypesTPCC(b *testing.B) {
+	warehouse, district, customer, stock := tpccUpdateFieldTypes()
+	cases := []struct {
+		name   string
+		schema []*types.FieldType
+	}{
+		{name: "warehouse", schema: warehouse},
+		{name: "district", schema: district},
+		{name: "customer", schema: customer},
+		{name: "stock", schema: stock},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				mutRowTPCCSink = MutRowFromTypes(tc.schema)
+			}
+			require.Equal(b, len(tc.schema), mutRowTPCCSink.Len())
+		})
+	}
+
+	b.Run("payment-plus-average-new-order", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			mutRowTPCCSink = MutRowFromTypes(warehouse)
+			mutRowTPCCSink = MutRowFromTypes(district)
+			mutRowTPCCSink = MutRowFromTypes(customer)
+			mutRowTPCCSink = MutRowFromTypes(district)
+			for range 10 {
+				mutRowTPCCSink = MutRowFromTypes(stock)
+			}
+		}
+		require.Equal(b, len(stock), mutRowTPCCSink.Len())
+	})
+}
+
+func BenchmarkMutRowFromValuesTPCC(b *testing.B) {
+	for _, value := range []string{"", strings.Repeat("x", 24), strings.Repeat("x", 500)} {
+		b.Run(fmt.Sprintf("value-size=%d", len(value)), func(b *testing.B) {
+			values := []any{int64(1), value}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				mutRowTPCCSink = MutRowFromValues(values...)
+			}
+			b.StopTimer()
+			require.Equal(b, value, mutRowTPCCSink.ToRow().GetString(1))
+		})
+	}
+}
+
+func BenchmarkMutRowVarLenGrowthTPCC(b *testing.B) {
+	value := []byte(strings.Repeat("x", 500))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		col := newMutRowVarLenColumn(0)
+		setMutRowBytes(col, value)
+		col.nullBitmap[0] = 1
+		mutRowVarLenColumnTPCCSink = col
+	}
+	b.StopTimer()
+	require.Equal(b, value, mutRowVarLenColumnTPCCSink.data)
+	require.Equal(b, int64(len(value)), mutRowVarLenColumnTPCCSink.offsets[1])
+	require.Equal(b, byte(1), mutRowVarLenColumnTPCCSink.nullBitmap[0])
+}
+
+func TestNewMutRowVarLenColumnIndependenceAndGrowth(t *testing.T) {
+	first := makeMutRowColumn("")
+	second := makeMutRowColumn("")
+
+	require.Equal(t, []int64{0, 0}, first.offsets)
+	require.Len(t, first.offsets, 2)
+	require.Equal(t, 2, cap(first.offsets))
+	require.Empty(t, first.data)
+	require.Equal(t, 1, cap(first.data))
+	require.Equal(t, []byte{1}, first.nullBitmap)
+	require.Equal(t, 1, cap(first.nullBitmap))
+	require.False(t, &first.offsets[0] == &second.offsets[0])
+	require.False(t, &first.nullBitmap[0] == &second.nullBitmap[0])
+
+	value := []byte(strings.Repeat("x", 500))
+	setMutRowBytes(first, value)
+	first.nullBitmap[0] = 1
+	require.Equal(t, value, first.data)
+	require.Equal(t, []int64{0, int64(len(value))}, first.offsets)
+	require.Equal(t, byte(1), first.nullBitmap[0])
+	require.Equal(t, []int64{0, 0}, second.offsets)
+	require.Empty(t, second.data)
+	require.Equal(t, byte(1), second.nullBitmap[0])
+}
+
+func tpccUpdateFieldTypes() (
+	warehouse, district, customer, stock []*types.FieldType,
+) {
+	const (
+		intType = iota
+		stringType
+		decimalType
+		datetimeType
+	)
+	makeTypes := func(spec ...int) []*types.FieldType {
+		result := make([]*types.FieldType, len(spec))
+		for i, kind := range spec {
+			mysqlType := byte(mysql.TypeLong)
+			switch kind {
+			case stringType:
+				mysqlType = mysql.TypeVarchar
+			case decimalType:
+				mysqlType = mysql.TypeNewDecimal
+			case datetimeType:
+				mysqlType = mysql.TypeDatetime
+			}
+			result[i] = types.NewFieldType(mysqlType)
+		}
+		return result
+	}
+
+	warehouse = makeTypes(
+		intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		decimalType, decimalType,
+	)
+	district = makeTypes(
+		intType, intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		decimalType, decimalType, intType,
+	)
+	customer = makeTypes(
+		intType, intType, intType,
+		stringType, stringType, stringType, stringType, stringType, stringType,
+		stringType, stringType, stringType,
+		datetimeType, stringType,
+		decimalType, decimalType, decimalType, decimalType,
+		intType, intType, stringType,
+	)
+	stock = makeTypes(
+		intType, intType, intType,
+		stringType, stringType, stringType, stringType, stringType,
+		stringType, stringType, stringType, stringType, stringType,
+		intType, intType, intType, stringType,
+	)
+	return warehouse, district, customer, stock
+}

--- a/pkg/util/chunk/mutrow_tpcc_bench_test.go
+++ b/pkg/util/chunk/mutrow_tpcc_bench_test.go
@@ -25,9 +25,37 @@ import (
 )
 
 var (
-	mutRowVarLenColumnTPCCSink *Column
-	mutRowTPCCSink             MutRow
+	mutRowVarLenColumnTPCCSink   *Column
+	mutRowFixedLenColumnTPCCSink *Column
+	mutRowTPCCSink               MutRow
 )
+
+func BenchmarkNewMutRowFixedLenColumnTPCC(b *testing.B) {
+	cases := []struct {
+		name string
+		size int
+	}{
+		{name: "float32", size: 4},
+		{name: "integer-or-duration", size: 8},
+		{name: "time", size: sizeTime},
+		{name: "decimal", size: types.MyDecimalStructSize},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				mutRowFixedLenColumnTPCCSink = newMutRowFixedLenColumn(tc.size)
+			}
+			b.StopTimer()
+			require.Len(b, mutRowFixedLenColumnTPCCSink.elemBuf, tc.size)
+			require.Len(b, mutRowFixedLenColumnTPCCSink.data, tc.size)
+			require.Len(b, mutRowFixedLenColumnTPCCSink.nullBitmap, 1)
+			require.Equal(b, &mutRowFixedLenColumnTPCCSink.elemBuf[0], &mutRowFixedLenColumnTPCCSink.data[0])
+			require.False(b, &mutRowFixedLenColumnTPCCSink.data[0] == &mutRowFixedLenColumnTPCCSink.nullBitmap[0])
+			require.Equal(b, byte(1), mutRowFixedLenColumnTPCCSink.nullBitmap[0])
+		})
+	}
+}
 
 func BenchmarkNewMutRowVarLenColumnTPCC(b *testing.B) {
 	for _, size := range []int{0, 2, 24, 50, 500} {
@@ -133,6 +161,32 @@ func TestNewMutRowVarLenColumnIndependenceAndGrowth(t *testing.T) {
 	require.Equal(t, []int64{0, 0}, second.offsets)
 	require.Empty(t, second.data)
 	require.Equal(t, byte(1), second.nullBitmap[0])
+}
+
+func TestNewMutRowFixedLen8ColumnIndependence(t *testing.T) {
+	first := MutRowFromValues(uint64(1))
+	second := MutRowFromValues(uint64(2))
+	firstCol := first.c.columns[0]
+	secondCol := second.c.columns[0]
+
+	require.Len(t, firstCol.elemBuf, sizeInt64)
+	require.Len(t, firstCol.data, sizeInt64)
+	require.Len(t, firstCol.nullBitmap, 1)
+	require.Equal(t, sizeInt64, cap(firstCol.elemBuf))
+	require.Equal(t, sizeInt64, cap(firstCol.data))
+	require.Equal(t, 1, cap(firstCol.nullBitmap))
+	require.Equal(t, &firstCol.elemBuf[0], &firstCol.data[0])
+	require.False(t, &firstCol.data[0] == &firstCol.nullBitmap[0])
+	require.False(t, &firstCol.data[0] == &secondCol.data[0])
+	require.False(t, &firstCol.nullBitmap[0] == &secondCol.nullBitmap[0])
+
+	first.SetValue(0, uint64(3))
+	require.Equal(t, uint64(3), first.ToRow().GetUint64(0))
+	require.Equal(t, uint64(2), second.ToRow().GetUint64(0))
+	firstCol.nullBitmap[0] = 0
+	require.True(t, first.ToRow().IsNull(0))
+	require.False(t, second.ToRow().IsNull(0))
+	require.Equal(t, byte(1), secondCol.nullBitmap[0])
 }
 
 func tpccUpdateFieldTypes() (

--- a/pkg/util/chunk/var_len_column_bench_test.go
+++ b/pkg/util/chunk/var_len_column_bench_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	benchmarkNewVarLenColumnSink  *Column
+	benchmarkRenewVarLenChunkSink *Chunk
+)
+
+func BenchmarkNewVarLenColumnTPCC(b *testing.B) {
+	for _, capacity := range []int{0, 1, InitialCapacity, 64, 1024} {
+		b.Run(fmt.Sprintf("capacity=%d", capacity), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchmarkNewVarLenColumnSink = newVarLenColumn(capacity)
+			}
+			b.StopTimer()
+			validateVarLenColumnBenchmark(b, benchmarkNewVarLenColumnSink, capacity, 0, 0)
+		})
+	}
+}
+
+func BenchmarkVarLenColumnBuildTPCC(b *testing.B) {
+	cases := []struct {
+		name     string
+		rows     int
+		valueLen int
+	}{
+		{name: "empty"},
+		{name: "rows=1/value=8", rows: 1, valueLen: 8},
+		{name: "rows=32/value=8", rows: 32, valueLen: 8},
+		{name: "rows=33/value=8", rows: 33, valueLen: 8},
+		{name: "rows=32/value=64", rows: 32, valueLen: 64},
+	}
+
+	for _, bc := range cases {
+		b.Run(bc.name, func(b *testing.B) {
+			value := strings.Repeat("x", bc.valueLen)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				col := newVarLenColumn(InitialCapacity)
+				for range bc.rows {
+					col.AppendString(value)
+				}
+				benchmarkNewVarLenColumnSink = col
+			}
+			b.StopTimer()
+			validateVarLenColumnBenchmark(
+				b,
+				benchmarkNewVarLenColumnSink,
+				InitialCapacity,
+				bc.rows,
+				bc.rows*bc.valueLen,
+			)
+		})
+	}
+}
+
+func BenchmarkRenewVarLenColumnsTPCC(b *testing.B) {
+	for _, columnCount := range []int{1, 4, 12} {
+		b.Run(fmt.Sprintf("columns=%d", columnCount), func(b *testing.B) {
+			columns := make([]*Column, columnCount)
+			for i := range columns {
+				columns[i] = newVarLenColumn(InitialCapacity)
+				columns[i].AppendString("abcdefgh")
+			}
+			source := &Chunk{
+				columns:      columns,
+				capacity:     InitialCapacity,
+				requiredRows: 1024,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchmarkRenewVarLenChunkSink = Renew(source, 1024)
+			}
+			b.StopTimer()
+			if got := benchmarkRenewVarLenChunkSink.NumCols(); got != columnCount {
+				b.Fatalf("unexpected column count: %d", got)
+			}
+			for _, col := range benchmarkRenewVarLenChunkSink.columns {
+				validateVarLenColumnBenchmark(b, col, InitialCapacity, 0, 0)
+			}
+		})
+	}
+}
+
+func validateVarLenColumnBenchmark(
+	b *testing.B,
+	col *Column,
+	initialCapacity int,
+	rows int,
+	dataLen int,
+) {
+	b.Helper()
+	if col == nil {
+		b.Fatal("nil column")
+	}
+	if col.length != rows || len(col.offsets) != rows+1 || len(col.data) != dataLen {
+		b.Fatalf(
+			"unexpected column shape: rows=%d offsets=%d data=%d",
+			col.length,
+			len(col.offsets),
+			len(col.data),
+		)
+	}
+	if rows == 0 {
+		if got, want := cap(col.offsets), initialCapacity+1; got != want {
+			b.Fatalf("unexpected offsets capacity: got %d want %d", got, want)
+		}
+		if got, want := cap(col.data), estimatedElemLen*initialCapacity; got != want {
+			b.Fatalf("unexpected data capacity: got %d want %d", got, want)
+		}
+		if got, want := cap(col.nullBitmap), (initialCapacity+7)/8; got != want {
+			b.Fatalf("unexpected null bitmap capacity: got %d want %d", got, want)
+		}
+	}
+}
+
+func TestVarLenColumnStorageIndependenceAndGrowth(t *testing.T) {
+	first := newVarLenColumn(InitialCapacity)
+	second := newVarLenColumn(InitialCapacity)
+
+	for i := range InitialCapacity + 1 {
+		first.AppendString(fmt.Sprintf("value-%02d", i))
+	}
+	second.AppendNull()
+
+	if got := first.GetString(InitialCapacity); got != "value-32" {
+		t.Fatalf("unexpected value after offsets growth: %q", got)
+	}
+	if first.IsNull(0) {
+		t.Fatal("first column unexpectedly contains a null")
+	}
+	if !second.IsNull(0) {
+		t.Fatal("second column lost its null")
+	}
+	if first.offsets[0] != 0 || second.offsets[0] != 0 {
+		t.Fatal("initial offsets changed")
+	}
+	if &first.offsets[0] == &second.offsets[0] {
+		t.Fatal("variable-length columns share offsets storage")
+	}
+	if &first.nullBitmap[0] == &second.nullBitmap[0] {
+		t.Fatal("variable-length columns share null-bitmap storage")
+	}
+}

--- a/pkg/util/rowcodec/decoder.go
+++ b/pkg/util/rowcodec/decoder.go
@@ -203,6 +203,18 @@ func NewChunkDecoder(columns []ColInfo, handleColIDs []int64, defDatum func(i in
 	}
 }
 
+// Reset resets a ChunkDecoder with new column metadata.
+func (d *ChunkDecoder) Reset(columns []ColInfo, handleColIDs []int64, defDatum func(i int, chk *chunk.Chunk) error, loc *time.Location) {
+	*d = ChunkDecoder{
+		decoder: decoder{
+			columns:      columns,
+			handleColIDs: handleColIDs,
+			loc:          loc,
+		},
+		defDatum: defDatum,
+	}
+}
+
 // DecodeToChunk decodes a row to chunk.
 func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, commitTS uint64, handle kv.Handle, chk *chunk.Chunk) error {
 	err := decoder.fromBytes(rowData)

--- a/pkg/util/rowcodec/decoder.go
+++ b/pkg/util/rowcodec/decoder.go
@@ -193,14 +193,9 @@ type ChunkDecoder struct {
 
 // NewChunkDecoder creates a NewChunkDecoder.
 func NewChunkDecoder(columns []ColInfo, handleColIDs []int64, defDatum func(i int, chk *chunk.Chunk) error, loc *time.Location) *ChunkDecoder {
-	return &ChunkDecoder{
-		decoder: decoder{
-			columns:      columns,
-			handleColIDs: handleColIDs,
-			loc:          loc,
-		},
-		defDatum: defDatum,
-	}
+	d := new(ChunkDecoder)
+	d.Reset(columns, handleColIDs, defDatum, loc)
+	return d
 }
 
 // Reset resets a ChunkDecoder with new column metadata.

--- a/pkg/util/rowcodec/decoder_reset_test.go
+++ b/pkg/util/rowcodec/decoder_reset_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkDecoderReset(t *testing.T) {
+	oldColumns := []ColInfo{{ID: 1, Ft: types.NewFieldType(mysql.TypeLonglong)}}
+	oldHandleIDs := []int64{1}
+	oldDefault := func(int, *chunk.Chunk) error { return nil }
+	decoder := NewChunkDecoder(oldColumns, oldHandleIDs, oldDefault, time.UTC)
+	decoder.row = row{
+		flags:          rowFlagLarge | rowFlagChecksum,
+		checksumHeader: checksumFlagExtra,
+		numNotNullCols: 1,
+		numNullCols:    1,
+		colIDs:         []byte{1},
+		offsets:        []uint16{1},
+		colIDs32:       []uint32{1},
+		offsets32:      []uint32{1},
+		data:           []byte{1},
+		checksum1:      1,
+		checksum2:      2,
+	}
+
+	newColumns := []ColInfo{{ID: 2, Ft: types.NewFieldType(mysql.TypeVarchar)}}
+	newHandleIDs := []int64{2}
+	newDefault := func(int, *chunk.Chunk) error { return nil }
+	location := time.FixedZone("reset", 3600)
+	decoder.Reset(newColumns, newHandleIDs, newDefault, location)
+
+	require.Equal(t, row{}, decoder.row)
+	require.Equal(t, newColumns, decoder.columns)
+	require.Equal(t, newHandleIDs, decoder.handleColIDs)
+	require.Same(t, location, decoder.loc)
+	require.NotNil(t, decoder.defDatum)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70649

Problem Summary:

Common execution paths repeatedly allocate small wrappers, decoder state, parameter metadata, chunk storage, and update-row buffers. Individually these costs are small, but they scale per statement, executor, chunk, or updated row.

### What changed and how does it work?

- Reuse executor-owned point-get decoder/result storage and update-row buffers with explicit reset boundaries.
- Avoid transient parameter and runtime-statistics allocations, cache immutable executor trace names, and initialize concurrent-map shards lazily under their existing locks.
- Co-allocate chunk storage only for common default-capacity layouts, with fallback behavior for other sizes and growth/independence tests.
- Skip zero offset adjustment during decoding and reuse immutable integer field-type constants.
- Add caller-representative point-get, expression, chunk, join, and TPCC update benchmarks.
- Keep ChunkDecoder construction and reset on one initialization path so a
  future decoder field cannot be omitted from the reused-state path.

The local benchmarks show allocation reductions on the targeted paths, including complete removal of the trace-name and integer-field-type allocations; timed hot paths improve or remain flat. A staged current-master prepared PointGet benchmark moves from about 10066 B/op and 133 allocs/op to about 9720 B/op and 130 allocs/op across the decoder, stats, and result-set changes. BatchPointGet receives only the applicable stats reduction (142 to 141 allocs/op). The cold update-row cases keep the same allocation count, while steady-state reuse provides the intended gain. No global mutable state or cross-package lifetime contract is introduced.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

```sh
go test ./pkg/executor/internal/exec ./pkg/executor/join ./pkg/executor ./pkg/expression ./pkg/util/chunk ./pkg/util/rowcodec
go test ./pkg/executor/internal/exec ./pkg/executor/join ./pkg/executor ./pkg/expression ./pkg/util/chunk -run '^$' -bench 'Benchmark(NextWrapper|NewConcurrentMap|UpdateExec|ParamMarkerIntHotPath|ExecBinaryParam|NewFixedLenColumn|NewMutRow|MutRow|NewVarLenColumn|VarLenColumn|RenewVarLenColumns)' -benchmem -benchtime=100ms -count=3
go test ./pkg/planner/core/tests/partition -run '^$' -bench '^BenchmarkNonPartitionPrepared(PointGetPlanCacheOn|BatchPointGetPlanCacheOn)$' -benchmem -benchtime=200ms -count=3
go build ./cmd/tidb-server
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve SQL execution performance by reducing transient allocations in executor, expression, and chunk hot paths
```
