### PR TITLE
pr template: optimize the release note guidance in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,11 +49,11 @@ Documentation
 
 ### Release note
 
-<!-- Select this option for changes visible to TiDB users or operators, such as compatibility changes, improvements, bug fixes, or new features. Leave this option unselected for internal changes with no user-facing impact, such as debug changes, flaky test fixes, code refactoring, or internal configurations that are not exposed to users. -->
+<!-- Select this option for changes that affect TiDB users or operators, such as compatibility changes, improvements, bug fixes, or new features. Leave this option unselected for internal changes with no user-facing impact, such as debugging changes, flaky test fixes, code refactoring, or internal configuration changes that are not exposed to users. -->
 
 - [ ] Needs to be included in the user-facing release notes
 
-If selected, write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**, to capture the intended user-facing impact), or leave it as `None` (in which case the release note bot will automatically generate one when preparing the release notes file).
+If selected, either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**, to capture the intended user-facing impact), or leave it as None to let the release note bot automatically generate one when preparing the release notes file.
 
 ```release-note
 None

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,7 +53,7 @@ Documentation
 
 - [ ] Needs to be included in the user-facing release notes
 
-<!-- If selected, you can either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**), or leave it as `None`, in which case the release note bot will automatically generate one when preparing the release notes file. -->
+If selected, you can either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**), or leave it as `None`, in which case the release note bot will automatically generate one when preparing the release notes file.
 
 ```release-note
 None

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,7 +53,7 @@ Documentation
 
 - [ ] Needs to be included in the user-facing release notes
 
-If selected, you can either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**), or leave it as `None`, in which case the release note bot will automatically generate one when preparing the release notes file.
+If selected, write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**, to capture the intended user-facing impact), or leave it as `None` (in which case the release note bot will automatically generate one when preparing the release notes file).
 
 ```release-note
 None

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,17 +45,15 @@ Side effects
 
 Documentation
 
-- [ ] Affects user behaviors
-- [ ] Contains syntax changes
-- [ ] Contains variable changes
-- [ ] Contains experimental features
-- [ ] Changes MySQL compatibility
+- [ ] Affects user documentation at <https://docs.pingcap.com/>
 
 ### Release note
 
-<!-- compatibility change, improvement, bugfix, and new feature need a release note -->
+<!-- Select this option for changes visible to TiDB users or operators, such as compatibility changes, improvements, bug fixes, or new features. Leave this option unselected for internal changes with no user-facing impact, such as debug changes, flaky test fixes, code refactoring, or internal configurations that are not exposed to users. -->
 
-Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.
+- [ ] Needs to be included in the user-facing release notes
+
+<!-- If selected, you can either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**), or leave it as `None`, in which case the release note bot will automatically generate one when preparing the release notes file. -->
 
 ```release-note
 None


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70831

Problem Summary:

The pull request template does not clearly guide contributors to indicate whether a change needs a user-facing release note. This makes later release note preparation, including AI-assisted generation, rely more heavily on inference from the PR context.

### What changed and how does it work?

- Simplify the documentation-impact checklist.
- Add a dedicated checkbox for user-facing release notes.
- Add concise hidden guidance that distinguishes user-facing changes from internal-only changes.
- Allow contributors to provide a release note directly or leave `None` for automated generation during release note preparation.

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user documentation at <https://docs.pingcap.com/>

### Release note

<!-- Select this option for changes visible to TiDB users or operators, such as compatibility changes, improvements, bug fixes, or new features. Leave this option unselected for internal changes with no user-facing impact, such as debug changes, flaky test fixes, code refactoring, or internal configurations that are not exposed to users. -->

- [ ] Needs to be included in the user-facing release notes

If selected, you can either write a release note below following [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) (**recommended**), or leave it as `None`, in which case the release note bot will automatically generate one when preparing the release notes file.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified the pull request template’s documentation checklist by retaining only the user-documentation checkbox.
  - Updated the release-note section with a checkbox indicating whether changes should appear in user-facing release notes.
  - Added visible guidance explaining when to select the checkbox and how release notes are handled when it is unselected or set to `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->