### PR TITLE
planner: dedupe generated columns from duplicate expression indexes

### DIFF
--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -87,11 +88,34 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 					if len(expression.ExtractColumns(col.VirtualExpr)) == 0 {
 						continue
 					}
-					exprToColumn[col.VirtualExpr] = col
+					// Multiple expression indexes can share the identical expression, each backed by its
+					// own hidden generated column. Map keys compare Expression by pointer identity, so
+					// without this check every duplicate would get its own entry and later lookups would
+					// pick one arbitrarily via Go's randomized map iteration, making plan selection
+					// (e.g. ORDER BY binding) unstable across otherwise identical query plannings. Keep
+					// the first column seen for a given expression so the choice is deterministic.
+					if !containsEqualExpr(exprToColumn, col.VirtualExpr) {
+						exprToColumn[col.VirtualExpr] = col
+					}
 				}
 			}
 		}
 	}
+}
+
+// containsEqualExpr reports whether exprToColumn already has a key structurally
+// equal to expr. Map lookup alone is insufficient because Expression keys of
+// dynamic type *ScalarFunction compare by pointer identity, not by value, so two
+// distinct hidden generated columns built from the identical expression text
+// would otherwise coexist as separate entries.
+func containsEqualExpr(exprToColumn ExprColumnMap, expr expression.Expression) bool {
+	hashCode := expr.HashCode()
+	for existing := range exprToColumn {
+		if bytes.Equal(existing.HashCode(), hashCode) {
+			return true
+		}
+	}
+	return false
 }
 
 func tryToSubstituteExpr(expr *expression.Expression, lp base.LogicalPlan, candidateExpr expression.Expression, tp types.EvalType, schema *expression.Schema, col *expression.Column) bool {

--- a/pkg/planner/core/rule_generate_column_substitute_test.go
+++ b/pkg/planner/core/rule_generate_column_substitute_test.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -29,6 +31,89 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
+
+// TestGcSubstituterDedupsDuplicateExpressionIndexes covers
+// https://github.com/pingcap/tidb/issues/70708: when two expression indexes
+// share the identical expression, each is backed by its own hidden generated
+// column with a structurally-equal but distinct VirtualExpr. Before the fix,
+// collectGenerateColumn added one ExprColumnMap entry per duplicate, and later
+// substitution picked among them via Go's randomized map iteration order,
+// making ORDER BY binding (and therefore access path selection) unstable
+// across otherwise identical query plannings. After the fix, only the first
+// hidden column seen for a given expression is kept, so the map always has a
+// single, deterministic entry for the shared expression.
+func TestGcSubstituterDedupsDuplicateExpressionIndexes(t *testing.T) {
+	originCfg := config.GetGlobalConfig()
+	newCfg := *originCfg
+	newCfg.Experimental.AllowsExpressionIndex = true
+	config.StoreGlobalConfig(&newCfg)
+	defer func() {
+		config.StoreGlobalConfig(originCfg)
+	}()
+
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (ns int, status int, ct int, ct2 int, st int, run int)")
+	tk.MustExec("alter table t add index default_idx (ns, (coalesce(ct, ct2)), st, run)")
+	tk.MustExec("alter table t add index by_a (ns, status, (coalesce(ct, ct2)), st, run)")
+
+	is := domain.GetDomain(tk.Session()).InfoSchema()
+	ctx := context.Background()
+	sql := "select * from t where ns = 1 order by coalesce(ct, ct2), st, run"
+	// Reuses tk's session and domain, so it must not close them: testkit.NewTestKit
+	// already registers a t.Cleanup that closes the domain (and its stats handle)
+	// when the test ends.
+	s := coretestsdk.CreatePlannerSuite(tk.Session(), is)
+
+	// Rebuild and re-run GcSubstituter's Optimize from scratch many times.
+	// Before the fix, collectGenerateColumn produced one ExprColumnMap entry
+	// per duplicate expression index, and substitution picked among them via
+	// Go's randomized map iteration order: which hidden column ORDER BY got
+	// bound to (identified by its UniqueID) varied from run to run even
+	// though the SQL, schema, and stats never changed. After the fix, only
+	// one entry ever exists, so the bound column is always the same.
+	var firstUniqueID int64 = -1
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		stmt, err := s.GetParser().ParseOneStmt(sql, "", "")
+		require.NoError(t, err, sql)
+		nodeW := resolve.NewNodeW(stmt)
+		p, err := core.BuildLogicalPlanForTest(ctx, s.GetSCtx(), nodeW, s.GetIS())
+		require.NoError(t, err)
+		lp := p.(base.LogicalPlan)
+
+		gc := &core.GcSubstituter{}
+		lp, _, err = gc.Optimize(ctx, lp)
+		require.NoError(t, err)
+
+		sort := findLogicalSort(t, lp)
+		require.NotEmpty(t, sort.ByItems)
+		col, ok := sort.ByItems[0].Expr.(*expression.Column)
+		require.True(t, ok, "expected ORDER BY to be substituted with a generated column, got %T", sort.ByItems[0].Expr)
+
+		if firstUniqueID == -1 {
+			firstUniqueID = col.UniqueID
+		} else {
+			require.Equal(t, firstUniqueID, col.UniqueID,
+				"ORDER BY bound to a different hidden generated column on iteration %d; duplicate expression indexes must resolve deterministically", i)
+		}
+	}
+}
+
+func findLogicalSort(t *testing.T, lp base.LogicalPlan) *logicalop.LogicalSort {
+	if sort, ok := lp.(*logicalop.LogicalSort); ok {
+		return sort
+	}
+	for _, child := range lp.Children() {
+		if sort := findLogicalSort(t, child); sort != nil {
+			return sort
+		}
+	}
+	require.Fail(t, "no LogicalSort found in plan tree")
+	return nil
+}
 
 // ➜  core git:(master) ✗ go tool pprof m5.file
 // File: ___5BenchmarkSubstituteExpression_in_github_com_pingcap_tidb_planner_core.test


### PR DESCRIPTION
Issue Number: close #70708

Problem Summary:

When two or more expression indexes contain the identical expression (for example `(coalesce(ct, ct2))` repeated across `default_idx` and `by_a`), TiDB creates one hidden generated column per index. `collectGenerateColumn` collects these into an `ExprColumnMap` keyed by `expression.Expression`. Because `Expression` values of dynamic type `*ScalarFunction` compare as distinct map keys by pointer identity rather than by value, each duplicate expression produced its own separate map entry instead of collapsing into one.

`GcSubstituter.substitute` later iterates this map to decide which hidden column to bind `ORDER BY` (and other clauses) to. Go map iteration order is randomized, so with more than one entry for the same expression, the same query — replanned with no change to schema, data, or statistics — could bind `ORDER BY` to a different hidden column from one planning to the next. When the bound column's `UniqueID` didn't match what physical access-path selection needed, sort elimination was missed and the optimizer fell back to a full table scan plus `TopN` instead of an index scan that already produced the required order.

### What changed and how does it work?

`collectGenerateColumn` now deduplicates before inserting into `ExprColumnMap`: a new helper, `containsEqualExpr`, checks whether an existing map key is already structurally equal (via `Expression.HashCode()`) to the candidate expression, and skips the insert if so. This keeps only the first hidden generated column seen for a given expression, so `ExprColumnMap` always has exactly one entry per distinct expression regardless of how many indexes repeat it — removing the dependency on map iteration order entirely.

This is the deduplication fix suggested in the issue. The iteration sources feeding `collectGenerateColumn` (`AllPossibleAccessPaths`, index columns, table columns) are all slice-backed and already iterate in a stable order across repeated plannings of the same schema, so "first seen" always resolves to the same column. The full canonical-hidden-column redesign tracked in #68032 (making virtual columns with equal expressions fully interchangeable for `UniqueID`-based property matching) is a separate, larger change and out of scope here.

No public API changed: `ExprColumnMap`'s type is untouched, so the existing benchmark and the other `collectGenerateColumn` caller in `logical_plan_builder.go` are unaffected other than also no longer accumulating redundant duplicate columns.

A regression test, `TestGcSubstituterDedupsDuplicateExpressionIndexes`, builds and runs `GcSubstituter.Optimize` from scratch 200 times against a table with two duplicate-expression indexes and asserts `ORDER BY` always binds to the same generated column. Verified this test fails on the pre-fix code (caught the mismatch by iteration 3 across 5 independent runs) and passes reliably with the fix.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where duplicate expression indexes on the same expression could cause query plans to become unstable, occasionally missing an available sort-eliminating index and falling back to a full table scan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when queries use multiple indexes with identical expressions.
  * Ensured `ORDER BY` clauses reliably bind to the same generated column instead of producing nondeterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->