### PR TITLE
*: migrate non-replacing AST visitors to in-place traversal part 1

### DIFF
--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -146,7 +146,7 @@ func findDependedColumnNames(schemaName ast.CIStr, tableName ast.CIStr, colDef *
 // FindColumnNamesInExpr returns a slice of ast.ColumnName which is referred in expr.
 func FindColumnNamesInExpr(expr ast.ExprNode) []*ast.ColumnName {
 	var c generatedColumnChecker
-	expr.Accept(&c)
+	ast.Walk(expr, &c)
 	return c.cols
 }
 
@@ -181,15 +181,15 @@ type generatedColumnChecker struct {
 	cols []*ast.ColumnName
 }
 
-func (*generatedColumnChecker) Enter(inNode ast.Node) (outNode ast.Node, skipChildren bool) {
-	return inNode, false
+func (*generatedColumnChecker) Enter(ast.Node) (skipChildren bool) {
+	return false
 }
 
-func (c *generatedColumnChecker) Leave(inNode ast.Node) (node ast.Node, ok bool) {
+func (c *generatedColumnChecker) Leave(inNode ast.Node) (ok bool) {
 	if x, ok := inNode.(*ast.ColumnName); ok {
 		c.cols = append(c.cols, x)
 	}
-	return inNode, true
+	return true
 }
 
 // checkModifyGeneratedColumn checks the modification between
@@ -296,24 +296,24 @@ type illegalFunctionChecker struct {
 	allowEmbedText        bool
 }
 
-func (c *illegalFunctionChecker) Enter(inNode ast.Node) (outNode ast.Node, skipChildren bool) {
+func (c *illegalFunctionChecker) Enter(inNode ast.Node) (skipChildren bool) {
 	switch node := inNode.(type) {
 	case *ast.FuncCallExpr:
 		// Grouping function is not allowed, issue #49909.
 		if node.FnName.L == ast.Grouping {
 			c.hasAggFunc = true
-			return inNode, true
+			return true
 		}
 		// Blocked functions & non-builtin functions is not allowed
 		_, isFunctionBlocked := expression.IllegalFunctions4GeneratedColumns[node.FnName.L]
 		if (isFunctionBlocked && !(c.allowEmbedText && node.FnName.L == ast.EmbedText)) || !expression.IsFunctionSupported(node.FnName.L) {
 			c.hasIllegalFunc = true
-			return inNode, true
+			return true
 		}
 		err := expression.VerifyArgsWrapper(node.FnName.L, len(node.Args))
 		if err != nil {
 			c.otherErr = err
-			return inNode, true
+			return true
 		}
 		_, isFuncGA := variable.GAFunction4ExpressionIndex[node.FnName.L]
 		if !isFuncGA {
@@ -322,32 +322,32 @@ func (c *illegalFunctionChecker) Enter(inNode ast.Node) (outNode ast.Node, skipC
 	case *ast.SubqueryExpr, *ast.ValuesExpr, *ast.VariableExpr:
 		// Subquery & `values(x)` & variable is not allowed
 		c.hasIllegalFunc = true
-		return inNode, true
+		return true
 	case *ast.AggregateFuncExpr:
 		// Aggregate function is not allowed
 		c.hasAggFunc = true
-		return inNode, true
+		return true
 	case *ast.RowExpr:
 		c.hasRowVal = true
-		return inNode, true
+		return true
 	case *ast.WindowFuncExpr:
 		c.hasWindowFunc = true
-		return inNode, true
+		return true
 	case *ast.FuncCastExpr:
 		c.hasCastArrayFunc = c.hasCastArrayFunc || node.Tp.IsArray()
 		if c.disallowCastArrayFunc && node.Tp.IsArray() {
 			c.otherErr = expression.ErrNotSupportedYet.GenWithStackByArgs("Use of CAST( .. AS .. ARRAY) outside of functional index in CREATE(non-SELECT)/ALTER TABLE or in general expressions")
-			return inNode, true
+			return true
 		}
 	case *ast.ParenthesesExpr:
-		return inNode, false
+		return false
 	}
 	c.disallowCastArrayFunc = true
-	return inNode, false
+	return false
 }
 
-func (*illegalFunctionChecker) Leave(inNode ast.Node) (node ast.Node, ok bool) {
-	return inNode, true
+func (*illegalFunctionChecker) Leave(ast.Node) (ok bool) {
+	return true
 }
 
 const (
@@ -363,7 +363,7 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 	// which admits only the dedicated STORED EMBED_TEXT form. Functional
 	// indexes keep EMBED_TEXT blocked by the general illegal-function list.
 	c := illegalFunctionChecker{allowEmbedText: genType == typeColumn}
-	expr.Accept(&c)
+	ast.Walk(expr, &c)
 	if c.hasIllegalFunc {
 		switch genType {
 		case typeColumn:

--- a/pkg/ddl/generated_column.go
+++ b/pkg/ddl/generated_column.go
@@ -185,7 +185,7 @@ func (*generatedColumnChecker) Enter(ast.Node) (skipChildren bool) {
 	return false
 }
 
-func (c *generatedColumnChecker) Leave(inNode ast.Node) (ok bool) {
+func (c *generatedColumnChecker) Leave(inNode ast.Node) (proceed bool) {
 	if x, ok := inNode.(*ast.ColumnName); ok {
 		c.cols = append(c.cols, x)
 	}
@@ -346,7 +346,7 @@ func (c *illegalFunctionChecker) Enter(inNode ast.Node) (skipChildren bool) {
 	return false
 }
 
-func (*illegalFunctionChecker) Leave(ast.Node) (ok bool) {
+func (*illegalFunctionChecker) Leave(ast.Node) (proceed bool) {
 	return true
 }
 

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -4955,7 +4955,7 @@ func (p *partitionExprChecker) Enter(n ast.Node) (skipChildren bool) {
 	return false
 }
 
-func (p *partitionExprChecker) Leave(ast.Node) (ok bool) {
+func (p *partitionExprChecker) Leave(ast.Node) (proceed bool) {
 	return p.err == nil
 }
 

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -760,7 +760,7 @@ func rewritePartitionQueryString(ctx sessionctx.Context, s *ast.PartitionOptions
 func getPartitionColSlices(sctx expression.BuildContext, tblInfo *model.TableInfo, s *ast.PartitionOptions) (partCols stringSlice, err error) {
 	if s.Expr != nil {
 		extractCols := newPartitionExprChecker(sctx, tblInfo)
-		s.Expr.Accept(extractCols)
+		ast.Walk(s.Expr, extractCols)
 		partColumns, err := extractCols.columns, extractCols.err
 		if err != nil {
 			return nil, err
@@ -1601,7 +1601,7 @@ func buildListPartitionDefinitions(ctx expression.BuildContext, defs []*ast.Part
 				}
 			} else {
 				for i := range vs {
-					vs[i].Accept(exprChecker)
+					ast.Walk(vs[i], exprChecker)
 					if exprChecker.err != nil {
 						return nil, exprChecker.err
 					}
@@ -1680,7 +1680,7 @@ func buildRangePartitionDefinitions(ctx expression.BuildContext, defs []*ast.Par
 		buf := new(bytes.Buffer)
 		// Range columns partitions support multi-column partitions.
 		for i, expr := range clause.Exprs {
-			expr.Accept(exprChecker)
+			ast.Walk(expr, exprChecker)
 			if exprChecker.err != nil {
 				return nil, exprChecker.err
 			}
@@ -1847,7 +1847,7 @@ func checkPartitionFuncValid(ctx expression.BuildContext, tblInfo *model.TableIn
 		return nil
 	}
 	exprChecker := newPartitionExprChecker(ctx, tblInfo, checkPartitionExprArgs, checkPartitionExprAllowed)
-	expr.Accept(exprChecker)
+	ast.Walk(expr, exprChecker)
 	if exprChecker.err != nil {
 		return errors.Trace(exprChecker.err)
 	}
@@ -4796,21 +4796,21 @@ type columnNameExtractor struct {
 	err              error
 }
 
-func (*columnNameExtractor) Enter(node ast.Node) (ast.Node, bool) {
-	return node, false
+func (*columnNameExtractor) Enter(ast.Node) bool {
+	return false
 }
 
-func (cne *columnNameExtractor) Leave(node ast.Node) (ast.Node, bool) {
+func (cne *columnNameExtractor) Leave(node ast.Node) bool {
 	if c, ok := node.(*ast.ColumnNameExpr); ok {
 		info := findColumnByName(c.Name.Name.L, cne.tblInfo)
 		if info != nil {
 			cne.extractedColumns = append(cne.extractedColumns, info)
-			return node, true
+			return true
 		}
 		cne.err = dbterror.ErrBadField.GenWithStackByArgs(c.Name.Name.O, "expression")
-		return nil, false
+		return false
 	}
-	return node, true
+	return true
 }
 
 func findColumnByName(colName string, tblInfo *model.TableInfo) *model.ColumnInfo {
@@ -4835,7 +4835,7 @@ func extractPartitionColumns(partExpr string, tblInfo *model.TableInfo) ([]*mode
 		tblInfo:          tblInfo,
 		extractedColumns: make([]*model.ColumnInfo, 0),
 	}
-	stmts[0].Accept(extractor)
+	ast.Walk(stmts[0], extractor)
 	if extractor.err != nil {
 		return nil, errors.Trace(extractor.err)
 	}
@@ -4940,23 +4940,23 @@ func newPartitionExprChecker(ctx expression.BuildContext, tbInfo *model.TableInf
 	return p
 }
 
-func (p *partitionExprChecker) Enter(n ast.Node) (node ast.Node, skipChildren bool) {
+func (p *partitionExprChecker) Enter(n ast.Node) (skipChildren bool) {
 	expr, ok := n.(ast.ExprNode)
 	if !ok {
-		return n, true
+		return true
 	}
 	for _, processor := range p.processors {
 		if err := processor(p.ctx, p.tbInfo, expr); err != nil {
 			p.err = err
-			return n, true
+			return true
 		}
 	}
 
-	return n, false
+	return false
 }
 
-func (p *partitionExprChecker) Leave(n ast.Node) (node ast.Node, ok bool) {
-	return n, p.err == nil
+func (p *partitionExprChecker) Leave(ast.Node) (ok bool) {
+	return p.err == nil
 }
 
 func (p *partitionExprChecker) extractColumns(_ expression.BuildContext, _ *model.TableInfo, expr ast.ExprNode) error {

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -308,26 +308,26 @@ type visibleChecker struct {
 	ok        bool
 }
 
-func (v *visibleChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+func (v *visibleChecker) Enter(in ast.Node) (skipChildren bool) {
 	if x, ok := in.(*ast.TableName); ok {
 		schema := x.Schema.L
 		if schema == "" {
 			schema = v.defaultDB
 		}
 		if !v.is.TableExists(ast.NewCIStr(schema), x.Name) {
-			return in, true
+			return true
 		}
 		activeRoles := v.ctx.GetSessionVars().ActiveRoles
 		if v.manager != nil && !v.manager.RequestVerification(activeRoles, schema, x.Name.L, "", mysql.SelectPriv) {
 			v.ok = false
 		}
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (*visibleChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+func (*visibleChecker) Leave(ast.Node) (proceed bool) {
+	return true
 }
 
 func (e *ShowExec) fetchShowBind() error {
@@ -364,7 +364,7 @@ func (e *ShowExec) fetchShowBind() error {
 			manager:   privilege.GetPrivilegeManager(e.Ctx()),
 			ok:        true,
 		}
-		stmt.Accept(&checker)
+		ast.Walk(stmt, &checker)
 		if !checker.ok {
 			continue
 		}

--- a/pkg/expression/inference_helper.go
+++ b/pkg/expression/inference_helper.go
@@ -41,16 +41,16 @@ type embedTextFnVisitor struct {
 	found bool
 }
 
-func (v *embedTextFnVisitor) Enter(in ast.Node) (ast.Node, bool) {
+func (v *embedTextFnVisitor) Enter(in ast.Node) bool {
 	if fnCall, ok := in.(*ast.FuncCallExpr); ok && fnCall.FnName.L == ast.EmbedText {
 		v.found = true
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (*embedTextFnVisitor) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (*embedTextFnVisitor) Leave(ast.Node) bool {
+	return true
 }
 
 // ContainsEmbedTextFunc reports whether expr contains EMBED_TEXT at any level.
@@ -59,7 +59,7 @@ func ContainsEmbedTextFunc(expr ast.ExprNode) bool {
 		return false
 	}
 	visitor := &embedTextFnVisitor{}
-	expr.Accept(visitor)
+	ast.Walk(expr, visitor)
 	return visitor.found
 }
 

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1392,19 +1392,19 @@ type ParamMarkerInPrepareChecker struct {
 	InPrepareStmt bool
 }
 
-// Enter implements Visitor Interface.
-func (pc *ParamMarkerInPrepareChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor Interface.
+func (pc *ParamMarkerInPrepareChecker) Enter(in ast.Node) (skipChildren bool) {
 	switch v := in.(type) {
 	case *driver.ParamMarkerExpr:
 		pc.InPrepareStmt = !v.InExecute
-		return v, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor Interface.
-func (pc *ParamMarkerInPrepareChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+// Leave implements InPlaceVisitor Interface.
+func (pc *ParamMarkerInPrepareChecker) Leave(ast.Node) (proceed bool) {
+	return true
 }
 
 // DisableParseJSONFlag4Expr disables ParseToJSONFlag for `expr` except Column.

--- a/pkg/parser/ast/ast.go
+++ b/pkg/parser/ast/ast.go
@@ -30,13 +30,13 @@ type Node interface {
 	Restore(ctx *format.RestoreCtx) error
 	// Accept accepts Visitor to visit itself.
 	// The returned node should replace original node.
-	// ok returns false to stop visiting.
+	// proceed returns false to stop visiting.
 	//
 	// Implementation of this method should first call visitor.Enter,
 	// assign the returned node to its method receiver, if skipChildren returns true,
 	// children should be skipped. Otherwise, call its children in particular order that
 	// later elements depends on former elements. Finally, return visitor.Leave.
-	Accept(v Visitor) (node Node, ok bool)
+	Accept(v Visitor) (node Node, proceed bool)
 	// AcceptInPlace accepts InPlaceVisitor to visit itself without replacing nodes.
 	// It is separate from Accept to avoid the runtime replacement checks and child
 	// writebacks that would otherwise make in-place traversal significantly slower.
@@ -45,7 +45,7 @@ type Node interface {
 	// derives AcceptInPlace implementations from Accept to keep them in sync. Every
 	// implementation must honor Enter's skipChildren result by skipping children
 	// while still calling Leave for the current node.
-	AcceptInPlace(v InPlaceVisitor) bool
+	AcceptInPlace(v InPlaceVisitor) (proceed bool)
 	// Text returns the utf8 encoding text of the element.
 	Text() string
 	// OriginalText returns the original text of the element.
@@ -160,8 +160,8 @@ type Visitor interface {
 	// Leave is called after children nodes have been visited.
 	// The returned node's type can be different from the input node if it is a ExprNode,
 	// Non-expression node must be the same type as the input node n.
-	// ok returns false to stop visiting.
-	Leave(n Node) (node Node, ok bool)
+	// proceed returns false to stop visiting.
+	Leave(n Node) (node Node, proceed bool)
 }
 
 // InPlaceVisitor visits a Node without replacing nodes.
@@ -174,8 +174,8 @@ type InPlaceVisitor interface {
 	// for the current node.
 	Enter(n Node) (skipChildren bool)
 	// Leave is called after children nodes have been visited.
-	// ok returns false to stop visiting.
-	Leave(n Node) (ok bool)
+	// proceed returns false to stop visiting.
+	Leave(n Node) (proceed bool)
 }
 
 // Walk visits node using Node.AcceptInPlace's traversal order and control flow.

--- a/pkg/parser/ast/ast.go
+++ b/pkg/parser/ast/ast.go
@@ -38,6 +38,7 @@ type Node interface {
 	// later elements depends on former elements. Finally, return visitor.Leave.
 	Accept(v Visitor) (node Node, proceed bool)
 	// AcceptInPlace accepts InPlaceVisitor to visit itself without replacing nodes.
+	// proceed returns false to stop visiting.
 	// It is separate from Accept to avoid the runtime replacement checks and child
 	// writebacks that would otherwise make in-place traversal significantly slower.
 	// Implementations must use the same traversal order and control flow as Accept,

--- a/pkg/parser/ast/util.go
+++ b/pkg/parser/ast/util.go
@@ -99,6 +99,6 @@ func (checker *readOnlyChecker) Enter(in Node) (skipChildren bool) {
 }
 
 // Leave implements InPlaceVisitor interface.
-func (checker *readOnlyChecker) Leave(Node) (ok bool) {
+func (checker *readOnlyChecker) Leave(Node) (proceed bool) {
 	return checker.readOnly
 }

--- a/pkg/parser/ast/util.go
+++ b/pkg/parser/ast/util.go
@@ -42,7 +42,7 @@ func IsReadOnly(node Node, checkGlobalVars bool) bool {
 			readOnly: true,
 		}
 
-		node.Accept(&checker)
+		Walk(node, &checker)
 		return checker.readOnly
 	case *ExplainStmt:
 		return !st.Analyze || IsReadOnly(st.Stmt, checkGlobalVars)
@@ -86,19 +86,19 @@ type readOnlyChecker struct {
 	readOnly bool
 }
 
-// Enter implements Visitor interface.
-func (checker *readOnlyChecker) Enter(in Node) (out Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *readOnlyChecker) Enter(in Node) (skipChildren bool) {
 	if node, ok := in.(*VariableExpr); ok {
 		// like func rewriteVariable(), this stands for SetVar.
 		if node.IsSystem && node.Value != nil {
 			checker.readOnly = false
-			return in, true
+			return true
 		}
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *readOnlyChecker) Leave(in Node) (out Node, ok bool) {
-	return in, checker.readOnly
+// Leave implements InPlaceVisitor interface.
+func (checker *readOnlyChecker) Leave(Node) (ok bool) {
+	return checker.readOnly
 }

--- a/pkg/parser/yy_parser.go
+++ b/pkg/parser/yy_parser.go
@@ -229,7 +229,7 @@ func (parser *Parser) lastErrorAsWarn() {
 
 func checkASTDepth(stmt ast.StmtNode) error {
 	checker := astDepthChecker{}
-	_, _ = stmt.Accept(&checker)
+	ast.Walk(stmt, &checker)
 	if checker.exceeded {
 		return ErrParse.GenWithStackByArgs("AST nesting depth exceeds maximum", strconv.Itoa(maxASTDepth))
 	}
@@ -241,18 +241,18 @@ type astDepthChecker struct {
 	exceeded bool
 }
 
-func (c *astDepthChecker) Enter(in ast.Node) (ast.Node, bool) {
+func (c *astDepthChecker) Enter(ast.Node) bool {
 	c.depth++
 	if c.depth > maxASTDepth {
 		c.exceeded = true
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (c *astDepthChecker) Leave(in ast.Node) (ast.Node, bool) {
+func (c *astDepthChecker) Leave(ast.Node) bool {
 	c.depth--
-	return in, !c.exceeded
+	return !c.exceeded
 }
 
 // ParseOneStmt parses a query and returns an ast.StmtNode.

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -6927,7 +6927,7 @@ func (b *PlanBuilder) buildWindowFunctionFrameBound(_ context.Context, spec *ast
 	expr := expression.Constant{Value: val, RetType: boundClause.Expr.GetType()}
 
 	checker := &expression.ParamMarkerInPrepareChecker{}
-	boundClause.Expr.Accept(checker)
+	ast.Walk(boundClause.Expr, checker)
 
 	// If it has paramMarker and is in prepare stmt. We don't need to eval it since its value is not decided yet.
 	if !checker.InPrepareStmt {
@@ -7011,7 +7011,7 @@ func (b *PlanBuilder) checkWindowFuncArgs(ctx context.Context, p base.LogicalPla
 		}
 		checker.InPrepareStmt = false
 		for _, expr := range windowFuncExpr.Args {
-			expr.Accept(checker)
+			ast.Walk(expr, checker)
 		}
 		desc, err := aggregation.NewWindowFuncDesc(b.ctx.GetExprCtx(), windowFuncExpr.Name, args, checker.InPrepareStmt)
 		if err != nil {
@@ -7130,7 +7130,7 @@ func (b *PlanBuilder) buildWindowFunctions(ctx context.Context, p base.LogicalPl
 		for _, windowFunc := range funcs {
 			checker.InPrepareStmt = false
 			for _, expr := range windowFunc.Args {
-				expr.Accept(checker)
+				ast.Walk(expr, checker)
 			}
 			desc, err := aggregation.NewWindowFuncDesc(b.ctx.GetExprCtx(), windowFunc.Name, args[preArgs:preArgs+len(windowFunc.Args)], checker.InPrepareStmt)
 			if err != nil {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3010,7 +3010,7 @@ func (b *PlanBuilder) resolveHavingAndOrderBy(ctx context.Context, sel *ast.Sele
 func (b *PlanBuilder) extractAggFuncsInExprs(exprs []ast.ExprNode) ([]*ast.AggregateFuncExpr, map[*ast.AggregateFuncExpr]int) {
 	extractor := &AggregateFuncExtractor{skipAggMap: b.correlatedAggMapper}
 	for _, expr := range exprs {
-		expr.Accept(extractor)
+		ast.Walk(expr, extractor)
 	}
 	aggList := extractor.AggFuncs
 	totalAggMapper := make(map[*ast.AggregateFuncExpr]int, len(aggList))
@@ -3024,8 +3024,7 @@ func (b *PlanBuilder) extractAggFuncsInExprs(exprs []ast.ExprNode) ([]*ast.Aggre
 func (b *PlanBuilder) extractAggFuncsInSelectFields(fields []*ast.SelectField) ([]*ast.AggregateFuncExpr, map[*ast.AggregateFuncExpr]int) {
 	extractor := &AggregateFuncExtractor{skipAggMap: b.correlatedAggMapper}
 	for _, f := range fields {
-		n, _ := f.Expr.Accept(extractor)
-		f.Expr = n.(ast.ExprNode)
+		ast.Walk(f.Expr, extractor)
 	}
 	aggList := extractor.AggFuncs
 	totalAggMapper := make(map[*ast.AggregateFuncExpr]int, len(aggList))
@@ -3039,8 +3038,7 @@ func (b *PlanBuilder) extractAggFuncsInSelectFields(fields []*ast.SelectField) (
 func (b *PlanBuilder) extractAggFuncsInByItems(byItems []*ast.ByItem) []*ast.AggregateFuncExpr {
 	extractor := &AggregateFuncExtractor{skipAggMap: b.correlatedAggMapper}
 	for _, f := range byItems {
-		n, _ := f.Expr.Accept(extractor)
-		f.Expr = n.(ast.ExprNode)
+		ast.Walk(f.Expr, extractor)
 	}
 	return extractor.AggFuncs
 }
@@ -3306,7 +3304,7 @@ func (r *correlatedAggregateResolver) collectFromWhere(p base.LogicalPlan, where
 		return nil
 	}
 	extractor := &AggregateFuncExtractor{skipAggMap: r.b.correlatedAggMapper}
-	_, _ = where.Accept(extractor)
+	ast.Walk(where, extractor)
 	r.b.curClause = whereClause
 	outerAggFuncs, err := r.b.extractCorrelatedAggFuncs(r.ctx, p, extractor.AggFuncs)
 	if err != nil {
@@ -3443,7 +3441,7 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			}
 			if index != -1 {
 				ret := g.fields[index].Expr
-				ret.Accept(extractor)
+				ast.Walk(ret, extractor)
 				if len(extractor.AggFuncs) != 0 {
 					err = plannererrors.ErrIllegalReference.GenWithStackByArgs(v.Name.OrigColName(), "reference to group function")
 				} else if ast.HasWindowFlag(ret) {
@@ -3471,7 +3469,7 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			return inNode, false
 		}
 		ret := g.fields[pos-1].Expr
-		ret.Accept(extractor)
+		ast.Walk(ret, extractor)
 		if len(extractor.AggFuncs) != 0 || ast.HasWindowFlag(ret) {
 			fieldName := g.fields[pos-1].AsName.String()
 			if fieldName == "" {
@@ -7251,8 +7249,7 @@ func (b *PlanBuilder) checkOriginWindowFrameBound(bound *ast.FrameBound, spec *a
 func extractWindowFuncs(fields []*ast.SelectField) []*ast.WindowFuncExpr {
 	extractor := &WindowFuncExtractor{}
 	for _, f := range fields {
-		n, _ := f.Expr.Accept(extractor)
-		f.Expr = n.(ast.ExprNode)
+		ast.Walk(f.Expr, extractor)
 	}
 	return extractor.windowFuncs
 }

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -75,15 +75,15 @@ type paramMarkerExtractor struct {
 	markers []ast.ParamMarkerExpr
 }
 
-func (*paramMarkerExtractor) Enter(in ast.Node) (ast.Node, bool) {
-	return in, false
+func (*paramMarkerExtractor) Enter(ast.Node) bool {
+	return false
 }
 
-func (e *paramMarkerExtractor) Leave(in ast.Node) (ast.Node, bool) {
+func (e *paramMarkerExtractor) Leave(in ast.Node) bool {
 	if x, ok := in.(*driver.ParamMarkerExpr); ok {
 		e.markers = append(e.markers, x)
 	}
-	return in, true
+	return true
 }
 
 // GeneratePlanCacheStmtWithAST generates the PlanCacheStmt structure for this AST.
@@ -93,7 +93,7 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 	paramSQL string, paramStmt ast.StmtNode, is infoschema.InfoSchema) (*PlanCacheStmt, base.Plan, int, error) {
 	vars := sctx.GetSessionVars()
 	var extractor paramMarkerExtractor
-	paramStmt.Accept(&extractor)
+	ast.Walk(paramStmt, &extractor)
 
 	// DDL Statements can not accept parameters
 	if _, ok := paramStmt.(ast.DDLNode); ok && len(extractor.markers) > 0 {
@@ -239,7 +239,7 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 	}
 
 	stmtProcessor := &planCacheStmtProcessor{ctx: ctx, is: is, stmt: preparedObj}
-	paramStmt.Accept(stmtProcessor)
+	ast.Walk(paramStmt, stmtProcessor)
 
 	if err = checkPreparedPriv(ctx, sctx, preparedObj, ret.InfoSchema); err != nil {
 		return nil, nil, 0, err
@@ -704,8 +704,8 @@ type planCacheStmtProcessor struct {
 	stmt *PlanCacheStmt
 }
 
-// Enter implements Visitor interface.
-func (f *planCacheStmtProcessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (f *planCacheStmtProcessor) Enter(in ast.Node) (skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.Limit:
 		f.stmt.limits = append(f.stmt.limits, node)
@@ -717,12 +717,12 @@ func (f *planCacheStmtProcessor) Enter(in ast.Node) (out ast.Node, skipChildren 
 			f.stmt.tables = append(f.stmt.tables, t)
 		}
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (*planCacheStmtProcessor) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+// Leave implements InPlaceVisitor interface.
+func (*planCacheStmtProcessor) Leave(ast.Node) (proceed bool) {
+	return true
 }
 
 // PointGetExecutorCache caches the PointGetExecutor to further improve its performance.
@@ -802,7 +802,7 @@ type PrepareStmtCacheEntry struct {
 // for prepared statements where the actual parameter values are not yet known).
 func ExtractAndSortParamMarkers(stmtNode ast.StmtNode) []ast.ParamMarkerExpr {
 	var extractor paramMarkerExtractor
-	stmtNode.Accept(&extractor)
+	ast.Walk(stmtNode, &extractor)
 	slices.SortFunc(extractor.markers, func(i, j ast.ParamMarkerExpr) int {
 		return cmp.Compare(i.(*driver.ParamMarkerExpr).Offset, j.(*driver.ParamMarkerExpr).Offset)
 	})
@@ -820,7 +820,7 @@ func ExtractAndSortParamMarkers(stmtNode ast.StmtNode) []ast.ParamMarkerExpr {
 // re-parse so that limit nodes and table references point into the new tree.
 func CollectPlanCacheStmtInfo(ctx context.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt, stmtNode ast.StmtNode) {
 	processor := &planCacheStmtProcessor{ctx: ctx, is: is, stmt: stmt}
-	stmtNode.Accept(processor)
+	ast.Walk(stmtNode, processor)
 }
 
 // DBName returns the dbName field (used for metadata lock during Execute).

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -72,7 +72,7 @@ func IsASTCacheable(ctx context.Context, sctx base.PlanContext, node ast.Node, i
 		maxNumParam:  getMaxParamLimit(sctx),
 		cteCanUsed:   make([]string, 0),
 	}
-	node.Accept(&checker)
+	ast.Walk(node, &checker)
 	return checker.cacheable, checker.reason
 }
 
@@ -92,8 +92,8 @@ type cacheableChecker struct {
 	withScopeOffset []int
 }
 
-// Enter implements Visitor interface.
-func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *cacheableChecker) Enter(in ast.Node) (skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.SelectStmt:
 		if node.With != nil {
@@ -110,7 +110,7 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 			if nRows*nCols > checker.maxNumParam { // to save memory
 				checker.cacheable = false
 				checker.reason = "too many values in the insert statement"
-				return in, true
+				return true
 			}
 		}
 	case *ast.PatternInExpr:
@@ -118,34 +118,34 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 		if checker.sumInListLen > checker.maxNumParam { // to save memory
 			checker.cacheable = false
 			checker.reason = "too many values in in-list"
-			return in, true
+			return true
 		}
 	case *ast.VariableExpr:
 		checker.cacheable = false
 		checker.reason = "query has user-defined variables is un-cacheable"
-		return in, true
+		return true
 	case *ast.ExistsSubqueryExpr:
-		return in, checker.skipForSubqueryDisabled()
+		return checker.skipForSubqueryDisabled()
 	case *ast.CommonTableExpression:
 		if node.IsRecursive {
 			// Recursive CTE can reference itself, so expose the name before traversing Query.
 			checker.cteCanUsed = append(checker.cteCanUsed, node.Name.L)
 		}
-		return in, false
+		return false
 	case *ast.SubqueryExpr:
-		return in, checker.skipForSubqueryDisabled()
+		return checker.skipForSubqueryDisabled()
 	case *ast.FuncCallExpr:
 		if _, found := expression.UnCacheableFunctions[node.FnName.L]; found {
 			checker.cacheable = false
 			checker.reason = fmt.Sprintf("query has '%v' is un-cacheable", node.FnName.L)
-			return in, true
+			return true
 		}
 	case *ast.OrderByClause:
 		for _, item := range node.Items {
 			if _, isParamMarker := item.Expr.(*driver.ParamMarkerExpr); isParamMarker {
 				checker.cacheable = false
 				checker.reason = "query has 'order by ?' is un-cacheable"
-				return in, true
+				return true
 			}
 		}
 	case *ast.GroupByClause:
@@ -153,7 +153,7 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 			if _, isParamMarker := item.Expr.(*driver.ParamMarkerExpr); isParamMarker {
 				checker.cacheable = false
 				checker.reason = "query has 'group by ?' is un-cacheable"
-				return in, true
+				return true
 			}
 		}
 	case *ast.Limit:
@@ -161,35 +161,35 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 			if _, isParamMarker := node.Count.(*driver.ParamMarkerExpr); isParamMarker && !checker.sctx.GetSessionVars().EnablePlanCacheForParamLimit {
 				checker.cacheable = false
 				checker.reason = "query has 'limit ?' is un-cacheable"
-				return in, true
+				return true
 			}
 		}
 		if node.Offset != nil {
 			if _, isParamMarker := node.Offset.(*driver.ParamMarkerExpr); isParamMarker && !checker.sctx.GetSessionVars().EnablePlanCacheForParamLimit {
 				checker.cacheable = false
 				checker.reason = "query has 'limit ?, 10' is un-cacheable"
-				return in, true
+				return true
 			}
 		}
 	case *ast.FrameBound:
 		if _, ok := node.Expr.(*driver.ParamMarkerExpr); ok {
 			checker.cacheable = false
 			checker.reason = "query has ? in window function frames is un-cacheable"
-			return in, true
+			return true
 		}
 	case *ast.TableName:
 		if checker.schema != nil {
 			if node.Schema.L == "" && slices.Contains(checker.cteCanUsed, node.Name.L) {
 				// Unqualified names can refer to CTEs in current scope; do not resolve them as physical tables.
-				return in, false
+				return false
 			}
 			checker.cacheable, checker.reason = checkTableCacheable(checker.ctx, checker.sctx, checker.schema, node, false)
 			if !checker.cacheable {
-				return in, true
+				return true
 			}
 		}
 	}
-	return in, false
+	return false
 }
 
 func (checker *cacheableChecker) skipForSubqueryDisabled() bool {
@@ -201,8 +201,8 @@ func (checker *cacheableChecker) skipForSubqueryDisabled() bool {
 	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *cacheableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
+// Leave implements InPlaceVisitor interface.
+func (checker *cacheableChecker) Leave(in ast.Node) (proceed bool) {
 	switch node := in.(type) {
 	case *ast.CommonTableExpression:
 		if !node.IsRecursive {
@@ -215,7 +215,7 @@ func (checker *cacheableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
 			checker.leaveWithScope()
 		}
 	}
-	return in, checker.cacheable
+	return checker.cacheable
 }
 
 func (checker *cacheableChecker) leaveWithScope() {
@@ -308,7 +308,7 @@ func NonPreparedPlanCacheableWithCtx(sctx base.PlanContext, node ast.Node, is in
 	checker := nonPrepCacheCheckerPool.Get().(*nonPreparedPlanCacheableChecker)
 	checker.reset(sctx, is, tableNames, maxNumParam)
 
-	node.Accept(checker)
+	ast.Walk(node, checker)
 	cacheable, reason := checker.cacheable, checker.reason
 
 	if !cacheable {
@@ -424,8 +424,8 @@ func (checker *nonPreparedPlanCacheableChecker) reset(sctx base.PlanContext, sch
 	checker.maxNumberParam = maxNumberParam
 }
 
-// Enter implements Visitor interface.
-func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (skipChildren bool) {
 	if checker.isFilterNode(in) {
 		checker.filterCnt++
 	}
@@ -435,13 +435,13 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 		*ast.ColumnNameExpr, *ast.DeleteStmt, *ast.FieldList, *ast.InsertStmt, *ast.IsNullExpr, *ast.Join,
 		*ast.OnCondition, *ast.ParenthesesExpr, *ast.PatternInExpr, *ast.RowExpr, *ast.SelectField,
 		*ast.SelectStmt, *ast.TableOptimizerHint, *ast.TableRefsClause, *ast.TableSource, *ast.UpdateStmt:
-		return in, !checker.cacheable // skip child if un-cacheable
+		return !checker.cacheable // skip child if un-cacheable
 	case *ast.Limit:
 		if !checker.sctx.GetSessionVars().EnablePlanCacheForParamLimit {
 			checker.cacheable = false
 			checker.reason = "query has 'limit ?' is un-cacheable"
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *ast.ColumnName:
 		if checker.filterCnt > 0 {
 			// this column is appearing some filters, e.g. `col = 1`
@@ -463,13 +463,13 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 				checker.reason = "some column is not found in table schema"
 			}
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *ast.FuncCallExpr:
 		if _, found := expression.UnCacheableFunctions[node.FnName.L]; found {
 			checker.cacheable = false
 			checker.reason = "query has un-cacheable functions"
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *driver.ValueExpr:
 		if node.GetType().GetFlag()&mysql.UnderScoreCharsetFlag > 0 {
 			// for safety, not support values with under-score charsets, e.g. select _latin1'abc' from t.
@@ -493,48 +493,48 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 			checker.cacheable = false
 			checker.reason = "query has too many constants"
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *ast.GroupByClause:
 		for _, item := range node.Items {
 			if _, isCol := item.Expr.(*ast.ColumnNameExpr); !isCol {
 				checker.cacheable = false
 				checker.reason = "only support group by {columns}'"
-				return in, !checker.cacheable
+				return !checker.cacheable
 			}
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *ast.OrderByClause:
 		for _, item := range node.Items {
 			if _, isCol := item.Expr.(*ast.ColumnNameExpr); !isCol {
 				checker.cacheable = false
 				checker.reason = "only support order by {columns}'"
-				return in, !checker.cacheable
+				return !checker.cacheable
 			}
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	case *ast.TableName:
 		if filter.IsSystemSchema(node.Schema.L) {
 			checker.cacheable = false
 			checker.reason = "access tables in system schema"
-			return in, !checker.cacheable
+			return !checker.cacheable
 		}
 		if checker.schema != nil {
 			checker.cacheable, checker.reason = checkTableCacheable(nil, checker.sctx, checker.schema, node, true)
 		}
-		return in, !checker.cacheable
+		return !checker.cacheable
 	}
 
 	checker.cacheable = false // unexpected cases
 	checker.reason = "query has some unsupported Node"
-	return in, !checker.cacheable
+	return !checker.cacheable
 }
 
-// Leave implements Visitor interface.
-func (checker *nonPreparedPlanCacheableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
+// Leave implements InPlaceVisitor interface.
+func (checker *nonPreparedPlanCacheableChecker) Leave(in ast.Node) (proceed bool) {
 	if checker.isFilterNode(in) {
 		checker.filterCnt--
 	}
-	return in, checker.cacheable
+	return checker.cacheable
 }
 
 func (*nonPreparedPlanCacheableChecker) isFilterNode(node ast.Node) bool {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4386,7 +4386,7 @@ type colNameInOnDupExtractor struct {
 	colNameMap map[types.FieldName]*ast.ColumnNameExpr
 }
 
-func (c *colNameInOnDupExtractor) Enter(node ast.Node) (ast.Node, bool) {
+func (c *colNameInOnDupExtractor) Enter(node ast.Node) bool {
 	switch x := node.(type) {
 	case *ast.ColumnNameExpr:
 		fieldName := types.FieldName{
@@ -4395,17 +4395,17 @@ func (c *colNameInOnDupExtractor) Enter(node ast.Node) (ast.Node, bool) {
 			ColName: x.Name.Name,
 		}
 		c.colNameMap[fieldName] = x
-		return node, true
+		return true
 	// We don't extract the column names from the sub select.
 	case *ast.SelectStmt, *ast.SetOprStmt:
-		return node, true
+		return true
 	default:
-		return node, false
+		return false
 	}
 }
 
-func (*colNameInOnDupExtractor) Leave(node ast.Node) (ast.Node, bool) {
-	return node, true
+func (*colNameInOnDupExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 func (b *PlanBuilder) buildSelectPlanOfInsert(ctx context.Context, insert *ast.InsertStmt, insertPlan *physicalop.Insert) error {
@@ -4435,7 +4435,7 @@ func (b *PlanBuilder) buildSelectPlanOfInsert(ctx context.Context, insert *ast.I
 			if !hasWildCard {
 				colExtractor := &colNameInOnDupExtractor{colNameMap: make(map[types.FieldName]*ast.ColumnNameExpr)}
 				for _, assign := range insert.OnDuplicate {
-					assign.Expr.Accept(colExtractor)
+					ast.Walk(assign.Expr, colExtractor)
 				}
 				actualColLen = len(sel.Fields.Fields)
 				for _, colName := range colExtractor.colNameMap {
@@ -4636,7 +4636,7 @@ var (
 		mysql.TypeTimestamp, mysql.TypeTimestamp, mysql.TypeTimestamp}
 )
 
-// importIntoCollAssignmentChecker implements ast.Visitor interface.
+// importIntoCollAssignmentChecker implements ast.InPlaceVisitor interface.
 // It is used to check the column assignment expressions in IMPORT INTO statement.
 // Currently, the import into column assignment only supports some simple expressions.
 type importIntoCollAssignmentChecker struct {
@@ -4654,7 +4654,7 @@ func checkImportIntoColAssignments(assignments []*ast.Assignment) (map[string]in
 	checker := newImportIntoCollAssignmentChecker()
 	for i, assign := range assignments {
 		checker.idx = i
-		assign.Expr.Accept(checker)
+		ast.Walk(assign.Expr, checker)
 		if checker.err != nil {
 			break
 		}
@@ -4662,65 +4662,65 @@ func checkImportIntoColAssignments(assignments []*ast.Assignment) (map[string]in
 	return checker.neededVars, checker.err
 }
 
-// Enter implements ast.Visitor interface.
-func (*importIntoCollAssignmentChecker) Enter(node ast.Node) (ast.Node, bool) {
-	return node, false
+// Enter implements ast.InPlaceVisitor interface.
+func (*importIntoCollAssignmentChecker) Enter(ast.Node) bool {
+	return false
 }
 
-// Leave implements ast.Visitor interface.
-func (v *importIntoCollAssignmentChecker) Leave(node ast.Node) (ast.Node, bool) {
+// Leave implements ast.InPlaceVisitor interface.
+func (v *importIntoCollAssignmentChecker) Leave(node ast.Node) bool {
 	switch n := node.(type) {
 	case *ast.ColumnNameExpr:
 		v.err = errors.Errorf("COLUMN reference is not supported in IMPORT INTO column assignment, index %d", v.idx)
-		return n, false
+		return false
 	case *ast.SubqueryExpr:
 		v.err = errors.Errorf("subquery is not supported in IMPORT INTO column assignment, index %d", v.idx)
-		return n, false
+		return false
 	case *ast.VariableExpr:
 		if n.IsSystem {
 			v.err = errors.Errorf("system variable is not supported in IMPORT INTO column assignment, index %d", v.idx)
-			return n, false
+			return false
 		}
 		if n.Value != nil {
 			v.err = errors.Errorf("setting a variable in IMPORT INTO column assignment is not supported, index %d", v.idx)
-			return n, false
+			return false
 		}
 		v.neededVars[strings.ToLower(n.Name)] = v.idx
 	case *ast.DefaultExpr:
 		v.err = errors.Errorf("FUNCTION default is not supported in IMPORT INTO column assignment, index %d", v.idx)
-		return n, false
+		return false
 	case *ast.WindowFuncExpr:
 		v.err = errors.Errorf("window FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.Name, v.idx)
-		return n, false
+		return false
 	case *ast.AggregateFuncExpr:
 		v.err = errors.Errorf("aggregate FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.F, v.idx)
-		return n, false
+		return false
 	case *ast.FuncCallExpr:
 		fnName := n.FnName.L
 		switch fnName {
 		case ast.Grouping:
 			v.err = errors.Errorf("FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.FnName.O, v.idx)
-			return n, false
+			return false
 		case ast.GetVar:
 			if len(n.Args) > 0 {
 				val, ok := n.Args[0].(*driver.ValueExpr)
 				if !ok || val.Kind() != types.KindString {
 					v.err = errors.Errorf("the argument of getvar should be a constant string in IMPORT INTO column assignment, index %d", v.idx)
-					return n, false
+					return false
 				}
 				v.neededVars[strings.ToLower(val.GetString())] = v.idx
 			}
 		default:
 			if !expression.IsFunctionSupported(fnName) {
 				v.err = errors.Errorf("FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.FnName.O, v.idx)
-				return n, false
+				return false
 			}
 		}
 	case *ast.ValuesExpr:
 		v.err = errors.Errorf("VALUES is not supported in IMPORT INTO column assignment, index %d", v.idx)
-		return n, false
+		return false
 	}
-	return node, v.err == nil
+	return v.err == nil
 }
 
 func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStmt) (base.Plan, error) {
@@ -5278,22 +5278,22 @@ type userVariableChecker struct {
 	hasUserVariables bool
 }
 
-func (e *userVariableChecker) Enter(in ast.Node) (ast.Node, bool) {
+func (e *userVariableChecker) Enter(in ast.Node) bool {
 	if _, ok := in.(*ast.VariableExpr); ok {
 		e.hasUserVariables = true
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (*userVariableChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (*userVariableChecker) Leave(ast.Node) bool {
+	return true
 }
 
 // Check for UserVariables
 func checkForUserVariables(in ast.Node) error {
 	v := &userVariableChecker{hasUserVariables: false}
-	_, ok := in.Accept(v)
+	ok := ast.Walk(in, v)
 	if !ok || v.hasUserVariables {
 		return dbterror.ErrViewSelectVariable
 	}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5293,8 +5293,8 @@ func (*userVariableChecker) Leave(ast.Node) bool {
 // Check for UserVariables
 func checkForUserVariables(in ast.Node) error {
 	v := &userVariableChecker{hasUserVariables: false}
-	ok := ast.Walk(in, v)
-	if !ok || v.hasUserVariables {
+	proceed := ast.Walk(in, v)
+	if !proceed || v.hasUserVariables {
 		return dbterror.ErrViewSelectVariable
 	}
 	return nil

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -992,7 +992,7 @@ func TestImportIntoCollAssignmentChecker(t *testing.T) {
 
 			checker := newImportIntoCollAssignmentChecker()
 			checker.idx = i
-			expr.Accept(checker)
+			ast.Walk(expr, checker)
 			if c.error != "" {
 				require.EqualError(t, checker.err, fmt.Sprintf("%s, index %d", c.error, i), c.expr)
 			} else {

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1130,22 +1130,22 @@ type subQueryChecker struct {
 	hasSubQuery bool
 }
 
-func (s *subQueryChecker) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
+func (s *subQueryChecker) Enter(in ast.Node) (skipChildren bool) {
 	if s.hasSubQuery {
-		return in, true
+		return true
 	}
 
 	if _, ok := in.(*ast.SubqueryExpr); ok {
 		s.hasSubQuery = true
-		return in, true
+		return true
 	}
 
-	return in, false
+	return false
 }
 
-func (s *subQueryChecker) Leave(in ast.Node) (ast.Node, bool) {
+func (s *subQueryChecker) Leave(ast.Node) bool {
 	// Before we enter the sub-query, we should keep visiting its children.
-	return in, !s.hasSubQuery
+	return !s.hasSubQuery
 }
 
 func isExprHasSubQuery(expr ast.Node) bool {
@@ -1155,7 +1155,7 @@ func isExprHasSubQuery(expr ast.Node) bool {
 		checker.hasSubQuery = false
 		subQueryCheckerPool.Put(checker)
 	}()
-	expr.Accept(checker)
+	ast.Walk(expr, checker)
 	return checker.hasSubQuery
 }
 

--- a/pkg/planner/core/subquery_plan_builder.go
+++ b/pkg/planner/core/subquery_plan_builder.go
@@ -30,31 +30,31 @@ type subqueryExprExtractor struct {
 	exprs []ast.ExprNode
 }
 
-// Enter implements Visitor interface.
-func (e *subqueryExprExtractor) Enter(n ast.Node) (ast.Node, bool) {
+// Enter implements InPlaceVisitor interface.
+func (e *subqueryExprExtractor) Enter(n ast.Node) bool {
 	switch subq := n.(type) {
 	case *ast.SubqueryExpr:
 		e.exprs = append(e.exprs, subq)
-		return n, true
+		return true
 	case *ast.ExistsSubqueryExpr:
 		e.exprs = append(e.exprs, subq)
-		return n, true
+		return true
 	case *ast.CompareSubqueryExpr:
 		e.exprs = append(e.exprs, subq)
-		return n, true
+		return true
 	case *ast.PatternInExpr:
 		if subq.Sel == nil {
-			return n, false
+			return false
 		}
 		e.exprs = append(e.exprs, subq)
-		return n, true
+		return true
 	}
-	return n, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (*subqueryExprExtractor) Leave(n ast.Node) (ast.Node, bool) {
-	return n, true
+// Leave implements InPlaceVisitor interface.
+func (*subqueryExprExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 func findColumnNameByUniqueID(p base.LogicalPlan, uniqueID int64) *ast.ColumnName {
@@ -107,7 +107,7 @@ func (b *PlanBuilder) appendAuxiliaryFieldsForSubqueries(ctx context.Context, p 
 			continue
 		}
 		extractor := &subqueryExprExtractor{}
-		node.Accept(extractor)
+		ast.Walk(node, extractor)
 		for _, expr := range extractor.exprs {
 			// Correlated aggregates are handled separately; here we only need the outer columns
 			// so subqueries inside deferred window expressions can still resolve against this query block.

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -57,17 +57,17 @@ type AggregateFuncExtractor struct {
 	AggFuncs []*ast.AggregateFuncExpr
 }
 
-// Enter implements Visitor interface.
-func (*AggregateFuncExtractor) Enter(n ast.Node) (ast.Node, bool) {
+// Enter implements InPlaceVisitor interface.
+func (*AggregateFuncExtractor) Enter(n ast.Node) bool {
 	switch n.(type) {
 	case *ast.SelectStmt, *ast.SetOprStmt:
-		return n, true
+		return true
 	}
-	return n, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (a *AggregateFuncExtractor) Leave(n ast.Node) (ast.Node, bool) {
+// Leave implements InPlaceVisitor interface.
+func (a *AggregateFuncExtractor) Leave(n ast.Node) bool {
 	//nolint: revive
 	switch v := n.(type) {
 	case *ast.AggregateFuncExpr:
@@ -75,33 +75,33 @@ func (a *AggregateFuncExtractor) Leave(n ast.Node) (ast.Node, bool) {
 			a.AggFuncs = append(a.AggFuncs, v)
 		}
 	}
-	return n, true
+	return true
 }
 
 // WindowFuncExtractor visits Expr tree.
-// It converts ColumnNameExpr to WindowFuncExpr and collects WindowFuncExpr.
+// It collects WindowFuncExpr from AST Node.
 type WindowFuncExtractor struct {
 	// WindowFuncs is the collected WindowFuncExprs.
 	windowFuncs []*ast.WindowFuncExpr
 }
 
-// Enter implements Visitor interface.
-func (*WindowFuncExtractor) Enter(n ast.Node) (ast.Node, bool) {
+// Enter implements InPlaceVisitor interface.
+func (*WindowFuncExtractor) Enter(n ast.Node) bool {
 	switch n.(type) {
 	case *ast.SelectStmt, *ast.SetOprStmt:
-		return n, true
+		return true
 	}
-	return n, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (a *WindowFuncExtractor) Leave(n ast.Node) (ast.Node, bool) {
+// Leave implements InPlaceVisitor interface.
+func (a *WindowFuncExtractor) Leave(n ast.Node) bool {
 	//nolint: revive
 	switch v := n.(type) {
 	case *ast.WindowFuncExpr:
 		a.windowFuncs = append(a.windowFuncs, v)
 	}
-	return n, true
+	return true
 }
 
 // extractStringFromStringSet helps extract string info from set.StringSet.

--- a/pkg/planner/core/util_test.go
+++ b/pkg/planner/core/util_test.go
@@ -26,6 +26,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	_ ast.InPlaceVisitor = (*colNameInOnDupExtractor)(nil)
+	_ ast.InPlaceVisitor = (*importIntoCollAssignmentChecker)(nil)
+	_ ast.InPlaceVisitor = (*userVariableChecker)(nil)
+	_ ast.InPlaceVisitor = (*subqueryExprExtractor)(nil)
+	_ ast.InPlaceVisitor = (*AggregateFuncExtractor)(nil)
+	_ ast.InPlaceVisitor = (*WindowFuncExtractor)(nil)
+)
+
 func tableNamesAsStr(tableNames []*ast.TableName) string {
 	names := []string{}
 	for _, tn := range tableNames {

--- a/pkg/table/constraint.go
+++ b/pkg/table/constraint.go
@@ -86,7 +86,7 @@ func IsSupportedExpr(constr *ast.Constraint) (bool, error) {
 		allowed: true,
 		name:    constr.Name,
 	}
-	constr.Expr.Accept(checker)
+	ast.Walk(constr.Expr, checker)
 	return checker.allowed, checker.reason
 }
 
@@ -133,37 +133,37 @@ type checkConstraintChecker struct {
 	name    string
 }
 
-// Enter implements Visitor interface.
-func (checker *checkConstraintChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *checkConstraintChecker) Enter(in ast.Node) (skipChildren bool) {
 	switch x := in.(type) {
 	case *ast.FuncCallExpr:
 		if _, ok := unsupportedNodeForCheckConstraint[x.FnName.L]; ok {
 			checker.allowed = false
 			checker.reason = dbterror.ErrCheckConstraintNamedFuncIsNotAllowed.GenWithStackByArgs(checker.name, x.FnName.L)
-			return in, true
+			return true
 		}
 	case *ast.VariableExpr:
 		// user defined or system variable is not allowed
 		checker.allowed = false
 		checker.reason = dbterror.ErrCheckConstraintVariables.GenWithStackByArgs(checker.name)
-		return in, true
+		return true
 	case *ast.SubqueryExpr, *ast.ExistsSubqueryExpr:
 		// subquery is not allowed
 		checker.allowed = false
 		checker.reason = dbterror.ErrCheckConstraintFuncIsNotAllowed.GenWithStackByArgs(checker.name)
-		return in, true
+		return true
 	case *ast.DefaultExpr:
 		// default expr is not allowed
 		checker.allowed = false
 		checker.reason = dbterror.ErrCheckConstraintNamedFuncIsNotAllowed.GenWithStackByArgs(checker.name, "default")
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *checkConstraintChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, checker.allowed
+// Leave implements InPlaceVisitor interface.
+func (checker *checkConstraintChecker) Leave(ast.Node) (proceed bool) {
+	return checker.allowed
 }
 
 // ContainsAutoIncrementCol checks if there is auto-increment col in given cols


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70622

Problem Summary:

The replacement-capable `ast.Visitor` API publishes returned children back into
their parents. Visitors that only inspect nodes or mutate the visited node in
place do not need that behavior, and the redundant AST writes prevent otherwise
read-only traversals from safely sharing a stable AST across goroutines.

The non-replacing traversal API is now available, but eligible visitors still
using `Node.Accept` continue to perform those unnecessary writebacks.

### What changed and how does it work?

This PR migrates eligible parser, planner, DDL, executor, expression, and table
visitors from `ast.Visitor`/`Node.Accept` to `ast.InPlaceVisitor`/`ast.Walk`.
The visitor callbacks preserve their existing traversal, skip, early-stop, and
direct in-place mutation behavior while no longer returning replacement nodes.

It also adds compile-time `ast.InPlaceVisitor` assertions for the migrated
planner visitors and clarifies traversal return names and visitor comments.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```text
make parser parser_yacc parser_fmt parser_unit_test
./tools/check/failpoint-go-test.sh pkg/expression -run '^TestEmbedTextASTHelpers$' -count=1
./tools/check/failpoint-go-test.sh pkg/planner/core -run '^(TestImportIntoCollAssignmentChecker)$' -count=1
./tools/check/failpoint-go-test.sh pkg/ddl -run '^(TestProcessModifyColumnOptionsGenerated|TestDropAndTruncatePartition)$' -count=1
./tools/check/failpoint-go-test.sh pkg/executor -run '^(TestShow)$' -count=1
make lint
git diff --check upstream/master...HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated expression and query analysis to use the latest AST traversal APIs.
  * Preserved existing behavior for generated columns, partitions, visibility checks, parameter detection, read-only validation, depth limits, plan caching, and subquery handling.
  * Maintained existing validation and error reporting across planning and table-constraint workflows.

* **Tests**
  * Added compile-time checks for updated AST visitor compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->