### PR TITLE
executor: fix race between MPP task dispatch and cancellation

### DIFF
--- a/pkg/executor/internal/mpp/BUILD.bazel
+++ b/pkg/executor/internal/mpp/BUILD.bazel
@@ -50,8 +50,9 @@ go_test(
     srcs = ["local_mpp_coordinator_test.go"],
     embed = [":mpp"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
+        "//pkg/kv",
         "//pkg/planner/core/operator/physicalop",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_stretchr_testify//require",

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -490,11 +490,9 @@ func (c *localMppCoordinator) dispatchAll(ctx context.Context) {
 		if atomic.LoadUint32(&c.closed) == 1 {
 			break
 		}
-		c.mu.Lock()
-		if task.State == kv.MppTaskReady {
-			task.State = kv.MppTaskRunning
+		if !c.tryStartDispatch(task) {
+			continue
 		}
-		c.mu.Unlock()
 		c.wg.Add(1)
 		boMaxSleep := copr.CopNextMaxBackoff
 		failpoint.Inject("ReduceCopNextMaxBackoff", func(value failpoint.Value) {
@@ -513,6 +511,19 @@ func (c *localMppCoordinator) dispatchAll(ctx context.Context) {
 	c.wg.Wait()
 	close(c.wgDoneChan)
 	close(c.respChan)
+}
+
+func (c *localMppCoordinator) tryStartDispatch(task *kv.MPPDispatchRequest) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Use the same lock as cancelMppTasks so starting and cancelling a task are
+	// ordered. If cancellation wins, dispatchAll skips the task. If dispatch
+	// wins, the task is running and its store is included in the cancel request.
+	if task.State != kv.MppTaskReady {
+		return false
+	}
+	task.State = kv.MppTaskRunning
+	return true
 }
 
 func (c *localMppCoordinator) sendError(err error) {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -17,10 +17,49 @@ package mpp
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDispatchCancelRace(t *testing.T) {
+	t.Run("cancel wins", func(t *testing.T) {
+		coordinator := &localMppCoordinator{}
+		task := &kv.MPPDispatchRequest{State: kv.MppTaskReady}
+
+		// Hold the coordinator lock so the dispatch goroutine cannot inspect the
+		// task until cancellation has changed its state.
+		coordinator.mu.Lock()
+		dispatchStarted := make(chan struct{})
+		dispatchResult := make(chan bool, 1)
+		go func() {
+			close(dispatchStarted)
+			dispatchResult <- coordinator.tryStartDispatch(task)
+		}()
+		<-dispatchStarted
+		task.State = kv.MppTaskCancelled
+		coordinator.mu.Unlock()
+
+		require.False(t, <-dispatchResult)
+		require.Equal(t, kv.MppTaskCancelled, task.State)
+	})
+
+	t.Run("dispatch wins", func(t *testing.T) {
+		coordinator := &localMppCoordinator{}
+		task := &kv.MPPDispatchRequest{State: kv.MppTaskReady}
+
+		require.True(t, coordinator.tryStartDispatch(task))
+
+		// cancelMppTasks takes the same lock and includes stores for tasks in the
+		// running state before marking all tasks as cancelled.
+		coordinator.mu.Lock()
+		stateWhenCancelStarted := task.State
+		task.State = kv.MppTaskCancelled
+		coordinator.mu.Unlock()
+		require.Equal(t, kv.MppTaskRunning, stateWhenCancelStarted)
+	})
+}
 
 func TestNeedReportExecutionSummary(t *testing.T) {
 	tableScan := &physicalop.PhysicalTableScan{}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #70685

Problem Summary:

`dispatchAll()` used to launch every MPP task even if `cancelMppTasks()` had already changed the task from `Ready` to `Cancelled`.

One possible ordering was:

1. An MPP dispatch error triggered cancellation.
2. `cancelMppTasks()` collected stores from tasks currently marked `Running`, then marked every task `Cancelled`.
3. `dispatchAll()` still launched a task that had not reached the running state when the cancellation snapshot was taken.
4. That task's TiFlash store was missing from the snapshot, and later cancellation calls returned early because the requests were already marked cancelled.

This PR fixes that state race only. It does not add retries for failed cancel RPCs and does not attempt to fix TiFlash-side task cleanup tracked by pingcap/tiflash#11059.

### What changed and how does it work?

MPP task startup now uses the same coordinator lock as cancellation:

- If cancellation gets the lock first, the task is already `Cancelled` and `dispatchAll()` skips it.
- If dispatch gets the lock first, the task becomes `Running`, so a following cancellation snapshot includes its store.

`TestDispatchCancelRace` covers both orderings. The cancel-first case fails with the previous unconditional-launch behavior and passes with this change.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test

Validation performed:

- `./tools/check/failpoint-go-test.sh pkg/executor/internal/mpp -run TestDispatchCancelRace -count=100`
- `./tools/check/failpoint-go-test.sh pkg/executor/internal/mpp -race -run TestDispatchCancelRace -count=20`
- `bazel test //pkg/executor/internal/mpp:mpp_test`
- `make bazel_prepare`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a race that could dispatch an MPP task after cancellation without including its TiFlash store in the cancellation request.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task dispatch reliability when cancellation occurs at the same time as task startup.
  * Ensured tasks are not started after cancellation, while preserving valid dispatches that begin first.

* **Tests**
  * Added coverage for dispatch and cancellation race conditions.
  * Expanded test execution across additional shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->