### PR TITLE
test: stabilize flaky TestSubscriptionIdleTimeoutWhileSendingEvents

### DIFF
--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -342,8 +342,16 @@ func TestSubscriptionIdleTimeoutWhileSendingEvents(t *testing.T) {
 	c.advanceCheckpoints()
 	c.flushAll()
 
-	req.Eventually(func() bool {
-		err := sub.PendingErrors()
-		return err != nil && strings.Contains(err.Error(), "has no activity")
-	}, 3*time.Second, 10*time.Millisecond)
+	deadline := time.Now().Add(3 * time.Second)
+	var lastErr error
+	for {
+		lastErr = sub.PendingErrors()
+		if lastErr != nil && strings.Contains(lastErr.Error(), "has no activity") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending errors did not contain %q within %s; last error: %v", "has no activity", 3*time.Second, lastErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70687

Problem Summary:
Flaky test `TestSubscriptionIdleTimeoutWhileSendingEvents` in `br/pkg/streamhelper` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

`require.Eventually` can timeout while its condition goroutine is still reading `FlushSubscriber.subscriptions`, then deferred `Drop` deletes from that map.

#### Fix

The final check still waits for the same pending error string over the same duration, but removes only the orphan condition goroutine that created the race.

#### Verification

Spec:
- target: `br/pkg/streamhelper :: TestSubscriptionIdleTimeoutWhileSendingEvents`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
race_signature passed.

Gate checklist:
- target_flaky: PASS
- race_signature: PASS
- package_failpoint: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./br/pkg/streamhelper -run '^TestSubscriptionIdleTimeoutWhileSendingEvents$' -count=1`
- `go test -race -tags=intest,deadlock ./br/pkg/streamhelper -run '^TestSubscriptionIdleTimeoutWhileSendingEvents$' -count=30`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of subscription idle-timeout validation.
  * Added clearer failure feedback when the expected timeout error is not observed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->