### PR TITLE
br: compare collate check privilege

### DIFF
--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -114,6 +114,7 @@ go_test(
         "client_test.go",
         "data_test.go",
         "db_test.go",
+        "export_test.go",
         "import_retry_test.go",
         "log_client_test.go",
         "main_test.go",

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -190,6 +190,8 @@ type Client struct {
 
 	// checkpoint information for log restore
 	useCheckpoint bool
+
+	privilegeTableRowsCollateCompatibility bool
 }
 
 // NewRestoreClient returns a new RestoreClient.
@@ -1176,7 +1178,13 @@ func (rc *Client) CheckSysTableCompatibility(dom *domain.Domain, tables []*metau
 					table.Info.Name.O,
 					col.Name, col.FieldType.String())
 			}
-			if !utils.IsTypeCompatible(backupCol.FieldType, col.FieldType) {
+			typeEq, collateEq := utils.IsTypeCompatible(backupCol.FieldType, col.FieldType)
+			collateCompatible := collateEq
+			if typeEq && !collateEq {
+				rc.privilegeTableRowsCollateCompatibility = true
+				collateCompatible = checkSysTableColumnCollateCompatibility(mysql.SystemDB, table.Info.Name.L, col.Name.L, backupCol.GetCollate(), col.GetCollate())
+			}
+			if !(typeEq && collateCompatible) {
 				log.Error("incompatible column",
 					zap.Stringer("table", table.Info.Name),
 					zap.String("col in cluster", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())),

--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -278,7 +278,44 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 
 	// other system tables in cluster have more columns(failed)
 	mockedDBTI := dbTI.Clone()
-	dbTI.Columns = append(dbTI.Columns, &model.ColumnInfo{Name: model.NewCIStr("new-name")})
+	mockedDBTI.Columns = append(dbTI.Columns, &model.ColumnInfo{Name: model.NewCIStr("new-name")})
+	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedDBTI,
+	}})
+	require.True(t, berrors.ErrRestoreIncompatibleSys.Equal(err))
+
+	// skip check collate
+	mockedDBTI = dbTI.Clone()
+	mockedDBTI.Columns[1].SetCollate("utf8mb4_bin")
+	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedDBTI,
+	}})
+	require.NoError(t, err)
+
+	// skip check collate but type mismatch
+	mockedDBTI = dbTI.Clone()
+	mockedDBTI.Columns[1].SetCollate("utf8mb4_bin")
+	mockedDBTI.Columns[1].FieldType.SetFlen(2000) // Columns[1] is `DB` char(64)
+	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedDBTI,
+	}})
+	require.True(t, berrors.ErrRestoreIncompatibleSys.Equal(err))
+
+	// another column collate mismatch
+	mockedDBTI = dbTI.Clone()
+	mockedDBTI.Columns[0].SetCollate("utf8mb4_general_ci")
+	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedDBTI,
+	}})
+	require.True(t, berrors.ErrRestoreIncompatibleSys.Equal(err))
+
+	// another column collate mismatch
+	mockedDBTI = dbTI.Clone()
+	mockedDBTI.Columns[1].SetCollate("utf8mb4_unicode_ci")
 	err = client.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
 		DB:   tmpSysDB,
 		Info: mockedDBTI,

--- a/br/pkg/restore/export_test.go
+++ b/br/pkg/restore/export_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package restore
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/stretchr/testify/require"
+)
+
+func (rc *Client) CheckPrivilegeTableRowsCollateCompatibility(
+	ctx context.Context,
+	dbNameL, tableNameL string,
+	upstreamTable, downstreamTable *model.TableInfo,
+) error {
+	return rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbNameL, tableNameL, upstreamTable, downstreamTable)
+}
+
+func testTableInfo(name string) *model.TableInfo {
+	return &model.TableInfo{
+		Name: model.NewCIStr(name),
+	}
+}
+
+func TestGenerateResetSQL(t *testing.T) {
+	// case #1: ignore non-mysql databases
+	mockDB := &database{
+		ExistingTables: map[string]*model.TableInfo{},
+		Name:           model.NewCIStr("non-mysql"),
+		TemporaryName:  utils.TemporaryDBName("non-mysql"),
+	}
+	for name := range sysPrivilegeTableMap {
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers := []string{"cloud_admin", "root"}
+	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+
+	// case #2: ignore non expected table
+	mockDB = &database{
+		ExistingTables: map[string]*model.TableInfo{},
+		Name:           model.NewCIStr("mysql"),
+		TemporaryName:  utils.TemporaryDBName("mysql"),
+	}
+	for name := range sysPrivilegeTableMap {
+		name += "non_available"
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers = []string{"cloud_admin", "root"}
+	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+
+	// case #3: only reset cloud admin account
+	for name := range sysPrivilegeTableMap {
+		mockDB.ExistingTables[name] = testTableInfo(name)
+	}
+	resetUsers = []string{"cloud_admin"}
+	sqls := generateResetSQLs(mockDB, resetUsers)
+	require.Equal(t, 8, len(sqls))
+	for _, sql := range sqls {
+		// for cloud_admin we only generate DELETE sql
+		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
+	}
+
+	// case #4: reset cloud admin/other account
+	resetUsers = []string{"cloud_admin", "cloud_other"}
+	sqls = generateResetSQLs(mockDB, resetUsers)
+	require.Equal(t, 16, len(sqls))
+	for _, sql := range sqls {
+		// for cloud_admin/cloud_other we only generate DELETE sql
+		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
+	}
+
+	// case #5: reset cloud admin && root account
+	resetUsers = []string{"cloud_admin", "root"}
+	sqls = generateResetSQLs(mockDB, resetUsers)
+	// 8 DELETE sqls for cloud admin and 1 UPDATE sql for root
+	require.Equal(t, 9, len(sqls))
+}

--- a/br/pkg/restore/systable_restore.go
+++ b/br/pkg/restore/systable_restore.go
@@ -176,7 +176,7 @@ func (rc *Client) ClearSystemUsers(ctx context.Context, resetUsers []string) err
 
 // RestoreSystemSchemas restores the system schema(i.e. the `mysql` schema).
 // Detail see https://github.com/pingcap/br/issues/679#issuecomment-762592254.
-func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) {
+func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) error {
 	sysDB := mysql.SystemDB
 
 	temporaryDB := utils.TemporaryDBName(sysDB)
@@ -184,18 +184,18 @@ func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) {
 
 	if !f.MatchSchema(sysDB) || !rc.withSysTable {
 		log.Debug("system database filtered out", zap.String("database", sysDB))
-		return
+		return nil
 	}
 	originDatabase, ok := rc.databases[temporaryDB.O]
 	if !ok {
 		log.Info("system database not backed up, skipping", zap.String("database", sysDB))
-		return
+		return nil
 	}
 	db, ok := rc.getDatabaseByName(sysDB)
 	if !ok {
 		// Or should we create the database here?
 		log.Warn("target database not exist, aborting", zap.String("database", sysDB))
-		return
+		return nil
 	}
 
 	tablesRestored := make([]string, 0, len(originDatabase.Tables))
@@ -207,15 +207,15 @@ func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) {
 					logutil.ShortError(err),
 					zap.Stringer("table", tableName),
 				)
+				return errors.Annotatef(err, "error during merging temporary tables into system tables, table: %s", tableName)
 			}
 			tablesRestored = append(tablesRestored, tableName.L)
 		}
 	}
 	if err := rc.afterSystemTablesReplaced(tablesRestored); err != nil {
-		for _, e := range multierr.Errors(err) {
-			log.Warn("error during reconfigurating the system tables", zap.String("database", sysDB), logutil.ShortError(e))
-		}
+		return errors.Annotate(err, "error during extra works after system tables replaced")
 	}
+	return nil
 }
 
 // database is a record of a database.
@@ -323,6 +323,11 @@ func (rc *Client) replaceTemporaryTableToSystable(ctx context.Context, ti *model
 
 	if db.ExistingTables[tableName] != nil {
 		whereNotClause := ""
+		if rc.privilegeTableRowsCollateCompatibility {
+			if err := rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbName, tableName, ti, db.ExistingTables[tableName]); err != nil {
+				return err
+			}
+		}
 		if rc.fullClusterRestore && sysPrivilegeTableMap[tableName] != "" {
 			// cloud_admin is a special user on tidb cloud, need to skip it.
 			/* #nosec G202: SQL string concatenation */
@@ -338,11 +343,6 @@ func (rc *Client) replaceTemporaryTableToSystable(ctx context.Context, ti *model
 		log.Info("replace into existing table",
 			zap.String("table", tableName),
 			zap.Stringer("schema", db.Name))
-		if rc.privilegeTableRowsCollateCompatibility {
-			if err := rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbName, tableName, ti, db.ExistingTables[tableName]); err != nil {
-				return err
-			}
-		}
 		// target column order may different with source cluster
 		columnNames := make([]string, 0, len(ti.Columns))
 		for _, col := range ti.Columns {

--- a/br/pkg/restore/systable_restore.go
+++ b/br/pkg/restore/systable_restore.go
@@ -207,6 +207,9 @@ func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) err
 					logutil.ShortError(err),
 					zap.Stringer("table", tableName),
 				)
+				if berrors.Is(err, berrors.ErrUnsupportedSystemTable) {
+					continue
+				}
 				return errors.Annotatef(err, "error during merging temporary tables into system tables, table: %s", tableName)
 			}
 			tablesRestored = append(tablesRestored, tableName.L)

--- a/br/pkg/restore/systable_restore.go
+++ b/br/pkg/restore/systable_restore.go
@@ -12,8 +12,10 @@ import (
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -68,6 +70,32 @@ var sysPrivilegeTableMap = map[string]string{
 func isUnrecoverableTable(tableName string) bool {
 	_, ok := unRecoverableTable[tableName]
 	return ok
+}
+
+type checkPrivilegeTableRowsCollateCompatibilitySQLPair struct {
+	upstreamCollateSQL   string
+	downstreamCollateSQL string
+	columns              map[string]struct{}
+}
+
+var collateCompatibilityTables = map[string]map[string]checkPrivilegeTableRowsCollateCompatibilitySQLPair{
+	"mysql": {
+		"db": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM __TiDB_BR_Temporary_mysql.db",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User FROM __TiDB_BR_Temporary_mysql.db GROUP BY Host, DB COLLATE utf8mb4_general_ci, User) as a",
+			columns:              map[string]struct{}{"db": {}},
+		},
+		"tables_priv": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM __TiDB_BR_Temporary_mysql.tables_priv",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci FROM __TiDB_BR_Temporary_mysql.tables_priv GROUP BY Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci) as a",
+			columns:              map[string]struct{}{"db": {}, "table_name": {}},
+		},
+		"columns_priv": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM __TiDB_BR_Temporary_mysql.columns_priv",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci, Column_name COLLATE utf8mb4_general_ci FROM __TiDB_BR_Temporary_mysql.columns_priv GROUP BY Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci, Column_name COLLATE utf8mb4_general_ci) as a",
+			columns:              map[string]struct{}{"db": {}, "table_name": {}, "column_name": {}},
+		},
+	},
 }
 
 func isStatsTable(tableName string) bool {
@@ -239,6 +267,7 @@ func (rc *Client) afterSystemTablesReplaced(tables []string) error {
 
 // replaceTemporaryTableToSystable replaces the temporary table to real system table.
 func (rc *Client) replaceTemporaryTableToSystable(ctx context.Context, ti *model.TableInfo, db *database) error {
+	dbName := db.Name.L
 	tableName := ti.Name.L
 	execSQL := func(sql string) error {
 		// SQLs here only contain table name and database name, seems it is no need to redact them.
@@ -309,6 +338,11 @@ func (rc *Client) replaceTemporaryTableToSystable(ctx context.Context, ti *model
 		log.Info("replace into existing table",
 			zap.String("table", tableName),
 			zap.Stringer("schema", db.Name))
+		if rc.privilegeTableRowsCollateCompatibility {
+			if err := rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbName, tableName, ti, db.ExistingTables[tableName]); err != nil {
+				return err
+			}
+		}
 		// target column order may different with source cluster
 		columnNames := make([]string, 0, len(ti.Columns))
 		for _, col := range ti.Columns {
@@ -340,4 +374,98 @@ func (rc *Client) cleanTemporaryDatabase(ctx context.Context, originDB string) {
 			logutil.ShortError(err),
 		)
 	}
+}
+
+func checkSysTableColumnCollateCompatibility(dbNameL, tableNameL, columnNameL, upstreamCollate, downstreamCollate string) bool {
+	if upstreamCollate != "utf8mb4_bin" || downstreamCollate != "utf8mb4_general_ci" {
+		return false
+	}
+	collateCompatibilityTableMap, exists := collateCompatibilityTables[dbNameL]
+	if !exists {
+		return false
+	}
+	collateCompatibilityColumnMap, exists := collateCompatibilityTableMap[tableNameL]
+	if !exists {
+		return false
+	}
+	_, exists = collateCompatibilityColumnMap.columns[columnNameL]
+	return exists
+}
+
+func (rc *Client) checkPrivilegeTableRowsCollateCompatibility(
+	ctx context.Context,
+	dbNameL, tableNameL string,
+	upstreamTable, downstreamTable *model.TableInfo,
+) error {
+	collateCompatibilityTableMap, exists := collateCompatibilityTables[dbNameL]
+	if !exists {
+		return nil
+	}
+	collateCompatibilityColumnMap, exists := collateCompatibilityTableMap[tableNameL]
+	if !exists {
+		return nil
+	}
+	colCount := 0
+	for _, col := range upstreamTable.Columns {
+		if _, exists := collateCompatibilityColumnMap.columns[col.Name.L]; exists {
+			if col.GetCollate() != "utf8mb4_bin" && col.GetCollate() != "utf8mb4_general_ci" {
+				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					"incompatible column collate, upstream table %s.%s column %s collate is %s but should be utf8mb4_bin or utf8mb4_general_ci",
+					dbNameL, tableNameL, col.Name.L, col.GetCollate())
+			}
+			colCount += 1
+		}
+	}
+	if colCount != len(collateCompatibilityColumnMap.columns) {
+		return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			"incompatible column collate, upstream table %s.%s has only %d compatible columns",
+			dbNameL, tableNameL, colCount)
+	}
+	colCount = 0
+	for _, col := range downstreamTable.Columns {
+		if _, exists := collateCompatibilityColumnMap.columns[col.Name.L]; exists {
+			if col.GetCollate() != "utf8mb4_general_ci" {
+				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					"incompatible column collate, downstream table %s.%s column %s collate is %s but should be utf8mb4_general_ci",
+					dbNameL, tableNameL, col.Name.L, col.GetCollate())
+			}
+			colCount += 1
+		}
+	}
+	if colCount != len(collateCompatibilityColumnMap.columns) {
+		return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			"incompatible column collate, downstream table %s.%s has only %d compatible columns",
+			dbNameL, tableNameL, colCount)
+	}
+	ectx := rc.db.se.GetSessionCtx().(sqlexec.RestrictedSQLExecutor)
+	rows, _, err := ectx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		collateCompatibilityColumnMap.upstreamCollateSQL,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get the count of privilege rows")
+	}
+	if len(rows) == 0 {
+		return errors.Errorf("failed to get the count of privilege rows")
+	}
+	upstreamCount := rows[0].GetInt64(0)
+	rows, _, err = ectx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		collateCompatibilityColumnMap.downstreamCollateSQL,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get the count of privilege rows")
+	}
+	if len(rows) == 0 {
+		return errors.Errorf("failed to get the count of privilege rows")
+	}
+	downstreamCount := rows[0].GetInt64(0)
+	if upstreamCount != downstreamCount {
+		return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			"there are duplicated privilege rows with collate utf8mb4_general_ci [upstream count %d != downstream count %d]",
+			upstreamCount, downstreamCount)
+	}
+	return nil
 }

--- a/br/pkg/restore/systable_restore.go
+++ b/br/pkg/restore/systable_restore.go
@@ -213,7 +213,9 @@ func (rc *Client) RestoreSystemSchemas(ctx context.Context, f filter.Filter) err
 		}
 	}
 	if err := rc.afterSystemTablesReplaced(tablesRestored); err != nil {
-		return errors.Annotate(err, "error during extra works after system tables replaced")
+		for _, e := range multierr.Errors(err) {
+			log.Warn("error during reconfigurating the system tables", zap.String("database", sysDB), logutil.ShortError(e))
+		}
 	}
 	return nil
 }

--- a/br/pkg/restore/systable_restore_test.go
+++ b/br/pkg/restore/systable_restore_test.go
@@ -1,72 +1,231 @@
 // Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
 
-package restore
+package restore_test
 
 import (
-	"regexp"
+	"context"
+	"fmt"
 	"testing"
 
-	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/gluetidb"
+	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/stretchr/testify/require"
 )
 
-func testTableInfo(name string) *model.TableInfo {
-	return &model.TableInfo{
-		Name: model.NewCIStr(name),
-	}
+type mustExecuteSession struct {
+	ctx context.Context
+	se  glue.Session
+	t   *testing.T
 }
 
-func TestGenerateResetSQL(t *testing.T) {
-	// case #1: ignore non-mysql databases
-	mockDB := &database{
-		ExistingTables: map[string]*model.TableInfo{},
-		Name:           model.NewCIStr("non-mysql"),
-		TemporaryName:  utils.TemporaryDBName("non-mysql"),
-	}
-	for name := range sysPrivilegeTableMap {
-		mockDB.ExistingTables[name] = testTableInfo(name)
-	}
-	resetUsers := []string{"cloud_admin", "root"}
-	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+func (se *mustExecuteSession) MustExecute(sql string) {
+	err := se.se.ExecuteInternal(se.ctx, sql)
+	require.NoError(se.t, err)
+}
 
-	// case #2: ignore non expected table
-	mockDB = &database{
-		ExistingTables: map[string]*model.TableInfo{},
-		Name:           model.NewCIStr("mysql"),
-		TemporaryName:  utils.TemporaryDBName("mysql"),
-	}
-	for name := range sysPrivilegeTableMap {
-		name += "non_available"
-		mockDB.ExistingTables[name] = testTableInfo(name)
-	}
-	resetUsers = []string{"cloud_admin", "root"}
-	require.Equal(t, 0, len(generateResetSQLs(mockDB, resetUsers)))
+const (
+	CreateDBSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.db (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Select_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Insert_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Update_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Delete_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Drop_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Grant_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  References_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Index_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Alter_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_tmp_table_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Lock_tables_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_view_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Show_view_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_routine_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Alter_routine_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Execute_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Event_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Trigger_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  PRIMARY KEY (Host,DB,User) /*T![clustered_index] NONCLUSTERED */
+)`
 
-	// case #3: only reset cloud admin account
-	for name := range sysPrivilegeTableMap {
-		mockDB.ExistingTables[name] = testTableInfo(name)
-	}
-	resetUsers = []string{"cloud_admin"}
-	sqls := generateResetSQLs(mockDB, resetUsers)
-	require.Equal(t, 8, len(sqls))
-	for _, sql := range sqls {
-		// for cloud_admin we only generate DELETE sql
-		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
-	}
+	CreateTableSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.tables_priv (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Table_name char(64) NOT NULL,
+  Grantor char(77) DEFAULT NULL,
+  Timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+  Table_priv set('Select','Insert','Update','Delete','Create','Drop','Grant','Index','Alter','Create View','Show View','Trigger','References') DEFAULT NULL,
+  Column_priv set('Select','Insert','Update','References') DEFAULT NULL,
+  PRIMARY KEY (Host,DB,User,Table_name) /*T![clustered_index] NONCLUSTERED */
+)`
 
-	// case #4: reset cloud admin/other account
-	resetUsers = []string{"cloud_admin", "cloud_other"}
-	sqls = generateResetSQLs(mockDB, resetUsers)
-	require.Equal(t, 16, len(sqls))
-	for _, sql := range sqls {
-		// for cloud_admin/cloud_other we only generate DELETE sql
-		require.Regexp(t, regexp.MustCompile("DELETE*"), sql)
-	}
+	CreateColumnSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.columns_priv (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Table_name char(64) NOT NULL,
+  Column_name char(64) NOT NULL,
+  Timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+  Column_priv set('Select','Insert','Update','References') DEFAULT NULL,
+  PRIMARY KEY (Host,DB,User,Table_name,Column_name) /*T![clustered_index] NONCLUSTERED */
+)`
+)
 
-	// case #5: reset cloud admin && root account
-	resetUsers = []string{"cloud_admin", "root"}
-	sqls = generateResetSQLs(mockDB, resetUsers)
-	// 8 DELETE sqls for cloud admin and 1 UPDATE sql for root
-	require.Equal(t, 9, len(sqls))
+func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
+	cluster := mc
+	ctx := context.Background()
+	g := gluetidb.New()
+	rc := restore.Client{}
+	defer rc.Close()
+	err := rc.Init(g, cluster.Storage)
+	require.NoError(t, err)
+
+	se, err := g.CreateSession(cluster.Storage)
+	require.NoError(t, err)
+	defer se.Close()
+	mse := &mustExecuteSession{ctx, se, t}
+	mse.MustExecute("CREATE DATABASE __TiDB_BR_Temporary_mysql")
+	defer mse.MustExecute("DROP DATABASE __TiDB_BR_Temporary_mysql")
+
+	downstreamDBTable, err := rc.GetTableSchema(cluster.Domain, model.NewCIStr("mysql"), model.NewCIStr("db"))
+	require.NoError(t, err)
+	downstreamTablesTable, err := rc.GetTableSchema(cluster.Domain, model.NewCIStr("mysql"), model.NewCIStr("tables_priv"))
+	require.NoError(t, err)
+	downstreamColumnsTable, err := rc.GetTableSchema(cluster.Domain, model.NewCIStr("mysql"), model.NewCIStr("columns_priv"))
+	require.NoError(t, err)
+	// case 1: privilege db
+	mse.MustExecute(CreateDBSQL)
+	backupTable, err := rc.GetTableSchema(cluster.Domain, model.NewCIStr("__TiDB_BR_Temporary_mysql"), model.NewCIStr("db"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','test','newroot')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','test','oldroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','Test','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.Error(t, err)
+	mse.MustExecute("DELETE FROM __TiDB_BR_Temporary_mysql.db WHERE DB = 'Test'")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','cafe','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','café','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.Error(t, err)
+	mse.MustExecute("DELETE FROM __TiDB_BR_Temporary_mysql.db WHERE DB = 'cafe'")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.db")
+
+	// case 2: privilege table
+	type privCase struct {
+		insertValues []string
+		deleteCond   []string
+	}
+	mse.MustExecute(CreateTableSQL)
+	backupTable, err = rc.GetTableSchema(cluster.Domain, model.NewCIStr("__TiDB_BR_Temporary_mysql"), model.NewCIStr("tables_priv"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES ('%','test','newroot','ta1')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES ('%','test','oldroot','ta1')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+	require.NoError(t, err)
+	cases := []privCase{
+		{
+			insertValues: []string{"('%','test','newroot','Ta1')"},
+			deleteCond:   []string{"Table_name = 'Ta1'"},
+		},
+		{
+			insertValues: []string{"('%','tEst','newroot','ta1')"},
+			deleteCond:   []string{"DB = 'tEst'"},
+		},
+		{
+			insertValues: []string{"('%','tEst','newroot','Ta1')"},
+			deleteCond:   []string{"DB = 'tEst'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','tá1')"},
+			deleteCond:   []string{"Table_name = 'tá1'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','tá1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','tá1')", "('%','tEst','newroot','Ta1')"},
+			deleteCond:   []string{"DB = 'tést'", "DB = 'tEst'"},
+		},
+	}
+	for _, cs := range cases {
+		for _, v := range cs.insertValues {
+			mse.MustExecute(fmt.Sprintf("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+		require.Error(t, err)
+		for _, v := range cs.deleteCond {
+			mse.MustExecute(fmt.Sprintf("DELETE FROM __TiDB_BR_Temporary_mysql.tables_priv WHERE %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+		require.NoError(t, err)
+	}
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.tables_priv")
+
+	// case 3: privilege column
+	mse.MustExecute(CreateColumnSQL)
+	backupTable, err = rc.GetTableSchema(cluster.Domain, model.NewCIStr("__TiDB_BR_Temporary_mysql"), model.NewCIStr("columns_priv"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES ('%','test','newroot','ta1','ca1')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES ('%','test','oldroot','ta1','ca1')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+	require.NoError(t, err)
+	cases = []privCase{
+		{
+			insertValues: []string{"('%','test','newroot','ta1','Ca1')"},
+			deleteCond:   []string{"Column_name = 'Ca1'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','Ta1','ca1')"},
+			deleteCond:   []string{"Table_name = 'Ta1'"},
+		},
+		{
+			insertValues: []string{"('%','Test','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'Test'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','ta1','cá1')"},
+			deleteCond:   []string{"Column_name = 'cá1'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','tá1','ca1')"},
+			deleteCond:   []string{"Table_name = 'tá1'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1','ca1')", "('%','Test','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'tést'", "DB = 'Test'"},
+		},
+	}
+	for _, cs := range cases {
+		for _, v := range cs.insertValues {
+			mse.MustExecute(fmt.Sprintf("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+		require.Error(t, err)
+		for _, v := range cs.deleteCond {
+			mse.MustExecute(fmt.Sprintf("DELETE FROM __TiDB_BR_Temporary_mysql.columns_priv WHERE %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+		require.NoError(t, err)
+	}
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.columns_priv")
 }

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1070,7 +1070,9 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 
 	// The cost of rename user table / replace into system table wouldn't be so high.
 	// So leave it out of the pipeline for easier implementation.
-	client.RestoreSystemSchemas(ctx, cfg.TableFilter)
+	if err = client.RestoreSystemSchemas(ctx, cfg.TableFilter); err != nil {
+		return errors.Trace(err)
+	}
 
 	schedulersRemovable = true
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -799,7 +799,7 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		}
 	}
 
-	if client.IsFullClusterRestore() && client.HasBackedUpSysDB() {
+	if cfg.WithSysTable && client.HasBackedUpSysDB() {
 		if err = client.CheckSysTableCompatibility(mgr.GetDomain(), tables); err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -55,16 +55,17 @@ const (
 // - target's flen and decimal should be bigger or equals to src's
 // - elements in target is superset of elements in src if they're enum or set type
 // - same charset and collate if they're string types
-func IsTypeCompatible(src types.FieldType, target types.FieldType) bool {
+func IsTypeCompatible(src types.FieldType, target types.FieldType) (typeEq, collateEq bool) {
+	collateEq = src.GetCollate() == target.GetCollate()
 	if mysql.HasNotNullFlag(src.GetFlag()) != mysql.HasNotNullFlag(target.GetFlag()) {
-		return false
+		return false, collateEq
 	}
 	if mysql.HasUnsignedFlag(src.GetFlag()) != mysql.HasUnsignedFlag(target.GetFlag()) {
-		return false
+		return false, collateEq
 	}
 	srcEType, dstEType := src.EvalType(), target.EvalType()
 	if srcEType != dstEType {
-		return false
+		return false, collateEq
 	}
 
 	getFLenAndDecimal := func(tp types.FieldType) (int, int) {
@@ -82,7 +83,7 @@ func IsTypeCompatible(src types.FieldType, target types.FieldType) bool {
 	srcFLen, srcDecimal := getFLenAndDecimal(src)
 	targetFLen, targetDecimal := getFLenAndDecimal(target)
 	if srcFLen > targetFLen || srcDecimal > targetDecimal {
-		return false
+		return false, collateEq
 	}
 
 	// if they're not enum or set type, elems will be empty
@@ -91,7 +92,7 @@ func IsTypeCompatible(src types.FieldType, target types.FieldType) bool {
 	srcElems := src.GetElems()
 	targetElems := target.GetElems()
 	if len(srcElems) > len(targetElems) {
-		return false
+		return false, collateEq
 	}
 	targetElemSet := make(map[string]struct{})
 	for _, item := range targetElems {
@@ -99,11 +100,10 @@ func IsTypeCompatible(src types.FieldType, target types.FieldType) bool {
 	}
 	for _, item := range srcElems {
 		if _, ok := targetElemSet[item]; !ok {
-			return false
+			return false, collateEq
 		}
 	}
-	return src.GetCharset() == target.GetCharset() &&
-		src.GetCollate() == target.GetCollate()
+	return src.GetCharset() == target.GetCharset(), collateEq
 }
 
 func GRPCConn(ctx context.Context, storeAddr string, tlsConf *tls.Config, opts ...grpc.DialOption) (*grpc.ClientConn, error) {

--- a/br/pkg/utils/misc_test.go
+++ b/br/pkg/utils/misc_test.go
@@ -31,34 +31,46 @@ func TestIsTypeCompatible(t *testing.T) {
 		src := types.NewFieldType(mysql.TypeInt24)
 		src.AddFlag(mysql.UnsignedFlag)
 		target := types.NewFieldType(mysql.TypeInt24)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 
 		src.DelFlag(mysql.UnsignedFlag)
 		target.AddFlag(mysql.UnsignedFlag)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq = IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// different not null flag
 		src := types.NewFieldType(mysql.TypeInt24)
 		src.AddFlag(mysql.NotNullFlag)
 		target := types.NewFieldType(mysql.TypeInt24)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 
 		src.DelFlag(mysql.NotNullFlag)
 		target.AddFlag(mysql.NotNullFlag)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq = IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// different evaluation type
 		src := types.NewFieldType(mysql.TypeInt24)
 		target := types.NewFieldType(mysql.TypeFloat)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src flen > target
 		src := types.NewFieldType(mysql.TypeInt24)
 		target := types.NewFieldType(mysql.TypeTiny)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src flen > target
@@ -66,7 +78,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetFlen(100)
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetFlag(99)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src decimal > target
@@ -74,7 +88,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetDecimal(5)
 		target := types.NewFieldType(mysql.TypeNewDecimal)
 		target.SetDecimal(4)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src has more elements
@@ -82,7 +98,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a"})
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible enum
@@ -90,7 +108,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a", "c", "d"})
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible charset
@@ -98,7 +118,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetCharset("gbk")
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetCharset("utf8")
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible collation
@@ -108,7 +130,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetCharset("utf8")
 		target.SetCollate("utf8_general_ci")
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.False(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeVarchar)
@@ -119,25 +143,33 @@ func TestIsTypeCompatible(t *testing.T) {
 		target.SetFlen(11)
 		target.SetCharset("utf8")
 		target.SetCollate("utf8_bin")
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeBlob)
 		target := types.NewFieldType(mysql.TypeLongBlob)
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeEnum)
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a", "b", "c"})
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeTimestamp)
 		target := types.NewFieldType(mysql.TypeTimestamp)
 		target.SetDecimal(3)
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 }
 

--- a/br/pkg/utils/misc_test.go
+++ b/br/pkg/utils/misc_test.go
@@ -77,7 +77,7 @@ func TestIsTypeCompatible(t *testing.T) {
 		src := types.NewFieldType(mysql.TypeVarchar)
 		src.SetFlen(100)
 		target := types.NewFieldType(mysql.TypeVarchar)
-		target.SetFlag(99)
+		target.SetFlen(99)
 		typeEq, collateEq := IsTypeCompatible(*src, *target)
 		require.False(t, typeEq)
 		require.True(t, collateEq)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64667

Problem Summary:
It is needed to restore privileges tables backed up from v6.5 to newly created v7.2+ clusters.
### What changed and how does it work?
permit to restore privileges tables from v6.5 to v7.2+ if all the data have the same behavior in `utf8mb4_bin` and `utf8mb4_general_ci`.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore compatibility checks for privilege system tables with differing collations.
  * Allows compatible collation differences while rejecting mismatched data types, column definitions, or incompatible row values.
  * Limits checks to explicitly requested system-table restores supported by the backup.
  * Restore operations now report relevant system-schema restoration failures instead of completing successfully.
  * Improved handling of cloud account privilege data resets during restore.

* **Tests**
  * Added coverage for collation compatibility, incompatible rows, and privilege reset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->