### PR TITLE
planner: remove redundant branches in the OR list (#58962) | tidb-test=5730244c023616144b344939ba89b36d00abe035

### DIFF
--- a/tests/integrationtest/r/planner/core/casetest/predicate_simplification.result
+++ b/tests/integrationtest/r/planner/core/casetest/predicate_simplification.result
@@ -308,3 +308,86 @@ HashAgg	8.00	root		group by:Column#7, Column#8, funcs:avg(distinct Column#6)->Co
   └─TableReader	10.00	root		data:Selection
     └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__predicate_simplification.t910beff5.col_41, "cwx!P4xaX)U"), or(ge(planner__core__casetest__predicate_simplification.t910beff5.col_41, "D1$9+VTpEe)"), and(ge(planner__core__casetest__predicate_simplification.t910beff5.col_41, "znRD*2pkmtm4"), le(planner__core__casetest__predicate_simplification.t910beff5.col_41, "PBueg(&tWY%dzsT(_")))
       └─TableFullScan	10000.00	cop[tikv]	table:t910beff5	keep order:false, stats:pseudo
+drop table if exists t1;
+create table t1 (a int, b decimal(65,30), c int);
+explain format=brief select * from t1 where a = 1 or a = 2 or a = 5 or a = 5 or a = 5;
+id	estRows	task	access object	operator info
+TableReader	30.00	root		data:Selection
+└─Selection	30.00	cop[tikv]		or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 2), eq(planner__core__casetest__predicate_simplification.t1.a, 5)))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where a = 1 or a = 2 or a = 5 or a = 5 or a = 5 or b = 1.1 or b = 2.2 or b = 3.3 or b = 3.3;
+id	estRows	task	access object	operator info
+TableReader	59.91	root		data:Selection
+└─Selection	59.91	cop[tikv]		or(or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 2), eq(planner__core__casetest__predicate_simplification.t1.a, 5))), or(eq(planner__core__casetest__predicate_simplification.t1.b, 1.1), or(eq(planner__core__casetest__predicate_simplification.t1.b, 2.2), eq(planner__core__casetest__predicate_simplification.t1.b, 3.3))))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where a = 1 and (b = 1.1 or b = 2.2 or b = 3.3 or b = 3.3);
+id	estRows	task	access object	operator info
+TableReader	0.03	root		data:Selection
+└─Selection	0.03	cop[tikv]		eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.b, 1.1), or(eq(planner__core__casetest__predicate_simplification.t1.b, 2.2), eq(planner__core__casetest__predicate_simplification.t1.b, 3.3)))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where a = 1 or (b = 1.1 and (a = 1 or a = 2 or a = 5 or a = 5 or a = 5));
+id	estRows	task	access object	operator info
+TableReader	10.03	root		data:Selection
+└─Selection	10.03	cop[tikv]		or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), and(eq(planner__core__casetest__predicate_simplification.t1.b, 1.1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 2), eq(planner__core__casetest__predicate_simplification.t1.a, 5)))))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where (a = 1 and (b = 2.2 or (c = 1 and (b = 1 or b = 1)))) or (b = 1.1 and b = 1.1 and (a = 1 or a = 2 or a = 5 or a = 5 or a = 5));
+id	estRows	task	access object	operator info
+TableReader	0.04	root		data:Selection
+└─Selection	0.04	cop[tikv]		or(and(eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.b, 2.2), and(eq(planner__core__casetest__predicate_simplification.t1.c, 1), eq(planner__core__casetest__predicate_simplification.t1.b, 1)))), and(eq(planner__core__casetest__predicate_simplification.t1.b, 1.1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), or(eq(planner__core__casetest__predicate_simplification.t1.a, 2), eq(planner__core__casetest__predicate_simplification.t1.a, 5)))))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where (c = 10 or (b + 1 > 10 and (a + 1 < 5 or a + 1 < 5 or a = 20))) and c + 1 < 10 and (a = 1 or a = 2 or a = 5 or a = 5 or b = 5 or b = 5);
+id	estRows	task	access object	operator info
+TableReader	20.48	root		data:Selection
+└─Selection	20.48	cop[tikv]		lt(plus(planner__core__casetest__predicate_simplification.t1.c, 1), 10), or(eq(planner__core__casetest__predicate_simplification.t1.c, 10), and(gt(plus(planner__core__casetest__predicate_simplification.t1.b, 1), 10), or(lt(plus(planner__core__casetest__predicate_simplification.t1.a, 1), 5), eq(planner__core__casetest__predicate_simplification.t1.a, 20)))), or(or(eq(planner__core__casetest__predicate_simplification.t1.a, 1), eq(planner__core__casetest__predicate_simplification.t1.a, 2)), or(eq(planner__core__casetest__predicate_simplification.t1.a, 5), eq(planner__core__casetest__predicate_simplification.t1.b, 5)))
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where (rand() * 10 = 1) or (rand() * 10 = 1);
+id	estRows	task	access object	operator info
+Selection	8000.00	root		or(eq(mul(rand(), 10), 1), eq(mul(rand(), 10), 1))
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+explain format=brief select * from t1 where (@a:=@a+1) or (@a:=@a+1);
+id	estRows	task	access object	operator info
+Selection	8000.00	root		or(istrue_with_null(setvar("a", plus(cast(getvar("a"), double BINARY), 1))), istrue_with_null(setvar("a", plus(getvar("a"), 1))))
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+drop table if exists t2;
+create table t2 (a datetime(6), b timestamp(6), index ia(a), index iab(a,b));
+explain format=brief select * from t2 where a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00';
+id	estRows	task	access object	operator info
+IndexReader	10.00	root		index:IndexRangeScan
+└─IndexRangeScan	10.00	cop[tikv]	table:t2, index:iab(a, b)	range:[2025-01-01 00:00:00.000000,2025-01-01 00:00:00.000000], keep order:false, stats:pseudo
+explain format=brief select * from t2 where (a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00') and (b = '2025-01-01 00:00:00' or b = '2025-01-01 00:00:00' or b = '2025-01-01 00:00:00');
+id	estRows	task	access object	operator info
+IndexReader	0.10	root		index:IndexRangeScan
+└─IndexRangeScan	0.10	cop[tikv]	table:t2, index:iab(a, b)	range:[2025-01-01 00:00:00.000000 2025-01-01 00:00:00.000000,2025-01-01 00:00:00.000000 2025-01-01 00:00:00.000000], keep order:false, stats:pseudo
+drop table if exists t3;
+create table t3 (a varchar(10) collate utf8mb4_general_ci, b varchar(10) collate utf8mb4_bin, index ia(a), index ib(b));
+explain format=brief select * from t3 where a = 'a' or a = 'a' or a = 'A';
+id	estRows	task	access object	operator info
+IndexLookUp	10.00	root		
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t3, index:ia(a)	range:["\x00A","\x00A"], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+explain format=brief select * from t3 where a = 'a' or a = 'a' or a = 'A' or b = _utf8mb4'b' or b = _latin1'b' or b = 'B';
+id	estRows	task	access object	operator info
+IndexMerge	29.98	root		type: union
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t3, index:ia(a)	range:["\x00A","\x00A"], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t3, index:ia(a)	range:["\x00A","\x00A"], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t3, index:ib(b)	range:["b","b"], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t3, index:ib(b)	range:["B","B"], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	29.98	cop[tikv]	table:t3	keep order:false, stats:pseudo
+explain format=brief select * from t3 where a = _utf8mb4'a' collate utf8mb4_unicode_ci or a = _utf8mb4'a' collate utf8mb4_0900_ai_ci or a = 'A' or b = 'b' or b = 'b' or b = 'B';
+id	estRows	task	access object	operator info
+TableReader	8006.00	root		data:Selection
+└─Selection	8006.00	cop[tikv]		or(or(eq(planner__core__casetest__predicate_simplification.t3.a, "a"), eq(planner__core__casetest__predicate_simplification.t3.a, "A")), or(eq(planner__core__casetest__predicate_simplification.t3.b, "b"), eq(planner__core__casetest__predicate_simplification.t3.b, "B")))
+  └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+drop table if exists t4;
+create table t4(a int, b int, c int, d int, index iab(a,b), index iac(a,c), index iad(a,d));
+explain format=brief select /*+ use_index_merge(t4) */ * from t4 where a = 1 and (b = 2 or c = 4 or b = 12 or c = 5 or d = 6 or c = 4 or c = 5 or d = 6);
+id	estRows	task	access object	operator info
+IndexMerge	8.00	root		type: union
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t4, index:iab(a, b)	range:[1 2,1 2], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t4, index:iac(a, c)	range:[1 4,1 4], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t4, index:iab(a, b)	range:[1 12,1 12], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t4, index:iac(a, c)	range:[1 5,1 5], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	0.10	cop[tikv]	table:t4, index:iad(a, d)	range:[1 6,1 6], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	8.00	cop[tikv]	table:t4	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -1055,7 +1055,7 @@ EXPLAIN format = brief SELECT * FROM t WHERE a = 1 AND (c = 13 OR c = 15 OR c = 
 id	estRows	task	access object	operator info
 IndexLookUp	0.05	root		
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ia(a)	range:[1,1], keep order:false, stats:pseudo
-└─Selection(Probe)	0.05	cop[tikv]		or(or(eq(planner__core__indexmerge_path.t.c, 13), or(eq(planner__core__indexmerge_path.t.c, 15), eq(planner__core__indexmerge_path.t.c, 5))), or(eq(planner__core__indexmerge_path.t.b, "12"), or(eq(planner__core__indexmerge_path.t.c, 13), eq(planner__core__indexmerge_path.t.b, "11"))))
+└─Selection(Probe)	0.05	cop[tikv]		or(or(eq(planner__core__indexmerge_path.t.c, 13), eq(planner__core__indexmerge_path.t.c, 15)), or(eq(planner__core__indexmerge_path.t.c, 5), or(eq(planner__core__indexmerge_path.t.b, "12"), eq(planner__core__indexmerge_path.t.b, "11"))))
   └─TableRowIDScan	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 SET @@tidb_opt_fix_control = '52869:on';
 EXPLAIN format = brief SELECT * FROM t WHERE a = 1 AND (b = '2' OR c = 3 OR d = '4');
@@ -1101,7 +1101,6 @@ IndexMerge	0.05	root		type: union
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ic(c)	range:[15,15], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ic(c)	range:[5,5], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:["12","12"], keep order:false, stats:pseudo
-├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ic(c)	range:[13,13], keep order:false, stats:pseudo
 ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:ib(b)	range:["11","11"], keep order:false, stats:pseudo
 └─Selection(Probe)	0.05	cop[tikv]		eq(planner__core__indexmerge_path.t.a, 1)
   └─TableRowIDScan	49.94	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/casetest/predicate_simplification.test
+++ b/tests/integrationtest/t/planner/core/casetest/predicate_simplification.test
@@ -146,3 +146,30 @@ CREATE TABLE `t910beff5` (
 INSERT INTO `t910beff5` VALUES(7,'CWHObI8-!amnYA'),(1,'g+!OHa@OTdsA2#JN'),(249,'cwx!P4xaX)U'),(118,'mlDJX^n+'),(0,'EOZ9*QUsH%qi)%'),(183,'9*Lzmwg%pxy'),(139,'!ME5dBDrOG5'),(127,'BNb8SajqZ'),(209,'IWS^j'),(68,'U9v99'),(187,'dE*Zzjz#0&'),(10,'iC'),(87,'jIgUfpWzE9#oQhn&#&'),(4,'BLmM2'),(153,'(BG(8nIFNyE$%i'),(51,'EDhm)%Fie~qReM');
 SELECT AVG(DISTINCT `t910beff5`.`col_40`) AS `r0` FROM `t910beff5` WHERE `t910beff5`.`col_41`>='D1$9+VTpEe)' OR `t910beff5`.`col_41` BETWEEN 'znRD*2pkmtm4' AND 'PBueg(&tWY%dzsT(_' GROUP BY `t910beff5`.`col_40`,`t910beff5`.`col_41` HAVING `t910beff5`.`col_41`='cwx!P4xaX)U';
 explain format=brief SELECT AVG(DISTINCT `t910beff5`.`col_40`) AS `r0` FROM `t910beff5` WHERE `t910beff5`.`col_41`>='D1$9+VTpEe)' OR `t910beff5`.`col_41` BETWEEN 'znRD*2pkmtm4' AND 'PBueg(&tWY%dzsT(_' GROUP BY `t910beff5`.`col_40`,`t910beff5`.`col_41` HAVING `t910beff5`.`col_41`='cwx!P4xaX)U';
+
+# Test removing redundant branches from OR list
+drop table if exists t1;
+create table t1 (a int, b decimal(65,30), c int);
+explain format=brief select * from t1 where a = 1 or a = 2 or a = 5 or a = 5 or a = 5;
+explain format=brief select * from t1 where a = 1 or a = 2 or a = 5 or a = 5 or a = 5 or b = 1.1 or b = 2.2 or b = 3.3 or b = 3.3;
+explain format=brief select * from t1 where a = 1 and (b = 1.1 or b = 2.2 or b = 3.3 or b = 3.3);
+explain format=brief select * from t1 where a = 1 or (b = 1.1 and (a = 1 or a = 2 or a = 5 or a = 5 or a = 5));
+explain format=brief select * from t1 where (a = 1 and (b = 2.2 or (c = 1 and (b = 1 or b = 1)))) or (b = 1.1 and b = 1.1 and (a = 1 or a = 2 or a = 5 or a = 5 or a = 5));
+explain format=brief select * from t1 where (c = 10 or (b + 1 > 10 and (a + 1 < 5 or a + 1 < 5 or a = 20))) and c + 1 < 10 and (a = 1 or a = 2 or a = 5 or a = 5 or b = 5 or b = 5);
+explain format=brief select * from t1 where (rand() * 10 = 1) or (rand() * 10 = 1);
+explain format=brief select * from t1 where (@a:=@a+1) or (@a:=@a+1);
+
+drop table if exists t2;
+create table t2 (a datetime(6), b timestamp(6), index ia(a), index iab(a,b));
+explain format=brief select * from t2 where a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00';
+explain format=brief select * from t2 where (a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00' or a = '2025-01-01 00:00:00') and (b = '2025-01-01 00:00:00' or b = '2025-01-01 00:00:00' or b = '2025-01-01 00:00:00');
+
+drop table if exists t3;
+create table t3 (a varchar(10) collate utf8mb4_general_ci, b varchar(10) collate utf8mb4_bin, index ia(a), index ib(b));
+explain format=brief select * from t3 where a = 'a' or a = 'a' or a = 'A';
+explain format=brief select * from t3 where a = 'a' or a = 'a' or a = 'A' or b = _utf8mb4'b' or b = _latin1'b' or b = 'B';
+explain format=brief select * from t3 where a = _utf8mb4'a' collate utf8mb4_unicode_ci or a = _utf8mb4'a' collate utf8mb4_0900_ai_ci or a = 'A' or b = 'b' or b = 'b' or b = 'B';
+
+drop table if exists t4;
+create table t4(a int, b int, c int, d int, index iab(a,b), index iac(a,c), index iad(a,d));
+explain format=brief select /*+ use_index_merge(t4) */ * from t4 where a = 1 and (b = 2 or c = 4 or b = 12 or c = 5 or d = 6 or c = 4 or c = 5 or d = 6);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #58962

Problem Summary:

PR #66197 backported the fix of #58962 (removing redundant branches in the OR list) to the v8.5.5 hotfix branch, but the fix was never brought to the v8.5.8 hotfix line. This PR cherry-picks it onto `release-8.5-20260826-v8.5.8`.

### What changed and how does it work?

- Cherry-pick the squashed change from #66197 onto `release-8.5-20260826-v8.5.8`.
- Add a new step in the rule `predicate_simplification` to remove duplicate expressions from OR lists, recursively for nested AND lists, using `HashCode()` like the existing `RemoveDupExprs()`.
- Regenerate one integration-test expectation in `planner/core/casetest/predicate_simplification`: on this branch, filters covered by every selected partial index path no longer produce a redundant probe-side `Selection` (brought by #70440).

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Tested with Go 1.25.12:

```text
go test -tags=intest -run '^TestPredicateSimplification$' ./pkg/planner/core/casetest/rule

integrationtest/planner/core/casetest/predicate_simplification: passed (result regenerated)
integrationtest/planner/core/indexmerge_path: passed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved query planning by removing redundant conditions from `OR` expressions.
  * Reduced duplicate index scans in index-merge execution plans.

* **Bug Fixes**
  * Improved simplification of nested `AND`/`OR` predicates across numeric, temporal, and text comparisons.
  * Preserved distinct behavior for non-deterministic expressions and incompatible collations.

* **Tests**
  * Added coverage for redundant predicate removal and related execution-plan changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->