### PR TITLE
planner: recompute CTE consumer count during preprocessing

### DIFF
--- a/pkg/executor/test/plancache/BUILD.bazel
+++ b/pkg/executor/test/plancache/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "plan_cache_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/config",
         "//pkg/expression",
@@ -17,6 +17,7 @@ go_test(
         "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/planner/core",
+        "//pkg/planner/core/base",
         "//pkg/session/sessmgr",
         "//pkg/sessionctx/vardef",
         "//pkg/testkit",

--- a/pkg/executor/test/plancache/plan_cache_test.go
+++ b/pkg/executor/test/plancache/plan_cache_test.go
@@ -27,11 +27,55 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/session/sessmgr"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPreparedCTERemainsInlinedAfterUnrelatedDDL(t *testing.T) {
+	for _, planCacheEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("plan_cache_%t", planCacheEnabled), func(t *testing.T) {
+			store := testkit.CreateMockStore(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec(fmt.Sprintf("set tidb_enable_prepared_plan_cache = %t", planCacheEnabled))
+			tk.MustExec("set tidb_opt_force_inline_cte = off")
+			tk.MustExec("create table source (a int)")
+			tk.MustExec("insert into source values (1)")
+
+			stmtID, _, _, err := tk.Session().PrepareStmt("with cte as (select * from source) select * from cte where a = ?")
+			require.NoError(t, err)
+
+			currentPlan := func() string {
+				stmtPlan := tk.Session().GetSessionVars().StmtCtx.GetPlan()
+				plan, ok := stmtPlan.(base.Plan)
+				require.Truef(t, ok, "statement plan has type %T, want base.Plan", stmtPlan)
+				return plannercore.ToString(plan)
+			}
+			executePrepared := func() string {
+				rs, err := tk.Session().ExecutePreparedStmt(context.Background(), stmtID, expression.Args2Expressions4Test(1))
+				require.NoError(t, err)
+				tk.ResultSetToResult(rs, "execute prepared CTE").Check(testkit.Rows("1"))
+				return currentPlan()
+			}
+
+			initialPlan := executePrepared()
+			require.NotContains(t, initialPlan, "CTEReader(")
+
+			ddlTK := testkit.NewTestKit(t, store)
+			ddlTK.MustExec("use test")
+			ddlTK.MustExec("create table unrelated (a int)")
+
+			planAfterDDL := executePrepared()
+			tk.MustQuery("with cte as (select * from source) select * from cte where a = 1").Check(testkit.Rows("1"))
+			directQueryPlanAfterDDL := currentPlan()
+			require.NotContains(t, directQueryPlanAfterDDL, "CTEReader(")
+			require.NotContains(t, planAfterDDL, "CTEReader(")
+		})
+	}
+}
 
 func TestPointGetPreparedPlan(t *testing.T) {
 	store := testkit.CreateMockStore(t)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -424,8 +424,13 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		with := p.preprocessWith
 		beforeOffset := len(with.cteCanUsed)
 		with.cteBeforeOffset = append(with.cteBeforeOffset, beforeOffset)
-		if cteNode, exist := node.(*ast.CommonTableExpression); exist && cteNode.IsRecursive {
-			with.cteCanUsed = append(with.cteCanUsed, cteNode.Name.L)
+		if cteNode, exist := node.(*ast.CommonTableExpression); exist {
+			// Preprocess can run repeatedly on a prepared statement's AST after schema changes.
+			// Recompute the consumer count instead of accumulating the result from an earlier run.
+			cteNode.ConsumerCount = 0
+			if cteNode.IsRecursive {
+				with.cteCanUsed = append(with.cteCanUsed, cteNode.Name.L)
+			}
 		}
 	case *ast.BeginStmt:
 		// If the begin statement was like following:

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -476,6 +477,46 @@ func TestPreprocessCTE(t *testing.T) {
 		err = stmts[0].Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &rs))
 		require.NoError(t, err)
 		require.Equal(t, tc.after, rs.String())
+	}
+}
+
+func TestPreprocessCTEConsumerCountIsIdempotent(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int)")
+
+	testCases := []struct {
+		name          string
+		sql           string
+		consumerCount int
+	}{
+		{
+			name:          "single consumer",
+			sql:           "with cte as (select * from t) select * from cte",
+			consumerCount: 1,
+		},
+		{
+			name:          "multiple consumers",
+			sql:           "with cte as (select * from t) select * from cte c1 join cte c2",
+			consumerCount: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt(testCase.sql, "", "")
+			require.NoError(t, err)
+			selectStmt := stmt.(*ast.SelectStmt)
+			cte := selectStmt.With.CTEs[0]
+
+			for range 2 {
+				nodeW := resolve.NewNodeW(stmt)
+				err = core.Preprocess(context.Background(), tk.Session(), nodeW)
+				require.NoError(t, err)
+				require.Equal(t, testCase.consumerCount, cte.ConsumerCount)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70759

Problem Summary:

Repeated preprocessing of a prepared statement AST accumulated the CTE consumer count. After an unrelated schema change caused the statement to be rebuilt, a single-reference CTE could therefore be materialized instead of inlined.

### What changed and how does it work?

Reset each CTE's consumer count when entering the CTE during preprocessing, so every preprocessing pass recomputes the count from the AST structure. Add regression coverage for repeated preprocessing and prepared-statement execution before and after unrelated DDL, with the prepared plan cache both disabled and enabled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where a prepared statement could incorrectly materialize a single-reference CTE after an unrelated DDL statement.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prepared CTE queries retaining incorrect plans after unrelated DDL operations on another connection.
  * Ensured CTE processing remains consistent when queries are analyzed repeatedly, preserving correct plan behavior.

* **Tests**
  * Added coverage for prepared CTE plan stability with plan caching enabled and disabled.
  * Added validation that repeated preprocessing produces consistent CTE consumer counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->