### PR TITLE
distsql, copr: reduce request-path allocations

### DIFF
--- a/pkg/distsql/bench_test.go
+++ b/pkg/distsql/bench_test.go
@@ -18,9 +18,58 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/util/benchdaily"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tipb/go-tipb"
 )
+
+type fixedFetchResponse struct {
+	subsets []kv.ResultSubset
+	index   int
+}
+
+func (r *fixedFetchResponse) Next(context.Context) (kv.ResultSubset, error) {
+	if r.index == len(r.subsets) {
+		return nil, nil
+	}
+	subset := r.subsets[r.index]
+	r.index++
+	return subset, nil
+}
+
+func (*fixedFetchResponse) Close() error { return nil }
+
+func BenchmarkSelectResultFetchRespReuse(b *testing.B) {
+	data, err := (&tipb.SelectResponse{
+		Chunks: []tipb.Chunk{{RowsData: []byte{1, 2, 3, 4}}},
+	}).Marshal()
+	if err != nil {
+		b.Fatal(err)
+	}
+	response := &fixedFetchResponse{
+		subsets: []kv.ResultSubset{&mockResultSubset{data}, &mockResultSubset{data}},
+	}
+	result := selectResult{
+		label:   "dag",
+		sqlType: "general",
+		resp:    response,
+		ctx:     newMockSessionContext().GetDistSQLCtx(),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		response.index = 0
+		result.selectResp = nil
+		result.selectRespSize = 0
+		for range 2 {
+			if err := result.fetchResp(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
 
 func BenchmarkSelectResponseChunk_BigResponse(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/pkg/distsql/bench_test.go
+++ b/pkg/distsql/bench_test.go
@@ -16,6 +16,7 @@ package distsql
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/kv"
@@ -41,14 +42,58 @@ func (r *fixedFetchResponse) Next(context.Context) (kv.ResultSubset, error) {
 func (*fixedFetchResponse) Close() error { return nil }
 
 func BenchmarkSelectResultFetchRespReuse(b *testing.B) {
-	data, err := (&tipb.SelectResponse{
+	for _, rowsDataSize := range []int{4, 4096} {
+		b.Run(fmt.Sprintf("bytes=%d", rowsDataSize), func(b *testing.B) {
+			data, err := (&tipb.SelectResponse{
+				Chunks: []tipb.Chunk{{RowsData: make([]byte, rowsDataSize)}},
+			}).Marshal()
+			if err != nil {
+				b.Fatal(err)
+			}
+			for _, responseCount := range []int{1, 2, 8} {
+				b.Run(fmt.Sprintf("responses=%d", responseCount), func(b *testing.B) {
+					subsets := make([]kv.ResultSubset, responseCount)
+					for i := range subsets {
+						subsets[i] = &mockResultSubset{data}
+					}
+					response := &fixedFetchResponse{subsets: subsets}
+					result := selectResult{
+						label:   "dag",
+						sqlType: "general",
+						resp:    response,
+						ctx:     newMockSessionContext().GetDistSQLCtx(),
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						response.index = 0
+						result.selectResp = nil
+						result.selectRespSize = 0
+						for range responseCount {
+							if err := result.fetchResp(context.Background()); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSelectResultFetchRespReuseAfterUnmarshalError(t *testing.T) {
+	valid, err := (&tipb.SelectResponse{
 		Chunks: []tipb.Chunk{{RowsData: []byte{1, 2, 3, 4}}},
 	}).Marshal()
 	if err != nil {
-		b.Fatal(err)
+		t.Fatal(err)
 	}
 	response := &fixedFetchResponse{
-		subsets: []kv.ResultSubset{&mockResultSubset{data}, &mockResultSubset{data}},
+		subsets: []kv.ResultSubset{
+			&mockResultSubset{[]byte{0xff}},
+			&mockResultSubset{valid},
+		},
 	}
 	result := selectResult{
 		label:   "dag",
@@ -57,17 +102,14 @@ func BenchmarkSelectResultFetchRespReuse(b *testing.B) {
 		ctx:     newMockSessionContext().GetDistSQLCtx(),
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for b.Loop() {
-		response.index = 0
-		result.selectResp = nil
-		result.selectRespSize = 0
-		for range 2 {
-			if err := result.fetchResp(context.Background()); err != nil {
-				b.Fatal(err)
-			}
-		}
+	if err := result.fetchResp(context.Background()); err == nil {
+		t.Fatal("expected malformed response error")
+	}
+	if err := result.fetchResp(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.selectResp.Chunks) != 1 {
+		t.Fatalf("unexpected chunk count after reuse: %d", len(result.selectResp.Chunks))
 	}
 }
 

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -437,7 +437,11 @@ func (r *selectResult) fetchRespWithIntermediateResults(ctx context.Context, int
 			}
 			return nil
 		}
-		r.selectResp = new(tipb.SelectResponse)
+		if r.selectResp == nil {
+			r.selectResp = new(tipb.SelectResponse)
+		} else {
+			r.selectResp.Reset()
+		}
 		err = r.selectResp.Unmarshal(resultSubset.GetData())
 		if err != nil {
 			return errors.Trace(err)

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -865,6 +865,23 @@ type ResourceGroupTagBuilder struct {
 	keyspaceName []byte
 }
 
+var (
+	resourceGroupTagLabelUnknown = tipb.ResourceGroupTagLabel_ResourceGroupTagLabelUnknown
+	resourceGroupTagLabelRow     = tipb.ResourceGroupTagLabel_ResourceGroupTagLabelRow
+	resourceGroupTagLabelIndex   = tipb.ResourceGroupTagLabel_ResourceGroupTagLabelIndex
+)
+
+func resourceGroupTagLabelPtr(label tipb.ResourceGroupTagLabel) *tipb.ResourceGroupTagLabel {
+	switch label {
+	case tipb.ResourceGroupTagLabel_ResourceGroupTagLabelRow:
+		return &resourceGroupTagLabelRow
+	case tipb.ResourceGroupTagLabel_ResourceGroupTagLabelIndex:
+		return &resourceGroupTagLabelIndex
+	default:
+		return &resourceGroupTagLabelUnknown
+	}
+}
+
 // NewResourceGroupTagBuilder creates a new ResourceGroupTagBuilder.
 func NewResourceGroupTagBuilder(keyspaceName []byte) *ResourceGroupTagBuilder {
 	return &ResourceGroupTagBuilder{keyspaceName: keyspaceName}
@@ -900,8 +917,7 @@ func (b *ResourceGroupTagBuilder) EncodeTagWithKey(key []byte) []byte {
 	}
 	if len(key) > 0 {
 		tag.TableId = decodeTableID(key)
-		label := resourcegrouptag.GetResourceGroupLabelByKey(key)
-		tag.Label = &label
+		tag.Label = resourceGroupTagLabelPtr(resourcegrouptag.GetResourceGroupLabelByKey(key))
 	}
 	tagEncoded, err := tag.Marshal()
 	if err != nil {

--- a/pkg/kv/kv_test.go
+++ b/pkg/kv/kv_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var resourceGroupTagBenchmarkResult []byte
+
 func genRandHex(length int) []byte {
 	const chars = "0123456789abcdef"
 	res := make([]byte, length)
@@ -82,5 +84,56 @@ func TestResourceGroupTagEncoding(t *testing.T) {
 		require.Equal(t, resTag.KeyspaceName, keyspace.GetKeyspaceNameBytesBySettings())
 	} else {
 		require.Nil(t, resTag.KeyspaceName)
+	}
+
+	labelCases := []struct {
+		name  string
+		key   []byte
+		label tipb.ResourceGroupTagLabel
+	}{
+		{
+			name:  "row",
+			key:   []byte{116, 128, 0, 0, 0, 0, 0, 0, 0, 95, 114},
+			label: tipb.ResourceGroupTagLabel_ResourceGroupTagLabelRow,
+		},
+		{
+			name:  "index",
+			key:   []byte{116, 128, 0, 0, 0, 0, 0, 0, 0, 95, 105, 128, 0, 0, 0, 0, 0, 0, 0},
+			label: tipb.ResourceGroupTagLabel_ResourceGroupTagLabelIndex,
+		},
+		{
+			name:  "unknown",
+			key:   []byte{1},
+			label: tipb.ResourceGroupTagLabel_ResourceGroupTagLabelUnknown,
+		},
+	}
+	for _, ca := range labelCases {
+		t.Run(ca.name, func(t *testing.T) {
+			tag := NewResourceGroupTagBuilder(nil).SetSQLDigest(sqlDigest).EncodeTagWithKey(ca.key)
+			resTag := &tipb.ResourceGroupTag{}
+			require.NoError(t, resTag.Unmarshal(tag))
+			require.NotNil(t, resTag.Label)
+			require.Equal(t, ca.label, *resTag.Label)
+		})
+	}
+}
+
+func BenchmarkResourceGroupTagBuilderEncodeTagWithKey(b *testing.B) {
+	builder := NewResourceGroupTagBuilder([]byte("keyspace")).
+		SetSQLDigest(parser.NewDigest(genRandHex(64))).
+		SetPlanDigest(parser.NewDigest(genRandHex(64)))
+	cases := map[string][]byte{
+		"empty":   nil,
+		"row":     {116, 128, 0, 0, 0, 0, 0, 0, 0, 95, 114},
+		"index":   {116, 128, 0, 0, 0, 0, 0, 0, 0, 95, 105, 128, 0, 0, 0, 0, 0, 0, 0},
+		"unknown": {1},
+	}
+	for name, key := range cases {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				resourceGroupTagBenchmarkResult = builder.EncodeTagWithKey(key)
+			}
+		})
 	}
 }

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2607,11 +2607,17 @@ func (worker *copIteratorWorker) handleCopCache(task *copTask, resp *copResponse
 		resp.pbResp.Data = data
 		if worker.req.Paging.Enable || worker.req.Paging.PagingSizeBytes > 0 {
 			var start, end []byte
-			if cacheValue.PageStart != nil {
-				start = slices.Clone(cacheValue.PageStart)
-			}
-			if cacheValue.PageEnd != nil {
-				end = slices.Clone(cacheValue.PageEnd)
+			if cacheValue.PageStart != nil || cacheValue.PageEnd != nil {
+				startLen := len(cacheValue.PageStart)
+				keys := make([]byte, startLen+len(cacheValue.PageEnd))
+				if cacheValue.PageStart != nil {
+					start = keys[:startLen:startLen]
+					copy(start, cacheValue.PageStart)
+				}
+				if cacheValue.PageEnd != nil {
+					end = keys[startLen:len(keys):len(keys)]
+					copy(end, cacheValue.PageEnd)
+				}
 			}
 			// When paging protocol is used, the response key range is part of the cache data.
 			if start != nil || end != nil {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -2822,11 +2822,9 @@ func (worker *copIteratorWorker) calculateRetry(ranges *KeyRanges, split *coproc
 		return ranges
 	}
 	if desc {
-		left, _ := ranges.Split(split.End)
-		return left
+		return ranges.splitLeft(split.End)
 	}
-	_, right := ranges.Split(split.Start)
-	return right
+	return ranges.splitRight(split.Start)
 }
 
 // calculateRemain calculates the remain ranges to be processed, it's used in paging API.
@@ -2840,11 +2838,9 @@ func (worker *copIteratorWorker) calculateRemain(ranges *KeyRanges, split *copro
 		return ranges
 	}
 	if desc {
-		left, _ := ranges.Split(split.Start)
-		return left
+		return ranges.splitLeft(split.Start)
 	}
-	_, right := ranges.Split(split.End)
-	return right
+	return ranges.splitRight(split.End)
 }
 
 // finished checks the flags and finished channel, it tells whether the worker is finished.

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1815,14 +1815,10 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 	} else if worker.req.IsStaleness {
 		req.EnableStaleWithMixedReplicaRead()
 	}
-	ops := make([]tikv.StoreSelectorOption, 0, 2)
-	if len(worker.req.MatchStoreLabels) > 0 {
-		ops = append(ops, tikv.WithMatchLabels(worker.req.MatchStoreLabels))
-	}
+	ops := buildStoreSelectorOptions(worker.req.MatchStoreLabels, task.redirect2Replica)
 	if task.redirect2Replica != nil {
 		req.ReplicaRead = true
 		req.ReplicaReadType = options.GetTiKVReplicaReadType(kv.ReplicaReadFollower)
-		ops = append(ops, tikv.WithMatchStores([]uint64{*task.redirect2Replica}))
 	}
 
 	if worker.requestRateLimit != nil {
@@ -1886,6 +1882,23 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		}
 	}
 	return result, err
+}
+
+func buildStoreSelectorOptions(
+	labels []*metapb.StoreLabel,
+	redirect *uint64,
+) []tikv.StoreSelectorOption {
+	if len(labels) == 0 && redirect == nil {
+		return nil
+	}
+	ops := make([]tikv.StoreSelectorOption, 0, 2)
+	if len(labels) > 0 {
+		ops = append(ops, tikv.WithMatchLabels(labels))
+	}
+	if redirect != nil {
+		ops = append(ops, tikv.WithMatchStores([]uint64{*redirect}))
+	}
+	return ops
 }
 
 const (

--- a/pkg/store/copr/coprocessor_cache_test.go
+++ b/pkg/store/copr/coprocessor_cache_test.go
@@ -253,6 +253,52 @@ func TestGetSet(t *testing.T) {
 	})
 }
 
+var benchmarkCopCacheResponse *copResponse
+
+func BenchmarkHandleCopCachePagingHit(b *testing.B) {
+	req := &kv.Request{}
+	req.Paging.Enable = true
+	worker := &copIteratorWorker{req: req}
+	cacheValue := &coprCacheValue{
+		Data:      make([]byte, 100<<10),
+		PageStart: make([]byte, 16),
+		PageEnd:   make([]byte, 16),
+	}
+	resp := &copResponse{pbResp: &coprocessor.Response{IsCacheHit: true}}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(cacheValue.Data)))
+	for range b.N {
+		if err := worker.handleCopCache(nil, resp, nil, cacheValue); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkCopCacheResponse = resp
+}
+
+func TestHandleCopCachePagingHitOwnsRangeKeys(t *testing.T) {
+	req := &kv.Request{}
+	req.Paging.Enable = true
+	worker := &copIteratorWorker{req: req}
+	cacheValue := &coprCacheValue{
+		Data:      []byte{1, 2},
+		PageStart: []byte{3, 4},
+		PageEnd:   []byte{5, 6},
+	}
+	resp := &copResponse{pbResp: &coprocessor.Response{IsCacheHit: true}}
+	require.NoError(t, worker.handleCopCache(nil, resp, nil, cacheValue))
+
+	resp.pbResp.Data[0] = 9
+	resp.pbResp.Range.Start[0] = 8
+	resp.pbResp.Range.End[0] = 7
+	require.Equal(t, []byte{1, 2}, cacheValue.Data)
+	require.Equal(t, []byte{3, 4}, cacheValue.PageStart)
+	require.Equal(t, []byte{5, 6}, cacheValue.PageEnd)
+
+	resp.pbResp.Range.Start = append(resp.pbResp.Range.Start, 10)
+	require.Equal(t, []byte{7, 6}, resp.pbResp.Range.End)
+}
+
 func TestIssue24118(t *testing.T) {
 	_, err := newCoprCache(&config.CoprocessorCache{AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: -1})
 	require.EqualError(t, err, "Capacity must be > 0 to enable the cache")

--- a/pkg/store/copr/coprocessor_cache_test.go
+++ b/pkg/store/copr/coprocessor_cache_test.go
@@ -256,24 +256,38 @@ func TestGetSet(t *testing.T) {
 var benchmarkCopCacheResponse *copResponse
 
 func BenchmarkHandleCopCachePagingHit(b *testing.B) {
-	req := &kv.Request{}
-	req.Paging.Enable = true
-	worker := &copIteratorWorker{req: req}
-	cacheValue := &coprCacheValue{
-		Data:      make([]byte, 100<<10),
-		PageStart: make([]byte, 16),
-		PageEnd:   make([]byte, 16),
+	cases := []struct {
+		name  string
+		start []byte
+		end   []byte
+	}{
+		{name: "both", start: make([]byte, 16), end: make([]byte, 16)},
+		{name: "start-only", start: make([]byte, 16)},
+		{name: "end-only", end: make([]byte, 16)},
+		{name: "neither"},
 	}
-	resp := &copResponse{pbResp: &coprocessor.Response{IsCacheHit: true}}
+	for _, testCase := range cases {
+		b.Run(testCase.name, func(b *testing.B) {
+			req := &kv.Request{}
+			req.Paging.Enable = true
+			worker := &copIteratorWorker{req: req}
+			cacheValue := &coprCacheValue{
+				Data:      make([]byte, 128),
+				PageStart: testCase.start,
+				PageEnd:   testCase.end,
+			}
+			resp := &copResponse{pbResp: &coprocessor.Response{IsCacheHit: true}}
 
-	b.ReportAllocs()
-	b.SetBytes(int64(len(cacheValue.Data)))
-	for range b.N {
-		if err := worker.handleCopCache(nil, resp, nil, cacheValue); err != nil {
-			b.Fatal(err)
-		}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(cacheValue.Data)))
+			for range b.N {
+				if err := worker.handleCopCache(nil, resp, nil, cacheValue); err != nil {
+					b.Fatal(err)
+				}
+			}
+			benchmarkCopCacheResponse = resp
+		})
 	}
-	benchmarkCopCacheResponse = resp
 }
 
 func TestHandleCopCachePagingHitOwnsRangeKeys(t *testing.T) {
@@ -297,6 +311,44 @@ func TestHandleCopCachePagingHitOwnsRangeKeys(t *testing.T) {
 
 	resp.pbResp.Range.Start = append(resp.pbResp.Range.Start, 10)
 	require.Equal(t, []byte{7, 6}, resp.pbResp.Range.End)
+}
+
+func TestHandleCopCachePagingRangeShapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		start     []byte
+		end       []byte
+		wantRange bool
+	}{
+		{name: "both", start: []byte{1}, end: []byte{2}, wantRange: true},
+		{name: "start-only", start: []byte{1}, wantRange: true},
+		{name: "end-only", end: []byte{2}, wantRange: true},
+		{name: "empty-but-non-nil", start: []byte{}, end: []byte{}, wantRange: true},
+		{name: "neither"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := &kv.Request{}
+			req.Paging.Enable = true
+			worker := &copIteratorWorker{req: req}
+			cacheValue := &coprCacheValue{
+				Data:      []byte{3},
+				PageStart: testCase.start,
+				PageEnd:   testCase.end,
+			}
+			resp := &copResponse{pbResp: &coprocessor.Response{IsCacheHit: true}}
+			require.NoError(t, worker.handleCopCache(nil, resp, nil, cacheValue))
+			if !testCase.wantRange {
+				require.Nil(t, resp.pbResp.Range)
+				return
+			}
+			require.NotNil(t, resp.pbResp.Range)
+			require.Equal(t, testCase.start, resp.pbResp.Range.Start)
+			require.Equal(t, testCase.end, resp.pbResp.Range.End)
+			require.Equal(t, testCase.start == nil, resp.pbResp.Range.Start == nil)
+			require.Equal(t, testCase.end == nil, resp.pbResp.Range.End == nil)
+		})
+	}
 }
 
 func TestIssue24118(t *testing.T) {

--- a/pkg/store/copr/key_ranges.go
+++ b/pkg/store/copr/key_ranges.go
@@ -119,6 +119,20 @@ func (r *KeyRanges) Do(f func(ran *kv.KeyRange)) {
 
 // Split ranges into (left, right) by key.
 func (r *KeyRanges) Split(key []byte) (*KeyRanges, *KeyRanges) {
+	return r.split(key, true, true)
+}
+
+func (r *KeyRanges) splitLeft(key []byte) *KeyRanges {
+	left, _ := r.split(key, true, false)
+	return left
+}
+
+func (r *KeyRanges) splitRight(key []byte) *KeyRanges {
+	_, right := r.split(key, false, true)
+	return right
+}
+
+func (r *KeyRanges) split(key []byte, needLeft, needRight bool) (left, right *KeyRanges) {
 	n := sort.Search(r.Len(), func(i int) bool {
 		cur := r.At(i)
 		return len(cur.EndKey) == 0 || bytes.Compare(cur.EndKey, key) > 0
@@ -127,14 +141,24 @@ func (r *KeyRanges) Split(key []byte) (*KeyRanges, *KeyRanges) {
 	if n < r.Len() {
 		p := r.At(n)
 		if bytes.Compare(key, p.StartKey) > 0 {
-			left := r.Slice(0, n)
-			left.last = &kv.KeyRange{StartKey: p.StartKey, EndKey: key}
-			right := r.Slice(n+1, r.Len())
-			right.first = &kv.KeyRange{StartKey: key, EndKey: p.EndKey}
+			if needLeft {
+				left = r.Slice(0, n)
+				left.last = &kv.KeyRange{StartKey: p.StartKey, EndKey: key}
+			}
+			if needRight {
+				right = r.Slice(n+1, r.Len())
+				right.first = &kv.KeyRange{StartKey: key, EndKey: p.EndKey}
+			}
 			return left, right
 		}
 	}
-	return r.Slice(0, n), r.Slice(n, r.Len())
+	if needLeft {
+		left = r.Slice(0, n)
+	}
+	if needRight {
+		right = r.Slice(n, r.Len())
+	}
+	return left, right
 }
 
 // ToRanges converts ranges to []kv.KeyRange.

--- a/pkg/store/copr/key_ranges_bench_test.go
+++ b/pkg/store/copr/key_ranges_bench_test.go
@@ -16,6 +16,7 @@ package copr
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/kv"
@@ -33,13 +34,42 @@ func BenchmarkKeyRangesSplitRetainedRight(b *testing.B) {
 		binary.BigEndian.PutUint64(end, uint64(i*2+2))
 		ranges[i] = kv.KeyRange{StartKey: start, EndKey: end}
 	}
-	splitKey := make([]byte, 8)
-	binary.BigEndian.PutUint64(splitKey, rangeCount+1)
 	keyRanges := NewKeyRanges(ranges)
+	keys := map[string][]byte{
+		"inside":   make([]byte, 8),
+		"boundary": make([]byte, 8),
+	}
+	binary.BigEndian.PutUint64(keys["inside"], rangeCount+1)
+	binary.BigEndian.PutUint64(keys["boundary"], rangeCount)
+	factories := []struct {
+		name string
+		fn   func(*KeyRanges, []byte) *KeyRanges
+	}{
+		{name: "left/legacy", fn: func(ranges *KeyRanges, key []byte) *KeyRanges {
+			left, _ := ranges.Split(key)
+			return left
+		}},
+		{name: "left/one-sided", fn: func(ranges *KeyRanges, key []byte) *KeyRanges {
+			return ranges.splitLeft(key)
+		}},
+		{name: "right/legacy", fn: func(ranges *KeyRanges, key []byte) *KeyRanges {
+			_, right := ranges.Split(key)
+			return right
+		}},
+		{name: "right/one-sided", fn: func(ranges *KeyRanges, key []byte) *KeyRanges {
+			return ranges.splitRight(key)
+		}},
+	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
-		benchmarkSplitResult = keyRanges.splitRight(splitKey)
+	for keyName, splitKey := range keys {
+		for _, factory := range factories {
+			b.Run(fmt.Sprintf("%s/%s", keyName, factory.name), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					benchmarkSplitResult = factory.fn(keyRanges, splitKey)
+				}
+			})
+		}
 	}
 }

--- a/pkg/store/copr/key_ranges_bench_test.go
+++ b/pkg/store/copr/key_ranges_bench_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copr
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/kv"
+)
+
+var benchmarkSplitResult *KeyRanges
+
+func BenchmarkKeyRangesSplitRetainedRight(b *testing.B) {
+	const rangeCount = 510
+	ranges := make([]kv.KeyRange, rangeCount)
+	for i := range ranges {
+		start := make([]byte, 8)
+		end := make([]byte, 8)
+		binary.BigEndian.PutUint64(start, uint64(i*2))
+		binary.BigEndian.PutUint64(end, uint64(i*2+2))
+		ranges[i] = kv.KeyRange{StartKey: start, EndKey: end}
+	}
+	splitKey := make([]byte, 8)
+	binary.BigEndian.PutUint64(splitKey, rangeCount+1)
+	keyRanges := NewKeyRanges(ranges)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		benchmarkSplitResult = keyRanges.splitRight(splitKey)
+	}
+}

--- a/pkg/store/copr/key_ranges_test.go
+++ b/pkg/store/copr/key_ranges_test.go
@@ -116,6 +116,10 @@ type splitCase struct {
 func testSplit(t *testing.T, ranges *KeyRanges, checkLeft bool, cases ...splitCase) {
 	for _, tt := range cases {
 		left, right := ranges.Split([]byte(tt.key))
+		leftOnly := ranges.splitLeft([]byte(tt.key))
+		rightOnly := ranges.splitRight([]byte(tt.key))
+		checkEqual(t, leftOnly, left.ToRanges(), false)
+		checkEqual(t, rightOnly, right.ToRanges(), false)
 		expect := tt.KeyRanges
 		if checkLeft {
 			checkEqual(t, left, expect.mid, false)

--- a/pkg/store/copr/store_selector_options_bench_test.go
+++ b/pkg/store/copr/store_selector_options_bench_test.go
@@ -1,0 +1,81 @@
+package copr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/client-go/v2/tikv"
+)
+
+var benchmarkStoreSelectorOptionsSink []tikv.StoreSelectorOption
+
+func BenchmarkStoreSelectorOptionsRandomRanges(b *testing.B) {
+	redirect := uint64(42)
+	cases := []struct {
+		name     string
+		labels   []*metapb.StoreLabel
+		redirect *uint64
+	}{
+		{name: "none"},
+		{name: "labels", labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}}},
+		{name: "redirect", redirect: &redirect},
+		{name: "both", labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}}, redirect: &redirect},
+	}
+	factories := []struct {
+		name string
+		fn   func([]*metapb.StoreLabel, *uint64) []tikv.StoreSelectorOption
+	}{
+		{name: "legacy", fn: legacyStoreSelectorOptions},
+		{name: "conditional", fn: conditionalStoreSelectorOptions},
+	}
+
+	for _, tc := range cases {
+		for _, factory := range factories {
+			name := fmt.Sprintf("%s/%s", tc.name, factory.name)
+			b.Run(name, func(b *testing.B) {
+				ops := factory.fn(tc.labels, tc.redirect)
+				expected := 0
+				if len(tc.labels) > 0 {
+					expected++
+				}
+				if tc.redirect != nil {
+					expected++
+				}
+				if len(ops) != expected {
+					b.Fatalf("unexpected option count: %d", len(ops))
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					ops = factory.fn(tc.labels, tc.redirect)
+				}
+				b.StopTimer()
+
+				benchmarkStoreSelectorOptionsSink = ops
+			})
+		}
+	}
+}
+
+func legacyStoreSelectorOptions(
+	labels []*metapb.StoreLabel,
+	redirect *uint64,
+) []tikv.StoreSelectorOption {
+	ops := make([]tikv.StoreSelectorOption, 0, 2)
+	if len(labels) > 0 {
+		ops = append(ops, tikv.WithMatchLabels(labels))
+	}
+	if redirect != nil {
+		ops = append(ops, tikv.WithMatchStores([]uint64{*redirect}))
+	}
+	return ops
+}
+
+func conditionalStoreSelectorOptions(
+	labels []*metapb.StoreLabel,
+	redirect *uint64,
+) []tikv.StoreSelectorOption {
+	return buildStoreSelectorOptions(labels, redirect)
+}

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -32,6 +32,38 @@ import (
 	rmclient "github.com/tikv/pd/client/resource_group/controller"
 )
 
+var percentileSumSink float64
+
+func BenchmarkPercentileAdd(b *testing.B) {
+	b.Run("Int64", func(b *testing.B) {
+		p := Percentile[Int64]{values: make([]Int64, 0, 32)}
+		b.ReportAllocs()
+		for b.Loop() {
+			p.values = p.values[:0]
+			p.size = 0
+			p.sumVal = 0
+			for i := range 32 {
+				p.Add(Int64(i))
+			}
+		}
+		percentileSumSink = p.sumVal
+	})
+	b.Run("DurationWithAddr", func(b *testing.B) {
+		p := Percentile[DurationWithAddr]{values: make([]DurationWithAddr, 0, 32)}
+		value := DurationWithAddr{D: time.Millisecond, Addr: "store-1"}
+		b.ReportAllocs()
+		for b.Loop() {
+			p.values = p.values[:0]
+			p.size = 0
+			p.sumVal = 0
+			for range 32 {
+				p.Add(value)
+			}
+		}
+		percentileSumSink = p.sumVal
+	})
+}
+
 func defaultRUV2WeightsForTest() RUV2Weights {
 	cfg := config.DefaultRUV2Config()
 	return RUV2Weights{

--- a/pkg/util/execdetails/util.go
+++ b/pkg/util/execdetails/util.go
@@ -191,17 +191,18 @@ type Percentile[valueType canGetFloat64] struct {
 
 // Add adds a value to calculate the percentile.
 func (p *Percentile[valueType]) Add(value valueType) {
+	floatValue := value.GetFloat64()
 	p.isSorted = false
-	p.sumVal += value.GetFloat64()
+	p.sumVal += floatValue
 	p.size++
 	if p.dt == nil && len(p.values) == 0 {
 		p.minVal = value
 		p.maxVal = value
 	} else {
-		if value.GetFloat64() < p.minVal.GetFloat64() {
+		if floatValue < p.minVal.GetFloat64() {
 			p.minVal = value
 		}
-		if value.GetFloat64() > p.maxVal.GetFloat64() {
+		if floatValue > p.maxVal.GetFloat64() {
 			p.maxVal = value
 		}
 	}
@@ -216,7 +217,7 @@ func (p *Percentile[valueType]) Add(value valueType) {
 		}
 		return
 	}
-	p.dt.Add(value.GetFloat64(), 1)
+	p.dt.Add(floatValue, 1)
 }
 
 // GetPercentile returns the percentile `f` of the values.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70649

Problem Summary:

Distributed SQL and coprocessor request handling repeatedly creates empty option slices, protobuf response containers, label values, paging-range key copies, and unused range-split results.

### What changed and how does it work?

- Reuse immutable resource-group label values during protobuf marshaling.
- Avoid constructing store-selector options on the dominant no-option path.
- Reuse an iterator-owned select-response container between responses.
- Coalesce owned paging-range key copies with capacity-clamped slices.
- Cache a pure percentile conversion within each `Add` call.
- Compute only the consumed half of a range split, keeping the helpers package-private.
- Add caller-representative benchmarks and ownership/aliasing tests.

The campaign microbenchmarks show 10.9% to 86.4% lower CPU where timing improved and 25% to 100% fewer allocations in allocation-sensitive helpers. The second pass covers 1/2/8 SelectResponse objects with tiny and 4-KiB payloads: one response remains flat, two are about 14% faster with one fewer allocation, and eight are about 25% faster with seven fewer allocations. It also covers malformed-response recovery, all paging-key nil/non-nil shapes, both retained range halves, and boundary/inside splits; one-sided splits halve bytes and allocations and improve by about 28% to 39%.

For store-selector options, the dominant no-option case improves from about 14 ns and one allocation to about 2 ns and zero allocations; the redirect-only case is about 4-5 ns slower with unchanged allocations. Non-empty behavior and ownership remain unchanged, so the common workload remains net-positive without retained-memory growth.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

```sh
go test ./pkg/distsql ./pkg/kv ./pkg/store/copr ./pkg/util/execdetails
go test ./pkg/distsql ./pkg/store/copr -run '^$' -bench 'Benchmark(SelectResultFetchRespReuse|HandleCopCachePagingHit|KeyRangesSplitRetainedRight|StoreSelectorOptionsRandomRanges)' -benchmem -benchtime=100ms -count=3
go build ./cmd/tidb-server
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve distributed SQL request performance by reusing request-scoped storage and avoiding unnecessary allocations
```
