### PR TITLE
ddl: restore legacy ingest checkpoints after upgrade

### DIFF
--- a/pkg/ddl/ingest/checkpoint.go
+++ b/pkg/ddl/ingest/checkpoint.go
@@ -489,6 +489,10 @@ type ReorgCheckpoint struct {
 	InstanceAddr   string `json:"instance_addr"`
 
 	PhysicalID int64 `json:"physical_id"`
+	// StartKey and EndKey retain the safe recovery range from checkpoints
+	// written before the checkpoint manager was scoped to one physical table.
+	StartKey kv.Key `json:"start_key,omitempty"`
+	EndKey   kv.Key `json:"end_key,omitempty"`
 	// TS of next engine ingest.
 	TS uint64 `json:"ts"`
 

--- a/pkg/ddl/job_scheduler.go
+++ b/pkg/ddl/job_scheduler.go
@@ -728,32 +728,36 @@ func getDDLReorgHandle(se *sess.Session, job *model.Job) (element *meta.Element,
 	return
 }
 
-func getImportedKeyFromCheckpoint(se *sess.Session, job *model.Job) (imported kv.Key, physicalTableID int64, err error) {
+// getReorgCheckpoint returns an empty checkpoint when reorg_meta does not
+// contain one, preserving the zero-value behavior of the old scalar return.
+func getReorgCheckpoint(se *sess.Session, job *model.Job) (*ingest.ReorgCheckpoint, error) {
 	sql := fmt.Sprintf("select reorg_meta from mysql.tidb_ddl_reorg where job_id = %d", job.ID)
 	ctx := kv.WithInternalSourceType(context.Background(), getDDLRequestSource(job.Type))
 	rows, err := se.Execute(ctx, sql, "get_handle")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if len(rows) == 0 {
-		return nil, 0, meta.ErrDDLReorgElementNotExist
+		return nil, meta.ErrDDLReorgElementNotExist
 	}
 	if !rows[0].IsNull(0) {
 		rawReorgMeta := rows[0].GetBytes(0)
 		var reorgMeta ingest.JobReorgMeta
 		err = json.Unmarshal(rawReorgMeta, &reorgMeta)
 		if err != nil {
-			return nil, 0, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 		if cp := reorgMeta.Checkpoint; cp != nil {
 			logutil.DDLIngestLogger().Info("resume physical table ID from checkpoint",
 				zap.Int64("jobID", job.ID),
 				zap.String("global sync key", hex.EncodeToString(cp.GlobalSyncKey)),
+				zap.String("legacy start key", hex.EncodeToString(cp.StartKey)),
+				zap.String("legacy end key", hex.EncodeToString(cp.EndKey)),
 				zap.Int64("checkpoint physical ID", cp.PhysicalID))
-			return cp.GlobalSyncKey, cp.PhysicalID, nil
+			return cp, nil
 		}
 	}
-	return
+	return new(ingest.ReorgCheckpoint), nil
 }
 
 // updateDDLReorgHandle update startKey, endKey physicalTableID and element of the handle.

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -483,19 +483,51 @@ func overwriteReorgInfoFromGlobalCheckpoint(w *worker, sess *sess.Session, job *
 		// We only overwrite from checkpoint when the job runs for the first time on this TiDB instance.
 		return nil
 	}
-	start, pid, err := getImportedKeyFromCheckpoint(sess, job)
+	checkpoint, err := getReorgCheckpoint(sess, job)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if pid != reorgInfo.PhysicalTableID {
+	if len(checkpoint.StartKey) > 0 && len(checkpoint.EndKey) > 0 {
+		if !overwriteLegacyReorgInfoFromCheckpoint(job, reorgInfo, checkpoint) {
+			return nil
+		}
+		err = updateDDLReorgHandle(
+			sess,
+			job.ID,
+			reorgInfo.StartKey,
+			reorgInfo.EndKey,
+			reorgInfo.PhysicalTableID,
+			reorgInfo.currElement,
+		)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	}
+
+	if checkpoint.PhysicalID != reorgInfo.PhysicalTableID {
 		// Current physical ID does not match checkpoint physical ID.
 		// Don't overwrite reorgInfo.StartKey.
 		return nil
 	}
-	if len(start) > 0 {
-		reorgInfo.StartKey = start
+	if len(checkpoint.GlobalSyncKey) > 0 {
+		reorgInfo.StartKey = checkpoint.GlobalSyncKey
 	}
 	return nil
+}
+
+func overwriteLegacyReorgInfoFromCheckpoint(job *model.Job, reorgInfo *reorgInfo, checkpoint *ingest.ReorgCheckpoint) bool {
+	// A non-positive physical ID is the zero-value result for a missing checkpoint.
+	if checkpoint.PhysicalID <= 0 {
+		return false
+	}
+	reorgInfo.StartKey = checkpoint.StartKey
+	reorgInfo.EndKey = checkpoint.EndKey
+	if len(reorgInfo.EndKey) > 0 {
+		reorgInfo.EndKey = adjustEndKeyAcrossVersion(job, reorgInfo.EndKey)
+	}
+	reorgInfo.PhysicalTableID = checkpoint.PhysicalID
+	return true
 }
 
 func extractElemIDs(r *reorgInfo) []int64 {

--- a/pkg/ddl/reorg_test.go
+++ b/pkg/ddl/reorg_test.go
@@ -15,11 +15,73 @@
 package ddl
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/ddl/ingest"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecodeLegacyReorgCheckpoint(t *testing.T) {
+	rawMeta := []byte(`{
+		"reorg_checkpoint": {
+			"global_sync_key": null,
+			"physical_id": 114,
+			"start_key": "bGVnYWN5LXN0YXJ0",
+			"end_key": "bGVnYWN5LWVuZA==",
+			"version": 1
+		}
+	}`)
+	var reorgMeta ingest.JobReorgMeta
+	err := json.Unmarshal(rawMeta, &reorgMeta)
+	require.NoError(t, err)
+	roundTripped, err := json.Marshal(reorgMeta)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Checkpoint map[string]json.RawMessage `json:"reorg_checkpoint"`
+	}
+	require.NoError(t, json.Unmarshal(roundTripped, &decoded))
+	require.Contains(t, decoded.Checkpoint, "start_key")
+	require.Contains(t, decoded.Checkpoint, "end_key")
+	require.Equal(t, int64(114), reorgMeta.Checkpoint.PhysicalID)
+	require.Equal(t, kv.Key("legacy-start"), reorgMeta.Checkpoint.StartKey)
+	require.Equal(t, kv.Key("legacy-end"), reorgMeta.Checkpoint.EndKey)
+
+	testCases := []struct {
+		name           string
+		reorgVersion   int64
+		expectedEndKey kv.Key
+	}{
+		{
+			name:           "current end key semantics",
+			reorgVersion:   model.CurrentReorgMetaVersion,
+			expectedEndKey: kv.Key("legacy-end"),
+		},
+		{
+			name:           "legacy end key semantics",
+			reorgVersion:   model.ReorgMetaVersion0,
+			expectedEndKey: kv.Key("legacy-end").Next(),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			job := &model.Job{ReorgMeta: &model.DDLReorgMeta{Version: testCase.reorgVersion}}
+			reorgInfo := &reorgInfo{
+				PhysicalTableID: 175,
+				StartKey:        kv.Key("current-start"),
+				EndKey:          kv.Key("current-end"),
+			}
+			require.True(t, overwriteLegacyReorgInfoFromCheckpoint(job, reorgInfo, reorgMeta.Checkpoint))
+			require.Equal(t, int64(114), reorgInfo.PhysicalTableID)
+			require.Equal(t, kv.Key("legacy-start"), reorgInfo.StartKey)
+			require.Equal(t, testCase.expectedEndKey, reorgInfo.EndKey)
+		})
+	}
+}
 
 func TestReorgCtxSetMaxProgress(t *testing.T) {
 	rc := &reorgCtx{}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70779

Problem Summary:

An ingest-mode `ADD INDEX` job started on v7.5 can persist a legacy checkpoint whose `physical_id`, `start_key`, and `end_key` describe the last globally safe import range. If the job is paused and resumed while upgrading to v8.3 or later, the newer checkpoint reader ignores the legacy range fields and can continue from a later reorg position. The job may then publish an index with missing entries.

### What changed and how does it work?

- Restore `start_key` and `end_key` in `ReorgCheckpoint` as decode-compatible legacy fields. They are omitted from newly written checkpoints.
- Read the complete checkpoint when recovering an ingest reorg job.
- When legacy range fields are present, restore the checkpoint physical table ID and full safe range through `overwriteLegacyReorgInfoFromCheckpoint`.
- Preserve the current per-physical-table checkpoint behavior when the legacy fields are absent, including the original behavior for a missing checkpoint.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where an ingest-mode `ADD INDEX` job resumed during an upgrade could publish an inconsistent index.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of reorganization jobs from existing checkpoints.
  - Preserved legacy start and end key ranges when restoring interrupted operations.
  - Ensured physical table and key-range information is correctly restored across supported versions.
  - Improved compatibility when checkpoint data is missing or uses older metadata formats.
- **Tests**
  - Added coverage for decoding and applying legacy checkpoint data.
  - Verified checkpoint key ranges and physical table information survive serialization and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->