### PR TITLE
planner: bind duplicate expression indexes to one hidden generated column

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1148,11 +1148,16 @@ func matchProperty(ds *logicalop.DataSource, path *util.AccessPath, prop *proper
 	matchResult := property.PropMatched
 	groupByColIdxs := make([]int, 0)
 	colIdx := 0
+	evalCtx := ds.SCtx().GetExprCtx().GetEvalCtx()
 	for _, sortItem := range prop.SortItems {
 		found := false
 		for ; colIdx < len(idxCols); colIdx++ {
 			// Case 1: this sort item is satisfied by the index column, go to match the next sort item.
-			if idxColLens[colIdx] == types.UnspecifiedLength && sortItem.Col.EqualColumn(idxCols[colIdx]) {
+			// EqualByExprAndID, not EqualColumn: when several expression indexes repeat the same
+			// expression, each one owns a distinct hidden generated column, and the sort item was
+			// substituted with only one of them. Those columns compute the same value, so an index
+			// carrying any of them still delivers the requested order.
+			if idxColLens[colIdx] == types.UnspecifiedLength && sortItem.Col.EqualByExprAndID(evalCtx, idxCols[colIdx]) {
 				found = true
 				colIdx++
 				break

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2199,12 +2199,15 @@ func TestVirtualExprPushDown(t *testing.T) {
 			key idx_exp_lower ((lower(s)))
 		)`)
 		tk.MustExec("insert into t_bug(s) values ('B'),('a')")
+		// `g` and the hidden column behind idx_exp_lower both evaluate lower(s), so the index
+		// order already satisfies ORDER BY g and the limit is pushed to the build side. This is
+		// the same plan the equivalent index on `g` gets just below.
 		tk.MustQuery("explain format='plan_tree' select /* issue:67981 */ * from t_bug force index (idx_exp_lower) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows(
 			"Projection root  test.t_bug.id, test.t_bug.s, test.t_bug.g",
-			"└─TopN root  test.t_bug.g, offset:0, count:1",
-			"  └─IndexLookUp root  ",
-			"    ├─IndexRangeScan(Build) cop[tikv] table:t_bug, index:idx_exp_lower(lower(`s`)) range:[\"a\",+inf], keep order:false, stats:pseudo",
-			"    └─TableRowIDScan(Probe) cop[tikv] table:t_bug keep order:false, stats:pseudo"))
+			"└─IndexLookUp root  limit embedded(offset:0, count:1)",
+			"  ├─Limit(Build) cop[tikv]  offset:0, count:1",
+			"  │ └─IndexRangeScan cop[tikv] table:t_bug, index:idx_exp_lower(lower(`s`)) range:[\"a\",+inf], keep order:true, stats:pseudo",
+			"  └─TableRowIDScan(Probe) cop[tikv] table:t_bug keep order:false, stats:pseudo"))
 		tk.MustQuery("select /* issue:67981 */ * from t_bug force index (idx_exp_lower) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows("2 a a"))
 		tk.MustQuery("explain format='plan_tree' select /* issue:67981 */ * from t_bug force index (g) where lower(s) >= 'a' order by g limit 1;").Check(testkit.Rows(
 			"Projection root  test.t_bug.id, test.t_bug.s, test.t_bug.g",

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -17,6 +17,7 @@ package issuetest
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/errno"
@@ -990,4 +991,66 @@ func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 		testKit.MustQuery("select a,min(a) from t where a=-1;").Check(testkit.Rows("<nil> <nil>"))
 		testKit.MustQuery("select a,min(a) from t where -1=a;").Check(testkit.Rows("<nil> <nil>"))
 	})
+}
+
+// TestDuplicateExpressionIndexOrdering covers the case where several expression indexes on one
+// table repeat the same expression. DDL creates one hidden generated column per index, and the
+// ORDER BY expression is substituted with only one of them, so the chosen plan used to depend on
+// Go map iteration order and flipped between plan builds of the same statement.
+func TestDuplicateExpressionIndexOrdering(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_dup_expr_idx")
+	tk.MustExec(`create table t_dup_expr_idx (
+		ns varchar(64) not null,
+		s  varchar(64),
+		st int not null,
+		k  int not null,
+		primary key (ns, st))`)
+	tk.MustExec("create index idx_default on t_dup_expr_idx (ns, (lower(s)), st)")
+	tk.MustExec("create index idx_k on t_dup_expr_idx (ns, k, (lower(s)), st)")
+	tk.MustExec("create index idx_s on t_dup_expr_idx (ns, s, (lower(s)), st)")
+	tk.MustExec("create index idx_st on t_dup_expr_idx (ns, st, (lower(s)))")
+	for i := range 200 {
+		tk.MustExec(fmt.Sprintf("insert into t_dup_expr_idx values ('ns%d', 'S%d', %d, %d)", i%4, i, i, i%5))
+	}
+	tk.MustExec("analyze table t_dup_expr_idx")
+
+	// Reports the index that supplies the ordering, or "sorted" when the plan had to sort
+	// instead. Naming the index alone is not enough: a plan that scans the right index with
+	// keep order:false and sorts on top still reads the whole range.
+	orderingIndex := func(sql string) string {
+		name := "no-index"
+		for _, row := range tk.MustQuery("explain format='brief' " + sql).Rows() {
+			op := fmt.Sprintf("%v", row[0])
+			if strings.Contains(op, "TopN") || strings.Contains(op, "Sort") {
+				return "sorted"
+			}
+			if !strings.Contains(op, "IndexRangeScan") {
+				continue
+			}
+			if !strings.Contains(fmt.Sprintf("%v", row[4]), "keep order:true") {
+				continue
+			}
+			obj := fmt.Sprintf("%v", row[3])
+			name = obj[strings.Index(obj, "index:")+len("index:"):]
+			name = name[:strings.Index(name, "(")]
+		}
+		return name
+	}
+
+	for _, c := range []struct{ sql, index string }{
+		// Only ns is bound, so the index that orders by the expression right after ns wins.
+		{"select ns, st from t_dup_expr_idx where ns = 'ns0' order by lower(s), st limit 5", "idx_default"},
+		// k is bound too, so the expression is the next ordering column of idx_k.
+		{"select ns, st from t_dup_expr_idx where ns = 'ns0' and k = 1 order by lower(s), st limit 5", "idx_k"},
+	} {
+		// Repeat: the bug reproduced only intermittently, in proportion to the number of
+		// duplicate-expression indexes.
+		for range 20 {
+			require.Equal(t, c.index, orderingIndex(c.sql), "sql: %s", c.sql)
+		}
+		require.Equal(t, c.index, orderingIndex("/* issue:70708 */ "+c.sql))
+	}
 }

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -87,11 +87,35 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 					if len(expression.ExtractColumns(col.VirtualExpr)) == 0 {
 						continue
 					}
-					exprToColumn[col.VirtualExpr] = col
+					addGenerateColumn(ectx, exprToColumn, col)
 				}
 			}
 		}
 	}
+}
+
+// addGenerateColumn records col as the substitution target for its virtual expression.
+//
+// Several expression indexes on one table may repeat the same expression, and DDL creates a
+// separate hidden generated column per index. Those columns are interchangeable as substitution
+// targets, so only one of them is kept: without this the map holds one entry per index and
+// substitute() picks between them in Go's randomized map order, which makes the resulting plan
+// differ between plan builds of the same statement.
+//
+// The canonical column is the one with the smallest UniqueID, i.e. the one declared earliest on
+// the table, so the choice is stable across plan builds.
+func addGenerateColumn(ectx expression.EvalContext, exprToColumn ExprColumnMap, col *expression.Column) {
+	for candidateExpr, existing := range exprToColumn {
+		if !existing.EqualByExprAndID(ectx, col) {
+			continue
+		}
+		if existing.UniqueID <= col.UniqueID {
+			return
+		}
+		delete(exprToColumn, candidateExpr)
+		break
+	}
+	exprToColumn[col.VirtualExpr] = col
 }
 
 func tryToSubstituteExpr(expr *expression.Expression, lp base.LogicalPlan, candidateExpr expression.Expression, tp types.EvalType, schema *expression.Schema, col *expression.Column) bool {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70708

Problem Summary:

When several expression indexes on one table repeat the same expression, DDL creates a separate hidden generated column per index (`_V$_idx_a_1`, `_V$_idx_b_2`, ...). `collectGenerateColumn` stores one `ExprColumnMap` entry per column, keyed by the `expression.Expression` **interface value**, i.e. pointer identity, so N duplicate-expression indexes leave N semantically identical entries in the map.

`GcSubstituter.substitute` then iterates that map in Go's randomized order and rewrites the `ORDER BY` expression with whichever candidate matches first. Two consequences:

- the same statement produces different plans between plan builds, and
- whenever the chosen column belongs to an index the optimizer cannot otherwise use, `matchProperty` finds no path that satisfies the ordering, and the plan falls back to a full range scan plus a root `TopN`.

`FORCE INDEX` hides the problem because index hints filter `PossibleAccessPaths` before this rule runs, leaving exactly one entry in the map. That makes the bug look like a costing problem when it is not.

This was reported by a customer running Temporal on TiDB. Temporal's `executions_visibility` schema repeats `COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))` in 30 indexes, so the ordering bound to `default_idx`'s column only about 1 time in 30.

### What changed and how does it work?

Two changes, both in the planner:

1. `collectGenerateColumn` now keeps a single canonical column per distinct expression instead of one per index. The canonical column is the one with the smallest `UniqueID`, i.e. declared earliest on the table, so the substitution is stable across plan builds.

2. `matchProperty` compares the sort item against index columns with `Column.EqualByExprAndID` instead of `EqualColumn`. Only one of the interchangeable columns was substituted, but they all compute the same value, so an index carrying any of them still delivers the requested order. `EqualByExprAndID` already falls back to `UniqueID` equality for non-virtual columns, so this only widens the virtual-column case, and it requires `RetType.Equal` so columns differing in type or collation are not matched.

The second change is what lets each query keep its own best index rather than pinning every query to the canonical column's index:

| query shape (Temporal `executions_visibility`, 50 plan builds each) | before | after |
| --- | --- | --- |
| `where namespace_id = ? order by coalesce(...)` | `TableScan`+`TopN` 43, `default_idx` 7 | `default_idx` 50 |
| `... and status = ?` | `TableScan`+`TopN` 34, `by_status` 7, `default_idx` 9 | `by_status` 50 |
| `... and workflow_id = ?` | `by_workflow_id` 50 | `by_workflow_id` 50 |

One existing expectation in `TestVirtualExprPushDown` changes. For the #67981 shape, where a user virtual column `g` and an expression index both evaluate `lower(s)`, the plan goes from a root `TopN` over the whole index range to the limit pushed into an ordered index scan. That is the same plan the equivalent index on `g` already gets just below it in the same test. The wrong-result mechanism #68046 guarded against was a `keep order:false` build side with a probe-side `TopN`; this change instead makes the build side ordered, so that path is not taken. Results were verified unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

New regression test `TestDuplicateExpressionIndexOrdering` in `pkg/planner/core/issuetest`. It asserts which index supplies the ordering (not merely which index is scanned, since a plan that scans the right index with `keep order:false` and sorts on top still reads the whole range), repeated across plan builds because the bug reproduced only intermittently. Verified failing before the change and passing after.

Manual verification:

- `go test -tags=intest,deadlock ./pkg/planner/core/...` — remaining failures (`TestHandleFineGrainedShuffle`, `TestNaturalJoinWithCorrelatedSubquery`, `TestVectorIndex`, `TestAnalyzeVectorIndex`, `TestTiFlashANNIndex`, `TestMppFineGrainedJoinAndAgg`, `TestPrepareOverMaxPreparedStmtCount`) reproduce identically on the base commit and are failpoint/TiFlash-mock/global-state artifacts.
- `tests/integrationtest/run-tests.sh` — full suite passes with no changes to any file under `tests/integrationtest/r`.
- Differential correctness check over 300 rows with mixed-case data, across several limits, filters and index hints, confirming `ORDER BY` on a user virtual column and on an expression index carrying the same expression return identical rows.
- `make lint`, `make bazel_prepare`.

Not verified locally: no real-TiKV run. Range building still matches condition columns to `IdxCols` by `UniqueID`, so a `WHERE` predicate on a duplicated expression is now deterministic but still only usable through the canonical column; that follow-up is noted on the issue.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where a table with several expression indexes sharing the same expression could produce unstable query plans and fail to select a suitable index for ORDER BY on that expression.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning for expression indexes with equivalent generated columns.
  * Queries using `ORDER BY` with repeated expression indexes now produce deterministic plans.
  * Enhanced index ordering and limit pushdown for eligible queries.

* **Tests**
  * Added regression coverage for duplicate expression indexes and stable query plans.
  * Expanded planner test sharding for improved test distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->