### PR TITLE
test: stabilize flaky TestPlanStatsLoadTimeout

### DIFF
--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -378,6 +378,7 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 		require.NoError(t, err)
 		testKit.MustExec("set global tidb_stats_load_pseudo_timeout=false")
 		nodeW := resolve.NewNodeW(stmt)
+		require.NoError(t, executor.ResetContextOfStmt(ctx, stmt))
 		_, _, err = planner.Optimize(context.TODO(), ctx, nodeW, is)
 		require.Error(t, err) // fail sql for timeout when pseudo=false
 
@@ -391,6 +392,7 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 		testKit.MustExec(sql)
 		failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/assertSyncWaitFailed")
 
+		require.NoError(t, executor.ResetContextOfStmt(ctx, stmt))
 		plan, _, err := planner.Optimize(context.TODO(), ctx, nodeW, is)
 		require.NoError(t, err) // not fail sql for timeout when pseudo=true
 		switch pp := plan.(type) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/69892

Problem Summary:
Flaky test `TestPlanStatsLoadTimeout` in `pkg/planner/core/casetest/planstats` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Direct optimizer invocation skipped normal per-statement context reset, making sync stats-load timeout behavior depend on stale test harness state.

#### Fix

Resetting StmtCtx preserves timeout and pseudo-fallback assertions while matching normal SQL execution semantics.

#### Verification

Spec:
- target: `pkg/planner/core/casetest/planstats :: TestPlanStatsLoadTimeout`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
package passed.
build passed.
lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package: PASS
- build: PASS
- lint: PASS

Commands:
- `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/planstats -json -run '^TestPlanStatsLoadTimeout$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/planstats -json -count=1`
- `make build`
- `make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #69892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plan statistics timeout test handling by resetting statement context before optimization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->