### PR TITLE
planner: fix panic when sorting a self-joined derived table

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -980,6 +980,67 @@ ORDER BY t1.a, t2.a, t3.a, var`
 		tk.MustQuery("SELECT /* issue:66706 */ ref0 FROM (SELECT v0.c0 AS ref0, SIGN(v0.c0) AS ref1 FROM v0) AS s WHERE ref1").Check(testkit.Rows("0.99"))
 		tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
 	})
+
+	// issue-70695-order-by-derived-table-joined-back-to-its-base-table
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		resetTestDB(t, tk)
+		tk.MustExec(`CREATE TABLE ti (
+			id CHAR(32) PRIMARY KEY CLUSTERED,
+			task_id VARCHAR(250) NOT NULL,
+			dag_id VARCHAR(250) NOT NULL,
+			run_id VARCHAR(250) NOT NULL,
+			map_index INT NOT NULL DEFAULT -1,
+			state VARCHAR(20),
+			priority_weight INT,
+			KEY ti_state (state))`)
+		tk.MustExec(`CREATE TABLE dr (
+			id INT PRIMARY KEY,
+			dag_id VARCHAR(250) NOT NULL,
+			run_id VARCHAR(250) NOT NULL,
+			logical_date DATETIME(6),
+			state VARCHAR(20),
+			UNIQUE KEY (dag_id, run_id))`)
+		tk.MustExec(`CREATE TABLE dm (
+			dag_id VARCHAR(250) PRIMARY KEY CLUSTERED,
+			max_active_tasks INT NOT NULL,
+			is_paused BOOL NOT NULL)`)
+		tk.MustExec("INSERT INTO ti VALUES ('00000000000000000000000000000001', 'task', 'dag', 'run', -1, 'scheduled', 1)")
+		tk.MustExec("INSERT INTO dr VALUES (1, 'dag', 'run', '2026-01-01 00:00:00', 'running')")
+		tk.MustExec("INSERT INTO dm VALUES ('dag', 16, false)")
+
+		// The derived table computes -priority_weight as a sort key, so the TopN gets a
+		// projection injected below it. The outer ORDER BY reads the derived table's
+		// columns, and the projection above the TopN must keep addressing the TopN's
+		// own output rather than the injected projection's wider one.
+		tk.MustQuery(`SELECT /* issue:70695 */ ti.id
+			FROM (
+				SELECT ti.id AS id, ti.task_id AS task_id, ti.dag_id AS dag_id,
+					ti.run_id AS run_id, ti.map_index AS map_index,
+					ti.priority_weight AS priority_weight,
+					ROW_NUMBER() OVER (
+						PARTITION BY ti.dag_id, ti.run_id
+						ORDER BY -ti.priority_weight, dr.logical_date, ti.map_index
+					) AS row_num,
+					dm.max_active_tasks AS dr_max_active_tasks,
+					ti.priority_weight AS priority_weight_for_ordering,
+					dr.logical_date AS logical_date_for_ordering,
+					ti.map_index AS map_index_for_ordering
+				FROM ti
+				JOIN dr ON dr.dag_id = ti.dag_id AND dr.run_id = ti.run_id
+				JOIN dm ON dm.dag_id = ti.dag_id
+				WHERE dr.state = 'running' AND dm.is_paused = false AND ti.state = 'scheduled'
+				ORDER BY -ti.priority_weight, dr.logical_date, ti.map_index
+			) candidates
+			JOIN ti ON ti.dag_id = candidates.dag_id
+				AND ti.task_id = candidates.task_id
+				AND ti.run_id = candidates.run_id
+				AND ti.map_index = candidates.map_index
+			WHERE candidates.dr_max_active_tasks >= candidates.row_num
+			ORDER BY -candidates.priority_weight_for_ordering,
+				candidates.logical_date_for_ordering,
+				candidates.map_index_for_ordering
+			LIMIT 16`).Check(testkit.Rows("00000000000000000000000000000001"))
+	})
 }
 
 func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {

--- a/pkg/planner/core/rule_inject_extra_projection.go
+++ b/pkg/planner/core/rule_inject_extra_projection.go
@@ -282,7 +282,6 @@ func InjectProjBelowSort(p base.PhysicalPlan, orderByItems []*util.ByItems) base
 	if origChildProj, isChildProj := childPlan.(*physicalop.PhysicalProjection); isChildProj {
 		refine4NeighbourProj(bottomProj, origChildProj)
 	}
-	refine4NeighbourProj(topProj, bottomProj)
 
 	return topProj
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70695

Problem Summary:

A query that sorts on a derived table joined back to its own base table panics
with `index out of range` instead of returning rows. After this change the same
`ORDER BY` query returns its rows, so Apache Airflow 3's scheduler, which emits
exactly this shape, can claim tasks on TiDB again. The only workaround before
was dropping the outer `ORDER BY`, which is the ordering the query exists to
produce.

### What changed and how does it work?

When a `TopN`/`Sort` orders by a scalar function, `InjectProjBelowSort` adds a
projection below it and one above, giving `topProj -> TopN -> bottomProj`, then
called `refine4NeighbourProj(topProj, bottomProj)`. Those two are not
neighbours, since the `TopN` sits between them, so the remap pointed `topProj`
at `bottomProj`'s columns while it actually reads the `TopN`'s output, running
past the end of its input chunk. Because `postOptimize` runs after
`ResolveIndices`, this corrupted already-resolved indexes. This drops the call:
`topProj`'s expressions already address the `TopN` positionally, and real
column aliasing is handled at runtime by `ColumnSwapHelper`. The adjacent
`refine4NeighbourProj(bottomProj, origChildProj)` is kept.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Added `issue-70695-order-by-derived-table-joined-back-to-its-base-table` to
`TestPlannerIssueRegressions`. Keeping that case and reverting only the fixed
file to master shows the panic; restoring it passes:

```
$ git checkout fa2a89347b -- pkg/planner/core/rule_inject_extra_projection.go
$ go test -tags=intest ./pkg/planner/core/issuetest/ \
    -run '^TestPlannerIssueRegressions$' -count=1
            	            	runtime error: index out of range [4] with length 1
--- FAIL: TestPlannerIssueRegressions (4.07s)
FAIL	github.com/pingcap/tidb/pkg/planner/core/issuetest	5.605s

$ git checkout 731778e47a -- pkg/planner/core/rule_inject_extra_projection.go
$ go test -tags=intest ./pkg/planner/core/issuetest/ \
    -run '^TestPlannerIssueRegressions$' -count=1
ok  	github.com/pingcap/tidb/pkg/planner/core/issuetest	6.524s
```

The other path through `InjectProjBelowSort` is #46580. Against this build its
hinted plan agrees with the unhinted one, and 20 repeats return the same rows:

```sql
CREATE TABLE t0(c0 INT);
CREATE TABLE t1(c0 BOOL, c1 BOOL);
INSERT INTO t1 VALUES (false, true), (true, true);
CREATE VIEW v0(c0, c1, c2) AS SELECT t1.c0, LOG10(t0.c0), t1.c0 FROM t0, t1;
INSERT INTO t0(c0) VALUES (3);
SELECT /*+ MERGE_JOIN(t1, t0, v0)*/v0.c2, t1.c0 FROM v0, t0 CROSS JOIN t1 ORDER BY -v0.c1;
-- (0,0) (0,1) (1,0) (1,1), same as the query without the hint
```

`pkg/planner/core` and `pkg/planner/core/casetest/...` were also run both ways;
their remaining failures reproduce with the fixed file reverted, so they are
pre-existing. All of this ran against unistore.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a panic that made a query fail with "index out of range" when it ordered by
columns of a derived table that was joined back to its own base table.
```

