### PR TITLE
server: support SPIFFE Workload API for MySQL TLS

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3350,8 +3350,8 @@ def go_deps():
         name = "com_github_microsoft_go_winio",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/Microsoft/go-winio",
-        sum = "h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=",
-        version = "v0.6.1",
+        sum = "h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=",
+        version = "v0.6.2",
     )
     go_repository(
         name = "com_github_miekg_dns",
@@ -5417,8 +5417,8 @@ def go_deps():
         name = "com_google_cloud_go_monitoring",
         build_file_proto_mode = "disable_global",
         importpath = "cloud.google.com/go/monitoring",
-        sum = "h1:vKiypZVFD/5a3BbQMvI4gZdl8445ITzXFh257XBgrS0=",
-        version = "v1.24.1",
+        sum = "h1:csSKiCJ+WVRgNkRzzz3BPoGjFhjPY23ZTcaenToJxMM=",
+        version = "v1.24.0",
     )
     go_repository(
         name = "com_google_cloud_go_networkconnectivity",
@@ -5698,8 +5698,8 @@ def go_deps():
         name = "com_google_cloud_go_trace",
         build_file_proto_mode = "disable_global",
         importpath = "cloud.google.com/go/trace",
-        sum = "h1:CALS1loyxJMnRiCwZSpdf8ac7iCsjreMxFD2WGxzzHU=",
-        version = "v1.11.5",
+        sum = "h1:c+I4YFjxRQjvAhRmSsmjpASUKq88chOX854ied0K/pE=",
+        version = "v1.11.3",
     )
     go_repository(
         name = "com_google_cloud_go_translate",
@@ -6110,13 +6110,6 @@ def go_deps():
         version = "v0.24.0",
     )
     go_repository(
-        name = "io_opencensus_go_contrib_exporter_stackdriver",
-        build_file_proto_mode = "disable_global",
-        importpath = "contrib.go.opencensus.io/exporter/stackdriver",
-        sum = "h1:xRc46S76eyn4ZF3jWX8I+aUSKVLw5EQ1aDvHwfV5W1o=",
-        version = "v0.13.15-0.20230702191903-2de6d2748484",
-    )
-    go_repository(
         name = "io_opentelemetry_go_auto_sdk",
         build_file_proto_mode = "disable_global",
         importpath = "go.opentelemetry.io/auto/sdk",
@@ -6192,13 +6185,6 @@ def go_deps():
         importpath = "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
         sum = "h1:FyjCyI9jVEfqhUh2MoSkmolPjfh5fp2hnV0b0irxH4Q=",
         version = "v1.22.0",
-    )
-    go_repository(
-        name = "io_opentelemetry_go_otel_exporters_prometheus",
-        build_file_proto_mode = "disable_global",
-        importpath = "go.opentelemetry.io/otel/exporters/prometheus",
-        sum = "h1:AHh/lAP1BHrY5gBwk8ncc25FXWm/gmmY3BX258z5nuk=",
-        version = "v0.57.0",
     )
     go_repository(
         name = "io_opentelemetry_go_otel_metric",
@@ -6367,27 +6353,6 @@ def go_deps():
         importpath = "google.golang.org/grpc/examples",
         sum = "h1:ExN12ndbJ608cboPYflpTny6mXSzPrDLh0iTaVrRrds=",
         version = "v0.0.0-20250407062114-b368379ef8f6",
-    )
-    go_repository(
-        name = "org_golang_google_grpc_gcp_observability",
-        build_file_proto_mode = "disable_global",
-        importpath = "google.golang.org/grpc/gcp/observability",
-        sum = "h1:2IQ7szW1gobfZaS/sDSAu2uxO0V/aTryMZvlcyqKqQA=",
-        version = "v1.0.1",
-    )
-    go_repository(
-        name = "org_golang_google_grpc_security_advancedtls",
-        build_file_proto_mode = "disable_global",
-        importpath = "google.golang.org/grpc/security/advancedtls",
-        sum = "h1:/KQ7VP/1bs53/aopk9QhuPyFAp9Dm9Ejix3lzYkCrDA=",
-        version = "v1.0.0",
-    )
-    go_repository(
-        name = "org_golang_google_grpc_stats_opencensus",
-        build_file_proto_mode = "disable_global",
-        importpath = "google.golang.org/grpc/stats/opencensus",
-        sum = "h1:evSYcRZaSToQp+borzWE52+03joezZeXcKJvZDfkUJA=",
-        version = "v1.0.0",
     )
     go_repository(
         name = "org_golang_google_protobuf",

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/spkg/bom v1.0.0
 	github.com/stathat/consistent v1.0.0
 	github.com/stretchr/testify v1.11.1
@@ -169,6 +170,7 @@ require (
 	cloud.google.com/go/longrunning v0.6.6 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 // indirect
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.11 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
@@ -197,6 +199,7 @@ require (
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -219,7 +222,6 @@ require (
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
-	google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
@@ -355,7 +357,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.29.11 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1347,6 +1347,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -1693,6 +1695,8 @@ github.com/go-fonts/liberation v0.2.0/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2H
 github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
@@ -2321,6 +2325,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/spkg/bom v1.0.0 h1:S939THe0ukL5WcTGiGqkgtaW5JW+O6ITaIlpJXTYY64=
 github.com/spkg/bom v1.0.0/go.mod h1:lAz2VbTuYNcvs7iaFF8WW0ufXrHShJ7ck1fYFFbVXJs=
 github.com/stathat/consistent v1.0.0 h1:ZFJ1QTRn8npNBKW065raSZ8xfOqhpb8vLOkfp4CcL/U=

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -47,7 +47,7 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 38,
+    shard_count = 39,
     deps = [
         "//pkg/config/deploymode",
         "//pkg/config/kerneltype",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -760,14 +761,16 @@ const (
 
 // Security is the security section of the config.
 type Security struct {
-	SkipGrantTable  bool     `toml:"skip-grant-table" json:"skip-grant-table"`
-	SSLCA           string   `toml:"ssl-ca" json:"ssl-ca"`
-	SSLCert         string   `toml:"ssl-cert" json:"ssl-cert"`
-	SSLKey          string   `toml:"ssl-key" json:"ssl-key"`
-	ClusterSSLCA    string   `toml:"cluster-ssl-ca" json:"cluster-ssl-ca"`
-	ClusterSSLCert  string   `toml:"cluster-ssl-cert" json:"cluster-ssl-cert"`
-	ClusterSSLKey   string   `toml:"cluster-ssl-key" json:"cluster-ssl-key"`
-	ClusterVerifyCN []string `toml:"cluster-verify-cn" json:"cluster-verify-cn"`
+	SkipGrantTable           bool     `toml:"skip-grant-table" json:"skip-grant-table"`
+	SSLCA                    string   `toml:"ssl-ca" json:"ssl-ca"`
+	SSLCert                  string   `toml:"ssl-cert" json:"ssl-cert"`
+	SSLKey                   string   `toml:"ssl-key" json:"ssl-key"`
+	SPIFFEWorkloadAPIAddr    string   `toml:"spiffe-workload-api-addr" json:"spiffe-workload-api-addr"`
+	SPIFFEWorkloadAPITimeout string   `toml:"spiffe-workload-api-timeout" json:"spiffe-workload-api-timeout"`
+	ClusterSSLCA             string   `toml:"cluster-ssl-ca" json:"cluster-ssl-ca"`
+	ClusterSSLCert           string   `toml:"cluster-ssl-cert" json:"cluster-ssl-cert"`
+	ClusterSSLKey            string   `toml:"cluster-ssl-key" json:"cluster-ssl-key"`
+	ClusterVerifyCN          []string `toml:"cluster-verify-cn" json:"cluster-verify-cn"`
 	// Used for auth plugin `tidb_session_token`.
 	SessionTokenSigningCert string `toml:"session-token-signing-cert" json:"session-token-signing-cert"`
 	SessionTokenSigningKey  string `toml:"session-token-signing-key" json:"session-token-signing-key"`
@@ -788,6 +791,13 @@ type Security struct {
 	AuthTokenRefreshInterval string `toml:"auth-token-refresh-interval" json:"auth-token-refresh-interval"`
 	// Disconnect directly when the password is expired
 	DisconnectOnExpiredPassword bool `toml:"disconnect-on-expired-password" json:"disconnect-on-expired-password"`
+}
+
+func (s *Security) validateSPIFFETLSExclusivity() error {
+	if s.SPIFFEWorkloadAPIAddr != "" && (s.SSLCA != "" || s.SSLCert != "" || s.SSLKey != "" || s.AutoTLS) {
+		return errors.New("[security] spiffe-workload-api-addr cannot be used with ssl-ca, ssl-cert, ssl-key, or auto-tls")
+	}
+	return nil
 }
 
 // The ErrConfigValidationFailed error is used so that external callers can do a type assertion
@@ -1312,6 +1322,8 @@ var defaultConf = Config{
 	EnableGlobalIndex:          false,
 	Security: Security{
 		SpilledFileEncryptionMethod: SpilledFileEncryptionMethodPlaintext,
+		SPIFFEWorkloadAPIAddr:       "",
+		SPIFFEWorkloadAPITimeout:    "30s",
 		EnableSEM:                   false,
 		SEMConfig:                   "",
 		AutoTLS:                     false,
@@ -1565,6 +1577,9 @@ func (c *Config) adjustSecurityConfig() error {
 	}
 	if len(sqlKeyPath) > 0 {
 		c.Security.SSLKey = sqlKeyPath
+	}
+	if err := c.Security.validateSPIFFETLSExclusivity(); err != nil {
+		return err
 	}
 	if sqlCAOverridden || sqlCertOverridden || sqlKeyOverridden {
 		if sqlCertOverridden != sqlKeyOverridden {
@@ -1856,6 +1871,22 @@ func (c *Config) Valid() error {
 	}
 
 	// test security
+	workloadAPITimeout, err := time.ParseDuration(c.Security.SPIFFEWorkloadAPITimeout)
+	if err != nil || workloadAPITimeout <= 0 {
+		return fmt.Errorf("[security] spiffe-workload-api-timeout must be a positive Go duration")
+	}
+	if c.Security.SPIFFEWorkloadAPIAddr != "" {
+		workloadAPIURL, err := url.Parse(c.Security.SPIFFEWorkloadAPIAddr)
+		if err != nil || !strings.HasPrefix(c.Security.SPIFFEWorkloadAPIAddr, "unix:///") ||
+			workloadAPIURL.Scheme != "unix" || workloadAPIURL.Host != "" || workloadAPIURL.Path == "" ||
+			!filepath.IsAbs(workloadAPIURL.Path) || workloadAPIURL.Opaque != "" || workloadAPIURL.User != nil ||
+			workloadAPIURL.RawQuery != "" || workloadAPIURL.ForceQuery || workloadAPIURL.Fragment != "" {
+			return fmt.Errorf("[security] spiffe-workload-api-addr must be an absolute unix:/// URI")
+		}
+	}
+	if err := c.Security.validateSPIFFETLSExclusivity(); err != nil {
+		return err
+	}
 	c.Security.SpilledFileEncryptionMethod = strings.ToLower(c.Security.SpilledFileEncryptionMethod)
 	switch c.Security.SpilledFileEncryptionMethod {
 	case SpilledFileEncryptionMethodPlaintext, SpilledFileEncryptionMethodAES128CTR:

--- a/pkg/config/config.toml.example
+++ b/pkg/config/config.toml.example
@@ -188,6 +188,15 @@ ssl-cert = ""
 # Path of file that contains X509 key in PEM format for connection with mysql client.
 ssl-key = ""
 
+# Absolute unix:/// SPIFFE Workload API endpoint used to obtain TiDB's X.509-SVID and trust bundle.
+# Peer SPIFFE IDs are carried in certificate URI SANs. URI identity is authoritative;
+# DNS VERIFY_IDENTITY compatibility is not provided. This option cannot be combined with
+# ssl-ca, ssl-cert, ssl-key, or auto-tls.
+spiffe-workload-api-addr = ""
+
+# Positive Go duration to wait at startup for the first valid SPIFFE X.509 context.
+spiffe-workload-api-timeout = "30s"
+
 # Path of file that contains list of trusted SSL CAs for connection with cluster components.
 cluster-ssl-ca = ""
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -199,6 +199,15 @@ ssl-cert = ""
 # Path of file that contains X509 key in PEM format for connection with mysql client.
 ssl-key = ""
 
+# Absolute unix:/// SPIFFE Workload API endpoint used to obtain TiDB's X.509-SVID and trust bundle.
+# Peer SPIFFE IDs are carried in certificate URI SANs. URI identity is authoritative;
+# DNS VERIFY_IDENTITY compatibility is not provided. This option cannot be combined with
+# ssl-ca, ssl-cert, ssl-key, or auto-tls.
+spiffe-workload-api-addr = ""
+
+# Positive Go duration to wait at startup for the first valid SPIFFE X.509 context.
+spiffe-workload-api-timeout = "30s"
+
 # Path of file that contains list of trusted SSL CAs for connection with cluster components.
 cluster-ssl-ca = ""
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1912,6 +1912,75 @@ func TestSecurityValid(t *testing.T) {
 	}
 }
 
+func TestSPIFFEWorkloadAPIConfig(t *testing.T) {
+	const workloadAPIAddr = "unix:///run/spire/sockets/agent.sock"
+
+	conf := NewConfig()
+	require.Empty(t, conf.Security.SPIFFEWorkloadAPIAddr)
+	require.Equal(t, "30s", conf.Security.SPIFFEWorkloadAPITimeout)
+	require.NoError(t, conf.Valid())
+
+	conf.Security.SPIFFEWorkloadAPITimeout = "0s"
+	require.ErrorContains(t, conf.Valid(), "spiffe-workload-api-timeout must be a positive Go duration")
+
+	conf = NewConfig()
+	conf.Security.SPIFFEWorkloadAPIAddr = workloadAPIAddr
+	conf.Security.SPIFFEWorkloadAPITimeout = "250ms"
+	require.NoError(t, conf.Valid())
+
+	for _, addr := range []string{
+		"unix:/run/spire/sockets/agent.sock",
+		"unix://spire/run/spire/sockets/agent.sock",
+		"tcp://127.0.0.1:8081",
+		"unix:///run/spire/sockets/agent.sock?query=true",
+	} {
+		conf := NewConfig()
+		conf.Security.SPIFFEWorkloadAPIAddr = addr
+		require.ErrorContains(t, conf.Valid(), "spiffe-workload-api-addr must be an absolute unix:/// URI", addr)
+	}
+
+	for _, timeout := range []string{"", "invalid", "0s", "-1s"} {
+		conf := NewConfig()
+		conf.Security.SPIFFEWorkloadAPIAddr = workloadAPIAddr
+		conf.Security.SPIFFEWorkloadAPITimeout = timeout
+		require.ErrorContains(t, conf.Valid(), "spiffe-workload-api-timeout must be a positive Go duration", timeout)
+	}
+
+	conflicts := []struct {
+		name      string
+		configure func(*Security)
+	}{
+		{name: "ssl-ca", configure: func(security *Security) { security.SSLCA = "ca.pem" }},
+		{name: "ssl-cert", configure: func(security *Security) { security.SSLCert = "cert.pem" }},
+		{name: "ssl-key", configure: func(security *Security) { security.SSLKey = "key.pem" }},
+		{name: "auto-tls", configure: func(security *Security) { security.AutoTLS = true }},
+	}
+	for _, conflict := range conflicts {
+		t.Run(conflict.name, func(t *testing.T) {
+			conf := NewConfig()
+			conf.Security.SPIFFEWorkloadAPIAddr = workloadAPIAddr
+			conflict.configure(&conf.Security)
+			require.ErrorContains(t, conf.Valid(), "spiffe-workload-api-addr cannot be used with ssl-ca, ssl-cert, ssl-key, or auto-tls")
+		})
+	}
+
+	conf = NewConfig()
+	conf.Security.SPIFFEWorkloadAPIAddr = workloadAPIAddr
+	conf.Security.ClusterSSLCA = "cluster-ca.pem"
+	conf.Security.ClusterSSLCert = "cluster-cert.pem"
+	conf.Security.ClusterSSLKey = "cluster-key.pem"
+	require.NoError(t, conf.Valid())
+
+	t.Run("starter SQL environment conflict", func(t *testing.T) {
+		t.Setenv(EnvSQLCA, "env-ca.pem")
+		t.Setenv(EnvSQLCert, "env-cert.pem")
+		t.Setenv(EnvSQLKey, "env-key.pem")
+		conf := NewConfig()
+		conf.Security.SPIFFEWorkloadAPIAddr = workloadAPIAddr
+		require.ErrorContains(t, conf.AdjustStarterConfig(true), "spiffe-workload-api-addr cannot be used with ssl-ca, ssl-cert, ssl-key, or auto-tls")
+	})
+}
+
 func TestTcpNoDelay(t *testing.T) {
 	c1 := NewConfig()
 	// check default value

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -62,7 +62,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
@@ -76,7 +75,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
-	"github.com/pingcap/tidb/pkg/util/tls"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
@@ -3515,20 +3513,7 @@ func (e *SimpleExec) executeAlterInstance(s *ast.AlterInstanceStmt) error {
 	if s.ReloadTLS {
 		logutil.BgLogger().Info("execute reload tls", zap.Bool("NoRollbackOnError", s.NoRollbackOnError))
 		sm := e.Ctx().GetSessionManager()
-		tlsCfg, _, err := util.LoadTLSCertificates(
-			variable.GetSysVar("ssl_ca").Value,
-			variable.GetSysVar("ssl_key").Value,
-			variable.GetSysVar("ssl_cert").Value,
-			config.GetGlobalConfig().Security.AutoTLS,
-			config.GetGlobalConfig().Security.RSAKeySize,
-		)
-		if err != nil {
-			if !s.NoRollbackOnError || tls.RequireSecureTransport.Load() {
-				return err
-			}
-			logutil.BgLogger().Warn("reload TLS fail but keep working without TLS due to 'no rollback on error'")
-		}
-		sm.UpdateTLSConfig(tlsCfg)
+		return sm.ReloadTLS(s.NoRollbackOnError)
 	}
 	return nil
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//pkg/server/internal/handshake",
         "//pkg/server/internal/parse",
         "//pkg/server/internal/resultset",
+        "//pkg/server/internal/spiffetls",
         "//pkg/server/internal/util",
         "//pkg/server/metrics",
         "//pkg/session",

--- a/pkg/server/internal/spiffetls/BUILD.bazel
+++ b/pkg/server/internal/spiffetls/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "spiffetls",
+    srcs = ["source.go"],
+    importpath = "github.com/pingcap/tidb/pkg/server/internal/spiffetls",
+    visibility = ["//pkg/server:__subpackages__"],
+    deps = [
+        "//pkg/util",
+        "//pkg/util/logutil",
+        "@com_github_spiffe_go_spiffe_v2//bundle/x509bundle",
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
+        "@com_github_spiffe_go_spiffe_v2//workloadapi",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "spiffetls_test",
+    timeout = "short",
+    srcs = ["source_test.go"],
+    embed = [":spiffetls"],
+    flaky = True,
+    shard_count = 7,
+    deps = [
+        "@com_github_spiffe_go_spiffe_v2//bundle/x509bundle",
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
+        "@com_github_spiffe_go_spiffe_v2//workloadapi",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/server/internal/spiffetls/source.go
+++ b/pkg/server/internal/spiffetls/source.go
@@ -1,0 +1,411 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spiffetls provides a rotating TLS configuration backed by the
+// SPIFFE Workload API.
+package spiffetls
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"go.uber.org/zap"
+)
+
+type workloadAPIClient interface {
+	WatchX509Context(context.Context, workloadapi.X509ContextWatcher) error
+	Close() error
+}
+
+// Source owns a Workload API watch and publishes its latest valid TLS
+// configuration through a stable dispatcher.
+type Source struct {
+	client            workloadAPIClient
+	baseTLSConfig     *tls.Config
+	requireClientCert bool
+
+	watchCtx    context.Context
+	cancelWatch context.CancelFunc
+	watchDone   chan error
+	watchWG     sync.WaitGroup
+
+	current    atomic.Pointer[tls.Config]
+	ready      chan struct{}
+	readyOnce  sync.Once
+	dispatcher *tls.Config
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// New starts watching addr and waits up to timeout for the first valid X.509
+// context. The first SVID returned by the Workload API is used, as prescribed
+// for the default Workload API identity.
+func New(addr string, timeout time.Duration, minTLSVersion string, requireClientCert bool) (*Source, error) {
+	if addr == "" {
+		return nil, errors.New("SPIFFE Workload API address is required")
+	}
+	if err := workloadapi.ValidateAddress(addr); err != nil {
+		return nil, fmt.Errorf("invalid SPIFFE Workload API address: %w", err)
+	}
+	workloadAPIURL, _ := url.Parse(addr)
+	if !strings.HasPrefix(addr, "unix:///") || workloadAPIURL.Scheme != "unix" || workloadAPIURL.Host != "" ||
+		workloadAPIURL.Path == "" || !filepath.IsAbs(workloadAPIURL.Path) {
+		return nil, errors.New("SPIFFE Workload API address must be an absolute unix:/// URI")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("SPIFFE Workload API startup timeout must be positive")
+	}
+
+	clientAuth := tls.VerifyClientCertIfGiven
+	if requireClientCert {
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+	baseTLSConfig, err := util.NewServerTLSConfig(minTLSVersion, clientAuth, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build SPIFFE server TLS policy: %w", err)
+	}
+
+	startupCtx, cancelStartup := context.WithTimeout(context.Background(), timeout)
+	defer cancelStartup()
+	client, err := workloadapi.New(
+		startupCtx,
+		workloadapi.WithAddr(addr),
+		workloadapi.WithLogger(workloadAPILogger{logger: logutil.BgLogger().Sugar()}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create SPIFFE Workload API client: %w", err)
+	}
+
+	return newSource(startupCtx, client, baseTLSConfig, requireClientCert)
+}
+
+func newSource(
+	startupCtx context.Context,
+	client workloadAPIClient,
+	baseTLSConfig *tls.Config,
+	requireClientCert bool,
+) (_ *Source, err error) {
+	watchCtx, cancelWatch := context.WithCancel(context.Background())
+	source := &Source{
+		client:            client,
+		baseTLSConfig:     baseTLSConfig,
+		requireClientCert: requireClientCert,
+		watchCtx:          watchCtx,
+		cancelWatch:       cancelWatch,
+		watchDone:         make(chan error, 1),
+		ready:             make(chan struct{}),
+	}
+
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, source.Close())
+		}
+	}()
+
+	source.watchWG.Add(1)
+	go func() {
+		defer source.watchWG.Done()
+		watchErr := source.client.WatchX509Context(source.watchCtx, source)
+		if source.watchCtx.Err() == nil {
+			logutil.BgLogger().Error("SPIFFE Workload API watch stopped; keeping the last valid TLS configuration", zap.Error(watchErr))
+		}
+		source.watchDone <- watchErr
+	}()
+
+	select {
+	case <-source.ready:
+		current := source.current.Load()
+		if current == nil {
+			return nil, errors.New("SPIFFE Workload API reported readiness without a TLS configuration")
+		}
+		source.dispatcher = source.newDispatcher(current)
+		return source, nil
+	case watchErr := <-source.watchDone:
+		if current := source.current.Load(); current != nil {
+			source.dispatcher = source.newDispatcher(current)
+			return source, nil
+		}
+		if watchErr == nil {
+			watchErr = errors.New("watch stopped without an error")
+		}
+		return nil, fmt.Errorf("SPIFFE Workload API watch stopped before the first valid X.509 context: %w", watchErr)
+	case <-startupCtx.Done():
+		if current := source.current.Load(); current != nil {
+			source.dispatcher = source.newDispatcher(current)
+			return source, nil
+		}
+		return nil, fmt.Errorf("waiting for the first valid SPIFFE X.509 context: %w", startupCtx.Err())
+	}
+}
+
+// TLSConfig returns a stable dispatcher that selects the latest valid
+// Workload API snapshot for each new TLS handshake.
+func (s *Source) TLSConfig() *tls.Config {
+	return s.dispatcher
+}
+
+// Close stops the Workload API watch and releases its connection. It is safe
+// to call Close more than once.
+func (s *Source) Close() error {
+	s.closeOnce.Do(func() {
+		s.cancelWatch()
+		s.closeErr = s.client.Close()
+		s.watchWG.Wait()
+	})
+	return s.closeErr
+}
+
+// OnX509ContextUpdate implements workloadapi.X509ContextWatcher.
+func (s *Source) OnX509ContextUpdate(x509Context *workloadapi.X509Context) {
+	tlsConfig, err := newTLSConfig(s.baseTLSConfig, x509Context, s.requireClientCert)
+	if err != nil {
+		logutil.BgLogger().Warn("Ignoring invalid SPIFFE X.509 context; keeping the last valid TLS configuration", zap.Error(err))
+		return
+	}
+
+	previous := s.current.Swap(tlsConfig)
+	oldID, oldSerial, oldNotAfter := tlsConfigIdentity(previous)
+	newID, newSerial, newNotAfter := tlsConfigIdentity(tlsConfig)
+	logutil.BgLogger().Info("accepted SPIFFE X.509 context",
+		zap.String("old-spiffe-id", oldID),
+		zap.String("old-serial-number", oldSerial),
+		zap.String("old-not-after", oldNotAfter),
+		zap.String("new-spiffe-id", newID),
+		zap.String("new-serial-number", newSerial),
+		zap.String("new-not-after", newNotAfter),
+	)
+	s.readyOnce.Do(func() {
+		close(s.ready)
+	})
+}
+
+// OnX509ContextWatchError implements workloadapi.X509ContextWatcher.
+func (s *Source) OnX509ContextWatchError(err error) {
+	if err == nil || s.watchCtx.Err() != nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	logutil.BgLogger().Warn("SPIFFE Workload API watch error; keeping the last valid TLS configuration", zap.Error(err))
+}
+
+func (s *Source) newDispatcher(initial *tls.Config) *tls.Config {
+	dispatcher := initial.Clone()
+	dispatcher.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		current := s.current.Load()
+		if current == nil {
+			return nil, errors.New("no valid SPIFFE TLS configuration is available")
+		}
+		return current, nil
+	}
+	dispatcher.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		current := s.current.Load()
+		if current == nil || len(current.Certificates) != 1 {
+			return nil, errors.New("no valid SPIFFE server certificate is available")
+		}
+		return &current.Certificates[0], nil
+	}
+	return dispatcher
+}
+
+func tlsConfigIdentity(tlsConfig *tls.Config) (id, serialNumber, notAfter string) {
+	if tlsConfig == nil || len(tlsConfig.Certificates) != 1 || tlsConfig.Certificates[0].Leaf == nil {
+		return "", "", ""
+	}
+	leaf := tlsConfig.Certificates[0].Leaf
+	spiffeID, err := x509svid.IDFromCert(leaf)
+	if err == nil {
+		id = spiffeID.String()
+	}
+	if leaf.SerialNumber != nil {
+		serialNumber = leaf.SerialNumber.String()
+	}
+	return id, serialNumber, leaf.NotAfter.UTC().Format(time.RFC3339)
+}
+
+func newTLSConfig(baseTLSConfig *tls.Config, x509Context *workloadapi.X509Context, requireClientCert bool) (*tls.Config, error) {
+	if x509Context == nil {
+		return nil, errors.New("X.509 context is nil")
+	}
+	if len(x509Context.SVIDs) == 0 || x509Context.SVIDs[0] == nil {
+		return nil, errors.New("X.509 context contains no default SVID")
+	}
+	if x509Context.Bundles == nil {
+		return nil, errors.New("X.509 context contains no bundles")
+	}
+
+	bundles, clientCAs, err := cloneBundles(x509Context.Bundles)
+	if err != nil {
+		return nil, err
+	}
+	tlsCertificate, err := validateServerSVID(x509Context.SVIDs[0], bundles)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := baseTLSConfig.Clone()
+	tlsConfig.Certificates = []tls.Certificate{tlsCertificate}
+	tlsConfig.ClientCAs = clientCAs
+	tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			if requireClientCert {
+				return errors.New("client did not provide an X.509-SVID")
+			}
+			return nil
+		}
+		if _, _, err := x509svid.Verify(state.PeerCertificates, bundles); err != nil {
+			return fmt.Errorf("verify client X.509-SVID: %w", err)
+		}
+		return nil
+	}
+	return tlsConfig, nil
+}
+
+func cloneBundles(bundles *x509bundle.Set) (*x509bundle.Set, *x509.CertPool, error) {
+	clonedBundles := make([]*x509bundle.Bundle, 0, bundles.Len())
+	clientCAs := x509.NewCertPool()
+	for _, bundle := range bundles.Bundles() {
+		authorities, err := cloneCertificates(bundle.X509Authorities())
+		if err != nil {
+			return nil, nil, fmt.Errorf("clone SPIFFE bundle %q: %w", bundle.TrustDomain(), err)
+		}
+		clonedBundles = append(clonedBundles, x509bundle.FromX509Authorities(bundle.TrustDomain(), authorities))
+		for _, authority := range authorities {
+			clientCAs.AddCert(authority)
+		}
+	}
+	return x509bundle.NewSet(clonedBundles...), clientCAs, nil
+}
+
+func validateServerSVID(svid *x509svid.SVID, bundles *x509bundle.Set) (tls.Certificate, error) {
+	if svid == nil {
+		return tls.Certificate{}, errors.New("default X.509-SVID is nil")
+	}
+	certificates, err := cloneCertificates(svid.Certificates)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("clone default X.509-SVID certificate chain: %w", err)
+	}
+	if len(certificates) == 0 {
+		return tls.Certificate{}, errors.New("default X.509-SVID contains no certificates")
+	}
+	if svid.PrivateKey == nil {
+		return tls.Certificate{}, errors.New("default X.509-SVID contains no private key")
+	}
+
+	privatePublicKey, err := x509.MarshalPKIXPublicKey(svid.PrivateKey.Public())
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal default X.509-SVID private key public component: %w", err)
+	}
+	certificatePublicKey, err := x509.MarshalPKIXPublicKey(certificates[0].PublicKey)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal default X.509-SVID certificate public key: %w", err)
+	}
+	if !bytes.Equal(privatePublicKey, certificatePublicKey) {
+		return tls.Certificate{}, errors.New("default X.509-SVID private key does not match its leaf certificate")
+	}
+
+	verifiedID, _, err := x509svid.Verify(certificates, bundles)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("verify default X.509-SVID: %w", err)
+	}
+	if verifiedID != svid.ID {
+		return tls.Certificate{}, fmt.Errorf("default X.509-SVID ID %q does not match certificate ID %q", svid.ID, verifiedID)
+	}
+	if err := verifyServerAuth(certificates, bundles, verifiedID.TrustDomain()); err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certificateDER := make([][]byte, 0, len(certificates))
+	for _, certificate := range certificates {
+		certificateDER = append(certificateDER, append([]byte(nil), certificate.Raw...))
+	}
+	return tls.Certificate{
+		Certificate: certificateDER,
+		PrivateKey:  svid.PrivateKey,
+		Leaf:        certificates[0],
+	}, nil
+}
+
+func verifyServerAuth(certificates []*x509.Certificate, bundles *x509bundle.Set, trustDomain spiffeid.TrustDomain) error {
+	bundle, err := bundles.GetX509BundleForTrustDomain(trustDomain)
+	if err != nil {
+		return fmt.Errorf("get bundle for default X.509-SVID trust domain: %w", err)
+	}
+	roots := x509.NewCertPool()
+	for _, authority := range bundle.X509Authorities() {
+		roots.AddCert(authority)
+	}
+	intermediates := x509.NewCertPool()
+	for _, certificate := range certificates[1:] {
+		intermediates.AddCert(certificate)
+	}
+	if _, err := certificates[0].Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		return fmt.Errorf("verify default X.509-SVID for server authentication: %w", err)
+	}
+	return nil
+}
+
+func cloneCertificates(certificates []*x509.Certificate) ([]*x509.Certificate, error) {
+	cloned := make([]*x509.Certificate, 0, len(certificates))
+	for index, certificate := range certificates {
+		if certificate == nil {
+			return nil, fmt.Errorf("certificate %d is nil", index)
+		}
+		parsed, err := x509.ParseCertificate(certificate.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse certificate %d: %w", index, err)
+		}
+		cloned = append(cloned, parsed)
+	}
+	return cloned, nil
+}
+
+type workloadAPILogger struct {
+	logger *zap.SugaredLogger
+}
+
+func (l workloadAPILogger) Debugf(format string, args ...any) {
+	l.logger.Debugf("SPIFFE Workload API: "+format, args...)
+}
+
+func (l workloadAPILogger) Infof(format string, args ...any) {
+	l.logger.Infof("SPIFFE Workload API: "+format, args...)
+}
+
+func (l workloadAPILogger) Warnf(format string, args ...any) {
+	l.logger.Warnf("SPIFFE Workload API: "+format, args...)
+}
+
+func (l workloadAPILogger) Errorf(format string, args ...any) {
+	l.logger.Errorf("SPIFFE Workload API: "+format, args...)
+}

--- a/pkg/server/internal/spiffetls/source.go
+++ b/pkg/server/internal/spiffetls/source.go
@@ -47,22 +47,19 @@ type workloadAPIClient interface {
 // Source owns a Workload API watch and publishes its latest valid TLS
 // configuration through a stable dispatcher.
 type Source struct {
+	closeErr          error
+	watchCtx          context.Context
 	client            workloadAPIClient
+	dispatcher        *tls.Config
 	baseTLSConfig     *tls.Config
+	cancelWatch       context.CancelFunc
+	watchDone         chan error
+	current           atomic.Pointer[tls.Config]
+	ready             chan struct{}
+	watchWG           sync.WaitGroup
+	readyOnce         sync.Once
+	closeOnce         sync.Once
 	requireClientCert bool
-
-	watchCtx    context.Context
-	cancelWatch context.CancelFunc
-	watchDone   chan error
-	watchWG     sync.WaitGroup
-
-	current    atomic.Pointer[tls.Config]
-	ready      chan struct{}
-	readyOnce  sync.Once
-	dispatcher *tls.Config
-
-	closeOnce sync.Once
-	closeErr  error
 }
 
 // New starts watching addr and waits up to timeout for the first valid X.509

--- a/pkg/server/internal/spiffetls/source_test.go
+++ b/pkg/server/internal/spiffetls/source_test.go
@@ -1,0 +1,600 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spiffetls
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPIFFETLSConfigClientVerification(t *testing.T) {
+	now := time.Now()
+	trustDomainA := spiffeid.RequireTrustDomainFromString("example.org")
+	trustDomainB := spiffeid.RequireTrustDomainFromString("federated.example")
+	authorityA := newTestAuthority(t, "authority-a", 1, now)
+	authorityB := newTestAuthority(t, "authority-b", 2, now)
+	serverCert, serverKey := newTestLeaf(t, authorityA, testLeafOptions{
+		serialNumber: 10,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		dnsNames:     []string{"server.example.org"},
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	serverSVID := newTestSVID(t, serverCert, serverKey)
+	bundleA := x509bundle.FromX509Authorities(trustDomainA, []*x509.Certificate{authorityA.certificate})
+	bundleB := x509bundle.FromX509Authorities(trustDomainB, []*x509.Certificate{authorityB.certificate})
+	x509Context := &workloadapi.X509Context{
+		SVIDs:   []*x509svid.SVID{serverSVID},
+		Bundles: x509bundle.NewSet(bundleA, bundleB),
+	}
+
+	optionalConfig, err := newTLSConfig(newTestBaseTLSConfig(false), x509Context, false)
+	require.NoError(t, err)
+	require.Equal(t, tls.VerifyClientCertIfGiven, optionalConfig.ClientAuth)
+	require.Len(t, optionalConfig.Certificates, 1)
+	require.NotNil(t, optionalConfig.VerifyConnection)
+
+	clientCert, clientKey := newTestLeaf(t, authorityA, testLeafOptions{
+		serialNumber: 20,
+		spiffeID:     "spiffe://example.org/client",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	serverState, serverErr, clientErr := runTLSHandshake(optionalConfig, newTestClientTLSConfig(
+		authorityA.certificate,
+		tlsCertificate(clientCert, clientKey),
+	))
+	require.NoError(t, serverErr)
+	require.NoError(t, clientErr)
+	require.NotEmpty(t, serverState.VerifiedChains, "native Go verification must populate VerifiedChains")
+	federatedClientCert, federatedClientKey := newTestLeaf(t, authorityB, testLeafOptions{
+		serialNumber: 23,
+		spiffeID:     "spiffe://federated.example/client",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	serverState, serverErr, clientErr = runTLSHandshake(optionalConfig, newTestClientTLSConfig(
+		authorityA.certificate,
+		tlsCertificate(federatedClientCert, federatedClientKey),
+	))
+	require.NoError(t, serverErr)
+	require.NoError(t, clientErr)
+	require.NotEmpty(t, serverState.VerifiedChains, "federated client verification must populate VerifiedChains")
+
+	_, serverErr, clientErr = runTLSHandshake(optionalConfig, newTestClientTLSConfig(authorityA.certificate))
+	require.NoError(t, serverErr)
+	require.NoError(t, clientErr)
+
+	requiredConfig, err := newTLSConfig(newTestBaseTLSConfig(true), x509Context, true)
+	require.NoError(t, err)
+	require.Equal(t, tls.RequireAndVerifyClientCert, requiredConfig.ClientAuth)
+	require.ErrorContains(t, requiredConfig.VerifyConnection(tls.ConnectionState{}), "did not provide")
+	_, serverErr, _ = runTLSHandshakeAndCloseClient(requiredConfig, newTestClientTLSConfig(authorityA.certificate))
+	require.Error(t, serverErr, "required client-certificate policy must reject a client without a certificate")
+
+	regularClientCert, _ := newTestLeaf(t, authorityA, testLeafOptions{
+		serialNumber: 21,
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	_, err = regularClientCert.Verify(x509.VerifyOptions{
+		Roots:     optionalConfig.ClientCAs,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err, "the conventional certificate must pass native verification")
+	require.ErrorContains(t, optionalConfig.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{regularClientCert},
+	}), "verify client X.509-SVID")
+
+	crossDomainCert, _ := newTestLeaf(t, authorityA, testLeafOptions{
+		serialNumber: 22,
+		spiffeID:     "spiffe://federated.example/client",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	_, err = crossDomainCert.Verify(x509.VerifyOptions{
+		Roots:     optionalConfig.ClientCAs,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err, "aggregated roots alone accept the cross-domain certificate")
+	require.ErrorContains(t, optionalConfig.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{crossDomainCert},
+	}), "verify client X.509-SVID")
+
+	// The published callback must retain its cloned bundle snapshot even if the
+	// Workload API objects are subsequently mutated.
+	bundleA.SetX509Authorities([]*x509.Certificate{authorityB.certificate})
+	require.NoError(t, optionalConfig.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{clientCert},
+	}))
+}
+
+func TestSPIFFETLSConfigRejectsInvalidServerSVID(t *testing.T) {
+	now := time.Now()
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	authority := newTestAuthority(t, "authority", 1, now)
+	bundle := x509bundle.FromX509Authorities(trustDomain, []*x509.Certificate{authority.certificate})
+	validCert, validKey := newTestLeaf(t, authority, testLeafOptions{
+		serialNumber: 10,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	validSVID := newTestSVID(t, validCert, validKey)
+	validContext := func(svid *x509svid.SVID) *workloadapi.X509Context {
+		return &workloadapi.X509Context{
+			SVIDs:   []*x509svid.SVID{svid},
+			Bundles: x509bundle.NewSet(bundle),
+		}
+	}
+
+	_, err := newTLSConfig(newTestBaseTLSConfig(false), validContext(validSVID), false)
+	require.NoError(t, err)
+
+	clientOnlyCert, clientOnlyKey := newTestLeaf(t, authority, testLeafOptions{
+		serialNumber: 11,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	_, err = newTLSConfig(newTestBaseTLSConfig(false), validContext(newTestSVID(t, clientOnlyCert, clientOnlyKey)), false)
+	require.ErrorContains(t, err, "server authentication")
+
+	expiredCert, expiredKey := newTestLeaf(t, authority, testLeafOptions{
+		serialNumber: 12,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		notBefore:    now.Add(-2 * time.Hour),
+		notAfter:     now.Add(-time.Hour),
+	})
+	_, err = newTLSConfig(newTestBaseTLSConfig(false), validContext(newTestSVID(t, expiredCert, expiredKey)), false)
+	require.ErrorContains(t, err, "verify default X.509-SVID")
+
+	wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	wrongKeySVID := *validSVID
+	wrongKeySVID.PrivateKey = wrongKey
+	_, err = newTLSConfig(newTestBaseTLSConfig(false), validContext(&wrongKeySVID), false)
+	require.ErrorContains(t, err, "does not match")
+
+	wrongIDSVID := *validSVID
+	wrongIDSVID.ID = spiffeid.RequireFromString("spiffe://example.org/other")
+	_, err = newTLSConfig(newTestBaseTLSConfig(false), validContext(&wrongIDSVID), false)
+	require.ErrorContains(t, err, "does not match certificate ID")
+
+	_, err = newTLSConfig(newTestBaseTLSConfig(false), &workloadapi.X509Context{
+		SVIDs:   []*x509svid.SVID{validSVID},
+		Bundles: x509bundle.NewSet(),
+	}, false)
+	require.ErrorContains(t, err, "verify default X.509-SVID")
+}
+
+func TestSPIFFESourceRotationLastGoodAndClose(t *testing.T) {
+	now := time.Now()
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	authority := newTestAuthority(t, "authority", 1, now)
+	bundle := x509bundle.FromX509Authorities(trustDomain, []*x509.Certificate{authority.certificate})
+	rotatedAuthority := newTestAuthority(t, "rotated-authority", 2, now)
+	rotatedBundle := x509bundle.FromX509Authorities(trustDomain, []*x509.Certificate{rotatedAuthority.certificate})
+	contextForSerial := func(signingAuthority testAuthority, trustBundle *x509bundle.Bundle, serial int64) *workloadapi.X509Context {
+		certificate, privateKey := newTestLeaf(t, signingAuthority, testLeafOptions{
+			serialNumber: serial,
+			spiffeID:     "spiffe://example.org/tidb/server",
+			extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			notBefore:    now.Add(-time.Minute),
+			notAfter:     now.Add(time.Hour),
+		})
+		return &workloadapi.X509Context{
+			SVIDs:   []*x509svid.SVID{newTestSVID(t, certificate, privateKey)},
+			Bundles: x509bundle.NewSet(trustBundle),
+		}
+	}
+
+	client := newFakeWorkloadAPIClient()
+	type sourceResult struct {
+		source *Source
+		err    error
+	}
+	resultCh := make(chan sourceResult, 1)
+	startupCtx, cancelStartup := context.WithTimeout(context.Background(), time.Second)
+	defer cancelStartup()
+	go func() {
+		source, err := newSource(startupCtx, client, newTestBaseTLSConfig(false), false)
+		resultCh <- sourceResult{source: source, err: err}
+	}()
+	<-client.started
+	client.updates <- contextForSerial(authority, bundle, 10)
+	<-client.delivered
+	result := <-resultCh
+	require.NoError(t, result.err)
+	source := result.source
+	dispatcher := source.TLSConfig()
+	require.NotNil(t, dispatcher)
+	require.Equal(t, "10", currentSerial(t, dispatcher))
+
+	invalidContext := contextForSerial(authority, bundle, 11)
+	wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	invalidContext.SVIDs[0].PrivateKey = wrongKey
+	client.updates <- invalidContext
+	<-client.delivered
+	require.Equal(t, "10", currentSerial(t, dispatcher), "invalid updates must retain the last good snapshot")
+
+	client.watchErrors <- errors.New("socket unavailable")
+	<-client.delivered
+	require.Equal(t, "10", currentSerial(t, dispatcher), "watch errors must retain the last good snapshot")
+
+	client.updates <- contextForSerial(rotatedAuthority, rotatedBundle, 12)
+	<-client.delivered
+	require.Same(t, dispatcher, source.TLSConfig(), "the dispatcher must remain stable across rotations")
+	require.Equal(t, "12", currentSerial(t, dispatcher))
+	certificate, err := dispatcher.GetCertificate(nil)
+	require.NoError(t, err)
+	require.Equal(t, "12", certificate.Leaf.SerialNumber.String(), "status lookup must see the rotated certificate")
+	rotatedClientCert, _ := newTestLeaf(t, rotatedAuthority, testLeafOptions{
+		serialNumber: 20,
+		spiffeID:     "spiffe://example.org/client",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	current, err := dispatcher.GetConfigForClient(nil)
+	require.NoError(t, err)
+	_, err = rotatedClientCert.Verify(x509.VerifyOptions{
+		Roots:     current.ClientCAs,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err, "the rotated client CA must be published with the rotated SVID")
+	require.NoError(t, current.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{rotatedClientCert},
+	}))
+
+	require.NoError(t, source.Close())
+	require.NoError(t, source.Close())
+	require.Equal(t, int32(1), client.closeCount.Load())
+	select {
+	case <-client.watchExited:
+	default:
+		require.Fail(t, "watch goroutine did not exit before Close returned")
+	}
+}
+
+func TestSPIFFESourceStartupTimeout(t *testing.T) {
+	client := newFakeWorkloadAPIClient()
+	startupCtx, cancelStartup := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelStartup()
+	source, err := newSource(startupCtx, client, newTestBaseTLSConfig(false), false)
+	require.Nil(t, source)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, int32(1), client.closeCount.Load())
+	select {
+	case <-client.watchExited:
+	default:
+		require.Fail(t, "watch goroutine did not exit after startup timeout")
+	}
+}
+
+func TestSPIFFESourceAcceptsInitialUpdateBeforeWatchStops(t *testing.T) {
+	now := time.Now()
+	authority := newTestAuthority(t, "authority", 1, now)
+	certificate, privateKey := newTestLeaf(t, authority, testLeafOptions{
+		serialNumber: 10,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	client := &updateThenReturnClient{x509Context: &workloadapi.X509Context{
+		SVIDs: []*x509svid.SVID{newTestSVID(t, certificate, privateKey)},
+		Bundles: x509bundle.NewSet(x509bundle.FromX509Authorities(
+			spiffeid.RequireTrustDomainFromString("example.org"),
+			[]*x509.Certificate{authority.certificate},
+		)),
+	}}
+	startupCtx, cancelStartup := context.WithTimeout(context.Background(), time.Second)
+	defer cancelStartup()
+	source, err := newSource(startupCtx, client, newTestBaseTLSConfig(false), false)
+	require.NoError(t, err)
+	require.Equal(t, "10", currentSerial(t, source.TLSConfig()))
+	require.NoError(t, source.Close())
+	require.Equal(t, int32(1), client.closeCount.Load())
+}
+
+func TestSPIFFESourceAcceptsInitialUpdateAsStartupExpires(t *testing.T) {
+	now := time.Now()
+	authority := newTestAuthority(t, "authority", 1, now)
+	certificate, privateKey := newTestLeaf(t, authority, testLeafOptions{
+		serialNumber: 10,
+		spiffeID:     "spiffe://example.org/tidb/server",
+		extKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		notBefore:    now.Add(-time.Minute),
+		notAfter:     now.Add(time.Hour),
+	})
+	startupCtx, cancelStartup := context.WithCancel(context.Background())
+	client := &updateThenCancelClient{
+		x509Context: &workloadapi.X509Context{
+			SVIDs: []*x509svid.SVID{newTestSVID(t, certificate, privateKey)},
+			Bundles: x509bundle.NewSet(x509bundle.FromX509Authorities(
+				spiffeid.RequireTrustDomainFromString("example.org"),
+				[]*x509.Certificate{authority.certificate},
+			)),
+		},
+		cancelStartup: cancelStartup,
+	}
+	source, err := newSource(startupCtx, client, newTestBaseTLSConfig(false), false)
+	require.NoError(t, err)
+	require.Equal(t, "10", currentSerial(t, source.TLSConfig()))
+	require.NoError(t, source.Close())
+}
+
+func TestSPIFFENewValidatesInputs(t *testing.T) {
+	_, err := New("", time.Second, "", false)
+	require.ErrorContains(t, err, "address is required")
+	_, err = New("tcp://127.0.0.1:1234", time.Second, "", false)
+	require.ErrorContains(t, err, "absolute unix:///")
+	_, err = New("unix:///tmp/spire-agent.sock", 0, "", false)
+	require.ErrorContains(t, err, "timeout must be positive")
+}
+
+type testAuthority struct {
+	certificate *x509.Certificate
+	privateKey  *ecdsa.PrivateKey
+}
+
+type testLeafOptions struct {
+	serialNumber int64
+	spiffeID     string
+	dnsNames     []string
+	extKeyUsage  []x509.ExtKeyUsage
+	notBefore    time.Time
+	notAfter     time.Time
+}
+
+func newTestAuthority(t *testing.T, commonName string, serialNumber int64, now time.Time) testAuthority {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serialNumber),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return testAuthority{certificate: certificate, privateKey: privateKey}
+}
+
+func newTestLeaf(t *testing.T, authority testAuthority, options testLeafOptions) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(options.serialNumber),
+		Subject:      pkix.Name{CommonName: options.spiffeID},
+		NotBefore:    options.notBefore,
+		NotAfter:     options.notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  options.extKeyUsage,
+		DNSNames:     options.dnsNames,
+	}
+	if options.spiffeID != "" {
+		spiffeURL, err := url.Parse(options.spiffeID)
+		require.NoError(t, err)
+		template.URIs = []*url.URL{spiffeURL}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, authority.certificate, &privateKey.PublicKey, authority.privateKey)
+	require.NoError(t, err)
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return certificate, privateKey
+}
+
+func newTestSVID(t *testing.T, certificate *x509.Certificate, privateKey *ecdsa.PrivateKey) *x509svid.SVID {
+	t.Helper()
+	id, err := x509svid.IDFromCert(certificate)
+	require.NoError(t, err)
+	return &x509svid.SVID{
+		ID:           id,
+		Certificates: []*x509.Certificate{certificate},
+		PrivateKey:   privateKey,
+	}
+}
+
+func newTestBaseTLSConfig(requireClientCert bool) *tls.Config {
+	clientAuth := tls.VerifyClientCertIfGiven
+	if requireClientCert {
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+	/* #nosec G402 -- TLS 1.2 is the minimum supported TiDB server version. */
+	return &tls.Config{MinVersion: tls.VersionTLS12, ClientAuth: clientAuth}
+}
+
+func tlsCertificate(certificate *x509.Certificate, privateKey *ecdsa.PrivateKey) tls.Certificate {
+	return tls.Certificate{
+		Certificate: [][]byte{certificate.Raw},
+		PrivateKey:  privateKey,
+		Leaf:        certificate,
+	}
+}
+
+func newTestClientTLSConfig(authority *x509.Certificate, certificates ...tls.Certificate) *tls.Config {
+	roots := x509.NewCertPool()
+	roots.AddCert(authority)
+	/* #nosec G402 -- TLS 1.2 is the minimum supported TiDB server version. */
+	return &tls.Config{
+		Certificates: certificates,
+		RootCAs:      roots,
+		ServerName:   "server.example.org",
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+type tlsHandshakeResult struct {
+	state tls.ConnectionState
+	err   error
+}
+
+func runTLSHandshake(serverConfig, clientConfig *tls.Config) (tls.ConnectionState, error, error) {
+	return runTLSHandshakeWithClientClose(serverConfig, clientConfig, false)
+}
+
+func runTLSHandshakeAndCloseClient(serverConfig, clientConfig *tls.Config) (tls.ConnectionState, error, error) {
+	return runTLSHandshakeWithClientClose(serverConfig, clientConfig, true)
+}
+
+func runTLSHandshakeWithClientClose(serverConfig, clientConfig *tls.Config, closeClientAfterHandshake bool) (tls.ConnectionState, error, error) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	_ = serverConn.SetDeadline(deadline)
+	_ = clientConn.SetDeadline(deadline)
+
+	serverTLS := tls.Server(serverConn, serverConfig)
+	clientTLS := tls.Client(clientConn, clientConfig)
+	serverResultCh := make(chan tlsHandshakeResult, 1)
+	clientErrCh := make(chan error, 1)
+	go func() {
+		err := serverTLS.Handshake()
+		serverResultCh <- tlsHandshakeResult{state: serverTLS.ConnectionState(), err: err}
+	}()
+	go func() {
+		clientErrCh <- clientTLS.Handshake()
+		if closeClientAfterHandshake {
+			_ = clientConn.Close()
+		}
+	}()
+	serverResult := <-serverResultCh
+	if serverResult.err != nil {
+		_ = serverConn.Close()
+	}
+	return serverResult.state, serverResult.err, <-clientErrCh
+}
+
+func currentSerial(t *testing.T, dispatcher *tls.Config) string {
+	t.Helper()
+	current, err := dispatcher.GetConfigForClient(nil)
+	require.NoError(t, err)
+	require.Len(t, current.Certificates, 1)
+	require.NotNil(t, current.Certificates[0].Leaf)
+	return current.Certificates[0].Leaf.SerialNumber.String()
+}
+
+type fakeWorkloadAPIClient struct {
+	updates     chan *workloadapi.X509Context
+	watchErrors chan error
+	delivered   chan struct{}
+	started     chan struct{}
+	watchExited chan struct{}
+	startOnce   sync.Once
+	closeCount  atomic.Int32
+}
+
+func newFakeWorkloadAPIClient() *fakeWorkloadAPIClient {
+	return &fakeWorkloadAPIClient{
+		updates:     make(chan *workloadapi.X509Context),
+		watchErrors: make(chan error),
+		delivered:   make(chan struct{}, 1),
+		started:     make(chan struct{}),
+		watchExited: make(chan struct{}),
+	}
+}
+
+func (c *fakeWorkloadAPIClient) WatchX509Context(ctx context.Context, watcher workloadapi.X509ContextWatcher) error {
+	c.startOnce.Do(func() {
+		close(c.started)
+	})
+	defer close(c.watchExited)
+	for {
+		select {
+		case x509Context := <-c.updates:
+			watcher.OnX509ContextUpdate(x509Context)
+			c.delivered <- struct{}{}
+		case err := <-c.watchErrors:
+			watcher.OnX509ContextWatchError(err)
+			c.delivered <- struct{}{}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (c *fakeWorkloadAPIClient) Close() error {
+	c.closeCount.Add(1)
+	return nil
+}
+
+type updateThenReturnClient struct {
+	x509Context *workloadapi.X509Context
+	closeCount  atomic.Int32
+}
+
+func (c *updateThenReturnClient) WatchX509Context(_ context.Context, watcher workloadapi.X509ContextWatcher) error {
+	watcher.OnX509ContextUpdate(c.x509Context)
+	return errors.New("watch stopped")
+}
+
+func (c *updateThenReturnClient) Close() error {
+	c.closeCount.Add(1)
+	return nil
+}
+
+type updateThenCancelClient struct {
+	x509Context   *workloadapi.X509Context
+	cancelStartup context.CancelFunc
+}
+
+func (c *updateThenCancelClient) WatchX509Context(ctx context.Context, watcher workloadapi.X509ContextWatcher) error {
+	watcher.OnX509ContextUpdate(c.x509Context)
+	c.cancelStartup()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (*updateThenCancelClient) Close() error {
+	return nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pingcap/tidb/pkg/resourcegroup"
 	servererr "github.com/pingcap/tidb/pkg/server/err"
 	"github.com/pingcap/tidb/pkg/server/internal/advertisedstatus"
+	"github.com/pingcap/tidb/pkg/server/internal/spiffetls"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/session/txninfo"
@@ -128,6 +129,7 @@ const normalClosedConnsCapacity = 1000
 type Server struct {
 	cfg               *config.Config
 	tlsConfig         unsafe.Pointer // *tls.Config
+	spiffeTLSSource   *spiffetls.Source
 	driver            IDriver
 	listener          net.Listener
 	socket            net.Listener
@@ -324,14 +326,37 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	s.capability = defaultCapability
 	setSystemTimeZoneVariable()
 
-	tlsConfig, autoReload, err := util.LoadTLSCertificates(
-		s.cfg.Security.SSLCA, s.cfg.Security.SSLKey, s.cfg.Security.SSLCert,
-		s.cfg.Security.AutoTLS, s.cfg.Security.RSAKeySize)
+	var (
+		tlsConfig  *tls.Config
+		autoReload bool
+		err        error
+	)
+	if s.cfg.Security.SPIFFEWorkloadAPIAddr != "" {
+		if s.cfg.Security.SSLCA != "" || s.cfg.Security.SSLCert != "" ||
+			s.cfg.Security.SSLKey != "" || s.cfg.Security.AutoTLS {
+			return nil, errors.New("SPIFFE Workload API TLS cannot be combined with ssl-ca, ssl-cert, ssl-key, or auto-tls")
+		}
+		var timeout time.Duration
+		timeout, err = time.ParseDuration(s.cfg.Security.SPIFFEWorkloadAPITimeout)
+		if err == nil {
+			s.spiffeTLSSource, err = spiffetls.New(
+				s.cfg.Security.SPIFFEWorkloadAPIAddr,
+				timeout,
+				s.cfg.Security.MinTLSVersion,
+				tlsutil.RequireSecureTransport.Load(),
+			)
+			if err == nil {
+				tlsConfig = s.spiffeTLSSource.TLSConfig()
+			}
+		}
+	} else {
+		tlsConfig, autoReload, err = util.LoadTLSCertificates(
+			s.cfg.Security.SSLCA, s.cfg.Security.SSLKey, s.cfg.Security.SSLCert,
+			s.cfg.Security.AutoTLS, s.cfg.Security.RSAKeySize)
+	}
 
-	// LoadTLSCertificates will auto generate certificates if autoTLS is enabled.
-	// It only returns an error if certificates are specified and invalid.
-	// In which case, we should halt server startup as a misconfiguration could
-	// lead to a connection downgrade.
+	// TLS initialization fails closed when explicitly configured material is
+	// invalid or the Workload API cannot provide an initial valid context.
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -357,7 +382,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		setSSLVariable(s.cfg.Security.SSLCA, s.cfg.Security.SSLKey, s.cfg.Security.SSLCert)
 		atomic.StorePointer(&s.tlsConfig, unsafe.Pointer(tlsConfig))
 		logutil.BgLogger().Info("mysql protocol server secure connection is enabled",
-			zap.Bool("client verification enabled", len(variable.GetSysVar("ssl_ca").Value) > 0))
+			zap.Bool("client verification enabled", s.spiffeTLSSource != nil || len(variable.GetSysVar("ssl_ca").Value) > 0))
 	}
 	if s.tlsConfig != nil {
 		s.capability |= mysql.ClientSSL
@@ -708,6 +733,10 @@ func (s *Server) closeListener() {
 	}
 	if s.authTokenCancelFunc != nil {
 		s.authTokenCancelFunc()
+	}
+	if s.spiffeTLSSource != nil {
+		err := s.spiffeTLSSource.Close()
+		terror.Log(errors.Trace(err))
 	}
 	s.wg.Wait()
 	metrics.ServerEventCounter.WithLabelValues(metrics.ServerStop).Inc()
@@ -1097,9 +1126,27 @@ func (s *Server) kill(connectionID uint64, query bool, maxExecutionTime bool, ru
 	killQuery(conn, maxExecutionTime, runaway)
 }
 
-// UpdateTLSConfig implements the SessionManager interface.
-func (s *Server) UpdateTLSConfig(cfg *tls.Config) {
-	atomic.StorePointer(&s.tlsConfig, unsafe.Pointer(cfg))
+// ReloadTLS implements the SessionManager interface.
+func (s *Server) ReloadTLS(noRollbackOnError bool) error {
+	if s.spiffeTLSSource != nil {
+		logutil.BgLogger().Info("SPIFFE Workload API TLS rotates automatically; skipping manual TLS reload")
+		return nil
+	}
+	tlsConfig, _, err := util.LoadTLSCertificates(
+		variable.GetSysVar("ssl_ca").Value,
+		variable.GetSysVar("ssl_key").Value,
+		variable.GetSysVar("ssl_cert").Value,
+		config.GetGlobalConfig().Security.AutoTLS,
+		config.GetGlobalConfig().Security.RSAKeySize,
+	)
+	if err != nil {
+		if !noRollbackOnError || tlsutil.RequireSecureTransport.Load() {
+			return err
+		}
+		logutil.BgLogger().Warn("reload TLS fail but keep working without TLS due to 'no rollback on error'")
+	}
+	atomic.StorePointer(&s.tlsConfig, unsafe.Pointer(tlsConfig))
+	return nil
 }
 
 // GetTLSConfig implements the SessionManager interface.

--- a/pkg/server/tests/tls/BUILD.bazel
+++ b/pkg/server/tests/tls/BUILD.bazel
@@ -5,10 +5,11 @@ go_test(
     timeout = "short",
     srcs = [
         "main_test.go",
+        "spiffe_test.go",
         "tls_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",
@@ -27,8 +28,10 @@ go_test(
         "//pkg/util/topsql/state",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_spiffe_go_spiffe_v2//proto/spiffe/workload",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
+        "@org_golang_google_grpc//:grpc",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/server/tests/tls/spiffe_test.go
+++ b/pkg/server/tests/tls/spiffe_test.go
@@ -1,0 +1,438 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tls
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
+	stderrors "errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb/pkg/config"
+	tidbserver "github.com/pingcap/tidb/pkg/server"
+	"github.com/pingcap/tidb/pkg/server/internal/testserverclient"
+	"github.com/pingcap/tidb/pkg/server/internal/testutil"
+	util2 "github.com/pingcap/tidb/pkg/server/internal/util"
+	"github.com/pingcap/tidb/pkg/server/tests/servertestkit"
+	tidbtls "github.com/pingcap/tidb/pkg/util/tls"
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const (
+	spiffeTestServerID       = "spiffe://example.org/tidb/server"
+	spiffeTestClientID       = "spiffe://example.org/client/allowed"
+	spiffeTestWrongClientID  = "spiffe://example.org/client/wrong"
+	spiffeTestSQLUser        = "spiffe_tls_user"
+	spiffeTestSQLAccessError = uint16(1045)
+)
+
+var spiffeTestSocketSequence atomic.Uint64
+
+type spiffeTestCertificate struct {
+	certificate *x509.Certificate
+	privateKey  *ecdsa.PrivateKey
+}
+
+type spiffeTestCA struct {
+	certificate *x509.Certificate
+	privateKey  *ecdsa.PrivateKey
+}
+
+func newSPIFFETestCA(t *testing.T, serial int64, commonName string) *spiffeTestCA {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		SubjectKeyId:          []byte(commonName),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &spiffeTestCA{certificate: certificate, privateKey: privateKey}
+}
+
+func (ca *spiffeTestCA) issueCertificate(t *testing.T, serial int64, spiffeID string, notAfter time.Time, usages ...x509.ExtKeyUsage) *spiffeTestCertificate {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:   big.NewInt(serial),
+		Subject:        pkix.Name{CommonName: fmt.Sprintf("SPIFFE test certificate %d", serial)},
+		NotBefore:      time.Now().Add(-time.Minute).UTC(),
+		NotAfter:       notAfter.UTC(),
+		KeyUsage:       x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:    usages,
+		AuthorityKeyId: ca.certificate.SubjectKeyId,
+	}
+	if spiffeID != "" {
+		uri, err := url.Parse(spiffeID)
+		require.NoError(t, err)
+		template.URIs = []*url.URL{uri}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.certificate, &privateKey.PublicKey, ca.privateKey)
+	require.NoError(t, err)
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return &spiffeTestCertificate{certificate: certificate, privateKey: privateKey}
+}
+
+func (c *spiffeTestCertificate) tlsCertificate() tls.Certificate {
+	return tls.Certificate{
+		Certificate: [][]byte{c.certificate.Raw},
+		PrivateKey:  c.privateKey,
+		Leaf:        c.certificate,
+	}
+}
+
+func newSPIFFEX509Context(t *testing.T, server *spiffeTestCertificate, bundle *spiffeTestCA) *workload.X509SVIDResponse {
+	t.Helper()
+
+	privateKey, err := x509.MarshalPKCS8PrivateKey(server.privateKey)
+	require.NoError(t, err)
+	return &workload.X509SVIDResponse{
+		Svids: []*workload.X509SVID{{
+			SpiffeId:    spiffeTestServerID,
+			X509Svid:    server.certificate.Raw,
+			X509SvidKey: privateKey,
+			Bundle:      bundle.certificate.Raw,
+		}},
+		FederatedBundles: map[string][]byte{},
+	}
+}
+
+type spiffeTestWorkloadAPI struct {
+	workload.UnimplementedSpiffeWorkloadAPIServer
+
+	mu       sync.Mutex
+	response *workload.X509SVIDResponse
+	watchers map[chan *workload.X509SVIDResponse]struct{}
+
+	server     *grpc.Server
+	listener   net.Listener
+	socketPath string
+	done       chan struct{}
+	stopOnce   sync.Once
+}
+
+func newSPIFFETestWorkloadAPI(t *testing.T, response *workload.X509SVIDResponse) *spiffeTestWorkloadAPI {
+	t.Helper()
+
+	socketPath := filepath.Join("/tmp", fmt.Sprintf("tidb-spiffe-%d-%d.sock", os.Getpid(), spiffeTestSocketSequence.Add(1)))
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	api := &spiffeTestWorkloadAPI{
+		response:   response,
+		watchers:   make(map[chan *workload.X509SVIDResponse]struct{}),
+		server:     grpc.NewServer(),
+		listener:   listener,
+		socketPath: socketPath,
+		done:       make(chan struct{}),
+	}
+	workload.RegisterSpiffeWorkloadAPIServer(api.server, api)
+	go func() {
+		defer close(api.done)
+		_ = api.server.Serve(listener)
+	}()
+	t.Cleanup(api.Stop)
+	return api
+}
+
+func (api *spiffeTestWorkloadAPI) Addr() string {
+	return (&url.URL{Scheme: "unix", Path: api.socketPath}).String()
+}
+
+func (api *spiffeTestWorkloadAPI) SetX509Context(response *workload.X509SVIDResponse) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	api.response = response
+	for watcher := range api.watchers {
+		select {
+		case watcher <- response:
+		default:
+			<-watcher
+			watcher <- response
+		}
+	}
+}
+
+func (api *spiffeTestWorkloadAPI) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.SpiffeWorkloadAPI_FetchX509SVIDServer) error {
+	updates := make(chan *workload.X509SVIDResponse, 1)
+	api.mu.Lock()
+	api.watchers[updates] = struct{}{}
+	response := api.response
+	api.mu.Unlock()
+	defer func() {
+		api.mu.Lock()
+		delete(api.watchers, updates)
+		api.mu.Unlock()
+	}()
+
+	if response != nil {
+		if err := stream.Send(response); err != nil {
+			return err
+		}
+	}
+	for {
+		select {
+		case response := <-updates:
+			if err := stream.Send(response); err != nil {
+				return err
+			}
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		}
+	}
+}
+
+func (api *spiffeTestWorkloadAPI) Stop() {
+	api.stopOnce.Do(func() {
+		api.server.Stop()
+		<-api.done
+		_ = os.Remove(api.socketPath)
+	})
+}
+
+func registerSPIFFETestTLSConfig(t *testing.T, name string, certificate *spiffeTestCertificate, observedServerCertificates chan<- *x509.Certificate) {
+	t.Helper()
+
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
+	if certificate != nil {
+		clientCertificate := certificate.tlsCertificate()
+		tlsConfig.Certificates = []tls.Certificate{clientCertificate}
+		// Go normally withholds a client certificate whose issuer is not in the
+		// server's acceptable-CA list. Force it onto the wire so the untrusted
+		// certificate case exercises the server's TLS rejection path.
+		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &clientCertificate, nil
+		}
+	}
+	if observedServerCertificates != nil {
+		tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
+			if len(state.PeerCertificates) > 0 {
+				select {
+				case observedServerCertificates <- state.PeerCertificates[0]:
+				default:
+				}
+			}
+			return nil
+		}
+	}
+	require.NoError(t, mysql.RegisterTLSConfig(name, tlsConfig))
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(name) })
+}
+
+func openSPIFFETestDB(cli *testserverclient.TestServerClient, user, tlsConfigName string) (*sql.DB, error) {
+	dsn := cli.GetDSN(func(cfg *mysql.Config) {
+		cfg.User = user
+		cfg.TLSConfig = tlsConfigName
+	})
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func requireSPIFFETestTLSFailure(t *testing.T, cli *testserverclient.TestServerClient, tlsConfigName string) {
+	t.Helper()
+
+	_, err := openSPIFFETestDB(cli, spiffeTestSQLUser, tlsConfigName)
+	require.Error(t, err)
+	var mysqlError *mysql.MySQLError
+	if stderrors.As(err, &mysqlError) {
+		require.NotEqual(t, spiffeTestSQLAccessError, mysqlError.Number, "certificate unexpectedly reached SQL authorization: %v", err)
+	}
+}
+
+func TestSPIFFEWorkloadAPITLS(t *testing.T) {
+	originalConfig := *config.GetGlobalConfig()
+	originalRequireSecureTransport := tidbtls.RequireSecureTransport.Load()
+	t.Cleanup(func() {
+		config.StoreGlobalConfig(&originalConfig)
+		tidbtls.RequireSecureTransport.Store(originalRequireSecureTransport)
+	})
+	tidbtls.RequireSecureTransport.Store(false)
+
+	now := time.Now().UTC()
+	firstCA := newSPIFFETestCA(t, 1, "SPIFFE test CA 1")
+	secondCA := newSPIFFETestCA(t, 2, "SPIFFE test CA 2")
+	untrustedCA := newSPIFFETestCA(t, 3, "SPIFFE untrusted CA")
+	firstServer := firstCA.issueCertificate(t, 11, spiffeTestServerID, now.Add(45*time.Minute), x509.ExtKeyUsageServerAuth)
+	secondServer := secondCA.issueCertificate(t, 12, spiffeTestServerID, now.Add(2*time.Hour), x509.ExtKeyUsageServerAuth)
+	matchingClient := firstCA.issueCertificate(t, 21, spiffeTestClientID, now.Add(time.Hour), x509.ExtKeyUsageClientAuth)
+	wrongClient := firstCA.issueCertificate(t, 22, spiffeTestWrongClientID, now.Add(time.Hour), x509.ExtKeyUsageClientAuth)
+	nonSPIFFEClient := firstCA.issueCertificate(t, 23, "", now.Add(time.Hour), x509.ExtKeyUsageClientAuth)
+	untrustedClient := untrustedCA.issueCertificate(t, 24, spiffeTestClientID, now.Add(time.Hour), x509.ExtKeyUsageClientAuth)
+	rotatedClient := secondCA.issueCertificate(t, 25, spiffeTestClientID, now.Add(time.Hour), x509.ExtKeyUsageClientAuth)
+
+	workloadAPI := newSPIFFETestWorkloadAPI(t, newSPIFFEX509Context(t, firstServer, firstCA))
+
+	testSuite := servertestkit.CreateTidbTestSuite(t)
+	cli := testserverclient.NewTestServerClient()
+	cfg := util2.NewTestConfig()
+	cfg.Port = 0
+	cfg.Status.ReportStatus = false
+	cfg.Security.SPIFFEWorkloadAPIAddr = workloadAPI.Addr()
+	cfg.Security.SPIFFEWorkloadAPITimeout = "5s"
+	config.StoreGlobalConfig(cfg)
+
+	tidbserver.RunInGoTestChan = make(chan struct{})
+	server, err := tidbserver.NewServer(cfg, testSuite.Tidbdrv)
+	require.NoError(t, err)
+	server.SetDomain(testSuite.Domain)
+	runError := make(chan error, 1)
+	go func() { runError <- server.Run(nil) }()
+	defer func() {
+		server.Close()
+		require.NoError(t, <-runError)
+	}()
+	<-tidbserver.RunInGoTestChan
+	cli.Port = testutil.GetPortFromTCPAddr(server.ListenAddr())
+
+	observedServerCertificates := make(chan *x509.Certificate, 8)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-root", nil, observedServerCertificates)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-matching", matchingClient, observedServerCertificates)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-wrong", wrongClient, nil)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-non-spiffe", nonSPIFFEClient, nil)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-untrusted", untrustedClient, nil)
+	registerSPIFFETestTLSConfig(t, "spiffe-test-rotated", rotatedClient, observedServerCertificates)
+
+	rootDB, err := openSPIFFETestDB(cli, "root", "spiffe-test-root")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rootDB.Close()) }()
+	getVariable := func(name string) string {
+		var returnedName, value string
+		require.NoError(t, rootDB.QueryRow(fmt.Sprintf("SHOW VARIABLES LIKE '%s'", name)).Scan(&returnedName, &value))
+		require.Equal(t, name, returnedName)
+		return value
+	}
+	require.Equal(t, "YES", getVariable("have_ssl"))
+	require.Equal(t, "YES", getVariable("have_openssl"))
+	require.Empty(t, getVariable("ssl_ca"))
+	require.Empty(t, getVariable("ssl_cert"))
+	require.Empty(t, getVariable("ssl_key"))
+	_, err = rootDB.Exec(fmt.Sprintf("CREATE USER '%s'@'%%' REQUIRE SAN 'URI:%s'", spiffeTestSQLUser, spiffeTestClientID))
+	require.NoError(t, err)
+	_, err = rootDB.Exec(fmt.Sprintf("GRANT ALL ON test.* TO '%s'@'%%'", spiffeTestSQLUser))
+	require.NoError(t, err)
+
+	// REQUIRE SAN authorization can only succeed when the TLS stack populated
+	// ConnectionState.VerifiedChains with the verified client X.509-SVID.
+	existingDB, err := openSPIFFETestDB(cli, spiffeTestSQLUser, "spiffe-test-matching")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, existingDB.Close()) }()
+	var one int
+	require.NoError(t, existingDB.QueryRow("SELECT 1").Scan(&one))
+	require.Equal(t, 1, one)
+
+	var initialObserved *x509.Certificate
+	require.Eventually(t, func() bool {
+		select {
+		case initialObserved = <-observedServerCertificates:
+			return initialObserved.SerialNumber.Cmp(firstServer.certificate.SerialNumber) == 0
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	_, err = openSPIFFETestDB(cli, spiffeTestSQLUser, "spiffe-test-wrong")
+	require.Error(t, err)
+	var mysqlError *mysql.MySQLError
+	require.ErrorAs(t, err, &mysqlError)
+	require.Equal(t, spiffeTestSQLAccessError, mysqlError.Number)
+
+	requireSPIFFETestTLSFailure(t, cli, "spiffe-test-untrusted")
+	requireSPIFFETestTLSFailure(t, cli, "spiffe-test-non-spiffe")
+
+	workloadAPI.SetX509Context(newSPIFFEX509Context(t, secondServer, secondCA))
+	expectedExpiry := secondServer.certificate.NotAfter.Format("Jan _2 15:04:05 2006 MST")
+	require.Eventually(t, func() bool {
+		stats, err := server.Stats(nil)
+		return err == nil && stats["Ssl_server_not_after"] == expectedExpiry
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// An established TLS session keeps working after rotation.
+	require.NoError(t, existingDB.QueryRow("SELECT 1").Scan(&one))
+	require.Equal(t, 1, one)
+
+	// Fresh handshakes atomically use the new SVID and matching trust bundle.
+	rotatedDB, err := openSPIFFETestDB(cli, spiffeTestSQLUser, "spiffe-test-rotated")
+	require.NoError(t, err)
+	require.NoError(t, rotatedDB.Close())
+	var rotatedObserved *x509.Certificate
+	require.Eventually(t, func() bool {
+		select {
+		case rotatedObserved = <-observedServerCertificates:
+			return rotatedObserved.SerialNumber.Cmp(secondServer.certificate.SerialNumber) == 0
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	requireSPIFFETestTLSFailure(t, cli, "spiffe-test-matching")
+
+	// Losing the socket retains the last-good snapshot, and file-oriented TLS
+	// reload statements are successful no-ops while SPIFFE mode is active.
+	workloadAPI.Stop()
+	for _, statement := range []string{
+		"ALTER INSTANCE RELOAD TLS",
+		"ALTER INSTANCE RELOAD TLS NO ROLLBACK ON ERROR",
+	} {
+		_, err = rootDB.Exec(statement)
+		require.NoError(t, err)
+		freshDB, err := openSPIFFETestDB(cli, spiffeTestSQLUser, "spiffe-test-rotated")
+		require.NoError(t, err)
+		require.NoError(t, freshDB.Close())
+	}
+}

--- a/pkg/session/sessmgr/processinfo.go
+++ b/pkg/session/sessmgr/processinfo.go
@@ -15,7 +15,6 @@
 package sessmgr
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"strings"
@@ -276,7 +275,7 @@ type Manager interface {
 	GetProcessInfo(id uint64) (*ProcessInfo, bool)
 	Kill(connectionID uint64, query bool, maxExecutionTime bool, runaway bool)
 	KillAllConnections()
-	UpdateTLSConfig(cfg *tls.Config)
+	ReloadTLS(noRollbackOnError bool) error
 	ServerID() uint64
 	// GetInternalSessionStartTSList gets all startTS of every transactions running in the current internal sessions.
 	GetInternalSessionStartTSList() []uint64

--- a/pkg/testkit/mocksessionmanager.go
+++ b/pkg/testkit/mocksessionmanager.go
@@ -15,7 +15,6 @@
 package testkit
 
 import (
-	"crypto/tls"
 	"maps"
 	"sync"
 
@@ -118,8 +117,9 @@ func (*MockSessionManager) Kill(uint64, bool, bool, bool) {
 func (*MockSessionManager) KillAllConnections() {
 }
 
-// UpdateTLSConfig implements the Manager.UpdateTLSConfig interface.
-func (*MockSessionManager) UpdateTLSConfig(*tls.Config) {
+// ReloadTLS implements the Manager.ReloadTLS interface.
+func (*MockSessionManager) ReloadTLS(bool) error {
+	return nil
 }
 
 // ServerID get server id.

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -411,24 +411,6 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 
 	requireTLS := tlsutil.RequireSecureTransport.Load()
 
-	var minTLSVersion uint16 = tls.VersionTLS12
-	switch tlsver := config.GetGlobalConfig().Security.MinTLSVersion; tlsver {
-	case "TLSv1.2":
-		minTLSVersion = tls.VersionTLS12
-	case "TLSv1.3":
-		minTLSVersion = tls.VersionTLS13
-	case "":
-	default:
-		logutil.BgLogger().Warn(
-			"Invalid TLS version, using default instead",
-			zap.String("tls-version", tlsver),
-		)
-	}
-	if minTLSVersion < tls.VersionTLS12 {
-		err = errors.New("Minimum TLS version pre-TLSv1.2 protocols are not allowed")
-		return
-	}
-
 	// Try loading CA cert.
 	clientAuthPolicy := tls.NoClientCert
 	if requireTLS {
@@ -453,26 +435,9 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 		}
 	}
 
-	// This excludes ciphers listed in tls.InsecureCipherSuites() and can be used to filter out more
-	var cipherSuites []uint16
-	var cipherNames []string
-	for _, sc := range tls.CipherSuites() {
-		switch sc.ID {
-		case tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:
-			logutil.BgLogger().Info("Disabling weak cipherSuite", zap.String("cipherSuite", sc.Name))
-		default:
-			cipherNames = append(cipherNames, sc.Name)
-			cipherSuites = append(cipherSuites, sc.ID)
-		}
-	}
-	logutil.BgLogger().Info("Enabled ciphersuites", zap.Strings("cipherNames", cipherNames))
-
-	/* #nosec G402 */
-	tlsConfig = &tls.Config{
-		ClientCAs:    certPool,
-		ClientAuth:   clientAuthPolicy,
-		MinVersion:   minTLSVersion,
-		CipherSuites: cipherSuites,
+	tlsConfig, err = NewServerTLSConfig(config.GetGlobalConfig().Security.MinTLSVersion, clientAuthPolicy, certPool)
+	if err != nil {
+		return nil, autoReload, err
 	}
 	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 		certs, err := tls.LoadX509KeyPair(cert, key)
@@ -488,6 +453,49 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool, rsaKeySize int) (tl
 		return newCerts, nil
 	}
 	return
+}
+
+// NewServerTLSConfig constructs the TLS version, cipher, and client-authentication
+// policy shared by all MySQL protocol server certificate providers.
+func NewServerTLSConfig(minTLSVersion string, clientAuth tls.ClientAuthType, clientCAs *x509.CertPool) (*tls.Config, error) {
+	minVersion := uint16(tls.VersionTLS12)
+	switch minTLSVersion {
+	case "TLSv1.2":
+		minVersion = tls.VersionTLS12
+	case "TLSv1.3":
+		minVersion = tls.VersionTLS13
+	case "":
+	default:
+		logutil.BgLogger().Warn(
+			"Invalid TLS version, using default instead",
+			zap.String("tls-version", minTLSVersion),
+		)
+	}
+	if minVersion < tls.VersionTLS12 {
+		return nil, errors.New("Minimum TLS version pre-TLSv1.2 protocols are not allowed")
+	}
+
+	// This excludes ciphers listed in tls.InsecureCipherSuites() and can be used to filter out more.
+	var cipherSuites []uint16
+	var cipherNames []string
+	for _, sc := range tls.CipherSuites() {
+		switch sc.ID {
+		case tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:
+			logutil.BgLogger().Info("Disabling weak cipherSuite", zap.String("cipherSuite", sc.Name))
+		default:
+			cipherNames = append(cipherNames, sc.Name)
+			cipherSuites = append(cipherSuites, sc.ID)
+		}
+	}
+	logutil.BgLogger().Info("Enabled ciphersuites", zap.Strings("cipherNames", cipherNames))
+
+	/* #nosec G402 */
+	return &tls.Config{
+		ClientCAs:    clientCAs,
+		ClientAuth:   clientAuth,
+		MinVersion:   minVersion,
+		CipherSuites: cipherSuites,
+	}, nil
 }
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70737

Problem Summary:

TiDB currently loads MySQL listener TLS credentials from PEM files. Deployments using SPIFFE must bridge those credentials to files and explicitly reload TiDB whenever short-lived certificates rotate.

### What changed and how does it work?

- Add `spiffe-workload-api-addr` and `spiffe-workload-api-timeout` security settings for an absolute Unix Workload API endpoint.
- Watch the default X.509-SVID and all local or federated trust bundles, then atomically apply valid rotations to new MySQL TLS handshakes.
- Fail startup when no valid initial context arrives, while retaining the last valid credentials across malformed updates or socket outages.
- Validate presented client certificates as SPIFFE X.509-SVIDs and preserve the startup-time `require_secure_transport` client-certificate policy.
- Keep file-based MySQL TLS mutually exclusive with SPIFFE mode and leave cluster TLS unchanged.
- Treat both `ALTER INSTANCE RELOAD TLS` forms as successful no-ops in SPIFFE mode because credentials rotate automatically.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validated focused classic and NextGen configuration tests, SPIFFE provider tests, real MySQL-protocol TLS tests, existing TLS regression tests, and `make lint`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support obtaining and automatically rotating MySQL listener TLS credentials through a SPIFFE Workload API Unix socket.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SPIFFE Workload API support for server TLS certificates, including automatic certificate rotation.
  - Added configuration for the Workload API endpoint and startup timeout.
  - Added SPIFFE URI-based client identity verification and certificate authorization support.

- **Bug Fixes**
  - Invalid SPIFFE certificates are rejected while the last valid certificate remains active.
  - Configuration now prevents incompatible combinations with traditional TLS settings and `auto-tls`.
  - TLS reload commands safely handle SPIFFE-managed certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->