### PR TITLE
dumpling: keep invisible columns in the dump field list

### DIFF
--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -540,7 +540,7 @@ func buildColumnProjection(
 		return columnProjection{}, nil
 	}
 
-	sourceColumns, hasGeneratedColumn, err := getWritableColumnNames(tctx, conn, dbName, table.Name)
+	sourceColumns, hasGeneratedColumn, hasInvisibleColumn, err := getWritableColumnNames(tctx, conn, dbName, table.Name)
 	if err != nil {
 		return columnProjection{}, err
 	}
@@ -558,7 +558,10 @@ func buildColumnProjection(
 	projection := columnProjection{
 		selectField: strings.Join(selectedFields, ","),
 	}
-	if !hasGeneratedColumn && len(sourceColumns) == len(selectedColumns) && !conf.CompleteInsert {
+	// "*" skips invisible columns, so it only stands in for the full field list
+	// when the table has none.
+	if !hasGeneratedColumn && !hasInvisibleColumn &&
+		len(sourceColumns) == len(selectedColumns) && !conf.CompleteInsert {
 		projection.selectField = "*"
 	}
 

--- a/dumpling/export/dump_test.go
+++ b/dumpling/export/dump_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -916,6 +917,60 @@ func TestColumnProjectionGeneratedColumn(t *testing.T) {
 	require.Equal(t, []string{"INT"}, columnTypes(projection.sourceTypes))
 	require.Equal(t, []string{"id"}, columnNames(projection.selectedTypes))
 	require.Equal(t, []string{"INT"}, columnTypes(projection.selectedTypes))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestColumnProjectionInvisibleColumn(t *testing.T) {
+	tctx, mock, baseConn := newMockDumpConn(t)
+	conf := DefaultConfig()
+	conf.Tables = NewDatabaseTables().AppendTables(database, []string{table}, []uint64{0})
+
+	// MySQL 8.0.23+ reports the generated invisible primary key as
+	// "auto_increment INVISIBLE" and a declared invisible column as "INVISIBLE".
+	mock.ExpectQuery("SHOW COLUMNS FROM").
+		WillReturnRows(sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).
+			AddRow("my_row_id", "bigint(20) unsigned", "NO", "PRI", nil, "auto_increment INVISIBLE").
+			AddRow("name", "varchar(12)", "YES", "", nil, "").
+			AddRow("hidden", "int(11)", "YES", "", nil, "INVISIBLE"))
+	mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf("SELECT `my_row_id`,`name`,`hidden` FROM `%s`.`%s` LIMIT 1", database, table))).
+		WillReturnRows(sqlmock.NewRowsWithColumnDefinition(
+			sqlmock.NewColumn("my_row_id").OfType("BIGINT", uint64(0)),
+			sqlmock.NewColumn("name").OfType("VARCHAR", ""),
+			sqlmock.NewColumn("hidden").OfType("INT", int64(0)),
+		).AddRow(1, "alice", 7))
+
+	require.NoError(t, prepareColumnProjection(tctx, conf, baseConn))
+	projection, ok := conf.columnProjection[tableName{db: database, table: table}]
+	require.True(t, ok)
+	// "*" would return only `name`, so the field list must stay explicit.
+	require.Equal(t, "`my_row_id`,`name`,`hidden`", projection.selectField)
+	require.Equal(t, []string{"my_row_id", "name", "hidden"}, columnNames(projection.sourceTypes))
+	require.Equal(t, []string{"my_row_id", "name", "hidden"}, columnNames(projection.selectedTypes))
+	require.Len(t, projection.selectedTypes, len(strings.Split(projection.selectField, ",")))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestColumnProjectionInvisibleGeneratedColumn(t *testing.T) {
+	tctx, mock, baseConn := newMockDumpConn(t)
+	conf := DefaultConfig()
+	conf.Tables = NewDatabaseTables().AppendTables(database, []string{table}, []uint64{0})
+
+	// A generated column that is also invisible reports "VIRTUAL GENERATED INVISIBLE".
+	mock.ExpectQuery("SHOW COLUMNS FROM").
+		WillReturnRows(sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).
+			AddRow("id", "int(11)", "NO", "PRI", nil, "").
+			AddRow("generated", "int(11)", "YES", "", nil, "VIRTUAL GENERATED INVISIBLE"))
+	mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf("SELECT `id` FROM `%s`.`%s` LIMIT 1", database, table))).
+		WillReturnRows(sqlmock.NewRowsWithColumnDefinition(
+			sqlmock.NewColumn("id").OfType("INT", int64(0)),
+		).AddRow(1))
+
+	require.NoError(t, prepareColumnProjection(tctx, conf, baseConn))
+	projection, ok := conf.columnProjection[tableName{db: database, table: table}]
+	require.True(t, ok)
+	require.Equal(t, "`id`", projection.selectField)
+	require.Equal(t, []string{"id"}, columnNames(projection.sourceTypes))
+	require.Equal(t, []string{"id"}, columnNames(projection.selectedTypes))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/dumpling/export/sql.go
+++ b/dumpling/export/sql.go
@@ -1072,24 +1072,52 @@ type tableName struct {
 	table string
 }
 
-func getWritableColumnNames(tctx *tcontext.Context, db *BaseConn, dbName, tableName string) ([]string, bool, error) {
+// parseColumnExtra reports what the EXTRA field of SHOW COLUMNS says about one
+// column. MySQL joins the markers with spaces, so EXTRA holds values such as
+// "VIRTUAL GENERATED INVISIBLE" or "auto_increment INVISIBLE" and must be read
+// token by token. Only "VIRTUAL GENERATED" and "STORED GENERATED" mark a
+// generated column; the unrelated single token "DEFAULT_GENERATED" does not.
+func parseColumnExtra(extra string) (generated, invisible bool) {
+	tokens := strings.Fields(extra)
+	for i, token := range tokens {
+		switch token {
+		case "GENERATED":
+			if i > 0 && (tokens[i-1] == "VIRTUAL" || tokens[i-1] == "STORED") {
+				generated = true
+			}
+		case "INVISIBLE":
+			invisible = true
+		}
+	}
+	return generated, invisible
+}
+
+func getWritableColumnNames(
+	tctx *tcontext.Context,
+	db *BaseConn,
+	dbName, tableName string,
+) (sourceColumns []string, hasGeneratedColumn, hasInvisibleColumn bool, err error) {
 	query := fmt.Sprintf("SHOW COLUMNS FROM `%s`.`%s`", escapeString(dbName), escapeString(tableName))
 	results, err := db.QuerySQLWithColumns(tctx, []string{"FIELD", "EXTRA"}, query)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
-	sourceColumns := make([]string, 0)
-	hasGeneratedColumn := false
+	sourceColumns = make([]string, 0)
 	for _, oneRow := range results {
 		fieldName, extra := oneRow[0], oneRow[1]
-		switch extra {
-		case "STORED GENERATED", "VIRTUAL GENERATED":
+		generated, invisible := parseColumnExtra(extra)
+		if generated {
 			hasGeneratedColumn = true
 			continue
 		}
+		// An invisible column is writable, so it stays in the dump. SELECT *
+		// never returns it, so the caller must not shorten the field list to "*".
+		if invisible {
+			hasInvisibleColumn = true
+		}
 		sourceColumns = append(sourceColumns, fieldName)
 	}
-	return sourceColumns, hasGeneratedColumn, nil
+	return sourceColumns, hasGeneratedColumn, hasInvisibleColumn, nil
 }
 
 func buildWhereClauses(handleColNames []string, handleVals [][]string) []string {

--- a/dumpling/export/sql_test.go
+++ b/dumpling/export/sql_test.go
@@ -1871,3 +1871,29 @@ func TestGetSpecifiedColumnValuesAndClose(t *testing.T) {
 	err = mock.ExpectationsWereMet()
 	require.NoError(t, err)
 }
+
+func TestParseColumnExtra(t *testing.T) {
+	// The EXTRA values below are what MySQL 8.4 reports for SHOW COLUMNS.
+	testCases := []struct {
+		extra     string
+		generated bool
+		invisible bool
+	}{
+		{"", false, false},
+		{"auto_increment", false, false},
+		{"VIRTUAL GENERATED", true, false},
+		{"STORED GENERATED", true, false},
+		{"INVISIBLE", false, true},
+		{"auto_increment INVISIBLE", false, true},
+		{"VIRTUAL GENERATED INVISIBLE", true, true},
+		{"STORED GENERATED INVISIBLE", true, true},
+		// A column with a default expression is not a generated column.
+		{"DEFAULT_GENERATED", false, false},
+		{"DEFAULT_GENERATED on update CURRENT_TIMESTAMP", false, false},
+	}
+	for _, testCase := range testCases {
+		generated, invisible := parseColumnExtra(testCase.extra)
+		require.Equal(t, testCase.generated, generated, "extra: %q", testCase.extra)
+		require.Equal(t, testCase.invisible, invisible, "extra: %q", testCase.extra)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #60515

Problem Summary:

`SHOW COLUMNS` joins the EXTRA markers with spaces. MySQL 8.0.23 and later report
`INVISIBLE` for a declared invisible column, `auto_increment INVISIBLE` for a generated
invisible primary key, and `VIRTUAL GENERATED INVISIBLE` for a generated column that is
also invisible.

`getWritableColumnNames` compared EXTRA as a whole string. Thus it missed all three forms.
It kept the invisible column in the source column list. It also did not treat an invisible
generated column as generated.

Then `buildColumnProjection` shortened the field list to `*`. But `SELECT *` never returns
an invisible column. The receiver held more columns than the result set. The dump stopped
with this error and wrote no rows:

```
sql: expected 1 destination arguments in Scan, not 2
```

### What changed and how does it work?

This change reads EXTRA token by token instead of as a whole string. Invisible columns stay
in the dump. The field list stays explicit when a table has an invisible column, so the
INSERT statement names the columns. This output agrees with `mysqldump`.

The single token `DEFAULT_GENERATED` stays a normal column.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

`dumpling/export/sql_test.go` covers the three EXTRA forms and the `DEFAULT_GENERATED`
case. `dumpling/export/dump_test.go` covers the field list that the dump builds for a
table with an invisible column.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a failure of dumpling on a table that has an invisible column. The dump stopped with
the error "sql: expected 1 destination arguments in Scan" and wrote no rows.
```
