### PR TITLE
privilege: support whole-segment URI SAN '*' wildcards

### DIFF
--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -917,8 +917,15 @@ func checkCertSAN(priv *globalPrivRecord, cert *x509.Certificate, sans map[util.
 		}
 		var givenMatchOne bool
 		for _, req := range requireOr {
-			if slices.Contains(given, req) {
+			if typ == util.URI && slices.ContainsFunc(given, func(san string) bool {
+				return matchURIWithWildcard(req, san)
+			}) {
 				givenMatchOne = true
+				break
+			}
+			if typ != util.URI && slices.Contains(given, req) {
+				givenMatchOne = true
+				break
 			}
 		}
 		if !givenMatchOne {
@@ -929,6 +936,31 @@ func checkCertSAN(priv *globalPrivRecord, cert *x509.Certificate, sans map[util.
 		}
 	}
 	return
+}
+
+// matchURIWithWildcard matches URI SANs while allowing a required segment that
+// is exactly "*" to match one non-empty segment.
+func matchURIWithWildcard(required, given string) bool {
+	if !strings.Contains(required, "*") {
+		return required == given
+	}
+	requiredSegments := strings.Split(required, "/")
+	givenSegments := strings.Split(given, "/")
+	if len(requiredSegments) != len(givenSegments) {
+		return false
+	}
+	for i, requiredSegment := range requiredSegments {
+		if requiredSegment == "*" {
+			if givenSegments[i] == "" {
+				return false
+			}
+			continue
+		}
+		if requiredSegment != givenSegments[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // DBIsVisible implements the Manager interface.

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -955,8 +955,10 @@ func matchURIWithWildcard(required, given string) bool {
 	}
 	if requiredURI.Scheme != givenURI.Scheme ||
 		requiredURI.Opaque != givenURI.Opaque ||
+		(requiredURI.User == nil) != (givenURI.User == nil) ||
 		requiredURI.User.String() != givenURI.User.String() ||
 		requiredURI.Host != givenURI.Host ||
+		requiredURI.OmitHost != givenURI.OmitHost ||
 		requiredURI.ForceQuery != givenURI.ForceQuery ||
 		requiredURI.RawQuery != givenURI.RawQuery ||
 		requiredURI.EscapedFragment() != givenURI.EscapedFragment() {

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -938,14 +939,31 @@ func checkCertSAN(priv *globalPrivRecord, cert *x509.Certificate, sans map[util.
 	return
 }
 
-// matchURIWithWildcard matches URI SANs while allowing a required segment that
-// is exactly "*" to match one non-empty segment.
+// matchURIWithWildcard matches URI SANs while allowing a required path segment
+// that is exactly "*" to match one non-empty path segment.
 func matchURIWithWildcard(required, given string) bool {
 	if !strings.Contains(required, "*") {
 		return required == given
 	}
-	requiredSegments := strings.Split(required, "/")
-	givenSegments := strings.Split(given, "/")
+	requiredURI, err := url.Parse(required)
+	if err != nil {
+		return false
+	}
+	givenURI, err := url.Parse(given)
+	if err != nil {
+		return false
+	}
+	if requiredURI.Scheme != givenURI.Scheme ||
+		requiredURI.Opaque != givenURI.Opaque ||
+		requiredURI.User.String() != givenURI.User.String() ||
+		requiredURI.Host != givenURI.Host ||
+		requiredURI.ForceQuery != givenURI.ForceQuery ||
+		requiredURI.RawQuery != givenURI.RawQuery ||
+		requiredURI.EscapedFragment() != givenURI.EscapedFragment() {
+		return false
+	}
+	requiredSegments := strings.Split(requiredURI.EscapedPath(), "/")
+	givenSegments := strings.Split(givenURI.EscapedPath(), "/")
 	if len(requiredSegments) != len(givenSegments) {
 		return false
 	}

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -969,14 +969,14 @@ func matchURIWithWildcard(required, given string) bool {
 	if len(requiredSegments) != len(givenSegments) {
 		return false
 	}
-	for i, requiredSegment := range requiredSegments {
-		if requiredSegment == "*" {
+	for i := range requiredSegments {
+		if requiredSegments[i] == "*" {
 			if givenSegments[i] == "" {
 				return false
 			}
 			continue
 		}
-		if requiredSegment != givenSegments[i] {
+		if requiredSegments[i] != givenSegments[i] {
 			return false
 		}
 	}

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -601,6 +601,47 @@ func TestCheckCertBasedAuth(t *testing.T) {
 	// test mismatch san
 	require.Error(t, tk.Session().Auth(&auth.UserIdentity{Username: "r15_san_only_fail", Hostname: "localhost"}, nil, nil, nil))
 
+	adminTK := testkit.NewTestKit(t, store)
+	authWithSANs := func(uriSANs, dnsSANs []string, ipSANs [][]byte) error {
+		tk.Session().GetSessionVars().TLSConnectionState = connectionState(
+			pkix.Name{}, pkix.Name{}, tls.TLS_AES_128_GCM_SHA256, func(cert *x509.Certificate) {
+				for _, uriSAN := range uriSANs {
+					uri, err := url.Parse(uriSAN)
+					require.NoError(t, err)
+					cert.URIs = append(cert.URIs, uri)
+				}
+				cert.DNSNames = dnsSANs
+				for _, ipSAN := range ipSANs {
+					cert.IPAddresses = append(cert.IPAddresses, ipSAN)
+				}
+			})
+		return tk.Session().Auth(&auth.UserIdentity{Username: "r14_san_only_pass", Hostname: "localhost"}, nil, nil, nil)
+	}
+
+	// A URI wildcard matches exactly one non-empty segment. Multiple URI
+	// requirements remain alternatives.
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN
+		'URI:spiffe://domain.com/no-match, URI:spiffe://domain.com/*/something/foo/*'`)
+	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/bar/something/foo/baz"}, nil, nil))
+	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/youpi/something/foo/yada"}, nil, nil))
+	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/extra/something/foo/baz"}, nil, nil))
+	require.Error(t, authWithSANs([]string{"spiffe://domain.com//something/foo/baz"}, nil, nil))
+	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/something/foo/"}, nil, nil))
+
+	// An asterisk has no special meaning unless it is the entire URI segment.
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'URI:spiffe://domain.com/foo*/bar'`)
+	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/foo*/bar"}, nil, nil))
+	require.Error(t, authWithSANs([]string{"spiffe://domain.com/foobar/bar"}, nil, nil))
+
+	// DNS and IP SAN requirements continue to use exact matching.
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'DNS:*.domain.com'`)
+	require.NoError(t, authWithSANs(nil, []string{"*.domain.com"}, nil))
+	require.Error(t, authWithSANs(nil, []string{"service.domain.com"}, nil))
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'IP:127.*'`)
+	require.Error(t, authWithSANs(nil, nil, [][]byte{{127, 0, 0, 1}}))
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'IP:127.0.0.1'`)
+	require.NoError(t, authWithSANs(nil, nil, [][]byte{{127, 0, 0, 1}}))
+
 	// test old data and broken data
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "r12_old_tidb_user", Hostname: "localhost"}, nil, nil, nil))
 	require.Error(t, tk.Session().Auth(&auth.UserIdentity{Username: "r13_broken_user", Hostname: "localhost"}, nil, nil, nil))

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -601,7 +601,17 @@ func TestCheckCertBasedAuth(t *testing.T) {
 	// test mismatch san
 	require.Error(t, tk.Session().Auth(&auth.UserIdentity{Username: "r15_san_only_fail", Hostname: "localhost"}, nil, nil, nil))
 
+	// test old data and broken data
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "r12_old_tidb_user", Hostname: "localhost"}, nil, nil, nil))
+	require.Error(t, tk.Session().Auth(&auth.UserIdentity{Username: "r13_broken_user", Hostname: "localhost"}, nil, nil, nil))
+}
+
+func TestCheckCertBasedAuthWithURIWildcard(t *testing.T) {
+	store := createStoreAndPrepareDB(t)
+
 	adminTK := testkit.NewTestKit(t, store)
+	adminTK.MustExec(`CREATE USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'URI:spiffe://domain.com/bar'`)
+	tk := testkit.NewTestKit(t, store)
 	authWithSANs := func(uriSANs, dnsSANs []string, ipSANs [][]byte) error {
 		tk.Session().GetSessionVars().TLSConnectionState = connectionState(
 			pkix.Name{}, pkix.Name{}, tls.TLS_AES_128_GCM_SHA256, func(cert *x509.Certificate) {
@@ -615,38 +625,34 @@ func TestCheckCertBasedAuth(t *testing.T) {
 					cert.IPAddresses = append(cert.IPAddresses, ipSAN)
 				}
 			})
-		return tk.Session().Auth(&auth.UserIdentity{Username: "r14_san_only_pass", Hostname: "localhost"}, nil, nil, nil)
+		return tk.Session().Auth(&auth.UserIdentity{Username: "uri_san_wildcard", Hostname: "localhost"}, nil, nil, nil)
 	}
 
 	// A URI wildcard matches exactly one non-empty segment. Multiple URI
 	// requirements remain alternatives.
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN
 		'URI:spiffe://domain.com/no-match, URI:spiffe://domain.com/*/something/foo/*'`)
 	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/bar/something/foo/baz"}, nil, nil))
 	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/youpi/something/foo/yada"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/extra/something/foo/baz"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com//something/foo/baz"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/something/foo/"}, nil, nil))
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'URI:spiffe://*/bar/*'`)
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'URI:spiffe://*/bar/*'`)
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/baz"}, nil, nil))
 
 	// An asterisk has no special meaning unless it is the entire URI segment.
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'URI:spiffe://domain.com/foo*/bar'`)
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'URI:spiffe://domain.com/foo*/bar'`)
 	require.NoError(t, authWithSANs([]string{"spiffe://domain.com/foo*/bar"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/foobar/bar"}, nil, nil))
 
 	// DNS and IP SAN requirements continue to use exact matching.
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'DNS:*.domain.com'`)
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'DNS:*.domain.com'`)
 	require.NoError(t, authWithSANs(nil, []string{"*.domain.com"}, nil))
 	require.Error(t, authWithSANs(nil, []string{"service.domain.com"}, nil))
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'IP:127.*'`)
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'IP:127.*'`)
 	require.Error(t, authWithSANs(nil, nil, [][]byte{{127, 0, 0, 1}}))
-	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'IP:127.0.0.1'`)
+	adminTK.MustExec(`ALTER USER 'uri_san_wildcard'@'localhost' REQUIRE SAN 'IP:127.0.0.1'`)
 	require.NoError(t, authWithSANs(nil, nil, [][]byte{{127, 0, 0, 1}}))
-
-	// test old data and broken data
-	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "r12_old_tidb_user", Hostname: "localhost"}, nil, nil, nil))
-	require.Error(t, tk.Session().Auth(&auth.UserIdentity{Username: "r13_broken_user", Hostname: "localhost"}, nil, nil, nil))
 }
 
 func connectionState(issuer, subject pkix.Name, cipher uint16, opt ...func(c *x509.Certificate)) *tls.ConnectionState {

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -627,6 +627,8 @@ func TestCheckCertBasedAuth(t *testing.T) {
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/extra/something/foo/baz"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com//something/foo/baz"}, nil, nil))
 	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/something/foo/"}, nil, nil))
+	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'URI:spiffe://*/bar/*'`)
+	require.Error(t, authWithSANs([]string{"spiffe://domain.com/bar/baz"}, nil, nil))
 
 	// An asterisk has no special meaning unless it is the entire URI segment.
 	adminTK.MustExec(`ALTER USER 'r14_san_only_pass'@'localhost' REQUIRE SAN 'URI:spiffe://domain.com/foo*/bar'`)

--- a/pkg/privilege/privileges/tidb_auth_token_test.go
+++ b/pkg/privilege/privileges/tidb_auth_token_test.go
@@ -262,6 +262,75 @@ func getSignedTokenString(priKey *rsa.PrivateKey, pairs map[string]any) (string,
 	return string(hack.String(bytes)), nil
 }
 
+func TestMatchURIWithWildcard(t *testing.T) {
+	testCases := []struct {
+		name     string
+		required string
+		given    string
+		match    bool
+	}{
+		{
+			name:     "exact URI",
+			required: "spiffe://domain.com/bar/something/foo/baz",
+			given:    "spiffe://domain.com/bar/something/foo/baz",
+			match:    true,
+		},
+		{
+			name:     "whole path segments",
+			required: "spiffe://domain.com/*/something/foo/*",
+			given:    "spiffe://domain.com/bar/something/foo/baz",
+			match:    true,
+		},
+		{
+			name:     "wildcard does not cross path separator",
+			required: "spiffe://domain.com/*/something/foo/*",
+			given:    "spiffe://domain.com/bar/extra/something/foo/baz",
+		},
+		{
+			name:     "wildcard does not match empty segment",
+			required: "spiffe://domain.com/*/something/foo/*",
+			given:    "spiffe://domain.com//something/foo/baz",
+		},
+		{
+			name:     "embedded asterisk is literal",
+			required: "spiffe://domain.com/foo*/bar",
+			given:    "spiffe://domain.com/foo*/bar",
+			match:    true,
+		},
+		{
+			name:     "embedded asterisk does not match partial segment",
+			required: "spiffe://domain.com/foo*/bar",
+			given:    "spiffe://domain.com/foobar/bar",
+		},
+		{
+			name:     "host wildcard is literal",
+			required: "spiffe://*/bar/*",
+			given:    "spiffe://domain.com/bar/baz",
+		},
+		{
+			name:     "scheme must match exactly",
+			required: "spiffe://domain.com/bar/*",
+			given:    "https://domain.com/bar/baz",
+		},
+		{
+			name:     "query wildcard is literal",
+			required: "spiffe://domain.com/bar/*?key=*",
+			given:    "spiffe://domain.com/bar/baz?key=value",
+		},
+		{
+			name:     "encoded slash stays within segment",
+			required: "spiffe://domain.com/bar/*",
+			given:    "spiffe://domain.com/bar/baz%2Fqux",
+			match:    true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.match, matchURIWithWildcard(testCase.required, testCase.given))
+		})
+	}
+}
+
 func TestAuthTokenClaims(t *testing.T) {
 	var jwksImpl JWKSImpl
 	now := time.Now()

--- a/pkg/privilege/privileges/tidb_auth_token_test.go
+++ b/pkg/privilege/privileges/tidb_auth_token_test.go
@@ -313,6 +313,26 @@ func TestMatchURIWithWildcard(t *testing.T) {
 			given:    "https://domain.com/bar/baz",
 		},
 		{
+			name:     "empty userinfo does not match absent userinfo",
+			required: "spiffe://@domain.com/bar/*",
+			given:    "spiffe://domain.com/bar/baz",
+		},
+		{
+			name:     "absent userinfo does not match empty userinfo",
+			required: "spiffe://domain.com/bar/*",
+			given:    "spiffe://@domain.com/bar/baz",
+		},
+		{
+			name:     "omitted authority does not match present empty authority",
+			required: "spiffe:/bar/*",
+			given:    "spiffe:///bar/baz",
+		},
+		{
+			name:     "present empty authority does not match omitted authority",
+			required: "spiffe:///bar/*",
+			given:    "spiffe:/bar/baz",
+		},
+		{
 			name:     "query wildcard is literal",
 			required: "spiffe://domain.com/bar/*?key=*",
 			given:    "spiffe://domain.com/bar/baz?key=value",


### PR DESCRIPTION
### What problem does this PR solve?
URI SANS can have very big cardinality, specially in Spiffe on k8s setups. Allowing for segment wildcard would make grant management significantly easier.

Issue Number: close #70702

Problem Summary:

### What changed and how does it work?

For URI SAN I am breaking the URI in segments delimited by `/`, then each segment is matched, when the grant segment is '*' then any value is accepted for that segment.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add support for '*' wildcards in SAN URI grants.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - URI-based certificate authentication supports wildcards, with each `*` matching one non-empty path segment.
  - Supports alternative URI requirements while preserving literal asterisks outside eligible path segments.

- **Bug Fixes**
  - Prevents wildcards from crossing path boundaries or matching empty segments.
  - Ensures URI scheme, host, user information, query, fragment, and other components match correctly.
  - DNS and IP certificate matching remain exact.

- **Tests**
  - Added coverage for wildcard behavior, URI alternatives, literal asterisks, and exact DNS/IP matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->