### PR TITLE
server, parser, sessiontxn: reduce common SQL path overhead

### DIFF
--- a/pkg/format/textrow/result_encoder.go
+++ b/pkg/format/textrow/result_encoder.go
@@ -158,6 +158,9 @@ func (d *ResultEncoder) EncodeData(src []byte) []byte {
 
 // encodeWith encodes bytes with the given encoding.
 func (d *ResultEncoder) encodeWith(src []byte, enc charset.Encoding) []byte {
+	if enc == charset.EncodingBinImpl {
+		return src
+	}
 	data, err := enc.Transform(&d.buffer, src, charset.OpEncodeReplace)
 	if err != nil {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))

--- a/pkg/format/textrow/result_encoder.go
+++ b/pkg/format/textrow/result_encoder.go
@@ -62,6 +62,8 @@ type ResultEncoder struct {
 	isBinary     bool
 	isNull       bool
 	dataIsBinary bool
+	dataChsID    uint16
+	dataChsValid bool
 }
 
 // NewResultEncoder creates a new ResultEncoder.
@@ -86,12 +88,20 @@ func (d *ResultEncoder) Clean() {
 
 // UpdateDataEncoding updates the data encoding.
 func (d *ResultEncoder) UpdateDataEncoding(chsID uint16) {
+	if d.dataChsValid && d.dataChsID == chsID {
+		return
+	}
+	d.dataChsValid = false
 	chs, _, err := charset.GetCharsetInfoByID(int(chsID))
 	if err != nil {
 		logutil.BgLogger().Warn("unknown charset ID", zap.Error(err))
 	}
 	d.dataEncoding = charset.FindEncodingTakeUTF8AsNoop(chs)
 	d.dataIsBinary = chsID == mysql.BinaryDefaultCollationID
+	if err == nil {
+		d.dataChsID = chsID
+		d.dataChsValid = true
+	}
 }
 
 // ColumnCharsetID returns the charset ID to advertise for a column in the

--- a/pkg/format/textrow/result_encoder.go
+++ b/pkg/format/textrow/result_encoder.go
@@ -51,7 +51,7 @@ type ResultEncoder struct {
 	// dataEncoding can be updated to match the column data charset.
 	dataEncoding charset.Encoding
 
-	buffer *bytes.Buffer
+	buffer bytes.Buffer
 
 	scratch []byte
 
@@ -69,7 +69,6 @@ func NewResultEncoder(chs string) *ResultEncoder {
 	return &ResultEncoder{
 		chsName:  chs,
 		encoding: charset.FindEncodingTakeUTF8AsNoop(chs),
-		buffer:   &bytes.Buffer{},
 		scratch:  make([]byte, 0, 48),
 		isBinary: chs == charset.CharsetBin,
 		isNull:   len(chs) == 0,
@@ -81,7 +80,7 @@ func NewResultEncoder(chs string) *ResultEncoder {
 // encoder must not be reused afterwards, as the Encode* methods would then
 // re-allocate a temporary buffer on every call.
 func (d *ResultEncoder) Clean() {
-	d.buffer = nil
+	d.buffer = bytes.Buffer{}
 	d.scratch = nil
 }
 
@@ -149,7 +148,7 @@ func (d *ResultEncoder) EncodeData(src []byte) []byte {
 
 // encodeWith encodes bytes with the given encoding.
 func (d *ResultEncoder) encodeWith(src []byte, enc charset.Encoding) []byte {
-	data, err := enc.Transform(d.buffer, src, charset.OpEncodeReplace)
+	data, err := enc.Transform(&d.buffer, src, charset.OpEncodeReplace)
 	if err != nil {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))
 	}

--- a/pkg/format/textrow/result_encoder_bench_test.go
+++ b/pkg/format/textrow/result_encoder_bench_test.go
@@ -15,6 +15,7 @@
 package textrow
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/parser/charset"
@@ -23,16 +24,27 @@ import (
 var benchmarkEncodedLengthSink int
 
 func BenchmarkEncodeWithWideRows(b *testing.B) {
-	encoder := NewResultEncoder(charset.CharsetUTF8MB4)
-	c := make([]byte, 119)
-	pad := make([]byte, 59)
-	total := 0
-	b.ReportAllocs()
-	for range b.N {
-		for range 510 {
-			total += len(encoder.encodeWith(c, charset.EncodingBinImpl))
-			total += len(encoder.encodeWith(pad, charset.EncodingBinImpl))
-		}
+	cases := []struct {
+		name   string
+		enc    charset.Encoding
+		first  []byte
+		second []byte
+	}{
+		{name: "binary-noop", enc: charset.EncodingBinImpl, first: make([]byte, 119), second: make([]byte, 59)},
+		{name: "gbk-transform", enc: charset.EncodingGBKImpl, first: bytes.Repeat([]byte("一"), 39), second: bytes.Repeat([]byte("二"), 19)},
 	}
-	benchmarkEncodedLengthSink = total
+	for _, testCase := range cases {
+		b.Run(testCase.name, func(b *testing.B) {
+			encoder := NewResultEncoder(charset.CharsetUTF8MB4)
+			total := 0
+			b.ReportAllocs()
+			for range b.N {
+				for range 510 {
+					total += len(encoder.encodeWith(testCase.first, testCase.enc))
+					total += len(encoder.encodeWith(testCase.second, testCase.enc))
+				}
+			}
+			benchmarkEncodedLengthSink = total
+		})
+	}
 }

--- a/pkg/format/textrow/result_encoder_bench_test.go
+++ b/pkg/format/textrow/result_encoder_bench_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textrow
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/charset"
+)
+
+var benchmarkEncodedLengthSink int
+
+func BenchmarkEncodeWithWideRows(b *testing.B) {
+	encoder := NewResultEncoder(charset.CharsetUTF8MB4)
+	c := make([]byte, 119)
+	pad := make([]byte, 59)
+	total := 0
+	b.ReportAllocs()
+	for range b.N {
+		for range 510 {
+			total += len(encoder.encodeWith(c, charset.EncodingBinImpl))
+			total += len(encoder.encodeWith(pad, charset.EncodingBinImpl))
+		}
+	}
+	benchmarkEncodedLengthSink = total
+}

--- a/pkg/format/textrow/result_encoder_test.go
+++ b/pkg/format/textrow/result_encoder_test.go
@@ -18,9 +18,31 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/format/textrow"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/stretchr/testify/require"
 )
+
+var benchmarkResultEncoderSink *textrow.ResultEncoder
+
+func BenchmarkNewResultEncoder(b *testing.B) {
+	for _, testCase := range []struct {
+		name string
+		chs  string
+	}{
+		{name: "utf8mb4", chs: charset.CharsetUTF8MB4},
+		{name: "binary", chs: charset.CharsetBin},
+		{name: "gbk", chs: "gbk"},
+		{name: "null", chs: ""},
+	} {
+		b.Run(testCase.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				benchmarkResultEncoderSink = textrow.NewResultEncoder(testCase.chs)
+			}
+		})
+	}
+}
 
 func TestResultEncoder(t *testing.T) {
 	// Encode bytes to utf-8.

--- a/pkg/format/textrow/result_encoder_test.go
+++ b/pkg/format/textrow/result_encoder_test.go
@@ -45,15 +45,50 @@ func BenchmarkNewResultEncoder(b *testing.B) {
 }
 
 func BenchmarkUpdateDataEncodingWideRows(b *testing.B) {
-	encoder := textrow.NewResultEncoder(charset.CharsetUTF8MB4)
-	b.ReportAllocs()
-	for range b.N {
-		for range 510 {
-			encoder.UpdateDataEncoding(mysql.DefaultCollationID)
-			encoder.UpdateDataEncoding(mysql.DefaultCollationID)
-		}
+	gbkCollation, err := charset.GetCollationByName(charset.CollationGBKBin)
+	require.NoError(b, err)
+	cases := []struct {
+		name string
+		ids  []uint16
+	}{
+		{name: "repeated", ids: []uint16{mysql.DefaultCollationID, mysql.DefaultCollationID}},
+		{name: "changing", ids: []uint16{mysql.DefaultCollationID, uint16(gbkCollation.ID)}},
 	}
-	benchmarkResultEncoderSink = encoder
+	for _, testCase := range cases {
+		b.Run(testCase.name, func(b *testing.B) {
+			encoder := textrow.NewResultEncoder(charset.CharsetUTF8MB4)
+			b.ReportAllocs()
+			for range b.N {
+				for range 510 {
+					for _, id := range testCase.ids {
+						encoder.UpdateDataEncoding(id)
+					}
+				}
+			}
+			benchmarkResultEncoderSink = encoder
+		})
+	}
+}
+
+func TestUpdateDataEncodingTransitions(t *testing.T) {
+	gbkCollation, err := charset.GetCollationByName(charset.CollationGBKBin)
+	require.NoError(t, err)
+
+	encoder := textrow.NewResultEncoder(charset.CharsetBin)
+	src := []byte("一")
+	gbk := []byte{0xd2, 0xbb}
+
+	encoder.UpdateDataEncoding(uint16(gbkCollation.ID))
+	require.Equal(t, gbk, encoder.EncodeData(src))
+	encoder.UpdateDataEncoding(uint16(gbkCollation.ID))
+	require.Equal(t, gbk, encoder.EncodeData(src))
+
+	encoder.UpdateDataEncoding(mysql.DefaultCollationID)
+	require.Equal(t, src, encoder.EncodeData(src))
+	encoder.UpdateDataEncoding(^uint16(0))
+	require.Equal(t, src, encoder.EncodeData(src))
+	encoder.UpdateDataEncoding(uint16(gbkCollation.ID))
+	require.Equal(t, gbk, encoder.EncodeData(src))
 }
 
 func TestResultEncoder(t *testing.T) {

--- a/pkg/format/textrow/result_encoder_test.go
+++ b/pkg/format/textrow/result_encoder_test.go
@@ -44,6 +44,18 @@ func BenchmarkNewResultEncoder(b *testing.B) {
 	}
 }
 
+func BenchmarkUpdateDataEncodingWideRows(b *testing.B) {
+	encoder := textrow.NewResultEncoder(charset.CharsetUTF8MB4)
+	b.ReportAllocs()
+	for range b.N {
+		for range 510 {
+			encoder.UpdateDataEncoding(mysql.DefaultCollationID)
+			encoder.UpdateDataEncoding(mysql.DefaultCollationID)
+		}
+	}
+	benchmarkResultEncoderSink = encoder
+}
+
 func TestResultEncoder(t *testing.T) {
 	// Encode bytes to utf-8.
 	d := textrow.NewResultEncoder("utf-8")

--- a/pkg/parser/charset/encoding.go
+++ b/pkg/parser/charset/encoding.go
@@ -48,6 +48,9 @@ func FindEncoding(charset string) Encoding {
 	if len(charset) == 0 {
 		return EncodingBinImpl
 	}
+	if charset == CharsetUTF8MB4 || charset == CharsetUTF8 {
+		return EncodingUTF8Impl
+	}
 	if e, exist := encodingMap[charset]; exist {
 		return e
 	}

--- a/pkg/parser/charset/encoding_test.go
+++ b/pkg/parser/charset/encoding_test.go
@@ -242,3 +242,28 @@ func TestEncodingGB18030(t *testing.T) {
 		require.Equal(t, tc.result, string(result), cmt)
 	}
 }
+
+var benchmarkEncoding charset.Encoding
+
+func BenchmarkFindEncoding(b *testing.B) {
+	charsets := []string{
+		charset.CharsetUTF8MB4,
+		charset.CharsetUTF8,
+		charset.CharsetGBK,
+		charset.CharsetLatin1,
+		charset.CharsetBin,
+		charset.CharsetASCII,
+		charset.CharsetGB18030,
+		"unknown",
+	}
+	for _, chs := range charsets {
+		b.Run(chs, func(b *testing.B) {
+			b.ReportAllocs()
+			var enc charset.Encoding
+			for range b.N {
+				enc = charset.FindEncoding(chs)
+			}
+			benchmarkEncoding = enc
+		})
+	}
+}

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -212,7 +212,29 @@ type clientConn struct {
 	extensions *extension.SessionExtensions
 
 	// Proxy Protocol Enabled
-	ppEnabled bool
+	ppEnabled         bool
+	queryMetricsCache queryMetricsObserverCache
+}
+
+type queryMetricsObserverCache struct {
+	sqlType  string
+	duration prometheus.Observer
+	rpc      prometheus.Observer
+}
+
+func (c *queryMetricsObserverCache) get(
+	sqlType, dbName, resourceGroupName string,
+) (duration, rpc prometheus.Observer) {
+	if dbName != "" || resourceGroupName != resourcegroup.DefaultResourceGroupName {
+		return metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, resourceGroupName),
+			metrics.QueryRPCHistogram.WithLabelValues(sqlType, dbName)
+	}
+	if c.duration == nil || c.sqlType != sqlType {
+		c.sqlType = sqlType
+		c.duration = metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, resourceGroupName)
+		c.rpc = metrics.QueryRPCHistogram.WithLabelValues(sqlType, dbName)
+	}
+	return c.duration, c.rpc
 }
 
 type userResourceLimits struct {
@@ -1417,8 +1439,9 @@ func (cc *clientConn) addQueryMetrics(cmd byte, startTime time.Time, err error) 
 	execDetails := vars.StmtCtx.GetExecDetails()
 
 	for _, dbName := range session.GetDBNames(vars) {
-		metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, vars.StmtCtx.ResourceGroupName).Observe(cost.Seconds())
-		metrics.QueryRPCHistogram.WithLabelValues(sqlType, dbName).Observe(float64(execDetails.RequestCount))
+		durationObserver, rpcObserver := cc.queryMetricsCache.get(sqlType, dbName, vars.StmtCtx.ResourceGroupName)
+		durationObserver.Observe(cost.Seconds())
+		rpcObserver.Observe(float64(execDetails.RequestCount))
 		if execDetails.ScanDetail != nil {
 			metrics.QueryProcessedKeyHistogram.WithLabelValues(sqlType, dbName).Observe(float64(execDetails.ScanDetail.ProcessedKeys))
 			iaStats := execdetails.GetIARemoteReadSegmentStats(execDetails.ScanDetail)

--- a/pkg/server/conn_metrics_bench_test.go
+++ b/pkg/server/conn_metrics_bench_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/resourcegroup"
+	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkClientConnAddMetricsPointSelect(b *testing.B) {
+	cc := newClientConnForMetricsBenchmark(b)
+	startTime := time.Now().Add(-time.Millisecond)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		cc.addMetrics(mysql.ComStmtExecute, startTime, nil)
+	}
+}
+
+func BenchmarkClientConnAddMetricsChangingLabels(b *testing.B) {
+	cc := newClientConnForMetricsBenchmark(b)
+	vars := cc.ctx.GetSessionVars()
+	startTime := time.Now().Add(-time.Millisecond)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if vars.StmtCtx.StmtType == "Select" {
+			vars.StmtCtx.StmtType = "Update"
+			vars.ResourceGroupName = "benchmark_rg"
+			vars.StmtCtx.ResourceGroupName = "benchmark_rg"
+		} else {
+			vars.StmtCtx.StmtType = "Select"
+			vars.ResourceGroupName = resourcegroup.DefaultResourceGroupName
+			vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName
+		}
+		cc.addMetrics(mysql.ComStmtExecute, startTime, nil)
+	}
+}
+
+func newClientConnForMetricsBenchmark(b *testing.B) *clientConn {
+	store := testkit.CreateMockStore(b)
+	se, err := session.CreateSession4Test(store)
+	require.NoError(b, err)
+	b.Cleanup(func() {
+		se.Close()
+	})
+
+	vars := se.GetSessionVars()
+	vars.StmtCtx.StmtType = "Select"
+	vars.ResourceGroupName = resourcegroup.DefaultResourceGroupName
+	vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName
+
+	cc := &clientConn{}
+	cc.ctx.TiDBContext = &TiDBContext{Session: se}
+	return cc
+}

--- a/pkg/server/conn_metrics_bench_test.go
+++ b/pkg/server/conn_metrics_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkClientConnAddMetricsPointSelect(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		cc.addMetrics(mysql.ComStmtExecute, startTime, nil)
+		cc.addQueryMetrics(mysql.ComStmtExecute, startTime, nil)
 	}
 }
 
@@ -53,7 +53,7 @@ func BenchmarkClientConnAddMetricsChangingLabels(b *testing.B) {
 			vars.ResourceGroupName = resourcegroup.DefaultResourceGroupName
 			vars.StmtCtx.ResourceGroupName = resourcegroup.DefaultResourceGroupName
 		}
-		cc.addMetrics(mysql.ComStmtExecute, startTime, nil)
+		cc.addQueryMetrics(mysql.ComStmtExecute, startTime, nil)
 	}
 }
 

--- a/pkg/server/conn_metrics_cache_test.go
+++ b/pkg/server/conn_metrics_cache_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/resourcegroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryMetricsObserverCache(t *testing.T) {
+	cache := queryMetricsObserverCache{}
+	duration, rpc := cache.get("Select", "", resourcegroup.DefaultResourceGroupName)
+	cachedDuration, cachedRPC := cache.get("Select", "", resourcegroup.DefaultResourceGroupName)
+	require.Same(t, duration, cachedDuration)
+	require.Same(t, rpc, cachedRPC)
+
+	otherDuration, sameRPC := cache.get("Select", "", "rg1")
+	require.NotSame(t, duration, otherDuration)
+	require.Same(t, rpc, sameRPC)
+	cachedDuration, cachedRPC = cache.get("Select", "", resourcegroup.DefaultResourceGroupName)
+	require.Same(t, duration, cachedDuration)
+	require.Same(t, rpc, cachedRPC)
+
+	otherDBDuration, otherDBRPC := cache.get("Select", "test", resourcegroup.DefaultResourceGroupName)
+	require.NotSame(t, duration, otherDBDuration)
+	require.NotSame(t, rpc, otherDBRPC)
+
+	otherSQLDuration, otherSQLRPC := cache.get("Update", "", resourcegroup.DefaultResourceGroupName)
+	require.NotSame(t, otherDuration, otherSQLDuration)
+	require.NotSame(t, sameRPC, otherSQLRPC)
+}

--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -141,14 +141,13 @@ func (p *PacketIO) SetReadTimeout(timeout time.Duration) {
 
 func (p *PacketIO) readOnePacket() ([]byte, error) {
 	var header [4]byte
-	r := io.NopCloser(p.bufReadConn)
 	if p.readTimeout > 0 {
 		if err := p.bufReadConn.SetReadDeadline(time.Now().Add(p.readTimeout)); err != nil {
 			return nil, err
 		}
 	}
 	if p.compressionAlgorithm == mysql.CompressionNone {
-		if _, err := io.ReadFull(r, header[:]); err != nil {
+		if _, err := io.ReadFull(p.bufReadConn, header[:]); err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
@@ -185,17 +184,13 @@ func (p *PacketIO) readOnePacket() ([]byte, error) {
 		}
 	}
 	if p.compressionAlgorithm == mysql.CompressionNone {
-		if _, err := io.ReadFull(r, data); err != nil {
+		if _, err := io.ReadFull(p.bufReadConn, data); err != nil {
 			return nil, errors.Trace(err)
 		}
 	} else {
 		if _, err := io.ReadFull(p.compressedReader, data); err != nil {
 			return nil, errors.Trace(err)
 		}
-	}
-	err := r.Close()
-	if err != nil {
-		return nil, errors.Trace(err)
 	}
 	return data, nil
 }

--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -65,11 +65,12 @@ type PacketIO struct {
 	// maxAllowedPacket is the maximum size of one packet in ReadPacket.
 	maxAllowedPacket uint64
 	// accumulatedLength count the length of totally received 'payload' in ReadPacket.
-	accumulatedLength    uint64
-	compressionAlgorithm int
-	zstdLevel            zstd.EncoderLevel
-	sequence             uint8
-	compressedSequence   uint8
+	accumulatedLength     uint64
+	compressionAlgorithm  int
+	zstdLevel             zstd.EncoderLevel
+	sequence              uint8
+	compressedSequence    uint8
+	pendingOutPacketBytes int
 }
 
 // NewPacketIO creates a new PacketIO with given net.Conn.
@@ -243,7 +244,11 @@ func (p *PacketIO) ReadPacket() ([]byte, error) {
 // WritePacket writes data that already have header
 func (p *PacketIO) WritePacket(data []byte) error {
 	length := len(data) - 4
-	server_metrics.OutPacketBytes.Add(float64(len(data)))
+	if p.compressionAlgorithm == mysql.CompressionNone {
+		p.pendingOutPacketBytes += len(data)
+	} else {
+		server_metrics.OutPacketBytes.Add(float64(len(data)))
+	}
 
 	maxPayloadLen := mysql.MaxPayloadLen
 
@@ -261,8 +266,10 @@ func (p *PacketIO) WritePacket(data []byte) error {
 			}
 		} else {
 			if n, err := p.bufWriter.Write(data[:4+maxPayloadLen]); err != nil {
+				p.flushOutPacketBytesMetric()
 				return errors.Trace(mysql.ErrBadConn)
 			} else if n != (4 + maxPayloadLen) {
+				p.flushOutPacketBytesMetric()
 				return errors.Trace(mysql.ErrBadConn)
 			}
 		}
@@ -286,9 +293,11 @@ func (p *PacketIO) WritePacket(data []byte) error {
 		return nil
 	}
 	if n, err := p.bufWriter.Write(data); err != nil {
+		p.flushOutPacketBytesMetric()
 		terror.Log(errors.Trace(err))
 		return errors.Trace(mysql.ErrBadConn)
 	} else if n != len(data) {
+		p.flushOutPacketBytesMetric()
 		return errors.Trace(mysql.ErrBadConn)
 	}
 	p.sequence++
@@ -297,6 +306,7 @@ func (p *PacketIO) WritePacket(data []byte) error {
 
 // Flush flushes buffered data to network.
 func (p *PacketIO) Flush() error {
+	p.flushOutPacketBytesMetric()
 	var err error
 	if p.compressionAlgorithm != mysql.CompressionNone {
 		err = p.compressedWriter.Flush()
@@ -311,6 +321,14 @@ func (p *PacketIO) Flush() error {
 		p.sequence = p.compressedSequence
 	}
 	return err
+}
+
+func (p *PacketIO) flushOutPacketBytesMetric() {
+	if p.pendingOutPacketBytes == 0 {
+		return
+	}
+	server_metrics.OutPacketBytes.Add(float64(p.pendingOutPacketBytes))
+	p.pendingOutPacketBytes = 0
 }
 
 func newCompressedWriter(w io.Writer, ca int, seq *uint8) *compressedWriter {

--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -65,11 +65,13 @@ type PacketIO struct {
 	// maxAllowedPacket is the maximum size of one packet in ReadPacket.
 	maxAllowedPacket uint64
 	// accumulatedLength count the length of totally received 'payload' in ReadPacket.
-	accumulatedLength     uint64
-	compressionAlgorithm  int
-	zstdLevel             zstd.EncoderLevel
-	sequence              uint8
-	compressedSequence    uint8
+	accumulatedLength    uint64
+	compressionAlgorithm int
+	zstdLevel            zstd.EncoderLevel
+	sequence             uint8
+	compressedSequence   uint8
+	// pendingOutPacketBytes batches uncompressed OutPacketBytes metric updates
+	// until the protocol flush boundary.
 	pendingOutPacketBytes int
 }
 
@@ -125,6 +127,7 @@ func (p *PacketIO) SetCompressionAlgorithm(ca int) {
 	p.compressedWriter.zstdLevel = p.zstdLevel
 	p.compressedReader = newCompressedReader(p.bufReadConn, ca, &p.compressedSequence)
 	p.compressedReader.zstdLevel = p.zstdLevel
+	p.flushOutPacketBytesMetric()
 	p.bufWriter.Flush()
 }
 

--- a/pkg/server/internal/packetio_test.go
+++ b/pkg/server/internal/packetio_test.go
@@ -37,6 +37,25 @@ func BenchmarkPacketIOWrite(b *testing.B) {
 	}
 }
 
+func BenchmarkPacketIOWriteRows(b *testing.B) {
+	const rows = 510
+	packet := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	pkt := &PacketIO{bufWriter: bufio.NewWriterSize(io.Discard, defaultWriterSize)}
+	b.ReportAllocs()
+	b.SetBytes(rows * int64(len(packet)))
+	b.ResetTimer()
+	for b.Loop() {
+		for range rows {
+			if err := pkt.WritePacket(packet); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := pkt.Flush(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestPacketIOWrite(t *testing.T) {
 	// Test write one packet
 	var outBuffer bytes.Buffer

--- a/pkg/server/internal/packetio_test.go
+++ b/pkg/server/internal/packetio_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
+	"fmt"
 	"io"
 	"testing"
 
@@ -25,6 +26,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/server/internal/testutil"
 	"github.com/pingcap/tidb/pkg/server/internal/util"
+	server_metrics "github.com/pingcap/tidb/pkg/server/metrics"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,22 +41,53 @@ func BenchmarkPacketIOWrite(b *testing.B) {
 }
 
 func BenchmarkPacketIOWriteRows(b *testing.B) {
-	const rows = 510
 	packet := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	pkt := &PacketIO{bufWriter: bufio.NewWriterSize(io.Discard, defaultWriterSize)}
-	b.ReportAllocs()
-	b.SetBytes(rows * int64(len(packet)))
-	b.ResetTimer()
-	for b.Loop() {
-		for range rows {
-			if err := pkt.WritePacket(packet); err != nil {
-				b.Fatal(err)
+	for _, packetCount := range []int{1, 8, 510} {
+		b.Run(fmt.Sprintf("packets=%d", packetCount), func(b *testing.B) {
+			pkt := &PacketIO{bufWriter: bufio.NewWriterSize(io.Discard, defaultWriterSize)}
+			b.ReportAllocs()
+			b.SetBytes(int64(packetCount * len(packet)))
+			b.ResetTimer()
+			for b.Loop() {
+				for range packetCount {
+					if err := pkt.WritePacket(packet); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := pkt.Flush(); err != nil {
+					b.Fatal(err)
+				}
 			}
-		}
-		if err := pkt.Flush(); err != nil {
-			b.Fatal(err)
-		}
+		})
 	}
+}
+
+type failingPacketWriter struct{}
+
+func (failingPacketWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestPacketIOOutPacketBytesMetricBatching(t *testing.T) {
+	packet := []byte{0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8}
+	pkt := &PacketIO{bufWriter: bufio.NewWriterSize(io.Discard, defaultWriterSize)}
+
+	before := promtestutil.ToFloat64(server_metrics.OutPacketBytes)
+	require.NoError(t, pkt.WritePacket(packet))
+	require.Equal(t, before, promtestutil.ToFloat64(server_metrics.OutPacketBytes))
+	require.NoError(t, pkt.Flush())
+	require.Equal(t, before+float64(len(packet)), promtestutil.ToFloat64(server_metrics.OutPacketBytes))
+	require.NoError(t, pkt.Flush())
+	require.Equal(t, before+float64(len(packet)), promtestutil.ToFloat64(server_metrics.OutPacketBytes))
+
+	pkt = &PacketIO{bufWriter: bufio.NewWriterSize(failingPacketWriter{}, 1)}
+	before = promtestutil.ToFloat64(server_metrics.OutPacketBytes)
+	require.Error(t, pkt.WritePacket(packet))
+	require.Equal(t, before+float64(len(packet)), promtestutil.ToFloat64(server_metrics.OutPacketBytes))
+
+	pkt = &PacketIO{bufWriter: bufio.NewWriterSize(io.Discard, defaultWriterSize)}
+	before = promtestutil.ToFloat64(server_metrics.OutPacketBytes)
+	require.NoError(t, pkt.WritePacket(packet))
+	pkt.SetCompressionAlgorithm(mysql.CompressionZlib)
+	require.Equal(t, before+float64(len(packet)), promtestutil.ToFloat64(server_metrics.OutPacketBytes))
 }
 
 func TestPacketIOWrite(t *testing.T) {

--- a/pkg/server/internal/packetio_tpcc_bench_test.go
+++ b/pkg/server/internal/packetio_tpcc_bench_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/server/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+var packetIOReadTPCCSink []byte
+
+func BenchmarkPacketIOReadOnePacketTPCC(b *testing.B) {
+	for _, size := range []int{1, 32, 128, 1024} {
+		for _, timeout := range []time.Duration{0, 30 * time.Second} {
+			name := fmt.Sprintf("payload=%d/timeout=%t", size, timeout > 0)
+			b.Run(name, func(b *testing.B) {
+				packet, payload := makeBenchmarkPacket(size)
+				conn := &replayPacketConn{packet: packet}
+				packetIO := NewPacketIO(util.NewBufferedReadConn(conn))
+				packetIO.SetReadTimeout(timeout)
+
+				b.ReportAllocs()
+				b.SetBytes(int64(len(packet)))
+				b.ResetTimer()
+				for b.Loop() {
+					conn.reset()
+					packetIO.sequence = 0
+					packetIO.accumulatedLength = 0
+					data, err := packetIO.readOnePacket()
+					if err != nil {
+						b.Fatal(err)
+					}
+					packetIOReadTPCCSink = data
+				}
+				b.StopTimer()
+
+				require.Equal(b, payload, packetIOReadTPCCSink)
+				if timeout > 0 {
+					require.Equal(b, 2, conn.readDeadlineCalls)
+				} else {
+					require.Zero(b, conn.readDeadlineCalls)
+				}
+				require.Zero(b, conn.closeCalls)
+			})
+		}
+	}
+}
+
+func TestPacketIOReadOnePacketDeadlineAndOwnership(t *testing.T) {
+	for _, timeout := range []time.Duration{0, 30 * time.Second} {
+		packet, payload := makeBenchmarkPacket(128)
+		conn := &replayPacketConn{packet: packet}
+		packetIO := NewPacketIO(util.NewBufferedReadConn(conn))
+		packetIO.SetReadTimeout(timeout)
+
+		data, err := packetIO.readOnePacket()
+		require.NoError(t, err)
+		require.Equal(t, payload, data)
+		if timeout > 0 {
+			require.Equal(t, 2, conn.readDeadlineCalls)
+		} else {
+			require.Zero(t, conn.readDeadlineCalls)
+		}
+		require.Zero(t, conn.closeCalls)
+
+		conn.packet[4] ^= 0xff
+		require.Equal(t, payload, data)
+	}
+}
+
+func makeBenchmarkPacket(payloadSize int) (packet, payload []byte) {
+	packet = make([]byte, payloadSize+4)
+	packet[0] = byte(payloadSize)
+	packet[1] = byte(payloadSize >> 8)
+	packet[2] = byte(payloadSize >> 16)
+	packet[3] = 0
+	for i := range payloadSize {
+		packet[i+4] = byte(i*31 + 7)
+	}
+	payload = append([]byte(nil), packet[4:]...)
+	return packet, payload
+}
+
+type replayPacketConn struct {
+	packet            []byte
+	offset            int
+	readDeadlineCalls int
+	closeCalls        int
+}
+
+func (c *replayPacketConn) reset() {
+	c.offset = 0
+	c.readDeadlineCalls = 0
+}
+
+func (c *replayPacketConn) Read(dst []byte) (int, error) {
+	if c.offset == len(c.packet) {
+		return 0, io.EOF
+	}
+	n := copy(dst, c.packet[c.offset:])
+	c.offset += n
+	return n, nil
+}
+
+func (*replayPacketConn) Write(src []byte) (int, error) {
+	return len(src), nil
+}
+
+func (c *replayPacketConn) Close() error {
+	c.closeCalls++
+	return nil
+}
+
+func (*replayPacketConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (*replayPacketConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (*replayPacketConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *replayPacketConn) SetReadDeadline(time.Time) error {
+	c.readDeadlineCalls++
+	return nil
+}
+
+func (*replayPacketConn) SetWriteDeadline(time.Time) error {
+	return nil
+}

--- a/pkg/sessiontxn/isolation/optimistic.go
+++ b/pkg/sessiontxn/isolation/optimistic.go
@@ -18,6 +18,7 @@ import (
 	"math"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -149,10 +150,12 @@ func (p *OptimisticTxnContextProvider) AdviseOptimizeWithPlan(plan any) (err err
 
 	if ok {
 		sessVars := p.sctx.GetSessionVars()
-		logutil.BgLogger().Debug("init txnStartTS with MaxUint64",
-			zap.Uint64("conn", sessVars.ConnectionID),
-			zap.String("text", sessVars.StmtCtx.OriginalSQL),
-		)
+		if ce := log.L().Check(zap.DebugLevel, "init txnStartTS with MaxUint64"); ce != nil {
+			ce.Write(
+				zap.Uint64("conn", sessVars.ConnectionID),
+				zap.String("text", sessVars.StmtCtx.OriginalSQL),
+			)
+		}
 
 		if err = p.forcePrepareConstStartTS(math.MaxUint64); err != nil {
 			logutil.BgLogger().Error("failed init txnStartTS with MaxUint64",

--- a/pkg/sessiontxn/isolation/optimistic_test.go
+++ b/pkg/sessiontxn/isolation/optimistic_test.go
@@ -15,6 +15,7 @@
 package isolation_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -23,20 +24,93 @@ import (
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner"
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/sessiontxn/isolation"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 	tikverr "github.com/tikv/client-go/v2/error"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+var benchmarkOptimisticTxnContextProvider *isolation.OptimisticTxnContextProvider
+
+func BenchmarkOptimisticTxnContextProviderResetForNewTxn(b *testing.B) {
+	sctx := mock.NewContext()
+	var providers [2]isolation.OptimisticTxnContextProvider
+	for i := range providers {
+		providers[i].ResetForNewTxn(sctx, false)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		providers[i&1].ResetForNewTxn(sctx, i&2 != 0)
+	}
+	benchmarkOptimisticTxnContextProvider = &providers[b.N&1]
+}
+
+func BenchmarkOptimisticTxnContextProviderAdvisePreparedPointGet(b *testing.B) {
+	logLevel := log.GetLevel()
+	log.SetLevel(zap.InfoLevel)
+	b.Cleanup(func() {
+		log.SetLevel(logLevel)
+	})
+
+	sctx := mock.NewContext()
+	var providers [2]isolation.OptimisticTxnContextProvider
+	plan := &plannercore.Execute{Plan: &plannercore.PointGetPlan{}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		provider := &providers[i&1]
+		provider.ResetForNewTxn(sctx, false)
+		if err := provider.AdviseOptimizeWithPlan(plan); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkOptimisticTxnContextProvider = &providers[b.N&1]
+}
+
+func TestOptimisticTxnContextProviderPointGetDebugLog(t *testing.T) {
+	var output bytes.Buffer
+	sink := zapcore.AddSync(&output)
+	logger, props, err := log.InitLoggerWithWriteSyncer(
+		&log.Config{Level: "debug"},
+		sink,
+		sink,
+	)
+	require.NoError(t, err)
+	restore := log.ReplaceGlobals(logger, props)
+	defer restore()
+
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().ConnectionID = 42
+	sctx.GetSessionVars().StmtCtx.OriginalSQL = "SELECT c FROM t WHERE id = ?"
+	var provider isolation.OptimisticTxnContextProvider
+	provider.ResetForNewTxn(sctx, false)
+
+	err = provider.AdviseOptimizeWithPlan(
+		&plannercore.Execute{Plan: &plannercore.PointGetPlan{}},
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.Sync())
+	require.Contains(t, output.String(), "init txnStartTS with MaxUint64")
+	require.Contains(t, output.String(), "conn=42")
+	require.Contains(t, output.String(), "text=\"SELECT c FROM t WHERE id = ?\"")
+}
 
 func TestOptimisticTxnContextProviderTS(t *testing.T) {
 	store := testkit.CreateMockStore(t)

--- a/pkg/sessiontxn/isolation/optimistic_test.go
+++ b/pkg/sessiontxn/isolation/optimistic_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
@@ -70,7 +71,7 @@ func BenchmarkOptimisticTxnContextProviderAdvisePreparedPointGet(b *testing.B) {
 
 	sctx := mock.NewContext()
 	var providers [2]isolation.OptimisticTxnContextProvider
-	plan := &plannercore.Execute{Plan: &plannercore.PointGetPlan{}}
+	plan := &plannercore.Execute{Plan: &physicalop.PointGetPlan{}}
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -103,7 +104,7 @@ func TestOptimisticTxnContextProviderPointGetDebugLog(t *testing.T) {
 	provider.ResetForNewTxn(sctx, false)
 
 	err = provider.AdviseOptimizeWithPlan(
-		&plannercore.Execute{Plan: &plannercore.PointGetPlan{}},
+		&plannercore.Execute{Plan: &physicalop.PointGetPlan{}},
 	)
 	require.NoError(t, err)
 	require.NoError(t, logger.Sync())

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -227,9 +227,11 @@ func (killer *SQLKiller) HandleSignal() error {
 		}
 		lastCheckTime := killer.lastCheckTime.Load()
 		if lastCheckTime == nil {
-			killer.lastCheckTime.Store(&now)
+			checkedAt := now
+			killer.lastCheckTime.Store(&checkedAt)
 		} else if now.Sub(*lastCheckTime) > checkConnectionAliveDur {
-			killer.lastCheckTime.Store(&now)
+			checkedAt := now
+			killer.lastCheckTime.Store(&checkedAt)
 			if !(*fn)() {
 				killer.sendKillSignal(QueryInterrupted)
 			}

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -15,7 +15,9 @@
 package sqlkiller
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -23,6 +25,81 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestHandleSignalConnectionAlive(t *testing.T) {
+	var killer SQLKiller
+	alive := func() bool { return true }
+	killer.IsConnectionAlive.Store(&alive)
+
+	require.NoError(t, killer.HandleSignal())
+	require.NotNil(t, killer.lastCheckTime.Load())
+
+	expired := time.Now().Add(-2 * time.Second)
+	killer.lastCheckTime.Store(&expired)
+	require.NoError(t, killer.HandleSignal())
+
+	dead := func() bool { return false }
+	killer.IsConnectionAlive.Store(&dead)
+	killer.lastCheckTime.Store(&expired)
+	require.Error(t, killer.HandleSignal())
+	require.Equal(t, QueryInterrupted, killer.GetKillSignal())
+
+	killer.Reset()
+	require.Equal(t, UnspecifiedKillSignal, killer.GetKillSignal())
+	require.Nil(t, killer.lastCheckTime.Load())
+}
+
+func BenchmarkSQLKillerHandleSignal(b *testing.B) {
+	b.Run("live-connection/recent-check", func(b *testing.B) {
+		var killer SQLKiller
+		alive := func() bool { return true }
+		killer.IsConnectionAlive.Store(&alive)
+		checkedAt := time.Now()
+		killer.lastCheckTime.Store(&checkedAt)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if err := killer.HandleSignal(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("no-connection-checker", func(b *testing.B) {
+		var killer SQLKiller
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if err := killer.HandleSignal(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("live-connection/elapsed-check", func(b *testing.B) {
+		var checks atomic.Int64
+		var killer SQLKiller
+		alive := func() bool {
+			checks.Add(1)
+			return true
+		}
+		killer.IsConnectionAlive.Store(&alive)
+		expired := time.Now().Add(-2 * time.Second)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			killer.lastCheckTime.Store(&expired)
+			if err := killer.HandleSignal(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		require.Equal(b, int64(b.N), checks.Load())
+	})
+}
 
 func TestSQLKillerConcurrentReset(t *testing.T) {
 	assertStateLockHeld := func(t *testing.T, killer *SQLKiller) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70649

Problem Summary:

SQL protocol and statement-infrastructure paths repeat small metrics, logging, encoding lookup, packet, and result-transform costs for every statement, packet, row, or column.

### What changed and how does it work?

- Cache common-label metric observers while retaining the existing path when labels change.
- Batch output-packet metric updates at every flush boundary, including
  connection compression setup and write errors, and remove a per-packet
  no-op closer.
- Avoid disabled-debug logger cloning and move SQL-killer timestamp formatting into uncommon signal-refresh branches.
- Fast-path canonical UTF-8 lookup and canonical no-op result transforms while preserving all fallback behavior.
- Keep result-encoder scratch storage local and cache collation with explicit invalidation on different or invalid input.
- Add caller-representative protocol, metric, encoding, transaction, and SQL-killer tests and benchmarks.

The campaign microbenchmarks show 16.8% to 86.7% lower CPU in the affected helpers and remove the targeted allocation completely where applicable. The second-pass packet benchmark is about 10% faster for one packet per flush, 46% faster for eight, and 51% faster for 510, with zero allocations in every case. Tests verify exact metric accounting before/after flush, repeated flush, write failure, and the handshake compression transition. Result-encoding benchmarks cover the binary no-op and GBK transforming fallbacks plus repeated, changing, and invalid collation transitions.

The earlier connection-alive-checker commit was removed during the second pass:
current upstream already moved that lifecycle out of executePlanCacheStmt, and
the rebased patch had incorrectly resurrected obsolete work. This PR does not
duplicate JSON, row, or wire-protocol serialization; all non-canonical encoding
paths continue to use the existing implementation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

```sh
go test ./pkg/format/textrow ./pkg/parser/charset ./pkg/server ./pkg/server/internal ./pkg/sessiontxn/isolation ./pkg/util/sqlkiller
go test ./pkg/format/textrow ./pkg/server ./pkg/server/internal -run '^$' -bench 'Benchmark(EncodeWithWideRows|UpdateDataEncodingWideRows|ClientConnAddMetrics|PacketIOWriteRows|PacketIOReadOnePacketTPCC)' -benchmem -benchtime=100ms -count=3
go build ./cmd/tidb-server
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Improve SQL protocol and statement-processing performance by reducing per-statement and per-row overhead
```
