### PR TITLE
test: stabilize flaky TestCTEIterationMemTracker

### DIFF
--- a/pkg/executor/test/cte/cte_test.go
+++ b/pkg/executor/test/cte/cte_test.go
@@ -218,6 +218,9 @@ func TestCTEIterationMemTracker(t *testing.T) {
 	tk.MustExec(insertStr)
 
 	tk.MustExec("set @@cte_max_recursion_depth=1000000")
+	originEnableTmpStorageOnOOM := fmt.Sprint(tk.MustQuery("select @@global.tidb_enable_tmp_storage_on_oom").Rows()[0][0])
+	tk.MustExec("set global tidb_enable_tmp_storage_on_oom=on")
+	defer tk.MustExec(fmt.Sprintf("set global tidb_enable_tmp_storage_on_oom=%s", originEnableTmpStorageOnOOM))
 	tk.MustExec("set global tidb_mem_oom_action = 'log';")
 	defer func() {
 		tk.MustExec("set global tidb_mem_oom_action = default;")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54379

Problem Summary:
Flaky test `TestCTEIterationMemTracker` in `pkg/executor/test/cte` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test asserted spill-to-disk while leaving `tidb_enable_tmp_storage_on_oom` dependent on external global state.

#### Fix

Enabling and restoring that global removes harness state leakage without weakening the CTE spill assertion or changing product behavior.

#### Verification

Spec:
- target: `pkg/executor/test/cte :: TestCTEIterationMemTracker`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_raw passed.
target_failpoint passed.

Gate checklist:
- diagnostic_tmp_storage_off: SKIPPED
- target_raw: PASS
- target_failpoint: PASS
- package_failpoint: BLOCKED
- package_raw: SKIPPED
- build: BLOCKED
- lint: BLOCKED

Commands:
- `go test -json -tags=intest,deadlock ./pkg/executor/test/cte -run '^TestCTEIterationMemTracker$' -count=1`
- `./tools/check/failpoint-go-test.sh pkg/executor/test/cte -run '^TestCTEIterationMemTracker$' -count=1`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #54379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage reliability for recursive common table expression (CTE) scenarios that spill data to disk when memory limits are reached.
  - Test execution now consistently validates temporary storage behavior under out-of-memory conditions while preserving the surrounding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->