### PR TITLE
planner, ttl: page SET keys by physical values

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -953,7 +953,95 @@ func noPrecisionLossCastCompatible(cast, argCol *types.FieldType) bool {
 	return true
 }
 
-func unwrapCast(sctx BuildContext, parentF *ScalarFunction, castOffset int) (Expression, bool) {
+func unwrapNoPrecisionLossCastColumn(cast *ScalarFunction, col *Column, setOnly bool) (*Column, bool) {
+	if col.RetType.GetType() == mysql.TypeSet {
+		// MySQL's CAST(SET AS UNSIGNED) reads the SET bitmask as an unsigned
+		// longlong. The bitmask is also the value encoded in table and index keys,
+		// so this particular cast can be removed when building ranges.
+		if cast.RetType.GetType() != mysql.TypeLonglong || !mysql.HasUnsignedFlag(cast.RetType.GetFlag()) {
+			return nil, false
+		}
+		col = col.Clone().(*Column)
+		// Use the cast's integer type so that the rewritten predicate can be
+		// pushed down. EnumSetAsIntFlag lets ranger distinguish this explicit
+		// physical-value comparison from MySQL's ordinary SET comparison rules.
+		col.RetType = cast.RetType.Clone()
+		col.RetType.AddFlag(mysql.EnumSetAsIntFlag)
+		return col, true
+	}
+	if setOnly {
+		return nil, false
+	}
+	if !noPrecisionLossCastCompatible(cast.RetType, col.RetType) {
+		return nil, false
+	}
+	return col, true
+}
+
+func isIntegerOrNullConstant(expr Expression) bool {
+	constant, ok := expr.(*Constant)
+	if !ok {
+		return false
+	}
+	switch constant.Value.Kind() {
+	case types.KindInt64, types.KindUint64, types.KindNull:
+		return true
+	default:
+		return false
+	}
+}
+
+func unwrapNoPrecisionLossSetCastsInRow(sctx BuildContext, expr Expression, constantRows ...Expression) (Expression, bool) {
+	row, ok := expr.(*ScalarFunction)
+	if !ok || row.FuncName.L != ast.RowFunc {
+		return expr, false
+	}
+
+	changed := false
+	args := make([]Expression, len(row.GetArgs()))
+	copy(args, row.GetArgs())
+	for i, arg := range args {
+		cast, ok := arg.(*ScalarFunction)
+		if !ok || cast.FuncName.L != ast.Cast {
+			continue
+		}
+		col, ok := cast.GetArgs()[0].(*Column)
+		if !ok || col.RetType.GetType() != mysql.TypeSet {
+			continue
+		}
+		for _, constantExpr := range constantRows {
+			constantRow := constantExpr.(*ScalarFunction)
+			if i >= len(constantRow.GetArgs()) || !isIntegerOrNullConstant(constantRow.GetArgs()[i]) {
+				return expr, false
+			}
+		}
+		unwrapped, ok := unwrapNoPrecisionLossCastColumn(cast, col, true)
+		if !ok {
+			continue
+		}
+		args[i] = unwrapped
+		changed = true
+	}
+	if !changed {
+		return expr, false
+	}
+	return NewFunctionInternal(sctx, ast.RowFunc, row.RetType, args...), true
+}
+
+func isConstantRow(expr Expression) bool {
+	row, ok := expr.(*ScalarFunction)
+	if !ok || row.FuncName.L != ast.RowFunc {
+		return false
+	}
+	for _, arg := range row.GetArgs() {
+		if _, ok := arg.(*Constant); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func unwrapCast(sctx BuildContext, parentF *ScalarFunction, castOffset int, setOnly bool) (Expression, bool) {
 	_, collation := parentF.CharsetAndCollation()
 	cast, ok := parentF.GetArgs()[castOffset].(*ScalarFunction)
 	if !ok || cast.FuncName.L != ast.Cast {
@@ -973,9 +1061,12 @@ func unwrapCast(sctx BuildContext, parentF *ScalarFunction, castOffset int) (Exp
 	if !ok {
 		return parentF, false
 	}
+	if c.RetType.GetType() == mysql.TypeSet && !isIntegerOrNullConstant(parentF.GetArgs()[1-castOffset]) {
+		return parentF, false
+	}
 
-	// current only consider varchar and integer
-	if !noPrecisionLossCastCompatible(cast.RetType, c.RetType) {
+	c, ok = unwrapNoPrecisionLossCastColumn(cast, c, setOnly)
+	if !ok {
 		return parentF, false
 	}
 
@@ -989,7 +1080,7 @@ func unwrapCast(sctx BuildContext, parentF *ScalarFunction, castOffset int) (Exp
 // eliminateCastFunction will detect the original arg before and the cast type after, once upon
 // there is no precision loss between them, current cast wrapper can be eliminated. For string
 // type, collation is also taken into consideration. (mainly used to build range or point)
-func eliminateCastFunction(sctx BuildContext, expr Expression) (_ Expression, changed bool) {
+func eliminateCastFunction(sctx BuildContext, expr Expression, setOnly bool) (_ Expression, changed bool) {
 	f, ok := expr.(*ScalarFunction)
 	if !ok {
 		return expr, false
@@ -1001,7 +1092,7 @@ func eliminateCastFunction(sctx BuildContext, expr Expression) (_ Expression, ch
 		rmCast := false
 		rmCastItems := make([]Expression, len(dnfItems))
 		for i, dnfItem := range dnfItems {
-			newExpr, curDowncast := eliminateCastFunction(sctx, dnfItem)
+			newExpr, curDowncast := eliminateCastFunction(sctx, dnfItem, setOnly)
 			rmCastItems[i] = newExpr
 			if curDowncast {
 				rmCast = true
@@ -1017,7 +1108,7 @@ func eliminateCastFunction(sctx BuildContext, expr Expression) (_ Expression, ch
 		rmCast := false
 		rmCastItems := make([]Expression, len(cnfItems))
 		for i, cnfItem := range cnfItems {
-			newExpr, curDowncast := eliminateCastFunction(sctx, cnfItem)
+			newExpr, curDowncast := eliminateCastFunction(sctx, cnfItem, setOnly)
 			rmCastItems[i] = newExpr
 			if curDowncast {
 				rmCast = true
@@ -1029,15 +1120,42 @@ func eliminateCastFunction(sctx BuildContext, expr Expression) (_ Expression, ch
 		}
 		return expr, false
 	case ast.EQ, ast.NullEQ, ast.LE, ast.GE, ast.LT, ast.GT:
+		if isConstantRow(f.GetArgs()[1]) {
+			if lhs, ok := unwrapNoPrecisionLossSetCastsInRow(sctx, f.GetArgs()[0], f.GetArgs()[1]); ok {
+				return NewFunctionInternal(sctx, f.FuncName.L, f.RetType, lhs, f.GetArgs()[1]), true
+			}
+		}
+		if isConstantRow(f.GetArgs()[0]) {
+			if rhs, ok := unwrapNoPrecisionLossSetCastsInRow(sctx, f.GetArgs()[1], f.GetArgs()[0]); ok {
+				return NewFunctionInternal(sctx, f.FuncName.L, f.RetType, f.GetArgs()[0], rhs), true
+			}
+		}
 		// for case: eq(cast(test.t2.a, varchar(100), "aaaaa"), once t2.a is covered by index or pk, try deconstructing it out.
-		if newF, ok := unwrapCast(sctx, f, 0); ok {
+		if newF, ok := unwrapCast(sctx, f, 0, setOnly); ok {
 			return newF, true
 		}
 		// for case: eq("aaaaa"， cast(test.t2.a, varchar(100)), once t2.a is covered by index or pk, try deconstructing it out.
-		if newF, ok := unwrapCast(sctx, f, 1); ok {
+		if newF, ok := unwrapCast(sctx, f, 1, setOnly); ok {
 			return newF, true
 		}
 	case ast.In:
+		if _, ok := f.GetArgs()[0].(*ScalarFunction); ok {
+			allConstantRows := true
+			for _, arg := range f.GetArgs()[1:] {
+				if !isConstantRow(arg) {
+					allConstantRows = false
+					break
+				}
+			}
+			if allConstantRows {
+				if lhs, ok := unwrapNoPrecisionLossSetCastsInRow(sctx, f.GetArgs()[0], f.GetArgs()[1:]...); ok {
+					newArgs := make([]Expression, len(f.GetArgs()))
+					copy(newArgs, f.GetArgs())
+					newArgs[0] = lhs
+					return NewFunctionInternal(sctx, f.FuncName.L, f.RetType, newArgs...), true
+				}
+			}
+		}
 		// case for: cast(a<int> as bigint) in (1,2,3), we could deconstruct column 'a out directly.
 		cast, ok := f.GetArgs()[0].(*ScalarFunction)
 		if !ok || cast.FuncName.L != ast.Cast {
@@ -1057,8 +1175,15 @@ func eliminateCastFunction(sctx BuildContext, expr Expression) (_ Expression, ch
 		if !ok {
 			return expr, false
 		}
-		// current only consider varchar and integer
-		if !noPrecisionLossCastCompatible(cast.RetType, c.RetType) {
+		if c.RetType.GetType() == mysql.TypeSet {
+			for _, arg := range f.GetArgs()[1:] {
+				if !isIntegerOrNullConstant(arg) {
+					return expr, false
+				}
+			}
+		}
+		c, ok = unwrapNoPrecisionLossCastColumn(cast, c, setOnly)
+		if !ok {
 			return expr, false
 		}
 		newArgs := []Expression{c}
@@ -1148,7 +1273,16 @@ func PushDownNot(ctx BuildContext, expr Expression) Expression {
 // 2: cast args should be one for original base column and one for constant.
 // 3: some collation compatibility and precision loss will be considered when remove this cast func.
 func EliminateNoPrecisionLossCast(sctx BuildContext, expr Expression) Expression {
-	newExpr, _ := eliminateCastFunction(sctx, expr)
+	newExpr, _ := eliminateCastFunction(sctx, expr, false)
+	return newExpr
+}
+
+// EliminateNoPrecisionLossSetCast removes CAST(SET AS UNSIGNED) before
+// predicate pushdown. Unlike the other supported no-loss casts, SET casts
+// cannot themselves be pushed down, so waiting until range construction is too
+// late. Other cast kinds are deliberately left unchanged here.
+func EliminateNoPrecisionLossSetCast(sctx BuildContext, expr Expression) Expression {
+	newExpr, _ := eliminateCastFunction(sctx, expr, true)
 	return newExpr
 }
 

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -17,6 +17,7 @@ package issuetest
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/errno"
@@ -990,4 +991,81 @@ func TestOnlyFullGroupCantFeelUnaryConstant(t *testing.T) {
 		testKit.MustQuery("select a,min(a) from t where a=-1;").Check(testkit.Rows("<nil> <nil>"))
 		testKit.MustQuery("select a,min(a) from t where -1=a;").Check(testkit.Rows("<nil> <nil>"))
 	})
+}
+
+func TestSetUnsignedCastRangeScan(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	members := make([]string, 64)
+	for i := range members {
+		members[i] = fmt.Sprintf("'e%d'", i+1)
+	}
+	tk.MustExec(fmt.Sprintf("create table t (s set(%s), id bigint, primary key(s, id) clustered, key idx_s_id(s, id))", strings.Join(members, ",")))
+	tk.MustExec("insert into t values (0, 0), (1, 1), (9007199254740992, 2), (9007199254740993, 3), (9223372036854775808, 4), (18446744073709551615, 5)")
+
+	tk.MustQuery("select cast(s as unsigned), id from t order by s, id").Check(testkit.Rows(
+		"0 0",
+		"1 1",
+		"9007199254740992 2",
+		"9007199254740993 3",
+		"9223372036854775808 4",
+		"18446744073709551615 5",
+	))
+	tk.MustQuery("select cast(s as unsigned), id from t where cast(s as unsigned) > 9007199254740992 order by s, id").Check(testkit.Rows(
+		"9007199254740993 3",
+		"9223372036854775808 4",
+		"18446744073709551615 5",
+	))
+
+	commonHandleQuery := "select /*+ use_index(t, primary) */ id from t where cast(s as unsigned) > 9007199254740992 order by s, id"
+	tk.MustHavePlan(commonHandleQuery, "TableRangeScan")
+	tk.MustNotHavePlan(commonHandleQuery, "TableFullScan")
+	tk.MustNotHavePlan(commonHandleQuery, "Sort")
+	secondaryIndexQuery := "select /*+ use_index(t, idx_s_id) */ id from t where cast(s as unsigned) > 9007199254740992 order by s, id"
+	tk.MustHavePlan(secondaryIndexQuery, "IndexRangeScan")
+	tk.MustNotHavePlan(secondaryIndexQuery, "IndexFullScan")
+	tk.MustNotHavePlan(secondaryIndexQuery, "Sort")
+
+	// TTL advances a composite cursor one key column at a time. Verify the
+	// disjunction used by that stack remains a keep-order common-handle scan.
+	ttlCursorQuery := "select /*+ use_index(t, primary) */ id from t where (cast(s as unsigned) = 9007199254740992 and id > 2) or cast(s as unsigned) > 9007199254740992 order by s, id limit 2"
+	tk.MustHavePlan(ttlCursorQuery, "TableRangeScan")
+	tk.MustNotHavePlan(ttlCursorQuery, "TableFullScan")
+	tk.MustNotHavePlan(ttlCursorQuery, "Sort")
+	tk.MustQuery(ttlCursorQuery).Check(testkit.Rows("3", "4"))
+
+	tk.MustExec("prepare set_cursor from 'select /*+ use_index(t, primary) */ id from t where cast(s as unsigned) > ? order by s, id'")
+	tk.MustExec("set @set_cursor_value = 9007199254740992")
+	tk.MustQuery("execute set_cursor using @set_cursor_value").Check(testkit.Rows("3", "4", "5"))
+	tk.MustExec("set @set_cursor_value = 9223372036854775808")
+	tk.MustQuery("execute set_cursor using @set_cursor_value").Check(testkit.Rows("5"))
+	tk.MustExec("deallocate prepare set_cursor")
+
+	rowRangeQuery := "select /*+ use_index(t, primary) */ id from t where (cast(s as unsigned), id) > (9007199254740992, 2) order by s, id"
+	tk.MustHavePlan(rowRangeQuery, "TableRangeScan")
+	tk.MustQuery(rowRangeQuery).Check(testkit.Rows("3", "4", "5"))
+	rowInQuery := "select /*+ use_index(t, primary) */ id from t where (cast(s as unsigned), id) in ((9007199254740993, 3), (9223372036854775808, 4)) order by s, id"
+	tk.MustHavePlan(rowInQuery, "Batch_Point_Get")
+	tk.MustQuery(rowInQuery).Check(testkit.Rows("3", "4"))
+
+	// Keep MySQL's distinction between string/real SET comparisons and an explicit
+	// unsigned integer cast. Only the latter is rewritten to physical key ranges.
+	tk.MustNotHavePlan("select /*+ use_index(t, primary) */ id from t where s > 9007199254740992", "TableRangeScan")
+	tk.MustNotHavePlan("select /*+ use_index(t, primary) */ id from t where s + 0 > 9007199254740992", "TableRangeScan")
+	tk.MustNotHavePlan("select /*+ use_index(t, primary) */ id from t where cast(s as signed) > 9007199254740992", "TableRangeScan")
+
+	tk.MustExec("create table empty_member (s set('', 'a'), id bigint, primary key(s, id) clustered)")
+	tk.MustExec("insert into empty_member values (0, 1), (1, 1)")
+	tk.MustQuery("select cast(s as unsigned), id from empty_member order by s").Check(testkit.Rows("0 1", "1 1"))
+	tk.MustQuery("select cast(s as unsigned), id from empty_member where cast(s as unsigned) = 0").Check(testkit.Rows("0 1"))
+	tk.MustQuery("select cast(s as unsigned), id from empty_member where cast(s as unsigned) > -1 order by s").Check(testkit.Rows("0 1", "1 1"))
+	tk.MustQuery("select cast(s as unsigned), id from empty_member where cast(s as unsigned) < 0").Check(testkit.Rows())
+	tk.MustQuery("select cast(s as unsigned), id from empty_member where cast(s as unsigned) > 3").Check(testkit.Rows())
+	tk.MustQuery("select cast(s as unsigned), id from empty_member where cast(s as unsigned) <= 4 order by s").Check(testkit.Rows("0 1", "1 1"))
+	emptyMemberDelete := "delete from empty_member where (cast(s as unsigned), id) in ((0, 1))"
+	tk.MustHavePlan(emptyMemberDelete, "Point_Get")
+	tk.MustExec(emptyMemberDelete)
+	tk.MustQuery("select cast(s as unsigned), id from empty_member").Check(testkit.Rows("1 1"))
 }

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -187,6 +187,14 @@ func (ds *DataSource) PredicatePushDown(predicates []expression.Expression) ([]e
 	// Add tidb_shard() prefix to the condtion for shard index in some scenarios
 	// TODO: remove it to the place building logical plan
 	predicates = utilfuncp.AddPrefix4ShardIndexes(ds, ds.SCtx(), predicates)
+	// Remove semantics-preserving casts before checking whether predicates can be
+	// pushed down. In particular, CAST(SET AS UNSIGNED) itself is not pushable,
+	// while its unwrapped physical SET value can be used to build table and index
+	// ranges. Doing this during stats derivation is too late for such predicates.
+	exprCtx := ds.SCtx().GetExprCtx()
+	for i, expr := range predicates {
+		predicates[i] = expression.EliminateNoPrecisionLossSetCast(exprCtx, expr)
+	}
 	ds.AllConds = predicates
 	dual := Conds2TableDual(ds, ds.AllConds)
 	if dual != nil {

--- a/pkg/ttl/sqlbuilder/sql.go
+++ b/pkg/ttl/sqlbuilder/sql.go
@@ -52,6 +52,29 @@ func writeDatum(restoreCtx *format.RestoreCtx, d types.Datum, ft *types.FieldTyp
 	return expr.Restore(restoreCtx)
 }
 
+func writePhysicalKeyDatum(restoreCtx *format.RestoreCtx, d types.Datum, ft *types.FieldType) error {
+	if ft.GetType() != mysql.TypeSet {
+		return writeDatum(restoreCtx, d, ft)
+	}
+	if d.IsNull() {
+		restoreCtx.WriteKeyWord("NULL")
+		return nil
+	}
+	var value uint64
+	switch d.Kind() {
+	case types.KindMysqlSet:
+		value = d.GetMysqlSet().Value
+	case types.KindUint64:
+		value = d.GetUint64()
+	case types.KindInt64:
+		value = uint64(d.GetInt64())
+	default:
+		return errors.Errorf("invalid SET key datum kind: %d", d.Kind())
+	}
+	restoreCtx.WritePlain(strconv.FormatUint(value, 10))
+	return nil
+}
+
 // FormatSQLDatum formats the datum to a value string in sql
 func FormatSQLDatum(d types.Datum, ft *types.FieldType) (string, error) {
 	var sb strings.Builder
@@ -160,7 +183,7 @@ func (b *SQLBuilder) WriteCommonCondition(cols []*model.ColumnInfo, op string, d
 		return errors.Errorf("invalid state: %v", b.state)
 	}
 
-	b.writeColNames(cols, len(cols) > 1)
+	b.writePhysicalKeyColNames(cols, len(cols) > 1)
 	b.restoreCtx.WritePlain(" ")
 	b.restoreCtx.WritePlain(op)
 	b.restoreCtx.WritePlain(" ")
@@ -200,7 +223,7 @@ func (b *SQLBuilder) WriteInCondition(cols []*model.ColumnInfo, dps ...[]types.D
 		return errors.Errorf("invalid state: %v", b.state)
 	}
 
-	b.writeColNames(cols, len(cols) > 1)
+	b.writePhysicalKeyColNames(cols, len(cols) > 1)
 	b.restoreCtx.WritePlain(" IN ")
 	b.restoreCtx.WritePlain("(")
 	first := true
@@ -274,6 +297,27 @@ func (b *SQLBuilder) writeColNames(cols []*model.ColumnInfo, writeBrackets bool)
 	}
 }
 
+func (b *SQLBuilder) writePhysicalKeyColNames(cols []*model.ColumnInfo, writeBrackets bool) {
+	if writeBrackets {
+		b.restoreCtx.WritePlain("(")
+	}
+	for i, col := range cols {
+		if i > 0 {
+			b.restoreCtx.WritePlain(", ")
+		}
+		if col.GetType() == mysql.TypeSet {
+			b.restoreCtx.WritePlain("CAST(")
+			b.writeColName(col)
+			b.restoreCtx.WritePlain(" AS UNSIGNED)")
+		} else {
+			b.writeColName(col)
+		}
+	}
+	if writeBrackets {
+		b.restoreCtx.WritePlain(")")
+	}
+}
+
 func (b *SQLBuilder) writeDataPoint(cols []*model.ColumnInfo, dp []types.Datum) error {
 	writeBrackets := len(cols) > 1
 	if len(cols) != len(dp) {
@@ -291,7 +335,7 @@ func (b *SQLBuilder) writeDataPoint(cols []*model.ColumnInfo, dp []types.Datum) 
 		} else {
 			b.restoreCtx.WritePlain(", ")
 		}
-		if err := writeDatum(b.restoreCtx, d, &cols[i].FieldType); err != nil {
+		if err := writePhysicalKeyDatum(b.restoreCtx, d, &cols[i].FieldType); err != nil {
 			return err
 		}
 	}

--- a/pkg/ttl/sqlbuilder/sql_test.go
+++ b/pkg/ttl/sqlbuilder/sql_test.go
@@ -930,6 +930,49 @@ func TestBuildDeleteSQL(t *testing.T) {
 	}
 }
 
+func TestSetPhysicalKeySQL(t *testing.T) {
+	setType := types.NewFieldTypeBuilder().SetType(mysql.TypeSet).SetElems([]string{"z", "a", "b"}).Build()
+	tbl := &cache.PhysicalTable{
+		Schema: ast.NewCIStr("test"),
+		TableInfo: &model.TableInfo{
+			Name: ast.NewCIStr("t"),
+		},
+		KeyColumns: []*model.ColumnInfo{
+			{Name: ast.NewCIStr("s"), FieldType: setType},
+			{Name: ast.NewCIStr("id"), FieldType: *types.NewFieldType(mysql.TypeLonglong)},
+		},
+		TimeColumn: &model.ColumnInfo{
+			Name:      ast.NewCIStr("created_at"),
+			FieldType: *types.NewFieldType(mysql.TypeDatetime),
+		},
+	}
+	setValue, err := types.ParseSetValue(setType.GetElems(), 5)
+	require.NoError(t, err)
+	key := []types.Datum{types.NewMysqlSetDatum(setValue, setType.GetCollate()), types.NewIntDatum(1)}
+	expire := time.UnixMilli(0).In(time.UTC)
+
+	generator, err := sqlbuilder.NewScanQueryGenerator(tbl, expire, nil, nil)
+	require.NoError(t, err)
+	firstSQL, err := generator.NextSQL(nil, 1)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT LOW_PRIORITY SQL_NO_CACHE `s`, `id` FROM `test`.`t` WHERE `created_at` < FROM_UNIXTIME(0) ORDER BY `s`, `id` ASC LIMIT 1", firstSQL)
+	nextSQL, err := generator.NextSQL([][]types.Datum{key}, 1)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT LOW_PRIORITY SQL_NO_CACHE `s`, `id` FROM `test`.`t` WHERE CAST(`s` AS UNSIGNED) = 5 AND `id` > 1 AND `created_at` < FROM_UNIXTIME(0) ORDER BY `s`, `id` ASC LIMIT 1", nextSQL)
+	afterPrefixSQL, err := generator.NextSQL(nil, 1)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT LOW_PRIORITY SQL_NO_CACHE `s`, `id` FROM `test`.`t` WHERE CAST(`s` AS UNSIGNED) > 5 AND `created_at` < FROM_UNIXTIME(0) ORDER BY `s`, `id` ASC LIMIT 1", afterPrefixSQL)
+
+	deleteSQL, err := sqlbuilder.BuildDeleteSQL(tbl, [][]types.Datum{key}, expire)
+	require.NoError(t, err)
+	require.Equal(t, "DELETE LOW_PRIORITY FROM `test`.`t` WHERE (CAST(`s` AS UNSIGNED), `id`) IN ((5, 1)) AND `created_at` < FROM_UNIXTIME(0) LIMIT 1", deleteSQL)
+
+	for _, sql := range []string{firstSQL, nextSQL, afterPrefixSQL, deleteSQL} {
+		_, _, err = parser.New().ParseSQL(sql)
+		require.NoError(t, err)
+	}
+}
+
 func d(vs ...any) []types.Datum {
 	datums := make([]types.Datum, len(vs))
 	for i, v := range vs {

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -1362,7 +1362,7 @@ func (d *Datum) convertToUint(ctx Context, target *FieldType) (Datum, error) {
 	case KindMysqlEnum:
 		val, err = ConvertFloatToUint(ctx.Flags(), d.GetMysqlEnum().ToNumber(), upperBound, tp)
 	case KindMysqlSet:
-		val, err = ConvertFloatToUint(ctx.Flags(), d.GetMysqlSet().ToNumber(), upperBound, tp)
+		val, err = ConvertUintToUint(d.GetMysqlSet().Value, upperBound, tp)
 	case KindBinaryLiteral, KindMysqlBit:
 		val, err = d.GetBinaryLiteral().ToInt(ctx)
 		if err == nil {
@@ -1983,6 +1983,11 @@ func (d *Datum) ToInt64(ctx Context) (int64, error) {
 	if d.Kind() == KindMysqlBit {
 		uintVal, err := d.GetBinaryLiteral().ToInt(ctx)
 		return int64(uintVal), err
+	}
+	if d.Kind() == KindMysqlSet {
+		// MySQL evaluates an explicit integer cast of SET from its physical
+		// bitmask, not through the display string or a floating-point value.
+		return int64(d.GetMysqlSet().Value), nil
 	}
 	return d.toSignedInteger(ctx, mysql.TypeLonglong)
 }

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -131,6 +131,9 @@ func TestToInt64(t *testing.T) {
 	testDatumToInt64(t, NewBinaryLiteralFromUint(100, -1), int64(100))
 	testDatumToInt64(t, Enum{Name: "a", Value: 1}, int64(1))
 	testDatumToInt64(t, Set{Name: "a", Value: 1}, int64(1))
+	testDatumToInt64(t, Set{Name: "a", Value: 9007199254740993}, int64(9007199254740993))
+	testDatumToInt64(t, Set{Name: "a", Value: uint64(1) << 63}, int64(math.MinInt64))
+	testDatumToInt64(t, Set{Name: "a", Value: math.MaxUint64}, int64(-1))
 	testDatumToInt64(t, CreateBinaryJSON(int64(3)), int64(3))
 
 	t1, err := ParseTime(DefaultStmtNoWarningContext, "2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 0)

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -1038,9 +1038,24 @@ func DetachCondAndBuildRangeForIndex(sctx *rangerctx.RangerContext, conditions [
 // detachCondAndBuildRange detaches the index filters from table filters and uses them to build ranges.
 func detachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int, rangeMaxSize int64, convertToSortKey bool, mergeConsecutive bool) (*DetachRangeResult, error) {
+	condCols := expression.ExtractColumnsFromExpressions(conditions, nil)
 	newTpSlice := make([]*types.FieldType, 0, len(cols))
 	for _, col := range cols {
-		newTpSlice = append(newTpSlice, newFieldType(col.RetType))
+		newTp := newFieldType(col.RetType)
+		if col.RetType.GetType() == mysql.TypeSet {
+			for _, condCol := range condCols {
+				if condCol.UniqueID == col.UniqueID && mysql.HasEnumSetAsIntFlag(condCol.RetType.GetFlag()) {
+					// EliminateNoPrecisionLossSetCast marks only columns that came
+					// from an explicit CAST(SET AS UNSIGNED). Preserve the physical
+					// SET type used to encode ranges, and carry the marker separately
+					// so ordinary SET comparisons retain their string semantics.
+					newTp = newTp.Clone()
+					newTp.AddFlag(mysql.EnumSetAsIntFlag)
+					break
+				}
+			}
+		}
+		newTpSlice = append(newTpSlice, newTp)
 	}
 
 	return detachCondAndBuildRangeRecursive(sctx, conditions, cols, lengths, newTpSlice, rangeMaxSize, convertToSortKey, mergeConsecutive)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -109,9 +109,9 @@ func rangePointEqualValueCmp(a, b *point) int {
 
 func convertPointsToSortKeyInPlace(sctx *rangerctx.RangerContext, points []*point, newTp *types.FieldType) error {
 	// Only handle normal string type here.
-	// Currently, set won't be pushed down and it shouldn't reach here in theory.
-	// For enum, we have separate logic for it, like handleEnumFromBinOp(). For now, it only supports point range,
-	// intervals are not supported. So we also don't need to handle enum here.
+	// SET ranges produced from CAST(SET AS UNSIGNED) already contain physical
+	// uint64 values. ENUM has separate handling in handleEnumFromBinOp(). Neither
+	// type needs a collation sort key here.
 	if newTp.EvalType() != types.ETString ||
 		newTp.GetType() == mysql.TypeEnum ||
 		newTp.GetType() == mysql.TypeSet {

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -179,7 +179,11 @@ func convertPointInPlace(sctx *rangerctx.RangerContext, p *point, newTp *types.F
 	case types.KindMaxValue, types.KindMinNotNull:
 		return nil
 	}
-	casted, err := p.value.ConvertTo(sctx.TypeCtx, newTp)
+	casted, valCmpCasted, convertedSetPoint := convertNumericSetPoint(p.value, newTp)
+	var err error
+	if !convertedSetPoint {
+		casted, err = p.value.ConvertTo(sctx.TypeCtx, newTp)
+	}
 	if err != nil {
 		// skip plan cache in this case for safety.
 		sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), p.value))
@@ -217,9 +221,11 @@ func convertPointInPlace(sctx *rangerctx.RangerContext, p *point, newTp *types.F
 		}
 		//revive:enable:empty-block
 	}
-	valCmpCasted, err := p.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
-	if err != nil {
-		return errors.Trace(err)
+	if !convertedSetPoint {
+		valCmpCasted, err = p.value.Compare(sctx.TypeCtx, &casted, collate.GetCollator(newTp.GetCollate()))
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 	p.value = casted
 	if valCmpCasted == 0 {
@@ -251,6 +257,45 @@ func convertPointInPlace(sctx *rangerctx.RangerContext, p *point, newTp *types.F
 		}
 	}
 	return nil
+}
+
+func convertNumericSetPoint(value types.Datum, ft *types.FieldType) (types.Datum, int, bool) {
+	var result types.Datum
+	if ft.GetType() != mysql.TypeSet || !mysql.HasEnumSetAsIntFlag(ft.GetFlag()) {
+		return result, 0, false
+	}
+
+	var numericValue uint64
+	valueCmpConverted := 0
+	switch value.Kind() {
+	case types.KindInt64:
+		intValue := value.GetInt64()
+		if intValue < 0 {
+			valueCmpConverted = -1
+		} else {
+			numericValue = uint64(intValue)
+		}
+	case types.KindUint64:
+		numericValue = value.GetUint64()
+	case types.KindMysqlSet:
+		numericValue = value.GetMysqlSet().Value
+	default:
+		return result, 0, false
+	}
+
+	maxValue := uint64(math.MaxUint64)
+	if len(ft.GetElems()) < 64 {
+		maxValue = uint64(1)<<len(ft.GetElems()) - 1
+	}
+	if numericValue > maxValue {
+		numericValue = maxValue
+		valueCmpConverted = 1
+	}
+	// SET and uint64 use the same comparable key encoding. Keeping the range
+	// point as uint64 also makes sorting exact without changing the ordinary
+	// (display-string) comparison behavior of KindMysqlSet datums.
+	result.SetUint64(numericValue)
+	return result, valueCmpConverted, true
 }
 
 func getRangesTotalDatumSize(ranges Ranges) (sum int64) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70836

Problem Summary:

TTL paginates a clustered common handle with SQL cursor predicates. A `SET` key is physically ordered by its unsigned bitmask, but TTL currently writes the display string into the cursor predicate. When the member declaration order differs from lexical order, a job can stop after the first page and leave expired rows behind.

Writing the cursor as `CAST(set_col AS UNSIGNED)` gives the correct physical position, but the planner did not turn that expression into a table/index range. TiDB also converted `SET` to unsigned through `float64`, which loses bits above `2^53`.

### What changed and how does it work?

- Convert `SET` to integer directly from its `uint64` bitmask, without an intermediate floating-point value.
- Recognize only the lossless `CAST(set_col AS UNSIGNED)` form when compared with integer constants. The planner removes that cast before predicate pushdown, marks the column as a physical-value comparison, and lets ranger build common-handle or secondary-index ranges from exact unsigned values.
- Preserve ordinary `SET` expressions. Bare `SET` comparisons, `set_col + 0`, and `CAST(set_col AS SIGNED)` are not rewritten by this optimization.
- Clamp out-of-domain constants while preserving inclusive/exclusive range semantics.
- Write TTL cursor, range, and DELETE key predicates as `CAST(set_col AS UNSIGNED)` with numeric bitmasks. `ORDER BY set_col` remains unchanged because the natural key order is already the physical bitmask order.
- Support composite row comparisons and row `IN`; TTL DELETE remains a point/batch-point lookup instead of a full scan.

This matches MySQL's implementation and behavior. In MySQL source, `Field_set` inherits the integer reader used by `Field_enum`, numeric context returns the SET bits as `longlong`, `Item_typecast_unsigned` calls `val_int()`, and ENUM/SET sort keys use integer order. MySQL 8.4 was also verified with a 64-member SET at `2^53 + 1`, `2^63`, and `UINT64_MAX`.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

The following Bazel targets pass with `--define gotags=intest`:

```text
//pkg/types:types_test
//pkg/util/ranger:ranger_test
//pkg/planner/core/issuetest:issuetest_test
//pkg/ttl/sqlbuilder:sqlbuilder_test
```

Manual verification used the issue reproduction on a TiUP playground with real TiKV, scan/delete batch size 1, and this TiDB binary. The first triggered TTL job finished with:

```json
{"total_rows":3,"success_rows":3,"error_rows":0,"total_scan_task":1,"scheduled_scan_task":1,"finished_scan_task":1}
```

The table was empty afterward. `EXPLAIN FORMAT='brief'` also showed `TableRangeScan` for the clustered primary key, `IndexRangeScan` for the secondary index, and `Point_Get` for the composite-key DELETE, with no `TableFullScan` or extra `Sort`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

```release-note
Fix an issue where TTL jobs might skip expired rows when a clustered primary key contains a SET column, and allow the optimizer to build exact ranges for `CAST(SET AS UNSIGNED)` without losing 64-bit precision.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved query optimization for `SET` columns compared as unsigned integers, enabling more efficient table, index, and point lookups.
  * Enhanced range scans, row comparisons, `IN` predicates, prepared statements, and TTL operations involving `SET` values.
  * Improved handling of large `SET` bitmask values without precision loss.

* **Bug Fixes**
  * Corrected physical-key SQL generation and range construction for `SET` columns, including `NULL` and boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->