### PR TITLE
executor: stabilize statement RU tests

### DIFF
--- a/pkg/executor/statement_ru_plan_walk_integration_test.go
+++ b/pkg/executor/statement_ru_plan_walk_integration_test.go
@@ -113,12 +113,17 @@ func drainStatementRURecordSet(t *testing.T, rs sqlexec.RecordSet) error {
 	}
 }
 
-func TestStatementRUAnalyzeNoDelayLifecycle(t *testing.T) {
-	originalCollectExecutionInfo := config.GetGlobalConfig().Instance.EnableCollectExecutionInfo.Load()
+func enableStatementRUExecutionInfo(t *testing.T) {
+	t.Helper()
+	original := config.GetGlobalConfig().Instance.EnableCollectExecutionInfo.Load()
 	config.GetGlobalConfig().Instance.EnableCollectExecutionInfo.Store(true)
 	t.Cleanup(func() {
-		config.GetGlobalConfig().Instance.EnableCollectExecutionInfo.Store(originalCollectExecutionInfo)
+		config.GetGlobalConfig().Instance.EnableCollectExecutionInfo.Store(original)
 	})
+}
+
+func TestStatementRUAnalyzeNoDelayLifecycle(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
 
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -197,6 +202,8 @@ func TestStatementRUAnalyzeNoDelayLifecycle(t *testing.T) {
 }
 
 func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	t.Run("producer plans publish only supported operator trees", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		tk := testkit.NewTestKit(t, store)
@@ -559,6 +566,8 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 }
 
 func TestStatementRUFileTransferOutcomeHandoff(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	t.Run("successful session outcome is consumed by delayed terminal", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		tk := testkit.NewTestKit(t, store)
@@ -705,6 +714,8 @@ func TestStatementRUFileTransferOutcomeHandoff(t *testing.T) {
 }
 
 func TestStatementRUPointGetTerminalPlanHandoff(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -778,6 +789,8 @@ func TestStatementRUPointGetTerminalPlanHandoff(t *testing.T) {
 }
 
 func TestStatementRUScalarSubqueryTerminalLifecycle(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	t.Run("real scalar SQL", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		tk := testkit.NewTestKit(t, store)
@@ -1042,6 +1055,8 @@ func TestStatementRUScalarSubqueryTerminalLifecycle(t *testing.T) {
 }
 
 func TestStatementRUCursorExclusion(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	t.Run("current-session restricted result set", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		tk := testkit.NewTestKit(t, store)
@@ -1132,6 +1147,8 @@ func TestStatementRUCursorExclusion(t *testing.T) {
 }
 
 func TestStatementRURetryAndReplay(t *testing.T) {
+	enableStatementRUExecutionInfo(t)
+
 	t.Run("pessimistic retry keeps production owner disabled", func(t *testing.T) {
 		store := testkit.CreateMockStore(t)
 		writer := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70747

Problem Summary:

Statement RU integration tests depend on instance-level execution information collection. Other executor tests can leave `tidb_enable_collect_execution_info` disabled, causing missing coprocessor scan details and order-dependent failures.

### What changed and how does it work?

Add a shared test helper that saves the current execution information setting, enables it for each Statement RU integration test, and restores the original value during cleanup. Apply the helper to every `TestStatementRU*` test in the integration test file.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

The previously failing order-dependent sequence passed 10 consecutive runs, and all `TestStatementRU*` package tests passed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved statement execution lifecycle test setup by consistently enabling execution information collection.
  * Ensured test configuration is restored after each test to prevent cross-test interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->