### PR TITLE
planner: fix correlated aggregate with decorrelation disabled

### DIFF
--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2583,6 +2583,63 @@ WHERE t1.id IN (SELECT MIN(id) FROM t1)`
 	require.NoError(t, err)
 }
 
+func TestNoDecorrelateCorrelatedAggregate(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int, c int)")
+	tk.MustExec("create table t2 (a int, b int)")
+	tk.MustExec("insert into t1 values (1, 10, 10), (1, 20, 10), (2, 30, 20)")
+	tk.MustExec("insert into t2 values (1, 1), (1, 2), (2, 3)")
+
+	testCases := []struct {
+		name string
+		sql  string
+		rows []string
+	}{
+		{
+			name: "outer aggregate",
+			sql: `select t1.a, sum(t1.b),
+				(select sum(t2.b) + sum(t1.b) from t2 where t2.a = t1.a)
+				from t1 group by t1.a order by t1.a`,
+			rows: []string{"1 30 33", "2 30 33"},
+		},
+		{
+			name: "mixed aggregate before outer aggregate",
+			sql: `select t1.a,
+				(select sum(t2.b + t1.c) + sum(t1.b) from t2 where t2.a = t1.a)
+				from t1 group by t1.a order by t1.a`,
+			rows: []string{"1 53", "2 53"},
+		},
+		{
+			name: "nested outer aggregate",
+			sql: `select t1.a,
+				(select sum(sum(t1.b) + t2.b) from t2 where t2.a = t1.a)
+				from t1 group by t1.a order by t1.a`,
+			rows: []string{"1 63", "2 33"},
+		},
+		{
+			name: "mixed aggregate",
+			sql: `select t1.a,
+				(select sum(t2.b + t1.c) from t2 where t2.a = t1.a)
+				from t1 group by t1.a order by t1.a`,
+			rows: []string{"1 23", "2 23"},
+		},
+	}
+
+	for _, noDecorrelate := range []int{0, 1} {
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("%s/no_decorrelate=%d", testCase.name, noDecorrelate), func(t *testing.T) {
+				tk := testkit.NewTestKit(t, store)
+				tk.MustExec("use test")
+				tk.MustExec(fmt.Sprintf("set session tidb_opt_enable_no_decorrelate_in_select = %d", noDecorrelate))
+				tk.MustQuery(testCase.sql).Check(testkit.Rows(testCase.rows...))
+			})
+		}
+	}
+}
+
 func TestIssue66619(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3057,10 +3057,6 @@ func (b *PlanBuilder) extractCorrelatedAggFuncs(ctx context.Context, p base.Logi
 			corCols = append(corCols, expression.ExtractCorColumns(expr)...)
 			cols = append(cols, expression.ExtractColumns(expr)...)
 		}
-		// If decorrelation is disabled, don't extract correlated aggregates
-		if b.noDecorrelate && len(corCols) > 0 {
-			continue
-		}
 		if len(corCols) > 0 && len(cols) == 0 {
 			outer = append(outer, agg)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70286

Problem Summary:

When `tidb_opt_enable_no_decorrelate_in_select` was enabled, correlated aggregate extraction skipped every aggregate function containing a correlated column.

As a result, an aggregate such as `SUM(t1.b)` inside a scalar subquery was not recognized as belonging to the outer query. It was instead evaluated in the inner subquery context, which could produce incorrect results. The early return also skipped the aggregate mapper update and per-aggregate temporary state reset, allowing one aggregate expression to affect the classification of subsequent expressions.

### What changed and how does it work?

Remove the decorrelation-specific early return from correlated aggregate extraction.

Aggregate ownership is determined by the columns referenced by the aggregate expression and should not depend on whether the resulting `Apply` operator is later decorrelated. The existing condition still extracts only aggregates that reference outer columns without referencing local inner columns, so mixed inner/outer aggregates are not incorrectly moved to the outer query.

The `tidb_opt_enable_no_decorrelate_in_select` setting continues to control the later decorrelation and `Apply` optimization steps.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect results for correlated aggregate queries when `tidb_opt_enable_no_decorrelate_in_select` is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of correlated aggregate queries when decorrelation is disabled.
  * Ensured correlated aggregate results remain consistent across supported query patterns and configuration settings.
* **Tests**
  * Added coverage for outer, mixed, nested, and correlated aggregate queries to verify consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->