### PR TITLE
test: stabilize flaky TestReplaceConflictMultipleKeysNonclusteredPk

### DIFF
--- a/lightning/pkg/errormanager/resolveconflict_test.go
+++ b/lightning/pkg/errormanager/resolveconflict_test.go
@@ -171,27 +171,28 @@ func TestReplaceConflictMultipleKeysNonclusteredPk(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(2, 1))
 	mockDB.ExpectExec("CREATE OR REPLACE VIEW `lightning_task_info`\\.conflict_view.*").
 		WillReturnResult(sqlmock.NewResult(3, 1))
+	const conflictIDBase = int64(9223372036854775000)
 	mockDB.ExpectQuery("\\QSELECT id, raw_key, index_name, raw_value, raw_handle FROM `lightning_task_info`.conflict_error_v4 WHERE table_name = ? AND kv_type = 0 AND id >= ? and id < ? ORDER BY id LIMIT ?\\E").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "raw_key", "index_name", "raw_value", "raw_handle"}).
-			AddRow(1, data2RowKey, "PRIMARY", data2RowValue, data1RowKey).
-			AddRow(2, data2RowKey, "PRIMARY", data3NonclusteredValue, data2NonclusteredKey).
-			AddRow(3, data6RowKey, "PRIMARY", data6RowValue, data5RowKey).
-			AddRow(4, data6RowKey, "PRIMARY", data7NonclusteredValue, data6NonclusteredKey))
+			AddRow(conflictIDBase+1, data2RowKey, "PRIMARY", data2RowValue, data1RowKey).
+			AddRow(conflictIDBase+2, data2RowKey, "PRIMARY", data3NonclusteredValue, data2NonclusteredKey).
+			AddRow(conflictIDBase+3, data6RowKey, "PRIMARY", data6RowValue, data5RowKey).
+			AddRow(conflictIDBase+4, data6RowKey, "PRIMARY", data7NonclusteredValue, data6NonclusteredKey))
 	mockDB.ExpectBegin()
 	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v4.*").
 		WithArgs(0, "a", nil, nil, data2NonclusteredKey, data2NonclusteredValue, 2,
 			0, "a", nil, nil, data6NonclusteredKey, data6NonclusteredValue, 2).
 		WillReturnResult(driver.ResultNoRows)
 	mockDB.ExpectCommit()
-	for range 2 {
+	for range 1 {
 		mockDB.ExpectQuery("\\QSELECT id, raw_key, index_name, raw_value, raw_handle FROM `lightning_task_info`.conflict_error_v4 WHERE table_name = ? AND kv_type = 0 AND id >= ? and id < ? ORDER BY id LIMIT ?\\E").
 			WillReturnRows(sqlmock.NewRows([]string{"id", "raw_key", "index_name", "raw_value", "raw_handle"}))
 	}
 	mockDB.ExpectQuery("\\QSELECT id, raw_key, raw_value FROM `lightning_task_info`.conflict_error_v4 WHERE table_name = ? AND kv_type <> 0 AND id >= ? and id < ? ORDER BY id LIMIT ?\\E").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "raw_key", "raw_value"}).
-			AddRow(1, data2NonclusteredKey, data2NonclusteredValue).
-			AddRow(2, data6NonclusteredKey, data6NonclusteredValue))
-	for range 2 {
+			AddRow(conflictIDBase+1, data2NonclusteredKey, data2NonclusteredValue).
+			AddRow(conflictIDBase+2, data6NonclusteredKey, data6NonclusteredValue))
+	for range 1 {
 		mockDB.ExpectQuery("\\QSELECT id, raw_key, raw_value FROM `lightning_task_info`.conflict_error_v4 WHERE table_name = ? AND kv_type <> 0 AND id >= ? and id < ? ORDER BY id LIMIT ?\\E").
 			WillReturnRows(sqlmock.NewRows([]string{"id", "raw_key", "raw_value"}))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70769

Problem Summary:
Flaky test `TestReplaceConflictMultipleKeysNonclusteredPk` in `lightning/pkg/errormanager` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Sqlmock expected a deterministic optional split follow-up query count, but `ReplaceConflictKeys` may legally process only one terminal empty range.

#### Fix

High mock conflict IDs remove only pagination split scheduling noise while preserving the same conflict rows, KVs, deletes, inserts, and assertions.

#### Verification

Spec:
- target: `lightning/pkg/errormanager :: TestReplaceConflictMultipleKeysNonclusteredPk`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
timing_repro passed.
build passed.
lint passed.

Gate checklist:
- target_flaky: PASS
- package: PASS
- timing_repro: PASS
- build: PASS
- lint: PASS

Commands:
- `go test -json -tags=intest,deadlock ./lightning/pkg/errormanager -run '^TestReplaceConflictMultipleKeysNonclusteredPk$' -count=1`
- `go test -json -tags=intest,deadlock ./lightning/pkg/errormanager -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated conflict-resolution test coverage to use large conflict identifiers.
  * Adjusted polling expectations for primary-key and non-primary-key conflict queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->