### PR TITLE
ingestor: copy key in sstWriter.writeKVs to avoid aliasing sortedKeyBuf

### DIFF
--- a/pkg/ingestor/ingestctrl/engine.go
+++ b/pkg/ingestor/ingestctrl/engine.go
@@ -1483,7 +1483,12 @@ func (sw *sstWriter) writeKVs(kvs []common.KvPair) error {
 			return errors.Trace(err)
 		}
 		sw.totalSize += int64(len(p.Key)) + int64(len(p.Val))
-		sw.lastKey = p.Key
+		// Copy the key instead of aliasing it: in the sorted path the caller
+		// (appendRowsSorted) stores encoded keys as slices into a reusable
+		// sortedKeyBuf. If we keep a reference here, the next batch reusing the
+		// buffer can overwrite the bytes sw.lastKey points to, making a
+		// non-duplicate key compare equal and get silently skipped.
+		sw.lastKey = append(sw.lastKey[:0], p.Key...)
 	}
 	sw.totalCount += int64(len(kvs))
 	sw.maxKey = append(sw.maxKey[:0], sw.lastKey...)

--- a/pkg/ingestor/ingestctrl/engine_test.go
+++ b/pkg/ingestor/ingestctrl/engine_test.go
@@ -275,3 +275,51 @@ func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
 	err = sstWriter.writer.Close()
 	require.NoError(t, err)
 }
+
+// TestSSTWriterWriteKVsReusedKeyBuffer verifies that writeKVs does not alias
+// sw.lastKey into a reusable key buffer. In the sorted path (appendRowsSorted)
+// all encoded keys of a batch are slices into one shared sortedKeyBuf which is
+// reset to offset 0 on every batch. If sw.lastKey keeps a reference into that
+// buffer, the next batch's first key can be written to the exact region
+// sw.lastKey points to, so bytes.Equal compares the key against itself and the
+// KV is silently skipped (data loss + checksum mismatch on IMPORT INTO).
+//
+// Reproduces the 3 + 1 + 3 equal-length-key pattern from issue #70716.
+func TestSSTWriterWriteKVsReusedKeyBuffer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sst")
+	writer, err := newSSTWriter(path, 16*1024)
+	require.NoError(t, err)
+	sw := &sstWriter{sstMeta: &sstMeta{path: path}, writer: writer, logger: log.L()}
+
+	// Simulate appendRowsSorted's reusable sortedKeyBuf: every key of a batch
+	// is a slice into one shared buffer, and the buffer is reset to offset 0
+	// between batches (exactly what `buf := w.sortedKeyBuf[:0]` does).
+	keyBuf := make([]byte, 0, 64)
+	encode := func(keys ...string) []common.KvPair {
+		keyBuf = keyBuf[:0]
+		kvs := make([]common.KvPair, 0, len(keys))
+		for _, k := range keys {
+			start := len(keyBuf)
+			keyBuf = append(keyBuf, k...)
+			kvs = append(kvs, common.KvPair{Key: keyBuf[start:], Val: []byte("v")})
+		}
+		return kvs
+	}
+
+	// Batch 1: three equal-length sorted KVs.
+	require.NoError(t, sw.writeKVs(encode("aaa", "bbb", "ccc")))
+	// Batch 2: a single KV leaves sw.lastKey pointing at buffer offset 0.
+	require.NoError(t, sw.writeKVs(encode("ddd")))
+	// Batch 3: three more sorted KVs. With the aliasing bug the first key
+	// ("eee") is written to the same region sw.lastKey references and is
+	// wrongly treated as a duplicate and skipped.
+	require.NoError(t, sw.writeKVs(encode("eee", "fff", "ggg")))
+
+	// totalSize only accumulates for actually-written keys (it is updated after
+	// the duplicate-skip `continue`), so it is the precise discriminator.
+	// 7 keys x (3-byte key + 1-byte val) = 28; the buggy code writes only 6 => 24.
+	require.Equal(t, int64(28), sw.totalSize)
+	require.Equal(t, int64(7), sw.totalCount)
+	require.NoError(t, sw.writer.Close())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70716

`IMPORT INTO ... FROM SELECT` into a table without a primary key/unique index can silently skip rows and fail the post-import checksum.

In the sorted import path, [`appendRowsSorted`](pkg/ingestor/ingestctrl/engine.go#L1210-L1222) stores all encoded keys of a batch as slices into one reusable `sortedKeyBuf`, reset to offset 0 on every batch. [`writeKVs`](pkg/ingestor/ingestctrl/engine.go#L1476-L1489) then kept `sw.lastKey = p.Key`, i.e. a reference *into* that reusable buffer.

When the next batch reuses the buffer, its first key can be written to the exact region `sw.lastKey` still points to. `bytes.Equal(p.Key, sw.lastKey)` then compares the key against itself and returns true, so the KV is treated as a duplicate and silently skipped.

### What is changed and how it works?

Copy the key into `sw.lastKey` instead of aliasing it, using the same `append(sw.lastKey[:0], p.Key...)` copy pattern already used elsewhere in this file.

### Check List

Tests:

- [x] Unit test `TestSSTWriterWriteKVsReusedKeyBuffer` reproduces the exact 3 + 1 + 3 equal-length-key pattern from the issue and asserts `totalSize`.

### Release note

```release-note
Fix a bug where `IMPORT INTO ... FROM SELECT` into a table without a primary key/unique index could silently skip rows and fail checksum verification.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain keys could be incorrectly treated as duplicates during batch ingestion.
  * Ensured all valid key-value entries are retained when processing reused buffers.

* **Tests**
  * Added coverage for repeated batch processing with shared key buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->