### PR TITLE
objstore: set correct part size in KS3 multipart uploads

### DIFF
--- a/pkg/objstore/s3store/ks3.go
+++ b/pkg/objstore/s3store/ks3.go
@@ -737,7 +737,6 @@ func (rs *KS3Storage) Create(ctx context.Context, name string, option *storeapi.
 			Bucket: aws.String(rs.options.Bucket),
 			Key:    aws.String(rs.options.Prefix + name),
 			Body:   rd,
-			Size:   1024 * 1024 * 5, // ks3 SDK need to set this value to non-zero.
 		}
 		s3Writer := &asyncWriter{wd: wd, wg: &sync.WaitGroup{}}
 		s3Writer.wg.Add(1)

--- a/pkg/objstore/s3store/s3_test.go
+++ b/pkg/objstore/s3store/s3_test.go
@@ -596,6 +596,95 @@ func TestMultiUploadErrorNotOverwritten(t *testing.T) {
 	CheckAccessStats(t, accessRec, 0, 0, 0, 5*1024*1024+6716)
 }
 
+func TestKS3CreateHonorsPartSize(t *testing.T) {
+	const (
+		partSize = 6 * 1024 * 1024
+		uploadID = "test-upload-id"
+	)
+
+	var (
+		mu                sync.Mutex
+		uploadedPartSizes = make(map[string]int)
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		switch {
+		case r.Method == http.MethodPost && query.Has("uploads"):
+			w.Header().Set("Content-Type", "application/xml")
+			_, err := fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult>
+  <Bucket>bucket</Bucket>
+  <Key>prefix/file</Key>
+  <UploadId>%s</UploadId>
+</InitiateMultipartUploadResult>`, uploadID)
+			if err != nil {
+				t.Errorf("write initiate multipart upload response: %v", err)
+			}
+		case r.Method == http.MethodPut && query.Get("uploadId") == uploadID:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read upload part request: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			partNumber := query.Get("partNumber")
+			mu.Lock()
+			uploadedPartSizes[partNumber] = len(body)
+			mu.Unlock()
+			w.Header().Set("ETag", fmt.Sprintf(`"etag-%s"`, partNumber))
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && query.Get("uploadId") == uploadID:
+			w.Header().Set("Content-Type", "application/xml")
+			_, err := fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult>
+  <Location>http://example.com/bucket/prefix/file</Location>
+  <Bucket>bucket</Bucket>
+  <Key>prefix/file</Key>
+  <ETag>"etag"</ETag>
+</CompleteMultipartUploadResult>`)
+			if err != nil {
+				t.Errorf("write complete multipart upload response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected KS3 request: %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	storage, err := NewKS3Storage(ctx, &backuppb.S3{
+		Region:          "test-region",
+		Endpoint:        server.URL,
+		Bucket:          "bucket",
+		Prefix:          "prefix",
+		AccessKey:       "access-key",
+		SecretAccessKey: "secret-access-key",
+		ForcePathStyle:  true,
+	}, &storeapi.Options{})
+	require.NoError(t, err)
+
+	writer, err := storage.Create(ctx, "file", &storeapi.WriterOption{
+		Concurrency: 2,
+		PartSize:    partSize,
+	})
+	require.NoError(t, err)
+
+	data := make([]byte, 2*partSize+1024)
+	n, err := writer.Write(ctx, data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	require.NoError(t, writer.Close(ctx))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, map[string]int{
+		"1": partSize,
+		"2": partSize,
+		"3": 1024,
+	}, uploadedPartSizes)
+}
+
 func mockGetObject(t *testing.T, s3api *mock.MockS3API, times int) {
 	t.Helper()
 	s3api.EXPECT().


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70673

Problem Summary:

The KS3 concurrent uploader sets the configured part size in `UploadOptions` in https://github.com/pingcap/tidb/pull/62771. But the fix is not correct, a fixed 5 MiB `UploadInput.Size` overwrites it inside the KS3 SDK.

### What changed and how does it work?

- Remove the obsolete fixed `UploadInput.Size` so the pinned KS3 SDK uses `UploadOptions.PartSize`.
- Add a regression test with a local multipart HTTP server that verifies the actual uploaded part sizes, not only the configured field.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where large global-sort operations using KS3 could fail after exceeding the multipart upload limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart uploads to KS3 now honor the configured part size instead of applying a fixed size limit.
  * Large uploads are split into parts according to the selected configuration, improving upload behavior and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->