### PR TITLE
expression: preserve binary casts during constant propagation

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -578,6 +578,20 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 	case *ScalarFunction:
 		substituted := false
 		hasFail := false
+		// A collation equality on a non-binary string does not establish byte identity.
+		// Keep a byte-sensitive cast on the original column instead of folding it after
+		// constant propagation substitutes a collation-equal value.
+		if ctx.IsConstantPropagateCheck() && v.FuncName.L == ast.Cast && types.IsBinaryStr(v.RetType) {
+			arg0, isColumn := v.GetArgs()[0].(*Column)
+			if isColumn {
+				id := schema.ColumnIndex(arg0)
+				if id != -1 && types.IsNonBinaryStr(schema.Columns[id].GetStaticType()) {
+					if _, isConstant := newExprs[id].(*Constant); isConstant {
+						return false, false, v
+					}
+				}
+			}
+		}
 		if v.FuncName.L == ast.Cast || v.FuncName.L == ast.Grouping {
 			var newArg Expression
 			substituted, hasFail, newArg = ColumnSubstituteImpl(ctx, v.GetArgs()[0], schema, newExprs, fail1Return)

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2660,4 +2660,21 @@ func TestBinCollationRangeForIndex(t *testing.T) {
 	require.Equal(t, "[eq(test.t.f, abc)]", expression.StringifyExpressionsWithCtx(ectx, accessConds))
 	require.Equal(t, "[eq(test.t.f, abc)]", expression.StringifyExpressionsWithCtx(ectx, remainedConds))
 	require.Equal(t, "[[\"\\x00A\\x00B\\x00C\",\"\\x00A\\x00B\\x00C\"]]", fmt.Sprintf("%v", ranges))
+
+	tk.MustExec("drop table if exists t_binary_literal")
+	tk.MustExec(`create table t_binary_literal (
+		a bigint primary key,
+		b bigint not null,
+		c varchar(64) character set utf8mb4 collate utf8mb4_general_ci not null,
+		key idx_bc (b, c)
+	)`)
+	tk.MustExec("insert into t_binary_literal values (1, 42, 'Alice'), (2, 42, 'alice')")
+	tk.MustQuery(`
+		select a, c
+		from t_binary_literal force index (idx_bc)
+		where b = 42
+			and c = _binary'Alice'
+			and cast(c as binary) = cast(_binary'Alice' as binary)
+		order by a
+	`).Check(testkit.Rows("1 Alice"))
 }


### PR DESCRIPTION
A non-binary collation equality does not prove byte identity. Keep direct binary casts on the original column when constant propagation would replace it with a constant, and add a regression for the indexed query path.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69852

Problem Summary:

For a string column using a non-binary, case-insensitive collation, an equality predicate proves collation equality but does not prove that the underlying bytes are identical.

During constant propagation, TiDB could replace the column inside `CAST(column AS BINARY)` with a collation-equal constant. The resulting constant comparison was folded to true, removing the byte-sensitive residual predicate. As a result, an index range could admit both `Alice` and `alice`, and the query incorrectly returned both rows even though the binary cast predicate should only match `Alice`.

### What changed and how does it work?

During constant propagation, column substitution now preserves the original cast expression when:

  - The expression directly casts a column.
  - The cast result is a binary string.
  - The source column is a non-binary string.
  - The column would be replaced with a constant.

This keeps the byte-sensitive comparison as a residual filter while preserving the existing index range construction.

The regression test extends the existing binary-collation ranger test with a case-insensitive composite index containing both `Alice` and `alice`. Without the fix, the query returns both rows. With the fix, only the byte-identical `Alice` row is returned.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect query results when constant propagation removes a byte-sensitive binary cast predicate under a non-binary collation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of binary comparisons on string columns with case-insensitive collations.
  * Preserved byte-sensitive comparison behavior when using binary casts, ensuring queries distinguish values such as `Alice` and `alice` correctly.

* **Tests**
  * Added coverage for indexed queries combining collation-aware and binary comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->