### PR TITLE
br: fix region not found

### DIFF
--- a/br/pkg/restore/log_client/import_retry.go
+++ b/br/pkg/restore/log_client/import_retry.go
@@ -114,11 +114,15 @@ func (o *RangeController) onError(_ context.Context, result RPCResult, region *s
 }
 
 func (o *RangeController) tryFindLeader(ctx context.Context, region *split.RegionInfo) (*metapb.Peer, error) {
-	backoffStrategy := utils.NewBackoffRetryAllErrorStrategy(4, 2*time.Second, 10*time.Second)
+	backoffStrategy := utils.NewBackoffRetryAllExceptStrategy(
+		4, 2*time.Second, 10*time.Second, isNonRetryErrForFindLeader)
 	return utils.WithRetryV2(ctx, backoffStrategy, func(ctx context.Context) (*metapb.Peer, error) {
 		r, err := o.metaClient.GetRegionByID(ctx, region.Region.Id)
 		if err != nil {
 			return nil, err
+		}
+		if r == nil || r.Region == nil {
+			return nil, errors.Annotatef(berrors.ErrKVEpochNotMatch, "region %d is not found", region.Region.Id)
 		}
 		if !split.CheckRegionEpoch(r, region) {
 			return nil, errors.Annotatef(berrors.ErrKVEpochNotMatch, "the current epoch of %s has changed", region)
@@ -128,6 +132,10 @@ func (o *RangeController) tryFindLeader(ctx context.Context, region *split.Regio
 		}
 		return nil, errors.Annotatef(berrors.ErrPDLeaderNotFound, "there is no leader for region %d", region.Region.Id)
 	})
+}
+
+func isNonRetryErrForFindLeader(err error) bool {
+	return berrors.ErrKVEpochNotMatch.Equal(err)
 }
 
 // handleRegionError handles the error happens internal in the region. Update the region info, and perform a suitable backoff.

--- a/br/pkg/restore/log_client/import_retry_test.go
+++ b/br/pkg/restore/log_client/import_retry_test.go
@@ -86,6 +86,18 @@ func initTestClient(isRawKv bool) *split.TestClient {
 	return split.NewTestClient(stores, regions, 6)
 }
 
+type nilRegionByIDClient struct {
+	*split.TestClient
+	regionID uint64
+}
+
+func (c *nilRegionByIDClient) GetRegionByID(ctx context.Context, regionID uint64) (*split.RegionInfo, error) {
+	if regionID == c.regionID {
+		return nil, nil
+	}
+	return c.TestClient.GetRegionByID(ctx, regionID)
+}
+
 func TestScanSuccess(t *testing.T) {
 	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
 	cli := initTestClient(false)
@@ -394,6 +406,79 @@ func TestRegionSplit(t *testing.T) {
 	assertRegions(t, firstRunRegions, "", "aay")
 	assertRegions(t, secondRunRegions, "", "aay", "aayy", "bba", "bbh", "cca", "")
 	require.NoError(t, err)
+
+	t.Run("missing region by ID falls back to range scan", func(t *testing.T) {
+		cli := initTestClient(false)
+		rs := utils.InitialRetryState(2, 0, 0)
+		ctx := context.Background()
+
+		regions, err := split.PaginateScanRegion(ctx, cli, []byte("aaz"), []byte("aazz"), 1)
+		require.NoError(t, err)
+		require.Len(t, regions, 1)
+		target := regions[0]
+
+		newRegions := []*split.RegionInfo{
+			{
+				Region: &metapb.Region{
+					Id:       42,
+					StartKey: target.Region.StartKey,
+					EndKey:   codec.EncodeBytes(nil, []byte("aayy")),
+				},
+				Leader: &metapb.Peer{
+					Id:      43,
+					StoreId: 1,
+				},
+			},
+			{
+				Region: &metapb.Region{
+					Id:       44,
+					StartKey: codec.EncodeBytes(nil, []byte("aayy")),
+					EndKey:   target.Region.EndKey,
+				},
+				Leader: &metapb.Peer{
+					Id:      45,
+					StoreId: 1,
+				},
+			},
+		}
+		splitRegion := func() {
+			for _, r := range newRegions {
+				cli.RegionsInfo.SetRegion(pdtypes.NewRegionInfo(r.Region, r.Leader))
+				cli.Regions[r.Region.Id] = r
+			}
+		}
+		notLeader := &import_sstpb.Error{
+			Message: "leader not found",
+			StoreError: &errorpb.Error{
+				NotLeader: &errorpb.NotLeader{
+					RegionId: target.Region.Id,
+				},
+			},
+		}
+
+		ctl := logclient.CreateRangeController(
+			[]byte(""), []byte(""), &nilRegionByIDClient{TestClient: cli, regionID: target.Region.Id}, &rs)
+		firstRunRegions := []*split.RegionInfo{}
+		secondRunRegions := []*split.RegionInfo{}
+		isSecondRun := false
+		err = ctl.ApplyFuncToRange(ctx, func(ctx context.Context, r *split.RegionInfo) logclient.RPCResult {
+			if !isSecondRun && r.Region.Id == target.Region.Id {
+				splitRegion()
+				isSecondRun = true
+				return logclient.RPCResultFromPBError(notLeader)
+			}
+			if isSecondRun {
+				secondRunRegions = append(secondRunRegions, r)
+			} else {
+				firstRunRegions = append(firstRunRegions, r)
+			}
+			return logclient.RPCResultOK()
+		})
+
+		assertRegions(t, firstRunRegions, "", "aay")
+		assertRegions(t, secondRunRegions, "", "aay", "aayy", "bba", "bbh", "cca", "")
+		require.NoError(t, err)
+	})
 }
 
 func TestRetryBackoff(t *testing.T) {

--- a/br/pkg/restore/split/client.go
+++ b/br/pkg/restore/split/client.go
@@ -340,7 +340,7 @@ func (c *pdClient) GetRegionByID(ctx context.Context, regionID uint64) (*RegionI
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if region == nil {
+	if region == nil || region.Meta == nil {
 		return nil, nil
 	}
 	return &RegionInfo{
@@ -474,8 +474,14 @@ func sendSplitRegionRequest(
 				if findLeaderErr != nil {
 					return false, nil, findLeaderErr
 				}
+				if newRegionInfo == nil || newRegionInfo.Region == nil {
+					return false, nil, berrors.ErrKVEpochNotMatch
+				}
 				if !CheckRegionEpoch(newRegionInfo, regionInfo) {
 					return false, nil, berrors.ErrKVEpochNotMatch
+				}
+				if newRegionInfo.Leader == nil {
+					return false, nil, berrors.ErrPDLeaderNotFound
 				}
 				log.Info("find new leader", zap.Uint64("new leader", newRegionInfo.Leader.Id))
 				regionInfo = newRegionInfo

--- a/br/pkg/restore/split/split_test.go
+++ b/br/pkg/restore/split/split_test.go
@@ -486,6 +486,45 @@ func (c *codecAwareMockPDClient) LoadKeyspace(context.Context, string) (*keyspac
 	return c.keyspaceMeta, nil
 }
 
+type nilRegionByIDMockPDClient struct {
+	*MockPDClientForSplit
+	regionID uint64
+}
+
+func (c *nilRegionByIDMockPDClient) WithCallerComponent(caller.Component) pd.Client {
+	return c
+}
+
+func (c *nilRegionByIDMockPDClient) GetRegionByID(
+	ctx context.Context,
+	regionID uint64,
+	opts ...opt.GetRegionOption,
+) (*router.Region, error) {
+	if regionID == c.regionID {
+		return nil, nil
+	}
+	return c.MockPDClientForSplit.GetRegionByID(ctx, regionID, opts...)
+}
+
+func containsKVEpochNotMatch(err error) bool {
+	if berrors.ErrKVEpochNotMatch.Equal(err) {
+		return true
+	}
+	if cause := errors.Cause(err); cause != nil && cause != err && berrors.ErrKVEpochNotMatch.Equal(cause) {
+		return true
+	}
+	errs, ok := err.(interface{ Errors() []error })
+	if !ok {
+		return false
+	}
+	for _, err := range errs.Errors() {
+		if containsKVEpochNotMatch(err) {
+			return true
+		}
+	}
+	return false
+}
+
 func newCodecV2PDClientForSplitTest(t *testing.T, mockClient *MockPDClientForSplit) *tikv.CodecPDClient {
 	codecPDClient, err := tikv.NewCodecPDClientWithKeyspace(tikv.ModeTxn, &codecAwareMockPDClient{
 		MockPDClientForSplit: mockClient,
@@ -1117,6 +1156,31 @@ func TestSplitEmptyRegion(t *testing.T) {
 //	[, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
 //	[bbj, cca), [cca, xxe), [xxe, xxz), [xxz, )
 func TestSplitAndScatter(t *testing.T) {
+	t.Run("not leader with missing region by ID returns epoch not match", func(t *testing.T) {
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/restore/split/not-leader-error", "return(false)"))
+		t.Cleanup(func() {
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/restore/split/not-leader-error"))
+		})
+
+		mockPDCli := NewMockPDClientForSplit()
+		regions := mockPDCli.SetRegions([][]byte{[]byte(""), []byte("m"), []byte("")})
+		mockPDCli.SetStores(map[uint64]*metapb.Store{
+			1: {Id: 1, Address: "127.0.0.1:1"},
+		})
+		splitRegion := &RegionInfo{
+			Region: regions[0],
+			Leader: &metapb.Peer{Id: regions[0].Id, StoreId: 1},
+		}
+		client := NewClient(&nilRegionByIDMockPDClient{
+			MockPDClientForSplit: mockPDCli,
+			regionID:             regions[0].Id,
+		}, nil, nil, 100, 4)
+
+		_, err := client.SplitWaitAndScatter(context.Background(), splitRegion, [][]byte{[]byte("a")})
+		require.Error(t, err)
+		require.True(t, containsKVEpochNotMatch(err), "unexpected error: %+v", err)
+	})
+
 	rangeBoundaries := [][]byte{[]byte(""), []byte("aay"), []byte("bba"), []byte("bbh"), []byte("cca"), []byte("")}
 	encodeBytes(rangeBoundaries)
 	mockPDCli := NewMockPDClientForSplit()

--- a/br/tests/br_key_locked/codec.go
+++ b/br/tests/br_key_locked/codec.go
@@ -93,7 +93,7 @@ func processRegionResult(region *router.Region, err error) (*router.Region, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if region == nil {
+	if region == nil || region.Meta == nil {
 		return nil, nil
 	}
 	err = decodeRegionMetaKey(region.Meta)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70494

Problem Summary:
The function `GetRegionByID` may return `nil` when PD server doesn't find the region.
### What changed and how does it work?
catch the situation and retry to scan regions again.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved region restoration and splitting when region metadata is unavailable or a region cannot be found.
  - Added safer handling for regions without leaders, preventing invalid retry behavior.
  - Refined retry handling so non-retryable epoch mismatch errors are returned promptly.
  - Improved fallback behavior to scan ranges when direct region lookup fails.
  - Enhanced error reporting for failed region operations, making failures more predictable and diagnosable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->