### PR TITLE
test: pin upgrade start version in TestUpgradeVersion284EnableTxnFile

### DIFF
--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1542,10 +1542,6 @@ func TestUpgradeVersion256PlanCacheSkipStatsOnBinding(t *testing.T) {
 }
 
 func TestUpgradeVersion284EnableTxnFile(t *testing.T) {
-	if kerneltype.IsClassic() {
-		t.Skip("this is only checked in next-gen kernel")
-	}
-
 	tests := []struct {
 		name          string
 		legacyValue   string

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1542,6 +1542,10 @@ func TestUpgradeVersion256PlanCacheSkipStatsOnBinding(t *testing.T) {
 }
 
 func TestUpgradeVersion284EnableTxnFile(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("this is only checked in next-gen kernel")
+	}
+
 	tests := []struct {
 		name          string
 		legacyValue   string

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -1564,7 +1564,10 @@ func TestUpgradeVersion284EnableTxnFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store, dom := session.CreateStoreAndBootstrap(t)
 			defer func() { require.NoError(t, store.Close()) }()
-			upgradeFromVersion := session.CurrentBootstrapVersion - 1
+			// The upgrade must start from 283 (= version284 - 1) so that the ver284
+			// step under test actually runs; deriving it from CurrentBootstrapVersion
+			// breaks on any branch that bumps the bootstrap version (issue #70691).
+			const upgradeFromVersion = int64(283)
 			var migrationCommitted atomicutil.Bool
 			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/session/afterUpgradeToVer284Commit", func(s sessionapi.Session) {
 				migrationCommitted.Store(!s.GetSessionVars().InTxn())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #70691

Problem Summary:

`TestUpgradeVersion284EnableTxnFile` derived its upgrade start version from `session.CurrentBootstrapVersion - 1`. Any PR that bumps the bootstrap version (e.g. #70599, `version284` -> `version285`) makes the upgrade under test start at 284, so `upgradeToVer284` never runs and all 5 subtests fail in `pull_unit_test_next_gen` (see issue #70691 for the full CI log and per-subtest failures).

Also, `upgradeToVer284` no-ops on the classic kernel, so the test's interesting assertions only apply to the next-gen kernel.

### What changed and how does it work?

- Pin the upgrade start version to 283 (= `version284 - 1`) so the ver284 migration step under test always executes, regardless of later bootstrap version bumps. Later upgrade steps (285+) still run afterwards and do not touch the txn-file variables.
- Restrict the test to the next-gen kernel (`kerneltype.IsClassic() -> t.Skip`), matching the kernel-conditional behavior of `upgradeToVer284` itself.

### Check List
Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded upgrade test coverage to run on both classic and next-generation kernels.
  * Standardized the test’s upgrade-from version to 283.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->