### PR TITLE
tests: avoid ADC lookup for fake GCS server

### DIFF
--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -83,6 +83,8 @@ func genStorageURI(t *testing.T) (host string, port uint16, uri string) {
 func genServerWithStorage(t *testing.T) (*fakestorage.Server, string) {
 	t.Helper()
 	gcsHost, gcsPort, cloudStorageURI := genStorageURI(t)
+	// Use the existing test-only unauthenticated path without probing GCE metadata.
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", t.TempDir()+"/missing-gcs-credentials.json")
 	opt := fakestorage.Options{
 		Scheme:     "http",
 		Host:       gcsHost,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70721

Problem Summary:

`TestAddIndexIngestShowReorgTp` uses a fake GCS endpoint. Creating the GCS client still attempts Application Default Credentials discovery, which can leave a two-second GCE metadata dial alive after the test passes. The common RealTiKV goleak check then fails the shard with `net.(*netFD).connect.func2`.

### What changed and how does it work?

Set `GOOGLE_APPLICATION_CREDENTIALS` to a guaranteed-missing temporary file in the fake-GCS helper. Credential discovery now fails synchronously before probing GCE metadata, and the existing `intest` fallback selects unauthenticated GCS access for the fake server. `testing.T.Setenv` restores the caller's previous environment automatically after each test.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```bash
./tools/check/failpoint-go-test.sh tests/realtikvtest/addindextest2 \
  -run '^TestAddIndexIngestShowReorgTp$' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by preventing unintended Google Cloud metadata lookups.
  * Tests now use an isolated, unauthenticated configuration during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->