### PR TITLE
ttl: split temporal clustered primary key scan ranges

### DIFF
--- a/docs/design/2026-09-03-ttl-temporal-clustered-pk-splitting.md
+++ b/docs/design/2026-09-03-ttl-temporal-clustered-pk-splitting.md
@@ -1,0 +1,48 @@
+# TTL Temporal Clustered Primary-Key Splitting
+
+## Motivation
+
+TTL normally divides a table by its primary-key Region distribution. A clustered
+primary key beginning with the TTL column already stores expired rows in one
+contiguous physical prefix, but `DATE`, `DATETIME`, and `TIMESTAMP` keys were not
+previously decoded into task boundaries. Such tables therefore received one full
+range task even when their records occupied many Regions.
+
+## Design
+
+When a common-handle clustered primary key starts with the TTL column and that
+column is `DATE`, `DATETIME(fsp)`, or `TIMESTAMP(fsp)`, the scheduler locates only
+the record-key range `[record_prefix, record_prefix + encode(expire_time))`.
+Regions wholly after the expiration cutoff do not contribute tasks. The final
+Region crossing the cutoff is retained because it can still contain expired rows;
+the SQL predicate `ttl_column < expire_time` remains the exact upper bound.
+
+Region boundaries are arbitrary byte strings. They may truncate the packed time
+or contain an invalid calendar value, so the scheduler maps each boundary to the
+greatest valid temporal value whose complete encoding does not exceed it. Adjacent
+tasks reuse the same mapped boundary, preventing gaps and overlap. In a composite
+key, multiple Regions that differ only in later primary-key columns can map to the
+same TTL value and are collapsed. This may reduce balance but does not change
+coverage.
+
+The tasks remain PK scans: `split_by` is `NULL`, pagination orders by the complete
+clustered primary key, and no secondary-index planner behavior is required. Range
+boundaries retain the existing textual PK-task encoding. `TIMESTAMP` boundaries
+are represented in UTC because TTL data sessions execute in UTC; `DATE` and
+`DATETIME` retain the global-time-zone wall-clock value used by TTL expiration.
+
+Other primary-key layouts retain the existing splitting behavior. In particular,
+expire-based Region pruning is not applied when the TTL column is not the first
+physical key column, because expired rows do not form a provably contiguous key
+prefix in that case.
+
+## Compatibility
+
+No task column or task encoding version is added. An older worker can parse the
+textual PK boundary, so this optimization does not use the secondary-index scan
+version gate. During a rolling upgrade, an old worker can interpret a UTC
+`TIMESTAMP` boundary in the former session time zone and incompletely cover that
+task; the expiration predicate still prevents deletion of unexpired rows, and a
+later TTL job retries omitted expired rows. The change depends on the UTC
+TTL-session behavior introduced by #70767 so current workers preserve the instant
+across DST transitions.

--- a/pkg/ttl/cache/BUILD.bazel
+++ b/pkg/ttl/cache/BUILD.bazel
@@ -51,7 +51,7 @@ go_test(
     ],
     embed = [":cache"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/infoschema",
         "//pkg/kv",

--- a/pkg/ttl/cache/split_test.go
+++ b/pkg/ttl/cache/split_test.go
@@ -15,6 +15,7 @@
 package cache_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -639,6 +640,161 @@ func TestSplitTTLScanRangesCommonHandleUnsignedInt(t *testing.T) {
 		checkRange(t, ranges[2], types.NewUintDatum(24), types.NewUintDatum(math.MaxInt64+9))
 		checkRange(t, ranges[3], types.NewUintDatum(math.MaxInt64+9), types.Datum{})
 	}
+}
+
+func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	utcPlus8 := time.FixedZone("UTC+8", 8*60*60)
+	cases := []struct {
+		name       string
+		columnType string
+		primaryKey string
+		loc        *time.Location
+		boundary   time.Time
+	}{
+		{"date", "date", "primary key(t) clustered", time.UTC, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{"datetime", "datetime", "primary key(t) clustered", time.UTC, time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)},
+		{"datetime6-composite", "datetime(6)", "primary key(t, id) clustered", time.UTC, time.Date(2020, 1, 1, 1, 2, 3, 123456000, time.UTC)},
+		{"timestamp", "timestamp", "primary key(t, id) clustered", utcPlus8, time.Date(2020, 1, 1, 1, 2, 3, 0, utcPlus8)},
+		{"timestamp3", "timestamp(3)", "primary key(t, id) clustered", utcPlus8, time.Date(2020, 1, 1, 1, 2, 3, 123000000, utcPlus8)},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := createTTLTableWithSQL(t, tk, fmt.Sprintf("temporal_%d", i), fmt.Sprintf(`
+				create table test.temporal_%d(
+					t %s not null,
+					id bigint not null default 0,
+					%s
+				) TTL = t + interval 1 day`, i, tc.columnType, tc.primaryKey))
+			require.True(t, tbl.IsCommonHandle)
+			require.Equal(t, tbl.TimeColumn.ID, tbl.KeyColumns[0].ID)
+
+			encodeTime := func(tm time.Time) []byte {
+				ft := tbl.TimeColumn.FieldType
+				datum := types.NewTimeDatum(types.NewTime(types.FromGoTime(tm), ft.GetType(), ft.GetDecimal()))
+				encoded, err := codec.EncodeKey(tc.loc, nil, datum)
+				require.NoError(t, err)
+				return encoded
+			}
+			recordPrefix := tablecodec.GenTableRecordPrefix(tbl.ID)
+			recordKey := func(encoded []byte) []byte {
+				return append(recordPrefix.Clone(), encoded...)
+			}
+			boundaryTime := types.NewTime(types.FromGoTime(tc.boundary),
+				tbl.TimeColumn.GetType(), tbl.TimeColumn.GetDecimal())
+			if tbl.TimeColumn.GetType() == mysql.TypeTimestamp {
+				require.NoError(t, boundaryTime.ConvertTimeZone(tc.loc, time.UTC))
+			}
+			boundaryString := boundaryTime.String()
+			checkTwoRanges := func(ranges []cache.ScanRange) {
+				require.Len(t, ranges, 2)
+				require.Empty(t, ranges[0].Start)
+				require.Equal(t, boundaryString, ranges[0].End[0].GetString())
+				require.Equal(t, ranges[0].End, ranges[1].Start)
+				require.Empty(t, ranges[1].End)
+			}
+
+			expireTime := time.Date(2025, 1, 1, 0, 0, 0, 0, tc.loc)
+			expireKey := recordKey(encodeTime(expireTime))
+			afterExpireKey := recordKey(encodeTime(expireTime.AddDate(1, 0, 0)))
+			encodedID, err := codec.EncodeKey(tc.loc, nil, types.NewIntDatum(42))
+			require.NoError(t, err)
+			exactBoundary := recordKey(append(encodeTime(tc.boundary), encodedID...))
+			expireCrossingEnd := recordKey(append(encodeTime(expireTime), encodedID...))
+
+			tikvStore := newMockTiKVStore(t)
+			tikvStore.addRegion(recordPrefix, exactBoundary)
+			tikvStore.addRegion(exactBoundary, expireCrossingEnd)
+			// Regions wholly after expire must not create tasks; the Region crossing
+			// expire is retained because its prefix can still contain expired rows.
+			tikvStore.addRegion(expireCrossingEnd, afterExpireKey)
+			tikvStore.addRegion(afterExpireKey, recordPrefix.PrefixNext())
+			ranges, err := tbl.SplitScanRangesBeforeExpire(
+				context.Background(), tikvStore, expireTime, tc.loc, 4)
+			require.NoError(t, err)
+			checkTwoRanges(ranges)
+
+			if tc.name != "datetime6-composite" {
+				return
+			}
+
+			// Exercise every truncation inside the fixed-width packed temporal
+			// payload. Each arbitrary Region boundary must map to a legal floor.
+			encodedBoundary := encodeTime(tc.boundary)
+			require.Len(t, encodedBoundary, 9)
+			for cut := 2; cut < len(encodedBoundary); cut++ {
+				partial := recordKey(encodedBoundary[:cut])
+				tikvStore.clearRegions()
+				tikvStore.addRegion(recordPrefix, partial)
+				tikvStore.addRegion(partial, expireKey)
+				tikvStore.addRegion(expireKey, afterExpireKey)
+				ranges, err = tbl.SplitScanRangesBeforeExpire(
+					context.Background(), tikvStore, expireTime, tc.loc, 3)
+				require.NoError(t, err)
+				require.Len(t, ranges, 2)
+				require.Equal(t, ranges[0].End, ranges[1].Start)
+				floorTime, err := types.ParseTime(types.DefaultStmtNoWarningContext,
+					ranges[0].End[0].GetString(), mysql.TypeDatetime, 6)
+				require.NoError(t, err)
+				floor, err := codec.EncodeKey(tc.loc, nil, types.NewTimeDatum(floorTime))
+				require.NoError(t, err)
+				require.LessOrEqual(t, bytes.Compare(recordKey(floor), partial), 0)
+			}
+
+			// A complete payload can still describe an invalid calendar date.
+			packTime := func(year, month, day int) uint64 {
+				ymd := ((uint64(year)*13+uint64(month))<<5 | uint64(day))
+				return (ymd << 17) << 24
+			}
+			illegal := recordKey(append([]byte{encodedBoundary[0]},
+				codec.EncodeUint(nil, packTime(2020, 2, 31))...))
+			tikvStore.clearRegions()
+			tikvStore.addRegion(recordPrefix, illegal)
+			tikvStore.addRegion(illegal, expireKey)
+			tikvStore.addRegion(expireKey, afterExpireKey)
+			ranges, err = tbl.SplitScanRangesBeforeExpire(
+				context.Background(), tikvStore, expireTime, tc.loc, 3)
+			require.NoError(t, err)
+			require.Len(t, ranges, 2)
+
+			// Boundaries differing only in later common-handle columns collapse
+			// safely to one TTL boundary without gaps or overlap.
+			encodedID1, err := codec.EncodeKey(tc.loc, nil, types.NewIntDatum(1))
+			require.NoError(t, err)
+			encodedID2, err := codec.EncodeKey(tc.loc, nil, types.NewIntDatum(2))
+			require.NoError(t, err)
+			boundary1 := recordKey(append(encodeTime(tc.boundary), encodedID1...))
+			boundary2 := recordKey(append(encodeTime(tc.boundary), encodedID2...))
+			nextBoundary := recordKey(encodeTime(tc.boundary.Add(time.Second)))
+			tikvStore.clearRegions()
+			tikvStore.addRegion(recordPrefix, boundary1)
+			tikvStore.addRegion(boundary1, boundary2)
+			tikvStore.addRegion(boundary2, nextBoundary)
+			tikvStore.addRegion(nextBoundary, expireKey)
+			tikvStore.addRegion(expireKey, afterExpireKey)
+			ranges, err = tbl.SplitScanRangesBeforeExpire(
+				context.Background(), tikvStore, expireTime, tc.loc, 5)
+			require.NoError(t, err)
+			require.Len(t, ranges, 3)
+			for i := 1; i < len(ranges); i++ {
+				require.Equal(t, ranges[i-1].End, ranges[i].Start)
+			}
+		})
+	}
+
+	// A temporal clustered key unrelated to the TTL column cannot be pruned by
+	// expire time and keeps the legacy full-range behavior.
+	tbl := createTTLTableWithSQL(t, tk, "temporal_not_ttl", `
+		create table test.temporal_not_ttl(
+			id datetime primary key clustered,
+			t datetime
+		) TTL = t + interval 1 day`)
+	ranges, err := tbl.SplitScanRangesBeforeExpire(
+		context.Background(), newMockTiKVStore(t), time.Now(), time.UTC, 4)
+	require.NoError(t, err)
+	require.Equal(t, []cache.ScanRange{{}}, ranges)
 }
 
 func TestSplitTTLScanRangesWithBytes(t *testing.T) {

--- a/pkg/ttl/cache/split_test.go
+++ b/pkg/ttl/cache/split_test.go
@@ -682,6 +682,20 @@ func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
 			recordKey := func(encoded []byte) []byte {
 				return append(recordPrefix.Clone(), encoded...)
 			}
+			encodeTaskBoundary := func(d types.Datum) []byte {
+				require.Equal(t, types.KindBytes, d.Kind())
+				ft := tbl.TimeColumn.FieldType
+				tm, err := types.ParseTime(types.DefaultStmtNoWarningContext,
+					d.GetString(), ft.GetType(), ft.GetDecimal())
+				require.NoError(t, err)
+				encodeLoc := tc.loc
+				if ft.GetType() == mysql.TypeTimestamp {
+					encodeLoc = time.UTC
+				}
+				encoded, err := codec.EncodeKey(encodeLoc, nil, types.NewTimeDatum(tm))
+				require.NoError(t, err)
+				return encoded
+			}
 			boundaryTime := types.NewTime(types.FromGoTime(tc.boundary),
 				tbl.TimeColumn.GetType(), tbl.TimeColumn.GetDecimal())
 			if tbl.TimeColumn.GetType() == mysql.TypeTimestamp {
@@ -691,6 +705,7 @@ func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
 			checkTwoRanges := func(ranges []cache.ScanRange) {
 				require.Len(t, ranges, 2)
 				require.Empty(t, ranges[0].Start)
+				require.Len(t, ranges[0].End, 1)
 				require.Equal(t, boundaryString, ranges[0].End[0].GetString())
 				require.Equal(t, ranges[0].End, ranges[1].Start)
 				require.Empty(t, ranges[1].End)
@@ -715,6 +730,7 @@ func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
 				context.Background(), tikvStore, expireTime, tc.loc, 4)
 			require.NoError(t, err)
 			checkTwoRanges(ranges)
+			require.Equal(t, encodeTime(tc.boundary), encodeTaskBoundary(ranges[0].End[0]))
 
 			if tc.name != "datetime6-composite" {
 				return
@@ -735,11 +751,7 @@ func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, ranges, 2)
 				require.Equal(t, ranges[0].End, ranges[1].Start)
-				floorTime, err := types.ParseTime(types.DefaultStmtNoWarningContext,
-					ranges[0].End[0].GetString(), mysql.TypeDatetime, 6)
-				require.NoError(t, err)
-				floor, err := codec.EncodeKey(tc.loc, nil, types.NewTimeDatum(floorTime))
-				require.NoError(t, err)
+				floor := encodeTaskBoundary(ranges[0].End[0])
 				require.LessOrEqual(t, bytes.Compare(recordKey(floor), partial), 0)
 			}
 
@@ -758,6 +770,8 @@ func TestSplitTTLScanRangesTemporalCommonHandle(t *testing.T) {
 				context.Background(), tikvStore, expireTime, tc.loc, 3)
 			require.NoError(t, err)
 			require.Len(t, ranges, 2)
+			floor := encodeTaskBoundary(ranges[0].End[0])
+			require.LessOrEqual(t, bytes.Compare(recordKey(floor), illegal), 0)
 
 			// Boundaries differing only in later common-handle columns collapse
 			// safely to one TTL boundary without gaps or overlap.

--- a/pkg/ttl/cache/table.go
+++ b/pkg/ttl/cache/table.go
@@ -327,6 +327,30 @@ func (t *PhysicalTable) SplitScanRanges(ctx context.Context, store kv.Storage, s
 	return []ScanRange{newFullRange()}, nil
 }
 
+// SplitScanRangesBeforeExpire splits the existing PK scan path and, when the
+// clustered primary key starts with the temporal TTL column, restricts Region
+// lookup to the physical prefix that can contain expired rows.
+func (t *PhysicalTable) SplitScanRangesBeforeExpire(
+	ctx context.Context,
+	store kv.Storage,
+	expireTime time.Time,
+	loc *time.Location,
+	splitCnt int,
+) ([]ScanRange, error) {
+	if len(t.KeyColumns) == 0 || !t.IsCommonHandle || t.TimeColumn == nil ||
+		t.KeyColumns[0].ID != t.TimeColumn.ID {
+		return t.SplitScanRanges(ctx, store, splitCnt)
+	}
+
+	ft := &t.KeyColumns[0].FieldType
+	switch ft.GetType() {
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		return t.splitTemporalCommonHandleRanges(ctx, store, expireTime, loc, splitCnt)
+	default:
+		return t.SplitScanRanges(ctx, store, splitCnt)
+	}
+}
+
 func unsignedEdge(d types.Datum) types.Datum {
 	if d.IsNull() {
 		return types.NewUintDatum(uint64(math.MaxInt64 + 1))
@@ -446,6 +470,177 @@ func (t *PhysicalTable) splitCommonHandleRanges(
 		curScanStart = curScanEnd
 	}
 	return scanRanges, nil
+}
+
+func (t *PhysicalTable) splitTemporalCommonHandleRanges(
+	ctx context.Context,
+	store kv.Storage,
+	expireTime time.Time,
+	loc *time.Location,
+	splitCnt int,
+) ([]ScanRange, error) {
+	if splitCnt <= 1 {
+		return []ScanRange{newFullRange()}, nil
+	}
+	tikvStore, ok := store.(tikv.Storage)
+	if !ok {
+		return []ScanRange{newFullRange()}, nil
+	}
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	recordPrefix := tablecodec.GenTableRecordPrefix(t.ID)
+	ft := &t.KeyColumns[0].FieldType
+	expireDatum := types.NewTimeDatum(types.NewTime(
+		types.FromGoTime(expireTime), ft.GetType(), ft.GetDecimal()))
+	encodedExpire, err := codec.EncodeKey(loc, nil, expireDatum)
+	if err != nil {
+		return nil, err
+	}
+	endKey := append(recordPrefix.Clone(), encodedExpire...)
+	if endKey.Cmp(recordPrefix) <= 0 {
+		return []ScanRange{newFullRange()}, nil
+	}
+
+	// Region lookup is limited to [recordPrefix, encodedExpire). A Region that
+	// crosses the cutoff is retained, while Regions wholly after it cannot add
+	// subtasks. The SQL expiration predicate remains the exact upper bound.
+	keyRanges, err := t.splitRawKeyRanges(ctx, tikvStore, recordPrefix, endKey, splitCnt)
+	if err != nil {
+		return nil, err
+	}
+	if len(keyRanges) <= 1 {
+		return []ScanRange{newFullRange()}, nil
+	}
+
+	scanRanges := make([]ScanRange, 0, len(keyRanges))
+	curStart := nullDatum()
+	for i, keyRange := range keyRanges {
+		curEnd := nullDatum()
+		if i != len(keyRanges)-1 {
+			curEnd, err = timeDatumAtOrBeforeRecordBoundary(keyRange.EndKey, recordPrefix, ft, loc)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !curStart.IsNull() && !curEnd.IsNull() {
+			cmp, err := curStart.Compare(types.StrictContext, &curEnd, collate.GetBinaryCollator())
+			intest.AssertNoError(err)
+			if err != nil {
+				return nil, err
+			}
+			if cmp >= 0 {
+				continue
+			}
+		}
+
+		scanRanges = append(scanRanges, newDatumRange(curStart, curEnd))
+		if curEnd.IsNull() {
+			break
+		}
+		curStart = curEnd
+	}
+	if len(scanRanges) == 0 {
+		return []ScanRange{newFullRange()}, nil
+	}
+
+	// Keep the existing PK task encoding so older workers can still parse these
+	// textual bounds. TIMESTAMP bounds are written in UTC because current TTL data
+	// SQL runs in UTC; DATE and DATETIME keep their wall-clock components.
+	for i := range scanRanges {
+		scanRanges[i].Start = temporalRangeAsBytes(scanRanges[i].Start)
+		scanRanges[i].End = temporalRangeAsBytes(scanRanges[i].End)
+	}
+	return scanRanges, nil
+}
+
+func temporalRangeAsBytes(r []types.Datum) []types.Datum {
+	if len(r) != 1 || r[0].Kind() != types.KindMysqlTime {
+		return r
+	}
+	return []types.Datum{types.NewBytesDatum([]byte(r[0].GetMysqlTime().String()))}
+}
+
+// timeDatumAtOrBeforeRecordBoundary maps an arbitrary Region boundary to the
+// greatest valid temporal value whose complete encoded key does not exceed the
+// boundary. Region keys can truncate a datum or contain an invalid packed
+// calendar value, so decoding the boundary directly is not reliable.
+func timeDatumAtOrBeforeRecordBoundary(
+	boundary, recordPrefix kv.Key,
+	ft *types.FieldType,
+	loc *time.Location,
+) (types.Datum, error) {
+	tp := ft.GetType()
+	fsp := ft.GetDecimal()
+	if fsp == types.UnspecifiedFsp {
+		fsp = types.DefaultFsp
+	}
+	if fsp < types.MinFsp || fsp > types.MaxFsp {
+		return nullDatum(), errors.Errorf("invalid temporal FSP: %d", fsp)
+	}
+
+	stepMicros := int64(1)
+	for i := fsp; i < types.MaxFsp; i++ {
+		stepMicros *= 10
+	}
+	minTime := time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxTime := time.Date(9999, 12, 31, 23, 59, 59, int(1_000_000-stepMicros)*1000, time.UTC)
+	if tp == mysql.TypeDate {
+		stepMicros = int64(24 * time.Hour / time.Microsecond)
+		maxTime = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
+	} else if tp == mysql.TypeTimestamp {
+		minTime = time.Date(1970, 1, 1, 0, 0, 1, 0, time.UTC)
+		maxTime = time.Date(2038, 1, 19, 3, 14, 7, int(1_000_000-stepMicros)*1000, time.UTC)
+	}
+	minMicros, maxMicros := minTime.UnixMicro(), maxTime.UnixMicro()
+
+	makeDatum := func(micros int64) types.Datum {
+		return types.NewTimeDatum(types.NewTime(types.FromGoTime(time.UnixMicro(micros).UTC()), tp, fsp))
+	}
+	encodeDatum := func(d types.Datum) (kv.Key, error) {
+		encodeLoc := loc
+		if tp == mysql.TypeTimestamp {
+			encodeLoc = time.UTC
+		}
+		encoded, err := codec.EncodeKey(encodeLoc, nil, d)
+		if err != nil {
+			return nil, err
+		}
+		key := make(kv.Key, 0, len(recordPrefix)+len(encoded))
+		key = append(key, recordPrefix...)
+		return append(key, encoded...), nil
+	}
+
+	zeroDatum := types.NewTimeDatum(types.NewTime(types.ZeroCoreTime, tp, fsp))
+	zeroKey, err := encodeDatum(zeroDatum)
+	if err != nil {
+		return nullDatum(), err
+	}
+	if boundary.Cmp(zeroKey) < 0 {
+		return zeroDatum, nil
+	}
+
+	low, high := int64(0), (maxMicros-minMicros)/stepMicros
+	best := int64(-1)
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate := makeDatum(minMicros + mid*stepMicros)
+		key, err := encodeDatum(candidate)
+		if err != nil {
+			return nullDatum(), err
+		}
+		if key.Cmp(boundary) <= 0 {
+			best = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if best < 0 {
+		return zeroDatum, nil
+	}
+	return makeDatum(minMicros + best*stepMicros), nil
 }
 
 func (t *PhysicalTable) splitRawKeyRanges(ctx context.Context, store tikv.Storage,

--- a/pkg/ttl/session/BUILD.bazel
+++ b/pkg/ttl/session/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/kv",
         "//pkg/parser/terror",
         "//pkg/sessionctx",
-        "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/sessiontxn",
         "//pkg/ttl/metrics",
@@ -32,7 +31,7 @@ go_test(
         "sysvar_test.go",
     ],
     flaky = True,
-    shard_count = 7,
+    shard_count = 6,
     deps = [
         ":session",
         "//pkg/sessionctx/vardef",

--- a/pkg/ttl/session/session.go
+++ b/pkg/ttl/session/session.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/ttl/metrics"
@@ -59,8 +58,6 @@ type Session interface {
 	ExecuteSQL(ctx context.Context, sql string, args ...any) ([]chunk.Row, error)
 	// RunInTxn executes the specified function in a txn
 	RunInTxn(ctx context.Context, fn func() error, mode TxnMode) (err error)
-	// ResetWithGlobalTimeZone resets the session time zone to global time zone
-	ResetWithGlobalTimeZone(ctx context.Context) error
 	// GlobalTimeZone returns the global timezone. It is used to compute expire time for TTL
 	GlobalTimeZone(ctx context.Context) (*time.Location, error)
 	// KillStmt kills the current statement execution
@@ -176,29 +173,6 @@ func (s *session) RunInTxn(ctx context.Context, fn func() error, txnMode TxnMode
 	tracer.EnterPhase(metrics.PhaseOther)
 
 	success = true
-	return err
-}
-
-// ResetWithGlobalTimeZone resets the session time zone to global time zone
-func (s *session) ResetWithGlobalTimeZone(ctx context.Context) error {
-	sessVar := s.sctx.GetSessionVars()
-	if sessVar.TimeZone != nil {
-		globalTZ, err := sessVar.GetGlobalSystemVar(ctx, vardef.TimeZone)
-		if err != nil {
-			return err
-		}
-
-		tz, err := sessVar.GetSessionOrGlobalSystemVar(ctx, vardef.TimeZone)
-		if err != nil {
-			return err
-		}
-
-		if globalTZ == tz {
-			return nil
-		}
-	}
-
-	_, err := s.ExecuteSQL(ctx, "SET @@time_zone=@@global.time_zone")
 	return err
 }
 

--- a/pkg/ttl/session/session_test.go
+++ b/pkg/ttl/session/session_test.go
@@ -55,18 +55,6 @@ func TestSessionRunInTxn(t *testing.T) {
 	tk2.MustQuery("select * from t order by id asc").Check(testkit.Rows("1 10", "3 30"))
 }
 
-func TestSessionResetTimeZone(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("set @@global.time_zone='UTC'")
-	tk.MustExec("set @@time_zone='Asia/Shanghai'")
-
-	se := session.NewSession(tk.Session(), func() {})
-	tk.MustQuery("select @@time_zone").Check(testkit.Rows("Asia/Shanghai"))
-	require.NoError(t, se.ResetWithGlobalTimeZone(context.TODO()))
-	tk.MustQuery("select @@time_zone").Check(testkit.Rows("UTC"))
-}
-
 func TestSessionKill(t *testing.T) {
 	store, do := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/ttl/sqlbuilder/BUILD.bazel
+++ b/pkg/ttl/sqlbuilder/BUILD.bazel
@@ -25,7 +25,7 @@ go_test(
         "sql_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         ":sqlbuilder",
         "//pkg/kv",

--- a/pkg/ttl/sqlbuilder/sql.go
+++ b/pkg/ttl/sqlbuilder/sql.go
@@ -181,12 +181,9 @@ func (b *SQLBuilder) WriteExpireCondition(expire time.Time) error {
 
 	b.writeColNames([]*model.ColumnInfo{b.tbl.TimeColumn}, false)
 	b.restoreCtx.WritePlain(" < ")
-	_, expireOffset := expire.Zone()
-	if b.tbl.TimeColumn.GetType() == mysql.TypeTimestamp || expireOffset == 0 {
+	if b.tbl.TimeColumn.GetType() == mysql.TypeTimestamp {
 		// TTL worker sessions execute in UTC. For TIMESTAMP, the expiration
 		// frontier is an instant, so FROM_UNIXTIME preserves that exact instant.
-		// It is also equivalent to the DATE/DATETIME wall clock when the captured
-		// global time zone has a zero offset at the expiration time.
 		b.restoreCtx.WritePlain("FROM_UNIXTIME(")
 		b.restoreCtx.WritePlain(strconv.FormatInt(expire.Unix(), 10))
 		b.restoreCtx.WritePlain(")")

--- a/pkg/ttl/sqlbuilder/sql.go
+++ b/pkg/ttl/sqlbuilder/sql.go
@@ -181,9 +181,23 @@ func (b *SQLBuilder) WriteExpireCondition(expire time.Time) error {
 
 	b.writeColNames([]*model.ColumnInfo{b.tbl.TimeColumn}, false)
 	b.restoreCtx.WritePlain(" < ")
-	b.restoreCtx.WritePlain("FROM_UNIXTIME(")
-	b.restoreCtx.WritePlain(strconv.FormatInt(expire.Unix(), 10))
-	b.restoreCtx.WritePlain(")")
+	_, expireOffset := expire.Zone()
+	if b.tbl.TimeColumn.GetType() == mysql.TypeTimestamp || expireOffset == 0 {
+		// TTL worker sessions execute in UTC. For TIMESTAMP, the expiration
+		// frontier is an instant, so FROM_UNIXTIME preserves that exact instant.
+		// It is also equivalent to the DATE/DATETIME wall clock when the captured
+		// global time zone has a zero offset at the expiration time.
+		b.restoreCtx.WritePlain("FROM_UNIXTIME(")
+		b.restoreCtx.WritePlain(strconv.FormatInt(expire.Unix(), 10))
+		b.restoreCtx.WritePlain(")")
+	} else {
+		// DATE and DATETIME have wall-clock semantics. expire is normalized to
+		// the global time zone by the scan worker; write that wall-clock value as
+		// a DATETIME constant so executing this SQL in UTC does not shift it.
+		b.restoreCtx.WriteKeyWord("CAST(")
+		b.restoreCtx.WriteString(expire.Format(time.DateTime))
+		b.restoreCtx.WriteKeyWord(" AS DATETIME)")
+	}
 	b.hasWriteExpireCond = true
 	return nil
 }

--- a/pkg/ttl/sqlbuilder/sql_test.go
+++ b/pkg/ttl/sqlbuilder/sql_test.go
@@ -464,7 +464,7 @@ func TestSQLBuilder(t *testing.T) {
 	shLoc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(shLoc)))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < CAST('1970-01-01 08:00:00' AS DATETIME)")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteSelect())
@@ -575,6 +575,42 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteInCondition(tp.KeyColumns, d("a"), d("b")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	mustBuild(b, "DELETE LOW_PRIORITY FROM `testp`.`tp` PARTITION(`p1`) WHERE `id` IN ('a', 'b') AND `time` < FROM_UNIXTIME(0)")
+}
+
+func TestExpireConditionPreservesTemporalSemanticsInUTCSession(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	// This instant is the second 01:15 during the New York DST fold.
+	expire := time.Date(2024, 11, 3, 6, 15, 0, 0, time.UTC).In(ny)
+	for _, tc := range []struct {
+		name     string
+		typeCode byte
+		expect   string
+	}{
+		{"timestamp", mysql.TypeTimestamp, fmt.Sprintf("FROM_UNIXTIME(%d)", expire.Unix())},
+		{"datetime", mysql.TypeDatetime, "CAST('2024-11-03 01:15:00' AS DATETIME)"},
+		{"date", mysql.TypeDate, "CAST('2024-11-03 01:15:00' AS DATETIME)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			timeColumn := &model.ColumnInfo{Name: ast.NewCIStr("expired_at"), FieldType: *types.NewFieldType(tc.typeCode)}
+			tbl := &cache.PhysicalTable{
+				Schema: ast.NewCIStr("test"),
+				TableInfo: &model.TableInfo{
+					Name: ast.NewCIStr("t"),
+				},
+				KeyColumns: []*model.ColumnInfo{{Name: ast.NewCIStr("id"), FieldType: *types.NewFieldType(mysql.TypeLong)}},
+				TimeColumn: timeColumn,
+			}
+			b := sqlbuilder.NewSQLBuilder(tbl)
+			require.NoError(t, b.WriteSelect())
+			require.NoError(t, b.WriteExpireCondition(expire))
+			sql, err := b.Build()
+			require.NoError(t, err)
+			require.Contains(t, sql, "`expired_at` < "+tc.expect)
+			_, _, err = parser.New().Parse(sql, "", "")
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestScanQueryGenerator(t *testing.T) {

--- a/pkg/ttl/sqlbuilder/sql_test.go
+++ b/pkg/ttl/sqlbuilder/sql_test.go
@@ -82,17 +82,17 @@ func TestEscape(t *testing.T) {
 		{
 			tp:  "select",
 			ds:  [][]types.Datum{d("key1'\";123`456\t\n\r")},
-			sql: "SELECT LOW_PRIORITY SQL_NO_CACHE `col1\"';123``456` FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` > 'key1\\'\\\";123`456\t\\n\\r' AND `time\"';123``456` < FROM_UNIXTIME(0)",
+			sql: "SELECT LOW_PRIORITY SQL_NO_CACHE `col1\"';123``456` FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` > 'key1\\'\\\";123`456\t\\n\\r' AND `time\"';123``456` < CAST('1970-01-01 00:00:00' AS DATETIME)",
 		},
 		{
 			tp:  "delete",
 			ds:  [][]types.Datum{d("key2'\";123`456\t\n\r")},
-			sql: "DELETE LOW_PRIORITY FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` IN ('key2\\'\\\";123`456\t\\n\\r') AND `time\"';123``456` < FROM_UNIXTIME(0)",
+			sql: "DELETE LOW_PRIORITY FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` IN ('key2\\'\\\";123`456\t\\n\\r') AND `time\"';123``456` < CAST('1970-01-01 00:00:00' AS DATETIME)",
 		},
 		{
 			tp:  "delete",
 			ds:  [][]types.Datum{d("key3'\";123`456\t\n\r"), d("key4'`\"")},
-			sql: "DELETE LOW_PRIORITY FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` IN ('key3\\'\\\";123`456\t\\n\\r', 'key4\\'`\\\"') AND `time\"';123``456` < FROM_UNIXTIME(0)",
+			sql: "DELETE LOW_PRIORITY FROM `testp;\"';123``456`.`tp\"';123``456` PARTITION(`p1\"';123``456`) WHERE `col1\"';123``456` IN ('key3\\'\\\";123`456\t\\n\\r', 'key4\\'`\\\"') AND `time\"';123``456` < CAST('1970-01-01 00:00:00' AS DATETIME)",
 		},
 	}
 
@@ -115,8 +115,7 @@ func TestEscape(t *testing.T) {
 		var tbName *ast.TableName
 		var keyColumnName, timeColumnName string
 		var values []string
-		var timeFunc string
-		var timeTS int64
+		var timeValue string
 		switch c.tp {
 		case "select":
 			stmt, ok := stmts[0].(*ast.SelectStmt)
@@ -128,8 +127,9 @@ func TestEscape(t *testing.T) {
 			values = []string{cond1.R.(ast.ValueExpr).GetValue().(string)}
 			cond2 := and.R.(*ast.BinaryOperationExpr)
 			timeColumnName = cond2.L.(*ast.ColumnNameExpr).Name.Name.O
-			timeFunc = cond2.R.(*ast.FuncCallExpr).FnName.L
-			timeTS = cond2.R.(*ast.FuncCallExpr).Args[0].(ast.ValueExpr).GetValue().(int64)
+			castExpr := cond2.R.(*ast.FuncCastExpr)
+			require.Equal(t, mysql.TypeDatetime, castExpr.Tp.GetType())
+			timeValue = castExpr.Expr.(ast.ValueExpr).GetValue().(string)
 		case "delete":
 			stmt, ok := stmts[0].(*ast.DeleteStmt)
 			require.True(t, ok)
@@ -144,8 +144,9 @@ func TestEscape(t *testing.T) {
 			}
 			cond2 := and.R.(*ast.BinaryOperationExpr)
 			timeColumnName = cond2.L.(*ast.ColumnNameExpr).Name.Name.O
-			timeFunc = cond2.R.(*ast.FuncCallExpr).FnName.L
-			timeTS = cond2.R.(*ast.FuncCallExpr).Args[0].(ast.ValueExpr).GetValue().(int64)
+			castExpr := cond2.R.(*ast.FuncCastExpr)
+			require.Equal(t, mysql.TypeDatetime, castExpr.Tp.GetType())
+			timeValue = castExpr.Expr.(ast.ValueExpr).GetValue().(string)
 		default:
 			require.FailNow(t, "invalid tp: %s", c.tp)
 		}
@@ -159,8 +160,7 @@ func TestEscape(t *testing.T) {
 		for i, row := range c.ds {
 			require.Equal(t, row[0].GetString(), values[i])
 		}
-		require.Equal(t, "from_unixtime", timeFunc)
-		require.Equal(t, int64(0), timeTS)
+		require.Equal(t, "1970-01-01 00:00:00", timeValue)
 	}
 }
 
@@ -471,7 +471,7 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteCommonCondition(t1.KeyColumns, ">", d("a1")))
 	must(b.WriteCommonCondition(t1.KeyColumns, "<=", d("c3")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 'a1' AND `id` <= 'c3' AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 'a1' AND `id` <= 'c3' AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteSelect())
@@ -501,7 +501,7 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	must(b.WriteOrderBy(t1.KeyColumns, false))
 	must(b.WriteLimit(128))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 'a1\\';\\'' AND `id` <= 'a2\\\"' AND `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 128")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 'a1\\';\\'' AND `id` <= 'a2\\\"' AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 128")
 
 	b = sqlbuilder.NewSQLBuilder(t2)
 	must(b.WriteSelect())
@@ -514,7 +514,7 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	must(b.WriteOrderBy(t2.KeyColumns, false))
 	must(b.WriteLimit(100))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b` FROM `test2`.`t2` WHERE (`a`, `b`) <= ('x2', 21) AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b` ASC LIMIT 100")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b` FROM `test2`.`t2` WHERE (`a`, `b`) <= ('x2', 21) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b` ASC LIMIT 100")
 
 	b = sqlbuilder.NewSQLBuilder(t2)
 	must(b.WriteSelect())
@@ -523,7 +523,7 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	must(b.WriteOrderBy(t2.KeyColumns, false))
 	must(b.WriteLimit(100))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b` FROM `test2`.`t2` WHERE `a` = 'x3' AND `b` > 31 AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b` ASC LIMIT 100")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b` FROM `test2`.`t2` WHERE `a` = 'x3' AND `b` > 31 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b` ASC LIMIT 100")
 
 	// test build delete queries
 	b = sqlbuilder.NewSQLBuilder(t1)
@@ -535,46 +535,46 @@ func TestSQLBuilder(t *testing.T) {
 	must(b.WriteDelete())
 	must(b.WriteInCondition(t1.KeyColumns, d("a")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN ('a') AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN ('a') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteDelete())
 	must(b.WriteInCondition(t1.KeyColumns, d("a"), d("b")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN ('a', 'b') AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN ('a', 'b') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteDelete())
 	must(b.WriteInCondition(t2.KeyColumns, d("a", 1)))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	must(b.WriteLimit(100))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1)) AND `time` < FROM_UNIXTIME(0) LIMIT 100")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1)) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 100")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteDelete())
 	must(b.WriteInCondition(t2.KeyColumns, d("a", 1), d("b", 2)))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
 	must(b.WriteLimit(100))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1), ('b', 2)) AND `time` < FROM_UNIXTIME(0) LIMIT 100")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1), ('b', 2)) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 100")
 
 	b = sqlbuilder.NewSQLBuilder(t1)
 	must(b.WriteDelete())
 	must(b.WriteInCondition(t2.KeyColumns, d("a", 1), d("b", 2)))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1), ('b', 2)) AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE (`a`, `b`) IN (('a', 1), ('b', 2)) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 
 	// test select partition table
 	b = sqlbuilder.NewSQLBuilder(tp)
 	must(b.WriteSelect())
 	must(b.WriteCommonCondition(tp.KeyColumns, ">", d("a1")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `testp`.`tp` PARTITION(`p1`) WHERE `id` > 'a1' AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `testp`.`tp` PARTITION(`p1`) WHERE `id` > 'a1' AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 
 	b = sqlbuilder.NewSQLBuilder(tp)
 	must(b.WriteDelete())
 	must(b.WriteInCondition(tp.KeyColumns, d("a"), d("b")))
 	must(b.WriteExpireCondition(time.UnixMilli(0).In(time.UTC)))
-	mustBuild(b, "DELETE LOW_PRIORITY FROM `testp`.`tp` PARTITION(`p1`) WHERE `id` IN ('a', 'b') AND `time` < FROM_UNIXTIME(0)")
+	mustBuild(b, "DELETE LOW_PRIORITY FROM `testp`.`tp` PARTITION(`p1`) WHERE `id` IN ('a', 'b') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME)")
 }
 
 func TestExpireConditionPreservesTemporalSemanticsInUTCSession(t *testing.T) {
@@ -663,7 +663,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 3,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 3",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 3",
 				},
 				{
 					nil, 5, "",
@@ -676,7 +676,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 3,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 3",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 3",
 				},
 				{
 					[][]types.Datum{}, 5, "",
@@ -691,11 +691,11 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 3,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` >= 1 AND `id` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 3",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` >= 1 AND `id` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 3",
 				},
 				{
 					result(d(10), 3), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 10 AND `id` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 10 AND `id` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 5",
 				},
 				{
 					result(d(15), 4), 5,
@@ -709,15 +709,15 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 3,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 3",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 3",
 				},
 				{
 					result(d(2), 3), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 2 AND `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 2 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 5",
 				},
 				{
 					result(d(4), 5), 6,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 4 AND `time` < FROM_UNIXTIME(0) ORDER BY `id` ASC LIMIT 6",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `id` FROM `test`.`t1` WHERE `id` > 4 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `id` ASC LIMIT 6",
 				},
 				{
 					result(d(7), 5), 5, "",
@@ -730,7 +730,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					nil, 5, "",
@@ -743,7 +743,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					nil, 5, "",
@@ -756,7 +756,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					[][]types.Datum{}, 5, "",
@@ -769,7 +769,7 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0xf0}), 4), 5, "",
@@ -784,39 +784,39 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` >= x'0e' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` >= x'0e' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x1a}), 5), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x20}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "y", []byte{0x0a}), 5), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'y' AND `c` > x'0a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'y' AND `c` > x'0a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "y", []byte{0x11}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'y' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'y' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "z", []byte{0x02}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(3, "a", []byte{0x01}), 5), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 3 AND `b` = 'a' AND `c` > x'01' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 3 AND `b` = 'a' AND `c` > x'01' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(3, "a", []byte{0x11}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 3 AND `b` > 'a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 3 AND `b` > 'a' AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(3, "c", []byte{0x12}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 3 AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 3 AND (`a`, `b`, `c`) < (100, 'z', x'ff') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(5, "e", []byte{0xa1}), 4), 5, "",
@@ -831,19 +831,19 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` >= 1 AND `a` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` >= 1 AND `a` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x1a}), 5), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND `a` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND `a` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x20}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND `a` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND `a` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "y", []byte{0x0a}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND `a` < 100 AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND `a` < 100 AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 			},
 		},
@@ -855,19 +855,19 @@ func TestScanQueryGenerator(t *testing.T) {
 			path: [][]any{
 				{
 					nil, 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` >= 'x' AND (`a`, `b`) < (100, 'z') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` >= 'x' AND (`a`, `b`) < (100, 'z') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x1a}), 5), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND (`a`, `b`) < (100, 'z') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` = 'x' AND `c` > x'1a' AND (`a`, `b`) < (100, 'z') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "x", []byte{0x20}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND (`a`, `b`) < (100, 'z') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` = 1 AND `b` > 'x' AND (`a`, `b`) < (100, 'z') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 				{
 					result(d(1, "y", []byte{0x0a}), 4), 5,
-					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND (`a`, `b`) < (100, 'z') AND `time` < FROM_UNIXTIME(0) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
+					"SELECT LOW_PRIORITY SQL_NO_CACHE `a`, `b`, `c` FROM `test2`.`t2` WHERE `a` > 1 AND (`a`, `b`) < (100, 'z') AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `a`, `b`, `c` ASC LIMIT 5",
 				},
 			},
 		},
@@ -937,25 +937,25 @@ func TestBuildDeleteSQL(t *testing.T) {
 			tbl:    t1,
 			expire: time.UnixMilli(0).In(time.UTC),
 			rows:   [][]types.Datum{d(1)},
-			sql:    "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN (1) AND `time` < FROM_UNIXTIME(0) LIMIT 1",
+			sql:    "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN (1) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 1",
 		},
 		{
 			tbl:    t1,
 			expire: time.UnixMilli(0).In(time.UTC),
 			rows:   [][]types.Datum{d(2), d(3), d(4)},
-			sql:    "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN (2, 3, 4) AND `time` < FROM_UNIXTIME(0) LIMIT 3",
+			sql:    "DELETE LOW_PRIORITY FROM `test`.`t1` WHERE `id` IN (2, 3, 4) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 3",
 		},
 		{
 			tbl:    t2,
 			expire: time.UnixMilli(0).In(time.UTC),
 			rows:   [][]types.Datum{d(1, "a")},
-			sql:    "DELETE LOW_PRIORITY FROM `test2`.`t2` WHERE (`a`, `b`) IN ((1, 'a')) AND `time` < FROM_UNIXTIME(0) LIMIT 1",
+			sql:    "DELETE LOW_PRIORITY FROM `test2`.`t2` WHERE (`a`, `b`) IN ((1, 'a')) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 1",
 		},
 		{
 			tbl:    t2,
 			expire: time.UnixMilli(0).In(time.UTC),
 			rows:   [][]types.Datum{d(1, "a"), d(2, "b")},
-			sql:    "DELETE LOW_PRIORITY FROM `test2`.`t2` WHERE (`a`, `b`) IN ((1, 'a'), (2, 'b')) AND `time` < FROM_UNIXTIME(0) LIMIT 2",
+			sql:    "DELETE LOW_PRIORITY FROM `test2`.`t2` WHERE (`a`, `b`) IN ((1, 'a'), (2, 'b')) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT 2",
 		},
 	}
 

--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -101,6 +101,7 @@ go_test(
         "//pkg/ttl/client",
         "//pkg/ttl/metrics",
         "//pkg/ttl/session",
+        "//pkg/ttl/sqlbuilder",
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/chunk",

--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/chunk",
+        "//pkg/util/codec",
         "//pkg/util/logutil",
         "//pkg/util/skip",
         "//pkg/util/sqlexec",

--- a/pkg/ttl/ttlworker/del_test.go
+++ b/pkg/ttl/ttlworker/del_test.go
@@ -364,7 +364,7 @@ func TestTTLDeleteTaskDoDelete(t *testing.T) {
 				idList = append(idList, strconv.FormatInt(row[0].GetInt64(), 10))
 			}
 			sql := fmt.Sprintf("DELETE LOW_PRIORITY FROM `test`.`t1` "+
-				"WHERE `_tidb_rowid` IN (%s) AND `time` < FROM_UNIXTIME(0) LIMIT %d",
+				"WHERE `_tidb_rowid` IN (%s) AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) LIMIT %d",
 				strings.Join(idList, ", "),
 				delBatch,
 			)

--- a/pkg/ttl/ttlworker/del_test.go
+++ b/pkg/ttl/ttlworker/del_test.go
@@ -261,7 +261,7 @@ func TestTTLDeleteTaskDoDelete(t *testing.T) {
 	}
 
 	delTask := func(batchCnt int) *ttlDeleteTask {
-		return newMockDeleteTask(t1, nRows(batchCnt*delBatch), time.UnixMilli(0))
+		return newMockDeleteTask(t1, nRows(batchCnt*delBatch), time.UnixMilli(0).UTC())
 	}
 
 	cases := []struct {

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -909,7 +909,8 @@ func (m *JobManager) lockNewJob(ctx context.Context, se session.Session, table *
 			return errors.Wrapf(err, "execute sql: %s", sql)
 		}
 
-		ranges, err := table.SplitScanRanges(ctx, m.store, getScanSplitCnt(se.GetStore()))
+		ranges, err := table.SplitScanRangesBeforeExpire(
+			ctx, m.store, expireTime, se.GetSessionVars().Location(), getScanSplitCnt(se.GetStore()))
 		if err != nil {
 			return errors.Wrap(err, "split scan ranges")
 		}

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -47,7 +47,9 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/client"
 	"github.com/pingcap/tidb/pkg/ttl/metrics"
 	"github.com/pingcap/tidb/pkg/ttl/session"
+	"github.com/pingcap/tidb/pkg/ttl/sqlbuilder"
 	"github.com/pingcap/tidb/pkg/ttl/ttlworker"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/skip"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -1971,4 +1973,185 @@ func TestTTLSummaryForTimeoutJob(t *testing.T) {
 	require.Equal(t, uint64(100), summary.SuccessRows)
 	require.Equal(t, uint64(0), summary.ErrorRows)
 	require.Equal(t, "job is timeout", summary.ScanTaskErr)
+}
+
+func TestTimestampPaginationAcrossTimeZones(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	waitAndStopTTLManager(t, dom)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@time_zone='UTC'")
+	t.Cleanup(func() { tk.MustExec("set @@global.time_zone='UTC'") })
+
+	testCases := []struct {
+		name     string
+		zone     string
+		location *time.Location
+		instants []string
+	}{
+		{
+			name:     "dst_fold",
+			zone:     "America/New_York",
+			location: mustLoadLocation(t, "America/New_York"),
+			// 05:30 and 06:30 UTC both display as 01:30 locally, but they
+			// are different TIMESTAMP values and must produce different cursors.
+			instants: []string{"2024-11-03 05:30:00.123456", "2024-11-03 06:30:00.123456", "2024-11-03 07:30:00.123456"},
+		},
+		{
+			name:     "dst_gap",
+			zone:     "America/New_York",
+			location: mustLoadLocation(t, "America/New_York"),
+			instants: []string{"2024-03-10 06:30:00.123456", "2024-03-10 07:30:00.123456", "2024-03-10 08:30:00.123456"},
+		},
+		{
+			name:     "fixed_offset",
+			zone:     "+05:30",
+			location: time.FixedZone("+05:30", 5*60*60+30*60),
+			instants: []string{"2024-01-01 00:00:00.123456", "2024-01-01 01:00:00.123456", "2024-01-01 02:00:00.123456"},
+		},
+		{
+			name:     "shanghai",
+			zone:     "Asia/Shanghai",
+			location: mustLoadLocation(t, "Asia/Shanghai"),
+			instants: []string{"2024-01-01 00:00:00.123456", "2024-01-01 01:00:00.123456", "2024-01-01 02:00:00.123456"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tk.MustExec("set @@global.time_zone=?", tc.zone)
+			tableName := "ttl_timestamp_" + tc.name
+			tk.MustExec(fmt.Sprintf(`create table %s(
+				expired_at timestamp(6) not null,
+				id bigint not null,
+				primary key(expired_at, id) clustered
+			) TTL=expired_at + interval 1 hour`, tableName))
+			for i, instant := range tc.instants {
+				tk.MustExec(fmt.Sprintf("insert into %s values (?, ?)", tableName), instant, i+1)
+			}
+
+			tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(tableName))
+			require.NoError(t, err)
+			ttlTbl, err := cache.NewPhysicalTable(ast.NewCIStr("test"), tbl.Meta(), ast.NewCIStr(""))
+			require.NoError(t, err)
+			expire := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).In(tc.location)
+			generator, err := sqlbuilder.NewScanQueryGenerator(ttlTbl, expire, nil, nil)
+			require.NoError(t, err)
+			se := session.NewSession(tk.Session(), func() {})
+			var previous [][]types.Datum
+			var ids []int64
+			for range 16 {
+				sql, err := generator.NextSQL(previous, 1)
+				require.NoError(t, err)
+				if sql == "" {
+					break
+				}
+				plan := tk.MustQuery("explain format='brief' " + sql)
+				plan.CheckContain("TableRangeScan")
+				plan.CheckNotContain("TopN")
+				plan.CheckNotContain("Sort")
+				rows, err := se.ExecuteSQL(context.Background(), sql)
+				require.NoError(t, err)
+				previous = make([][]types.Datum, len(rows))
+				for i, row := range rows {
+					previous[i] = row.GetDatumRow(ttlTbl.KeyColumnTypes)
+					ids = append(ids, previous[i][1].GetInt64())
+				}
+			}
+			require.True(t, generator.IsExhausted())
+			require.Equal(t, []int64{1, 2, 3}, ids)
+		})
+	}
+}
+
+func mustLoadLocation(t *testing.T, name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	require.NoError(t, err)
+	return loc
+}
+
+func TestTTLExpirationPredicatesInUTCSession(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	waitAndStopTTLManager(t, dom)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.time_zone='America/New_York'")
+	t.Cleanup(func() { tk.MustExec("set @@global.time_zone='UTC'") })
+	// This is the protocol used by TTL's shared session pool. The expiration
+	// time below is still expressed in the captured global location.
+	tk.MustExec("set @@time_zone='UTC'")
+
+	newTTLTable := func(name string) *cache.PhysicalTable {
+		tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(name))
+		require.NoError(t, err)
+		ttlTbl, err := cache.NewPhysicalTable(ast.NewCIStr("test"), tbl.Meta(), ast.NewCIStr(""))
+		require.NoError(t, err)
+		return ttlTbl
+	}
+	deleteKeys := [][]types.Datum{
+		{types.NewIntDatum(1)},
+		{types.NewIntDatum(2)},
+		{types.NewIntDatum(3)},
+		{types.NewIntDatum(4)},
+	}
+	ny := mustLoadLocation(t, "America/New_York")
+	// 06:30 UTC is the second occurrence of 01:30 in the New York DST fold.
+	foldCutoff := time.Date(2024, 11, 3, 6, 30, 0, 0, time.UTC).In(ny)
+
+	tk.MustExec(`create table ttl_timestamp_delete(
+		id bigint primary key clustered,
+		expired_at timestamp(6) not null
+	) TTL=expired_at + interval 1 hour`)
+	tk.MustExec(`insert into ttl_timestamp_delete values
+		(1, '2024-11-03 05:30:00'),
+		(2, '2024-11-03 06:30:00'),
+		(3, '2024-11-03 07:30:00'),
+		(4, '2024-11-03 05:45:00')`)
+	// Simulate a TTL value updated after scan but before delete. The DELETE
+	// must recheck expiration and preserve this row.
+	tk.MustExec("update ttl_timestamp_delete set expired_at='2024-11-03 07:45:00' where id=4")
+	deleteSQL, err := sqlbuilder.BuildDeleteSQL(newTTLTable("ttl_timestamp_delete"), deleteKeys, foldCutoff)
+	require.NoError(t, err)
+	tk.MustExec(deleteSQL)
+	tk.MustQuery("select id from ttl_timestamp_delete order by id").Check(testkit.Rows("2", "3", "4"))
+
+	// DATETIME retains the global-zone wall clock even though the statement is
+	// executed in UTC. Equality is not expired because TTL uses a strict bound.
+	tk.MustExec(`create table ttl_datetime_delete(
+		id bigint primary key clustered,
+		expired_at datetime(6) not null
+	) TTL=expired_at + interval 1 hour`)
+	tk.MustExec(`insert into ttl_datetime_delete values
+		(1, '2024-11-03 01:29:59'),
+		(2, '2024-11-03 01:30:00'),
+		(3, '2024-11-03 01:30:01'),
+		(4, '2024-11-03 01:00:00')`)
+	tk.MustExec("update ttl_datetime_delete set expired_at='2024-11-03 02:00:00' where id=4")
+	deleteSQL, err = sqlbuilder.BuildDeleteSQL(newTTLTable("ttl_datetime_delete"), deleteKeys, foldCutoff)
+	require.NoError(t, err)
+	// Reproduce #70032: the global time zone changes after scan has captured
+	// its cutoff but before delete. The pooled TTL session remains in UTC, and
+	// the DATETIME predicate carries the captured New York wall-clock value.
+	tk.MustExec("set @@global.time_zone='+08:00'")
+	tk.MustExec(deleteSQL)
+	tk.MustQuery("select id from ttl_datetime_delete order by id").Check(testkit.Rows("2", "3", "4"))
+	tk.MustExec("set @@global.time_zone='America/New_York'")
+
+	// DATE uses the same wall-clock rule. A midnight cutoff gives an exact DATE
+	// equality case without involving a time-of-day conversion.
+	tk.MustExec(`create table ttl_date_delete(
+		id bigint primary key clustered,
+		expired_at date not null
+	) TTL=expired_at + interval 1 day`)
+	tk.MustExec(`insert into ttl_date_delete values
+		(1, '2024-11-02'),
+		(2, '2024-11-03'),
+		(3, '2024-11-04'),
+		(4, '2024-11-01')`)
+	tk.MustExec("update ttl_date_delete set expired_at='2024-11-05' where id=4")
+	dateCutoff := time.Date(2024, 11, 3, 0, 0, 0, 0, ny)
+	deleteSQL, err = sqlbuilder.BuildDeleteSQL(newTTLTable("ttl_date_delete"), deleteKeys, dateCutoff)
+	require.NoError(t, err)
+	tk.MustExec(deleteSQL)
+	tk.MustQuery("select id from ttl_date_delete order by id").Check(testkit.Rows("2", "3", "4"))
 }

--- a/pkg/ttl/ttlworker/scan.go
+++ b/pkg/ttl/ttlworker/scan.go
@@ -178,6 +178,17 @@ func (t *ttlScanTask) doScanWithSession(ctx context.Context, delCh chan<- *ttlDe
 		wg.Wait()
 	}()
 
+	// TTL data SQL is executed in UTC so that every TIMESTAMP literal denotes
+	// one unambiguous instant, including during a DST fold. Expiration itself is
+	// still defined by the global time zone. Keep that location on expireTime so
+	// DATE/DATETIME predicates retain their wall-clock semantics, and pass the
+	// same value to both scan and delete workers.
+	globalTimeZone, err := rawSess.GlobalTimeZone(scanCtx)
+	if err != nil {
+		return errors.Wrap(err, "get global time zone for TTL expiration condition")
+	}
+	expireTime := t.ExpireTime.In(globalTimeZone)
+
 	now := rawSess.Now()
 	safeExpire, err := t.tbl.EvalExpireTime(taskCtx, rawSess, now)
 	if err != nil {
@@ -203,13 +214,13 @@ func (t *ttlScanTask) doScanWithSession(ctx context.Context, delCh chan<- *ttlDe
 		)
 	}
 
-	sess, restoreSession, err := NewScanSession(scanCtx, rawSess, t.tbl, t.ExpireTime)
+	sess, restoreSession, err := NewScanSession(scanCtx, rawSess, t.tbl, expireTime)
 	if err != nil {
 		return err
 	}
 	defer terror.Call(restoreSession)
 
-	generator, err := sqlbuilder.NewScanQueryGenerator(t.tbl, t.ExpireTime, t.ScanRangeStart, t.ScanRangeEnd)
+	generator, err := sqlbuilder.NewScanQueryGenerator(t.tbl, expireTime, t.ScanRangeStart, t.ScanRangeEnd)
 	if err != nil {
 		return err
 	}
@@ -284,7 +295,7 @@ func (t *ttlScanTask) doScanWithSession(ctx context.Context, delCh chan<- *ttlDe
 			jobID:      t.JobID,
 			scanID:     t.ScanID,
 			tbl:        t.tbl,
-			expire:     t.ExpireTime,
+			expire:     expireTime,
 			rows:       lastResult,
 			statistics: t.statistics,
 		}

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session/syssession"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -29,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -468,6 +471,62 @@ func TestScanTaskDoScan(t *testing.T) {
 	task.schemaChangeIdx = 1
 	task.schemaChangeInRetry = 2
 	task.runDoScanForTest(1, "table 'test.t1' meta changed, should abort current job: [schema:1146]Table 'test.t1' doesn't exist")
+
+	t.Run("persisted temporal clustered-PK range", func(t *testing.T) {
+		tbl := newMockTTLTbl(t, "clustered_pk_range")
+		tbl.TimeColumn.FieldType = *types.NewFieldType(mysql.TypeTimestamp)
+		idColumn := &model.ColumnInfo{
+			ID:        2,
+			Name:      ast.NewCIStr("id"),
+			Offset:    1,
+			FieldType: *types.NewFieldType(mysql.TypeLonglong),
+			State:     model.StatePublic,
+		}
+		tbl.Columns = append(tbl.Columns, idColumn)
+		tbl.IsCommonHandle = true
+		tbl.KeyColumns = []*model.ColumnInfo{tbl.TimeColumn, idColumn}
+		tbl.KeyColumnTypes = []*types.FieldType{&tbl.TimeColumn.FieldType, &idColumn.FieldType}
+
+		globalLoc := time.FixedZone("UTC+8", 8*60*60)
+		boundary := time.Date(2024, 1, 2, 3, 4, 5, 0, globalLoc)
+		// The task keeps the existing textual PK boundary format. TIMESTAMP is
+		// stored as UTC wall time because TTL scan sessions execute in UTC.
+		boundaryText := boundary.UTC().Format(time.DateTime)
+		encodedRange, err := codec.EncodeKey(time.UTC, nil,
+			types.NewBytesDatum([]byte(boundaryText)))
+		require.NoError(t, err)
+		scanRange, err := codec.Decode(encodedRange, len(encodedRange))
+		require.NoError(t, err)
+
+		expire := boundary.Add(time.Hour)
+		scanTask := &ttlScanTask{
+			ctx: cache.SetMockExpireTime(context.Background(), expire),
+			TTLTask: &cache.TTLTask{
+				ExpireTime:     expire,
+				ScanRangeStart: scanRange,
+			},
+			tbl:        tbl,
+			statistics: &ttlStatistics{},
+		}
+		pool := newMockSessionPool(t, tbl)
+		defer pool.AssertNoSessionInUse()
+		pool.se.sessionVars.TimeZone = globalLoc
+		pool.se.executeSQL = func(_ context.Context, sql string, _ ...any) ([]chunk.Row, error) {
+			require.Contains(t, sql, "FROM `test`.`clustered_pk_range`")
+			require.Contains(t, sql, fmt.Sprintf("`time` >= '%s'", boundaryText))
+			require.Contains(t, sql, "ORDER BY `time`, `id` ASC LIMIT 3")
+			return newMockRows(t, &tbl.TimeColumn.FieldType, &idColumn.FieldType).
+				Append(boundary, 1).Rows(), nil
+		}
+
+		origLimit := vardef.TTLScanBatchSize.Load()
+		vardef.TTLScanBatchSize.Store(3)
+		defer vardef.TTLScanBatchSize.Store(origLimit)
+		delCh := make(chan *ttlDeleteTask, 1)
+		result := scanTask.doScan(context.Background(), delCh, pool)
+		require.NoError(t, result.err)
+		require.Equal(t, types.NewIntDatum(1), (<-delCh).rows[0][1])
+	})
 }
 
 func TestScanTaskCheck(t *testing.T) {

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -306,7 +306,7 @@ func (t *mockScanTask) selectSQL(i int) string {
 	if i == 0 {
 		op = ">="
 	}
-	return fmt.Sprintf("SELECT LOW_PRIORITY SQL_NO_CACHE `_tidb_rowid` FROM `test`.`t1` WHERE `_tidb_rowid` %s %d AND `time` < FROM_UNIXTIME(0) ORDER BY `_tidb_rowid` ASC LIMIT 3", op, i*100)
+	return fmt.Sprintf("SELECT LOW_PRIORITY SQL_NO_CACHE `_tidb_rowid` FROM `test`.`t1` WHERE `_tidb_rowid` %s %d AND `time` < CAST('1970-01-01 00:00:00' AS DATETIME) ORDER BY `_tidb_rowid` ASC LIMIT 3", op, i*100)
 }
 
 func (t *mockScanTask) runDoScanForTest(delTaskCnt int, errString string) *ttlScanTaskExecResult {

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -108,7 +108,8 @@ func (w *mockScanWorker) pollDelTask() *ttlDeleteTask {
 		require.NotNil(w.t, del)
 		require.NotNil(w.t, del.statistics)
 		require.Same(w.t, w.curTask.tbl, del.tbl)
-		require.Equal(w.t, w.curTask.ExpireTime, del.expire)
+		require.True(w.t, w.curTask.ExpireTime.Equal(del.expire))
+		require.Equal(w.t, time.UTC, del.expire.Location())
 		require.NotEqual(w.t, 0, len(del.rows))
 		return del
 	case <-time.After(10 * time.Second):
@@ -326,7 +327,6 @@ func (t *mockScanTask) runDoScanForTest(delTaskCnt int, errString string) *ttlSc
 	r := t.doScan(context.TODO(), t.delCh, t.sessPool)
 	require.NotNil(t.t, t.sessPool.lastSession)
 	require.True(t.t, t.sessPool.lastSession.inPool)
-	require.Greater(t.t, t.sessPool.lastSession.resetTimeZoneCalls, 0)
 	require.NotNil(t.t, r)
 	require.Same(t.t, t.ttlScanTask, r.task)
 	if errString == "" {
@@ -370,7 +370,8 @@ loop:
 		require.NotNil(t.t, del.statistics)
 		require.Same(t.t, t.statistics, del.statistics)
 		require.Same(t.t, t.tbl, del.tbl)
-		require.Equal(t.t, t.ExpireTime, del.expire)
+		require.True(t.t, t.ExpireTime.Equal(del.expire))
+		require.Equal(t.t, time.UTC, del.expire.Location())
 		if i < len(t.sqlRetry)-1 {
 			require.Equal(t.t, 3, len(del.rows))
 			require.Equal(t.t, 1, len(del.rows[2]))

--- a/pkg/ttl/ttlworker/session.go
+++ b/pkg/ttl/ttlworker/session.go
@@ -63,103 +63,100 @@ func withSession(pool syssession.Pool, fn func(session.Session) error) error {
 			if err != nil {
 				return err
 			}
-			defer restore()
+			defer terror.Call(restore)
 			return fn(se)
 		})
 	})
 }
 
-func prepareSession(se session.Session) (func(), error) {
+func prepareSession(se session.Session) (func() error, error) {
 	originalRetryLimit := se.GetSessionVars().RetryLimit
 	originalEnable1PC := se.GetSessionVars().Enable1PC
 	originalEnableAsyncCommit := se.GetSessionVars().EnableAsyncCommit
 	originalTimeZone, restoreTimeZone := "", false
 	originalIsolationReadEngines, restoreIsolationReadEngines := "", false
+	restoreRetryLimit, restoreEnable1PC, restoreEnableAsyncCommit := false, false, false
 
-	restore := func() {
-		_, err := se.ExecuteSQL(context.Background(), fmt.Sprintf("set tidb_retry_limit=%d", originalRetryLimit))
-		if err != nil {
-			logutil.BgLogger().Warn("fail to reset tidb_retry_limit", zap.Int64("originalRetryLimit", originalRetryLimit), zap.Error(err))
-			se.AvoidReuse()
-			return
-		}
-
-		if !originalEnable1PC {
-			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=OFF")
-			terror.Log(err)
-			if err != nil {
-				se.AvoidReuse()
+	restore := func() error {
+		var restoreErr error
+		restoreVar := func(name, sql string, args ...any) {
+			_, err := se.ExecuteSQL(context.Background(), sql, args...)
+			if err == nil {
 				return
 			}
+			logutil.BgLogger().Warn("fail to restore TTL session variable", zap.String("variable", name), zap.Error(err))
+			restoreErr = multierr.Append(restoreErr, errors.Wrapf(err, "restore %s", name))
 		}
-
-		if !originalEnableAsyncCommit {
-			_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=OFF")
-			terror.Log(err)
-			if err != nil {
-				se.AvoidReuse()
-				return
-			}
+		if restoreRetryLimit {
+			restoreVar("tidb_retry_limit", fmt.Sprintf("set tidb_retry_limit=%d", originalRetryLimit))
 		}
-
+		if restoreEnable1PC && !originalEnable1PC {
+			restoreVar("tidb_enable_1pc", "set tidb_enable_1pc=OFF")
+		}
+		if restoreEnableAsyncCommit && !originalEnableAsyncCommit {
+			restoreVar("tidb_enable_async_commit", "set tidb_enable_async_commit=OFF")
+		}
 		if restoreTimeZone {
-			_, err = se.ExecuteSQL(context.Background(), "set @@time_zone=%?", originalTimeZone)
-			terror.Log(err)
-			if err != nil {
-				se.AvoidReuse()
-				return
-			}
+			restoreVar("time_zone", "set @@time_zone=%?", originalTimeZone)
 		}
-
 		if restoreIsolationReadEngines {
-			_, err = se.ExecuteSQL(context.Background(), "set tidb_isolation_read_engines=%?", originalIsolationReadEngines)
-			terror.Log(err)
-			if err != nil {
-				se.AvoidReuse()
-				return
-			}
+			restoreVar("tidb_isolation_read_engines", "set tidb_isolation_read_engines=%?", originalIsolationReadEngines)
 		}
+		if restoreErr != nil {
+			se.AvoidReuse()
+		}
+		return restoreErr
+	}
+	cleanupOnError := func(setupErr error) (func() error, error) {
+		restoreErr := restore()
+		// A SET statement may have taken effect even when its execution returned
+		// an error. Never put a partially prepared session back into the pool.
+		se.AvoidReuse()
+		return nil, multierr.Append(setupErr, restoreErr)
 	}
 
 	// store and set the retry limit to 0
+	restoreRetryLimit = true
 	_, err := se.ExecuteSQL(context.Background(), "set tidb_retry_limit=0")
 	if err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
 
 	// set enable 1pc to ON
+	restoreEnable1PC = true
 	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_1pc=ON")
 	if err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
 
 	// set enable async commit to ON
+	restoreEnableAsyncCommit = true
 	_, err = se.ExecuteSQL(context.Background(), "set tidb_enable_async_commit=ON")
 	if err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
 
 	// Force rollback the session to guarantee the session is not in any explicit transaction
 	if _, err = se.ExecuteSQL(context.Background(), "ROLLBACK"); err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
 
 	// set the time zone to UTC
 	rows, err := se.ExecuteSQL(context.Background(), "select @@time_zone")
 	if err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
 
 	if len(rows) == 0 || rows[0].Len() == 0 {
-		return nil, errors.New("failed to get time_zone variable")
+		return cleanupOnError(errors.New("failed to get time_zone variable"))
 	}
 	originalTimeZone = rows[0].GetString(0)
 
+	restoreTimeZone = true
 	_, err = se.ExecuteSQL(context.Background(), "set @@time_zone='UTC'")
 	if err != nil {
-		return nil, err
+		return cleanupOnError(err)
 	}
-	restoreTimeZone = true
 
 	// allow the session in TTL to use all read engines.
 	_, hasTiDBEngine := se.GetSessionVars().IsolationReadEngines[kv.TiDB]
@@ -168,20 +165,19 @@ func prepareSession(se session.Session) (func(), error) {
 	if !hasTiDBEngine || !hasTiKVEngine || !hasTiFlashEngine {
 		rows, err := se.ExecuteSQL(context.Background(), "select @@tidb_isolation_read_engines")
 		if err != nil {
-			return nil, err
+			return cleanupOnError(err)
 		}
 
 		if len(rows) == 0 || rows[0].Len() == 0 {
-			return nil, errors.New("failed to get tidb_isolation_read_engines variable")
+			return cleanupOnError(errors.New("failed to get tidb_isolation_read_engines variable"))
 		}
 		originalIsolationReadEngines = rows[0].GetString(0)
 
+		restoreIsolationReadEngines = true
 		_, err = se.ExecuteSQL(context.Background(), "set tidb_isolation_read_engines='tikv,tiflash,tidb'")
 		if err != nil {
-			return nil, err
+			return cleanupOnError(err)
 		}
-
-		restoreIsolationReadEngines = true
 	}
 
 	return restore, nil
@@ -199,9 +195,10 @@ func newTableSession(se session.Session, tbl *cache.PhysicalTable, expire time.T
 func NewScanSession(ctx context.Context, se session.Session, tbl *cache.PhysicalTable, expire time.Time) (*ttlTableSession, func() error, error) {
 	origConcurrency := se.GetSessionVars().DistSQLScanConcurrency()
 	origPaging := se.GetSessionVars().EnablePaging
+	origInternalSQLScanUserTable := se.GetSessionVars().InternalSQLScanUserTable
 	se.GetSessionVars().InternalSQLScanUserTable = true
 	restore := func() error {
-		se.GetSessionVars().InternalSQLScanUserTable = false
+		se.GetSessionVars().InternalSQLScanUserTable = origInternalSQLScanUserTable
 		_, err := se.ExecuteSQL(context.Background(), "set @@tidb_distsql_scan_concurrency=%?", origConcurrency)
 		terror.Log(err)
 		if err != nil {
@@ -220,6 +217,9 @@ func NewScanSession(ctx context.Context, se session.Session, tbl *cache.Physical
 	// Set the distsql scan concurrency to 1 to reduce the number of cop tasks in TTL scan.
 	if _, err := se.ExecuteSQL(ctx, "set @@tidb_distsql_scan_concurrency=1"); err != nil {
 		terror.Log(restore())
+		// The SET may have taken effect before returning an error. Even if the
+		// best-effort restore succeeds, do not return this session to the pool.
+		se.AvoidReuse()
 		return nil, nil, err
 	}
 
@@ -229,6 +229,7 @@ func NewScanSession(ctx context.Context, se session.Session, tbl *cache.Physical
 	// Disable it to make the scan more efficient.
 	if _, err := se.ExecuteSQL(ctx, "set @@tidb_enable_paging=OFF"); err != nil {
 		terror.Log(restore())
+		se.AvoidReuse()
 		return nil, nil, err
 	}
 

--- a/pkg/ttl/ttlworker/session.go
+++ b/pkg/ttl/ttlworker/session.go
@@ -250,10 +250,6 @@ func (s *ttlTableSession) ExecuteSQLWithCheck(ctx context.Context, sql string) (
 		return nil, false, errors.New("global TTL job is disabled")
 	}
 
-	if err := s.ResetWithGlobalTimeZone(ctx); err != nil {
-		return nil, false, err
-	}
-
 	var result []chunk.Row
 	shouldRetry := true
 	err := s.RunInTxn(ctx, func() error {

--- a/pkg/ttl/ttlworker/session_integration_test.go
+++ b/pkg/ttl/ttlworker/session_integration_test.go
@@ -407,8 +407,14 @@ func TestNewScanSession(t *testing.T) {
 				return nil
 			}))
 			require.True(t, called)
-			// internal should not close
-			require.False(t, sysSe.IsInternalClosed())
+			if errSQL == "" {
+				// A successfully restored session remains reusable.
+				require.False(t, sysSe.IsInternalClosed())
+			} else {
+				// A setup statement can take effect before returning its error.
+				// Discard the session even when best-effort restoration succeeded.
+				require.True(t, sysSe.IsInternalClosed())
+			}
 		})
 	}
 

--- a/pkg/ttl/ttlworker/session_test.go
+++ b/pkg/ttl/ttlworker/session_test.go
@@ -17,6 +17,8 @@ package ttlworker
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -163,6 +165,7 @@ type mockSession struct {
 	t *testing.T
 	sessionctx.Context
 	sessionVars       *variable.SessionVars
+	globalTimeZone    *time.Location
 	sessionInfoSchema infoschema.InfoSchema
 	executeSQL        func(ctx context.Context, sql string, args ...any) ([]chunk.Row, error)
 	rows              []chunk.Row
@@ -171,6 +174,127 @@ type mockSession struct {
 	closed            bool
 	commitErr         error
 	killed            chan struct{}
+}
+
+type failAfterExecuteSession struct {
+	session.Session
+	failSQL  string
+	failAt   int
+	seen     int
+	avoided  bool
+	executed []string
+}
+
+func (s *failAfterExecuteSession) ExecuteSQL(ctx context.Context, sql string, args ...any) ([]chunk.Row, error) {
+	rows, err := s.Session.ExecuteSQL(ctx, sql, args...)
+	s.executed = append(s.executed, sql)
+	if err != nil || !strings.EqualFold(sql, s.failSQL) {
+		return rows, err
+	}
+	s.seen++
+	if s.seen == s.failAt {
+		return nil, errors.New("injected session error")
+	}
+	return rows, nil
+}
+
+func (s *failAfterExecuteSession) AvoidReuse() {
+	s.avoided = true
+}
+
+type prepareSessionMock struct {
+	*mockSession
+	timeZone             string
+	isolationReadEngines string
+	avoided              bool
+}
+
+func newPrepareSessionMock(t *testing.T, timeZone string) *prepareSessionMock {
+	s := &prepareSessionMock{
+		mockSession:          newMockSession(t),
+		timeZone:             timeZone,
+		isolationReadEngines: "tikv",
+	}
+	s.sessionVars.RetryLimit = 7
+	s.sessionVars.Enable1PC = false
+	s.sessionVars.EnableAsyncCommit = false
+	s.setTimeZone(timeZone)
+	s.setIsolationReadEngines("tikv")
+	return s
+}
+
+func (s *prepareSessionMock) setTimeZone(timeZone string) {
+	s.timeZone = timeZone
+	switch timeZone {
+	case "UTC":
+		s.sessionVars.TimeZone = time.UTC
+	case "SYSTEM":
+		s.sessionVars.TimeZone = time.Local
+	case "+08:00":
+		s.sessionVars.TimeZone = time.FixedZone("+08:00", 8*60*60)
+	default:
+		loc, err := time.LoadLocation(timeZone)
+		require.NoError(s.t, err)
+		s.sessionVars.TimeZone = loc
+	}
+}
+
+func (s *prepareSessionMock) setIsolationReadEngines(value string) {
+	s.isolationReadEngines = value
+	s.sessionVars.IsolationReadEngines = make(map[kv.StoreType]struct{})
+	for _, engine := range strings.Split(value, ",") {
+		switch strings.TrimSpace(engine) {
+		case "tidb":
+			s.sessionVars.IsolationReadEngines[kv.TiDB] = struct{}{}
+		case "tikv":
+			s.sessionVars.IsolationReadEngines[kv.TiKV] = struct{}{}
+		case "tiflash":
+			s.sessionVars.IsolationReadEngines[kv.TiFlash] = struct{}{}
+		}
+	}
+}
+
+func (s *prepareSessionMock) ExecuteSQL(_ context.Context, sql string, args ...any) ([]chunk.Row, error) {
+	lowerSQL := strings.ToLower(sql)
+	switch lowerSQL {
+	case "select @@time_zone":
+		return newMockRows(s.t, types.NewFieldType(mysql.TypeString)).Append(s.timeZone).Rows(), nil
+	case "select @@tidb_isolation_read_engines":
+		return newMockRows(s.t, types.NewFieldType(mysql.TypeString)).Append(s.isolationReadEngines).Rows(), nil
+	case "set tidb_enable_1pc=on":
+		s.sessionVars.Enable1PC = true
+	case "set tidb_enable_1pc=off":
+		s.sessionVars.Enable1PC = false
+	case "set tidb_enable_async_commit=on":
+		s.sessionVars.EnableAsyncCommit = true
+	case "set tidb_enable_async_commit=off":
+		s.sessionVars.EnableAsyncCommit = false
+	case "set @@time_zone='utc'":
+		s.setTimeZone("UTC")
+	case "set @@time_zone=%?":
+		s.setTimeZone(args[0].(string))
+	case "set tidb_isolation_read_engines='tikv,tiflash,tidb'":
+		s.setIsolationReadEngines("tikv,tiflash,tidb")
+	case "set tidb_isolation_read_engines=%?":
+		s.setIsolationReadEngines(args[0].(string))
+	case "rollback":
+		return nil, nil
+	default:
+		const retryPrefix = "set tidb_retry_limit="
+		if !strings.HasPrefix(lowerSQL, retryPrefix) {
+			return nil, errors.New("unexpected SQL: " + sql)
+		}
+		value, err := strconv.ParseInt(strings.TrimPrefix(lowerSQL, retryPrefix), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		s.sessionVars.RetryLimit = value
+	}
+	return nil, nil
+}
+
+func (s *prepareSessionMock) AvoidReuse() {
+	s.avoided = true
 }
 
 func newMockSession(t *testing.T, tbl ...*cache.PhysicalTable) *mockSession {
@@ -184,6 +308,7 @@ func newMockSession(t *testing.T, tbl ...*cache.PhysicalTable) *mockSession {
 		t:                 t,
 		sessionInfoSchema: newMockInfoSchema(tbls...),
 		sessionVars:       sessVars,
+		globalTimeZone:    time.UTC,
 		killed:            make(chan struct{}),
 	}
 }
@@ -244,7 +369,7 @@ func (s *mockSession) RunInTxn(_ context.Context, fn func() error, _ session.Txn
 
 // GlobalTimeZone returns the global timezone
 func (s *mockSession) GlobalTimeZone(_ context.Context) (*time.Location, error) {
-	return time.Local, nil
+	return s.globalTimeZone, nil
 }
 
 // KillStmt kills the current statement execution
@@ -299,6 +424,142 @@ func TestExecuteSQLWithCheck(t *testing.T) {
 	require.EqualError(t, err, "mockCommitErr")
 	require.True(t, shouldRetry)
 	require.Nil(t, rows)
+}
+
+func TestPrepareSessionUsesUTCAndRestoresState(t *testing.T) {
+	for _, timeZone := range []string{"SYSTEM", "+08:00", "Asia/Shanghai"} {
+		t.Run(timeZone, func(t *testing.T) {
+			se := newPrepareSessionMock(t, timeZone)
+
+			restore, err := prepareSession(se)
+			require.NoError(t, err)
+			require.Equal(t, "UTC", se.timeZone)
+			require.Equal(t, int64(0), se.sessionVars.RetryLimit)
+			require.True(t, se.sessionVars.Enable1PC)
+			require.True(t, se.sessionVars.EnableAsyncCommit)
+			require.Contains(t, se.GetSessionVars().IsolationReadEngines, kv.TiDB)
+			require.Contains(t, se.GetSessionVars().IsolationReadEngines, kv.TiKV)
+			require.Contains(t, se.GetSessionVars().IsolationReadEngines, kv.TiFlash)
+
+			require.NoError(t, restore())
+			require.Equal(t, timeZone, se.timeZone)
+			require.Equal(t, int64(7), se.sessionVars.RetryLimit)
+			require.False(t, se.sessionVars.Enable1PC)
+			require.False(t, se.sessionVars.EnableAsyncCommit)
+			require.Len(t, se.GetSessionVars().IsolationReadEngines, 1)
+			require.Contains(t, se.GetSessionVars().IsolationReadEngines, kv.TiKV)
+			require.False(t, se.avoided)
+		})
+	}
+}
+
+func TestPrepareSessionFailureCannotPollutePool(t *testing.T) {
+	setupSQLs := []string{
+		"set tidb_retry_limit=0",
+		"set tidb_enable_1pc=ON",
+		"set tidb_enable_async_commit=ON",
+		"ROLLBACK",
+		"select @@time_zone",
+		"set @@time_zone='UTC'",
+		"select @@tidb_isolation_read_engines",
+		"set tidb_isolation_read_engines='tikv,tiflash,tidb'",
+	}
+	for _, failSQL := range setupSQLs {
+		t.Run(failSQL, func(t *testing.T) {
+			base := newPrepareSessionMock(t, "Asia/Shanghai")
+			se := &failAfterExecuteSession{Session: base, failSQL: failSQL, failAt: 1}
+
+			restore, err := prepareSession(se)
+			require.Nil(t, restore)
+			require.ErrorContains(t, err, "injected session error")
+			require.True(t, se.avoided)
+			// The failing statement is applied before its injected error. Cleanup
+			// still restores every variable whose setup may have taken effect.
+			require.Equal(t, "Asia/Shanghai", base.timeZone)
+			require.Equal(t, int64(7), base.sessionVars.RetryLimit)
+			require.False(t, base.sessionVars.Enable1PC)
+			require.False(t, base.sessionVars.EnableAsyncCommit)
+			require.Len(t, base.GetSessionVars().IsolationReadEngines, 1)
+			require.Contains(t, base.GetSessionVars().IsolationReadEngines, kv.TiKV)
+		})
+	}
+}
+
+func TestPrepareSessionRestoreFailureContinuesCleanup(t *testing.T) {
+	restoreSQLs := []string{
+		"set tidb_retry_limit=7",
+		"set tidb_enable_1pc=OFF",
+		"set tidb_enable_async_commit=OFF",
+		"set @@time_zone=%?",
+		"set tidb_isolation_read_engines=%?",
+	}
+	for _, failSQL := range restoreSQLs {
+		t.Run(failSQL, func(t *testing.T) {
+			base := newPrepareSessionMock(t, "Asia/Shanghai")
+			se := &failAfterExecuteSession{Session: base}
+			restore, err := prepareSession(se)
+			require.NoError(t, err)
+			se.failSQL = failSQL
+			se.failAt = 1
+			err = restore()
+			require.Error(t, err)
+			require.True(t, se.avoided)
+			// Restoration never returns early: all five restore statements run.
+			for _, sql := range restoreSQLs {
+				require.Contains(t, se.executed, sql)
+			}
+			require.Equal(t, "Asia/Shanghai", base.timeZone)
+			require.Equal(t, int64(7), base.sessionVars.RetryLimit)
+			require.False(t, base.sessionVars.Enable1PC)
+			require.False(t, base.sessionVars.EnableAsyncCommit)
+			require.Len(t, base.GetSessionVars().IsolationReadEngines, 1)
+			require.Contains(t, base.GetSessionVars().IsolationReadEngines, kv.TiKV)
+		})
+	}
+}
+
+func TestNewScanSessionRestoresStateAndDiscardsPartialSetup(t *testing.T) {
+	for _, original := range []bool{false, true} {
+		t.Run(fmt.Sprintf("restore internal scan flag %t", original), func(t *testing.T) {
+			se := newMockSession(t)
+			se.sessionVars.InternalSQLScanUserTable = original
+			_, restore, err := NewScanSession(context.Background(), se, nil, time.Time{})
+			require.NoError(t, err)
+			require.True(t, se.sessionVars.InternalSQLScanUserTable)
+			require.NoError(t, restore())
+			require.Equal(t, original, se.sessionVars.InternalSQLScanUserTable)
+		})
+	}
+
+	for _, failSQL := range []string{
+		"set @@tidb_distsql_scan_concurrency=1",
+		"set @@tidb_enable_paging=OFF",
+	} {
+		t.Run("setup failure "+failSQL, func(t *testing.T) {
+			se := &failAfterExecuteSession{
+				Session: newMockSession(t),
+				failSQL: failSQL,
+				failAt:  1,
+			}
+			_, restore, err := NewScanSession(context.Background(), se, nil, time.Time{})
+			require.Nil(t, restore)
+			require.ErrorContains(t, err, "injected session error")
+			require.True(t, se.avoided)
+		})
+	}
+
+	t.Run("restore failure continues cleanup", func(t *testing.T) {
+		se := &failAfterExecuteSession{
+			Session: newMockSession(t),
+			failSQL: "set @@tidb_distsql_scan_concurrency=%?",
+			failAt:  1,
+		}
+		_, restore, err := NewScanSession(context.Background(), se, nil, time.Time{})
+		require.NoError(t, err)
+		require.ErrorContains(t, restore(), "injected session error")
+		require.True(t, se.avoided)
+		require.Contains(t, se.executed, "set @@tidb_enable_paging=%?")
+	})
 }
 
 func TestValidateTTLWork(t *testing.T) {

--- a/pkg/ttl/ttlworker/session_test.go
+++ b/pkg/ttl/ttlworker/session_test.go
@@ -162,16 +162,15 @@ func newMockSessionPool(t *testing.T, tbl ...*cache.PhysicalTable) *mockSessionP
 type mockSession struct {
 	t *testing.T
 	sessionctx.Context
-	sessionVars        *variable.SessionVars
-	sessionInfoSchema  infoschema.InfoSchema
-	executeSQL         func(ctx context.Context, sql string, args ...any) ([]chunk.Row, error)
-	rows               []chunk.Row
-	execErr            error
-	resetTimeZoneCalls int
-	inPool             bool
-	closed             bool
-	commitErr          error
-	killed             chan struct{}
+	sessionVars       *variable.SessionVars
+	sessionInfoSchema infoschema.InfoSchema
+	executeSQL        func(ctx context.Context, sql string, args ...any) ([]chunk.Row, error)
+	rows              []chunk.Row
+	execErr           error
+	inPool            bool
+	closed            bool
+	commitErr         error
+	killed            chan struct{}
 }
 
 func newMockSession(t *testing.T, tbl ...*cache.PhysicalTable) *mockSession {
@@ -243,13 +242,6 @@ func (s *mockSession) RunInTxn(_ context.Context, fn func() error, _ session.Txn
 	return s.commitErr
 }
 
-func (s *mockSession) ResetWithGlobalTimeZone(_ context.Context) (err error) {
-	require.False(s.t, s.inPool)
-	require.False(s.t, s.closed)
-	s.resetTimeZoneCalls++
-	return nil
-}
-
 // GlobalTimeZone returns the global timezone
 func (s *mockSession) GlobalTimeZone(_ context.Context) (*time.Location, error) {
 	return time.Local, nil
@@ -287,14 +279,12 @@ func TestExecuteSQLWithCheck(t *testing.T) {
 	require.EqualError(t, err, "mockErr")
 	require.True(t, shouldRetry)
 	require.Nil(t, rows)
-	require.Equal(t, 1, s.resetTimeZoneCalls)
 
 	s.sessionInfoSchema = newMockInfoSchema()
 	rows, shouldRetry, err = tblSe.ExecuteSQLWithCheck(ctx, "select 1")
 	require.EqualError(t, err, "table 'test.t1' meta changed, should abort current job: [schema:1146]Table 'test.t1' doesn't exist")
 	require.False(t, shouldRetry)
 	require.Nil(t, rows)
-	require.Equal(t, 2, s.resetTimeZoneCalls)
 
 	s.sessionInfoSchema = newMockInfoSchema(tbl.TableInfo)
 	s.execErr = nil
@@ -303,14 +293,12 @@ func TestExecuteSQLWithCheck(t *testing.T) {
 	require.False(t, shouldRetry)
 	require.Equal(t, 1, len(rows))
 	require.Equal(t, int64(12), rows[0].GetInt64(0))
-	require.Equal(t, 3, s.resetTimeZoneCalls)
 
 	s.commitErr = errors.New("mockCommitErr")
 	rows, shouldRetry, err = tblSe.ExecuteSQLWithCheck(ctx, "select 1")
 	require.EqualError(t, err, "mockCommitErr")
 	require.True(t, shouldRetry)
 	require.Nil(t, rows)
-	require.Equal(t, 4, s.resetTimeZoneCalls)
 }
 
 func TestValidateTTLWork(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62180

Problem Summary:

TTL PK-range splitting does not decode temporal common handles. A table whose clustered primary key starts with its `DATE`, `DATETIME`, or `TIMESTAMP` TTL column therefore falls back to one full-range task, even though expired rows occupy a contiguous physical key prefix.

Merge dependency: #70767. TTL data sessions must use UTC before persisted `TIMESTAMP` PK boundaries can preserve an unambiguous instant across DST transitions.

### What changed and how does it work?

- For a clustered common handle beginning with the temporal TTL column, locate Regions only in `[record_prefix, record_prefix + encode(expire_time))`.
- Keep the Region crossing the expiration key, while excluding Regions wholly after it. The TTL SQL predicate remains the exact expiration check.
- Map truncated or invalid packed temporal Region boundaries to the greatest valid temporal value whose encoded key does not exceed the boundary.
- Persist boundaries using the existing textual PK task format. `TIMESTAMP` uses UTC; `DATE` and `DATETIME` retain TTL wall-clock semantics.
- Keep `split_by = NULL` and paginate by the complete clustered primary key. No secondary-index scan or planner dependency is introduced.
- Do not add a version gate. An old worker can parse the task format; during a rolling upgrade it may incompletely cover a UTC `TIMESTAMP` range, but the expiration predicate still prevents deletion of unexpired rows and later TTL jobs retry omissions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Improve TTL task splitting for tables whose clustered primary key starts with a `DATE`, `DATETIME`, or `TIMESTAMP` TTL column by splitting and pruning Regions before the expiration cutoff.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TTL range splitting for tables with clustered primary keys beginning with DATE, DATETIME, or TIMESTAMP columns.
  * Added expiration-aware scan boundaries to avoid processing records beyond the TTL cutoff.
  * Preserved correct temporal semantics across time zones, including daylight-saving transitions.
* **Bug Fixes**
  * Corrected expiration predicates for DATE and DATETIME columns.
  * Improved TTL session cleanup and isolation after setup or restoration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->