### PR TITLE
autoid, ddl: fix duplicate IDs during cross-database rename

### DIFF
--- a/pkg/autoid_service/autoid.go
+++ b/pkg/autoid_service/autoid.go
@@ -48,17 +48,92 @@ const (
 	autoIDLeaderPath = "tidb/autoid/leader"
 )
 
-type autoIDKey struct {
-	dbID  int64
-	tblID int64
-}
-
 type autoIDValue struct {
 	sync.Mutex
-	base       int64
-	end        int64
-	isUnsigned bool
-	token      chan struct{}
+	base        int64
+	end         int64
+	currentDBID int64
+	isUnsigned  bool
+	token       chan struct{}
+}
+
+func (alloc *autoIDValue) getIncrementIDAccessor(
+	ctx context.Context,
+	txn kv.Transaction,
+	requestDBID int64,
+	tblID int64,
+) (meta.AutoIDAccessor, int64, error) {
+	m := meta.NewMutator(txn)
+	dbID, err := alloc.resolveCurrentDBID(ctx, m, requestDBID, tblID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return m.GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5), dbID, nil
+}
+
+func (alloc *autoIDValue) resolveCurrentDBID(ctx context.Context, m *meta.Mutator, requestDBID, tblID int64) (int64, error) {
+	candidates := make([]int64, 0, 2)
+	addCandidate := func(dbID int64) {
+		if dbID == 0 {
+			return
+		}
+		for _, candidate := range candidates {
+			if candidate == dbID {
+				return
+			}
+		}
+		candidates = append(candidates, dbID)
+	}
+	addCandidate(alloc.currentDBID)
+	addCandidate(requestDBID)
+
+	requestDBExists := false
+	for _, dbID := range candidates {
+		tblInfo, err := m.GetTable(dbID, tblID)
+		if err != nil {
+			if meta.ErrDBNotExists.Equal(err) {
+				continue
+			}
+			return 0, errors.Trace(err)
+		}
+		if dbID == requestDBID {
+			requestDBExists = true
+		}
+		if tblInfo != nil {
+			return dbID, nil
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return 0, errors.Trace(err)
+	}
+	dbInfos, err := m.ListDatabases()
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	for _, dbInfo := range dbInfos {
+		if err := ctx.Err(); err != nil {
+			return 0, errors.Trace(err)
+		}
+		tables, err := m.ListSimpleTables(dbInfo.ID)
+		if err != nil {
+			if meta.ErrDBNotExists.Equal(err) {
+				continue
+			}
+			return 0, errors.Trace(err)
+		}
+		for _, tbl := range tables {
+			if tbl.ID == tblID {
+				return dbInfo.ID, nil
+			}
+		}
+	}
+	// Compatibility path for callers that initialize an auto ID before the table
+	// meta is created, for example CREATE TABLE ... AUTO_INCREMENT=N.
+	if requestDBExists {
+		return requestDBID, nil
+	}
+	return 0, errors.Errorf("cannot resolve autoid table location, table ID %d not found", tblID)
 }
 
 func (alloc *autoIDValue) alloc4Unsigned(ctx context.Context, store kv.Storage, dbID, tblID int64, isUnsigned bool,
@@ -79,13 +154,17 @@ func (alloc *autoIDValue) alloc4Unsigned(ctx context.Context, store kv.Storage, 
 	// The local rest is not enough for alloc.
 	if uint64(alloc.base)+uint64(n1) > uint64(alloc.end) || alloc.base == 0 {
 		var newBase, newEnd int64
+		var resolvedDBID int64
 		nextStep := int64(batch)
 		fromBase := alloc.base
 
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
-		err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-			idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5)
-			var err1 error
+		err := kv.RunInNewTxn(ctx, store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+			idAcc, resolved, err1 := alloc.getIncrementIDAccessor(txnCtx, txn, dbID, tblID)
+			if err1 != nil {
+				return err1
+			}
+			resolvedDBID = resolved
 			newBase, err1 = idAcc.Get()
 			if err1 != nil {
 				return err1
@@ -115,9 +194,11 @@ func (alloc *autoIDValue) alloc4Unsigned(ctx context.Context, store kv.Storage, 
 		if uint64(newBase) == math.MaxUint64 {
 			return 0, 0, errAutoincReadFailed
 		}
+		alloc.currentDBID = resolvedDBID
 		logutil.BgLogger().Info("alloc4Unsigned from",
 			zap.String("category", "autoid service"),
 			zap.Int64("dbID", dbID),
+			zap.Int64("resolvedDBID", resolvedDBID),
 			zap.Int64("tblID", tblID),
 			zap.Int64("from base", fromBase),
 			zap.Int64("from end", alloc.end),
@@ -154,13 +235,17 @@ func (alloc *autoIDValue) alloc4Signed(ctx context.Context,
 	// If alloc.base is 0, the alloc may not be initialized, force fetch from remote.
 	if alloc.base+n1 > alloc.end || alloc.base == 0 {
 		var newBase, newEnd int64
+		var resolvedDBID int64
 		nextStep := int64(batch)
 		fromBase := alloc.base
 
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
-		err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-			idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5)
-			var err1 error
+		err := kv.RunInNewTxn(ctx, store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+			idAcc, resolved, err1 := alloc.getIncrementIDAccessor(txnCtx, txn, dbID, tblID)
+			if err1 != nil {
+				return err1
+			}
+			resolvedDBID = resolved
 			newBase, err1 = idAcc.Get()
 			if err1 != nil {
 				return err1
@@ -191,9 +276,11 @@ func (alloc *autoIDValue) alloc4Signed(ctx context.Context,
 		if newBase == math.MaxInt64 {
 			return 0, 0, errAutoincReadFailed
 		}
+		alloc.currentDBID = resolvedDBID
 		logutil.BgLogger().Info("alloc4Signed from",
 			zap.String("category", "autoid service"),
 			zap.Int64("dbID", dbID),
+			zap.Int64("resolvedDBID", resolvedDBID),
 			zap.Int64("tblID", tblID),
 			zap.Int64("from base", fromBase),
 			zap.Int64("from end", alloc.end),
@@ -222,10 +309,15 @@ func (alloc *autoIDValue) rebase4Unsigned(ctx context.Context,
 
 	var newBase, newEnd uint64
 	var oldValue int64
+	var resolvedDBID int64
 	startTime := time.Now()
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
-	err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5)
+	err := kv.RunInNewTxn(ctx, store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+		idAcc, resolved, err1 := alloc.getIncrementIDAccessor(txnCtx, txn, dbID, tblID)
+		if err1 != nil {
+			return err1
+		}
+		resolvedDBID = resolved
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1
@@ -245,9 +337,11 @@ func (alloc *autoIDValue) rebase4Unsigned(ctx context.Context,
 	logutil.BgLogger().Info("rebase4Unsigned from",
 		zap.String("category", "autoid service"),
 		zap.Int64("dbID", dbID),
+		zap.Int64("resolvedDBID", resolvedDBID),
 		zap.Int64("tblID", tblID),
 		zap.Int64("from", oldValue),
 		zap.Uint64("to", newEnd))
+	alloc.currentDBID = resolvedDBID
 	alloc.base, alloc.end = int64(newBase), int64(newEnd)
 	return nil
 }
@@ -264,10 +358,15 @@ func (alloc *autoIDValue) rebase4Signed(ctx context.Context, store kv.Storage, d
 	}
 
 	var oldValue, newBase, newEnd int64
+	var resolvedDBID int64
 	startTime := time.Now()
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
-	err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5)
+	err := kv.RunInNewTxn(ctx, store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+		idAcc, resolved, err1 := alloc.getIncrementIDAccessor(txnCtx, txn, dbID, tblID)
+		if err1 != nil {
+			return err1
+		}
+		resolvedDBID = resolved
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1
@@ -285,10 +384,12 @@ func (alloc *autoIDValue) rebase4Signed(ctx context.Context, store kv.Storage, d
 
 	logutil.BgLogger().Info("rebase4Signed from",
 		zap.Int64("dbID", dbID),
+		zap.Int64("resolvedDBID", resolvedDBID),
 		zap.Int64("tblID", tblID),
 		zap.Int64("from", oldValue),
 		zap.Int64("to", newEnd),
 		zap.String("category", "autoid service"))
+	alloc.currentDBID = resolvedDBID
 	alloc.base, alloc.end = newBase, newEnd
 	return nil
 }
@@ -296,7 +397,7 @@ func (alloc *autoIDValue) rebase4Signed(ctx context.Context, store kv.Storage, d
 // Service implement the grpc AutoIDAlloc service, defined in kvproto/pkg/autoid.
 type Service struct {
 	autoIDLock sync.Mutex
-	autoIDMap  map[autoIDKey]*autoIDValue
+	autoIDMap  map[int64]*autoIDValue
 
 	leaderShip owner.Manager
 	store      kv.Storage
@@ -333,7 +434,7 @@ func New(selfAddr string, etcdAddr []string, store kv.Storage, tlsConfig *tls.Co
 func newWithCli(selfAddr string, cli *clientv3.Client, store kv.Storage) *Service {
 	l := owner.NewOwnerManager(context.Background(), cli, "autoid", selfAddr, autoIDLeaderPath)
 	service := &Service{
-		autoIDMap:  make(map[autoIDKey]*autoIDValue),
+		autoIDMap:  make(map[int64]*autoIDValue),
 		leaderShip: l,
 		store:      store,
 	}
@@ -371,7 +472,7 @@ func MockForTest(store kv.Storage) autoid.AutoIDAllocClient {
 	if !ok {
 		ret = &mockClient{
 			Service{
-				autoIDMap:  make(map[autoIDKey]*autoIDValue),
+				autoIDMap:  make(map[int64]*autoIDValue),
 				leaderShip: nil,
 				store:      store,
 			},
@@ -449,17 +550,17 @@ func (s *Service) AllocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 }
 
 func (s *Service) getAlloc(dbID, tblID int64, isUnsigned bool) *autoIDValue {
-	key := autoIDKey{dbID: dbID, tblID: tblID}
 	s.autoIDLock.Lock()
 	defer s.autoIDLock.Unlock()
 
-	val, ok := s.autoIDMap[key]
+	val, ok := s.autoIDMap[tblID]
 	if !ok {
 		val = &autoIDValue{
-			isUnsigned: isUnsigned,
-			token:      make(chan struct{}, 1),
+			currentDBID: dbID,
+			isUnsigned:  isUnsigned,
+			token:       make(chan struct{}, 1),
 		}
-		s.autoIDMap[key] = val
+		s.autoIDMap[tblID] = val
 	}
 
 	return val
@@ -490,10 +591,14 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 		}
 		// This item is not initialized, get the data from remote.
 		var currentEnd int64
+		var resolvedDBID int64
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
-		err := kv.RunInNewTxn(ctx, s.store, true, func(_ context.Context, txn kv.Transaction) error {
-			idAcc := meta.NewMutator(txn).GetAutoIDAccessors(req.DbID, req.TblID).IncrementID(model.TableInfoVersion5)
-			var err1 error
+		err := kv.RunInNewTxn(ctx, s.store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+			idAcc, resolved, err1 := val.getIncrementIDAccessor(txnCtx, txn, req.DbID, req.TblID)
+			if err1 != nil {
+				return err1
+			}
+			resolvedDBID = resolved
 			currentEnd, err1 = idAcc.Get()
 			if err1 != nil {
 				return err1
@@ -505,6 +610,7 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 		if err != nil {
 			return &autoid.AutoIDResponse{Errmsg: []byte(err.Error())}, nil
 		}
+		val.currentDBID = resolvedDBID
 		return &autoid.AutoIDResponse{
 			Min: currentEnd,
 			Max: currentEnd,
@@ -531,8 +637,13 @@ func (s *Service) allocAutoID(ctx context.Context, req *autoid.AutoIDRequest) (*
 func (alloc *autoIDValue) forceRebase(ctx context.Context, store kv.Storage, dbID, tblID, requiredBase int64, isUnsigned bool) error {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnMeta)
 	var oldValue int64
-	err := kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
-		idAcc := meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5)
+	var resolvedDBID int64
+	err := kv.RunInNewTxn(ctx, store, true, func(txnCtx context.Context, txn kv.Transaction) error {
+		idAcc, resolved, err1 := alloc.getIncrementIDAccessor(txnCtx, txn, dbID, tblID)
+		if err1 != nil {
+			return err1
+		}
+		resolvedDBID = resolved
 		currentEnd, err1 := idAcc.Get()
 		if err1 != nil {
 			return err1
@@ -553,11 +664,13 @@ func (alloc *autoIDValue) forceRebase(ctx context.Context, store kv.Storage, dbI
 	}
 	logutil.BgLogger().Info("forceRebase from",
 		zap.Int64("dbID", dbID),
+		zap.Int64("resolvedDBID", resolvedDBID),
 		zap.Int64("tblID", tblID),
 		zap.Int64("from", oldValue),
 		zap.Int64("to", requiredBase),
 		zap.Bool("isUnsigned", isUnsigned),
 		zap.String("category", "autoid service"))
+	alloc.currentDBID = resolvedDBID
 	alloc.base, alloc.end = requiredBase, requiredBase
 	return nil
 }

--- a/pkg/autoid_service/autoid_test.go
+++ b/pkg/autoid_service/autoid_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -121,6 +124,13 @@ func checkCurrValue(t *testing.T, cli autoid.AutoIDAllocClient, to dest, minv, m
 	require.Equal(t, resp, &autoid.AutoIDResponse{Min: minv, Max: maxv})
 }
 
+func testKeyspaceID() uint32 {
+	if kerneltype.IsClassic() {
+		return uint32(tikv.NullspaceID)
+	}
+	return uint32(0xFFFFFF - 1)
+}
+
 func autoIDRequest(t *testing.T, cli autoid.AutoIDAllocClient, to dest, unsigned bool, n uint64, keyspaceID uint32, more ...int64) autoIDResp {
 	increment := int64(1)
 	offset := int64(1)
@@ -145,6 +155,136 @@ func rebaseRequest(t *testing.T, cli autoid.AutoIDAllocClient, to dest, unsigned
 	}
 	resp, err := cli.Rebase(context.Background(), req)
 	return rebaseResp{resp, err, t}
+}
+
+func readSepAutoIncIDBase(t *testing.T, store kv.Storage, dbID, tblID int64) int64 {
+	t.Helper()
+	var base int64
+	err := kv.RunInNewTxn(context.Background(), store, false, func(_ context.Context, txn kv.Transaction) error {
+		var err error
+		base, err = meta.NewMutator(txn).GetAutoIDAccessors(dbID, tblID).IncrementID(model.TableInfoVersion5).Get()
+		return err
+	})
+	require.NoError(t, err)
+	return base
+}
+
+func TestCrossDBRenameSepAutoIncUsesCurrentTableLocation(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t, mockstore.WithDDLChecker())
+	tk := testkit.NewTestKit(t, store)
+	cli := MockForTest(store)
+	mockCli, ok := cli.(*mockClient)
+	require.True(t, ok)
+	keyspaceID := testKeyspaceID()
+
+	tk.MustExec("drop database if exists sp_autoid_old")
+	tk.MustExec("drop database if exists sp_autoid_new")
+	tk.MustExec("create database sp_autoid_old")
+	tk.MustExec("create database sp_autoid_new")
+	tk.MustExec("create table sp_autoid_old.t(id int primary key auto_increment) AUTO_ID_CACHE=1")
+
+	is := dom.InfoSchema()
+	oldDBInfo, ok := is.SchemaByName(ast.NewCIStr("sp_autoid_old"))
+	require.True(t, ok)
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("sp_autoid_old"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+	oldDest := dest{dbID: oldDBInfo.ID, tblID: tableID}
+
+	autoIDRequest(t, cli, oldDest, false, 1, keyspaceID).check(0, 1)
+	require.Equal(t, int64(batch), readSepAutoIncIDBase(t, store, oldDest.dbID, tableID))
+
+	tk.MustExec("rename table sp_autoid_old.t to sp_autoid_new.t")
+	is = dom.InfoSchema()
+	newDBInfo, ok := is.SchemaByName(ast.NewCIStr("sp_autoid_new"))
+	require.True(t, ok)
+	newDest := dest{dbID: newDBInfo.ID, tblID: tableID}
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, oldDest.dbID, tableID))
+	require.Equal(t, int64(batch), readSepAutoIncIDBase(t, store, newDest.dbID, tableID))
+
+	// A stale TiDB may continue to request IDs with the old dbID until its local
+	// allocator is transferred. It must keep using its existing in-memory range.
+	autoIDRequest(t, cli, oldDest, false, batch-1, keyspaceID).check(1, batch)
+	// When the stale request refills, the service resolves the table's current
+	// dbID and extends the new db key instead of resurrecting the old key.
+	autoIDRequest(t, cli, oldDest, false, 1, keyspaceID).check(batch, batch+1)
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, oldDest.dbID, tableID))
+	require.Equal(t, int64(batch*2), readSepAutoIncIDBase(t, store, newDest.dbID, tableID))
+
+	var force = struct{}{}
+	rebaseRequest(t, cli, newDest, false, 12000, force).check("")
+	// Old and new dbIDs must share the same service-side allocator by tableID.
+	// Otherwise, the stale old-db request could keep allocating from an old range
+	// after another TiDB rebases the new-db allocator.
+	autoIDRequest(t, cli, oldDest, false, 1, keyspaceID).check(12000, 12001)
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, oldDest.dbID, tableID))
+	require.Equal(t, int64(16000), readSepAutoIncIDBase(t, store, newDest.dbID, tableID))
+
+	tk.MustExec("drop database sp_autoid_old")
+	mockCli.autoIDLock.Lock()
+	clear(mockCli.autoIDMap)
+	mockCli.autoIDLock.Unlock()
+	// Simulate autoid service owner switch. The new owner starts with an empty
+	// allocator map and may receive a stale request carrying the old dbID. It
+	// should still resolve by tableID to the remaining table in the new db.
+	autoIDRequest(t, cli, oldDest, false, 1, keyspaceID).check(16000, 16001)
+	require.Equal(t, int64(20000), readSepAutoIncIDBase(t, store, newDest.dbID, tableID))
+}
+
+func TestCrossDBRenameConflictsWithFirstRefill(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t, mockstore.WithDDLChecker())
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database sp_autoid_race_old")
+	tk.MustExec("create database sp_autoid_race_new")
+	tk.MustExec("create table sp_autoid_race_old.t(id int primary key auto_increment) AUTO_ID_CACHE=1")
+
+	is := dom.InfoSchema()
+	oldDBInfo, ok := is.SchemaByName(ast.NewCIStr("sp_autoid_race_old"))
+	require.True(t, ok)
+	newDBInfo, ok := is.SchemaByName(ast.NewCIStr("sp_autoid_race_new"))
+	require.True(t, ok)
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("sp_autoid_race_old"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+
+	// Start the first refill before rename. Its snapshot sees the table in the
+	// old database and the old auto-increment key does not exist yet.
+	refillTxn, err := store.Begin()
+	require.NoError(t, err)
+	refillMeta := meta.NewMutator(refillTxn)
+	tblInfo, err := refillMeta.GetTable(oldDBInfo.ID, tableID)
+	require.NoError(t, err)
+	require.NotNil(t, tblInfo)
+	_, err = refillMeta.GetAutoIDAccessors(oldDBInfo.ID, tableID).
+		IncrementID(model.TableInfoVersion5).Inc(batch)
+	require.NoError(t, err)
+
+	// Rename commits a tombstone for the absent old key. The stale refill must
+	// conflict instead of committing an independent range under the old dbID.
+	tk.MustExec("rename table sp_autoid_race_old.t to sp_autoid_race_new.t")
+	err = refillTxn.Commit(context.Background())
+	require.Error(t, err)
+	require.True(t, kv.IsTxnRetryableError(err), err)
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, oldDBInfo.ID, tableID))
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, newDBInfo.ID, tableID))
+
+	// Retrying through the service with the stale dbID resolves the new table
+	// location and reserves the first range only on the destination key.
+	oldDest := dest{dbID: oldDBInfo.ID, tblID: tableID}
+	autoIDRequest(t, MockForTest(store), oldDest, false, 1, testKeyspaceID()).check(0, 1)
+	require.Equal(t, int64(0), readSepAutoIncIDBase(t, store, oldDBInfo.ID, tableID))
+	require.Equal(t, int64(batch), readSepAutoIncIDBase(t, store, newDBInfo.ID, tableID))
+}
+
+func TestCreateSepAutoIncWithInitialBase(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithDDLChecker())
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("drop database if exists sp_autoid_create")
+	tk.MustExec("create database sp_autoid_create")
+	tk.MustExec("create table sp_autoid_create.t(id int primary key auto_increment) AUTO_INCREMENT=10 AUTO_ID_CACHE=1")
+	tk.MustExec("insert into sp_autoid_create.t values ()")
+	tk.MustQuery("select * from sp_autoid_create.t").Check(testkit.Rows("10"))
 }
 
 func TestAPI(t *testing.T) {

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -975,6 +975,12 @@ func checkAndRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, t
 		tblInfo.AutoIDSchemaID = 0
 	}
 
+	err = moveSepAutoIncIDOnCrossDBRename(t, tblInfo, args.OldSchemaID, args.NewSchemaID)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+
 	tblInfo.Name = args.NewTableName
 	err = t.CreateTableOrView(args.NewSchemaID, tblInfo)
 	if err != nil {
@@ -994,6 +1000,49 @@ func checkAndRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, t
 	}
 
 	return ver, nil
+}
+
+func moveSepAutoIncIDOnCrossDBRename(t *meta.Mutator, tblInfo *model.TableInfo, oldSchemaID, newSchemaID int64) error {
+	if oldSchemaID == newSchemaID || !tblInfo.SepAutoInc() || tblInfo.GetAutoIncrementColInfo() == nil {
+		return nil
+	}
+
+	oldAutoIncID := t.GetAutoIDAccessors(oldSchemaID, tblInfo.ID).IncrementID(model.TableInfoVersion5)
+	newAutoIncID := t.GetAutoIDAccessors(newSchemaID, tblInfo.ID).IncrementID(model.TableInfoVersion5)
+	oldBase, err := oldAutoIncID.Get()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newBase, err := newAutoIncID.Get()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := newAutoIncID.Put(maxAutoIDBase(oldBase, newBase, tblInfo.IsAutoIncColUnsigned())); err != nil {
+		return errors.Trace(err)
+	}
+	// Del skips the write when the key does not exist. Force the old key into
+	// the transaction buffer first so the final delete leaves a tombstone and
+	// conflicts with a concurrent first refill that observed the table in the
+	// old database. Without this write conflict, that refill could commit after
+	// the rename and resurrect the old allocator key from zero.
+	if err := oldAutoIncID.Put(oldBase); err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(oldAutoIncID.Del())
+}
+
+func maxAutoIDBase(a, b int64, isUnsigned bool) int64 {
+	if isUnsigned {
+		if uint64(a) >= uint64(b) {
+			return a
+		}
+		return b
+	}
+	if a >= b {
+		return a
+	}
+	return b
 }
 
 func adjustForeignKeyChildTableInfoAfterRenameTable(

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -503,31 +503,14 @@ func (d *ClientDiscover) ResetConn(reason error) {
 }
 
 func (sp *singlePointAlloc) Transfer(databaseID, tableID int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), singlePointWriteOperationTimeout)
-	defer cancel()
-	return sp.transfer(ctx, databaseID, tableID)
+	return sp.transfer(databaseID, tableID)
 }
 
-func (sp *singlePointAlloc) transfer(ctx context.Context, databaseID, tableID int64) error {
+func (sp *singlePointAlloc) transfer(databaseID, tableID int64) error {
 	sp.stateMu.Lock()
 	defer sp.stateMu.Unlock()
-	if sp.dbID == databaseID && sp.tblID == tableID {
-		return nil
-	}
-	// Re-fetch the authoritative source base because a cold allocator may not have observed IDs allocated by other TiDBs.
-	_, _, err := sp.alloc(ctx, 0, 1, 1)
-	if err != nil {
-		return err
-	}
-	transferBase := sp.lastAllocated.Load()
-	sourceDBID, sourceTableID := sp.dbID, sp.tblID
 	sp.dbID = databaseID
 	sp.tblID = tableID
-	if err := sp.rebase(ctx, transferBase, false); err != nil {
-		sp.dbID = sourceDBID
-		sp.tblID = sourceTableID
-		return err
-	}
 	return nil
 }
 

--- a/pkg/meta/autoid/autoid_service_test.go
+++ b/pkg/meta/autoid/autoid_service_test.go
@@ -401,48 +401,17 @@ func TestAutoIDRPCRetryPolicy(t *testing.T) {
 }
 
 func TestSinglePointAllocTransfer(t *testing.T) {
-	t.Run("uses authoritative source base", func(t *testing.T) {
-		mockCli := &mockAutoIDClient{
-			allocResp:  &autoid.AutoIDResponse{Min: 2, Max: 2},
-			rebaseResp: &autoid.RebaseResponse{},
-		}
+	t.Run("updates local owner without RPC", func(t *testing.T) {
+		mockCli := &mockAutoIDClient{}
 		allocator := newTestSinglePointAlloc(mockCli)
+		allocator.lastAllocated.Store(4)
 
-		require.NoError(t, allocator.Transfer(2, 1))
+		require.NoError(t, allocator.Transfer(2, 3))
 		require.Equal(t, int64(2), allocator.dbID)
-		require.Equal(t, int64(1), mockCli.allocCallCount.Load())
-		require.NotNil(t, mockCli.allocReq)
-		require.Equal(t, int64(1), mockCli.allocReq.DbID)
-		require.Equal(t, uint64(0), mockCli.allocReq.N)
-		require.NotNil(t, mockCli.rebaseReq)
-		require.Equal(t, int64(2), mockCli.rebaseReq.Base)
-	})
-
-	t.Run("uses one deadline for transfer RPCs", func(t *testing.T) {
-		missingDeadlineErr := errors.New("missing transfer deadline")
-		var sourceDeadline, destinationDeadline time.Time
-		mockCli := &mockAutoIDClient{
-			alloc: func(ctx context.Context, _ int64, _ *autoid.AutoIDRequest) (*autoid.AutoIDResponse, error) {
-				var ok bool
-				sourceDeadline, ok = ctx.Deadline()
-				if !ok {
-					return nil, missingDeadlineErr
-				}
-				return &autoid.AutoIDResponse{Min: 2, Max: 2}, nil
-			},
-			rebase: func(ctx context.Context, _ int64, _ *autoid.RebaseRequest) (*autoid.RebaseResponse, error) {
-				var ok bool
-				destinationDeadline, ok = ctx.Deadline()
-				if !ok {
-					return nil, missingDeadlineErr
-				}
-				return &autoid.RebaseResponse{}, nil
-			},
-		}
-		allocator := newTestSinglePointAlloc(mockCli)
-
-		require.NoError(t, allocator.Transfer(2, 1))
-		require.Equal(t, sourceDeadline, destinationDeadline)
+		require.Equal(t, int64(3), allocator.tblID)
+		require.Equal(t, int64(4), allocator.Base())
+		require.Equal(t, int64(0), mockCli.allocCallCount.Load())
+		require.Equal(t, int64(0), mockCli.rebaseCallCount.Load())
 	})
 
 	t.Run("uses a deadline for force rebase", func(t *testing.T) {
@@ -458,32 +427,6 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		allocator := newTestSinglePointAlloc(mockCli)
 
 		require.NoError(t, allocator.ForceRebase(2))
-	})
-
-	t.Run("keeps source owner when destination rebase fails", func(t *testing.T) {
-		rebaseErr := errors.New("rebase failed")
-		mockCli := &mockAutoIDClient{
-			allocResp: &autoid.AutoIDResponse{Min: 2, Max: 2},
-			rebaseErr: rebaseErr,
-		}
-		allocator := newTestSinglePointAlloc(mockCli)
-
-		require.ErrorIs(t, allocator.Transfer(2, 1), rebaseErr)
-		require.Equal(t, int64(1), allocator.dbID)
-		require.Equal(t, int64(1), allocator.tblID)
-	})
-
-	t.Run("uses local bound when the source base is stale", func(t *testing.T) {
-		mockCli := &mockAutoIDClient{
-			allocResp:  &autoid.AutoIDResponse{Min: 0, Max: 0},
-			rebaseResp: &autoid.RebaseResponse{},
-		}
-		allocator := newTestSinglePointAlloc(mockCli)
-		allocator.lastAllocated.Store(4)
-
-		require.NoError(t, allocator.Transfer(2, 1))
-		require.NotNil(t, mockCli.rebaseReq)
-		require.Equal(t, int64(4), mockCli.rebaseReq.Base)
 	})
 
 	t.Run("does not regress after a lower rebase", func(t *testing.T) {
@@ -570,6 +513,7 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.NoError(t, <-transferDone)
 		require.Equal(t, int64(0), allocatedMin)
 		require.Equal(t, int64(2), allocatedMax)
+		state.destinationBase.Store(2)
 		minBase, maxBase, err := allocator.Alloc(context.Background(), 1, 1, 1)
 		require.NoError(t, err)
 		require.Equal(t, int64(2), minBase)
@@ -577,9 +521,8 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(3), allocator.Base())
 
 		requireAllocRequest(t, <-state.allocRequests, 1, 2)
-		requireAllocRequest(t, <-state.allocRequests, 1, 0)
-		requireRebaseRequest(t, <-state.rebaseRequests, 2, 2)
 		requireAllocRequest(t, <-state.allocRequests, 2, 1)
+		require.Equal(t, 0, len(state.rebaseRequests))
 	})
 
 	t.Run("transfers after an in-flight rebase", func(t *testing.T) {
@@ -604,6 +547,7 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 
 		require.NoError(t, <-rebaseErr)
 		require.NoError(t, <-transferDone)
+		state.destinationBase.Store(4)
 		minBase, maxBase, err := allocator.Alloc(context.Background(), 1, 1, 1)
 		require.NoError(t, err)
 		require.Equal(t, int64(4), minBase)
@@ -611,9 +555,8 @@ func TestSinglePointAllocTransfer(t *testing.T) {
 		require.Equal(t, int64(5), allocator.Base())
 
 		requireRebaseRequest(t, <-state.rebaseRequests, 1, 4)
-		requireAllocRequest(t, <-state.allocRequests, 1, 0)
-		requireRebaseRequest(t, <-state.rebaseRequests, 2, 4)
 		requireAllocRequest(t, <-state.allocRequests, 2, 1)
+		require.Equal(t, 0, len(state.rebaseRequests))
 	})
 }
 
@@ -789,12 +732,6 @@ func TestAutoIDRPCRetry(t *testing.T) {
 			name string
 			run  func(context.Context, *singlePointAlloc) error
 		}{
-			{
-				name: "transfer",
-				run: func(ctx context.Context, allocator *singlePointAlloc) error {
-					return allocator.transfer(ctx, 33, 44)
-				},
-			},
 			{
 				name: "force rebase",
 				run: func(ctx context.Context, allocator *singlePointAlloc) error {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70784

Problem Summary:

For tables using `AUTO_ID_CACHE=1`, the autoid service used `(dbID, tableID)` as its in-memory allocator identity. During a cross-database `RENAME TABLE`, TiDB nodes apply the schema diff and call `Allocator.Transfer` independently. A stale TiDB could therefore allocate from the source DB key while another TiDB allocated from the destination DB key, allowing the same physical table to receive duplicate auto-increment IDs.

### What changed and how does it work?

- Key the autoid service allocator cache by globally unique table ID, so requests carrying old and new DB IDs are serialized by the same in-memory allocator.
- Resolve the table's current DB ID from transactional metadata whenever the service touches KV (cold lookup, refill, rebase, or force rebase). The service keeps the resolved DB ID as a fast-path hint; ordinary in-memory allocations do not add a KV read.
- During cross-database rename, move the separate auto-increment high-water mark to the destination DB key in the same DDL metadata transaction that moves the table. The transaction also forces a tombstone for an absent source key, so a concurrent first refill cannot commit under the old DB ID after rename.
- Make the TiDB-side single-point allocator `Transfer` update only its local DB/table routing. High-water transfer is now owned by the atomic DDL transaction.
- Add coverage for stale old-DB requests, owner switch after dropping the source database, force rebase, create-table initial base, and the first-refill/write-conflict race.

The extra metadata lookup is limited to the service's existing KV slow paths (normally one refill per internal batch of 4000 IDs); service cache-hit allocations are unchanged.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Test commands:

```text
go test -tags=intest ./pkg/autoid_service -count=1
go test -race -tags=intest ./pkg/autoid_service -run '^(TestCrossDBRenameConflictsWithFirstRefill|TestCrossDBRenameSepAutoIncUsesCurrentTableLocation)$' -count=1
go test ./pkg/meta/autoid -run '^(TestSinglePointAllocTransfer|TestAutoIDRPCRetry|TestAutoIDRPCRetryPolicy|TestAllocCanceledRPCReturnsQuickly|TestRebaseCanceledRPCReturnsQuickly)$' -count=1
go test -tags=intest ./pkg/ddl -run '^(TestAutoIncrementTableOption|TestAutoIncrementForceAutoIDCache|TestRenameConcurrentAutoID)$' -count=1
go test -tags=intest ./pkg/executor/test/ddl -run '^TestRenameTableWithReload$' -count=1
go test -tags=intest ./pkg/autoid_service ./pkg/meta/autoid ./pkg/ddl ./pkg/executor/test/ddl -run '^$' -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix a potential duplicate auto-increment ID issue when a table using `AUTO_ID_CACHE=1` is renamed across databases.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed separated auto-increment allocation after tables move between databases, ensuring new IDs continue from the table’s current location.
  - Improved handling of concurrent table renames and ID allocation retries to prevent conflicting or incorrect reservations.
  - Corrected initialization for tables created with a specified `AUTO_INCREMENT` value, including when caching is enabled.
  - Auto-increment operations now reliably identify the table’s owning database, including during transitions and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->