### PR TITLE
executor, infoschema: expose phase-specific backoff types

### DIFF
--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -943,6 +943,7 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 	})
 	var row []types.Datum
 	user := ""
+	var copBackoffTypes []string
 	tz := sctx.GetSessionVars().Location()
 	startFlag := false
 	for index, line := range log {
@@ -953,6 +954,7 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 		if !startFlag && strings.HasPrefix(line, variable.SlowLogStartPrefixStr) {
 			row = make([]types.Datum, len(e.outputCols))
 			user = ""
+			copBackoffTypes = copBackoffTypes[:0]
 			valid := e.setColumnValue(sctx, row, tz, variable.SlowLogTimeStr, line[len(variable.SlowLogStartPrefixStr):], e.checker, fileLine)
 			if valid {
 				startFlag = true
@@ -984,6 +986,12 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 					host := parseUserOrHostValue(fields[1])
 					valid = e.setColumnValue(sctx, row, tz, variable.SlowLogHostStr, host, e.checker, fileLine)
 				} else if strings.HasPrefix(line, variable.SlowLogCopBackoffPrefix) {
+					field, _, ok := strings.Cut(line, variable.SlowLogSpaceMarkStr)
+					const totalTimesSuffix = "_total_times"
+					if ok && len(field) > len(variable.SlowLogCopBackoffPrefix)+len(totalTimesSuffix) && strings.HasSuffix(field, totalTimesSuffix) {
+						backoffType := field[len(variable.SlowLogCopBackoffPrefix) : len(field)-len(totalTimesSuffix)]
+						copBackoffTypes = append(copBackoffTypes, backoffType)
+					}
 					valid = e.setColumnValue(sctx, row, tz, variable.SlowLogBackoffDetail, line, e.checker, fileLine)
 				} else if strings.HasPrefix(line, variable.SlowLogWarnings+variable.SlowLogSpaceMarkStr) {
 					line = line[len(variable.SlowLogWarnings+variable.SlowLogSpaceMarkStr):]
@@ -1023,6 +1031,11 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 				}
 				// Get the sql string, and mark the start flag to false.
 				_ = e.setColumnValue(sctx, row, tz, variable.SlowLogQuerySQLStr, string(hack.Slice(line)), e.checker, fileLine)
+				if len(copBackoffTypes) > 0 {
+					slices.Sort(copBackoffTypes)
+					copBackoffTypes = slices.Compact(copBackoffTypes)
+					_ = e.setColumnValue(sctx, row, tz, execdetails.CopBackoffTypesStr, fmt.Sprintf("%v", copBackoffTypes), e.checker, fileLine)
+				}
 				e.setDefaultValue(row)
 				e.memConsume(types.EstimatedMemUsage(row, 1))
 				data = append(data, row)
@@ -1153,7 +1166,8 @@ func getColumnValueFactoryByName(colName string, columnIdx int) (slowQueryColumn
 			row[columnIdx] = types.NewFloat64Datum(v)
 			return true, nil
 		}, nil
-	case variable.SlowLogUserStr, variable.SlowLogHostStr, execdetails.BackoffTypesStr, variable.SlowLogDBStr, variable.SlowLogIndexNamesStr, variable.SlowLogDigestStr,
+	case variable.SlowLogUserStr, variable.SlowLogHostStr, execdetails.BackoffTypesStr, execdetails.PrewriteBackoffTypesStr,
+		execdetails.CommitBackoffTypesStr, execdetails.CopBackoffTypesStr, variable.SlowLogDBStr, variable.SlowLogIndexNamesStr, variable.SlowLogDigestStr,
 		variable.SlowLogStatsInfoStr, variable.SlowLogCopProcAddr, variable.SlowLogCopWaitAddr, variable.SlowLogPlanDigest,
 		variable.SlowLogPrevStmt, variable.SlowLogQuerySQLStr, variable.SlowLogWarnings, variable.SlowLogSessAliasStr,
 		variable.SlowLogResourceGroup, variable.SlowLogRequestUnitV2Detail, execdetails.ReadPoolTaskDetailsStr:

--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -251,6 +251,16 @@ func TestSlowQuery(t *testing.T) {
 	f, err := os.CreateTemp("", "tidb-slow-*.log")
 	require.NoError(t, err)
 	_, err = f.WriteString(`
+# Time: 2018-01-01T00:00:00+08:00
+# Backoff_types: [txnLock]
+select /* legacy backoff types */ 1;
+# Time: 2018-01-01T00:00:01+08:00
+# Prewrite_Backoff_types: [txnLock]
+# Commit_Backoff_types: [regionMiss]
+# Cop_backoff_txnLockFast_total_times: 2 Cop_backoff_txnLockFast_total_time: 0.2 Cop_backoff_txnLockFast_max_time: 0.1 Cop_backoff_txnLockFast_max_addr: 127.0.0.1 Cop_backoff_txnLockFast_avg_time: 0.1 Cop_backoff_txnLockFast_p90_time: 0.1
+# Cop_backoff_txnLockFast_total_times: 1 Cop_backoff_txnLockFast_total_time: 0.1
+# Cop_backoff_regionMiss_total_times: 1 Cop_backoff_regionMiss_total_time: 0.1 Cop_backoff_regionMiss_max_time: 0.1 Cop_backoff_regionMiss_max_addr: 127.0.0.1 Cop_backoff_regionMiss_avg_time: 0.1 Cop_backoff_regionMiss_p90_time: 0.1
+select /* phase-specific backoff types */ 1;
 # Time: 2019-01-01T00:00:00+08:00
 # Request_unit_v2: 123.45
 # Request_unit_v2_detail: total_ru:123.45, tidb_ru:100.00, tikv_ru:20.00, tiflash_ru:3.45
@@ -312,6 +322,16 @@ SELECT original_sql, bind_sql, default_db, status, create_time, update_time, cha
 
 	tk.MustExec("set @@time_zone='+08:00'")
 	tk.MustExec(fmt.Sprintf("set @@tidb_slow_query_file='%v'", f.Name()))
+	tk.MustQuery("select column_name from information_schema.columns where table_schema = 'INFORMATION_SCHEMA' " +
+		"and table_name = 'CLUSTER_SLOW_QUERY' and column_name in " +
+		"('PREWRITE_BACKOFF_TYPES', 'COMMIT_BACKOFF_TYPES', 'COP_BACKOFF_TYPES') order by ordinal_position").
+		Check(testkit.Rows("Prewrite_Backoff_types", "Commit_Backoff_types", "Cop_backoff_types"))
+	tk.MustQuery("select concat(backoff_types, '|', prewrite_backoff_types, '|', commit_backoff_types, '|', cop_backoff_types) " +
+		"from information_schema.slow_query where query = 'select /* legacy backoff types */ 1;'").
+		Check(testkit.Rows("[txnLock]|||"))
+	tk.MustQuery("select concat(backoff_types, '|', prewrite_backoff_types, '|', commit_backoff_types, '|', cop_backoff_types) " +
+		"from information_schema.slow_query where query = 'select /* phase-specific backoff types */ 1;'").
+		Check(testkit.Rows("|[txnLock]|[regionMiss]|[regionMiss txnLockFast]"))
 	tk.MustQuery("select count(*) from `information_schema`.`slow_query` where time > '2020-10-16 20:08:13' and time < '2020-10-16 21:08:13'").Check(testkit.Rows("1"))
 	tk.MustQuery("select count(*) from `information_schema`.`slow_query` where time > '2019-10-13 20:08:13' and time < '2020-10-16 21:08:13'").Check(testkit.Rows("2"))
 	// Cover tidb issue 34320

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -198,7 +198,7 @@ select * from t;`
 		`0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,23333,65536,0,0,0,30000,3000,10000,1000,500000,500005,300000,300005,0,0,,` +
 		`Cop_backoff_regionMiss_total_times: 200 Cop_backoff_regionMiss_total_time: 0.2 Cop_backoff_regionMiss_max_time: 0.2 Cop_backoff_regionMiss_max_addr: 127.0.0.1 Cop_backoff_regionMiss_avg_time: 0.2 Cop_backoff_regionMiss_p90_time: 0.2 Cop_backoff_rpcPD_total_times: 200 Cop_backoff_rpcPD_total_time: 0.2 Cop_backoff_rpcPD_max_time: 0.2 Cop_backoff_rpcPD_max_addr: 127.0.0.1 Cop_backoff_rpcPD_avg_time: 0.2 Cop_backoff_rpcPD_p90_time: 0.2 Cop_backoff_rpcTiKV_total_times: 200 Cop_backoff_rpcTiKV_total_time: 0.2 Cop_backoff_rpcTiKV_max_time: 0.2 Cop_backoff_rpcTiKV_max_addr: 127.0.0.1 Cop_backoff_rpcTiKV_avg_time: 0.2 Cop_backoff_rpcTiKV_p90_time: 0.2,` +
 		`0,0,1,0,1,1,0,default,2.158,2.123,0.05,0.01,0.021,1,1,150,total_ru:150.00, tidb_ru:0.00, tikv_ru:100.00, tiflash_ru:50.00,,60e9378c746d9a2be1c791047e008967cf252eb6de9167ad3aa6098fa2d523f4,` +
-		`,update t set i = 1;,null,select * from t;`
+		`,update t set i = 1;,null,,,[regionMiss rpcPD rpcTiKV],select * from t;`
 	require.Equal(t, expectRecordString, recordString)
 
 	// Issue 20928
@@ -221,7 +221,7 @@ select * from t;`
 		`0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,23333,65536,0,0,0,30000,3000,10000,1000,500000,500005,300000,300005,0,0,,` +
 		`Cop_backoff_regionMiss_total_times: 200 Cop_backoff_regionMiss_total_time: 0.2 Cop_backoff_regionMiss_max_time: 0.2 Cop_backoff_regionMiss_max_addr: 127.0.0.1 Cop_backoff_regionMiss_avg_time: 0.2 Cop_backoff_regionMiss_p90_time: 0.2 Cop_backoff_rpcPD_total_times: 200 Cop_backoff_rpcPD_total_time: 0.2 Cop_backoff_rpcPD_max_time: 0.2 Cop_backoff_rpcPD_max_addr: 127.0.0.1 Cop_backoff_rpcPD_avg_time: 0.2 Cop_backoff_rpcPD_p90_time: 0.2 Cop_backoff_rpcTiKV_total_times: 200 Cop_backoff_rpcTiKV_total_time: 0.2 Cop_backoff_rpcTiKV_max_time: 0.2 Cop_backoff_rpcTiKV_max_addr: 127.0.0.1 Cop_backoff_rpcTiKV_avg_time: 0.2 Cop_backoff_rpcTiKV_p90_time: 0.2,` +
 		`0,0,1,0,1,1,0,default,2.158,2.123,0.05,0.01,0.021,1,1,150,total_ru:150.00, tidb_ru:0.00, tikv_ru:100.00, tiflash_ru:50.00,,60e9378c746d9a2be1c791047e008967cf252eb6de9167ad3aa6098fa2d523f4,` +
-		`,update t set i = 1;,null,select * from t;`
+		`,update t set i = 1;,null,,,[regionMiss rpcPD rpcTiKV],select * from t;`
 	require.Equal(t, expectRecordString, recordString)
 
 	// fix sql contain '# ' bug

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -993,6 +993,9 @@ var slowQueryCols = []columnInfo{
 	{name: variable.SlowLogBinaryPlan, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
 	{name: variable.SlowLogPrevStmt, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
 	{name: variable.SlowLogSessionConnectAttrs, tp: mysql.TypeJSON, size: types.UnspecifiedLength},
+	{name: execdetails.PrewriteBackoffTypesStr, tp: mysql.TypeVarchar, size: 1024},
+	{name: execdetails.CommitBackoffTypesStr, tp: mysql.TypeVarchar, size: 1024},
+	{name: execdetails.CopBackoffTypesStr, tp: mysql.TypeVarchar, size: 1024},
 	{name: variable.SlowLogQuerySQLStr, tp: mysql.TypeLongBlob, size: types.UnspecifiedLength},
 }
 

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -159,6 +159,12 @@ const (
 	CommitBackoffTimeStr = "Commit_backoff_time"
 	// BackoffTypesStr means the backoff type.
 	BackoffTypesStr = "Backoff_types"
+	// PrewriteBackoffTypesStr means the backoff types during transaction prewrite.
+	PrewriteBackoffTypesStr = "Prewrite_Backoff_types"
+	// CommitBackoffTypesStr means the backoff types during transaction commit.
+	CommitBackoffTypesStr = "Commit_Backoff_types"
+	// CopBackoffTypesStr means the backoff types during coprocessor execution.
+	CopBackoffTypesStr = "Cop_backoff_types"
 	// SlowestPrewriteRPCDetailStr means the details of the slowest RPC during the transaction 2pc prewrite process.
 	SlowestPrewriteRPCDetailStr = "Slowest_prewrite_rpc_detail"
 	// CommitPrimaryRPCDetailStr means the details of the slowest RPC during the transaction 2pc commit process.
@@ -282,10 +288,10 @@ func (d ExecDetails) String() string {
 			parts = append(parts, CommitBackoffTimeStr+": "+strconv.FormatFloat(time.Duration(commitBackoffTime).Seconds(), 'f', -1, 64))
 		}
 		if len(commitDetails.Mu.PrewriteBackoffTypes) > 0 {
-			parts = append(parts, "Prewrite_"+BackoffTypesStr+": "+fmt.Sprintf("%v", commitDetails.Mu.PrewriteBackoffTypes))
+			parts = append(parts, PrewriteBackoffTypesStr+": "+fmt.Sprintf("%v", commitDetails.Mu.PrewriteBackoffTypes))
 		}
 		if len(commitDetails.Mu.CommitBackoffTypes) > 0 {
-			parts = append(parts, "Commit_"+BackoffTypesStr+": "+fmt.Sprintf("%v", commitDetails.Mu.CommitBackoffTypes))
+			parts = append(parts, CommitBackoffTypesStr+": "+fmt.Sprintf("%v", commitDetails.Mu.CommitBackoffTypes))
 		}
 		if commitDetails.Mu.SlowestPrewrite.ReqTotalTime > 0 {
 			parts = append(parts, SlowestPrewriteRPCDetailStr+": {total:"+strconv.FormatFloat(commitDetails.Mu.SlowestPrewrite.ReqTotalTime.Seconds(), 'f', 3, 64)+
@@ -398,10 +404,10 @@ func (d ExecDetails) ToZapFields() (fields []zap.Field) {
 			fields = append(fields, zap.String("commit_backoff_time", fmt.Sprintf("%v", strconv.FormatFloat(time.Duration(commitBackoffTime).Seconds(), 'f', -1, 64)+"s")))
 		}
 		if len(commitDetails.Mu.PrewriteBackoffTypes) > 0 {
-			fields = append(fields, zap.String("Prewrite_"+BackoffTypesStr, fmt.Sprintf("%v", commitDetails.Mu.PrewriteBackoffTypes)))
+			fields = append(fields, zap.String(PrewriteBackoffTypesStr, fmt.Sprintf("%v", commitDetails.Mu.PrewriteBackoffTypes)))
 		}
 		if len(commitDetails.Mu.CommitBackoffTypes) > 0 {
-			fields = append(fields, zap.String("Commit_"+BackoffTypesStr, fmt.Sprintf("%v", commitDetails.Mu.CommitBackoffTypes)))
+			fields = append(fields, zap.String(CommitBackoffTypesStr, fmt.Sprintf("%v", commitDetails.Mu.CommitBackoffTypes)))
 		}
 		if commitDetails.Mu.SlowestPrewrite.ReqTotalTime > 0 {
 			fields = append(fields, zap.String(SlowestPrewriteRPCDetailStr, "total:"+strconv.FormatFloat(commitDetails.Mu.SlowestPrewrite.ReqTotalTime.Seconds(), 'f', 3, 64)+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70832

Problem Summary:

The slow-query tables expose only the legacy `BACKOFF_TYPES` column. They ignore the phase-specific prewrite and commit fields already written to slow logs, and coprocessor backoff types are available only inside `BACKOFF_DETAIL`.

### What changed and how does it work?

- add `PREWRITE_BACKOFF_TYPES`, `COMMIT_BACKOFF_TYPES`, and `COP_BACKOFF_TYPES` to `INFORMATION_SCHEMA.SLOW_QUERY` and `CLUSTER_SLOW_QUERY`
- map the existing prewrite and commit slow-log fields to their corresponding columns
- derive coprocessor types from existing `Cop_backoff_<type>_total_times` detail lines, then sort and deduplicate them
- preserve the existing `BACKOFF_TYPES` semantics for historical slow logs

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add phase-specific prewrite, commit, and coprocessor backoff type columns to the `INFORMATION_SCHEMA.SLOW_QUERY` and `CLUSTER_SLOW_QUERY` tables.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slow query results now include separate prewrite, commit, and coprocessor backoff type details.
  * Coprocessor backoff types are collected, deduplicated, and presented in a consistent order.
  * Added corresponding columns to slow-query views, including `SLOW_QUERY` and `CLUSTER_SLOW_QUERY`.

* **Bug Fixes**
  * Improved parsing and reporting of coprocessor backoff information in slow query logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->