### PR TITLE
dxf, server: add DXF nodes HTTP API

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -789,6 +789,43 @@ These APIs are registered only on TiDB instances running in the TiDB-X SYSTEM ke
 
 The `/dxf/...` APIs are for DXF (Distributed eXecution Framework) operator observability and emergency runtime tuning. In TiDB-X, DXF runs as a shared SYSTEM-keyspace service for resource-intensive work such as IMPORT INTO and distributed add index, so some APIs are called on a SYSTEM-keyspace TiDB process but target a user keyspace parameter.
 
+### List DXF nodes
+
+This API lists the TiDB nodes registered with DXF. The response is ordered by `host` and omits the internal `keyspace_id` field.
+
+Usage:
+
+```shell
+curl http://{TiDBIP}:10080/dxf/nodes
+```
+
+Parameters: none.
+
+Response fields:
+
+- `host`: The TiDB execution ID in `IP:PORT` form.
+- `role`: The node's configured TiDB service scope. `dxf_service` is the normal value for TiDB-X DXF nodes; `background`, an empty string, or another configured scope can also appear.
+- `cpu_count`: The number of CPU slots available to DXF on the node.
+
+Example response:
+
+```json
+[
+ {
+  "host": "192.168.1.10:5000",
+  "role": "dxf_service",
+  "cpu_count": 8
+ },
+ {
+  "host": "192.168.1.11:5000",
+  "role": "background",
+  "cpu_count": 16
+ }
+]
+```
+
+If no DXF nodes are registered, the response is `[]`.
+
 ### Get the DXF schedule status
 
 This API returns the scheduler view used by cluster controllers to decide how many DXF worker nodes are needed. It includes the number of scheduled tasks, current and required TiDB/TiKV worker counts, busy DXF nodes, and temporary scheduler flags such as `pause_scale_in`.

--- a/pkg/dxf/framework/handle/status.go
+++ b/pkg/dxf/framework/handle/status.go
@@ -91,6 +91,20 @@ func GetActiveTaskSummary(ctx context.Context) (*storage.ActiveTaskSummary, erro
 	return summary, nil
 }
 
+// GetDXFNodes returns all nodes registered in mysql.dist_framework_meta.
+func GetDXFNodes(ctx context.Context) ([]proto.ManagedNode, error) {
+	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
+	manager, err := storage.GetTaskManager()
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := manager.GetAllNodes(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return nodes, nil
+}
+
 // ListHistoryTasks lists history tasks with keyset pagination and optional keyspace filter.
 func ListHistoryTasks(ctx context.Context, pageSize int, pageToken int64, keyspace string) (*storage.HistoryTaskPage, error) {
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)

--- a/pkg/dxf/framework/handle/status.go
+++ b/pkg/dxf/framework/handle/status.go
@@ -91,8 +91,8 @@ func GetActiveTaskSummary(ctx context.Context) (*storage.ActiveTaskSummary, erro
 	return summary, nil
 }
 
-// GetDXFNodes returns all nodes registered in mysql.dist_framework_meta.
-func GetDXFNodes(ctx context.Context) ([]proto.ManagedNode, error) {
+// ListManagedNodes returns all nodes registered in mysql.dist_framework_meta.
+func ListManagedNodes(ctx context.Context) ([]proto.ManagedNode, error) {
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
 	manager, err := storage.GetTaskManager()
 	if err != nil {

--- a/pkg/server/handler/tests/dxf_test.go
+++ b/pkg/server/handler/tests/dxf_test.go
@@ -156,6 +156,40 @@ func TestDXFAPI(t *testing.T) {
 		require.EqualValues(t, 2, out.PerKeyspace["ks1"])
 	})
 
+	t.Run("nodes api", func(t *testing.T) {
+		runAndCheckReqFn(t, http.StatusBadRequest, "This api only support GET method", func() (*http.Response, error) {
+			return ts.PostStatus("/dxf/nodes", "", bytes.NewBuffer([]byte("")))
+		})
+
+		tm, ctx := setupTaskManager(t)
+		_, err := tm.ExecuteSQLWithNewSession(ctx, "delete from mysql.dist_framework_meta")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, err := tm.ExecuteSQLWithNewSession(ctx, "delete from mysql.dist_framework_meta")
+			require.NoError(t, err)
+			require.NoError(t, tm.InitMeta(ctx, ":4000", ""))
+		})
+
+		body := runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
+			return ts.FetchStatus("/dxf/nodes")
+		})
+		require.JSONEq(t, "[]", string(body))
+
+		_, err = tm.ExecuteSQLWithNewSession(ctx, `
+			insert into mysql.dist_framework_meta(host, role, cpu_count, keyspace_id)
+			values (":4002", "background", 8, -1), (":4001", "", 4, -1)`)
+		require.NoError(t, err)
+		body = runAndCheckReqFn(t, http.StatusOK, "", func() (*http.Response, error) {
+			return ts.FetchStatus("/dxf/nodes")
+		})
+		var nodes []map[string]any
+		require.NoError(t, json.Unmarshal(body, &nodes))
+		require.Equal(t, []map[string]any{
+			{"host": ":4001", "role": "", "cpu_count": float64(4)},
+			{"host": ":4002", "role": "background", "cpu_count": float64(8)},
+		}, nodes)
+	})
+
 	t.Run("max concurrent task api", func(t *testing.T) {
 		restore := proto.SetMaxConcurrentTaskForTest(proto.DefaultMaxConcurrentTask)
 		defer restore()
@@ -623,6 +657,7 @@ func TestDXFMaintenanceAPINotAvailableInUserKeyspace(t *testing.T) {
 	ts.StatusPort = testutil.GetPortFromTCPAddr(ts.server.StatusListenerAddr())
 
 	for _, path := range []string{
+		"/dxf/nodes",
 		"/dxf/schedule/task_cleanup_batch_size",
 		"/dxf/schedule/max_concurrent_task",
 	} {

--- a/pkg/server/handler/tikvhandler/BUILD.bazel
+++ b/pkg/server/handler/tikvhandler/BUILD.bazel
@@ -73,7 +73,9 @@ go_test(
     srcs = ["dxf_test.go"],
     embed = [":tikvhandler"],
     flaky = True,
+    shard_count = 2,
     deps = [
+        "//pkg/dxf/framework/proto",
         "//pkg/dxf/framework/schstatus",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -104,6 +104,7 @@ type dxfNode struct {
 
 // DXFNodesHandler handles listing nodes registered in `mysql.dist_framework_meta`.
 type DXFNodesHandler struct {
+	// Keep this dependency injectable for testing errors and cancellation without replacing global task-manager state.
 	getNodes func(context.Context) ([]proto.ManagedNode, error)
 }
 

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -96,6 +96,48 @@ func (*DXFActiveTaskHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	handler.WriteData(w, summary)
 }
 
+type dxfNode struct {
+	Host     string `json:"host"`
+	Role     string `json:"role"`
+	CPUCount int    `json:"cpu_count"`
+}
+
+// DXFNodesHandler handles listing nodes registered in `mysql.dist_framework_meta`.
+type DXFNodesHandler struct {
+	getNodes func(context.Context) ([]proto.ManagedNode, error)
+}
+
+// NewDXFNodesHandler creates a new DXFNodesHandler.
+func NewDXFNodesHandler() *DXFNodesHandler {
+	return &DXFNodesHandler{getNodes: handle.GetDXFNodes}
+}
+
+// ServeHTTP implements http.Handler interface.
+func (h *DXFNodesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		handler.WriteError(w, errors.Errorf("This api only support GET method"))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), requestDefaultTimeout)
+	defer cancel()
+	nodes, err := h.getNodes(ctx)
+	if err != nil {
+		logutil.BgLogger().Warn("failed to get DXF nodes", zap.Error(err))
+		handler.WriteErrorWithCode(w, http.StatusInternalServerError, err)
+		return
+	}
+	result := make([]dxfNode, len(nodes))
+	for i, node := range nodes {
+		result[i] = dxfNode{
+			Host:     node.ID,
+			Role:     node.Role,
+			CPUCount: node.CPUCount,
+		}
+	}
+	handler.WriteData(w, result)
+}
+
 // DXFTaskHistoryHandler handles listing history tasks in `mysql.tidb_global_task_history`.
 type DXFTaskHistoryHandler struct{}
 

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -104,7 +104,8 @@ type dxfNode struct {
 
 // DXFNodesHandler handles listing nodes registered in `mysql.dist_framework_meta`.
 type DXFNodesHandler struct {
-	// Keep this dependency injectable for testing errors and cancellation without replacing global task-manager state.
+	// Keep this dependency injectable for testing errors and cancellation
+	// without replacing global task-manager state.
 	getNodes func(context.Context) ([]proto.ManagedNode, error)
 }
 

--- a/pkg/server/handler/tikvhandler/dxf.go
+++ b/pkg/server/handler/tikvhandler/dxf.go
@@ -111,7 +111,7 @@ type DXFNodesHandler struct {
 
 // NewDXFNodesHandler creates a new DXFNodesHandler.
 func NewDXFNodesHandler() *DXFNodesHandler {
-	return &DXFNodesHandler{getNodes: handle.GetDXFNodes}
+	return &DXFNodesHandler{getNodes: handle.ListManagedNodes}
 }
 
 // ServeHTTP implements http.Handler interface.

--- a/pkg/server/handler/tikvhandler/dxf_test.go
+++ b/pkg/server/handler/tikvhandler/dxf_test.go
@@ -15,13 +15,51 @@
 package tikvhandler
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
 	"github.com/pingcap/tidb/pkg/dxf/framework/schstatus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDXFNodesHandler(t *testing.T) {
+	t.Run("read error", func(t *testing.T) {
+		h := &DXFNodesHandler{
+			getNodes: func(context.Context) ([]proto.ManagedNode, error) {
+				return nil, errors.New("injected read error")
+			},
+		}
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/dxf/nodes", nil))
+
+		require.Equal(t, http.StatusInternalServerError, recorder.Code)
+		require.Equal(t, "injected read error", recorder.Body.String())
+	})
+
+	t.Run("canceled request", func(t *testing.T) {
+		var observedErr error
+		h := &DXFNodesHandler{
+			getNodes: func(ctx context.Context) ([]proto.ManagedNode, error) {
+				observedErr = ctx.Err()
+				return []proto.ManagedNode{}, nil
+			},
+		}
+		reqCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req := httptest.NewRequest(http.MethodGet, "/dxf/nodes", nil).WithContext(reqCtx)
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, req)
+
+		require.ErrorIs(t, observedErr, context.Canceled)
+		require.Equal(t, http.StatusOK, recorder.Code)
+		require.JSONEq(t, "[]", recorder.Body.String())
+	})
+}
 
 func TestParsePauseScaleInFlag(t *testing.T) {
 	_, _, err := parsePauseScaleInFlag(&http.Request{})

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -272,6 +272,7 @@ func (s *Server) startHTTPServer() {
 		router.Handle("/dxf/schedule", tikvhandler.NewDXFScheduleHandler()).Name("DXF_Schedule")
 		router.Handle("/dxf/schedule/tune", tikvhandler.NewDXFScheduleTuneHandler(tikvHandlerTool.Store.(kv.Storage))).Name("DXF_Schedule_Tune")
 		router.Handle("/dxf/task/active", tikvhandler.NewDXFActiveTaskHandler()).Name("DXF_Task_Active")
+		router.Handle("/dxf/nodes", tikvhandler.NewDXFNodesHandler()).Name("DXF_Nodes")
 		router.Handle("/dxf/task/history", tikvhandler.NewDXFTaskHistoryHandler()).Name("DXF_Task_History")
 		// These APIs update only the TiDB process that handles the request and are not persisted.
 		router.Handle("/dxf/schedule/max_concurrent_task", tikvhandler.NewDXFTaskMaxConcurrentHandler()).Name("DXF_Schedule_Max_Concurrent_Task")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #67640

Problem Summary:

In TiDB-X, DXF metadata is stored in the `SYSTEM` keyspace, but operators currently need to query `mysql.dist_framework_meta` directly to inspect registered DXF nodes. Exposing this information over HTTP helps diagnose DXF node availability and service-scope assignment issues.

### What changed and how does it work?

- Add `GET /dxf/nodes` to TiDB-X `SYSTEM` keyspace status servers.
- Return registered DXF nodes ordered by `host`, with `host`, `role`, and `cpu_count`; intentionally omit `keyspace_id`.
- Reuse the existing `TaskManager.GetAllNodes` read path and propagate request cancellation.
- Return `[]` for an empty table, reject non-GET requests, and report read failures.
- Add endpoint, route-isolation, error, cancellation, and response-contract tests.
- Document the new HTTP API.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```shell
./tools/check/failpoint-go-test.sh pkg/server/handler/tikvhandler -run TestDXFNodesHandler -count=1
./tools/check/failpoint-go-test.sh pkg/server/handler/tests -run 'TestDXFAPI|TestDXFMaintenanceAPINotAvailableInUserKeyspace' -tags=intest,deadlock,nextgen -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add the `/dxf/nodes` HTTP API for listing DXF nodes from TiDB-X `SYSTEM` keyspace status servers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/dxf/nodes` API endpoint for listing registered TiDB-X nodes.
  * Responses include each node’s host, role, and CPU count, sorted by host.
  * Returns an empty list when no nodes are registered.

* **Documentation**
  * Added API documentation covering request methods, response fields, behavior, and examples.

* **Bug Fixes**
  * Improved error handling for node lookup failures and canceled requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->