### PR TITLE
*: migrate non-replacing AST visitors to in-place traversal part 2

### DIFF
--- a/pkg/bindinfo/binding.go
+++ b/pkg/bindinfo/binding.go
@@ -350,7 +350,7 @@ func CollectTableNames(in ast.Node) []*ast.TableName {
 		collector.tableNames = nil
 		tableNameCollectorPool.Put(collector)
 	}()
-	in.Accept(collector)
+	ast.Walk(in, collector)
 	return collector.tableNames
 }
 
@@ -370,18 +370,18 @@ func newCollectTableName() *tableNameCollector {
 	}
 }
 
-// Enter implements Visitor interface.
-func (c *tableNameCollector) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (c *tableNameCollector) Enter(in ast.Node) (skipChildren bool) {
 	if node, ok := in.(*ast.TableName); ok {
 		c.tableNames = append(c.tableNames, node)
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (*tableNameCollector) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+// Leave implements InPlaceVisitor interface.
+func (*tableNameCollector) Leave(ast.Node) bool {
+	return true
 }
 
 // prepareHints builds ID and Hint for Bindings. If sctx is not nil, we check if
@@ -568,23 +568,23 @@ type paramChecker struct {
 	hasParam bool
 }
 
-func (e *paramChecker) Enter(in ast.Node) (ast.Node, bool) {
+func (e *paramChecker) Enter(in ast.Node) bool {
 	if _, ok := in.(*driver.ParamMarkerExpr); ok {
 		e.hasParam = true
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (*paramChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (*paramChecker) Leave(ast.Node) bool {
+	return true
 }
 
 // hasParam checks whether the statement contains any parameters.
 // For example, `create binding using select * from t where a=?` contains a parameter '?'.
 func hasParam(stmt ast.Node) bool {
 	p := new(paramChecker)
-	stmt.Accept(p)
+	ast.Walk(stmt, p)
 	return p.hasParam
 }
 

--- a/pkg/bindinfo/binding_plan_generation.go
+++ b/pkg/bindinfo/binding_plan_generation.go
@@ -689,15 +689,15 @@ type subqueryOffsetExtractor struct {
 	offsets map[int]struct{}
 }
 
-func (e *subqueryOffsetExtractor) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
+func (e *subqueryOffsetExtractor) Enter(in ast.Node) (skipChildren bool) {
 	if subq, ok := in.(*ast.SubqueryExpr); ok {
 		collectSubqueryOffsets(subq.Query, e.offsets)
 	}
-	return in, false
+	return false
 }
 
-func (*subqueryOffsetExtractor) Leave(in ast.Node) (node ast.Node, ok bool) {
-	return in, true
+func (*subqueryOffsetExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 func collectSubqueryOffsets(node ast.ResultSetNode, offsets map[int]struct{}) {
@@ -730,8 +730,8 @@ func collectSubqueryOffsetsFromSelectList(list *ast.SetOprSelectList, offsets ma
 	}
 }
 
-// Enter implements ast.Visitor interface.
-func (e *tableNameExtractor) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
+// Enter implements ast.InPlaceVisitor interface.
+func (e *tableNameExtractor) Enter(in ast.Node) (skipChildren bool) {
 	if name, ok := in.(*ast.TableName); ok {
 		t := &tableName{
 			schema: name.Schema.L,
@@ -744,12 +744,12 @@ func (e *tableNameExtractor) Enter(in ast.Node) (node ast.Node, skipChildren boo
 			e.tableNames[t.String()] = t
 		}
 	}
-	return in, false
+	return false
 }
 
-// Leave implements ast.Visitor interface.
-func (*tableNameExtractor) Leave(in ast.Node) (node ast.Node, ok bool) {
-	return in, true
+// Leave implements ast.InPlaceVisitor interface.
+func (*tableNameExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 // extractSelectTableNames returns the table names in the SELECT statement.
@@ -762,7 +762,7 @@ func extractSelectTableNames(defaultSchema string, node ast.StmtNode) []*tableNa
 		defaultSchema: defaultSchema,
 		tableNames:    make(map[string]*tableName),
 	}
-	selStmt.Accept(extractor)
+	ast.Walk(selStmt, extractor)
 
 	names := make([]*tableName, 0, len(extractor.tableNames))
 	for _, name := range extractor.tableNames {
@@ -784,7 +784,7 @@ func extractNoDecorrelateQBs(node ast.StmtNode) []ast.CIStr {
 	selStmt.Accept(assigner)
 
 	extractor := &subqueryOffsetExtractor{offsets: make(map[int]struct{})}
-	selStmt.Accept(extractor)
+	ast.Walk(selStmt, extractor)
 
 	if len(extractor.offsets) == 0 {
 		return nil
@@ -814,32 +814,32 @@ type predicateColumnExtractor struct {
 	allowAnyTable bool
 }
 
-func (e *predicateColumnExtractor) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
+func (e *predicateColumnExtractor) Enter(in ast.Node) (skipChildren bool) {
 	switch n := in.(type) {
 	case *ast.SubqueryExpr:
 		// Only consider predicates in the current SELECT, skip inner queries to avoid mixing scopes.
-		return in, true
+		return true
 	case *ast.ColumnNameExpr:
 		if n.Name == nil {
-			return in, false
+			return false
 		}
 		if !e.allowAnyTable {
 			if n.Name.Table.L == "" {
-				return in, false
+				return false
 			}
 			if !matchesColumnTable(e.table, n.Name) {
-				return in, false
+				return false
 			}
 		} else if n.Name.Schema.L != "" && n.Name.Schema.L != e.table.schema {
-			return in, false
+			return false
 		}
 		e.columns[n.Name.Name.L] = struct{}{}
 	}
-	return in, false
+	return false
 }
 
-func (*predicateColumnExtractor) Leave(in ast.Node) (node ast.Node, ok bool) {
-	return in, true
+func (*predicateColumnExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 func matchesColumnTable(target *tableName, name *ast.ColumnName) bool {
@@ -906,7 +906,7 @@ func collectJoinPredicates(node ast.ResultSetNode, extractor *predicateColumnExt
 	switch n := node.(type) {
 	case *ast.Join:
 		if n.On != nil && n.On.Expr != nil {
-			n.On.Expr.Accept(extractor)
+			ast.Walk(n.On.Expr, extractor)
 		}
 		collectJoinPredicates(n.Left, extractor)
 		collectJoinPredicates(n.Right, extractor)
@@ -937,7 +937,7 @@ func extractSelectIndexHints(sctx sessionctx.Context, defaultSchema string, node
 			allowAnyTable: allowAnyTable,
 		}
 		if selStmt.Where != nil {
-			selStmt.Where.Accept(extractor)
+			ast.Walk(selStmt.Where, extractor)
 		}
 		if selStmt.From != nil && selStmt.From.TableRefs != nil {
 			collectJoinPredicates(selStmt.From.TableRefs, extractor)

--- a/pkg/domain/extract.go
+++ b/pkg/domain/extract.go
@@ -288,7 +288,7 @@ func (w *extractWorker) handleIsView(ctx context.Context, p *extractPlanPackage)
 			if err != nil {
 				return err
 			}
-			node.Accept(tne)
+			ast.Walk(node, tne)
 		}
 	}
 	if tne.err != nil {

--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -146,22 +146,22 @@ func findFK(is infoschema.InfoSchema, dbName, tableName string, tableMap map[tab
 	return nil
 }
 
-func (*tableNameExtractor) Enter(in ast.Node) (ast.Node, bool) {
+func (*tableNameExtractor) Enter(in ast.Node) bool {
 	if _, ok := in.(*ast.TableName); ok {
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (tne *tableNameExtractor) Leave(in ast.Node) (ast.Node, bool) {
+func (tne *tableNameExtractor) Leave(in ast.Node) bool {
 	if tne.err != nil {
-		return in, true
+		return true
 	}
 	if t, ok := in.(*ast.TableName); ok {
 		isView, err := tne.handleIsView(t)
 		if err != nil {
 			tne.err = err
-			return in, true
+			return true
 		}
 		schema := t.Schema
 		if schema.L == "" {
@@ -178,7 +178,7 @@ func (tne *tableNameExtractor) Leave(in ast.Node) (ast.Node, bool) {
 			}
 		}
 	}
-	return in, true
+	return true
 }
 
 func (tne *tableNameExtractor) handleIsView(t *ast.TableName) (bool, error) {
@@ -200,7 +200,7 @@ func (tne *tableNameExtractor) handleIsView(t *ast.TableName) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	node.Accept(tne)
+	ast.Walk(node, tne)
 	return true, nil
 }
 
@@ -844,7 +844,7 @@ func extractTableNames(ctx context.Context, sctx sessionctx.Context,
 		cteNames: make(map[string]struct{}),
 	}
 	for _, execStmt := range execStmts {
-		execStmt.Accept(tableExtractor)
+		ast.Walk(execStmt, tableExtractor)
 	}
 	if tableExtractor.err != nil {
 		return nil, tableExtractor.err

--- a/pkg/lightning/mydump/view_import.go
+++ b/pkg/lightning/mydump/view_import.go
@@ -140,10 +140,10 @@ func hasWithClause(n ast.Node) bool {
 	}
 }
 
-func (c *viewDependencyCollector) Enter(n ast.Node) (ast.Node, bool) {
+func (c *viewDependencyCollector) Enter(n ast.Node) bool {
 	if hasWithClause(n) {
 		c.pushCTEScope()
-		return n, false
+		return false
 	}
 
 	switch node := n.(type) {
@@ -153,10 +153,10 @@ func (c *viewDependencyCollector) Enter(n ast.Node) (ast.Node, bool) {
 			// traversing Query.
 			c.recordCTEName(node.Name.L)
 		}
-		return n, false
+		return false
 	case *ast.TableName:
 		if node.Schema.O == "" && c.isCTEName(node.Name.L) {
-			return n, true
+			return true
 		}
 
 		schema := node.Schema.L
@@ -165,13 +165,13 @@ func (c *viewDependencyCollector) Enter(n ast.Node) (ast.Node, bool) {
 			schema = strings.ToLower(c.currentSchema)
 		}
 		c.deps.add(tableKey(schema, node.Name.L))
-		return n, true
+		return true
 	default:
-		return n, false
+		return false
 	}
 }
 
-func (c *viewDependencyCollector) Leave(n ast.Node) (ast.Node, bool) {
+func (c *viewDependencyCollector) Leave(n ast.Node) bool {
 	if node, ok := n.(*ast.CommonTableExpression); ok && !node.IsRecursive {
 		// Non-recursive CTE becomes visible only after its definition has
 		// been fully traversed.
@@ -180,7 +180,7 @@ func (c *viewDependencyCollector) Leave(n ast.Node) (ast.Node, bool) {
 	if hasWithClause(n) {
 		c.popCTEScope()
 	}
-	return n, true
+	return true
 }
 
 // NewSchemaImportPlan builds a schema import plan, including ordered view imports when needed.
@@ -276,7 +276,7 @@ func parseViewSchemaSQL(p *parser.Parser, currentView filter.Table, sql string) 
 		currentSchema: currentView.Schema,
 		deps:          make(tableNameSet),
 	}
-	createStmt.Select.Accept(collector)
+	ast.Walk(createStmt.Select, collector)
 
 	deps := slices.Collect(maps.Keys(collector.deps))
 

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3902,17 +3902,17 @@ func (b *PlanBuilder) checkOnlyFullGroupByWithOutGroupClause(p base.LogicalPlan,
 	resolver.curClause = fieldList
 	for idx, field := range sel.Fields.Fields {
 		resolver.exprIdx = idx
-		field.Accept(&resolver)
+		ast.Walk(field, &resolver)
 	}
 	if len(resolver.nonAggCols) > 0 {
 		if sel.Having != nil {
-			sel.Having.Expr.Accept(&resolver)
+			ast.Walk(sel.Having.Expr, &resolver)
 		}
 		if sel.OrderBy != nil {
 			resolver.curClause = orderByClause
 			for idx, byItem := range sel.OrderBy.Items {
 				resolver.exprIdx = idx
-				byItem.Expr.Accept(&resolver)
+				ast.Walk(byItem.Expr, &resolver)
 			}
 		}
 	}
@@ -3971,43 +3971,43 @@ type colResolverForOnlyFullGroupBy struct {
 	curClause             clauseCode
 }
 
-func (c *colResolverForOnlyFullGroupBy) Enter(node ast.Node) (ast.Node, bool) {
+func (c *colResolverForOnlyFullGroupBy) Enter(node ast.Node) bool {
 	switch t := node.(type) {
 	case *ast.AggregateFuncExpr:
 		c.hasAggFuncOrAnyValue = true
 		if c.curClause == orderByClause {
 			c.firstOrderByAggColIdx = c.exprIdx
 		}
-		return node, true
+		return true
 	case *ast.FuncCallExpr:
 		// enable function `any_value` in aggregation even `ONLY_FULL_GROUP_BY` is set
 		if t.FnName.L == ast.AnyValue {
 			c.hasAggFuncOrAnyValue = true
-			return node, true
+			return true
 		}
 	case *ast.ColumnNameExpr:
 		c.nonAggCols = append(c.nonAggCols, t.Name)
 		c.nonAggColIdxs = append(c.nonAggColIdxs, c.exprIdx)
-		return node, true
+		return true
 	case *ast.SubqueryExpr:
-		return node, true
+		return true
 	}
-	return node, false
+	return false
 }
 
-func (*colResolverForOnlyFullGroupBy) Leave(node ast.Node) (ast.Node, bool) {
-	return node, true
+func (*colResolverForOnlyFullGroupBy) Leave(ast.Node) bool {
+	return true
 }
 
 type aggColNameResolver struct {
 	colNameResolver
 }
 
-func (*aggColNameResolver) Enter(inNode ast.Node) (ast.Node, bool) {
+func (*aggColNameResolver) Enter(inNode ast.Node) bool {
 	if _, ok := inNode.(*ast.ColumnNameExpr); ok {
-		return inNode, true
+		return true
 	}
-	return inNode, false
+	return false
 }
 
 func allColFromAggExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldName]struct{}) {
@@ -4017,7 +4017,7 @@ func allColFromAggExprNode(p base.LogicalPlan, n ast.Node, names map[*types.Fiel
 			names: names,
 		},
 	}
-	n.Accept(extractor)
+	ast.Walk(n, extractor)
 }
 
 type colNameResolver struct {
@@ -4025,22 +4025,22 @@ type colNameResolver struct {
 	names map[*types.FieldName]struct{}
 }
 
-func (*colNameResolver) Enter(inNode ast.Node) (ast.Node, bool) {
+func (*colNameResolver) Enter(inNode ast.Node) bool {
 	switch inNode.(type) {
 	case *ast.ColumnNameExpr, *ast.SubqueryExpr, *ast.AggregateFuncExpr:
-		return inNode, true
+		return true
 	}
-	return inNode, false
+	return false
 }
 
-func (c *colNameResolver) Leave(inNode ast.Node) (ast.Node, bool) {
+func (c *colNameResolver) Leave(inNode ast.Node) bool {
 	if v, ok := inNode.(*ast.ColumnNameExpr); ok {
 		idx, err := expression.FindFieldName(c.p.OutputNames(), v.Name)
 		if err == nil && idx >= 0 {
 			c.names[c.p.OutputNames()[idx]] = struct{}{}
 		}
 	}
-	return inNode, true
+	return true
 }
 
 func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldName]struct{}) {
@@ -4048,7 +4048,7 @@ func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldNa
 		p:     p,
 		names: names,
 	}
-	n.Accept(extractor)
+	ast.Walk(n, extractor)
 }
 
 // resolveGbyExprs resolves group by expressions from the group by clause of a select statement.
@@ -6158,7 +6158,7 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 	utlr := &updatableTableListResolver{
 		resolveCtx: b.resolveCtx,
 	}
-	update.Accept(utlr)
+	ast.Walk(update, utlr)
 	orderedList, np, allAssignmentsAreConstant, err := b.buildUpdateLists(ctx, utlr.updatableTableList, update.List, p)
 	if err != nil {
 		return nil, err
@@ -7468,15 +7468,15 @@ type updatableTableListResolver struct {
 	resolveCtx         *resolve.Context
 }
 
-func (*updatableTableListResolver) Enter(inNode ast.Node) (ast.Node, bool) {
-	switch v := inNode.(type) {
+func (*updatableTableListResolver) Enter(inNode ast.Node) bool {
+	switch inNode.(type) {
 	case *ast.UpdateStmt, *ast.TableRefsClause, *ast.Join, *ast.TableSource, *ast.TableName:
-		return v, false
+		return false
 	}
-	return inNode, true
+	return true
 }
 
-func (u *updatableTableListResolver) Leave(inNode ast.Node) (ast.Node, bool) {
+func (u *updatableTableListResolver) Leave(inNode ast.Node) bool {
 	if v, ok := inNode.(*ast.TableSource); ok {
 		if s, ok := v.Source.(*ast.TableName); ok {
 			if v.AsName.L != "" {
@@ -7496,7 +7496,7 @@ func (u *updatableTableListResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			}
 		}
 	}
-	return inNode, true
+	return true
 }
 
 // ExtractTableList is a wrapper for tableListExtractor and removes duplicate TableName
@@ -7511,7 +7511,7 @@ func ExtractTableList(node *resolve.NodeW, asName bool) []*ast.TableName {
 		tableNames: []*ast.TableName{},
 		resolveCtx: node.GetResolveContext(),
 	}
-	node.Node.Accept(e)
+	ast.Walk(node.Node, e)
 	tableNames := e.tableNames
 	m := make(map[string]map[string]*ast.TableName) // k1: schemaName, k2: tableName, v: ast.TableName
 	for _, x := range tableNames {
@@ -7540,7 +7540,7 @@ type tableListExtractor struct {
 	resolveCtx *resolve.Context
 }
 
-func (e *tableListExtractor) Enter(n ast.Node) (_ ast.Node, skipChildren bool) {
+func (e *tableListExtractor) Enter(n ast.Node) (skipChildren bool) {
 	innerExtract := func(inner ast.Node, resolveCtx *resolve.Context) []*ast.TableName {
 		if inner == nil {
 			return nil
@@ -7550,7 +7550,7 @@ func (e *tableListExtractor) Enter(n ast.Node) (_ ast.Node, skipChildren bool) {
 			tableNames: []*ast.TableName{},
 			resolveCtx: resolveCtx,
 		}
-		inner.Accept(innerExtractor)
+		ast.Walk(inner, innerExtractor)
 		return innerExtractor.tableNames
 	}
 
@@ -7597,7 +7597,7 @@ func (e *tableListExtractor) Enter(n ast.Node) (_ ast.Node, skipChildren bool) {
 				}
 			}
 		}
-		return n, true
+		return true
 
 	case *ast.ShowStmt:
 		if x.DBName != "" {
@@ -7655,11 +7655,11 @@ func (e *tableListExtractor) Enter(n ast.Node) (_ ast.Node, skipChildren bool) {
 			e.tableNames = append(e.tableNames, innerExtract(v.PreparedAst.Stmt, v.ResolveCtx)...)
 		}
 	}
-	return n, false
+	return false
 }
 
-func (*tableListExtractor) Leave(n ast.Node) (ast.Node, bool) {
-	return n, true
+func (*tableListExtractor) Leave(ast.Node) bool {
+	return true
 }
 
 func collectTableName(node ast.ResultSetNode, updatableName *map[string]bool, info *map[string]*ast.TableName) {

--- a/pkg/planner/indexadvisor/utils.go
+++ b/pkg/planner/indexadvisor/utils.go
@@ -51,25 +51,25 @@ func NormalizeDigest(sqlText string) (normalizedSQL, digest string) {
 
 type nodeVisitor struct {
 	enter func(n ast.Node) (skip bool)
-	leave func(n ast.Node) (ok bool)
+	leave func(n ast.Node) (proceed bool)
 }
 
-func (v *nodeVisitor) Enter(n ast.Node) (out ast.Node, skipChildren bool) {
+func (v *nodeVisitor) Enter(n ast.Node) (skipChildren bool) {
 	if v.enter != nil {
-		return n, v.enter(n)
+		return v.enter(n)
 	}
-	return n, false
+	return false
 }
 
-func (v *nodeVisitor) Leave(n ast.Node) (out ast.Node, ok bool) {
+func (v *nodeVisitor) Leave(n ast.Node) bool {
 	if v.leave != nil {
-		return n, v.leave(n)
+		return v.leave(n)
 	}
-	return n, true
+	return true
 }
 
-func visitNode(n ast.Node, enter func(n ast.Node) (skip bool), leave func(n ast.Node) (ok bool)) {
-	n.Accept(&nodeVisitor{enter, leave})
+func visitNode(n ast.Node, enter func(n ast.Node) (skip bool), leave func(n ast.Node) (proceed bool)) {
+	ast.Walk(n, &nodeVisitor{enter, leave})
 }
 
 // CollectTableNamesFromQuery returns all referenced table names in the given Query text.

--- a/pkg/util/generatedexpr/generated_expr.go
+++ b/pkg/util/generatedexpr/generated_expr.go
@@ -33,25 +33,25 @@ type nameResolver struct {
 	err       error
 }
 
-// Enter implements ast.Visitor interface.
-func (*nameResolver) Enter(inNode ast.Node) (ast.Node, bool) {
-	return inNode, false
+// Enter implements ast.InPlaceVisitor interface.
+func (*nameResolver) Enter(ast.Node) bool {
+	return false
 }
 
-// Leave implements ast.Visitor interface.
-func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
+// Leave implements ast.InPlaceVisitor interface.
+func (nr *nameResolver) Leave(inNode ast.Node) bool {
 	//nolint: revive,all_revive
 	switch v := inNode.(type) {
 	case *ast.ColumnNameExpr:
 		for _, col := range nr.tableInfo.Columns {
 			if col.Name.L == v.Name.Name.L {
-				return inNode, true
+				return true
 			}
 		}
 		nr.err = errors.Errorf("can't find column %s in %s", v.Name.Name.O, nr.tableInfo.Name.O)
-		return inNode, false
+		return false
 	}
-	return inNode, true
+	return true
 }
 
 // ParseExpression parses an ExprNode from a string.
@@ -77,7 +77,7 @@ func ParseExpression(expr string) (node ast.ExprNode, err error) {
 // SimpleResolveName resolves all column names in the expression node.
 func SimpleResolveName(node ast.ExprNode, tblInfo *model.TableInfo) (ast.ExprNode, error) {
 	nr := nameResolver{tblInfo, nil}
-	if _, ok := node.Accept(&nr); !ok {
+	if !ast.Walk(node, &nr) {
 		return nil, errors.Trace(nr.err)
 	}
 	return node, nil

--- a/pkg/util/hint/hint_processor.go
+++ b/pkg/util/hint/hint_processor.go
@@ -429,7 +429,7 @@ func CheckBindingFromHistoryComplete(node ast.Node, hintStr string) (complete bo
 		complete: true,
 		tables:   make(map[ast.CIStr]struct{}, 2),
 	}
-	node.Accept(&checker)
+	ast.Walk(node, &checker)
 	return checker.complete, checker.reason
 }
 
@@ -440,13 +440,13 @@ type bindableChecker struct {
 	tables   map[ast.CIStr]struct{}
 }
 
-// Enter implements Visitor interface.
-func (checker *bindableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *bindableChecker) Enter(in ast.Node) (skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.ExistsSubqueryExpr, *ast.SubqueryExpr:
 		checker.complete = false
 		checker.reason = "auto-generated hint for queries with sub queries might not be complete, the plan might change even after creating this binding"
-		return in, true
+		return true
 	case *ast.TableName:
 		if _, ok := checker.tables[node.Schema]; !ok {
 			checker.tables[node.Name] = struct{}{}
@@ -454,13 +454,13 @@ func (checker *bindableChecker) Enter(in ast.Node) (out ast.Node, skipChildren b
 		if len(checker.tables) >= 3 {
 			checker.complete = false
 			checker.reason = "auto-generated hint for queries with more than 3 table join might not be complete, the plan might change even after creating this binding"
-			return in, true
+			return true
 		}
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *bindableChecker) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, checker.complete
+// Leave implements InPlaceVisitor interface.
+func (checker *bindableChecker) Leave(ast.Node) bool {
+	return checker.complete
 }

--- a/pkg/util/parser/ast.go
+++ b/pkg/util/parser/ast.go
@@ -26,7 +26,7 @@ import (
 // GetDefaultDB checks if all tables in the AST have explicit DBName. If not, return specified DBName.
 func GetDefaultDB(sel ast.StmtNode, dbName string) string {
 	implicitDB := &implicitDatabase{}
-	sel.Accept(implicitDB)
+	ast.Walk(sel, implicitDB)
 	if implicitDB.hasImplicit {
 		return dbName
 	}
@@ -37,20 +37,20 @@ type implicitDatabase struct {
 	hasImplicit bool
 }
 
-func (i *implicitDatabase) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+func (i *implicitDatabase) Enter(in ast.Node) (skipChildren bool) {
 	switch x := in.(type) {
 	case *ast.TableName:
 		if x.Schema.L == "" {
 			i.hasImplicit = true
 		}
-		return in, true
+		return true
 	default:
-		return in, i.hasImplicit
+		return i.hasImplicit
 	}
 }
 
-func (*implicitDatabase) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+func (*implicitDatabase) Leave(ast.Node) bool {
+	return true
 }
 
 func findTablePos(s, t string) int {

--- a/pkg/workloadlearning/handle.go
+++ b/pkg/workloadlearning/handle.go
@@ -710,19 +710,21 @@ type DBNameExtractor struct {
 	DBs map[string]struct{}
 }
 
+var _ ast.InPlaceVisitor = (*DBNameExtractor)(nil)
+
 // Enter is called when entering a node in the AST.
 // It extracts the database name from TableName AST node and saving it in DBs map.
-func (e *DBNameExtractor) Enter(n ast.Node) (ast.Node, bool) {
+func (e *DBNameExtractor) Enter(n ast.Node) bool {
 	if table, ok := n.(*ast.TableName); ok {
 		if e.DBs == nil {
 			e.DBs = make(map[string]struct{})
 		}
 		e.DBs[table.Schema.L] = struct{}{}
 	}
-	return n, false
+	return false
 }
 
 // Leave is called when leaving a node in the AST.
-func (*DBNameExtractor) Leave(n ast.Node) (ast.Node, bool) {
-	return n, true
+func (*DBNameExtractor) Leave(ast.Node) bool {
+	return true
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70622

Problem Summary:

The replacement-capable `ast.Visitor` API publishes returned child nodes back
into their parent AST. Visitors that only inspect nodes do not need replacement,
so using `Node.Accept` for those visitors causes unnecessary AST writes and
prevents otherwise read-only traversals from safely sharing a stable AST.

#70674 migrated the first batch of eligible visitors. Additional read-only
visitors in planner resolution, binding and hint processing, and supporting
utilities still used the replacement-capable traversal.

### What changed and how does it work?

This is part 2 of #70674. It migrates 17 additional non-rewriting visitors from
`ast.Visitor`/`Node.Accept` to `ast.InPlaceVisitor`/`ast.Walk` across planner,
bindinfo, domain, Lightning, generated-expression, hint, parser utility,
workload-learning, and index-advisor code.

The migration preserves the existing traversal order, skip-children decisions,
and early-stop behavior. The planner table-list visitors still update external
resolver state and copied `TableName` values, but do not modify the traversed
AST. All concrete call sites are migrated, including recursive plan-replayer
view traversal. Visitors that modify AST nodes, such as `selectOffsetAssigner`,
remain on the replacement-capable API.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```text
./tools/check/failpoint-go-test.sh pkg/planner/core -run '^(TestExtractTableList|TestGroupByWhenNotExistCols|TestResolvingCorrelatedAggregate|TestVisitInfo|TestNameResolver)$' -count=1
go test ./pkg/planner/core/issuetest -run '^TestOnlyFullGroupCantFeelUnaryConstant$' -tags=intest,deadlock -count=1
./tools/check/failpoint-go-test.sh pkg/bindinfo -run '^(TestExtractTableName|TestGenPlanWithSCtx|TestExplainExploreIndexHints|TestExplainExploreIndexHintWithAlias|TestExplainExploreNoDecorrelateHint|TestPlanGeneration|TestDefaultDB)$' -count=1
go test ./pkg/bindinfo/tests -run '^TestInvalidBindingCheck$' -tags=intest,deadlock -count=1
./tools/check/failpoint-go-test.sh pkg/lightning/mydump -run '^TestParseViewSchemaSQL$' -count=1
go test ./pkg/planner/indexadvisor -run '^(TestCollectTableFromQuery|TestCollectSelectColumnsFromQuery|TestCollectOrderByColumnsFromQuery|TestCollectDNFColumnsFromQuery|TestCollectIndexableColumnsFromQuery)$' -tags=intest,deadlock -count=1
./tools/check/failpoint-go-test.sh pkg/domain -run '^TestExtractHandlePlanTask$' -count=1
./tools/check/failpoint-go-test.sh pkg/executor/test/planreplayer -run '^TestPlanReplayer$' -count=1
./tools/check/failpoint-go-test.sh pkg/table/tables -run '^TestTableFromMeta$' -count=1
./tools/check/failpoint-go-test.sh pkg/infoschema/test/clustertablestest -run '^TestErrorCasesCreateBindingFromHistory$' -count=1
make lint
git diff --check upstream/master...HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQL parsing and analysis to use the current AST traversal mechanism.
  * Preserved existing table, column, parameter, database, view, and dependency extraction behavior.
  * Maintained existing traversal controls, including subtree skipping and scope filtering.
  * Improved compatibility across query planning, hint processing, generated expressions, and workload analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->