### PR TITLE
ttl: fix flaky TestTTLStatusCache

### DIFF
--- a/pkg/ttl/cache/ttlstatus_test.go
+++ b/pkg/ttl/cache/ttlstatus_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/cache"
 	"github.com/pingcap/tidb/pkg/ttl/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTTLStatusCache(t *testing.T) {
@@ -32,6 +33,21 @@ func TestTTLStatusCache(t *testing.T) {
 	sv := server.CreateMockServer(t, store)
 	sv.SetDomain(dom)
 	defer sv.Close()
+
+	// Stop the TTL job manager so its background GC cannot delete the rows inserted
+	// below: JobManager.DoGC runs `DELETE FROM mysql.tidb_ttl_table_status WHERE
+	// current_job_status IS NULL AND table_id NOT IN (real table ids)` when the manager
+	// acquires leadership (and every 10 minutes). The rows inserted by this test have
+	// fake table IDs and NULL current_job_status, so if the GC fires mid-test the
+	// accumulated len(isc.Tables) assertions become flaky. Same rationale and pattern
+	// as waitAndStopTTLManager in pkg/ttl/ttlworker/job_manager_integration_test.go.
+	for i := 0; i < 300 && dom.TTLJobManager() == nil; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if jm := dom.TTLJobManager(); jm != nil {
+		jm.Stop()
+		require.NoError(t, jm.WaitStopped(context.Background(), 10*time.Second))
+	}
 
 	conn := server.CreateMockConn(t, sv)
 	sctx := conn.Context().Session


### PR DESCRIPTION
Issue Number: close #69615

### Problem

`TestTTLStatusCache` in `pkg/ttl/cache` is flaky: the assertion at `ttlstatus_test.go:177` (`assert.Equal(t, index+1, len(isc.Tables))`) intermittently fails with "Not equal" (see e.g. the `merged_unit_test_ddlv1/592` build log, where subtests fail in cascade starting from index 3).

Root cause: the TTL job manager runs in the background of the mock domain. Its `DoGC` (`pkg/ttl/ttlworker/job_manager.go`) executes

```sql
DELETE FROM mysql.tidb_ttl_table_status
WHERE current_job_status IS NULL AND table_id NOT IN (real table ids)
```

when the manager acquires leadership, and every 10 minutes. `TestTTLStatusCache` inserts rows with fake table IDs (0-14) and NULL `current_job_status`, so whenever the GC fires mid-test the accumulated rows are deleted and the `len(isc.Tables)` assertion breaks. This matches the CI evidence: nearly every subtest has been reported flaky over time (#69611-#69621), always at the same shared assertion.

### What's Changed

Stop the TTL job manager at the start of the test, so its background GC cannot delete the rows the test relies on. This is the same pattern already used by `waitAndStopTTLManager` in `pkg/ttl/ttlworker/job_manager_integration_test.go` ("stop TTLJobManager to avoid background GC racing with local assertions").

### How Has This Been Tested?

- Mechanism verified: simulating the GC delete mid-test reproduces the exact failure (`len(isc.Tables)` "Not equal"), confirming the root cause.
- `go test -tags intest ./pkg/ttl/cache -run TestTTLStatusCache -count=50` -> 50/50 PASS
- `go test -tags intest ./pkg/ttl/cache -run TestTTLStatusCache -race -count=20` -> PASS, no data race
- `go test -tags intest ./pkg/ttl/cache` -> all tests pass (no regression)

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TTL status cache test reliability by coordinating background cleanup before validating results.
  * Prevented intermittent test failures caused by test data being removed during assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->