### PR TITLE
util: prevent SQLKiller panic during concurrent reset (#70557)

### DIFF
--- a/pkg/util/sqlkiller/BUILD.bazel
+++ b/pkg/util/sqlkiller/BUILD.bazel
@@ -20,4 +20,8 @@ go_test(
     srcs = ["sqlkiller_test.go"],
     embed = [":sqlkiller"],
     flaky = True,
+    deps = [
+        "//pkg/testkit/testfailpoint",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/util/sqlkiller/sqlkiller.go
+++ b/pkg/util/sqlkiller/sqlkiller.go
@@ -61,8 +61,8 @@ type SQLKiller struct {
 // SendKillSignal sends a kill signal to the query.
 func (killer *SQLKiller) SendKillSignal(reason killSignal) {
 	if atomic.CompareAndSwapUint32(&killer.Signal, 0, reason) {
-		status := atomic.LoadUint32(&killer.Signal)
-		err := killer.getKillError(status)
+		failpoint.InjectCall("beforeLogKillSignal")
+		err := killer.getKillError(reason)
 		logutil.BgLogger().Warn("kill initiated", zap.Uint64("connection ID", killer.ConnID.Load()), zap.String("reason", err.Error()))
 	}
 }
@@ -167,9 +167,10 @@ func (killer *SQLKiller) CheckConnectionAlive() {
 
 // Reset resets the SqlKiller.
 func (killer *SQLKiller) Reset() {
-	if atomic.LoadUint32(&killer.Signal) != 0 {
+	status := atomic.SwapUint32(&killer.Signal, UnspecifiedKillSignal)
+	failpoint.InjectCall("afterResetKillSignalSwap")
+	if status != UnspecifiedKillSignal {
 		logutil.BgLogger().Warn("kill finished", zap.Uint64("conn", killer.ConnID.Load()))
 	}
-	atomic.StoreUint32(&killer.Signal, 0)
 	killer.lastCheckTime.Store(nil)
 }

--- a/pkg/util/sqlkiller/sqlkiller_test.go
+++ b/pkg/util/sqlkiller/sqlkiller_test.go
@@ -14,7 +14,12 @@
 
 package sqlkiller
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
+	"github.com/stretchr/testify/require"
+)
 
 func TestConnectionAliveCallbackCleanupKeepsNewerCallback(t *testing.T) {
 	var killer SQLKiller
@@ -50,4 +55,35 @@ func TestConnectionAliveCallbackCleanupKeepsNewerCallback(t *testing.T) {
 	if newCallbackCalls != 1 {
 		t.Fatalf("expected newer callback to be cleared, got %d calls", newCallbackCalls)
 	}
+}
+
+func TestSQLKillerConcurrentReset(t *testing.T) {
+	t.Run("reset after successful kill signal CAS", func(t *testing.T) {
+		killer := &SQLKiller{}
+		const beforeLogFailpoint = "github.com/pingcap/tidb/pkg/util/sqlkiller/" +
+			"beforeLogKillSignal"
+		testfailpoint.EnableCall(t, beforeLogFailpoint, func() {
+			killer.Reset()
+		})
+
+		require.NotPanics(t, func() {
+			killer.SendKillSignal(QueryInterrupted)
+		})
+		require.Equal(t, UnspecifiedKillSignal, killer.GetKillSignal())
+		require.NoError(t, killer.HandleSignal())
+	})
+
+	t.Run("kill signal after reset clear", func(t *testing.T) {
+		killer := &SQLKiller{}
+		killer.SendKillSignal(QueryInterrupted)
+		const afterResetFailpoint = "github.com/pingcap/tidb/pkg/util/sqlkiller/" +
+			"afterResetKillSignalSwap"
+		testfailpoint.EnableCall(t, afterResetFailpoint, func() {
+			killer.SendKillSignal(MaxExecTimeExceeded)
+		})
+
+		killer.Reset()
+		require.Equal(t, MaxExecTimeExceeded, killer.GetKillSignal())
+		require.Error(t, killer.HandleSignal())
+	})
 }


### PR DESCRIPTION
This is a release-8.5-specific backport of #70557.

### What problem does this PR solve?

Issue Number: ref #70545

A successful `SendKillSignal` can race with `Reset`. On release-8.5, `SendKillSignal` used the mutable signal value again after the CAS; if `Reset` cleared it in between, the error lookup could return nil and the logging path could panic. `Reset` also used a separate load/store pair, which could clear a newer signal sent between those operations.

### What changed and how does it work?

release-8.5 does not have the complete kill-event state machine used by master, so this is a minimal branch-specific adaptation:

- After the successful CAS, construct the kill error from the already captured `reason` instead of reloading the mutable signal.
- Reset the signal with one atomic swap and log from the swapped-out value, so a later kill signal is not lost.
- Add failpoints and regression tests for both CAS/Reset interleavings.

### Check List

Tests

- [x] Unit test
  - `go test -tags=intest,deadlock ./pkg/util/sqlkiller -run '^TestSQLKillerConcurrentReset$' -count=1`\n  - `GOTOOLCHAIN=go1.25.12 CC=clang go test -race -ldflags='-linkmode=external' -tags=intest,deadlock ./pkg/util/sqlkiller -run '^TestSQLKillerConcurrentReset$' -count=1`\n  - `go test -tags=intest,deadlock ./pkg/util/sqlkiller -run '^TestConnectionAliveCallbackCleanupKeepsNewerCallback$' -count=1`\n  - `git diff --check`\n- [ ] Integration test\n- [ ] Manual test\n\n`make lint` completed successfully, although its optional asciicheck installer reported that the removed upstream module `github.com/tdakkota/asciicheck@v0.2.0` could not be fetched. `make bazel_prepare` is blocked by the same pre-existing external dependency and made no generated source changes.\n\nSide effects\n\n- [ ] Performance regression: Consumes more CPU\n- [ ] Performance regression: Consumes more Memory\n- [ ] Breaking backward compatibility\n\n### Release note\n\n```release-note\nFix a race between sending and resetting a SQLKiller signal that could panic or lose a newer kill signal.\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resetting SQL kill signals during concurrent signal delivery.
  * Ensured reset operations consistently clear stale kill state while preserving newly delivered signals.
  * Prevented potential race-related panics and incorrect kill status handling.

* **Tests**
  * Added coverage for concurrent reset and kill-signal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->