### PR TITLE
metrics: report statement RU v3 in observability fields

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1849,18 +1849,6 @@ func (a *ExecStmt) finalizeStatementRUV2Metrics() {
 	}
 }
 
-func calculateStatementTotalRUV2(metrics *execdetails.RUV2Metrics, weights execdetails.RUV2Weights, ruDetail *util.RUDetails) float64 {
-	var tiKVRU, tiFlashRU float64
-	if ruDetail != nil {
-		tiKVRU = ruDetail.TiKVRUV2()
-		tiFlashRU = ruDetail.TiflashRU()
-	}
-	if metrics == nil {
-		return tiKVRU + tiFlashRU
-	}
-	return metrics.TotalRU(weights, tiKVRU, tiFlashRU)
-}
-
 func (a *ExecStmt) recordLastQueryInfo(err error) {
 	sessVars := a.Ctx.GetSessionVars()
 	// Record diagnostic information for DML statements
@@ -2308,7 +2296,7 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	stmtExecInfo.KeyspaceName = keyspaceName
 	stmtExecInfo.KeyspaceID = keyspaceID
 	stmtExecInfo.RUDetail = ruDetail
-	stmtExecInfo.TotalRUV2 = calculateStatementTotalRUV2(sessVars.RUV2Metrics, sessVars.RUV2Weights(), ruDetail)
+	stmtExecInfo.TotalRUV2 = stmtCtx.GetRUV3Total()
 	stmtExecInfo.ResourceGroupName = sessVars.StmtCtx.ResourceGroupName
 	stmtExecInfo.CPUUsages = sessVars.SQLCPUUsages.GetCPUUsages()
 	stmtExecInfo.PlanCacheUnqualified = sessVars.StmtCtx.PlanCacheUnqualified()

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1834,19 +1834,6 @@ func (a *ExecStmt) finalizeStatementRUV2Metrics() {
 		return
 	}
 	execdetails.SyncRUV2MetricsFromRUDetails(sessVars.RUV2Metrics, ruDetail)
-
-	weights := sessVars.RUV2Weights()
-	tidbRU := sessVars.RUV2Metrics.CalculateRUValues(weights)
-
-	dctx := a.Ctx.GetDistSQLCtx()
-	if dctx == nil || dctx.RUConsumptionReporter == nil || len(dctx.ResourceGroupName) == 0 {
-		return
-	}
-	tikvRU := ruDetail.TiKVRUV2()
-	tiflashRU := ruDetail.TiflashRU()
-	if tikvRU > 0 || tidbRU > 0 || tiflashRU > 0 {
-		dctx.RUConsumptionReporter.ReportRUV2Consumption(dctx.ResourceGroupName, tikvRU, tidbRU, tiflashRU)
-	}
 }
 
 func (a *ExecStmt) recordLastQueryInfo(err error) {

--- a/pkg/executor/adapter_slow_log.go
+++ b/pkg/executor/adapter_slow_log.go
@@ -266,6 +266,7 @@ func SetSlowLogItems(a *ExecStmt, txnTS uint64, hasMoreResults bool, items *vari
 	items.ResourceGroupName = stmtCtx.ResourceGroupName
 	items.RUDetails = ruDetails
 	items.RUV2Metrics = ruv2Metrics
+	items.RUV3Total = stmtCtx.GetRUV3Total()
 	items.CPUUsages = sessVars.SQLCPUUsages.GetCPUUsages()
 	items.StorageKV = stmtCtx.IsTiKV.Load()
 	items.StorageMPP = stmtCtx.IsTiFlash.Load()

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -263,6 +263,10 @@ func publishStatementRUMetricsSafely(finalized statementRUFinalizedSnapshot) {
 		statementRUScanByteWeight*finalized.units.ScanBytes +
 			statementRUNetByteWeight*finalized.units.NetBytes,
 	)
+	metrics.RUV3Unit.WithLabelValues(metrics.LblRUV3UnitCPUWork).Add(finalized.units.CPUWork)
+	metrics.RUV3Unit.WithLabelValues(metrics.LblRUV3UnitScanBytes).Add(finalized.units.ScanBytes)
+	metrics.RUV3Unit.WithLabelValues(metrics.LblRUV3UnitNetBytes).Add(finalized.units.NetBytes)
+	metrics.RUV3Unit.WithLabelValues(metrics.LblRUV3UnitFrontendCompileBytes).Add(finalized.units.FrontendCompileBytes)
 }
 
 func publishStatementRUCalibrationSafely(

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -240,6 +240,11 @@ func publishStatementRUFinalizedSnapshot(
 	stmt *ExecStmt,
 	finalized statementRUFinalizedSnapshot,
 ) {
+	if stmt != nil && stmt.Ctx != nil {
+		if sessVars := stmt.Ctx.GetSessionVars(); sessVars != nil && sessVars.StmtCtx != nil {
+			sessVars.StmtCtx.SetRUV3Total(finalized.result.TotalRU)
+		}
+	}
 	publishStatementRUMetricsSafely(finalized)
 	publishStatementRUCalibrationSafely(stmt, statementRUCalibrationSnapshot{
 		State: finalized.calibrationState,

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -245,11 +245,27 @@ func publishStatementRUFinalizedSnapshot(
 			sessVars.StmtCtx.SetRUV3Total(finalized.result.TotalRU)
 		}
 	}
+	reportStatementRUV3ConsumptionSafely(stmt, finalized.result.TotalRU)
 	publishStatementRUMetricsSafely(finalized)
 	publishStatementRUCalibrationSafely(stmt, statementRUCalibrationSnapshot{
 		State: finalized.calibrationState,
 		Units: finalized.units,
 	})
+}
+
+func reportStatementRUV3ConsumptionSafely(stmt *ExecStmt, totalRU float64) {
+	defer func() {
+		_ = recover()
+	}()
+	if stmt == nil || stmt.Ctx == nil || totalRU <= 0 {
+		return
+	}
+	dctx := stmt.Ctx.GetDistSQLCtx()
+	if dctx == nil || dctx.RUConsumptionReporter == nil || len(dctx.ResourceGroupName) == 0 {
+		return
+	}
+	// TODO: distinguish TiDB/KV/Flash RU.
+	dctx.RUConsumptionReporter.ReportRUV2Consumption(dctx.ResourceGroupName, 0, totalRU, 0)
 }
 
 // publishStatementRUMetricsSafely projects one immutable finalized snapshot to

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -368,6 +368,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(RUV3Total)
 	prometheus.MustRegister(RUV3BySQLType)
 	prometheus.MustRegister(RUV3ByEngine)
+	prometheus.MustRegister(RUV3Unit)
 
 	prometheus.MustRegister(NetworkTransmissionStats)
 

--- a/pkg/metrics/ru_v2.go
+++ b/pkg/metrics/ru_v2.go
@@ -49,6 +49,16 @@ var (
 	RUV3Total     prometheus.Counter
 	RUV3BySQLType *prometheus.CounterVec
 	RUV3ByEngine  *prometheus.CounterVec
+	RUV3Unit      *prometheus.CounterVec
+)
+
+const (
+	LblRUV3Unit = "unit"
+
+	LblRUV3UnitCPUWork              = "cpu_work"
+	LblRUV3UnitScanBytes            = "scan_bytes"
+	LblRUV3UnitNetBytes             = "net_bytes"
+	LblRUV3UnitFrontendCompileBytes = "frontend_compile_bytes"
 )
 
 var (
@@ -301,6 +311,15 @@ func InitRUV3Metrics() {
 			Name:      "ru_by_engine_total",
 			Help:      "Counter of resource unit consumption by engine for RU v3.",
 		}, []string{LblEngine},
+	)
+
+	RUV3Unit = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "ruv3",
+			Name:      "unit_total",
+			Help:      "Counter of raw statement units for RU v3.",
+		}, []string{LblRUV3Unit},
 	)
 }
 

--- a/pkg/metrics/ru_v2.go
+++ b/pkg/metrics/ru_v2.go
@@ -52,6 +52,7 @@ var (
 	RUV3Unit      *prometheus.CounterVec
 )
 
+// RUV3 unit label constants define the label name and values for RU v3 raw unit metrics.
 const (
 	LblRUV3Unit = "unit"
 

--- a/pkg/resourcegroup/checker.go
+++ b/pkg/resourcegroup/checker.go
@@ -45,6 +45,6 @@ type ConsumptionReporter interface {
 	// ReportConsumption report the consumption directly, it's used at
 	// scenarios that the `ResourceGroupKVInterceptor` is not available.
 	ReportConsumption(resourceGroupName string, consumption *rmpb.Consumption)
-	// ReportRUV2Consumption reports engine-split RU v2 consumption for observation.
+	// ReportRUV2Consumption reports RU consumption through the legacy engine-slot API.
 	ReportRUV2Consumption(resourceGroupName string, tikvRUV2, tidbRUV2, tiflashRUV2 float64)
 }

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -375,6 +375,7 @@ type StatementContext struct {
 	planHint       string
 	planHintSet    bool
 	binaryPlan     string
+	ruv3Total      float64
 	// indexForce is set if any table in the query has a force or use index applied
 	indexForce bool
 	// To avoid cycle import, we use interface{} for the following two fields.
@@ -919,6 +920,16 @@ func (sc *StatementContext) GetBinaryPlan() string {
 // SetBinaryPlan sets the binaryPlan field of stmtctx
 func (sc *StatementContext) SetBinaryPlan(binaryPlan string) {
 	sc.binaryPlan = binaryPlan
+}
+
+// GetRUV3Total gets the statement-local RU v3 total.
+func (sc *StatementContext) GetRUV3Total() float64 {
+	return sc.ruv3Total
+}
+
+// SetRUV3Total sets the statement-local RU v3 total.
+func (sc *StatementContext) SetRUV3Total(total float64) {
+	sc.ruv3Total = total
 }
 
 // GetResourceGroupTagger returns the implementation of kv.ResourceGroupTagBuilder related to self.

--- a/pkg/sessionctx/variable/slow_log.go
+++ b/pkg/sessionctx/variable/slow_log.go
@@ -145,9 +145,9 @@ const (
 	SlowLogStorageFromKV = "Storage_from_kv"
 	// SlowLogStorageFromMPP is used to indicate whether the statement read data from TiFlash.
 	SlowLogStorageFromMPP = "Storage_from_mpp"
-	// SlowLogRequestUnitV2 is the RU v2 total for the statement.
+	// SlowLogRequestUnitV2 is the legacy slow log key for statement RU.
 	SlowLogRequestUnitV2 = "Request_unit_v2"
-	// SlowLogRequestUnitV2Detail is the RU v2 detailed metrics for the statement.
+	// SlowLogRequestUnitV2Detail is the legacy slow log key for detailed statement RU metrics.
 	SlowLogRequestUnitV2Detail = "Request_unit_v2_detail"
 
 	// The following constants define the set of fields for SlowQueryLogItems
@@ -305,6 +305,7 @@ type SlowQueryLogItems struct {
 	ResourceGroupName string
 	RUDetails         *util.RUDetails
 	RUV2Metrics       *execdetails.RUV2Metrics
+	RUV3Total         float64
 	MemMax            int64
 	DiskMax           int64
 	CPUUsages         ppcpuusage.CPUUsages
@@ -574,17 +575,9 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	}
 	writeSlowLogItem(&buf, SlowLogStorageFromKV, strconv.FormatBool(logItems.StorageKV))
 	writeSlowLogItem(&buf, SlowLogStorageFromMPP, strconv.FormatBool(logItems.StorageMPP))
-	var tiKVRU, tiFlashRU float64
-	if logItems.RUDetails != nil {
-		tiKVRU = logItems.RUDetails.TiKVRUV2()
-		tiFlashRU = logItems.RUDetails.TiflashRU()
-	}
-	total, formatted := execdetails.FormatRUV2Summary(logItems.RUV2Metrics, s.RUV2Weights(), tiKVRU, tiFlashRU)
-	if len(total) > 0 {
-		writeSlowLogItem(&buf, SlowLogRequestUnitV2, total)
-	}
-	if len(formatted) > 0 {
-		writeSlowLogItem(&buf, SlowLogRequestUnitV2Detail, formatted)
+	if logItems.RUV3Total > 0 {
+		writeSlowLogItem(&buf, SlowLogRequestUnitV2, strconv.FormatFloat(logItems.RUV3Total, 'f', 2, 64))
+		writeSlowLogItem(&buf, SlowLogRequestUnitV2Detail, "")
 	}
 	if len(logItems.SessionConnectAttrs) > 0 {
 		// Encode into a temporary buffer first so that a (practically impossible)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70373

Problem Summary: metrics: report statement RU v3 in observability fields

### What changed and how does it work?

- Cache finalized statement RU v3 total on `StatementContext`.
- Use RU v3 total for slow log `Request_unit_v2`.
- Leave slow log `Request_unit_v2_detail` empty.
- Use RU v3 total for statement summary `AVG_REQUEST_UNIT_V2` and `MAX_REQUEST_UNIT_V2`.
- Report RU v3 total through the legacy resource group RU reporter as TiDB RU, without splitting TiKV/TiFlash.
- Add RU v3 unit metrics with labels for each raw unit.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed RU usage metrics for CPU work, scanned data, network traffic, and frontend compilation.
  * RU totals are now captured consistently for statements, slow logs, and resource-group reporting.
  * Slow logs now display the finalized total RU value with simplified details.

* **Improvements**
  * Improved reliability when reporting statement RU consumption.
  * Updated RU reporting documentation and clarified legacy statement RU fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->