### PR TITLE
ddl: fix wait fts ready in ddl add index

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1096,7 +1096,15 @@ func (*worker) checkColumnarIndexProcessFromTiKV(jobCtx *jobContext, tbl table.T
 		}
 		tikvStores[store.Store.ID] = store
 	}
-	progress, err := infosync.CalculateColumnarIndexProgress(tbl.Meta().ID, indexID, tikvStores)
+	indexInfo := tbl.Meta().FindIndexByID(indexID)
+	if indexInfo == nil {
+		return false, 0, errors.Errorf("could not find indexInfo by %d", indexID)
+	}
+	columnarIndexType := indexInfo.GetColumnarIndexType()
+	if columnarIndexType == model.ColumnarIndexTypeNA {
+		return false, 0, errors.Trace(dbterror.ErrUnsupportedAddColumnarIndex.GenWithStackByArgs("Columnar does not support index types."))
+	}
+	progress, err := infosync.CalculateColumnarIndexProgress(tbl.Meta().ID, indexID, columnarIndexType, tikvStores)
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -950,7 +950,7 @@ func CleanTiFlashProgressCache() {
 }
 
 // CalculateColumnarIndexProgress calculates columnar index progress
-func CalculateColumnarIndexProgress(tableID, indexID int64, tikvStores map[int64]pdhttp.StoreInfo) (float64, error) {
+func CalculateColumnarIndexProgress(tableID, indexID int64, columnarIndexType model.ColumnarIndexType, tikvStores map[int64]pdhttp.StoreInfo) (float64, error) {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -969,15 +969,24 @@ func CalculateColumnarIndexProgress(tableID, indexID int64, tikvStores map[int64
 			}
 			continue
 		}
-		indexReady += columnarStatus.VectorIndexReady
+		switch columnarIndexType {
+		case model.ColumnarIndexTypeFulltext:
+			if !columnarStatus.HasFtsIndexReady {
+				return 0, errors.Errorf("fts-index-ready not found in TiKV columnar_status response from %s (store %d); please check TiKV version", addr, storeStat.Store.ID)
+			}
+			indexReady += columnarStatus.FtsIndexReady
+		default:
+			indexReady += columnarStatus.VectorIndexReady
+		}
 		total += columnarStatus.Total
 	}
 	if total == 0 {
 		return 0, nil
 	}
-	logutil.BgLogger().Debug("CalculateColumnarIndexProgress", zap.Int64("tableID", tableID), zap.Int64("indexID", indexID), zap.Uint("indexReady", indexReady), zap.Uint("total", total), zap.Float64("progress", float64(indexReady)/float64(total)))
+	progress := float64(indexReady) / float64(total)
+	logutil.BgLogger().Debug("CalculateColumnarIndexProgress", zap.Int64("tableID", tableID), zap.Int64("indexID", indexID), zap.String("columnarIndexType", columnarIndexType.SQLName()), zap.Uint("indexReady", indexReady), zap.Uint("total", total), zap.Float64("progress", progress))
 
-	return float64(indexReady) / float64(total), nil
+	return progress, nil
 }
 
 // SetTiFlashGroupConfig is a helper function to set tiflash rule group config

--- a/pkg/store/helper/BUILD.bazel
+++ b/pkg/store/helper/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     ],
     embed = [":helper"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/infoschema/context",

--- a/pkg/store/helper/helper.go
+++ b/pkg/store/helper/helper.go
@@ -970,7 +970,10 @@ func SyncTableSchemaToTiFlash(statusAddress string, keyspaceID tikv.KeyspaceID, 
 type ColumnarStatusResp struct {
 	Ready            uint `json:"ready"`
 	VectorIndexReady uint `json:"vector-index-ready"`
+	FtsIndexReady    uint `json:"fts-index-ready"`
 	Total            uint `json:"total"`
+	// HasFtsIndexReady reports whether the JSON payload contains "fts-index-ready".
+	HasFtsIndexReady bool `json:"-"`
 }
 
 // CollectColumnarStatusWithCtx collects the columnar status from the TiKV status API.
@@ -1010,9 +1013,23 @@ func CollectColumnarStatusWithCtx(ctx context.Context, statusAddress string, key
 	if err != nil {
 		return columnarStatus, errors.Trace(err)
 	}
-	err = json.Unmarshal(body, &columnarStatus)
+	type columnarStatusPayload struct {
+		Ready            uint  `json:"ready"`
+		VectorIndexReady uint  `json:"vector-index-ready"`
+		FtsIndexReady    *uint `json:"fts-index-ready"`
+		Total            uint  `json:"total"`
+	}
+	var payload columnarStatusPayload
+	err = json.Unmarshal(body, &payload)
 	if err != nil {
 		return columnarStatus, errors.Trace(err)
+	}
+	columnarStatus.Ready = payload.Ready
+	columnarStatus.VectorIndexReady = payload.VectorIndexReady
+	columnarStatus.Total = payload.Total
+	if payload.FtsIndexReady != nil {
+		columnarStatus.HasFtsIndexReady = true
+		columnarStatus.FtsIndexReady = *payload.FtsIndexReady
 	}
 	if columnarStatus.Ready != columnarStatus.Total {
 		logutil.BgLogger().Info("columnar status not ready", zap.Uint("ready", columnarStatus.Ready), zap.Uint("total", columnarStatus.Total))

--- a/pkg/store/helper/helper_test.go
+++ b/pkg/store/helper/helper_test.go
@@ -645,6 +645,57 @@ func TestComputeTiFlashStatus(t *testing.T) {
 	}
 }
 
+func TestCollectColumnarStatusFTSIndexReady(t *testing.T) {
+	testCases := []struct {
+		name             string
+		response         string
+		ftsIndexReady    uint
+		hasFtsIndexReady bool
+	}{
+		{
+			name:             "present",
+			response:         `{"ready":3,"vector-index-ready":2,"fts-index-ready":1,"total":4}`,
+			ftsIndexReady:    1,
+			hasFtsIndexReady: true,
+		},
+		{
+			name:             "present zero",
+			response:         `{"ready":3,"vector-index-ready":2,"fts-index-ready":0,"total":4}`,
+			ftsIndexReady:    0,
+			hasFtsIndexReady: true,
+		},
+		{
+			name:             "missing on older TiKV",
+			response:         `{"ready":3,"vector-index-ready":2,"total":4}`,
+			ftsIndexReady:    0,
+			hasFtsIndexReady: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/kvengine/columnar_status", r.URL.Path)
+				require.Equal(t, "7", r.URL.Query().Get("keyspace_id"))
+				require.Equal(t, "9", r.URL.Query().Get("table_id"))
+				require.Equal(t, "11", r.URL.Query().Get("index_id"))
+				_, err := w.Write([]byte(testCase.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			indexID := int64(11)
+			status, err := helper.CollectColumnarStatusWithCtx(context.Background(), strings.TrimPrefix(server.URL, "http://"), 7, 9, &indexID)
+			require.NoError(t, err)
+			require.Equal(t, uint(3), status.Ready)
+			require.Equal(t, uint(2), status.VectorIndexReady)
+			require.Equal(t, testCase.ftsIndexReady, status.FtsIndexReady)
+			require.Equal(t, testCase.hasFtsIndexReady, status.HasFtsIndexReady)
+			require.Equal(t, uint(4), status.Total)
+		})
+	}
+}
+
 // TestTableRange tests the first part of GetPDRegionStats.
 func TestTableRange(t *testing.T) {
 	startKey := tablecodec.GenTableRecordPrefix(1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70800 

Problem Summary:
Wait fulltext index ready timeout in add fulltext index ddl.

### What changed and how does it work?
Fix the status response fields from tikv server.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

### Manual test
```
CREATE TABLE t (id INT PRIMARY KEY, title TEXT);
ALTER TABLE t SET TIFLASH REPLICA 1;
-- wait information_schema.tiflash_replica AVAILABLE=1
INSERT INTO t VALUES (1, 'small payload');
ALTER TABLE t ADD FULLTEXT INDEX ft_title(title);
```
```
  Verified fixed.

  With TiFlash replica AVAILABLE=1 and one existing row (small payload), this statement:

  ALTER TABLE t ADD FULLTEXT INDEX ft_title(title);

  completed in 0.66s.

  DDL job 20 reached add columnar index / public / synced, and SHOW CREATE TABLE contains FULLTEXT INDEX ft_title(title).

  All three TiKV status servers reported:

  {"ready":1,"vector-index-ready":0,"fts-index-ready":1,"total":1}

  TiDB now selects fts-index-ready for FULLTEXT indexes instead of incorrectly using vector-index-ready. The small-table DDL
  hang is resolved; no CSE memtable flush is required.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved columnar index progress reporting by distinguishing full-text and vector indexes.
  * Added validation to reject unsupported index types.
  * Added handling for TiKV responses where full-text index readiness information is unavailable.
  * Preserved accurate readiness values when the full-text status is present, including values of 0 and 1.

* **Tests**
  * Expanded coverage for columnar status responses and compatibility with older TiKV versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->