### PR TITLE
unistore, planner: report scanned bytes for UniStore RU explain

### DIFF
--- a/pkg/planner/core/explain_ru_test.go
+++ b/pkg/planner/core/explain_ru_test.go
@@ -70,7 +70,6 @@ func TestExplainAnalyzeRUFormatIncreasesWithScannedBytes(t *testing.T) {
 
 	tk.MustExec("drop table if exists t_unistore_ru_scan_bytes")
 	tk.MustExec("create table t_unistore_ru_scan_bytes(a int primary key, b varchar(4096))")
-	tk.MustExec("insert into t_unistore_ru_scan_bytes values (1, repeat('a', 4096)), (2, repeat('b', 4096))")
 	getReaderCumRU := func() float64 {
 		rows := tk.MustQuery("explain analyze format = 'ru' select * from t_unistore_ru_scan_bytes").Rows()
 		require.NotEmpty(t, rows)
@@ -78,7 +77,13 @@ func TestExplainAnalyzeRUFormatIncreasesWithScannedBytes(t *testing.T) {
 		require.NoError(t, err)
 		return ru
 	}
-	beforeInsertRU := getReaderCumRU()
-	tk.MustExec("insert into t_unistore_ru_scan_bytes values (3, repeat('c', 4096)), (4, repeat('d', 4096))")
-	require.Greater(t, getReaderCumRU(), beforeInsertRU)
+
+	previousRU := getReaderCumRU()
+	for i := 0; i < 20; i++ {
+		firstID := i*2 + 1
+		tk.MustExec("insert into t_unistore_ru_scan_bytes values (" + strconv.Itoa(firstID) + ", repeat('a', 4096)), (" + strconv.Itoa(firstID+1) + ", repeat('b', 4096))")
+		currentRU := getReaderCumRU()
+		require.Greater(t, currentRU, previousRU)
+		previousRU = currentRU
+	}
 }

--- a/pkg/planner/core/explain_ru_test.go
+++ b/pkg/planner/core/explain_ru_test.go
@@ -15,6 +15,7 @@
 package core_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/planner/core"
@@ -60,4 +61,24 @@ func TestExplainAnalyzeRUFormat(t *testing.T) {
 		require.Equal(t, tt.SQL, output[i].SQL)
 		require.Equal(t, output[i].Rows, toStringRows(tk.MustQuery(tt.SQL).Rows()))
 	}
+}
+
+func TestExplainAnalyzeRUFormatIncreasesWithScannedBytes(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t_unistore_ru_scan_bytes")
+	tk.MustExec("create table t_unistore_ru_scan_bytes(a int primary key, b varchar(4096))")
+	tk.MustExec("insert into t_unistore_ru_scan_bytes values (1, repeat('a', 4096)), (2, repeat('b', 4096))")
+	getReaderCumRU := func() float64 {
+		rows := tk.MustQuery("explain analyze format = 'ru' select * from t_unistore_ru_scan_bytes").Rows()
+		require.NotEmpty(t, rows)
+		ru, err := strconv.ParseFloat(rows[0][4].(string), 64)
+		require.NoError(t, err)
+		return ru
+	}
+	beforeInsertRU := getReaderCumRU()
+	tk.MustExec("insert into t_unistore_ru_scan_bytes values (3, repeat('c', 4096)), (4, repeat('d', 4096))")
+	require.Greater(t, getReaderCumRU(), beforeInsertRU)
 }

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -602,9 +602,9 @@ func genRespWithMPPExec(chunks []tipb.Chunk, intermediateOutput []*tipb.Intermed
 		Ndvs:                ndvs,
 		EncodeType:          dagReq.EncodeType,
 	}
-	executors := dagReq.Executors
-	mppExecs := flattenMppExec(exec, make([]mppExec, 0, len(executors)))
 	if dagReq.GetCollectExecutionSummaries() {
+		executors := dagReq.Executors
+		mppExecs := flattenMppExec(exec, make([]mppExec, 0, len(executors)))
 		// for simplicity, we assume all executors to be spending the same amount of time as the request
 		timeProcessed := uint64(dur / time.Nanosecond)
 		execSummary := make([]*tipb.ExecutorExecutionSummary, len(executors))
@@ -632,18 +632,9 @@ func genRespWithMPPExec(chunks []tipb.Chunk, intermediateOutput []*tipb.Intermed
 	resp.ExecDetails = &kvrpcpb.ExecDetails{
 		TimeDetail: &kvrpcpb.TimeDetail{ProcessWallTimeMs: uint64(dur / time.Millisecond)},
 	}
-	var processedVersions uint64
-	for _, e := range mppExecs {
-		switch s := e.(type) {
-		case *tableScanExec:
-			processedVersions += uint64(s.rowCnt)
-		case *indexScanExec:
-			processedVersions += uint64(s.rowCnt)
-		}
-	}
 	resp.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{
 		TimeDetail:   resp.ExecDetails.TimeDetail,
-		ScanDetailV2: &kvrpcpb.ScanDetailV2{ProcessedVersions: processedVersions},
+		ScanDetailV2: exec.scanDetail(),
 	}
 	data, mErr := proto.Marshal(selResp)
 	if mErr != nil {

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler_test.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler_test.go
@@ -636,6 +636,7 @@ func (*mockExchSenderChildExec) getIntermediateFieldTypes() []*types.FieldType {
 func (*mockExchSenderChildExec) takeIntermediateResults() []*chunk.Chunk       { return nil }
 func (*mockExchSenderChildExec) getFieldTypes() []*types.FieldType             { return nil }
 func (*mockExchSenderChildExec) buildSummary() *tipb.ExecutorExecutionSummary  { return nil }
+func (*mockExchSenderChildExec) scanDetail() *kvrpcpb.ScanDetailV2             { return &kvrpcpb.ScanDetailV2{} }
 
 func TestExchSenderExecNextReturnsWhenCtxCanceledBeforeTunnelConnected(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -70,6 +70,7 @@ type mppExec interface {
 	takeIntermediateResults() []*chunk.Chunk
 	getFieldTypes() []*types.FieldType
 	buildSummary() *tipb.ExecutorExecutionSummary
+	scanDetail() *kvrpcpb.ScanDetailV2
 }
 
 type baseMPPExec struct {
@@ -93,6 +94,49 @@ func (b *baseMPPExec) getFieldTypes() []*types.FieldType {
 
 func (b *baseMPPExec) buildSummary() *tipb.ExecutorExecutionSummary {
 	return b.execSummary.buildSummary()
+}
+
+func (b *baseMPPExec) scanDetail() *kvrpcpb.ScanDetailV2 {
+	detail := &kvrpcpb.ScanDetailV2{}
+	for _, child := range b.children {
+		mergeScanDetailV2(detail, child.scanDetail())
+	}
+	return detail
+}
+
+func mergeScanDetailV2(dst, src *kvrpcpb.ScanDetailV2) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.ProcessedVersions += src.ProcessedVersions
+	dst.ProcessedVersionsSize += src.ProcessedVersionsSize
+	dst.TotalVersions += src.TotalVersions
+	dst.RocksdbDeleteSkippedCount += src.RocksdbDeleteSkippedCount
+	dst.RocksdbKeySkippedCount += src.RocksdbKeySkippedCount
+	dst.RocksdbBlockCacheHitCount += src.RocksdbBlockCacheHitCount
+	dst.RocksdbBlockReadCount += src.RocksdbBlockReadCount
+	dst.RocksdbBlockReadByte += src.RocksdbBlockReadByte
+	dst.RocksdbBlockReadNanos += src.RocksdbBlockReadNanos
+	dst.GetSnapshotNanos += src.GetSnapshotNanos
+	dst.ReadIndexProposeWaitNanos += src.ReadIndexProposeWaitNanos
+	dst.ReadIndexConfirmWaitNanos += src.ReadIndexConfirmWaitNanos
+	dst.ReadPoolScheduleWaitNanos += src.ReadPoolScheduleWaitNanos
+	dst.TotalVersionsSize += src.TotalVersionsSize
+	dst.IaCacheHitCount += src.IaCacheHitCount
+	dst.IaRemoteReadSegmentCount += src.IaRemoteReadSegmentCount
+	dst.IaRemoteReadSegmentBytes += src.IaRemoteReadSegmentBytes
+	dst.IaRemoteReadSegmentNanos += src.IaRemoteReadSegmentNanos
+}
+
+func recordScannedKV(detail *kvrpcpb.ScanDetailV2, key, value []byte) {
+	if detail == nil {
+		return
+	}
+	detail.ProcessedVersions++
+	detail.TotalVersions++
+	kvSize := uint64(len(key) + len(value))
+	detail.ProcessedVersionsSize += kvSize
+	detail.TotalVersionsSize += kvSize
 }
 
 func (b *baseMPPExec) open() error {
@@ -138,6 +182,7 @@ type tableScanExec struct {
 	counts        []int64
 	ndvs          []int64
 	rowCnt        int64
+	scanStats     kvrpcpb.ScanDetailV2
 
 	chk      *chunk.Chunk
 	result   chan scanResult
@@ -170,6 +215,7 @@ func (e *tableScanExec) Process(key, value []byte, commitTS uint64) error {
 		tblID := tablecodec.DecodeTableID(key)
 		e.chk.AppendInt64(*e.physTblIDColIdx, tblID)
 	}
+	recordScannedKV(&e.scanStats, key, value)
 	e.rowCnt++
 
 	if e.chk.IsFull() {
@@ -187,6 +233,10 @@ func (e *tableScanExec) Process(key, value []byte, commitTS uint64) error {
 	default:
 	}
 	return nil
+}
+
+func (e *tableScanExec) scanDetail() *kvrpcpb.ScanDetailV2 {
+	return &e.scanStats
 }
 
 func (e *tableScanExec) open() error {
@@ -290,6 +340,7 @@ type indexScanExec struct {
 	prevVals      [][]byte
 	rowCnt        int64
 	ndvCnt        int64
+	scanStats     kvrpcpb.ScanDetailV2
 	chk           *chunk.Chunk
 	chkIdx        int
 	chunks        []*chunk.Chunk
@@ -372,6 +423,7 @@ func (e *indexScanExec) Process(key, value []byte, _ uint64) error {
 		e.chk.AppendBytes(*e.commonHandleKeyIdx, commonHandle.Encoded())
 	}
 
+	recordScannedKV(&e.scanStats, key, value)
 	if e.chk.IsFull() {
 		e.chunks = append(e.chunks, e.chk)
 		if e.paging != nil {
@@ -381,6 +433,10 @@ func (e *indexScanExec) Process(key, value []byte, _ uint64) error {
 		e.chk = chunk.NewChunkWithCapacity(e.fieldTypes, DefaultBatchSize)
 	}
 	return nil
+}
+
+func (e *indexScanExec) scanDetail() *kvrpcpb.ScanDetailV2 {
+	return &e.scanStats
 }
 
 func (e *indexScanExec) open() error {
@@ -455,6 +511,7 @@ type indexLookUpExec struct {
 	extraReaderProvider dbreader.ExtraDbReaderProvider
 	buildTableScan      func(*dbreader.DBReader, []kv.KeyRange) (*tableScanExec, error)
 	indexChunks         []*chunk.Chunk
+	tableScanStats      kvrpcpb.ScanDetailV2
 }
 
 func (e *indexLookUpExec) open() error {
@@ -488,6 +545,7 @@ func (e *indexLookUpExec) next() (ret *chunk.Chunk, _ error) {
 				if err != nil {
 					panic(err)
 				}
+				mergeScanDetailV2(&e.tableScanStats, tblScan.scanDetail())
 			}()
 
 			readCnt := 0
@@ -524,6 +582,12 @@ func (e *indexLookUpExec) next() (ret *chunk.Chunk, _ error) {
 	}
 
 	return ret, nil
+}
+
+func (e *indexLookUpExec) scanDetail() *kvrpcpb.ScanDetailV2 {
+	detail := e.baseMPPExec.scanDetail()
+	mergeScanDetailV2(detail, &e.tableScanStats)
+	return detail
 }
 
 func (e *indexLookUpExec) fetchTableScans() (tableScans []*tableScanExec, counts []int, indexChk *chunk.Chunk, err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70373

Problem Summary: lanner: report scanned bytes for UniStore RU explain

### What changed and how does it work?

Track scanned KV size in UniStore table scan and index scan executors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `EXPLAIN ANALYZE` resource-usage reporting so RU consumption better reflects scanned rows and data volume.
  - Enhanced distributed-query execution summaries with more complete table and index scan metrics, including processed data, versions, and storage details.
  - Improved aggregation of scan statistics across nested operations and index lookups for more consistent performance insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->