### PR TITLE
executor: account statement RU for joins and aggregations

### DIFF
--- a/pkg/executor/statement_ru_plan_walk.go
+++ b/pkg/executor/statement_ru_plan_walk.go
@@ -473,14 +473,14 @@ func calculateStatementRUPlanChildFirst(
 		*physicalop.PhysicalIndexJoin, *physicalop.PhysicalIndexHashJoin,
 		*physicalop.PhysicalIndexMergeJoin:
 		state := collectStatementRUJoinUnits(
-			tree, operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
+			operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
 		)
 		if state != statementRUOperatorComplete {
 			return statementRUOperatorResult{state: state}
 		}
 	case *physicalop.PhysicalHashAgg, *physicalop.PhysicalStreamAgg:
 		state := collectStatementRUAggregationUnits(
-			tree, operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
+			operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
 		)
 		if state != statementRUOperatorComplete {
 			return statementRUOperatorResult{state: state}
@@ -520,13 +520,16 @@ func calculateStatementRUPlanChildFirst(
 	}
 }
 
-// collectStatementRUJoinUnits charges one supported root Join occurrence.
-// CPUWork is (left child rows + right child rows) multiplied by the subtype's
-// audited expression slots; JoinOutputRows is the occurrence's own observed
-// output. HashJoin additionally owns completed lookup-state rows. Cop/TiFlash,
-// FullOuter, mismatched child roles, and incomplete evidence fail closed.
+// collectStatementRUJoinUnits charges one supported root Join occurrence using
+// these formulas:
+//
+//	CPUWork = (left child rows + right child rows) * expression count
+//	JoinOutputRows = output rows
+//	HashStateRows = completed HashJoin lookup-state rows
+//
+// statementRUJoinContractForPlan defines the expression count for each Join
+// subtype. Cop/TiFlash, FullOuter, and incomplete runtime evidence fail closed.
 func collectStatementRUJoinUnits(
-	tree plannercore.FlatPlanTree,
 	operator *plannercore.FlatOperator,
 	children []statementRUOperatorResult,
 	outputRows int64,
@@ -535,29 +538,15 @@ func collectStatementRUJoinUnits(
 	calculator *statementRUCalculator,
 ) statementRUOperatorState {
 	delta := statementRUCalculator{}
-	if operator == nil || !operator.IsRoot || len(children) != 2 ||
-		!children[0].outputRowsObserved || !children[1].outputRowsObserved || !outputRowsObserved {
-		return statementRUOperatorUnsupported
-	}
-	physicalJoin, ok := operator.Origin.(base.PhysicalPlan)
-	if !ok || len(physicalJoin.Children()) != 2 || len(operator.ChildrenIdx) != 2 {
+	if !operator.IsRoot || !children[0].outputRowsObserved || !children[1].outputRowsObserved || !outputRowsObserved {
 		return statementRUOperatorUnsupported
 	}
 	contract, ok := statementRUJoinContractForPlan(operator.Origin)
 	if !ok {
 		return statementRUOperatorUnsupported
 	}
-	for ordinal, childIndex := range operator.ChildrenIdx {
-		if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil {
-			return statementRUOperatorInvalid
-		}
-		if tree[childIndex].Origin != physicalJoin.Children()[ordinal] ||
-			tree[childIndex].Label != contract.childLabels[ordinal] {
-			return statementRUOperatorUnsupported
-		}
-	}
-	inputRows, valid := checkedStatementRURowSum(children[0].outputRows, children[1].outputRows)
-	if !valid || !addStatementRUCPUWork(&delta, float64(inputRows)*float64(contract.expressionCount)) ||
+	inputRows := float64(children[0].outputRows) + float64(children[1].outputRows)
+	if !addStatementRUCPUWork(&delta, inputRows*float64(contract.expressionCount)) ||
 		!addStatementRUJoinOutputRows(&delta, float64(outputRows)) {
 		return statementRUOperatorInvalid
 	}
@@ -586,14 +575,18 @@ func collectStatementRUJoinUnits(
 }
 
 type statementRUJoinContract struct {
-	childLabels     [2]plannercore.OperatorLabel
-	expressionCount int64
+	expressionCount int
 	hashState       bool
 }
 
 // statementRUJoinContractForPlan is the single support matrix for root Join
-// accounting. Each subtype defines its audited expression slots and the
-// build/probe labels expected on its two FlatPlanTree child occurrences.
+// accounting. Its expression count formulas are:
+//
+//	HashJoin       = EqualConditions + NAEqualConditions + LeftConditions + RightConditions + OtherConditions
+//	MergeJoin      = CompareFuncs + LeftConditions + RightConditions + OtherConditions
+//	IndexJoin      = OuterJoinKeys + LeftConditions + RightConditions + OtherConditions + CompareFilters.OpType
+//	IndexHashJoin  = OuterHashKeys + LeftConditions + RightConditions + OtherConditions + CompareFilters.OpType
+//	IndexMergeJoin = CompareFuncs + OuterCompareFuncs + LeftConditions + RightConditions + OtherConditions + CompareFilters.OpType
 func statementRUJoinContractForPlan(plan base.Plan) (statementRUJoinContract, bool) {
 	contract := statementRUJoinContract{}
 	compareFilterCount := func(filters *physicalop.ColWithCmpFuncManager) int {
@@ -602,104 +595,46 @@ func statementRUJoinContractForPlan(plan base.Plan) (statementRUJoinContract, bo
 		}
 		return len(filters.OpType)
 	}
-	indexLabels := func(innerChildIdx int) ([2]plannercore.OperatorLabel, bool) {
-		switch innerChildIdx {
-		case 0:
-			return [2]plannercore.OperatorLabel{plannercore.ProbeSide, plannercore.BuildSide}, true
-		case 1:
-			return [2]plannercore.OperatorLabel{plannercore.BuildSide, plannercore.ProbeSide}, true
-		default:
-			return [2]plannercore.OperatorLabel{}, false
-		}
-	}
 	var joinType base.JoinType
-	var valid bool
 	switch join := plan.(type) {
 	case *physicalop.PhysicalHashJoin:
-		if join.InnerChildIdx < 0 || join.InnerChildIdx > 1 ||
-			len(join.LeftJoinKeys) != len(join.RightJoinKeys) ||
-			len(join.LeftNAJoinKeys) != len(join.RightNAJoinKeys) {
-			return statementRUJoinContract{}, false
-		}
 		joinType = join.JoinType
 		contract.hashState = true
-		if join.UseOuterToBuild {
-			contract.childLabels[join.InnerChildIdx] = plannercore.ProbeSide
-			contract.childLabels[1-join.InnerChildIdx] = plannercore.BuildSide
-		} else {
-			contract.childLabels[join.InnerChildIdx] = plannercore.BuildSide
-			contract.childLabels[1-join.InnerChildIdx] = plannercore.ProbeSide
-		}
-		contract.expressionCount, valid = checkedStatementRUExpressionCount(
-			len(join.EqualConditions), len(join.NAEqualConditions), len(join.LeftConditions),
-			len(join.RightConditions), len(join.OtherConditions),
-		)
+		contract.expressionCount = len(join.EqualConditions) + len(join.NAEqualConditions) +
+			len(join.LeftConditions) + len(join.RightConditions) + len(join.OtherConditions)
 	case *physicalop.PhysicalMergeJoin:
-		if len(join.LeftJoinKeys) != len(join.RightJoinKeys) {
-			return statementRUJoinContract{}, false
-		}
 		joinType = join.JoinType
-		contract.childLabels = [2]plannercore.OperatorLabel{plannercore.ProbeSide, plannercore.BuildSide}
-		if join.JoinType == base.RightOuterJoin {
-			contract.childLabels = [2]plannercore.OperatorLabel{plannercore.BuildSide, plannercore.ProbeSide}
-		}
-		contract.expressionCount, valid = checkedStatementRUExpressionCount(
-			len(join.CompareFuncs), len(join.LeftConditions), len(join.RightConditions), len(join.OtherConditions),
-		)
+		contract.expressionCount = len(join.CompareFuncs) + len(join.LeftConditions) +
+			len(join.RightConditions) + len(join.OtherConditions)
 	case *physicalop.PhysicalIndexJoin:
-		if len(join.OuterJoinKeys) != len(join.InnerJoinKeys) {
-			return statementRUJoinContract{}, false
-		}
 		joinType = join.JoinType
-		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
-		if !valid {
-			return statementRUJoinContract{}, false
-		}
-		contract.expressionCount, valid = checkedStatementRUExpressionCount(
-			len(join.OuterJoinKeys), len(join.LeftConditions), len(join.RightConditions),
-			len(join.OtherConditions), compareFilterCount(join.CompareFilters),
-		)
+		contract.expressionCount = len(join.OuterJoinKeys) + len(join.LeftConditions) +
+			len(join.RightConditions) + len(join.OtherConditions) + compareFilterCount(join.CompareFilters)
 	case *physicalop.PhysicalIndexHashJoin:
-		if len(join.OuterHashKeys) != len(join.InnerHashKeys) {
-			return statementRUJoinContract{}, false
-		}
 		joinType = join.JoinType
-		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
-		if !valid {
-			return statementRUJoinContract{}, false
-		}
-		contract.expressionCount, valid = checkedStatementRUExpressionCount(
-			len(join.OuterHashKeys), len(join.LeftConditions), len(join.RightConditions),
-			len(join.OtherConditions), compareFilterCount(join.CompareFilters),
-		)
+		contract.expressionCount = len(join.OuterHashKeys) + len(join.LeftConditions) +
+			len(join.RightConditions) + len(join.OtherConditions) + compareFilterCount(join.CompareFilters)
 	case *physicalop.PhysicalIndexMergeJoin:
-		if join.NeedOuterSort != (len(join.OuterCompareFuncs) > 0) {
-			return statementRUJoinContract{}, false
-		}
 		joinType = join.JoinType
-		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
-		if !valid {
-			return statementRUJoinContract{}, false
-		}
-		contract.expressionCount, valid = checkedStatementRUExpressionCount(
-			len(join.CompareFuncs), len(join.OuterCompareFuncs), len(join.LeftConditions),
-			len(join.RightConditions), len(join.OtherConditions), compareFilterCount(join.CompareFilters),
-		)
+		contract.expressionCount = len(join.CompareFuncs) + len(join.OuterCompareFuncs) +
+			len(join.LeftConditions) + len(join.RightConditions) + len(join.OtherConditions) +
+			compareFilterCount(join.CompareFilters)
 	default:
 		return statementRUJoinContract{}, false
 	}
-	return contract, valid && joinType != base.FullOuterJoin
+	return contract, joinType != base.FullOuterJoin
 }
 
 // collectStatementRUAggregationUnits charges one supported root or TiKV cop
-// Aggregation occurrence. CPUWork is child rows multiplied by GroupByItems plus
-// AggFuncs. Root HashAgg owns completed producer group-map state; TiKV HashAgg
-// uses observed response-summary output as produced group state. A response
-// with a missing summary contributes no rows while other valid responses remain
-// chargeable. StreamAgg has no hash state. TiFlash, malformed evidence, and an
-// occurrence with no valid summary remain unsupported.
+// Aggregation occurrence using these formulas:
+//
+//	CPUWork = child rows * (GroupByItems + AggFuncs)
+//	HashStateRows = completed root HashAgg group-map rows, or observed TiKV HashAgg output rows
+//
+// A response with a missing summary contributes no rows while other valid
+// responses remain chargeable. StreamAgg has no hash state. TiFlash, malformed
+// evidence, and an occurrence with no valid summary remain unsupported.
 func collectStatementRUAggregationUnits(
-	tree plannercore.FlatPlanTree,
 	operator *plannercore.FlatOperator,
 	children []statementRUOperatorResult,
 	outputRows int64,
@@ -708,19 +643,7 @@ func collectStatementRUAggregationUnits(
 	calculator *statementRUCalculator,
 ) statementRUOperatorState {
 	delta := statementRUCalculator{}
-	if operator == nil || !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 ||
-		!children[0].outputRowsObserved || !outputRowsObserved || len(operator.ChildrenIdx) != 1 {
-		return statementRUOperatorUnsupported
-	}
-	physicalAgg, ok := operator.Origin.(base.PhysicalPlan)
-	if !ok || len(physicalAgg.Children()) != 1 {
-		return statementRUOperatorUnsupported
-	}
-	childIndex := operator.ChildrenIdx[0]
-	if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil {
-		return statementRUOperatorInvalid
-	}
-	if tree[childIndex].Origin != physicalAgg.Children()[0] {
+	if !statementRUOperatorRunsAtSupportedSite(operator) || !children[0].outputRowsObserved || !outputRowsObserved {
 		return statementRUOperatorUnsupported
 	}
 	var baseAgg *physicalop.BasePhysicalAgg
@@ -734,8 +657,8 @@ func collectStatementRUAggregationUnits(
 	default:
 		return statementRUOperatorUnsupported
 	}
-	expressionCount, ok := checkedStatementRUExpressionCount(len(baseAgg.GroupByItems), len(baseAgg.AggFuncs))
-	if !ok || !addStatementRUCPUWork(
+	expressionCount := len(baseAgg.GroupByItems) + len(baseAgg.AggFuncs)
+	if !addStatementRUCPUWork(
 		&delta,
 		float64(children[0].outputRows)*float64(expressionCount),
 	) {
@@ -779,24 +702,6 @@ func collectStatementRUAggregationUnits(
 		return statementRUOperatorInvalid
 	}
 	return statementRUOperatorComplete
-}
-
-func checkedStatementRUExpressionCount(parts ...int) (int64, bool) {
-	var total int64
-	for _, part := range parts {
-		if part < 0 || int64(part) > math.MaxInt64-total {
-			return 0, false
-		}
-		total += int64(part)
-	}
-	return total, true
-}
-
-func checkedStatementRURowSum(left, right int64) (int64, bool) {
-	if left < 0 || right < 0 || left > math.MaxInt64-right {
-		return 0, false
-	}
-	return left + right, true
 }
 
 func mergeStatementRUOperatorState(left, right statementRUOperatorState) statementRUOperatorState {

--- a/pkg/executor/statement_ru_plan_walk.go
+++ b/pkg/executor/statement_ru_plan_walk.go
@@ -51,8 +51,9 @@ const (
 // that this supported occurrence was calculated from the evidence currently
 // visible at finalization; it does not claim producer-side evidence coverage.
 type statementRUOperatorResult struct {
-	state      statementRUOperatorState
-	outputRows int64
+	state              statementRUOperatorState
+	outputRows         int64
+	outputRowsObserved bool
 }
 
 type statementRUOperatorRU struct {
@@ -182,7 +183,7 @@ func (a *ExecStmt) finishStatementRU(terminalErr error) {
 		}
 
 		// The fresh-session slice must use a flat plan rooted at this ExecStmt.
-		// General flat-plan generation identity remains outside this layer.
+		// General flat-plan generation identity is not statement-RU evidence.
 		if len(flat.Main) == 0 || flat.Main[0] == nil || flat.Main[0].Origin != a.Plan {
 			return
 		}
@@ -241,10 +242,9 @@ func calculateStatementRUInternal(
 		return statementRUFinalizedSnapshot{}, false
 	}
 	calculator := newStatementRUCalculator(setup)
-	// Transport bytes are statement evidence in both the current producer and
-	// the demo model. Read them once; do not attribute the same aggregate to
-	// every Reader occurrence. Missing evidence contributes zero to the
-	// best-effort ResultOnly value.
+	// Transport bytes are statement-owned evidence. Read them once; do not
+	// attribute the same aggregate to every Reader occurrence. Missing evidence
+	// contributes zero to the best-effort ResultOnly value.
 	if metrics != nil && !metrics.Bypass() {
 		netBytes := metrics.TiKVCoprocessorResponseBytes()
 		if netBytes < 0 {
@@ -328,11 +328,24 @@ func calculateStatementRUPlanChildFirst(
 	}
 
 	outputRows := int64(0)
+	outputRowsObserved := false
 	if runtimeStatsColl != nil {
 		if operator.IsRoot {
-			outputRows = runtimeStatsColl.GetPlanActRows(operator.Origin.ID())
+			snapshot := runtimeStatsColl.GetRootRowsSnapshot(operator.Origin.ID())
+			if snapshot.Invalid() {
+				return statementRUOperatorResult{state: statementRUOperatorInvalid}
+			}
+			outputRows = snapshot.Rows
+			outputRowsObserved = snapshot.Observed()
 		} else {
-			_, outputRows = runtimeStatsColl.GetCopCountAndRows(operator.Origin.ID())
+			snapshot := runtimeStatsColl.GetCopRowsSnapshot(operator.Origin.ID())
+			if snapshot.Invalid {
+				return statementRUOperatorResult{state: statementRUOperatorInvalid}
+			}
+			outputRows = snapshot.Rows
+			// Missing summary slots remain marked by Complete, but do not discard
+			// rows from other valid responses for the same cop occurrence.
+			outputRowsObserved = snapshot.Observed()
 		}
 	}
 	if outputRows < 0 {
@@ -456,6 +469,22 @@ func calculateStatementRUPlanChildFirst(
 		if !addStatementRUCPUWork(calculator, float64(children[0].outputRows)) {
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
+	case *physicalop.PhysicalHashJoin, *physicalop.PhysicalMergeJoin,
+		*physicalop.PhysicalIndexJoin, *physicalop.PhysicalIndexHashJoin,
+		*physicalop.PhysicalIndexMergeJoin:
+		state := collectStatementRUJoinUnits(
+			tree, operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
+		)
+		if state != statementRUOperatorComplete {
+			return statementRUOperatorResult{state: state}
+		}
+	case *physicalop.PhysicalHashAgg, *physicalop.PhysicalStreamAgg:
+		state := collectStatementRUAggregationUnits(
+			tree, operator, children, outputRows, outputRowsObserved, runtimeStatsColl, calculator,
+		)
+		if state != statementRUOperatorComplete {
+			return statementRUOperatorResult{state: state}
+		}
 	case *physicalop.PhysicalTableScan, *physicalop.PhysicalIndexScan:
 		// TableScan and IndexScan do not contribute units directly. Their scan
 		// evidence is accounted for by the owning Reader boundary.
@@ -484,7 +513,290 @@ func calculateStatementRUPlanChildFirst(
 		}
 	}
 
-	return statementRUOperatorResult{state: statementRUOperatorComplete, outputRows: outputRows}
+	return statementRUOperatorResult{
+		state:              statementRUOperatorComplete,
+		outputRows:         outputRows,
+		outputRowsObserved: outputRowsObserved,
+	}
+}
+
+// collectStatementRUJoinUnits charges one supported root Join occurrence.
+// CPUWork is (left child rows + right child rows) multiplied by the subtype's
+// audited expression slots; JoinOutputRows is the occurrence's own observed
+// output. HashJoin additionally owns completed lookup-state rows. Cop/TiFlash,
+// FullOuter, mismatched child roles, and incomplete evidence fail closed.
+func collectStatementRUJoinUnits(
+	tree plannercore.FlatPlanTree,
+	operator *plannercore.FlatOperator,
+	children []statementRUOperatorResult,
+	outputRows int64,
+	outputRowsObserved bool,
+	runtimeStatsColl *execdetails.RuntimeStatsColl,
+	calculator *statementRUCalculator,
+) statementRUOperatorState {
+	delta := statementRUCalculator{}
+	if operator == nil || !operator.IsRoot || len(children) != 2 ||
+		!children[0].outputRowsObserved || !children[1].outputRowsObserved || !outputRowsObserved {
+		return statementRUOperatorUnsupported
+	}
+	physicalJoin, ok := operator.Origin.(base.PhysicalPlan)
+	if !ok || len(physicalJoin.Children()) != 2 || len(operator.ChildrenIdx) != 2 {
+		return statementRUOperatorUnsupported
+	}
+	contract, ok := statementRUJoinContractForPlan(operator.Origin)
+	if !ok {
+		return statementRUOperatorUnsupported
+	}
+	for ordinal, childIndex := range operator.ChildrenIdx {
+		if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil {
+			return statementRUOperatorInvalid
+		}
+		if tree[childIndex].Origin != physicalJoin.Children()[ordinal] ||
+			tree[childIndex].Label != contract.childLabels[ordinal] {
+			return statementRUOperatorUnsupported
+		}
+	}
+	inputRows, valid := checkedStatementRURowSum(children[0].outputRows, children[1].outputRows)
+	if !valid || !addStatementRUCPUWork(&delta, float64(inputRows)*float64(contract.expressionCount)) ||
+		!addStatementRUJoinOutputRows(&delta, float64(outputRows)) {
+		return statementRUOperatorInvalid
+	}
+	if contract.hashState {
+		if runtimeStatsColl == nil {
+			return statementRUOperatorUnsupported
+		}
+		snapshot, found := runtimeStatsColl.GetRootHashStateRowsSnapshot(operator.Origin.ID())
+		if !found {
+			return statementRUOperatorUnsupported
+		}
+		if !snapshot.Complete() {
+			if snapshot.Invalid() {
+				return statementRUOperatorInvalid
+			}
+			return statementRUOperatorUnsupported
+		}
+		if !addStatementRUHashStateRows(&delta, float64(snapshot.Rows)) {
+			return statementRUOperatorInvalid
+		}
+	}
+	if !mergeStatementRUUnitDelta(calculator, delta.units) {
+		return statementRUOperatorInvalid
+	}
+	return statementRUOperatorComplete
+}
+
+type statementRUJoinContract struct {
+	childLabels     [2]plannercore.OperatorLabel
+	expressionCount int64
+	hashState       bool
+}
+
+// statementRUJoinContractForPlan is the single support matrix for root Join
+// accounting. Each subtype defines its audited expression slots and the
+// build/probe labels expected on its two FlatPlanTree child occurrences.
+func statementRUJoinContractForPlan(plan base.Plan) (statementRUJoinContract, bool) {
+	contract := statementRUJoinContract{}
+	compareFilterCount := func(filters *physicalop.ColWithCmpFuncManager) int {
+		if filters == nil {
+			return 0
+		}
+		return len(filters.OpType)
+	}
+	indexLabels := func(innerChildIdx int) ([2]plannercore.OperatorLabel, bool) {
+		switch innerChildIdx {
+		case 0:
+			return [2]plannercore.OperatorLabel{plannercore.ProbeSide, plannercore.BuildSide}, true
+		case 1:
+			return [2]plannercore.OperatorLabel{plannercore.BuildSide, plannercore.ProbeSide}, true
+		default:
+			return [2]plannercore.OperatorLabel{}, false
+		}
+	}
+	var joinType base.JoinType
+	var valid bool
+	switch join := plan.(type) {
+	case *physicalop.PhysicalHashJoin:
+		if join.InnerChildIdx < 0 || join.InnerChildIdx > 1 ||
+			len(join.LeftJoinKeys) != len(join.RightJoinKeys) ||
+			len(join.LeftNAJoinKeys) != len(join.RightNAJoinKeys) {
+			return statementRUJoinContract{}, false
+		}
+		joinType = join.JoinType
+		contract.hashState = true
+		if join.UseOuterToBuild {
+			contract.childLabels[join.InnerChildIdx] = plannercore.ProbeSide
+			contract.childLabels[1-join.InnerChildIdx] = plannercore.BuildSide
+		} else {
+			contract.childLabels[join.InnerChildIdx] = plannercore.BuildSide
+			contract.childLabels[1-join.InnerChildIdx] = plannercore.ProbeSide
+		}
+		contract.expressionCount, valid = checkedStatementRUExpressionCount(
+			len(join.EqualConditions), len(join.NAEqualConditions), len(join.LeftConditions),
+			len(join.RightConditions), len(join.OtherConditions),
+		)
+	case *physicalop.PhysicalMergeJoin:
+		if len(join.LeftJoinKeys) != len(join.RightJoinKeys) {
+			return statementRUJoinContract{}, false
+		}
+		joinType = join.JoinType
+		contract.childLabels = [2]plannercore.OperatorLabel{plannercore.ProbeSide, plannercore.BuildSide}
+		if join.JoinType == base.RightOuterJoin {
+			contract.childLabels = [2]plannercore.OperatorLabel{plannercore.BuildSide, plannercore.ProbeSide}
+		}
+		contract.expressionCount, valid = checkedStatementRUExpressionCount(
+			len(join.CompareFuncs), len(join.LeftConditions), len(join.RightConditions), len(join.OtherConditions),
+		)
+	case *physicalop.PhysicalIndexJoin:
+		if len(join.OuterJoinKeys) != len(join.InnerJoinKeys) {
+			return statementRUJoinContract{}, false
+		}
+		joinType = join.JoinType
+		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
+		if !valid {
+			return statementRUJoinContract{}, false
+		}
+		contract.expressionCount, valid = checkedStatementRUExpressionCount(
+			len(join.OuterJoinKeys), len(join.LeftConditions), len(join.RightConditions),
+			len(join.OtherConditions), compareFilterCount(join.CompareFilters),
+		)
+	case *physicalop.PhysicalIndexHashJoin:
+		if len(join.OuterHashKeys) != len(join.InnerHashKeys) {
+			return statementRUJoinContract{}, false
+		}
+		joinType = join.JoinType
+		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
+		if !valid {
+			return statementRUJoinContract{}, false
+		}
+		contract.expressionCount, valid = checkedStatementRUExpressionCount(
+			len(join.OuterHashKeys), len(join.LeftConditions), len(join.RightConditions),
+			len(join.OtherConditions), compareFilterCount(join.CompareFilters),
+		)
+	case *physicalop.PhysicalIndexMergeJoin:
+		if join.NeedOuterSort != (len(join.OuterCompareFuncs) > 0) {
+			return statementRUJoinContract{}, false
+		}
+		joinType = join.JoinType
+		contract.childLabels, valid = indexLabels(join.InnerChildIdx)
+		if !valid {
+			return statementRUJoinContract{}, false
+		}
+		contract.expressionCount, valid = checkedStatementRUExpressionCount(
+			len(join.CompareFuncs), len(join.OuterCompareFuncs), len(join.LeftConditions),
+			len(join.RightConditions), len(join.OtherConditions), compareFilterCount(join.CompareFilters),
+		)
+	default:
+		return statementRUJoinContract{}, false
+	}
+	return contract, valid && joinType != base.FullOuterJoin
+}
+
+// collectStatementRUAggregationUnits charges one supported root or TiKV cop
+// Aggregation occurrence. CPUWork is child rows multiplied by GroupByItems plus
+// AggFuncs. Root HashAgg owns completed producer group-map state; TiKV HashAgg
+// uses observed response-summary output as produced group state. A response
+// with a missing summary contributes no rows while other valid responses remain
+// chargeable. StreamAgg has no hash state. TiFlash, malformed evidence, and an
+// occurrence with no valid summary remain unsupported.
+func collectStatementRUAggregationUnits(
+	tree plannercore.FlatPlanTree,
+	operator *plannercore.FlatOperator,
+	children []statementRUOperatorResult,
+	outputRows int64,
+	outputRowsObserved bool,
+	runtimeStatsColl *execdetails.RuntimeStatsColl,
+	calculator *statementRUCalculator,
+) statementRUOperatorState {
+	delta := statementRUCalculator{}
+	if operator == nil || !statementRUOperatorRunsAtSupportedSite(operator) || len(children) != 1 ||
+		!children[0].outputRowsObserved || !outputRowsObserved || len(operator.ChildrenIdx) != 1 {
+		return statementRUOperatorUnsupported
+	}
+	physicalAgg, ok := operator.Origin.(base.PhysicalPlan)
+	if !ok || len(physicalAgg.Children()) != 1 {
+		return statementRUOperatorUnsupported
+	}
+	childIndex := operator.ChildrenIdx[0]
+	if childIndex < 0 || childIndex >= len(tree) || tree[childIndex] == nil {
+		return statementRUOperatorInvalid
+	}
+	if tree[childIndex].Origin != physicalAgg.Children()[0] {
+		return statementRUOperatorUnsupported
+	}
+	var baseAgg *physicalop.BasePhysicalAgg
+	hashAgg := false
+	switch agg := operator.Origin.(type) {
+	case *physicalop.PhysicalHashAgg:
+		hashAgg = true
+		baseAgg = &agg.BasePhysicalAgg
+	case *physicalop.PhysicalStreamAgg:
+		baseAgg = &agg.BasePhysicalAgg
+	default:
+		return statementRUOperatorUnsupported
+	}
+	expressionCount, ok := checkedStatementRUExpressionCount(len(baseAgg.GroupByItems), len(baseAgg.AggFuncs))
+	if !ok || !addStatementRUCPUWork(
+		&delta,
+		float64(children[0].outputRows)*float64(expressionCount),
+	) {
+		return statementRUOperatorInvalid
+	}
+	if !hashAgg {
+		if !mergeStatementRUUnitDelta(calculator, delta.units) {
+			return statementRUOperatorInvalid
+		}
+		return statementRUOperatorComplete
+	}
+	if runtimeStatsColl == nil {
+		return statementRUOperatorUnsupported
+	}
+	if operator.IsRoot {
+		snapshot, found := runtimeStatsColl.GetRootHashStateRowsSnapshot(operator.Origin.ID())
+		if !found {
+			return statementRUOperatorUnsupported
+		}
+		if !snapshot.Complete() {
+			if snapshot.Invalid() {
+				return statementRUOperatorInvalid
+			}
+			return statementRUOperatorUnsupported
+		}
+		if !addStatementRUHashStateRows(&delta, float64(snapshot.Rows)) {
+			return statementRUOperatorInvalid
+		}
+		if !mergeStatementRUUnitDelta(calculator, delta.units) {
+			return statementRUOperatorInvalid
+		}
+		return statementRUOperatorComplete
+	}
+	// Each valid TiKV HashAgg execution summary reports the group states produced
+	// by that response. Missing response summaries are marked by execdetails and
+	// skipped; outputRows contains only the observed summaries.
+	if !addStatementRUHashStateRows(&delta, float64(outputRows)) {
+		return statementRUOperatorInvalid
+	}
+	if !mergeStatementRUUnitDelta(calculator, delta.units) {
+		return statementRUOperatorInvalid
+	}
+	return statementRUOperatorComplete
+}
+
+func checkedStatementRUExpressionCount(parts ...int) (int64, bool) {
+	var total int64
+	for _, part := range parts {
+		if part < 0 || int64(part) > math.MaxInt64-total {
+			return 0, false
+		}
+		total += int64(part)
+	}
+	return total, true
+}
+
+func checkedStatementRURowSum(left, right int64) (int64, bool) {
+	if left < 0 || right < 0 || left > math.MaxInt64-right {
+		return 0, false
+	}
+	return left + right, true
 }
 
 func mergeStatementRUOperatorState(left, right statementRUOperatorState) statementRUOperatorState {
@@ -587,12 +899,48 @@ func addStatementRUScanBytes(calculator *statementRUCalculator, scanBytes float6
 	return !math.IsInf(calculator.units.ScanBytes, 0)
 }
 
+func addStatementRUHashStateRows(calculator *statementRUCalculator, rows float64) bool {
+	if calculator == nil || rows < 0 || math.IsNaN(rows) || math.IsInf(rows, 0) {
+		return false
+	}
+	calculator.units.HashStateRows += rows
+	return !math.IsInf(calculator.units.HashStateRows, 0)
+}
+
+func addStatementRUJoinOutputRows(calculator *statementRUCalculator, rows float64) bool {
+	if calculator == nil || rows < 0 || math.IsNaN(rows) || math.IsInf(rows, 0) {
+		return false
+	}
+	calculator.units.JoinOutputRows += rows
+	return !math.IsInf(calculator.units.JoinOutputRows, 0)
+}
+
+// mergeStatementRUUnitDelta commits one fully validated operator occurrence.
+// Mutating a copy prevents a later field overflow from retaining a partial
+// occurrence in the statement-local calculator.
+func mergeStatementRUUnitDelta(calculator *statementRUCalculator, delta statementRURawUnits) bool {
+	if calculator == nil {
+		return false
+	}
+	merged := *calculator
+	if !addStatementRUCPUWork(&merged, delta.CPUWork) ||
+		!addStatementRUScanBytes(&merged, delta.ScanBytes) ||
+		!addStatementRUHashStateRows(&merged, delta.HashStateRows) ||
+		!addStatementRUJoinOutputRows(&merged, delta.JoinOutputRows) {
+		return false
+	}
+	*calculator = merged
+	return true
+}
+
 func addStatementRURawUnits(left, right statementRURawUnits) statementRURawUnits {
 	return statementRURawUnits{
 		CPUWork:              left.CPUWork + right.CPUWork,
 		ScanBytes:            left.ScanBytes + right.ScanBytes,
 		NetBytes:             left.NetBytes + right.NetBytes,
 		FrontendCompileBytes: left.FrontendCompileBytes + right.FrontendCompileBytes,
+		HashStateRows:        left.HashStateRows + right.HashStateRows,
+		JoinOutputRows:       left.JoinOutputRows + right.JoinOutputRows,
 	}
 }
 
@@ -602,5 +950,7 @@ func subtractStatementRURawUnits(left, right statementRURawUnits) statementRURaw
 		ScanBytes:            left.ScanBytes - right.ScanBytes,
 		NetBytes:             left.NetBytes - right.NetBytes,
 		FrontendCompileBytes: left.FrontendCompileBytes - right.FrontendCompileBytes,
+		HashStateRows:        left.HashStateRows - right.HashStateRows,
+		JoinOutputRows:       left.JoinOutputRows - right.JoinOutputRows,
 	}
 }

--- a/pkg/executor/statement_ru_plan_walk_bench_test.go
+++ b/pkg/executor/statement_ru_plan_walk_bench_test.go
@@ -17,7 +17,10 @@ package executor
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/kv"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 var (
@@ -68,6 +71,57 @@ func BenchmarkStatementRUOperatorCalculation(b *testing.B) {
 	}
 }
 
+func BenchmarkStatementRUJoinAggOperatorCalculation(b *testing.B) {
+	b.Run("join", func(b *testing.B) {
+		// This timer contains the Join occurrence's checked input sum and typed
+		// CPU/output/state accumulation. It excludes evidence lookup and traversal.
+		b.ReportAllocs()
+		for b.Loop() {
+			calculator := statementRUCalculator{}
+			inputRows, valid := checkedStatementRURowSum(100, 50)
+			valid = valid && addStatementRUCPUWork(&calculator, float64(inputRows)*3)
+			valid = valid && addStatementRUJoinOutputRows(&calculator, 40)
+			valid = valid && addStatementRUHashStateRows(&calculator, 50)
+			statementRUCalculatorSink = calculator
+			statementRUCalculatedSink = valid
+		}
+	})
+
+	b.Run("hash-aggregation", func(b *testing.B) {
+		// This timer contains the HashAgg occurrence's CPU/state accumulation.
+		// It excludes executor group-map construction and evidence lookup.
+		b.ReportAllocs()
+		for b.Loop() {
+			calculator := statementRUCalculator{}
+			valid := addStatementRUCPUWork(&calculator, 100*3)
+			valid = valid && addStatementRUHashStateRows(&calculator, 25)
+			statementRUCalculatorSink = calculator
+			statementRUCalculatedSink = valid
+		}
+	})
+}
+
+func BenchmarkStatementRUExecutionDetailsAggregation(b *testing.B) {
+	zero := uint64(0)
+	rows := uint64(25)
+	summary := &tipb.ExecutorExecutionSummary{
+		TimeProcessedNs: &zero,
+		NumProducedRows: &rows,
+		NumIterations:   &zero,
+	}
+	var reuse *execdetails.RuntimeStatsColl
+
+	// This timer covers one cop-response expectation, typed summary merge, and
+	// value-only snapshot. It excludes protobuf decoding and network transport.
+	b.ReportAllocs()
+	for b.Loop() {
+		reuse = execdetails.NewRuntimeStatsColl(reuse)
+		reuse.RecordExpectedCopResponseSummaries([]int{1})
+		reuse.RecordOneCopTask(1, kv.TiKV, summary)
+		statementRUCalculatedSink = reuse.GetCopRowsSnapshot(1).Observed()
+	}
+}
+
 func BenchmarkStatementRUTreeTraversal(b *testing.B) {
 	fixture := newStatementRUSimpleSelectFixture(b)
 	flat := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
@@ -99,6 +153,8 @@ func BenchmarkStatementRUFinalizePublication(b *testing.B) {
 			ScanBytes:            10,
 			NetBytes:             20,
 			FrontendCompileBytes: fixture.owner.calculationSetup.frontendCompileBytes,
+			HashStateRows:        7,
+			JoinOutputRows:       8,
 		},
 	}
 

--- a/pkg/executor/statement_ru_plan_walk_bench_test.go
+++ b/pkg/executor/statement_ru_plan_walk_bench_test.go
@@ -73,13 +73,12 @@ func BenchmarkStatementRUOperatorCalculation(b *testing.B) {
 
 func BenchmarkStatementRUJoinAggOperatorCalculation(b *testing.B) {
 	b.Run("join", func(b *testing.B) {
-		// This timer contains the Join occurrence's checked input sum and typed
-		// CPU/output/state accumulation. It excludes evidence lookup and traversal.
+		// This timer contains the Join occurrence's typed CPU/output/state
+		// accumulation. It excludes evidence lookup and traversal.
 		b.ReportAllocs()
 		for b.Loop() {
 			calculator := statementRUCalculator{}
-			inputRows, valid := checkedStatementRURowSum(100, 50)
-			valid = valid && addStatementRUCPUWork(&calculator, float64(inputRows)*3)
+			valid := addStatementRUCPUWork(&calculator, (100+50)*3)
 			valid = valid && addStatementRUJoinOutputRows(&calculator, 40)
 			valid = valid && addStatementRUHashStateRows(&calculator, 50)
 			statementRUCalculatorSink = calculator

--- a/pkg/executor/statement_ru_plan_walk_integration_test.go
+++ b/pkg/executor/statement_ru_plan_walk_integration_test.go
@@ -203,6 +203,12 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 		tk.MustExec("use test")
 		tk.MustExec("create table t(a int primary key, b int, c int, index idx_b(b))")
 		tk.MustExec("insert into t values (1, 10, 100), (2, 20, 200), (3, 30, 300)")
+		tk.MustExec("create table nullable_join(a int)")
+		tk.MustExec("insert into nullable_join values (1), (null), (2)")
+		tk.MustExec("create table naaj_a(a int, b int, c int)")
+		tk.MustExec("create table naaj_b(a int, b int, c int)")
+		tk.MustExec("insert into naaj_a values (1, 1, 1)")
+		tk.MustExec("insert into naaj_b values (1, 2, 2), (1, null, 3)")
 		tk.MustExec("set @@tidb_enable_non_prepared_plan_cache = off")
 
 		var observation *statementRUObservation
@@ -212,12 +218,14 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 			}
 		})
 		type calibrationObservation struct {
-			count         int
-			state         string
-			cpuWork       float64
-			scanBytes     float64
-			netBytes      float64
-			frontendBytes float64
+			count          int
+			state          string
+			cpuWork        float64
+			scanBytes      float64
+			netBytes       float64
+			frontendBytes  float64
+			hashStateRows  float64
+			joinOutputRows float64
 		}
 		connectionID := tk.Session().GetSessionVars().ConnectionID
 		var calibrationMu sync.Mutex
@@ -225,7 +233,7 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 		testfailpoint.EnableCall(t, statementRUCalibrationUnitsFailpoint, func(
 			observedConnectionID uint64,
 			state string,
-			cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
+			cpuWork, scanBytes, netBytes, frontendCompileBytes, hashStateRows, joinOutputRows float64,
 		) {
 			if observedConnectionID != connectionID {
 				return
@@ -238,16 +246,24 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 			calibration.scanBytes = scanBytes
 			calibration.netBytes = netBytes
 			calibration.frontendBytes = frontendCompileBytes
+			calibration.hashStateRows = hashStateRows
+			calibration.joinOutputRows = joinOutputRows
 		})
 		type operatorExpectation func(base.Plan) bool
 		testCases := []struct {
 			name           string
+			before         []string
+			after          []string
 			query          string
 			rows           [][]any
 			expectOperator operatorExpectation
 			sortRows       bool
 			wantPublish    bool
 			wantCPUWork    bool
+			wantHashState  bool
+			wantHashRows   float64
+			wantJoinOutput bool
+			wantRootAndCop bool
 		}{
 			{name: "Selection", query: "select * from t ignore index (idx_b) where b > 10", rows: testkit.Rows("2 20 200", "3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSelection], sortRows: true, wantPublish: true, wantCPUWork: true},
 			{name: "Sort", query: "select * from t ignore index (idx_b) order by b desc", rows: testkit.Rows("3 30 300", "2 20 200", "1 10 100"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSort], wantPublish: true, wantCPUWork: true},
@@ -255,10 +271,28 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 			{name: "Limit", query: "select * from t ignore index (idx_b) limit 2", rows: testkit.Rows("1 10 100", "2 20 200"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalLimit], wantPublish: true, wantCPUWork: true},
 			{name: "IndexReader", query: "select b from t use index (idx_b) where b >= 20", rows: testkit.Rows("20", "30"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexReader], sortRows: true, wantPublish: true},
 			{name: "IndexLookup", query: "select * from t use index (idx_b) where b >= 20", rows: testkit.Rows("2 20 200", "3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexLookUpReader], sortRows: true, wantPublish: true},
+			{name: "HashJoin optimized", before: []string{"set tidb_hash_join_version = 'optimized'"}, query: "select /*+ HASH_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a", rows: testkit.Rows("1 10 100 1 10 100", "2 20 200 2 20 200", "3 30 300 3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantHashState: true, wantJoinOutput: true},
+			{name: "HashJoin legacy", before: []string{"set tidb_hash_join_version = 'legacy'"}, after: []string{"set tidb_hash_join_version = 'optimized'"}, query: "select /*+ HASH_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a", rows: testkit.Rows("1 10 100 1 10 100", "2 20 200 2 20 200", "3 30 300 3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantHashState: true, wantJoinOutput: true},
+			{name: "HashJoin legacy excludes ordinary null keys", before: []string{"set tidb_hash_join_version = 'legacy'"}, after: []string{"set tidb_hash_join_version = 'optimized'"}, query: "select /*+ HASH_JOIN(n1, n2) */ * from nullable_join n1 join nullable_join n2 on n1.a = n2.a", rows: testkit.Rows("1 1", "2 2"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantHashState: true, wantHashRows: 2, wantJoinOutput: true},
+			{name: "HashJoin legacy NAAJ includes null bucket", before: []string{"set tidb_hash_join_version = 'legacy'", "set tidb_enable_null_aware_anti_join = on"}, after: []string{"set tidb_enable_null_aware_anti_join = default", "set tidb_hash_join_version = 'optimized'"}, query: "select * from naaj_a where (a, b) not in (select a, b from naaj_b)", rows: testkit.Rows(), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashJoin], wantPublish: true, wantCPUWork: true, wantHashState: true, wantHashRows: 2},
+			{name: "MergeJoin", query: "select /*+ MERGE_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a", rows: testkit.Rows("1 10 100 1 10 100", "2 20 200 2 20 200", "3 30 300 3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalMergeJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantJoinOutput: true},
+			{name: "IndexJoin", query: "select /*+ INL_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a", rows: testkit.Rows("1 10 100 1 10 100", "2 20 200 2 20 200", "3 30 300 3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantJoinOutput: true},
+			{name: "IndexHashJoin", query: "select /*+ INL_HASH_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a", rows: testkit.Rows("1 10 100 1 10 100", "2 20 200 2 20 200", "3 30 300 3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalIndexHashJoin], sortRows: true, wantPublish: true, wantCPUWork: true, wantJoinOutput: true},
+			{name: "HashAgg parallel", query: "select /*+ HASH_AGG() */ count(*) from t group by b", rows: testkit.Rows("1", "1", "1"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashAgg], sortRows: true, wantPublish: true, wantCPUWork: true, wantHashState: true, wantHashRows: 6, wantRootAndCop: true},
+			{name: "HashAgg serial", before: []string{"set tidb_hashagg_partial_concurrency = 1", "set tidb_hashagg_final_concurrency = 1"}, after: []string{"set tidb_hashagg_partial_concurrency = default", "set tidb_hashagg_final_concurrency = default"}, query: "select /*+ HASH_AGG() */ count(*) from t group by b", rows: testkit.Rows("1", "1", "1"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalHashAgg], sortRows: true, wantPublish: true, wantCPUWork: true, wantHashState: true, wantHashRows: 6, wantRootAndCop: true},
+			{name: "StreamAgg", query: "select /*+ STREAM_AGG() */ count(*) from t group by b", rows: testkit.Rows("1", "1", "1"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalStreamAgg], sortRows: true, wantPublish: true, wantCPUWork: true, wantRootAndCop: true},
 			{name: "unsupported Projection", query: "select b + 1 from t ignore index (idx_b)", rows: testkit.Rows("11", "21", "31"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalProjection], sortRows: true},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				for _, sql := range tc.before {
+					tk.MustExec(sql)
+				}
+				defer func() {
+					for _, sql := range tc.after {
+						tk.MustExec(sql)
+					}
+				}()
 				observation = nil
 				calibrationMu.Lock()
 				calibration = calibrationObservation{}
@@ -304,6 +338,14 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 				require.True(t, slices.ContainsFunc(flat.Main, func(operator *plannercore.FlatOperator) bool {
 					return operator != nil && operator.Origin != nil && tc.expectOperator(operator.Origin)
 				}), "query plan does not contain expected operator: %s; flat plan: %v", tc.query, planSummary)
+				if tc.wantRootAndCop {
+					require.True(t, slices.ContainsFunc(flat.Main, func(operator *plannercore.FlatOperator) bool {
+						return operator != nil && operator.IsRoot && tc.expectOperator(operator.Origin)
+					}), "query plan does not contain expected root operator: %s; flat plan: %v", tc.query, planSummary)
+					require.True(t, slices.ContainsFunc(flat.Main, func(operator *plannercore.FlatOperator) bool {
+						return operator != nil && !operator.IsRoot && tc.expectOperator(operator.Origin)
+					}), "query plan does not contain expected cop operator: %s; flat plan: %v", tc.query, planSummary)
+				}
 
 				calibrationMu.Lock()
 				published := calibration
@@ -319,6 +361,15 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 				require.GreaterOrEqual(t, published.netBytes, float64(0))
 				if tc.wantCPUWork {
 					require.Positive(t, published.cpuWork)
+				}
+				if tc.wantHashState {
+					require.Positive(t, published.hashStateRows)
+				}
+				if tc.wantHashRows > 0 {
+					require.Equal(t, tc.wantHashRows, published.hashStateRows)
+				}
+				if tc.wantJoinOutput {
+					require.Positive(t, published.joinOutputRows)
 				}
 			})
 		}

--- a/pkg/executor/statement_ru_plan_walk_integration_test.go
+++ b/pkg/executor/statement_ru_plan_walk_integration_test.go
@@ -142,7 +142,7 @@ func TestStatementRUAnalyzeNoDelayLifecycle(t *testing.T) {
 	testfailpoint.EnableCall(t, statementRUCalibrationUnitsFailpoint, func(
 		observedConnectionID uint64,
 		state string,
-		_, scanBytes, _, _ float64,
+		_, scanBytes, _, _, _, _ float64,
 	) {
 		if observedConnectionID != connectionID {
 			return

--- a/pkg/executor/statement_ru_plan_walk_test.go
+++ b/pkg/executor/statement_ru_plan_walk_test.go
@@ -386,75 +386,6 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 		})
 	}
 
-	for _, tc := range []struct {
-		name   string
-		kind   string
-		adjust func(base.PhysicalPlan)
-	}{
-		{
-			name: "HashJoin inner child is left build side",
-			kind: "hash",
-			adjust: func(plan base.PhysicalPlan) {
-				plan.(*physicalop.PhysicalHashJoin).InnerChildIdx = 0
-			},
-		},
-		{
-			name: "HashJoin outer child is build side",
-			kind: "hash",
-			adjust: func(plan base.PhysicalPlan) {
-				join := plan.(*physicalop.PhysicalHashJoin)
-				join.InnerChildIdx = 0
-				join.UseOuterToBuild = true
-			},
-		},
-		{
-			name: "MergeJoin right outer side roles",
-			kind: "merge",
-			adjust: func(plan base.PhysicalPlan) {
-				plan.(*physicalop.PhysicalMergeJoin).JoinType = base.RightOuterJoin
-			},
-		},
-		{
-			name: "IndexJoin inner child is left",
-			kind: "index",
-			adjust: func(plan base.PhysicalPlan) {
-				plan.(*physicalop.PhysicalIndexJoin).InnerChildIdx = 0
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			fixture := newStatementRUSimpleSelectFixture(t)
-			join, left, right := newJoin(fixture, tc.kind)
-			tc.adjust(join)
-			recordJoinRows(fixture, join, left, right)
-			if tc.kind == "hash" {
-				recordHashState(fixture, join, 2, true, false)
-			}
-			setPlan(fixture, join)
-			want := statementRURawUnits{
-				CPUWork:              5,
-				NetBytes:             20,
-				FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
-				JoinOutputRows:       4,
-			}
-			if tc.kind == "hash" {
-				want.HashStateRows = 2
-			}
-			requirePublication(t, fixture, want)
-		})
-	}
-
-	t.Run("Join fails closed on wrong side role", func(t *testing.T) {
-		fixture := newStatementRUSimpleSelectFixture(t)
-		join, left, right := newJoin(fixture, "merge")
-		recordJoinRows(fixture, join, left, right)
-		setPlan(fixture, join)
-		flat, ok := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
-		require.True(t, ok)
-		flat.Main[flat.Main[0].ChildrenIdx[0]].Label = plannercore.BuildSide
-		requireNoPublication(t, fixture)
-	})
-
 	t.Run("HashJoin fails closed on incomplete state", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)
 		join, left, right := newJoin(fixture, "hash")
@@ -490,21 +421,6 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 		recordHashState(fixture, join, 2, true, false)
 		setPlan(fixture, join)
 		requireNoPublication(t, fixture)
-	})
-
-	t.Run("Join fails closed on row overflow", func(t *testing.T) {
-		fixture := newStatementRUSimpleSelectFixture(t)
-		join, left, right := newJoin(fixture, "merge")
-		recordRootRows(fixture, left, math.MaxInt64)
-		recordRootRows(fixture, right, 1)
-		recordRootRows(fixture, join, 1)
-		setPlan(fixture, join)
-		requireNoPublication(t, fixture)
-	})
-
-	t.Run("expression count overflow fails closed", func(t *testing.T) {
-		_, valid := checkedStatementRUExpressionCount(math.MaxInt, 1)
-		require.False(t, valid)
 	})
 
 	t.Run("operator unit delta merge is atomic", func(t *testing.T) {

--- a/pkg/executor/statement_ru_plan_walk_test.go
+++ b/pkg/executor/statement_ru_plan_walk_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
@@ -31,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/sqlkiller"
@@ -110,11 +112,13 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 	}
 	recordRootRows := func(fixture statementRUSimpleSelectFixture, plan base.Plan, rows int64) {
 		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
-			GetBasicRuntimeStats(plan.ID(), true).SetRowNum(rows)
+			GetBasicRuntimeStats(plan.ID(), true).Record(0, int(rows))
 	}
 	recordCopRows := func(fixture statementRUSimpleSelectFixture, plan base.Plan, rows uint64) {
 		zero := uint64(0)
-		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RecordOneCopTask(
+		coll := fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
+		coll.RecordExpectedCopResponseSummaries([]int{plan.ID()})
+		coll.RecordOneCopTask(
 			plan.ID(),
 			kv.TiKV,
 			&tipb.ExecutorExecutionSummary{
@@ -164,6 +168,41 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 			TablePlan: tableScan,
 		}).Init(planCtx, 0, plannerutil.IndexLookUpPushDownNone)
 		return indexLookup, indexScan, tableScan
+	}
+	newTableReader := func(fixture statementRUSimpleSelectFixture) (*physicalop.PhysicalTableReader, *physicalop.PhysicalTableScan) {
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		scan := (&physicalop.PhysicalTableScan{
+			Table:     &model.TableInfo{},
+			StoreType: kv.TiKV,
+		}).Init(planCtx, 0)
+		scan.SetSchema(expression.NewSchema())
+		reader := (&physicalop.PhysicalTableReader{
+			TablePlan:  scan,
+			TablePlans: []base.PhysicalPlan{scan},
+			StoreType:  kv.TiKV,
+		}).Init(planCtx, 0)
+		reader.SetSchema(expression.NewSchema())
+		return reader, scan
+	}
+	recordHashState := func(
+		fixture statementRUSimpleSelectFixture,
+		plan base.Plan,
+		rows int64,
+		complete bool,
+		invalid bool,
+	) {
+		stats := execdetails.NewHashStateRuntimeStats()
+		stats.AddRows(uint64(rows))
+		if complete {
+			stats.Complete()
+		}
+		if invalid {
+			stats.Invalidate()
+		}
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(
+			plan.ID(),
+			stats,
+		)
 	}
 	requirePublication := func(
 		t *testing.T,
@@ -228,6 +267,389 @@ func TestStatementRUCalculationTraversal(t *testing.T) {
 			ScanBytes: 1009,
 		})
 	})
+
+	newJoin := func(
+		fixture statementRUSimpleSelectFixture,
+		kind string,
+	) (base.PhysicalPlan, *physicalop.PhysicalTableReader, *physicalop.PhysicalTableReader) {
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		left, _ := newTableReader(fixture)
+		right, _ := newTableReader(fixture)
+		leftKey := &expression.Column{Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)}
+		rightKey := &expression.Column{Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)}
+		baseJoin := physicalop.BasePhysicalJoin{
+			JoinType:      base.InnerJoin,
+			InnerChildIdx: 1,
+			LeftJoinKeys:  []*expression.Column{leftKey},
+			RightJoinKeys: []*expression.Column{rightKey},
+		}
+		var join base.PhysicalPlan
+		switch kind {
+		case "hash":
+			join = physicalop.PhysicalHashJoin{
+				BasePhysicalJoin: baseJoin,
+				EqualConditions:  []*expression.ScalarFunction{{}},
+			}.Init(planCtx, &property.StatsInfo{}, 0)
+		case "merge":
+			join = physicalop.PhysicalMergeJoin{
+				BasePhysicalJoin: baseJoin,
+				CompareFuncs:     make([]expression.CompareFunc, 1),
+			}.Init(planCtx, &property.StatsInfo{}, 0)
+		case "index":
+			indexJoin := physicalop.PhysicalIndexJoin{BasePhysicalJoin: baseJoin}
+			indexJoin.OuterJoinKeys = []*expression.Column{leftKey}
+			indexJoin.InnerJoinKeys = []*expression.Column{rightKey}
+			join = indexJoin.Init(planCtx, &property.StatsInfo{}, 0)
+		case "index_hash":
+			indexJoin := physicalop.PhysicalIndexJoin{BasePhysicalJoin: baseJoin}
+			indexJoin.OuterHashKeys = []*expression.Column{leftKey}
+			indexJoin.InnerHashKeys = []*expression.Column{rightKey}
+			join = physicalop.PhysicalIndexHashJoin{PhysicalIndexJoin: indexJoin}.Init(planCtx)
+		case "index_merge":
+			indexJoin := physicalop.PhysicalIndexJoin{BasePhysicalJoin: baseJoin}
+			join = physicalop.PhysicalIndexMergeJoin{
+				PhysicalIndexJoin: indexJoin,
+				CompareFuncs:      make([]expression.CompareFunc, 1),
+			}.Init(planCtx)
+		default:
+			require.FailNow(t, "unknown join kind", kind)
+		}
+		join.SetChildren(left, right)
+		return join, left, right
+	}
+	recordJoinRows := func(
+		fixture statementRUSimpleSelectFixture,
+		join base.PhysicalPlan,
+		left, right *physicalop.PhysicalTableReader,
+	) {
+		recordRootRows(fixture, left, 3)
+		recordRootRows(fixture, right, 2)
+		recordRootRows(fixture, join, 4)
+	}
+
+	for _, tc := range []struct {
+		kind            string
+		expressionCount int64
+	}{
+		{kind: "hash", expressionCount: 12},
+		{kind: "merge", expressionCount: 10},
+		{kind: "index", expressionCount: 15},
+		{kind: "index_hash", expressionCount: 15},
+		{kind: "index_merge", expressionCount: 21},
+	} {
+		t.Run("Join formula counts every expression family "+tc.kind, func(t *testing.T) {
+			fixture := newStatementRUSimpleSelectFixture(t)
+			join, left, right := newJoin(fixture, tc.kind)
+			setCommonConditions := func(baseJoin *physicalop.BasePhysicalJoin) {
+				baseJoin.LeftConditions = make(expression.CNFExprs, 2)
+				baseJoin.RightConditions = make(expression.CNFExprs, 3)
+				baseJoin.OtherConditions = make(expression.CNFExprs, 4)
+			}
+			switch typed := join.(type) {
+			case *physicalop.PhysicalHashJoin:
+				setCommonConditions(&typed.BasePhysicalJoin)
+				typed.NAEqualConditions = make([]*expression.ScalarFunction, 2)
+				typed.LeftNAJoinKeys = make([]*expression.Column, 2)
+				typed.RightNAJoinKeys = make([]*expression.Column, 2)
+			case *physicalop.PhysicalMergeJoin:
+				setCommonConditions(&typed.BasePhysicalJoin)
+			case *physicalop.PhysicalIndexJoin:
+				setCommonConditions(&typed.BasePhysicalJoin)
+				typed.CompareFilters = &physicalop.ColWithCmpFuncManager{OpType: make([]string, 5)}
+			case *physicalop.PhysicalIndexHashJoin:
+				setCommonConditions(&typed.BasePhysicalJoin)
+				typed.CompareFilters = &physicalop.ColWithCmpFuncManager{OpType: make([]string, 5)}
+			case *physicalop.PhysicalIndexMergeJoin:
+				setCommonConditions(&typed.BasePhysicalJoin)
+				typed.NeedOuterSort = true
+				typed.OuterCompareFuncs = make([]expression.CompareFunc, 2)
+				typed.LeftConditions = make(expression.CNFExprs, 3)
+				typed.RightConditions = make(expression.CNFExprs, 4)
+				typed.OtherConditions = make(expression.CNFExprs, 5)
+				typed.CompareFilters = &physicalop.ColWithCmpFuncManager{OpType: make([]string, 6)}
+			}
+			recordJoinRows(fixture, join, left, right)
+			if tc.kind == "hash" {
+				recordHashState(fixture, join, 2, true, false)
+			}
+			setPlan(fixture, join)
+			want := statementRURawUnits{
+				CPUWork:              5 * float64(tc.expressionCount),
+				NetBytes:             20,
+				FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+				JoinOutputRows:       4,
+			}
+			if tc.kind == "hash" {
+				want.HashStateRows = 2
+			}
+			requirePublication(t, fixture, want)
+		})
+	}
+
+	for _, tc := range []struct {
+		name   string
+		kind   string
+		adjust func(base.PhysicalPlan)
+	}{
+		{
+			name: "HashJoin inner child is left build side",
+			kind: "hash",
+			adjust: func(plan base.PhysicalPlan) {
+				plan.(*physicalop.PhysicalHashJoin).InnerChildIdx = 0
+			},
+		},
+		{
+			name: "HashJoin outer child is build side",
+			kind: "hash",
+			adjust: func(plan base.PhysicalPlan) {
+				join := plan.(*physicalop.PhysicalHashJoin)
+				join.InnerChildIdx = 0
+				join.UseOuterToBuild = true
+			},
+		},
+		{
+			name: "MergeJoin right outer side roles",
+			kind: "merge",
+			adjust: func(plan base.PhysicalPlan) {
+				plan.(*physicalop.PhysicalMergeJoin).JoinType = base.RightOuterJoin
+			},
+		},
+		{
+			name: "IndexJoin inner child is left",
+			kind: "index",
+			adjust: func(plan base.PhysicalPlan) {
+				plan.(*physicalop.PhysicalIndexJoin).InnerChildIdx = 0
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newStatementRUSimpleSelectFixture(t)
+			join, left, right := newJoin(fixture, tc.kind)
+			tc.adjust(join)
+			recordJoinRows(fixture, join, left, right)
+			if tc.kind == "hash" {
+				recordHashState(fixture, join, 2, true, false)
+			}
+			setPlan(fixture, join)
+			want := statementRURawUnits{
+				CPUWork:              5,
+				NetBytes:             20,
+				FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+				JoinOutputRows:       4,
+			}
+			if tc.kind == "hash" {
+				want.HashStateRows = 2
+			}
+			requirePublication(t, fixture, want)
+		})
+	}
+
+	t.Run("Join fails closed on wrong side role", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, right := newJoin(fixture, "merge")
+		recordJoinRows(fixture, join, left, right)
+		setPlan(fixture, join)
+		flat, ok := fixture.stmt.Ctx.GetSessionVars().StmtCtx.GetFlatPlan().(*plannercore.FlatPhysicalPlan)
+		require.True(t, ok)
+		flat.Main[flat.Main[0].ChildrenIdx[0]].Label = plannercore.BuildSide
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("HashJoin fails closed on incomplete state", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, right := newJoin(fixture, "hash")
+		recordJoinRows(fixture, join, left, right)
+		recordHashState(fixture, join, 2, false, false)
+		setPlan(fixture, join)
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("HashJoin fails closed on invalid state", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, right := newJoin(fixture, "hash")
+		recordJoinRows(fixture, join, left, right)
+		recordHashState(fixture, join, 2, true, true)
+		setPlan(fixture, join)
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("Join fails closed on missing child rows", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, _ := newJoin(fixture, "merge")
+		recordRootRows(fixture, left, 3)
+		recordRootRows(fixture, join, 4)
+		setPlan(fixture, join)
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("Join fails closed on FULL OUTER source drift", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, right := newJoin(fixture, "hash")
+		join.(*physicalop.PhysicalHashJoin).JoinType = base.FullOuterJoin
+		recordJoinRows(fixture, join, left, right)
+		recordHashState(fixture, join, 2, true, false)
+		setPlan(fixture, join)
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("Join fails closed on row overflow", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		join, left, right := newJoin(fixture, "merge")
+		recordRootRows(fixture, left, math.MaxInt64)
+		recordRootRows(fixture, right, 1)
+		recordRootRows(fixture, join, 1)
+		setPlan(fixture, join)
+		requireNoPublication(t, fixture)
+	})
+
+	t.Run("expression count overflow fails closed", func(t *testing.T) {
+		_, valid := checkedStatementRUExpressionCount(math.MaxInt, 1)
+		require.False(t, valid)
+	})
+
+	t.Run("operator unit delta merge is atomic", func(t *testing.T) {
+		calculator := statementRUCalculator{units: statementRURawUnits{
+			CPUWork:   7,
+			ScanBytes: math.MaxFloat64,
+		}}
+		before := calculator
+		require.False(t, mergeStatementRUUnitDelta(&calculator, statementRURawUnits{
+			CPUWork:   5,
+			ScanBytes: math.MaxFloat64,
+		}))
+		require.Equal(t, before, calculator)
+	})
+
+	newAggregation := func(
+		fixture statementRUSimpleSelectFixture,
+		hash bool,
+		child base.PhysicalPlan,
+	) base.PhysicalPlan {
+		planCtx := fixture.stmt.Ctx.(*mock.Context)
+		baseAgg := &physicalop.BasePhysicalAgg{
+			GroupByItems: []expression.Expression{expression.NewOne(), expression.NewOne()},
+			AggFuncs:     make([]*aggregation.AggFuncDesc, 3),
+		}
+		var agg base.PhysicalPlan
+		if hash {
+			agg = baseAgg.InitForHash(planCtx, &property.StatsInfo{}, 0, expression.NewSchema())
+		} else {
+			agg = baseAgg.InitForStream(planCtx, &property.StatsInfo{}, 0, expression.NewSchema())
+		}
+		agg.SetChildren(child)
+		return agg
+	}
+
+	for _, hash := range []bool{true, false} {
+		name := "StreamAgg"
+		if hash {
+			name = "HashAgg"
+		}
+		t.Run("root "+name+" occurrence", func(t *testing.T) {
+			fixture := newStatementRUSimpleSelectFixture(t)
+			reader, _ := newTableReader(fixture)
+			agg := newAggregation(fixture, hash, reader)
+			recordRootRows(fixture, reader, 3)
+			recordRootRows(fixture, agg, 2)
+			if hash {
+				recordHashState(fixture, agg, 2, true, false)
+			}
+			setPlan(fixture, agg)
+			want := statementRURawUnits{
+				CPUWork:              15,
+				NetBytes:             20,
+				FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+			}
+			if hash {
+				want.HashStateRows = 2
+			}
+			requirePublication(t, fixture, want)
+		})
+	}
+
+	t.Run("root HashAgg distinguishes observed zero from missing rows", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		reader, _ := newTableReader(fixture)
+		agg := newAggregation(fixture, true, reader)
+		recordRootRows(fixture, reader, 0)
+		recordRootRows(fixture, agg, 0)
+		recordHashState(fixture, agg, 0, true, false)
+		setPlan(fixture, agg)
+		requirePublication(t, fixture, statementRURawUnits{
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+
+		missing := newStatementRUSimpleSelectFixture(t)
+		missingReader, _ := newTableReader(missing)
+		missingAgg := newAggregation(missing, true, missingReader)
+		recordRootRows(missing, missingAgg, 0)
+		recordHashState(missing, missingAgg, 0, true, false)
+		setPlan(missing, missingAgg)
+		requireNoPublication(t, missing)
+	})
+
+	t.Run("TiKV cop HashAgg charges valid responses when another summary is missing", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		reader, scan := newTableReader(fixture)
+		agg := newAggregation(fixture, true, scan)
+		reader.TablePlan = agg
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(agg)
+		recordCopRows(fixture, scan, 3)
+		recordCopRows(fixture, agg, 2)
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
+			RecordExpectedCopResponseSummaries([]int{scan.ID(), agg.ID()})
+		recordScan(fixture, agg, 1, 1, 10)
+		setPlan(fixture, reader)
+		requirePublication(t, fixture, statementRURawUnits{
+			CPUWork:              15,
+			HashStateRows:        2,
+			ScanBytes:            10,
+			NetBytes:             20,
+			FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+		})
+	})
+
+	t.Run("TiKV cop HashAgg still requires one valid summary", func(t *testing.T) {
+		fixture := newStatementRUSimpleSelectFixture(t)
+		reader, scan := newTableReader(fixture)
+		agg := newAggregation(fixture, true, scan)
+		reader.TablePlan = agg
+		reader.TablePlans = physicalop.FlattenListPushDownPlan(agg)
+		fixture.stmt.Ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
+			RecordExpectedCopResponseSummaries([]int{scan.ID(), agg.ID()})
+		recordScan(fixture, agg, 1, 1, 10)
+		setPlan(fixture, reader)
+		requireNoPublication(t, fixture)
+	})
+
+	for _, hash := range []bool{true, false} {
+		name := "StreamAgg"
+		if hash {
+			name = "HashAgg"
+		}
+		t.Run("TiKV cop "+name+" occurrence", func(t *testing.T) {
+			fixture := newStatementRUSimpleSelectFixture(t)
+			reader, scan := newTableReader(fixture)
+			agg := newAggregation(fixture, hash, scan)
+			reader.TablePlan = agg
+			reader.TablePlans = physicalop.FlattenListPushDownPlan(agg)
+			recordCopRows(fixture, scan, 3)
+			recordCopRows(fixture, agg, 2)
+			recordScan(fixture, agg, 1, 1, 10)
+			setPlan(fixture, reader)
+			want := statementRURawUnits{
+				CPUWork:              15,
+				ScanBytes:            10,
+				NetBytes:             20,
+				FrontendCompileBytes: float64(len(statementRUSimpleSelectSQLForTest)),
+			}
+			if hash {
+				want.HashStateRows = 2
+			}
+			requirePublication(t, fixture, want)
+		})
+	}
 
 	t.Run("Reader scan evidence is collected during calculation", func(t *testing.T) {
 		fixture := newStatementRUSimpleSelectFixture(t)

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -32,6 +32,8 @@ const (
 	statementRUScanByteWeight            = 1.0
 	statementRUNetByteWeight             = 1.0
 	statementRUFrontendCompileByteWeight = 1.0
+	statementRUHashStateRowWeight        = 1.0
+	statementRUJoinOutputRowWeight       = 1.0
 )
 
 type statementRURawUnits struct {
@@ -49,6 +51,12 @@ type statementRURawUnits struct {
 	// FrontendCompileBytes is the UTF-8 byte length of the source SQL text seen
 	// by the compiler.
 	FrontendCompileBytes float64
+	// HashStateRows counts entries admitted to completed, operator-owned hash
+	// lookup or group-state structures.
+	HashStateRows float64
+	// JoinOutputRows counts rows produced by supported Join occurrences after
+	// their join conditions and join-type semantics are applied.
+	JoinOutputRows float64
 }
 
 type statementRUResultOnly struct {
@@ -176,7 +184,7 @@ type statementRUScanEvidence struct {
 
 // classifyStatementRUScanEvidence converts a value copy of one Reader's scan
 // evidence into one raw-unit contribution. Zero-valued fields have no presence
-// bit, so a tuple that cannot run the demo formula is unavailable unless it is
+// bit, so a tuple that cannot satisfy the scan-byte formula is unavailable unless it is
 // provably contradictory. No RuntimeStatsColl or ScanDetail pointer survives.
 func classifyStatementRUScanEvidence(totalKeys, processedKeys, processedBytes int64) statementRUScanEvidence {
 	if totalKeys < 0 || processedKeys < 0 || processedBytes < 0 {
@@ -223,6 +231,8 @@ func validStatementRURawUnits(units statementRURawUnits) bool {
 		units.ScanBytes,
 		units.NetBytes,
 		units.FrontendCompileBytes,
+		units.HashStateRows,
+		units.JoinOutputRows,
 	} {
 		if unit < 0 || math.IsNaN(unit) || math.IsInf(unit, 0) {
 			return false
@@ -235,7 +245,9 @@ func calculateStatementRUResultOnly(units statementRURawUnits) statementRUResult
 	return statementRUResultOnly{TotalRU: statementRUCPUWorkWeight*units.CPUWork +
 		statementRUScanByteWeight*units.ScanBytes +
 		statementRUNetByteWeight*units.NetBytes +
-		statementRUFrontendCompileByteWeight*units.FrontendCompileBytes}
+		statementRUFrontendCompileByteWeight*units.FrontendCompileBytes +
+		statementRUHashStateRowWeight*units.HashStateRows +
+		statementRUJoinOutputRowWeight*units.JoinOutputRows}
 }
 
 func publishStatementRUFinalizedSnapshot(
@@ -251,7 +263,7 @@ func publishStatementRUFinalizedSnapshot(
 
 // publishStatementRUMetricsSafely projects one immutable finalized snapshot to
 // the existing RU v3 counters. ResultOnly retains aggregate CPUWork rather than
-// a site split, so this layer preserves the lower-layer engine boundary:
+// a site split, so publication preserves the producer-owned engine boundary:
 // TiKV receives only scan and network work, while Total and SQLType receive the
 // complete best-effort result.
 func publishStatementRUMetricsSafely(finalized statementRUFinalizedSnapshot) {
@@ -289,5 +301,7 @@ func publishStatementRUCalibrationSafely(
 		snapshot.Units.ScanBytes,
 		snapshot.Units.NetBytes,
 		snapshot.Units.FrontendCompileBytes,
+		snapshot.Units.HashStateRows,
+		snapshot.Units.JoinOutputRows,
 	)
 }

--- a/pkg/executor/statement_ru_result_test.go
+++ b/pkg/executor/statement_ru_result_test.go
@@ -130,7 +130,7 @@ func observeStatementRUCalibrationForTest(
 	testfailpoint.EnableCall(t, statementRUCalibrationFailpointForTest, func(
 		_ uint64,
 		stateName string,
-		cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
+		cpuWork, scanBytes, netBytes, frontendCompileBytes, hashStateRows, joinOutputRows float64,
 	) {
 		state := statementRUCalibrationUnknown
 		switch stateName {
@@ -148,6 +148,8 @@ func observeStatementRUCalibrationForTest(
 				ScanBytes:            scanBytes,
 				NetBytes:             netBytes,
 				FrontendCompileBytes: frontendCompileBytes,
+				HashStateRows:        hashStateRows,
+				JoinOutputRows:       joinOutputRows,
 			},
 		})
 	})
@@ -354,17 +356,39 @@ func TestStatementRUResultValueContracts(t *testing.T) {
 				ScanBytes:            10,
 				NetBytes:             20,
 				FrontendCompileBytes: 15,
+				HashStateRows:        7,
+				JoinOutputRows:       8,
 			},
 		}
 		finalized, ok := calculator.finalize()
 		require.True(t, ok)
-		require.Equal(t, statementRUResultOnly{TotalRU: 50}, finalized.result)
+		require.Equal(t, statementRUResultOnly{TotalRU: 65}, finalized.result)
 		require.Equal(t, statementRUCalibrationIncomplete, finalized.calibrationState)
 	})
 
 	t.Run("placeholder formula stays pinned", func(t *testing.T) {
-		units := statementRURawUnits{CPUWork: 5, ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15}
-		require.Equal(t, statementRUResultOnly{TotalRU: 50}, calculateStatementRUResultOnly(units))
+		units := statementRURawUnits{
+			CPUWork: 5, ScanBytes: 10, NetBytes: 20, FrontendCompileBytes: 15,
+			HashStateRows: 7, JoinOutputRows: 8,
+		}
+		require.Equal(t, statementRUResultOnly{TotalRU: 65}, calculateStatementRUResultOnly(units))
+	})
+
+	t.Run("operator unit arithmetic preserves Join and Agg units", func(t *testing.T) {
+		baseUnits := statementRURawUnits{
+			CPUWork: 1, ScanBytes: 2, NetBytes: 3, FrontendCompileBytes: 4,
+			HashStateRows: 5, JoinOutputRows: 6,
+		}
+		delta := statementRURawUnits{
+			CPUWork: 7, ScanBytes: 8, NetBytes: 9, FrontendCompileBytes: 10,
+			HashStateRows: 11, JoinOutputRows: 12,
+		}
+		combined := addStatementRURawUnits(baseUnits, delta)
+		require.Equal(t, statementRURawUnits{
+			CPUWork: 8, ScanBytes: 10, NetBytes: 12, FrontendCompileBytes: 14,
+			HashStateRows: 16, JoinOutputRows: 18,
+		}, combined)
+		require.Equal(t, delta, subtractStatementRURawUnits(combined, baseUnits))
 	})
 
 	t.Run("engine projection preserves the lower layer boundary", func(t *testing.T) {
@@ -457,7 +481,9 @@ func TestStatementRUResultValueContracts(t *testing.T) {
 			"units",
 		}, statementRUFieldNames(calculatorType))
 		unitsType := reflect.TypeOf(statementRURawUnits{})
-		require.Equal(t, []string{"CPUWork", "ScanBytes", "NetBytes", "FrontendCompileBytes"}, statementRUFieldNames(unitsType))
+		require.Equal(t, []string{
+			"CPUWork", "ScanBytes", "NetBytes", "FrontendCompileBytes", "HashStateRows", "JoinOutputRows",
+		}, statementRUFieldNames(unitsType))
 		resultType := reflect.TypeOf(statementRUResultOnly{})
 		require.Equal(t, []string{"TotalRU"}, statementRUFieldNames(resultType))
 		snapshotType := reflect.TypeOf(statementRUCalibrationSnapshot{})

--- a/tests/realtikvtest/sessiontest/BUILD.bazel
+++ b/tests/realtikvtest/sessiontest/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/store/helper",
         "//pkg/testkit",
         "//pkg/testkit/testfailpoint",
+        "//pkg/util/chunk",
         "//pkg/util/sqlkiller",
         "//tests/realtikvtest",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/tests/realtikvtest/sessiontest/statement_ru_test.go
+++ b/tests/realtikvtest/sessiontest/statement_ru_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,8 @@ type statementRURealTiKVObservation struct {
 	scanBytes        float64
 	netBytes         float64
 	frontendBytes    float64
+	hashStateRows    float64
+	joinOutputRows   float64
 }
 
 func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
@@ -53,17 +56,15 @@ func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
 	tk.MustExec("set @@tidb_enable_non_prepared_plan_cache = off")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int)")
-	tk.MustExec("insert into t values (1, 10)")
+	tk.MustExec("insert into t values (1, 10), (2, 20), (3, 30)")
+	tk.MustExec("set tidb_hash_join_version = 'optimized'")
 
 	connectionID := tk.Session().GetSessionVars().ConnectionID
 	observation := &statementRURealTiKVObservation{}
-	totalBefore := testutil.ToFloat64(metrics.RUV3Total)
-	readBefore := testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))
-	tikvBefore := testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))
 	testfailpoint.EnableCall(t, statementRUCalibrationUnitsFailpoint, func(
 		observedConnectionID uint64,
 		calibrationState string,
-		cpuWork, scanBytes, netBytes, frontendCompileBytes float64,
+		cpuWork, scanBytes, netBytes, frontendCompileBytes, hashStateRows, joinOutputRows float64,
 	) {
 		if observedConnectionID != connectionID {
 			return
@@ -76,46 +77,126 @@ func TestStatementRUSimpleSelectRealTiKV(t *testing.T) {
 		observation.scanBytes = scanBytes
 		observation.netBytes = netBytes
 		observation.frontendBytes = frontendCompileBytes
+		observation.hashStateRows = hashStateRows
+		observation.joinOutputRows = joinOutputRows
 	})
-	const query = "select * from t"
-	rs, err := tk.ExecWithContext(context.Background(), query)
-	require.NoError(t, err)
-	require.NotNil(t, rs)
-	rows, err := session.GetRows4Test(context.Background(), tk.Session(), rs)
-	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	require.Equal(t, int64(1), rows[0].GetInt64(0))
-	require.Equal(t, int64(10), rows[0].GetInt64(1))
 
-	finisher, ok := rs.(interface{ Finish() error })
-	require.True(t, ok)
-	require.NoError(t, finisher.Finish())
-	require.NoError(t, finisher.Finish())
-	observation.Lock()
-	require.Zero(t, observation.calibrationUnits)
-	observation.Unlock()
-	require.Equal(t, totalBefore, testutil.ToFloat64(metrics.RUV3Total))
-	require.Equal(t, readBefore, testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead)))
-	require.Equal(t, tikvBefore, testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV)))
+	testCases := []struct {
+		name           string
+		query          string
+		rowCount       int
+		validateRows   func(*testing.T, []chunk.Row)
+		wantCPUWork    bool
+		wantHashState  bool
+		wantJoinOutput bool
+	}{
+		{
+			name:     "reader",
+			query:    "select * from t",
+			rowCount: 3,
+			validateRows: func(t *testing.T, rows []chunk.Row) {
+				for _, row := range rows {
+					require.Equal(t, row.GetInt64(0)*10, row.GetInt64(1))
+				}
+			},
+		},
+		{
+			name:     "hash join",
+			query:    "select /*+ HASH_JOIN(t1, t2) */ * from t t1 join t t2 on t1.a = t2.a",
+			rowCount: 3,
+			validateRows: func(t *testing.T, rows []chunk.Row) {
+				for _, row := range rows {
+					require.Equal(t, row.GetInt64(0), row.GetInt64(2))
+					require.Equal(t, row.GetInt64(1), row.GetInt64(3))
+				}
+			},
+			wantCPUWork:    true,
+			wantHashState:  true,
+			wantJoinOutput: true,
+		},
+		{
+			name:     "hash aggregation",
+			query:    "select /*+ HASH_AGG() */ count(*) from t group by b",
+			rowCount: 3,
+			validateRows: func(t *testing.T, rows []chunk.Row) {
+				for _, row := range rows {
+					require.Equal(t, int64(1), row.GetInt64(0))
+				}
+			},
+			wantCPUWork:   true,
+			wantHashState: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			observation.Lock()
+			observation.calibrationUnits = 0
+			observation.calibrationState = ""
+			observation.cpuWork = 0
+			observation.scanBytes = 0
+			observation.netBytes = 0
+			observation.frontendBytes = 0
+			observation.hashStateRows = 0
+			observation.joinOutputRows = 0
+			observation.Unlock()
 
-	require.NoError(t, rs.Close())
-	require.NoError(t, rs.Close())
-	observation.Lock()
-	defer observation.Unlock()
-	t.Logf("statement RU observation: calibration=%d state=%s cpu=%v scan=%v net=%v frontend=%v",
-		observation.calibrationUnits,
-		observation.calibrationState, observation.cpuWork, observation.scanBytes, observation.netBytes, observation.frontendBytes)
-	require.Equal(t, 1, observation.calibrationUnits)
-	require.Equal(t, "incomplete", observation.calibrationState)
-	require.Zero(t, observation.cpuWork)
-	require.Positive(t, observation.scanBytes)
-	require.Positive(t, observation.netBytes)
-	require.Equal(t, float64(len(query)), observation.frontendBytes)
-	require.InDelta(t, observation.cpuWork+observation.scanBytes+observation.netBytes+observation.frontendBytes,
-		testutil.ToFloat64(metrics.RUV3Total)-totalBefore, 1e-9)
-	require.InDelta(t, observation.cpuWork+observation.scanBytes+observation.netBytes+observation.frontendBytes,
-		testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))-readBefore, 1e-9)
-	require.InDelta(t, observation.scanBytes+observation.netBytes,
-		testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))-tikvBefore, 1e-9)
-	require.Equal(t, observation.netBytes, float64(tk.Session().GetSessionVars().RUV2Metrics.TiKVCoprocessorResponseBytes()))
+			totalBefore := testutil.ToFloat64(metrics.RUV3Total)
+			readBefore := testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))
+			tikvBefore := testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))
+			rs, err := tk.ExecWithContext(context.Background(), tc.query)
+			require.NoError(t, err)
+			require.NotNil(t, rs)
+			rows, err := session.GetRows4Test(context.Background(), tk.Session(), rs)
+			require.NoError(t, err)
+			require.Len(t, rows, tc.rowCount)
+			tc.validateRows(t, rows)
+
+			finisher, ok := rs.(interface{ Finish() error })
+			require.True(t, ok)
+			require.NoError(t, finisher.Finish())
+			require.NoError(t, finisher.Finish())
+			observation.Lock()
+			require.Zero(t, observation.calibrationUnits)
+			observation.Unlock()
+			require.Equal(t, totalBefore, testutil.ToFloat64(metrics.RUV3Total))
+			require.Equal(t, readBefore, testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead)))
+			require.Equal(t, tikvBefore, testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV)))
+
+			require.NoError(t, rs.Close())
+			require.NoError(t, rs.Close())
+			observation.Lock()
+			defer observation.Unlock()
+			t.Logf("statement RU observation: calibration=%d state=%s cpu=%v scan=%v net=%v frontend=%v hash_state=%v join_output=%v",
+				observation.calibrationUnits, observation.calibrationState, observation.cpuWork, observation.scanBytes,
+				observation.netBytes, observation.frontendBytes, observation.hashStateRows, observation.joinOutputRows)
+			require.Equal(t, 1, observation.calibrationUnits)
+			require.Equal(t, "incomplete", observation.calibrationState)
+			if tc.wantCPUWork {
+				require.Positive(t, observation.cpuWork)
+			} else {
+				require.Zero(t, observation.cpuWork)
+			}
+			if tc.wantHashState {
+				require.Positive(t, observation.hashStateRows)
+			} else {
+				require.Zero(t, observation.hashStateRows)
+			}
+			if tc.wantJoinOutput {
+				require.Positive(t, observation.joinOutputRows)
+			} else {
+				require.Zero(t, observation.joinOutputRows)
+			}
+			require.Positive(t, observation.scanBytes)
+			require.Positive(t, observation.netBytes)
+			require.Equal(t, float64(len(tc.query)), observation.frontendBytes)
+			totalUnits := observation.cpuWork + observation.scanBytes + observation.netBytes + observation.frontendBytes +
+				observation.hashStateRows + observation.joinOutputRows
+			require.InDelta(t, totalUnits, testutil.ToFloat64(metrics.RUV3Total)-totalBefore, 1e-9)
+			require.InDelta(t, totalUnits,
+				testutil.ToFloat64(metrics.RUV3BySQLType.WithLabelValues(metrics.LblSQLTypeRead))-readBefore, 1e-9)
+			require.InDelta(t, observation.scanBytes+observation.netBytes,
+				testutil.ToFloat64(metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV))-tikvBefore, 1e-9)
+			require.Equal(t, observation.netBytes, float64(tk.Session().GetSessionVars().RUV2Metrics.TiKVCoprocessorResponseBytes()))
+		})
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70445

Problem Summary:

The existing statement-RU calculator accounts for Reader-owned scan bytes and unary operators, but Join and Aggregation occurrences still do not retrieve their operator-local CPU, hash-state, or join-output units from execution evidence.

This PR is the second layer of a stack on #70638. The lower layer defines and produces the typed execution evidence; this layer only consumes that evidence for statement-RU calculation and final publication.

### What changed and how does it work?

- Extend the existing `FlatPlanTree.ChildrenIdx` child-first calculation with:
  - root HashJoin, MergeJoin, IndexJoin, IndexHashJoin, and IndexMergeJoin;
  - root HashAgg and StreamAgg;
  - TiKV cop HashAgg and StreamAgg.
- Calculate Join CPU work as `(left child rows + right child rows) * audited expression slots`, record each Join occurrence's own output rows, and add completed HashJoin state rows.
- Calculate Aggregation CPU work as `child rows * (GroupByItems + AggFuncs)`; root HashAgg consumes producer-owned group-map state, while TiKV HashAgg consumes complete produced-group summaries.
- Validate physical child identity, left/right or build/probe roles, execution site, expression-key alignment, row presence, lifecycle completion, and checked arithmetic. Full Outer Join, cop Join, TiFlash/MPP Join or Aggregation, unsupported topology, and partial or contradictory evidence fail closed.
- Keep Reader scan ownership, existing unary formulas, Projection fail-closed behavior, and the canonical exactly-once value freeze unchanged. ResultOnly and calibration still derive from the same immutable snapshot, and calibration remains Incomplete because response summaries do not prove physical-attempt coverage.
- Add `HashStateRows` and `JoinOutputRows` to the immutable statement-RU unit snapshot without changing the lower layer's runtime-stat display contract.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Ready validation:

- `make bazel_prepare`
- `./tools/check/failpoint-go-test.sh pkg/executor -run '^TestStatementRU(CalculationTraversal|ResultValueContracts|ResultSetTerminalOutcomes|JoinAndAggregationIntegration)$' -count=1`
- `tiup playground v9.0.0-beta.2.pre-nightly --mode tikv-slim --tag realtikvtest-70638-split`
- `./tools/check/failpoint-go-test.sh tests/realtikvtest/sessiontest -run '^TestStatementRUSimpleSelectRealTiKV$' -count=1`
- `bazel build //pkg/executor:executor_test //tests/realtikvtest/sessiontest:sessiontest_test`
- `make lint`
- `git diff --check`

The RealTiKV run used TiUP's explicit nightly selector. The running PD endpoint reported `v9.0.0-beta.2.pre-363-g8cabcf1`; the scoped test passed and the playground/tag were stopped and cleaned afterward.

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Eligible statements perform the existing bounded child-first traversal with additional occurrence-local arithmetic. This PR adds no execution-details producers or long-lived evidence storage.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded resource-unit accounting to include hash-state processing and join output rows.
  * Added RU calculation support for joins and aggregations across multiple execution strategies.
  * Improved handling of incomplete execution data for more reliable RU totals.

* **Bug Fixes**
  * Ensured resource-unit totals and adjustments preserve join and aggregation metrics.

* **Tests**
  * Added comprehensive coverage for reader, join, and aggregation queries across unit, integration, benchmark, and real-environment tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->