### PR TITLE
statistics: fix flaky TestConcurrentLoadHistTimeout

### DIFF
--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -78,6 +78,16 @@ func TestConcurrentLoadHist(t *testing.T) {
 func TestConcurrentLoadHistTimeout(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
+	// Disable the stats sync-load worker so that the concurrent load requests triggered by
+	// `analyze table t` (and the lease-based reload) cannot fully load the columns asynchronously.
+	// Otherwise, once a column becomes IsFullLoad, removeHistLoadedColumns filters it out and
+	// SendLoadRequests returns nil, making `require.Error(rs)` flaky (see pingcap/tidb#68364).
+	originConfig := config.GetGlobalConfig()
+	newConfig := config.NewConfig()
+	newConfig.Performance.StatsLoadConcurrency = -1 // no worker to consume channel
+	config.StoreGlobalConfig(newConfig)
+	defer config.StoreGlobalConfig(originConfig)
+
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #68364

`TestConcurrentLoadHistTimeout` in `pkg/statistics/handle/syncload` was flaky.

Root cause: `SubLoadWorker` goroutines run asynchronously in the background. They could promote columns to `IsFullLoad` **before** `removeHistLoadedColumns` executed, causing `SendLoadRequests` to return `nil`. The subsequent `require.Error(rs)` then became non-deterministic — sometimes the worker hadn't finished yet (pass), sometimes it had (fail).

### What changed and how does it work?

Set `StatsLoadConcurrency = -1` at the start of the test to disable the async background worker, making the test fully synchronous and deterministic.

### Check List

Tests
- [x] Unit test

### Release note

```release-note
None
```

### Notes

Two sibling tests (`TestConcurrentLoadHistWithPanicAndFail`, `TestRetry`) fail at baseline due to missing `make failpoint-enable`; this is unrelated to this change.
