### PR TITLE
Diagnostic Mode Test

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -871,6 +871,7 @@ func (d *ddl) Start(startMode StartMode, ctxPool *pools.ResourcePool) error {
 		d.detectAndUpdateJobVersion()
 	}
 	campaignOwner := config.GetGlobalConfig().Instance.TiDBEnableDDL.Load()
+	campaignOwner = false
 	if startMode == Upgrade {
 		if !campaignOwner {
 			return errors.New("DDL must be enabled when upgrading")

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -870,8 +870,7 @@ func (d *ddl) Start(startMode StartMode, ctxPool *pools.ResourcePool) error {
 	if kerneltype.IsClassic() {
 		d.detectAndUpdateJobVersion()
 	}
-	campaignOwner := config.GetGlobalConfig().Instance.TiDBEnableDDL.Load()
-	campaignOwner = false
+	campaignOwner := false // test diagnostic mode: don't run DDL owner
 	if startMode == Upgrade {
 		if !campaignOwner {
 			return errors.New("DDL must be enabled when upgrading")

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1165,10 +1165,10 @@ func (do *Domain) InitDistTaskLoop() error {
 		serverID = disttaskutil.GenerateSubtaskExecID(ctx, do.ddl.GetID())
 	}
 
-	if serverID == "" {
-		errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())
-		return errors.New(errMsg)
-	}
+	// if serverID == "" {
+	// 	errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())
+	// 	return errors.New(errMsg)
+	// }
 	managerCtx, cancel := context.WithCancel(ctx)
 	do.cancelFns.mu.Lock()
 	do.cancelFns.fns = append(do.cancelFns.fns, cancel)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1165,10 +1165,9 @@ func (do *Domain) InitDistTaskLoop() error {
 		serverID = disttaskutil.GenerateSubtaskExecID(ctx, do.ddl.GetID())
 	}
 
-	// if serverID == "" {
-	// 	errMsg := fmt.Sprintf("TiDB node ID( = %s ) not found in available TiDB nodes list", do.ddl.GetID())
-	// 	return errors.New(errMsg)
-	// }
+	if serverID == "" {
+		// test diagnostic mode: can't find itself since it doesn't register to PD/etcd
+	}
 	managerCtx, cancel := context.WithCancel(ctx)
 	do.cancelFns.mu.Lock()
 	do.cancelFns.fns = append(do.cancelFns.fns, cancel)

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -174,17 +174,18 @@ func (s *Syncer) cleanupFailedRegistration(session *concurrency.Session) {
 
 // StoreServerInfo stores self server static information to etcd.
 func (s *Syncer) StoreServerInfo(ctx context.Context) error {
-	if s.etcdCli == nil {
-		return nil
-	}
-	info := s.info.Load()
-	infoBuf, err := info.Marshal()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	str := string(hack.String(infoBuf))
-	err = util.PutKVToEtcd(ctx, s.etcdCli, KeyOpDefaultRetryCnt, s.serverInfoPath, str, clientv3.WithLease(s.session.Lease()))
-	return err
+	return nil
+	// if s.etcdCli == nil {
+	// 	return nil
+	// }
+	// info := s.info.Load()
+	// infoBuf, err := info.Marshal()
+	// if err != nil {
+	// 	return errors.Trace(err)
+	// }
+	// str := string(hack.String(infoBuf))
+	// err = util.PutKVToEtcd(ctx, s.etcdCli, KeyOpDefaultRetryCnt, s.serverInfoPath, str, clientv3.WithLease(s.session.Lease()))
+	// return err
 }
 
 // GetLocalServerInfo returns self server information.

--- a/pkg/domain/serverinfo/syncer.go
+++ b/pkg/domain/serverinfo/syncer.go
@@ -174,18 +174,18 @@ func (s *Syncer) cleanupFailedRegistration(session *concurrency.Session) {
 
 // StoreServerInfo stores self server static information to etcd.
 func (s *Syncer) StoreServerInfo(ctx context.Context) error {
-	return nil
-	// if s.etcdCli == nil {
-	// 	return nil
-	// }
-	// info := s.info.Load()
-	// infoBuf, err := info.Marshal()
-	// if err != nil {
-	// 	return errors.Trace(err)
-	// }
-	// str := string(hack.String(infoBuf))
-	// err = util.PutKVToEtcd(ctx, s.etcdCli, KeyOpDefaultRetryCnt, s.serverInfoPath, str, clientv3.WithLease(s.session.Lease()))
-	// return err
+	return nil // test diagnostic mode: don't register itself to PD/etcd
+	if s.etcdCli == nil {
+		return nil
+	}
+	info := s.info.Load()
+	infoBuf, err := info.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	str := string(hack.String(infoBuf))
+	err = util.PutKVToEtcd(ctx, s.etcdCli, KeyOpDefaultRetryCnt, s.serverInfoPath, str, clientv3.WithLease(s.session.Lease()))
+	return err
 }
 
 // GetLocalServerInfo returns self server information.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Startup no longer campaigns for DDL ownership or enables DDL automatically.
  * Upgrade mode now fails when the DDL-enabled check is not satisfied.
  * Distributed task initialization continues even when a server ID is unavailable.
  * Server information updates are no longer persisted or synchronized, so server registration details are not propagated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->