### PR TITLE
executor, util: fix hash join v2 null build key

### DIFF
--- a/pkg/executor/join/anti_semi_join_probe_test.go
+++ b/pkg/executor/join/anti_semi_join_probe_test.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -287,6 +288,51 @@ func TestAntiSemiJoinBasic(t *testing.T) {
 	testAntiSemiJoin(t, false, true, false)  // Left side build with other condition
 	testAntiSemiJoin(t, true, false, false)  // Right side build without other condition
 	testAntiSemiJoin(t, true, true, false)   // Right side build with other condition
+}
+
+func TestAntiSemiJoinTypeNullBuildKey(t *testing.T) {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().InitChunkSize = 1
+	ctx.GetSessionVars().MaxChunkSize = 1
+
+	nullTp := types.NewFieldType(mysql.TypeNull)
+	blobTp := types.NewFieldType(mysql.TypeBlob)
+	leftSchema := buildSchema([]*types.FieldType{nullTp})
+	rightSchema := buildSchema([]*types.FieldType{blobTp})
+
+	leftChk := chunk.NewChunkWithCapacity([]*types.FieldType{nullTp}, 1)
+	leftChk.AppendNull(0)
+	rightChk := chunk.NewChunkWithCapacity([]*types.FieldType{blobTp}, 1)
+	rightChk.AppendBytes(0, []byte{})
+
+	leftDataSource := &testutil.MockDataSource{
+		BaseExecutor: exec.NewBaseExecutor(ctx, leftSchema, 0),
+		GenData:      []*chunk.Chunk{leftChk},
+	}
+	rightDataSource := &testutil.MockDataSource{
+		BaseExecutor: exec.NewBaseExecutor(ctx, rightSchema, 0),
+		GenData:      []*chunk.Chunk{rightChk},
+	}
+	leftDataSource.PrepareChunks()
+	rightDataSource.PrepareChunks()
+
+	leftKey := &expression.Column{Index: 0, RetType: nullTp}
+	rightKey := &expression.Column{Index: 0, RetType: blobTp}
+	info := &hashJoinInfo{
+		ctx:              ctx,
+		schema:           leftSchema,
+		leftExec:         leftDataSource,
+		rightExec:        rightDataSource,
+		joinType:         base.AntiSemiJoin,
+		rightAsBuildSide: false,
+		buildKeys:        []*expression.Column{leftKey},
+		probeKeys:        []*expression.Column{rightKey},
+		lUsed:            []int{0},
+	}
+
+	result := getSortedResults(t, buildHashJoinV2Exec(info), []*types.FieldType{nullTp})
+	require.Len(t, result, 1)
+	require.True(t, result[0].IsNull(0))
 }
 
 func TestAntiSemiJoinDuplicateKeys(t *testing.T) {

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -619,6 +619,9 @@ func preAllocForSerializedKeyBuffer(
 				serializedKeyLens[j] += sizeByteNum + int(column.GetJSON(physicalRowindex).CalculateHashValueSize())
 			}
 		case mysql.TypeNull:
+			for _, physicalRowIndex := range usedRows {
+				canSkip(physicalRowIndex)
+			}
 		default:
 			return serializedKeysBuffer, errors.Errorf("unsupport column type for pre-alloc %d", tps[i].GetType())
 		}
@@ -836,6 +839,7 @@ func serializeKeysImpl(
 				serializedKeys[logicalRowIndex] = append(serializedKeys[logicalRowIndex], jsonHashBuffer...)
 			}
 		case mysql.TypeNull:
+			// TODO: NULL-safe equal joins need to serialize TypeNull as a valid join key.
 		default:
 			return errors.Errorf("unsupport column type for encode %d", tp.GetType())
 		}

--- a/tests/integrationtest/r/executor/jointest/hash_join.result
+++ b/tests/integrationtest/r/executor/jointest/hash_join.result
@@ -382,3 +382,18 @@ NULL	5
 2	2
 3	NULL
 3	1
+set @@tidb_hash_join_version = optimized;
+drop table if exists t0;
+create table t0(c0 BLOB(249));
+insert into t0 values ('');
+select v.c0
+from (select NULL as c0 from t0) v
+where v.c0 NOT IN (
+select t0.c0
+from t0
+where t0.c0 = v.c0
+);
+c0
+NULL
+drop table t0;
+set @@tidb_hash_join_version = default;

--- a/tests/integrationtest/t/executor/jointest/hash_join.test
+++ b/tests/integrationtest/t/executor/jointest/hash_join.test
@@ -201,3 +201,18 @@ select * from t1 where exists (select 1 from t2 where t1.col0 = t2.col0) order b
 select * from t1 where not exists (select 1 from t2 where t1.col0 = t2.col0) order by t1.col0, t1.col1;
 select * from t1 where exists (select 1 from t2 where t1.col0 = t2.col0 and t1.col1 > t2.col1) order by t1.col0, t1.col1;
 select * from t1 where not exists (select 1 from t2 where t1.col0 = t2.col0 and t1.col1 > t2.col1) order by t1.col0, t1.col1;
+
+# https://github.com/pingcap/tidb/issues/70672
+set @@tidb_hash_join_version = optimized;
+drop table if exists t0;
+create table t0(c0 BLOB(249));
+insert into t0 values ('');
+select v.c0
+from (select NULL as c0 from t0) v
+where v.c0 NOT IN (
+    select t0.c0
+    from t0
+    where t0.c0 = v.c0
+);
+drop table t0;
+set @@tidb_hash_join_version = default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, ...]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70672

Problem Summary:

Hash Join V2 incorrectly treats a `TypeNull` build key as a valid serialized key. When the probe key is an empty binary string, the empty serialized keys collide and an anti semi join can incorrectly filter out the NULL build row.

### What changed and how does it work?

Mark rows with `TypeNull` join keys in `nullVector` during serialized-key pre-allocation, so they are excluded from the valid join-key set and are not matched against empty binary keys. Add unit and integration regression tests for the left-build anti semi join case from #70672.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix incorrect filtering of NULL rows in Hash Join V2 anti semi joins when the probe key is an empty binary string.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `NOT IN` and anti-join handling when comparisons involve `NULL` values and empty BLOB values.
  * Corrected results for optimized hash joins in these edge cases.

* **Tests**
  * Added coverage for `NULL`-typed join keys and correlated `NOT IN` queries involving BLOB columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->