### PR TITLE
ddl: support drop materialized view and log

### DIFF
--- a/pkg/ddl/bdr/bdr_test.go
+++ b/pkg/ddl/bdr/bdr_test.go
@@ -196,6 +196,14 @@ func TestIsDenied(t *testing.T) {
 		{ast.BDRRoleSecondary, model.ActionDropTable, true},
 		{ast.BDRRoleNone, model.ActionDropTable, false},
 
+		// Roles for materialized view drop actions.
+		{ast.BDRRolePrimary, model.ActionDropMaterializedView, true},
+		{ast.BDRRoleSecondary, model.ActionDropMaterializedView, true},
+		{ast.BDRRoleNone, model.ActionDropMaterializedView, false},
+		{ast.BDRRolePrimary, model.ActionDropMaterializedViewLog, true},
+		{ast.BDRRoleSecondary, model.ActionDropMaterializedViewLog, true},
+		{ast.BDRRoleNone, model.ActionDropMaterializedViewLog, false},
+
 		// Roles for ActionAddColumn
 		{ast.BDRRolePrimary, model.ActionAddColumn, false},
 		{ast.BDRRoleSecondary, model.ActionAddColumn, true},

--- a/pkg/ddl/delete_range.go
+++ b/pkg/ddl/delete_range.go
@@ -293,7 +293,7 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, wrapper DelRangeExecWrap
 				return errors.Trace(err)
 			}
 		}
-	case model.ActionDropTable:
+	case model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		tableID := job.TableID
 		// The startKey here is for compatibility with previous versions, old version did not endKey so don't have to deal with.
 		args, err := model.GetFinishedDropTableArgs(job)

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4489,17 +4489,19 @@ func (e *executor) dropTableObject(
 			}
 		}
 
+		involvingSchemas := buildDropTableInvolvingSchemaInfo(e.ctx, is, schema.Name.L, tableInfo.Meta())
 		job := &model.Job{
-			Version:        model.GetJobVerInUse(),
-			SchemaID:       schema.ID,
-			TableID:        tableInfo.Meta().ID,
-			SchemaName:     schema.Name.L,
-			SchemaState:    schema.State,
-			TableName:      tableInfo.Meta().Name.L,
-			Type:           jobType,
-			BinlogInfo:     &model.HistoryInfo{},
-			CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
-			SQLMode:        ctx.GetSessionVars().SQLMode,
+			Version:             model.GetJobVerInUse(),
+			SchemaID:            schema.ID,
+			TableID:             tableInfo.Meta().ID,
+			SchemaName:          schema.Name.L,
+			SchemaState:         schema.State,
+			TableName:           tableInfo.Meta().Name.L,
+			Type:                jobType,
+			BinlogInfo:          &model.HistoryInfo{},
+			InvolvingSchemaInfo: involvingSchemas,
+			CDCWriteSource:      ctx.GetSessionVars().CDCWriteSource,
+			SQLMode:             ctx.GetSessionVars().SQLMode,
 		}
 		args := &model.DropTableArgs{
 			Identifiers: objectIdents,
@@ -4535,6 +4537,39 @@ func (e *executor) dropTableObject(
 		}
 	}
 	return nil
+}
+
+func buildDropTableInvolvingSchemaInfo(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+	schemaName string,
+	tableInfo *model.TableInfo,
+) []model.InvolvingSchemaInfo {
+	involvingSchemas := []model.InvolvingSchemaInfo{{
+		Database: schemaName,
+		Table:    tableInfo.Name.L,
+	}}
+	if tableInfo.MaterializedViewLog != nil {
+		if baseTbl, ok := is.TableByID(ctx, tableInfo.MaterializedViewLog.BaseTableID); ok {
+			involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
+				Database: schemaName,
+				Table:    baseTbl.Meta().Name.L,
+			})
+		}
+	}
+	if tableInfo.MaterializedView != nil {
+		for _, baseTableID := range tableInfo.MaterializedView.BaseTableIDs {
+			baseTbl, ok := is.TableByID(ctx, baseTableID)
+			if !ok {
+				continue
+			}
+			involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
+				Database: schemaName,
+				Table:    baseTbl.Meta().Name.L,
+			})
+		}
+	}
+	return involvingSchemas
 }
 
 // adminCheckTableBeforeDrop runs `admin check table` for the table to be dropped.

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4499,7 +4499,10 @@ func (e *executor) dropTableObject(
 			}
 		}
 
-		involvingSchemas := buildDropTableInvolvingSchemaInfo(e.ctx, is, schema.Name.L, tableInfo.Meta())
+		involvingSchemas, err := buildDropTableInvolvingSchemaInfo(e.ctx, is, schema.Name.L, tableInfo.Meta())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		job := &model.Job{
 			Version:             model.GetJobVerInUse(),
 			SchemaID:            schema.ID,
@@ -4554,7 +4557,7 @@ func buildDropTableInvolvingSchemaInfo(
 	is infoschema.InfoSchema,
 	schemaName string,
 	tableInfo *model.TableInfo,
-) []model.InvolvingSchemaInfo {
+) ([]model.InvolvingSchemaInfo, error) {
 	involvingSchemas := []model.InvolvingSchemaInfo{{
 		Database: schemaName,
 		Table:    tableInfo.Name.L,
@@ -4577,9 +4580,32 @@ func buildDropTableInvolvingSchemaInfo(
 				Database: schemaName,
 				Table:    baseTbl.Meta().Name.L,
 			})
+
+			baseMViewInfo := baseTbl.Meta().MaterializedViewBase
+			if baseMViewInfo == nil || baseMViewInfo.MLogID == 0 {
+				continue
+			}
+			mlogTbl, ok := is.TableByID(ctx, baseMViewInfo.MLogID)
+			if !ok {
+				return nil, infoschema.ErrTableNotExists.GenWithStackByArgs(
+					schemaName, fmt.Sprintf("(Table ID %d)", baseMViewInfo.MLogID),
+				)
+			}
+			mlogInfo := mlogTbl.Meta().MaterializedViewLog
+			if mlogInfo == nil || mlogInfo.BaseTableID != baseTableID {
+				return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs(
+					"drop materialized view: invalid materialized view log metadata",
+				)
+			}
+			if hasMaterializedViewID(mlogInfo.DependentMViewIDs, tableInfo.ID) {
+				involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
+					Database: schemaName,
+					Table:    mlogTbl.Meta().Name.L,
+				})
+			}
 		}
 	}
-	return involvingSchemas
+	return involvingSchemas, nil
 }
 
 // adminCheckTableBeforeDrop runs `admin check table` for the table to be dropped.
@@ -4659,6 +4685,9 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	tblInfo := tb.Meta()
 	if tblInfo.IsView() || tblInfo.IsSequence() {
 		return infoschema.ErrTableNotExists.GenWithStackByArgs(schema.Name.O, tblInfo.Name.O)
+	}
+	if err := checkTableMaterializedViewConstraints(tblInfo, "TRUNCATE TABLE"); err != nil {
+		return errors.Trace(err)
 	}
 	if tblInfo.TableCacheStatusType != model.TableCacheStatusDisable {
 		return dbterror.ErrOptOnCacheTable.GenWithStackByArgs("Truncate Table")

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4381,9 +4381,11 @@ const (
 	tableObject objectType = iota
 	viewObject
 	sequenceObject
+	materializedViewObject
+	materializedViewLogObject
 )
 
-// dropTableObject provides common logic to DROP TABLE/VIEW/SEQUENCE.
+// dropTableObject provides common logic to drop table-like objects, views, and sequences.
 func (e *executor) dropTableObject(
 	ctx sessionctx.Context,
 	objects []*ast.TableName,
@@ -4404,18 +4406,26 @@ func (e *executor) dropTableObject(
 		fkCheck      bool
 	)
 	switch tableObjectType {
-	case tableObject:
+	case tableObject, materializedViewObject, materializedViewLogObject:
 		dropExistErr = infoschema.ErrTableDropExists
-		jobType = model.ActionDropTable
 		objectIdents = make([]ast.Ident, len(objects))
-		fkCheck = ctx.GetSessionVars().ForeignKeyChecks
 		for i, tn := range objects {
 			objectIdents[i] = ast.Ident{Schema: tn.Schema, Name: tn.Name}
 		}
-		for _, tn := range objects {
-			if referredFK := checkTableHasForeignKeyReferred(is, tn.Schema.L, tn.Name.L, objectIdents, fkCheck); referredFK != nil {
-				return errors.Trace(dbterror.ErrForeignKeyCannotDropParent.GenWithStackByArgs(tn.Name, referredFK.ChildFKName, referredFK.ChildTable))
+		if tableObjectType == tableObject {
+			jobType = model.ActionDropTable
+			fkCheck = ctx.GetSessionVars().ForeignKeyChecks
+			for _, tn := range objects {
+				if referredFK := checkTableHasForeignKeyReferred(is, tn.Schema.L, tn.Name.L, objectIdents, fkCheck); referredFK != nil {
+					return errors.Trace(dbterror.ErrForeignKeyCannotDropParent.GenWithStackByArgs(tn.Name, referredFK.ChildFKName, referredFK.ChildTable))
+				}
 			}
+		}
+		switch tableObjectType {
+		case materializedViewObject:
+			jobType = model.ActionDropMaterializedView
+		case materializedViewLogObject:
+			jobType = model.ActionDropMaterializedViewLog
 		}
 	case viewObject:
 		dropExistErr = infoschema.ErrTableDropExists
@@ -4452,12 +4462,12 @@ func (e *executor) dropTableObject(
 			return dbterror.ErrForbiddenDDL.FastGenByArgs(fmt.Sprintf("Drop tidb system table '%s.%s'", tn.Schema.L, tn.Name.L))
 		}
 		switch tableObjectType {
-		case tableObject:
+		case tableObject, materializedViewObject, materializedViewLogObject:
 			if !tableInfo.Meta().IsBaseTable() {
 				notExistTables = append(notExistTables, fullti.String())
 				continue
 			}
-			if !allowMaterializedViewRelated {
+			if tableObjectType == tableObject && !allowMaterializedViewRelated {
 				if err := checkTableMaterializedViewConstraints(tableInfo.Meta(), "DROP TABLE"); err != nil {
 					return errors.Trace(err)
 				}
@@ -4517,7 +4527,7 @@ func (e *executor) dropTableObject(
 		}
 
 		// unlock table after drop
-		if tableObjectType != tableObject {
+		if tableObjectType == viewObject || tableObjectType == sequenceObject {
 			continue
 		}
 		if !config.TableLockEnabled() {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -117,6 +117,8 @@ type Executor interface {
 	CreateMaterializedViewLog(ctx sessionctx.Context, stmt *ast.CreateMaterializedViewLogStmt) error
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
 	DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
+	DropMaterializedView(ctx sessionctx.Context, stmt *ast.DropMaterializedViewStmt) error
+	DropMaterializedViewLog(ctx sessionctx.Context, stmt *ast.DropMaterializedViewLogStmt) error
 	RecoverTable(ctx sessionctx.Context, recoverTableInfo *model.RecoverTableInfo) (err error)
 	RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *model.RecoverSchemaInfo) error
 	DropView(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4389,6 +4389,7 @@ func (e *executor) dropTableObject(
 	objects []*ast.TableName,
 	ifExists bool,
 	tableObjectType objectType,
+	allowMaterializedViewRelated bool,
 ) error {
 	var (
 		notExistTables []string
@@ -4455,6 +4456,11 @@ func (e *executor) dropTableObject(
 			if !tableInfo.Meta().IsBaseTable() {
 				notExistTables = append(notExistTables, fullti.String())
 				continue
+			}
+			if !allowMaterializedViewRelated {
+				if err := checkTableMaterializedViewConstraints(tableInfo.Meta(), "DROP TABLE"); err != nil {
+					return errors.Trace(err)
+				}
 			}
 
 			tempTableType := tableInfo.Meta().TempTableType
@@ -4576,12 +4582,28 @@ func adminCheckTableBeforeDrop(sessPool *sess.Pool, fullti ast.Ident) error {
 
 // DropTable will proceed even if some table in the list does not exists.
 func (e *executor) DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error) {
-	return e.dropTableObject(ctx, stmt.Tables, stmt.IfExists, tableObject)
+	return e.dropTableObject(ctx, stmt.Tables, stmt.IfExists, tableObject, false)
 }
 
 // DropView will proceed even if some view in the list does not exists.
 func (e *executor) DropView(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error) {
-	return e.dropTableObject(ctx, stmt.Tables, stmt.IfExists, viewObject)
+	return e.dropTableObject(ctx, stmt.Tables, stmt.IfExists, viewObject, false)
+}
+
+func checkTableMaterializedViewConstraints(tblInfo *model.TableInfo, op string) error {
+	if tblInfo.MaterializedViewLog != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view log table", op))
+	}
+	if tblInfo.MaterializedView != nil {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on materialized view table", op))
+	}
+	if tblInfo.MaterializedViewBase != nil && len(tblInfo.MaterializedViewBase.MViewIDs) > 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on base table with materialized view dependencies", op))
+	}
+	if tblInfo.MaterializedViewBase != nil && tblInfo.MaterializedViewBase.MLogID != 0 {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs(fmt.Sprintf("%s on base table with materialized view log", op))
+	}
+	return nil
 }
 
 func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
@@ -6297,7 +6319,7 @@ func (e *executor) AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequence
 }
 
 func (e *executor) DropSequence(ctx sessionctx.Context, stmt *ast.DropSequenceStmt) (err error) {
-	return e.dropTableObject(ctx, stmt.Sequences, stmt.IfExists, sequenceObject)
+	return e.dropTableObject(ctx, stmt.Sequences, stmt.IfExists, sequenceObject, false)
 }
 
 func (e *executor) AlterIndexVisibility(ctx sessionctx.Context, ident ast.Ident, indexName ast.CIStr, visibility ast.IndexVisibility) error {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4471,6 +4471,7 @@ func (e *executor) dropTableObject(
 				if err := checkTableMaterializedViewConstraints(tableInfo.Meta(), "DROP TABLE"); err != nil {
 					return errors.Trace(err)
 				}
+				failpoint.InjectCall("afterCheckDropTableMaterializedViewConstraints", tableInfo.Meta().ID)
 			}
 
 			tempTableType := tableInfo.Meta().TempTableType
@@ -4689,6 +4690,7 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if err := checkTableMaterializedViewConstraints(tblInfo, "TRUNCATE TABLE"); err != nil {
 		return errors.Trace(err)
 	}
+	failpoint.InjectCall("afterCheckTruncateTableMaterializedViewConstraints", tblInfo.ID)
 	if tblInfo.TableCacheStatusType != model.TableCacheStatusDisable {
 		return dbterror.ErrOptOnCacheTable.GenWithStackByArgs("Truncate Table")
 	}

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -66,6 +66,29 @@ var (
 	mockDDLErrOnce = int64(0)
 )
 
+// rollbackTxnError marks an error that must roll back the whole DDL transaction
+// before the job error is persisted.
+type rollbackTxnError struct {
+	cause error
+}
+
+func (e *rollbackTxnError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *rollbackTxnError) Unwrap() error {
+	return e.cause
+}
+
+func newRollbackTxnError(err error) error {
+	return &rollbackTxnError{cause: err}
+}
+
+func isRollbackTxnError(err error) bool {
+	var target *rollbackTxnError
+	return goerrors.As(err, &target)
+}
+
 // GetWaitTimeWhenErrorOccurred return waiting interval when processing DDL jobs encounter errors.
 func GetWaitTimeWhenErrorOccurred() time.Duration {
 	return time.Duration(atomic.LoadInt64(&WaitTimeWhenErrorOccurred))
@@ -675,7 +698,17 @@ func (w *worker) transitOneJobStep(
 		// then shouldn't discard the KV modification.
 		// And the job state is rollback done, it means the job was already finished, also shouldn't discard too.
 		// Otherwise, we should discard the KV modification when running job.
-		w.sess.Reset()
+		if isRollbackTxnError(runJobErr) {
+			w.sess.Rollback()
+			txn, txnErr := w.prepareTxn(job)
+			if txnErr != nil {
+				jobCtx.unlockSchemaVersion(jobCtx, job.ID)
+				return 0, txnErr
+			}
+			jobCtx.metaMut = meta.NewMutator(txn)
+		} else {
+			w.sess.Reset()
+		}
 		// If error happens after updateSchemaVersion(), then the schemaVer is updated.
 		// Result in the retry duration is up to 2 * lease.
 		schemaVer = 0

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -393,6 +393,7 @@ func JobNeedGC(job *model.Job) bool {
 		}
 		switch job.Type {
 		case model.ActionDropSchema, model.ActionDropTable,
+			model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog,
 			model.ActionTruncateTable,
 			model.ActionDropPrimaryKey,
 			model.ActionDropTablePartition, model.ActionTruncateTablePartition,
@@ -1020,7 +1021,8 @@ func (w *worker) runOneJobStep(
 		ver, err = onRepairTable(jobCtx, job)
 	case model.ActionCreateView:
 		ver, err = onCreateView(jobCtx, job)
-	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
+	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence,
+		model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		ver, err = w.onDropTableOrView(jobCtx, job)
 	case model.ActionDropTablePartition:
 		ver, err = w.onDropTablePartition(jobCtx, job)

--- a/pkg/ddl/job_worker_test.go
+++ b/pkg/ddl/job_worker_test.go
@@ -224,6 +224,10 @@ func TestJobNeedGC(t *testing.T) {
 	require.True(t, ddl.JobNeedGC(job))
 	job = &model.Job{Type: model.ActionAddPrimaryKey, State: model.JobStateRollbackDone}
 	require.True(t, ddl.JobNeedGC(job))
+	job = &model.Job{Type: model.ActionDropMaterializedView, State: model.JobStateDone}
+	require.True(t, ddl.JobNeedGC(job))
+	job = &model.Job{Type: model.ActionDropMaterializedViewLog, State: model.JobStateDone}
+	require.True(t, ddl.JobNeedGC(job))
 	job = &model.Job{Type: model.ActionCreateMaterializedView, State: model.JobStateDone, TableID: 123}
 	require.False(t, ddl.JobNeedGC(job))
 	job = &model.Job{Type: model.ActionCreateMaterializedView, State: model.JobStateRollbackDone}

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -705,7 +705,7 @@ func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMater
 	}
 
 	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: s.ViewName.Name}}}
-	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject)
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
 }
 
 func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMaterializedViewLogStmt) error {
@@ -748,7 +748,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 
 	failpoint.Inject("pauseDropMaterializedViewLogAfterCheck", func() {})
 	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
-	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject)
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
 }
 
 func appendDropMaterializedViewNotExistsNote(ctx sessionctx.Context, schemaName, tableName ast.CIStr) {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -675,6 +675,88 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	return errors.Trace(e.createTableWithInfoPost(ctx, mvTableInfo, jobW.SchemaID, scatterScope))
 }
 
+func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMaterializedViewStmt) error {
+	is := e.infoCache.GetLatest()
+	schemaName := s.ViewName.Schema
+	if schemaName.O == "" {
+		if ctx.GetSessionVars().CurrentDB == "" {
+			return errors.Trace(plannererrors.ErrNoDB)
+		}
+		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
+		s.ViewName.Schema = schemaName
+	}
+	if _, ok := is.SchemaByName(schemaName); !ok {
+		if s.IfExists {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.ViewName.Name)
+			return nil
+		}
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+	tbl, err := is.TableByName(e.ctx, schemaName, s.ViewName.Name)
+	if err != nil {
+		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.ViewName.Name)
+			return nil
+		}
+		return err
+	}
+	if tbl.Meta().MaterializedView == nil {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, s.ViewName.Name, "MATERIALIZED VIEW")
+	}
+
+	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: s.ViewName.Name}}}
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject)
+}
+
+func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMaterializedViewLogStmt) error {
+	is := e.infoCache.GetLatest()
+	schemaName := s.Table.Schema
+	if schemaName.O == "" {
+		if ctx.GetSessionVars().CurrentDB == "" {
+			return errors.Trace(plannererrors.ErrNoDB)
+		}
+		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
+		s.Table.Schema = schemaName
+	}
+	if _, ok := is.SchemaByName(schemaName); !ok {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+	baseTable, err := is.TableByName(e.ctx, schemaName, s.Table.Name)
+	if err != nil {
+		return err
+	}
+	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+	}
+	baseTableID := baseTable.Meta().ID
+
+	mlogName := model.MaterializedViewLogTableName(baseTable.Meta().Name)
+	mlogTable, err := is.TableByName(e.ctx, schemaName, mlogName)
+	if err != nil {
+		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, mlogName)
+			return nil
+		}
+		return err
+	}
+	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
+	}
+	if hasMaterializedViewDependsOnBaseTable(baseTable.Meta()) {
+		return errDropMaterializedViewLogDependent(schemaName.O, s.Table.Name.O)
+	}
+
+	failpoint.Inject("pauseDropMaterializedViewLogAfterCheck", func() {})
+	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject)
+}
+
+func appendDropMaterializedViewNotExistsNote(ctx sessionctx.Context, schemaName, tableName ast.CIStr) {
+	ctx.GetSessionVars().StmtCtx.AppendNote(infoschema.ErrTableDropExists.FastGenByArgs(
+		ast.Ident{Schema: schemaName, Name: tableName}.String(),
+	))
+}
+
 func initMaterializedViewReorgMetaFromVariables(job *model.Job, sctx sessionctx.Context) error {
 	m := NewDDLReorgMeta(sctx)
 	sessionVars := sctx.GetSessionVars() //nolint:forbidigo

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -1222,10 +1222,6 @@ func hasVisiblePublicIndexWithPrefixCoveringGroupByColumns(
 	return mviewutil.HasIndexWithPrefixCoveringColumns(baseTableInfo, groupByCols, excludedIndexName, true)
 }
 
-func buildDeleteMViewRefreshAlertSQL(mviewID int64) string {
-	return sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID = %?", mviewID)
-}
-
 func restoreNodeToCanonicalSQL(node ast.Node) (string, error) {
 	var sb strings.Builder
 	rctx := format.NewRestoreCtx(format.DefaultRestoreFlags|format.RestoreStringWithoutCharset, &sb)

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -714,7 +714,7 @@ func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMater
 	}
 
 	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: s.ViewName.Name}}}
-	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, materializedViewObject, true)
 }
 
 func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMaterializedViewLogStmt) error {
@@ -750,7 +750,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	failpoint.InjectCall("afterCheckDropMaterializedViewLog")
 	failpoint.Inject("pauseDropMaterializedViewLogAfterCheck", func() {})
 	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
-	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)
+	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, materializedViewLogObject, true)
 }
 
 func appendDropMaterializedViewNotExistsNote(ctx sessionctx.Context, schemaName, tableName ast.CIStr) {

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -725,7 +725,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	if err != nil {
 		return err
 	}
-	if baseTable.Meta().IsView() || baseTable.Meta().IsSequence() || baseTable.Meta().TempTableType != model.TempTableNone {
+	if !isValidMaterializedViewLogBaseTable(schemaName.L, baseTable.Meta()) {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
 	}
 	baseTableID := baseTable.Meta().ID
@@ -746,6 +746,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 		return errDropMaterializedViewLogDependent(schemaName.O, s.Table.Name.O)
 	}
 
+	failpoint.InjectCall("afterCheckDropMaterializedViewLog")
 	failpoint.Inject("pauseDropMaterializedViewLogAfterCheck", func() {})
 	dropStmt := &ast.DropTableStmt{IfExists: s.IfExists, Tables: []*ast.TableName{{Schema: schemaName, Name: mlogName}}}
 	return e.dropTableObject(ctx, dropStmt.Tables, dropStmt.IfExists, tableObject, true)

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -675,22 +675,30 @@ func (e *executor) CreateMaterializedView(ctx sessionctx.Context, s *ast.CreateM
 	return errors.Trace(e.createTableWithInfoPost(ctx, mvTableInfo, jobW.SchemaID, scatterScope))
 }
 
-func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMaterializedViewStmt) error {
+func (e *executor) getMaterializedViewSchema(ctx sessionctx.Context, tableName *ast.TableName) (infoschema.InfoSchema, ast.CIStr, error) {
 	is := e.infoCache.GetLatest()
-	schemaName := s.ViewName.Schema
+	schemaName := tableName.Schema
 	if schemaName.O == "" {
 		if ctx.GetSessionVars().CurrentDB == "" {
-			return errors.Trace(plannererrors.ErrNoDB)
+			return is, schemaName, errors.Trace(plannererrors.ErrNoDB)
 		}
 		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
-		s.ViewName.Schema = schemaName
+		tableName.Schema = schemaName
 	}
 	if _, ok := is.SchemaByName(schemaName); !ok {
-		if s.IfExists {
+		return is, schemaName, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+	return is, schemaName, nil
+}
+
+func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMaterializedViewStmt) error {
+	is, schemaName, err := e.getMaterializedViewSchema(ctx, s.ViewName)
+	if err != nil {
+		if s.IfExists && infoschema.ErrDatabaseNotExists.Equal(err) {
 			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.ViewName.Name)
 			return nil
 		}
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+		return err
 	}
 	tbl, err := is.TableByName(e.ctx, schemaName, s.ViewName.Name)
 	if err != nil {
@@ -709,17 +717,9 @@ func (e *executor) DropMaterializedView(ctx sessionctx.Context, s *ast.DropMater
 }
 
 func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMaterializedViewLogStmt) error {
-	is := e.infoCache.GetLatest()
-	schemaName := s.Table.Schema
-	if schemaName.O == "" {
-		if ctx.GetSessionVars().CurrentDB == "" {
-			return errors.Trace(plannererrors.ErrNoDB)
-		}
-		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
-		s.Table.Schema = schemaName
-	}
-	if _, ok := is.SchemaByName(schemaName); !ok {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	is, schemaName, err := e.getMaterializedViewSchema(ctx, s.Table)
+	if err != nil {
+		return err
 	}
 	baseTable, err := is.TableByName(e.ctx, schemaName, s.Table.Name)
 	if err != nil {
@@ -742,7 +742,7 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	if mlogTable.Meta().MaterializedViewLog == nil || mlogTable.Meta().MaterializedViewLog.BaseTableID != baseTableID {
 		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName.O, mlogName, "MATERIALIZED VIEW LOG")
 	}
-	if hasMaterializedViewDependsOnBaseTable(baseTable.Meta()) {
+	if hasMaterializedViewDependsOnMaterializedViewLog(mlogTable.Meta()) {
 		return errDropMaterializedViewLogDependent(schemaName.O, s.Table.Name.O)
 	}
 

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -731,11 +731,13 @@ func (e *executor) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMa
 	}
 	baseTableID := baseTable.Meta().ID
 
+	// IF EXISTS only suppresses a missing derived MLog. A missing schema or base
+	// table remains an error because it is required to resolve the logical target.
 	mlogName := model.MaterializedViewLogTableName(baseTable.Meta().Name)
 	mlogTable, err := is.TableByName(e.ctx, schemaName, mlogName)
 	if err != nil {
 		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
-			appendDropMaterializedViewNotExistsNote(ctx, schemaName, mlogName)
+			appendDropMaterializedViewNotExistsNote(ctx, schemaName, s.Table.Name)
 			return nil
 		}
 		return err

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -679,10 +679,11 @@ func (e *executor) getMaterializedViewSchema(ctx sessionctx.Context, tableName *
 	is := e.infoCache.GetLatest()
 	schemaName := tableName.Schema
 	if schemaName.O == "" {
-		if ctx.GetSessionVars().CurrentDB == "" {
+		sessionVars := ctx.GetSessionVars() //nolint:forbidigo
+		if sessionVars.CurrentDB == "" {
 			return is, schemaName, errors.Trace(plannererrors.ErrNoDB)
 		}
-		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
+		schemaName = ast.NewCIStr(sessionVars.CurrentDB)
 		tableName.Schema = schemaName
 	}
 	if _, ok := is.SchemaByName(schemaName); !ok {

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -1115,10 +1115,27 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 			return nil, errors.Trace(err)
 		}
 		if mlog == nil || mlog.MaterializedViewLog == nil {
-			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("drop materialized view: invalid materialized view log")
+			// The executor rejects this corrupted metadata before submitting the job.
+			// Do not leave an already-started DROP job retrying in delete-only state.
+			logutil.DDLLogger().Error(
+				"drop materialized view: materialized view log is missing or invalid during dependency cleanup",
+				zap.Int64("mviewID", job.TableID),
+				zap.Int64("baseTableID", baseID),
+				zap.Int64("mlogID", mlogID),
+			)
+			continue
 		}
 		if mlog.MaterializedViewLog.BaseTableID != baseID {
-			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("drop materialized view: invalid materialized view log metadata")
+			// See the missing-MLog branch above. This is a permanent metadata error,
+			// not a retryable DDL failure after the DROP job has started.
+			logutil.DDLLogger().Error(
+				"drop materialized view: materialized view log belongs to a different base table during dependency cleanup",
+				zap.Int64("mviewID", job.TableID),
+				zap.Int64("baseTableID", baseID),
+				zap.Int64("mlogID", mlogID),
+				zap.Int64("mlogBaseTableID", mlog.MaterializedViewLog.BaseTableID),
+			)
+			continue
 		}
 		if !hasMaterializedViewID(mlog.MaterializedViewLog.DependentMViewIDs, job.TableID) {
 			continue

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -969,7 +969,11 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 	switch {
 	case droppingTable.MaterializedView != nil:
 		if len(droppingTable.MaterializedView.BaseTableIDs) == 0 {
-			return nil, errors.New("materialized view must reference at least one base table")
+			logutil.DDLLogger().Warn(
+				"materialized view has no base tables in metadata, skip dependency cleanup when dropping",
+				zap.Int64("mviewID", droppingTable.ID),
+			)
+			return nil, nil
 		}
 		baseTableIDs = droppingTable.MaterializedView.BaseTableIDs
 		apply = func(base *model.TableInfo) {
@@ -1011,7 +1015,10 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 		}
 		processed[baseID] = struct{}{}
 		base, err := jobCtx.metaMut.GetTable(job.SchemaID, baseID)
-		if err != nil || base == nil {
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if base == nil {
 			continue
 		}
 		var mlogID int64

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -855,12 +855,44 @@ func (w *worker) deleteCreateMaterializedViewRefreshAlert(jobCtx *jobContext, mv
 	if ctx == nil {
 		ctx = w.workCtx
 	}
-	_, err := w.sess.Execute(ctx, buildDeleteMViewRefreshAlertSQL(mviewID), "mview-refresh-alert-delete")
-	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) { err = errors.New(val.(string)) })
+	var err error
+	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) {
+		err = errors.New(val.(string))
+	})
+	if err == nil {
+		_, err = w.sess.Execute(ctx, buildDeleteMViewRefreshAlertSQL(mviewID), "mview-refresh-alert-delete")
+	}
 	if infoschema.ErrTableNotExists.Equal(err) {
 		return nil
 	}
 	return errors.Trace(err)
+}
+
+func hasMaterializedViewDependsOnBaseTable(baseTableInfo *model.TableInfo) bool {
+	return baseTableInfo.MaterializedViewBase != nil && len(baseTableInfo.MaterializedViewBase.MViewIDs) > 0
+}
+
+func errDropMaterializedViewLogDependent(schemaName, baseTableName string) error {
+	return errors.Errorf("cannot drop materialized view log on %s.%s: dependent materialized views exist", schemaName, baseTableName)
+}
+
+func checkDropMaterializedViewLogHasNoDependentMVs(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) error {
+	if droppingTable.MaterializedViewLog == nil {
+		return nil
+	}
+	baseTableID := droppingTable.MaterializedViewLog.BaseTableID
+	baseTblInfo, err := getTableInfo(jobCtx.metaMut, baseTableID, job.SchemaID)
+	if err != nil {
+		if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+	if hasMaterializedViewDependsOnBaseTable(baseTblInfo) {
+		job.State = model.JobStateCancelled
+		return errDropMaterializedViewLogDependent(job.SchemaName, baseTblInfo.Name.O)
+	}
+	return nil
 }
 
 func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) ([]schemaIDAndTableInfo, error) {

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -998,6 +998,15 @@ func hasMaterializedViewDependsOnMaterializedViewLog(mlogTableInfo *model.TableI
 	return mlogTableInfo.MaterializedViewLog != nil && len(mlogTableInfo.MaterializedViewLog.DependentMViewIDs) > 0
 }
 
+func hasMaterializedViewID(ids []int64, mviewID int64) bool {
+	for _, id := range ids {
+		if id == mviewID {
+			return true
+		}
+	}
+	return false
+}
+
 func removeMaterializedViewID(ids []int64, mviewID int64) ([]int64, bool) {
 	removed := false
 	filtered := ids[:0]
@@ -1107,6 +1116,12 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 		}
 		if mlog == nil || mlog.MaterializedViewLog == nil {
 			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("drop materialized view: invalid materialized view log")
+		}
+		if mlog.MaterializedViewLog.BaseTableID != baseID {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("drop materialized view: invalid materialized view log metadata")
+		}
+		if !hasMaterializedViewID(mlog.MaterializedViewLog.DependentMViewIDs, job.TableID) {
+			continue
 		}
 		var removed bool
 		mlog.MaterializedViewLog.DependentMViewIDs, removed = removeMaterializedViewID(mlog.MaterializedViewLog.DependentMViewIDs, job.TableID)

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -847,6 +847,7 @@ func (w *worker) deleteMaterializedViewLogPurgeInfos(jobCtx *jobContext, mlogIDs
 		for i, id := range batch {
 			args[i] = id
 		}
+		/* #nosec G202: only the placeholder count is dynamic; IDs are escaped by sqlescape. */
 		_, err := w.sess.Execute(ctx,
 			sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
 			"mlog-purge-info-delete")
@@ -928,6 +929,7 @@ func (w *worker) deleteCreateMaterializedViewRefreshInfos(jobCtx *jobContext, mv
 		for i, id := range batch {
 			args[i] = id
 		}
+		/* #nosec G202: only the placeholder count is dynamic; IDs are escaped by sqlescape. */
 		_, err := w.sess.Execute(ctx,
 			sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
 			"mview-refresh-info-delete")
@@ -973,6 +975,7 @@ func (w *worker) deleteCreateMaterializedViewRefreshAlerts(jobCtx *jobContext, m
 			err = errors.New(val.(string))
 		})
 		if err == nil {
+			/* #nosec G202: only the placeholder count is dynamic; IDs are escaped by sqlescape. */
 			_, err = w.sess.Execute(ctx,
 				sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
 				"mview-refresh-alert-delete")

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -35,6 +35,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const materializedViewInfoDeleteBatchSize = 1000
+
 func (w *worker) onCreateMaterializedViewLog(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetCreateMaterializedViewLogArgs(job)
 	if err != nil {
@@ -827,20 +829,43 @@ func execCreateMaterializedViewLogPurgeInfoUpsert(ctx context.Context, ddlSess *
 }
 
 func (w *worker) deleteMaterializedViewLogPurgeInfo(jobCtx *jobContext, mlogID int64) error {
+	return w.deleteMaterializedViewLogPurgeInfos(jobCtx, []int64{mlogID})
+}
+
+func (w *worker) deleteMaterializedViewLogPurgeInfos(jobCtx *jobContext, mlogIDs []int64) error {
+	if len(mlogIDs) == 0 {
+		return nil
+	}
 	ctx := jobCtx.stepCtx
 	if ctx == nil {
 		ctx = w.workCtx
 	}
-	_, err := w.sess.Execute(ctx, sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID = %?", mlogID), "mlog-purge-info-delete")
-	failpoint.Inject("mockDeleteMaterializedViewLogPurgeInfoTableNotExists", func(val failpoint.Value) {
-		if val.(bool) {
-			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mlog_purge_info")
+	for start := 0; start < len(mlogIDs); start += materializedViewInfoDeleteBatchSize {
+		end := min(start+materializedViewInfoDeleteBatchSize, len(mlogIDs))
+		batch := mlogIDs[start:end]
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
 		}
-	})
-	if infoschema.ErrTableNotExists.Equal(err) {
-		return nil
+		_, err := w.sess.Execute(ctx,
+			sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mlog_purge_info WHERE MLOG_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
+			"mlog-purge-info-delete")
+		failpoint.Inject("mockDeleteMaterializedViewLogPurgeInfoTableNotExists", func(val failpoint.Value) {
+			if val.(bool) {
+				err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mlog_purge_info")
+			}
+		})
+		failpoint.Inject("mockDeleteMaterializedViewLogPurgeInfoErr", func(val failpoint.Value) {
+			err = errors.New(val.(string))
+		})
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
-	return errors.Trace(err)
+	return nil
 }
 
 func execCreateMaterializedViewRefreshInfoUpsert(ctx context.Context, ddlSess *sess.Session, mviewID int64, readTS uint64, lastSuccess, next *int64, shouldUpdate bool) error {
@@ -885,38 +910,81 @@ VALUES (%?, %?, %?) ON DUPLICATE KEY UPDATE LAST_SUCCESS_READ_TSO = VALUES(LAST_
 }
 
 func (w *worker) deleteCreateMaterializedViewRefreshInfo(jobCtx *jobContext, mviewID int64) error {
+	return w.deleteCreateMaterializedViewRefreshInfos(jobCtx, []int64{mviewID})
+}
+
+func (w *worker) deleteCreateMaterializedViewRefreshInfos(jobCtx *jobContext, mviewIDs []int64) error {
+	if len(mviewIDs) == 0 {
+		return nil
+	}
 	ctx := jobCtx.stepCtx
 	if ctx == nil {
 		ctx = w.workCtx
 	}
-	_, err := w.sess.Execute(ctx, sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID = %?", mviewID), "mview-refresh-info-delete")
-	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshInfoTableNotExists", func(val failpoint.Value) {
-		if val.(bool) {
-			err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_info")
+	for start := 0; start < len(mviewIDs); start += materializedViewInfoDeleteBatchSize {
+		end := min(start+materializedViewInfoDeleteBatchSize, len(mviewIDs))
+		batch := mviewIDs[start:end]
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
 		}
-	})
-	if infoschema.ErrTableNotExists.Equal(err) {
-		return nil
+		_, err := w.sess.Execute(ctx,
+			sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_info WHERE MVIEW_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
+			"mview-refresh-info-delete")
+		failpoint.Inject("mockDeleteCreateMaterializedViewRefreshInfoTableNotExists", func(val failpoint.Value) {
+			if val.(bool) {
+				err = infoschema.ErrTableNotExists.GenWithStackByArgs("mysql", "tidb_mview_refresh_info")
+			}
+		})
+		failpoint.Inject("mockDeleteCreateMaterializedViewRefreshInfoErr", func(val failpoint.Value) {
+			err = errors.New(val.(string))
+		})
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
-	return errors.Trace(err)
+	return nil
 }
 
 func (w *worker) deleteCreateMaterializedViewRefreshAlert(jobCtx *jobContext, mviewID int64) error {
+	return w.deleteCreateMaterializedViewRefreshAlerts(jobCtx, []int64{mviewID})
+}
+
+func (w *worker) deleteCreateMaterializedViewRefreshAlerts(jobCtx *jobContext, mviewIDs []int64) error {
+	if len(mviewIDs) == 0 {
+		return nil
+	}
 	ctx := jobCtx.stepCtx
 	if ctx == nil {
 		ctx = w.workCtx
 	}
-	var err error
-	failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) {
-		err = errors.New(val.(string))
-	})
-	if err == nil {
-		_, err = w.sess.Execute(ctx, buildDeleteMViewRefreshAlertSQL(mviewID), "mview-refresh-alert-delete")
+	for start := 0; start < len(mviewIDs); start += materializedViewInfoDeleteBatchSize {
+		end := min(start+materializedViewInfoDeleteBatchSize, len(mviewIDs))
+		batch := mviewIDs[start:end]
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		var err error
+		failpoint.Inject("mockDeleteCreateMaterializedViewRefreshAlertErr", func(val failpoint.Value) {
+			err = errors.New(val.(string))
+		})
+		if err == nil {
+			_, err = w.sess.Execute(ctx,
+				sqlescape.MustEscapeSQL("DELETE FROM mysql.tidb_mview_refresh_alert WHERE MVIEW_ID IN ("+strings.Repeat("%?,", len(batch)-1)+"%?)", args...),
+				"mview-refresh-alert-delete")
+		}
+		if infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
-	if infoschema.ErrTableNotExists.Equal(err) {
-		return nil
-	}
-	return errors.Trace(err)
+	return nil
 }
 
 func hasMaterializedViewDependsOnBaseTable(baseTableInfo *model.TableInfo) bool {

--- a/pkg/ddl/mview_worker.go
+++ b/pkg/ddl/mview_worker.go
@@ -389,6 +389,7 @@ func (w *worker) rollbackCreateMaterializedView(jobCtx *jobContext, job *model.J
 
 func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, createdTable *model.TableInfo) ([]schemaIDAndTableInfo, error) {
 	var baseTableIDs []int64
+	var mlogTableIDs []int64
 	var apply func(*model.TableInfo) error
 	switch {
 	case createdTable.MaterializedView != nil:
@@ -397,6 +398,9 @@ func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, 
 			return nil, errors.New("materialized view must reference at least one base table")
 		}
 		baseTableIDs = createdTable.MaterializedView.BaseTableIDs
+		if args, ok := jobCtx.jobArgs.(*model.CreateMaterializedViewArgs); ok && args != nil {
+			mlogTableIDs = args.MLogTableIDs
+		}
 		apply = func(base *model.TableInfo) error {
 			if base.MaterializedViewBase == nil {
 				base.MaterializedViewBase = &model.MaterializedViewBaseInfo{}
@@ -424,7 +428,7 @@ func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, 
 	default:
 		return nil, nil
 	}
-	extraInfos := make([]schemaIDAndTableInfo, 0, len(baseTableIDs))
+	extraInfos := make([]schemaIDAndTableInfo, 0, len(baseTableIDs)+len(mlogTableIDs))
 	processed := make(map[int64]struct{}, len(baseTableIDs))
 	for _, baseID := range baseTableIDs {
 		if baseID == 0 {
@@ -449,6 +453,53 @@ func updateMaterializedViewBaseInfoOnCreate(jobCtx *jobContext, job *model.Job, 
 			return nil, errors.Trace(err)
 		}
 		extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: base})
+	}
+	processedMLogs := make(map[int64]struct{}, len(mlogTableIDs))
+	for _, mlogID := range mlogTableIDs {
+		if mlogID == 0 {
+			job.State = model.JobStateCancelled
+			return nil, errors.New("materialized view log id is invalid")
+		}
+		if _, ok := processedMLogs[mlogID]; ok {
+			continue
+		}
+		processedMLogs[mlogID] = struct{}{}
+		mlog, err := getTableInfo(jobCtx.metaMut, mlogID, job.SchemaID)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return nil, errors.Trace(err)
+		}
+		if mlog.MaterializedViewLog == nil {
+			job.State = model.JobStateCancelled
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: invalid materialized view log")
+		}
+		isBaseTable := false
+		for _, baseID := range baseTableIDs {
+			if mlog.MaterializedViewLog.BaseTableID == baseID {
+				isBaseTable = true
+				break
+			}
+		}
+		if !isBaseTable {
+			job.State = model.JobStateCancelled
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("create materialized view: materialized view log does not belong to a base table")
+		}
+		dependent := false
+		for _, mviewID := range mlog.MaterializedViewLog.DependentMViewIDs {
+			if mviewID == createdTable.ID {
+				dependent = true
+				break
+			}
+		}
+		if dependent {
+			continue
+		}
+		mlog.MaterializedViewLog.DependentMViewIDs = append(mlog.MaterializedViewLog.DependentMViewIDs, createdTable.ID)
+		if err := updateTable(jobCtx.metaMut, job.SchemaID, mlog, true); err != nil {
+			job.State = model.JobStateCancelled
+			return nil, errors.Trace(err)
+		}
+		extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: mlog})
 	}
 	return extraInfos, nil
 }
@@ -872,12 +923,32 @@ func hasMaterializedViewDependsOnBaseTable(baseTableInfo *model.TableInfo) bool 
 	return baseTableInfo.MaterializedViewBase != nil && len(baseTableInfo.MaterializedViewBase.MViewIDs) > 0
 }
 
+func hasMaterializedViewDependsOnMaterializedViewLog(mlogTableInfo *model.TableInfo) bool {
+	return mlogTableInfo.MaterializedViewLog != nil && len(mlogTableInfo.MaterializedViewLog.DependentMViewIDs) > 0
+}
+
+func removeMaterializedViewID(ids []int64, mviewID int64) ([]int64, bool) {
+	removed := false
+	filtered := ids[:0]
+	for _, id := range ids {
+		if id == mviewID {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, id)
+	}
+	return filtered, removed
+}
+
 func errDropMaterializedViewLogDependent(schemaName, baseTableName string) error {
 	return errors.Errorf("cannot drop materialized view log on %s.%s: dependent materialized views exist", schemaName, baseTableName)
 }
 
 func checkDropMaterializedViewLogHasNoDependentMVs(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) error {
 	if droppingTable.MaterializedViewLog == nil {
+		return nil
+	}
+	if !hasMaterializedViewDependsOnMaterializedViewLog(droppingTable) {
 		return nil
 	}
 	baseTableID := droppingTable.MaterializedViewLog.BaseTableID
@@ -888,11 +959,8 @@ func checkDropMaterializedViewLogHasNoDependentMVs(jobCtx *jobContext, job *mode
 		}
 		return errors.Trace(err)
 	}
-	if hasMaterializedViewDependsOnBaseTable(baseTblInfo) {
-		job.State = model.JobStateCancelled
-		return errDropMaterializedViewLogDependent(job.SchemaName, baseTblInfo.Name.O)
-	}
-	return nil
+	job.State = model.JobStateCancelled
+	return errDropMaterializedViewLogDependent(job.SchemaName, baseTblInfo.Name.O)
 }
 
 func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, droppingTable *model.TableInfo) ([]schemaIDAndTableInfo, error) {
@@ -946,8 +1014,27 @@ func updateMaterializedViewBaseInfoOnDrop(jobCtx *jobContext, job *model.Job, dr
 		if err != nil || base == nil {
 			continue
 		}
+		var mlogID int64
+		if droppingTable.MaterializedView != nil && base.MaterializedViewBase != nil {
+			mlogID = base.MaterializedViewBase.MLogID
+		}
 		apply(base)
 		extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: base})
+		if mlogID == 0 {
+			continue
+		}
+		mlog, err := jobCtx.metaMut.GetTable(job.SchemaID, mlogID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if mlog == nil || mlog.MaterializedViewLog == nil {
+			return nil, dbterror.ErrInvalidDDLJob.GenWithStackByArgs("drop materialized view: invalid materialized view log")
+		}
+		var removed bool
+		mlog.MaterializedViewLog.DependentMViewIDs, removed = removeMaterializedViewID(mlog.MaterializedViewLog.DependentMViewIDs, job.TableID)
+		if removed {
+			extraInfos = append(extraInfos, schemaIDAndTableInfo{schemaID: job.SchemaID, tblInfo: mlog})
+		}
 	}
 	return extraInfos, nil
 }

--- a/pkg/ddl/mview_worker_test.go
+++ b/pkg/ddl/mview_worker_test.go
@@ -73,3 +73,66 @@ func TestUpdateMaterializedViewBaseInfoOnCreateMissingBaseTable(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestUpdateMaterializedViewBaseInfoOnDropPropagatesGetTableError(t *testing.T) {
+	store, err := mockstore.NewMockStore()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	err = kv.RunInNewTxn(context.Background(), store, true, func(_ context.Context, txn kv.Transaction) error {
+		metaMut := meta.NewMutator(txn)
+		job := &model.Job{SchemaID: 1}
+		droppingTable := &model.TableInfo{
+			ID: 2,
+			MaterializedView: &model.MaterializedViewInfo{
+				BaseTableIDs: []int64{3},
+			},
+		}
+
+		_, err := updateMaterializedViewBaseInfoOnDrop(&jobContext{metaMut: metaMut}, job, droppingTable)
+		require.Error(t, err)
+		require.True(t, meta.ErrDBNotExists.Equal(err))
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestUpdateMaterializedViewBaseInfoOnDropWithoutBaseTables(t *testing.T) {
+	droppingTable := &model.TableInfo{
+		ID:               2,
+		MaterializedView: &model.MaterializedViewInfo{},
+	}
+
+	extraInfos, err := updateMaterializedViewBaseInfoOnDrop(&jobContext{}, &model.Job{TableID: droppingTable.ID}, droppingTable)
+	require.NoError(t, err)
+	require.Empty(t, extraInfos)
+}
+
+func TestBuildDropTableInvolvingSchemaInfo(t *testing.T) {
+	base1 := &model.TableInfo{ID: 1, Name: ast.NewCIStr("base1")}
+	base2 := &model.TableInfo{ID: 2, Name: ast.NewCIStr("base2")}
+	mv := &model.TableInfo{
+		ID:   3,
+		Name: ast.NewCIStr("mv"),
+		MaterializedView: &model.MaterializedViewInfo{
+			BaseTableIDs: []int64{base1.ID, base2.ID},
+		},
+	}
+	mlog := &model.TableInfo{
+		ID:   4,
+		Name: ast.NewCIStr("$mlog$base1"),
+		MaterializedViewLog: &model.MaterializedViewLogInfo{
+			BaseTableID: base1.ID,
+		},
+	}
+	is := infoschema.MockInfoSchema([]*model.TableInfo{base1, base2, mv, mlog})
+
+	require.Equal(t, []model.InvolvingSchemaInfo{
+		{Database: "test", Table: "mv"},
+		{Database: "test", Table: "base1"},
+		{Database: "test", Table: "base2"},
+	}, buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv))
+	require.Equal(t, []model.InvolvingSchemaInfo{
+		{Database: "test", Table: "$mlog$base1"},
+		{Database: "test", Table: "base1"},
+	}, buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mlog))
+}

--- a/pkg/ddl/mview_worker_test.go
+++ b/pkg/ddl/mview_worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -124,15 +125,116 @@ func TestBuildDropTableInvolvingSchemaInfo(t *testing.T) {
 			BaseTableID: base1.ID,
 		},
 	}
+	base1.MaterializedViewBase = &model.MaterializedViewBaseInfo{MLogID: mlog.ID}
+	mlog.MaterializedViewLog.DependentMViewIDs = []int64{mv.ID}
 	is := infoschema.MockInfoSchema([]*model.TableInfo{base1, base2, mv, mlog})
 
+	involving, err := buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv)
+	require.NoError(t, err)
+	require.Equal(t, []model.InvolvingSchemaInfo{
+		{Database: "test", Table: "mv"},
+		{Database: "test", Table: "base1"},
+		{Database: "test", Table: "$mlog$base1"},
+		{Database: "test", Table: "base2"},
+	}, involving)
+
+	mlog.MaterializedViewLog.DependentMViewIDs = nil
+	involving, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv)
+	require.NoError(t, err)
 	require.Equal(t, []model.InvolvingSchemaInfo{
 		{Database: "test", Table: "mv"},
 		{Database: "test", Table: "base1"},
 		{Database: "test", Table: "base2"},
-	}, buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv))
+	}, involving)
+
+	base1.MaterializedViewBase.MLogID = 99
+	_, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv)
+	require.Error(t, err)
+	require.True(t, infoschema.ErrTableNotExists.Equal(err))
+
+	involving, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mlog)
+	require.NoError(t, err)
 	require.Equal(t, []model.InvolvingSchemaInfo{
 		{Database: "test", Table: "$mlog$base1"},
 		{Database: "test", Table: "base1"},
-	}, buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mlog))
+	}, involving)
+}
+
+func TestUpdateMaterializedViewBaseInfoOnDropMLogDependency(t *testing.T) {
+	runCase := func(t *testing.T, dependent bool, mlogExists bool, wrongBaseTableID bool) {
+		store, err := mockstore.NewMockStore()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+		err = kv.RunInNewTxn(context.Background(), store, true, func(_ context.Context, txn kv.Transaction) error {
+			metaMut := meta.NewMutator(txn)
+			require.NoError(t, metaMut.CreateDatabase(&model.DBInfo{ID: 1, Name: ast.NewCIStr("test")}))
+
+			base := &model.TableInfo{
+				ID:   1,
+				Name: ast.NewCIStr("base"),
+				MaterializedViewBase: &model.MaterializedViewBaseInfo{
+					MLogID:   2,
+					MViewIDs: []int64{3},
+				},
+			}
+			mlog := &model.TableInfo{
+				ID:   2,
+				Name: ast.NewCIStr("$mlog$base"),
+				MaterializedViewLog: &model.MaterializedViewLogInfo{
+					BaseTableID: 1,
+				},
+			}
+			if dependent {
+				mlog.MaterializedViewLog.DependentMViewIDs = []int64{3}
+			}
+			if wrongBaseTableID {
+				mlog.MaterializedViewLog.BaseTableID = 4
+			}
+			require.NoError(t, metaMut.CreateTableOrView(1, base))
+			if mlogExists {
+				require.NoError(t, metaMut.CreateTableOrView(1, mlog))
+			}
+
+			droppingTable := &model.TableInfo{
+				ID: 3,
+				MaterializedView: &model.MaterializedViewInfo{
+					BaseTableIDs: []int64{1},
+				},
+			}
+			extraInfos, err := updateMaterializedViewBaseInfoOnDrop(
+				&jobContext{metaMut: metaMut},
+				&model.Job{SchemaID: 1, TableID: droppingTable.ID},
+				droppingTable,
+			)
+			if !dependent {
+				require.NoError(t, err)
+				require.Len(t, extraInfos, 1)
+				return nil
+			}
+			if !mlogExists || wrongBaseTableID {
+				require.Error(t, err)
+				require.True(t, dbterror.ErrInvalidDDLJob.Equal(err))
+				return nil
+			}
+			require.NoError(t, err)
+			require.Len(t, extraInfos, 2)
+			require.Empty(t, extraInfos[1].tblInfo.MaterializedViewLog.DependentMViewIDs)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("dependent mlog is updated", func(t *testing.T) {
+		runCase(t, true, true, false)
+	})
+	t.Run("unrelated mlog is not updated", func(t *testing.T) {
+		runCase(t, false, true, false)
+	})
+	t.Run("missing mlog is rejected", func(t *testing.T) {
+		runCase(t, true, false, false)
+	})
+	t.Run("mlog with wrong base table is rejected", func(t *testing.T) {
+		runCase(t, true, true, true)
+	})
 }

--- a/pkg/ddl/mview_worker_test.go
+++ b/pkg/ddl/mview_worker_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
-	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -151,6 +150,16 @@ func TestBuildDropTableInvolvingSchemaInfo(t *testing.T) {
 	_, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv)
 	require.Error(t, err)
 	require.True(t, infoschema.ErrTableNotExists.Equal(err))
+	base1.MaterializedViewBase.MLogID = mlog.ID
+
+	// A missing base table must not prevent dropping an orphaned MView.
+	is = infoschema.MockInfoSchema([]*model.TableInfo{base1, mv, mlog})
+	involving, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mv)
+	require.NoError(t, err)
+	require.Equal(t, []model.InvolvingSchemaInfo{
+		{Database: "test", Table: "mv"},
+		{Database: "test", Table: "base1"},
+	}, involving)
 
 	involving, err = buildDropTableInvolvingSchemaInfo(context.Background(), is, "test", mlog)
 	require.NoError(t, err)
@@ -161,7 +170,7 @@ func TestBuildDropTableInvolvingSchemaInfo(t *testing.T) {
 }
 
 func TestUpdateMaterializedViewBaseInfoOnDropMLogDependency(t *testing.T) {
-	runCase := func(t *testing.T, dependent bool, mlogExists bool, wrongBaseTableID bool) {
+	runCase := func(t *testing.T, dependent bool, baseExists bool, mlogExists bool, wrongBaseTableID bool) {
 		store, err := mockstore.NewMockStore()
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, store.Close()) })
@@ -191,7 +200,9 @@ func TestUpdateMaterializedViewBaseInfoOnDropMLogDependency(t *testing.T) {
 			if wrongBaseTableID {
 				mlog.MaterializedViewLog.BaseTableID = 4
 			}
-			require.NoError(t, metaMut.CreateTableOrView(1, base))
+			if baseExists {
+				require.NoError(t, metaMut.CreateTableOrView(1, base))
+			}
 			if mlogExists {
 				require.NoError(t, metaMut.CreateTableOrView(1, mlog))
 			}
@@ -207,14 +218,20 @@ func TestUpdateMaterializedViewBaseInfoOnDropMLogDependency(t *testing.T) {
 				&model.Job{SchemaID: 1, TableID: droppingTable.ID},
 				droppingTable,
 			)
+			if !baseExists {
+				require.NoError(t, err)
+				require.Empty(t, extraInfos)
+				return nil
+			}
 			if !dependent {
 				require.NoError(t, err)
 				require.Len(t, extraInfos, 1)
 				return nil
 			}
 			if !mlogExists || wrongBaseTableID {
-				require.Error(t, err)
-				require.True(t, dbterror.ErrInvalidDDLJob.Equal(err))
+				require.NoError(t, err)
+				require.Len(t, extraInfos, 1)
+				require.Empty(t, extraInfos[0].tblInfo.MaterializedViewBase.MViewIDs)
 				return nil
 			}
 			require.NoError(t, err)
@@ -226,15 +243,18 @@ func TestUpdateMaterializedViewBaseInfoOnDropMLogDependency(t *testing.T) {
 	}
 
 	t.Run("dependent mlog is updated", func(t *testing.T) {
-		runCase(t, true, true, false)
+		runCase(t, true, true, true, false)
 	})
 	t.Run("unrelated mlog is not updated", func(t *testing.T) {
-		runCase(t, false, true, false)
+		runCase(t, false, true, true, false)
 	})
-	t.Run("missing mlog is rejected", func(t *testing.T) {
-		runCase(t, true, false, false)
+	t.Run("missing base table is skipped", func(t *testing.T) {
+		runCase(t, true, false, true, false)
 	})
-	t.Run("mlog with wrong base table is rejected", func(t *testing.T) {
-		runCase(t, true, true, true)
+	t.Run("missing mlog does not retry a started drop", func(t *testing.T) {
+		runCase(t, true, true, false, false)
+	})
+	t.Run("mlog with wrong base table does not retry a started drop", func(t *testing.T) {
+		runCase(t, true, true, true, true)
 	})
 }

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -640,7 +640,8 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, job *model.Job) (ver 
 		ver, err = rollingbackDropColumn(jobCtx, job)
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
 		ver, err = rollingbackDropIndex(jobCtx, job)
-	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
+	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence,
+		model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		err = rollingbackDropTableOrView(jobCtx, job)
 	case model.ActionDropTablePartition:
 		ver, err = rollingbackDropTablePartition(jobCtx, job)

--- a/pkg/ddl/sanity_check.go
+++ b/pkg/ddl/sanity_check.go
@@ -89,7 +89,7 @@ func expectedDeleteRangeCnt(ctx delRangeCntCtx, job *model.Job) (int, error) {
 			return 0, errors.Trace(err)
 		}
 		return len(args.AllDroppedTableIDs), nil
-	case model.ActionDropTable:
+	case model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		args, err := model.GetFinishedDropTableArgs(job)
 		if err != nil {
 			return 0, errors.Trace(err)
@@ -251,6 +251,14 @@ func (e *executor) checkHistoryJobInTest(ctx sessionctx.Context, historyJob *mod
 			}
 		case model.ActionCreateMaterializedViewLog:
 			if _, ok := st.(*ast.CreateMaterializedViewLogStmt); !ok {
+				panic(fmt.Sprintf("job ID %d, parse ddl job failed, query %s", historyJob.ID, historyJob.Query))
+			}
+		case model.ActionDropMaterializedView:
+			if _, ok := st.(*ast.DropMaterializedViewStmt); !ok {
+				panic(fmt.Sprintf("job ID %d, parse ddl job failed, query %s", historyJob.ID, historyJob.Query))
+			}
+		case model.ActionDropMaterializedViewLog:
+			if _, ok := st.(*ast.DropMaterializedViewLogStmt); !ok {
 				panic(fmt.Sprintf("job ID %d, parse ddl job failed, query %s", historyJob.ID, historyJob.Query))
 			}
 		case model.ActionCreateSchema:

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -217,6 +217,27 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
+		for _, tblInfo := range tables {
+			if tblInfo.MaterializedView != nil {
+				if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, tblInfo.ID); err != nil {
+					return ver, errors.Trace(err)
+				}
+				if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, tblInfo.ID); err != nil {
+					logutil.DDLLogger().Warn(
+						"drop schema: failed to delete materialized view refresh alert",
+						zap.String("schemaName", job.SchemaName),
+						zap.String("tableName", tblInfo.Name.O),
+						zap.Int64("mviewID", tblInfo.ID),
+						zap.Error(err),
+					)
+				}
+			}
+			if tblInfo.MaterializedViewLog != nil {
+				if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, tblInfo.ID); err != nil {
+					return ver, errors.Trace(err)
+				}
+			}
+		}
 
 		// Best-effort cleanup - log errors but continue with DROP DATABASE
 		if err := batchDeleteTableAffinityGroups(jobCtx, tables); err != nil {

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -251,6 +251,9 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 				mlogIDs = append(mlogIDs, tblInfo.ID)
 			}
 		}
+		// Refresh and purge records drive MView and MLog maintenance, so their
+		// cleanup must roll back DROP DATABASE on failure. Refresh alerts are
+		// advisory state, so retaining stale alerts is preferable to blocking DDL.
 		if err = w.deleteCreateMaterializedViewRefreshInfos(jobCtx, mviewIDs); err != nil {
 			return ver, newRollbackTxnError(errors.Trace(err))
 		}

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -217,29 +217,6 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		// TODO: Consider batching or chunking the refresh and purge cleanup
-		// statements when dropping a database with many materialized views.
-		for _, tblInfo := range tables {
-			if tblInfo.MaterializedView != nil {
-				if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, tblInfo.ID); err != nil {
-					return ver, errors.Trace(err)
-				}
-				if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, tblInfo.ID); err != nil {
-					logutil.DDLLogger().Warn(
-						"drop schema: failed to delete materialized view refresh alert",
-						zap.String("schemaName", job.SchemaName),
-						zap.String("tableName", tblInfo.Name.O),
-						zap.Int64("mviewID", tblInfo.ID),
-						zap.Error(err),
-					)
-				}
-			}
-			if tblInfo.MaterializedViewLog != nil {
-				if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, tblInfo.ID); err != nil {
-					return ver, errors.Trace(err)
-				}
-			}
-		}
 
 		// Best-effort cleanup - log errors but continue with DROP DATABASE
 		if err := batchDeleteTableAffinityGroups(jobCtx, tables); err != nil {
@@ -262,6 +239,30 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		// we only drop meta key of database, but not drop tables' meta keys.
 		if err = metaMut.DropDatabase(dbInfo.ID); err != nil {
 			break
+		}
+
+		mviewIDs := make([]int64, 0)
+		mlogIDs := make([]int64, 0)
+		for _, tblInfo := range tables {
+			if tblInfo.MaterializedView != nil {
+				mviewIDs = append(mviewIDs, tblInfo.ID)
+			}
+			if tblInfo.MaterializedViewLog != nil {
+				mlogIDs = append(mlogIDs, tblInfo.ID)
+			}
+		}
+		if err = w.deleteCreateMaterializedViewRefreshInfos(jobCtx, mviewIDs); err != nil {
+			return ver, newRollbackTxnError(errors.Trace(err))
+		}
+		if err = w.deleteCreateMaterializedViewRefreshAlerts(jobCtx, mviewIDs); err != nil {
+			logutil.DDLLogger().Warn(
+				"drop schema: failed to delete materialized view refresh alerts",
+				zap.String("schemaName", job.SchemaName),
+				zap.Error(err),
+			)
+		}
+		if err = w.deleteMaterializedViewLogPurgeInfos(jobCtx, mlogIDs); err != nil {
+			return ver, newRollbackTxnError(errors.Trace(err))
 		}
 
 		// Split tables into multiple jobs to avoid too big records in the notifier.

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -217,6 +217,8 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
+		// TODO: Consider batching or chunking the refresh and purge cleanup
+		// statements when dropping a database with many materialized views.
 		for _, tblInfo := range tables {
 			if tblInfo.MaterializedView != nil {
 				if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, tblInfo.ID); err != nil {

--- a/pkg/ddl/schema_version.go
+++ b/pkg/ddl/schema_version.go
@@ -357,7 +357,7 @@ func updateSchemaVersion(jobCtx *jobContext, job *model.Job, multiInfos ...schem
 		SetSchemaDiffForDropTablePartition(diff, job, jobCtx)
 	case model.ActionRecoverTable:
 		SetSchemaDiffForRecoverTable(diff, job, jobCtx)
-	case model.ActionDropTable:
+	case model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		SetSchemaDiffForDropTable(diff, job, jobCtx)
 	case model.ActionReorganizePartition:
 		SetSchemaDiffForReorganizePartition(diff, job, jobCtx)

--- a/pkg/ddl/schematracker/BUILD.bazel
+++ b/pkg/ddl/schematracker/BUILD.bazel
@@ -51,7 +51,7 @@ go_test(
     ],
     embed = [":schematracker"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 22,
     deps = [
         "//pkg/executor",
         "//pkg/infoschema",

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -303,6 +303,16 @@ func (d *Checker) CreateMaterializedView(ctx sessionctx.Context, stmt *ast.Creat
 	return d.realExecutor.CreateMaterializedView(ctx, stmt)
 }
 
+// DropMaterializedView implements the DDL interface.
+func (d *Checker) DropMaterializedView(ctx sessionctx.Context, stmt *ast.DropMaterializedViewStmt) error {
+	return d.realExecutor.DropMaterializedView(ctx, stmt)
+}
+
+// DropMaterializedViewLog implements the DDL interface.
+func (d *Checker) DropMaterializedViewLog(ctx sessionctx.Context, stmt *ast.DropMaterializedViewLogStmt) error {
+	return d.realExecutor.DropMaterializedViewLog(ctx, stmt)
+}
+
 // DropTable implements the DDL interface.
 func (d *Checker) DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error) {
 	err = d.realExecutor.DropTable(ctx, stmt)

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -310,7 +310,20 @@ func (d *Checker) DropMaterializedView(ctx sessionctx.Context, stmt *ast.DropMat
 
 // DropMaterializedViewLog implements the DDL interface.
 func (d *Checker) DropMaterializedViewLog(ctx sessionctx.Context, stmt *ast.DropMaterializedViewLogStmt) error {
-	return d.realExecutor.DropMaterializedViewLog(ctx, stmt)
+	err := d.realExecutor.DropMaterializedViewLog(ctx, stmt)
+	if err != nil || d.closed.Load() {
+		return err
+	}
+	if err := d.tracker.DropMaterializedViewLog(ctx, stmt); err != nil {
+		panic(err)
+	}
+	schemaName := stmt.Table.Schema
+	if schemaName.O == "" {
+		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
+	}
+	d.checkTableInfo(ctx, schemaName, model.MaterializedViewLogTableName(stmt.Table.Name))
+	d.checkTableInfo(ctx, schemaName, stmt.Table.Name)
+	return nil
 }
 
 // DropTable implements the DDL interface.

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -357,6 +357,16 @@ func (*SchemaTracker) CreateMaterializedView(sessionctx.Context, *ast.CreateMate
 	return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("CREATE MATERIALIZED VIEW is not supported in schema tracker")
 }
 
+// DropMaterializedView implements the DDL interface.
+func (*SchemaTracker) DropMaterializedView(sessionctx.Context, *ast.DropMaterializedViewStmt) error {
+	return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("DROP MATERIALIZED VIEW is not supported in schema tracker")
+}
+
+// DropMaterializedViewLog implements the DDL interface.
+func (*SchemaTracker) DropMaterializedViewLog(sessionctx.Context, *ast.DropMaterializedViewLogStmt) error {
+	return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("DROP MATERIALIZED VIEW LOG is not supported in schema tracker")
+}
+
 // DropTable implements the DDL interface.
 func (d *SchemaTracker) DropTable(_ sessionctx.Context, stmt *ast.DropTableStmt) (err error) {
 	notExistTables := make([]string, 0, len(stmt.Tables))

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -363,8 +363,55 @@ func (*SchemaTracker) DropMaterializedView(sessionctx.Context, *ast.DropMaterial
 }
 
 // DropMaterializedViewLog implements the DDL interface.
-func (*SchemaTracker) DropMaterializedViewLog(sessionctx.Context, *ast.DropMaterializedViewLogStmt) error {
-	return dbterror.ErrGeneralUnsupportedDDL.GenWithStack("DROP MATERIALIZED VIEW LOG is not supported in schema tracker")
+func (d *SchemaTracker) DropMaterializedViewLog(ctx sessionctx.Context, s *ast.DropMaterializedViewLogStmt) error {
+	schemaName := s.Table.Schema
+	if schemaName.O == "" {
+		if ctx == nil || ctx.GetSessionVars().CurrentDB == "" {
+			return errors.Trace(plannererrors.ErrNoDB)
+		}
+		schemaName = ast.NewCIStr(ctx.GetSessionVars().CurrentDB)
+	}
+	schema := d.SchemaByName(schemaName)
+	if schema == nil {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(schemaName)
+	}
+
+	baseTable, err := d.TableByName(context.Background(), schemaName, s.Table.Name)
+	if err != nil {
+		return err
+	}
+	if baseTable.IsView() || baseTable.IsSequence() || baseTable.TempTableType != model.TempTableNone ||
+		baseTable.MaterializedView != nil || baseTable.MaterializedViewLog != nil {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, s.Table.Name, "BASE TABLE")
+	}
+
+	mlogName := model.MaterializedViewLogTableName(baseTable.Name)
+	mlogTable, err := d.TableByName(context.Background(), schemaName, mlogName)
+	if err != nil {
+		if s.IfExists && infoschema.ErrTableNotExists.Equal(err) {
+			return nil
+		}
+		return err
+	}
+	if mlogTable.MaterializedViewLog == nil || mlogTable.MaterializedViewLog.BaseTableID != baseTable.ID {
+		return dbterror.ErrWrongObject.GenWithStackByArgs(schemaName, mlogName, "MATERIALIZED VIEW LOG")
+	}
+	if len(mlogTable.MaterializedViewLog.DependentMViewIDs) > 0 {
+		return errors.Errorf("cannot drop materialized view log on %s.%s: dependent materialized views exist", schemaName, s.Table.Name)
+	}
+
+	if err := d.DeleteTable(schemaName, mlogName); err != nil {
+		return err
+	}
+	if baseTable.MaterializedViewBase != nil && baseTable.MaterializedViewBase.MLogID != 0 {
+		baseTable = baseTable.Clone()
+		baseTable.MaterializedViewBase.MLogID = 0
+		if len(baseTable.MaterializedViewBase.MViewIDs) == 0 {
+			baseTable.MaterializedViewBase = nil
+		}
+		return d.PutTable(schemaName, baseTable)
+	}
+	return nil
 }
 
 // DropTable implements the DDL interface.

--- a/pkg/ddl/schematracker/dm_tracker_test.go
+++ b/pkg/ddl/schematracker/dm_tracker_test.go
@@ -770,3 +770,47 @@ func TestCreateMaterializedViewLogTruncatesLongPhysicalName(t *testing.T) {
 	mlogInfo := mustTableByName(t, tracker, "test", mlogName.O)
 	require.NotNil(t, mlogInfo.MaterializedViewLog)
 }
+
+func TestDropMaterializedViewLog(t *testing.T) {
+	tracker := schematracker.NewSchemaTracker(2)
+	tracker.CreateTestDB(nil)
+	execCreate(t, tracker, "create table test.t (a int)")
+
+	sctx := mock.NewContext()
+	p := parser.New()
+	createStmt, err := p.ParseOneStmt("create materialized view log on test.t (a)", "", "")
+	require.NoError(t, err)
+	require.NoError(t, tracker.CreateMaterializedViewLog(sctx, createStmt.(*ast.CreateMaterializedViewLogStmt)))
+
+	dropStmt, err := p.ParseOneStmt("drop materialized view log on test.t", "", "")
+	require.NoError(t, err)
+	require.NoError(t, tracker.DropMaterializedViewLog(sctx, dropStmt.(*ast.DropMaterializedViewLogStmt)))
+
+	_, err = tracker.TableByName(context.Background(), ast.NewCIStr("test"), model.MaterializedViewLogTableName(ast.NewCIStr("t")))
+	require.ErrorIs(t, err, infoschema.ErrTableNotExists)
+	baseTable := mustTableByName(t, tracker, "test", "t")
+	require.Nil(t, baseTable.MaterializedViewBase)
+}
+
+func TestDropMaterializedViewLogWithDependentMaterializedView(t *testing.T) {
+	tracker := schematracker.NewSchemaTracker(2)
+	tracker.CreateTestDB(nil)
+	execCreate(t, tracker, "create table test.t (a int)")
+
+	sctx := mock.NewContext()
+	p := parser.New()
+	createStmt, err := p.ParseOneStmt("create materialized view log on test.t (a)", "", "")
+	require.NoError(t, err)
+	require.NoError(t, tracker.CreateMaterializedViewLog(sctx, createStmt.(*ast.CreateMaterializedViewLogStmt)))
+
+	mlogName := model.MaterializedViewLogTableName(ast.NewCIStr("t"))
+	mlogTable := mustTableByName(t, tracker, "test", mlogName.O).Clone()
+	mlogTable.MaterializedViewLog.DependentMViewIDs = []int64{123}
+	require.NoError(t, tracker.PutTable(ast.NewCIStr("test"), mlogTable))
+
+	dropStmt, err := p.ParseOneStmt("drop materialized view log on test.t", "", "")
+	require.NoError(t, err)
+	err = tracker.DropMaterializedViewLog(sctx, dropStmt.(*ast.DropMaterializedViewLogStmt))
+	require.ErrorContains(t, err, "dependent materialized views exist")
+	require.NotNil(t, mustTableByName(t, tracker, "test", mlogName.O).MaterializedViewLog)
+}

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -82,6 +82,8 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 			if err != nil {
 				return ver, err
 			}
+		}
+		if job.Type == model.ActionDropTable || job.Type == model.ActionDropMaterializedViewLog {
 			err = checkDropMaterializedViewLogHasNoDependentMVs(jobCtx, job, tblInfo)
 			if err != nil {
 				return ver, err

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -139,7 +139,7 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 		}
 		if tblInfo.MaterializedView != nil {
 			if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, job.TableID); err != nil {
-				return ver, errors.Trace(err)
+				return ver, newRollbackTxnError(errors.Trace(err))
 			}
 			if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, job.TableID); err != nil {
 				logutil.DDLLogger().Warn(
@@ -153,7 +153,7 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 		}
 		if tblInfo.MaterializedViewLog != nil {
 			if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, job.TableID); err != nil {
-				return ver, errors.Trace(err)
+				return ver, newRollbackTxnError(errors.Trace(err))
 			}
 		}
 		// Placement rules cannot be removed immediately after drop table / truncate table, because the

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -82,6 +82,10 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 			if err != nil {
 				return ver, err
 			}
+			err = checkDropMaterializedViewLogHasNoDependentMVs(jobCtx, job, tblInfo)
+			if err != nil {
+				return ver, err
+			}
 		}
 		if jobCtx.oldDDLCtx != nil && tblInfo.TTLInfo != nil {
 			if err := jobCtx.oldDDLCtx.deleteTTLTableFromExternalWorkload(jobCtx.ctx, tblInfo.ID); err != nil {
@@ -106,7 +110,11 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 		ruleIDs := append(getPartitionRuleIDs(jobCtx.store.GetCodec(), job.SchemaName, tblInfo), label.NewRuleID(jobCtx.store.GetCodec(), job.SchemaName, tblInfo.Name.L, ""))
 
 		args.OldPartitionIDs = oldIDs
-		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State)
+		extraInfos, extraErr := updateMaterializedViewBaseInfoOnDrop(jobCtx, job, tblInfo)
+		if extraErr != nil {
+			return ver, errors.Trace(extraErr)
+		}
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State, extraInfos...)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -127,6 +135,25 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 			e := infosync.DeleteTiFlashTableSyncProgress(tblInfo)
 			if e != nil {
 				logutil.DDLLogger().Error("DeleteTiFlashTableSyncProgress fails", zap.Error(e))
+			}
+		}
+		if tblInfo.MaterializedView != nil {
+			if err = w.deleteCreateMaterializedViewRefreshInfo(jobCtx, job.TableID); err != nil {
+				return ver, errors.Trace(err)
+			}
+			if err = w.deleteCreateMaterializedViewRefreshAlert(jobCtx, job.TableID); err != nil {
+				logutil.DDLLogger().Warn(
+					"drop table/view: failed to delete materialized view refresh alert",
+					zap.String("schemaName", job.SchemaName),
+					zap.String("tableName", tblInfo.Name.O),
+					zap.Int64("mviewID", job.TableID),
+					zap.Error(err),
+				)
+			}
+		}
+		if tblInfo.MaterializedViewLog != nil {
+			if err = w.deleteMaterializedViewLogPurgeInfo(jobCtx, job.TableID); err != nil {
+				return ver, errors.Trace(err)
 			}
 		}
 		// Placement rules cannot be removed immediately after drop table / truncate table, because the

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -78,6 +78,10 @@ func (w *worker) onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int6
 	case model.StatePublic:
 		// public -> write only
 		if job.Type == model.ActionDropTable {
+			if err = checkTableMaterializedViewConstraints(tblInfo, "DROP TABLE"); err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
 			err = checkDropTableHasForeignKeyReferredInOwner(jobCtx.infoCache, job, args)
 			if err != nil {
 				return ver, err
@@ -504,6 +508,10 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, job *model.Job) (ver int64,
 	if tblInfo.IsView() || tblInfo.IsSequence() {
 		job.State = model.JobStateCancelled
 		return ver, infoschema.ErrTableNotExists.GenWithStackByArgs(job.SchemaName, tblInfo.Name.O)
+	}
+	if err = checkTableMaterializedViewConstraints(tblInfo, "TRUNCATE TABLE"); err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
 	}
 	// Copy the old tableInfo for later usage.
 	oldTblInfo := tblInfo.Clone()

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -176,6 +176,10 @@ func (e *DDLExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 		err = e.ddlExecutor.CreateMaterializedView(e.Ctx(), x)
 	case *ast.CreateMaterializedViewLogStmt:
 		err = e.ddlExecutor.CreateMaterializedViewLog(e.Ctx(), x)
+	case *ast.DropMaterializedViewStmt:
+		err = e.ddlExecutor.DropMaterializedView(e.Ctx(), x)
+	case *ast.DropMaterializedViewLogStmt:
+		err = e.ddlExecutor.DropMaterializedViewLog(e.Ctx(), x)
 	case *ast.DropIndexStmt:
 		err = e.executeDropIndex(x)
 	case *ast.DropDatabaseStmt:

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "ddl_test.go",
         "main_test.go",
+        "materialized_view_basic_test.go",
         "materialized_view_create_test.go",
         "materialized_view_drop_test.go",
     ],

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "ddl_test.go",
         "main_test.go",
         "materialized_view_create_test.go",
+        "materialized_view_drop_test.go",
     ],
     flaky = True,
     shard_count = 50,

--- a/pkg/executor/test/ddl/materialized_view_basic_test.go
+++ b/pkg/executor/test/ddl/materialized_view_basic_test.go
@@ -340,11 +340,34 @@ func TestDropTableMaterializedViewConstraints(t *testing.T) {
 	require.ErrorContains(t, err, "DROP TABLE on materialized view log table")
 	err = tk.ExecToErr("drop table t_drop_constraints")
 	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
+
+	err = tk.ExecToErr("truncate table mv_drop_constraints")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view table")
+	err = tk.ExecToErr("truncate table `$mlog$t_drop_constraints`")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on materialized view log table")
+	err = tk.ExecToErr("truncate table t_drop_constraints")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view dependencies")
 	tk.MustExec("drop materialized view mv_drop_constraints")
 	err = tk.ExecToErr("drop table t_drop_constraints")
 	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view log")
+	err = tk.ExecToErr("truncate table t_drop_constraints")
+	require.ErrorContains(t, err, "TRUNCATE TABLE on base table with materialized view log")
 	tk.MustExec("drop materialized view log on t_drop_constraints")
+	tk.MustExec("truncate table t_drop_constraints")
 	tk.MustExec("drop table t_drop_constraints")
+}
+
+func TestDropMaterializedViewWhenDisabled(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_when_disabled (a int not null)")
+	tk.MustExec("create materialized view log on t_drop_when_disabled (a)")
+	tk.MustExec("create materialized view mv_drop_when_disabled (a, cnt) as select a, count(1) from t_drop_when_disabled group by a")
+
+	tk.MustExec("set tidb_mview_enable = off")
+	tk.MustExec("drop materialized view mv_drop_when_disabled")
+	tk.MustExec("drop materialized view log on t_drop_when_disabled")
 }
 
 func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {
@@ -403,6 +426,7 @@ func TestDropMaterializedViewIfExists(t *testing.T) {
 	require.ErrorContains(t, err, "is not BASE TABLE")
 
 	tk.MustExec("drop materialized view log if exists on t_no_mlog_drop_if_exists")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Note 1051 Unknown table 'test.t_no_mlog_drop_if_exists'"))
 	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
 	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
 }

--- a/pkg/executor/test/ddl/materialized_view_basic_test.go
+++ b/pkg/executor/test/ddl/materialized_view_basic_test.go
@@ -1,0 +1,408 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/stretchr/testify/require"
+)
+
+func newMViewTestKit(t testing.TB, store kv.Storage) *testkit.TestKit {
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set tidb_mview_enable = on")
+	return tk
+}
+
+func TestCreateMaterializedViewAndLog(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set div_precision_increment = 9")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+
+	tk.MustExec("set tidb_mview_enable = off")
+	err := tk.ExecToErr("create materialized view log on t (a, b)")
+	require.ErrorContains(t, err, "tidb_mview_enable")
+	tk.MustExec("set tidb_mview_enable = on")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("set tidb_mview_enable = off")
+	err = tk.ExecToErr("create materialized view mv_disabled (a, s, cnt) as select a, sum(b), count(1) from t group by a")
+	require.ErrorContains(t, err, "tidb_mview_enable")
+	tk.MustExec("set tidb_mview_enable = on")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mviewTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("mv"))
+	require.NoError(t, err)
+
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	require.Equal(t, mlogTable.Meta().ID, baseTable.Meta().MaterializedViewBase.MLogID)
+	require.Contains(t, baseTable.Meta().MaterializedViewBase.MViewIDs, mviewTable.Meta().ID)
+	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+	require.Equal(t, baseTable.Meta().ID, mlogTable.Meta().MaterializedViewLog.BaseTableID)
+	require.Equal(t, []int64{mviewTable.Meta().ID}, mlogTable.Meta().MaterializedViewLog.DependentMViewIDs)
+	require.NotNil(t, mviewTable.Meta().MaterializedView)
+	require.Equal(t, model.MViewInitBuildReady, mviewTable.Meta().MaterializedView.GetInitBuildState())
+	require.Equal(t, 9, mviewTable.Meta().MaterializedView.DefinitionDivPrecisionIncrement)
+
+	tk.MustQuery("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = ?", mlogTable.Meta().ID).Check(testkit.Rows("1"))
+	tk.MustQuery("select last_success_read_tso > 0 from mysql.tidb_mview_refresh_info where mview_id = ?", mviewTable.Meta().ID).Check(testkit.Rows("1"))
+}
+
+func TestCreateMaterializedViewLogBasic(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+	expectedSQLMode := tk.Session().GetSessionVars().SQLMode
+
+	tk.MustExec("create materialized view log on t (a) purge start with cast('2026-01-02 03:04:05' as datetime) next cast('2026-01-02 03:14:05' as datetime) alert rows 1234")
+	tk.MustQuery("select count(*) from information_schema.tables where table_schema='test' and table_name='$mlog$t'").Check(testkit.Rows("1"))
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+	require.Equal(t, mlogTable.Meta().ID, baseTable.Meta().MaterializedViewBase.MLogID)
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogTable.Meta().ID)).Check(testkit.Rows("1"))
+
+	mlogInfo := mlogTable.Meta().MaterializedViewLog
+	require.NotNil(t, mlogInfo)
+	require.Equal(t, baseTable.Meta().ID, mlogInfo.BaseTableID)
+	require.Equal(t, []ast.CIStr{ast.NewCIStr("a")}, mlogInfo.Columns)
+	require.Equal(t, "DEFERRED", mlogInfo.PurgeMethod)
+	require.Equal(t, "CAST('2026-01-02 03:04:05' AS DATETIME)", mlogInfo.PurgeStartWith)
+	require.Equal(t, "CAST('2026-01-02 03:14:05' AS DATETIME)", mlogInfo.PurgeNext)
+	require.NotNil(t, mlogInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(1234), *mlogInfo.LogAccumulationAlertRows)
+	require.Equal(t, expectedSQLMode, mlogInfo.DefinitionSQLMode)
+
+	var hasDMLType, hasOldNew bool
+	for _, col := range mlogTable.Meta().Columns {
+		if col.Name.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) {
+			hasDMLType = true
+		}
+		if col.Name.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
+			hasOldNew = true
+			require.Equal(t, mysql.TypeTiny, col.FieldType.GetType())
+		}
+	}
+	require.True(t, hasDMLType)
+	require.True(t, hasOldNew)
+	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
+}
+
+func TestCreateMaterializedViewLogPreservesTextColumnTypes(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_text_types (id bigint not null primary key, c_tiny tinytext, c_text text, c_medium mediumtext, c_long longtext)")
+	tk.MustExec("create materialized view log on t_text_types (id, c_tiny, c_text, c_medium, c_long)")
+
+	showCreate := tk.MustQuery("show create table `$mlog$t_text_types`").Rows()[0][1].(string)
+	require.Contains(t, showCreate, "  `c_tiny` tinytext DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_text` text DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_medium` mediumtext DEFAULT NULL")
+	require.Contains(t, showCreate, "  `c_long` longtext DEFAULT NULL")
+}
+
+func TestCreateMaterializedViewColumnFlags(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table base_mv_flags(id bigint not null auto_increment primary key, g1 int not null, v1 bigint not null, key idx_g1_id(g1, id))")
+	tk.MustExec("create materialized view log on base_mv_flags(id, g1, v1) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_flags (g1, cnt, s_v1, min_id, max_id) as select g1, count(1), sum(v1), min(id), max(id) from base_mv_flags group by g1")
+	for _, col := range []string{"min_id", "max_id"} {
+		tk.MustQuery(fmt.Sprintf("select column_key from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='%s'", col)).Check(testkit.Rows(""))
+		tk.MustQuery(fmt.Sprintf("select extra from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='%s'", col)).Check(testkit.Rows(""))
+	}
+}
+
+func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table base_test(id int, v1 int, v2 int, v3 int, v4 int, index k(v1,v2,v3,v4))")
+	tk.MustExec("create materialized view log on base_test(v1, v2) purge next date_add(now(), interval 1 hour)")
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v1'").
+		Check(testkit.Rows(""))
+	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v2'").
+		Check(testkit.Rows(""))
+}
+
+func TestCreateMaterializedViewLogRejectsDuplicateColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_dup (id bigint not null primary key, g1 int not null)")
+
+	err := tk.ExecToErr("create materialized view log on t_dup (id, id)")
+	require.ErrorContains(t, err, "Duplicate column name")
+}
+
+func TestCreateMaterializedViewLogNameLengthByRune(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	maxBaseNameLen := mysql.MaxTableNameLength - len([]rune(model.MaterializedViewLogTableNamePrefix))
+	maxName := strings.Repeat("表", maxBaseNameLen)
+	maxMLogName := model.MaterializedViewLogTableName(ast.NewCIStr(maxName)).O
+	require.Equal(t, mysql.MaxTableNameLength, len([]rune(maxMLogName)))
+	tk.MustExec(fmt.Sprintf("create table `%s` (a int)", maxName))
+	tk.MustExec(fmt.Sprintf("create materialized view log on `%s` (a)", maxName))
+	tk.MustQuery(fmt.Sprintf("select count(*) from information_schema.tables where table_schema='test' and table_name='%s'", maxMLogName)).Check(testkit.Rows("1"))
+
+	tooLongName := strings.Repeat("表", maxBaseNameLen+1)
+	require.Equal(t, maxMLogName, model.MaterializedViewLogTableName(ast.NewCIStr(tooLongName)).O)
+	tk.MustExec(fmt.Sprintf("create table `%s` (a int)", tooLongName))
+	err := tk.ExecToErr(fmt.Sprintf("create materialized view log on `%s` (a)", tooLongName))
+	require.ErrorContains(t, err, "already exists")
+}
+
+func TestCreateMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+
+	err := tk.ExecToErr("create materialized view log on t (a) purge immediate")
+	require.Truef(t, dbterror.ErrGeneralUnsupportedDDL.Equal(err), "err %v", err)
+	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
+	err = tk.ExecToErr("create materialized view log on t (a) purge start with 1 next date_add(now(), interval 1 hour)")
+	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
+	err = tk.ExecToErr("create materialized view log on t (a) purge next 600")
+	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
+	tk.MustExec("create materialized view log on t (a) purge start with now() next date_add(now(), interval 1 hour)")
+}
+
+func TestCreateMaterializedViewLogAccumulationAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_alert_default (a int)")
+	tk.MustExec("create table t_alert_zero (a int)")
+	tk.MustExec("create table t_alert_custom (a int)")
+	tk.MustExec("create table t_alert_negative (a int)")
+
+	err := tk.ExecToErr("create materialized view log on t_alert_negative (a) alert rows -1")
+	require.ErrorContains(t, err, "invalid ALERT ROWS value: -1 (must be non-negative)")
+	tk.MustExec("create materialized view log on t_alert_default (a)")
+	tk.MustExec("create materialized view log on t_alert_zero (a) alert rows 0")
+	tk.MustExec("create materialized view log on t_alert_custom (a) alert rows 2048")
+
+	getMLogInfo := func(baseTable string) *model.MaterializedViewLogInfo {
+		is := dom.InfoSchema()
+		mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$"+baseTable))
+		require.NoError(t, err)
+		require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+		return mlogTable.Meta().MaterializedViewLog
+	}
+
+	defaultInfo := getMLogInfo("t_alert_default")
+	require.Nil(t, defaultInfo.LogAccumulationAlertRows)
+	defaultRows, defaultEnabled := defaultInfo.EffectiveLogAccumulationAlertRows()
+	require.False(t, defaultEnabled)
+	require.Equal(t, uint64(0), defaultRows)
+
+	zeroInfo := getMLogInfo("t_alert_zero")
+	require.NotNil(t, zeroInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(0), *zeroInfo.LogAccumulationAlertRows)
+	zeroRows, zeroEnabled := zeroInfo.EffectiveLogAccumulationAlertRows()
+	require.False(t, zeroEnabled)
+	require.Equal(t, uint64(0), zeroRows)
+
+	customInfo := getMLogInfo("t_alert_custom")
+	require.NotNil(t, customInfo.LogAccumulationAlertRows)
+	require.Equal(t, uint64(2048), *customInfo.LogAccumulationAlertRows)
+	customRows, customEnabled := customInfo.EffectiveLogAccumulationAlertRows()
+	require.True(t, customEnabled)
+	require.Equal(t, uint64(2048), customRows)
+}
+
+func TestCreateMaterializedViewLogMetaColumnNameConflict(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_conflict (`_MLOG$_DML_TYPE` int, a int)")
+	tk.MustGetErrCode("create materialized view log on t_conflict (`_MLOG$_DML_TYPE`, a)", 1060)
+}
+
+func TestCreateMaterializedViewLogRejectUnsupportedColumns(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	for _, tableName := range []string{"t_tinyblob", "t_blob", "t_mediumblob", "t_longblob"} {
+		tk.MustExec(fmt.Sprintf("create table %s (id bigint not null primary key, b %s null)", tableName, tableName[2:]))
+		err := tk.ExecToErr(fmt.Sprintf("create materialized view log on %s (id, b)", tableName))
+		require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG does not support BLOB column b")
+	}
+
+	tk.MustExec("create table t_text_ok (id bigint not null primary key, c1 tinytext null, c2 text null, c3 mediumtext null, c4 longtext null)")
+	tk.MustExec("create materialized view log on t_text_ok (id, c1, c2, c3, c4)")
+	tk.MustExec("create table t_json (id bigint not null primary key, j json null)")
+	err := tk.ExecToErr("create materialized view log on t_json (id, j)")
+	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG does not support JSON column j")
+
+	tk.MustExec("create table t_gen (id bigint not null primary key, g1 int not null, g_virtual int as (g1 + 1) virtual, g_stored int as (g1 + 2) stored)")
+	tk.MustExec("create materialized view log on t_gen (id, g_virtual, g_stored)")
+	tk.MustExec("create table t_untracked_unsupported (id bigint not null primary key, b blob null, j json null, g int as (id + 1) stored)")
+	tk.MustExec("create materialized view log on t_untracked_unsupported (id)")
+}
+
+func TestMaterializedViewCommentLength(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_mv_comment_len (id bigint not null primary key, g1 int not null, v1 bigint not null, key idx_g1(g1))")
+	tk.MustExec("create materialized view log on t_mv_comment_len (id, g1, v1)")
+
+	maxTableCommentLength := ddl.MaxCommentLength * 2
+	commentMaxLen := strings.Repeat("y", maxTableCommentLength)
+	commentTooLong := strings.Repeat("y", maxTableCommentLength+1)
+	createMVSQL := func(name, comment string) string {
+		return fmt.Sprintf("create materialized view %s (g1, cnt) comment = '%s' refresh fast as select g1, count(1) from t_mv_comment_len group by g1", name, comment)
+	}
+	errTooLongComment := func(name string) string {
+		return fmt.Sprintf("Comment for table '%s' is too long (max = %d)", name, maxTableCommentLength)
+	}
+
+	tk.MustExec("set @@sql_mode='STRICT_TRANS_TABLES'")
+	tk.MustExec(createMVSQL("mv_comment_max", commentMaxLen))
+	err := tk.ExecToErr(createMVSQL("mv_comment_too_long", commentTooLong))
+	require.ErrorContains(t, err, errTooLongComment("mv_comment_too_long"))
+
+	tk.MustExec("set @@sql_mode=''")
+	tk.MustExec(createMVSQL("mv_comment_truncated", commentTooLong))
+	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1628|"+errTooLongComment("mv_comment_truncated")))
+	tk.MustQuery("select length(table_comment) from information_schema.tables where table_schema = 'test' and table_name = 'mv_comment_truncated'").Check(testkit.Rows(strconv.Itoa(maxTableCommentLength)))
+}
+
+func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	err := tk.ExecToErr("create materialized view mv_bad_next (a, s, cnt) refresh fast next 300 as select a, sum(b), count(1) from t group by a")
+	require.ErrorContains(t, err, "REFRESH NEXT expression must return DATETIME/TIMESTAMP")
+	err = tk.ExecToErr("create materialized view mv_bad_start (a, s, cnt) refresh fast start with 1 next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+	require.ErrorContains(t, err, "REFRESH START WITH expression must return DATETIME/TIMESTAMP")
+	tk.MustExec("create materialized view mv_ok (a, s, cnt) refresh fast start with now() next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+}
+
+func TestDropTableMaterializedViewConstraints(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_constraints (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_drop_constraints (a, b)")
+	tk.MustExec("create materialized view mv_drop_constraints (a, s, cnt) as select a, sum(b), count(1) from t_drop_constraints group by a")
+	err := tk.ExecToErr("drop table mv_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on materialized view table")
+	err = tk.ExecToErr("drop table `$mlog$t_drop_constraints`")
+	require.ErrorContains(t, err, "DROP TABLE on materialized view log table")
+	err = tk.ExecToErr("drop table t_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
+	tk.MustExec("drop materialized view mv_drop_constraints")
+	err = tk.ExecToErr("drop table t_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view log")
+	tk.MustExec("drop materialized view log on t_drop_constraints")
+	tk.MustExec("drop table t_drop_constraints")
+}
+
+func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_mlog_purge_state (a int)")
+	tk.MustExec("create materialized view log on t_drop_mlog_purge_state (a)")
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t_drop_mlog_purge_state"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Check(testkit.Rows("1"))
+	tk.MustExec("drop materialized view log on t_drop_mlog_purge_state")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).Check(testkit.Rows("0"))
+}
+
+func TestDropMaterializedViewLogBeforeBaseTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_seq (a int)")
+	tk.MustExec("create materialized view log on t_drop_seq (a)")
+	tk.MustExec("drop materialized view log on t_drop_seq")
+	tk.MustExec("drop table if exists t_drop_seq")
+}
+
+func TestDropMaterializedViewIfExists(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop materialized view if exists missing_mv")
+	tk.MustExec("drop materialized view if exists missing_schema.missing_mv")
+
+	err := tk.ExecToErr("drop materialized view log if exists on missing_base")
+	require.ErrorContains(t, err, "Table 'test.missing_base' doesn't exist")
+	err = tk.ExecToErr("drop materialized view log if exists on missing_schema.missing_base")
+	require.ErrorContains(t, err, "Table 'missing_schema.missing_base' doesn't exist")
+
+	tk.MustExec("create table t_drop_if_exists (a int not null)")
+	tk.MustExec("create table t_no_mlog_drop_if_exists (a int not null)")
+	tk.MustExec("create materialized view log on t_drop_if_exists (a)")
+	tk.MustExec("create materialized view mv_drop_if_exists (a, cnt) as select a, count(1) from t_drop_if_exists group by a")
+
+	err = tk.ExecToErr("drop materialized view if exists t_drop_if_exists")
+	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
+	err = tk.ExecToErr("drop materialized view log if exists on mv_drop_if_exists")
+	require.ErrorContains(t, err, "is not BASE TABLE")
+
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+
+	tk.MustExec("create view v_drop_if_exists as select * from t_drop_if_exists")
+	err = tk.ExecToErr("drop materialized view log if exists on v_drop_if_exists")
+	require.ErrorContains(t, err, "is not BASE TABLE")
+
+	tk.MustExec("drop materialized view log if exists on t_no_mlog_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+}

--- a/pkg/executor/test/ddl/materialized_view_create_test.go
+++ b/pkg/executor/test/ddl/materialized_view_create_test.go
@@ -31,10 +31,8 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
-	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
-	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,112 +40,6 @@ func newMViewTestKit(t testing.TB, store kv.Storage) *testkit.TestKit {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set tidb_mview_enable = on")
 	return tk
-}
-
-func TestCreateMaterializedViewAndLog(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("set div_precision_increment = 9")
-	tk.MustExec("create table t (a int not null, b int not null)")
-	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-
-	tk.MustExec("set tidb_mview_enable = off")
-	err := tk.ExecToErr("create materialized view log on t (a, b)")
-	require.ErrorContains(t, err, "tidb_mview_enable")
-	tk.MustExec("set tidb_mview_enable = on")
-	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("set tidb_mview_enable = off")
-	err = tk.ExecToErr("create materialized view mv_disabled (a, s, cnt) as select a, sum(b), count(1) from t group by a")
-	require.ErrorContains(t, err, "tidb_mview_enable")
-	tk.MustExec("set tidb_mview_enable = on")
-	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
-	tk.MustQuery("select a, s, cnt from mv order by a").Check(testkit.Rows("1 15 2", "2 7 1"))
-
-	is := dom.InfoSchema()
-	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
-	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t"))
-	require.NoError(t, err)
-	mviewTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("mv"))
-	require.NoError(t, err)
-
-	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
-	require.Equal(t, mlogTable.Meta().ID, baseTable.Meta().MaterializedViewBase.MLogID)
-	require.Contains(t, baseTable.Meta().MaterializedViewBase.MViewIDs, mviewTable.Meta().ID)
-	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
-	require.Equal(t, baseTable.Meta().ID, mlogTable.Meta().MaterializedViewLog.BaseTableID)
-	require.Equal(t, []int64{mviewTable.Meta().ID}, mlogTable.Meta().MaterializedViewLog.DependentMViewIDs)
-	require.NotNil(t, mviewTable.Meta().MaterializedView)
-	require.Equal(t, model.MViewInitBuildReady, mviewTable.Meta().MaterializedView.GetInitBuildState())
-	require.Equal(t, 9, mviewTable.Meta().MaterializedView.DefinitionDivPrecisionIncrement)
-
-	tk.MustQuery("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = ?", mlogTable.Meta().ID).Check(testkit.Rows("1"))
-	tk.MustQuery("select last_success_read_tso > 0 from mysql.tidb_mview_refresh_info where mview_id = ?", mviewTable.Meta().ID).Check(testkit.Rows("1"))
-}
-
-func TestCreateMaterializedViewLogBasic(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t (a int, b int)")
-	expectedSQLMode := tk.Session().GetSessionVars().SQLMode
-
-	tk.MustExec("create materialized view log on t (a) purge start with cast('2026-01-02 03:04:05' as datetime) next cast('2026-01-02 03:14:05' as datetime) alert rows 1234")
-
-	tk.MustQuery("select count(*) from information_schema.tables where table_schema='test' and table_name='$mlog$t'").Check(testkit.Rows("1"))
-
-	is := dom.InfoSchema()
-	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
-	require.NoError(t, err)
-	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t"))
-	require.NoError(t, err)
-
-	require.NotNil(t, baseTable.Meta().MaterializedViewBase)
-	require.Equal(t, mlogTable.Meta().ID, baseTable.Meta().MaterializedViewBase.MLogID)
-	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogTable.Meta().ID)).
-		Check(testkit.Rows("1"))
-
-	mlogInfo := mlogTable.Meta().MaterializedViewLog
-	require.NotNil(t, mlogInfo)
-	require.Equal(t, baseTable.Meta().ID, mlogInfo.BaseTableID)
-	require.Equal(t, []ast.CIStr{ast.NewCIStr("a")}, mlogInfo.Columns)
-	require.Equal(t, "DEFERRED", mlogInfo.PurgeMethod)
-	require.Equal(t, "CAST('2026-01-02 03:04:05' AS DATETIME)", mlogInfo.PurgeStartWith)
-	require.Equal(t, "CAST('2026-01-02 03:14:05' AS DATETIME)", mlogInfo.PurgeNext)
-	require.NotNil(t, mlogInfo.LogAccumulationAlertRows)
-	require.Equal(t, uint64(1234), *mlogInfo.LogAccumulationAlertRows)
-	require.Equal(t, expectedSQLMode, mlogInfo.DefinitionSQLMode)
-
-	var hasDMLType, hasOldNew bool
-	for _, col := range mlogTable.Meta().Columns {
-		if col.Name.L == strings.ToLower(model.MaterializedViewLogDMLTypeColumnName) {
-			hasDMLType = true
-		}
-		if col.Name.L == strings.ToLower(model.MaterializedViewLogOldNewColumnName) {
-			hasOldNew = true
-			require.Equal(t, mysql.TypeTiny, col.FieldType.GetType())
-		}
-	}
-	require.True(t, hasDMLType)
-	require.True(t, hasOldNew)
-
-	tk.MustGetErrMsg("create materialized view log on t (a)", "[schema:1050]Table 'test.$mlog$t' already exists")
-}
-
-func TestCreateMaterializedViewLogPreservesTextColumnTypes(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec("create table t_text_types (id bigint not null primary key, c_tiny tinytext, c_text text, c_medium mediumtext, c_long longtext)")
-	tk.MustExec("create materialized view log on t_text_types (id, c_tiny, c_text, c_medium, c_long)")
-
-	showCreate := tk.MustQuery("show create table `$mlog$t_text_types`").Rows()[0][1].(string)
-	require.Contains(t, showCreate, "  `c_tiny` tinytext DEFAULT NULL")
-	require.Contains(t, showCreate, "  `c_text` text DEFAULT NULL")
-	require.Contains(t, showCreate, "  `c_medium` mediumtext DEFAULT NULL")
-	require.Contains(t, showCreate, "  `c_long` longtext DEFAULT NULL")
 }
 
 func TestCreateMaterializedViewLogPreSplitOptions(t *testing.T) {
@@ -180,70 +72,6 @@ func TestCreateMaterializedViewLogPreSplitOptions(t *testing.T) {
 	require.Contains(t, regionNames, fmt.Sprintf("t_%d_r_2305843009213693952", mlogTable.Meta().ID))
 	require.Contains(t, regionNames, fmt.Sprintf("t_%d_r_4611686018427387904", mlogTable.Meta().ID))
 	require.Contains(t, regionNames, fmt.Sprintf("t_%d_r_6917529027641081856", mlogTable.Meta().ID))
-}
-
-func TestCreateMaterializedViewLogPurgeExprTypeValidation(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t (a int, b int)")
-
-	err := tk.ExecToErr("create materialized view log on t (a) purge immediate")
-	require.Truef(t, dbterror.ErrGeneralUnsupportedDDL.Equal(err), "err %v", err)
-	require.ErrorContains(t, err, "PURGE IMMEDIATE is not supported for CREATE MATERIALIZED VIEW LOG")
-
-	err = tk.ExecToErr("create materialized view log on t (a) purge start with 1 next date_add(now(), interval 1 hour)")
-	require.ErrorContains(t, err, "PURGE START WITH expression must return DATETIME/TIMESTAMP")
-
-	err = tk.ExecToErr("create materialized view log on t (a) purge next 600")
-	require.ErrorContains(t, err, "PURGE NEXT expression must return DATETIME/TIMESTAMP")
-
-	tk.MustExec("create materialized view log on t (a) purge start with now() next date_add(now(), interval 1 hour)")
-}
-
-func TestCreateMaterializedViewLogAccumulationAlert(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_alert_default (a int)")
-	tk.MustExec("create table t_alert_zero (a int)")
-	tk.MustExec("create table t_alert_custom (a int)")
-	tk.MustExec("create table t_alert_negative (a int)")
-
-	err := tk.ExecToErr("create materialized view log on t_alert_negative (a) alert rows -1")
-	require.ErrorContains(t, err, "invalid ALERT ROWS value: -1 (must be non-negative)")
-
-	tk.MustExec("create materialized view log on t_alert_default (a)")
-	tk.MustExec("create materialized view log on t_alert_zero (a) alert rows 0")
-	tk.MustExec("create materialized view log on t_alert_custom (a) alert rows 2048")
-
-	getMLogInfo := func(baseTable string) *model.MaterializedViewLogInfo {
-		is := dom.InfoSchema()
-		mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$"+baseTable))
-		require.NoError(t, err)
-		require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
-		return mlogTable.Meta().MaterializedViewLog
-	}
-
-	defaultInfo := getMLogInfo("t_alert_default")
-	require.Nil(t, defaultInfo.LogAccumulationAlertRows)
-	defaultRows, defaultEnabled := defaultInfo.EffectiveLogAccumulationAlertRows()
-	require.False(t, defaultEnabled)
-	require.Equal(t, uint64(0), defaultRows)
-
-	zeroInfo := getMLogInfo("t_alert_zero")
-	require.NotNil(t, zeroInfo.LogAccumulationAlertRows)
-	require.Equal(t, uint64(0), *zeroInfo.LogAccumulationAlertRows)
-	zeroRows, zeroEnabled := zeroInfo.EffectiveLogAccumulationAlertRows()
-	require.False(t, zeroEnabled)
-	require.Equal(t, uint64(0), zeroRows)
-
-	customInfo := getMLogInfo("t_alert_custom")
-	require.NotNil(t, customInfo.LogAccumulationAlertRows)
-	require.Equal(t, uint64(2048), *customInfo.LogAccumulationAlertRows)
-	customRows, customEnabled := customInfo.EffectiveLogAccumulationAlertRows()
-	require.True(t, customEnabled)
-	require.Equal(t, uint64(2048), customRows)
 }
 
 func TestCreateMaterializedViewLogPurgeInfoNextUnixSecondsDerivation(t *testing.T) {
@@ -321,14 +149,6 @@ func TestCreateMaterializedViewLogPurgeInfoNextUnixSecondsUsesScheduleTimeZone(t
 	)).Check(testkit.Rows("1 0"))
 }
 
-func TestCreateMaterializedViewLogMetaColumnNameConflict(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_conflict (`_MLOG$_DML_TYPE` int, a int)")
-	tk.MustGetErrCode("create materialized view log on t_conflict (`_MLOG$_DML_TYPE`, a)", 1060)
-}
-
 func TestCreateMaterializedViewLogRejectNonBaseObject(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := newMViewTestKit(t, store)
@@ -364,29 +184,6 @@ func TestCreateMaterializedViewLogRejectNonBaseObject(t *testing.T) {
 	require.Contains(t, err.Error(), "is not BASE TABLE")
 }
 
-func TestCreateMaterializedViewLogRejectUnsupportedColumns(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	for _, tableName := range []string{"t_tinyblob", "t_blob", "t_mediumblob", "t_longblob"} {
-		tk.MustExec(fmt.Sprintf("create table %s (id bigint not null primary key, b %s null)", tableName, tableName[2:]))
-		err := tk.ExecToErr(fmt.Sprintf("create materialized view log on %s (id, b)", tableName))
-		require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG does not support BLOB column b")
-	}
-
-	tk.MustExec("create table t_text_ok (id bigint not null primary key, c1 tinytext null, c2 text null, c3 mediumtext null, c4 longtext null)")
-	tk.MustExec("create materialized view log on t_text_ok (id, c1, c2, c3, c4)")
-	tk.MustExec("create table t_json (id bigint not null primary key, j json null)")
-	err := tk.ExecToErr("create materialized view log on t_json (id, j)")
-	require.ErrorContains(t, err, "CREATE MATERIALIZED VIEW LOG does not support JSON column j")
-
-	tk.MustExec("create table t_gen (id bigint not null primary key, g1 int not null, g_virtual int as (g1 + 1) virtual, g_stored int as (g1 + 2) stored)")
-	tk.MustExec("create materialized view log on t_gen (id, g_virtual, g_stored)")
-	tk.MustExec("create table t_untracked_unsupported (id bigint not null primary key, b blob null, j json null, g int as (id + 1) stored)")
-	tk.MustExec("create materialized view log on t_untracked_unsupported (id)")
-}
-
 func TestCreateMaterializedViewLogUpdatesPlacementBundle(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := newMViewTestKit(t, store)
@@ -415,74 +212,6 @@ func TestCreateMaterializedViewLogAllowsGeneratedColumns(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
 	require.Equal(t, []ast.CIStr{ast.NewCIStr("id"), ast.NewCIStr("gv"), ast.NewCIStr("gs")}, mlogTable.Meta().MaterializedViewLog.Columns)
-}
-
-func TestCreateMaterializedViewLogColumnKeyFlag(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table base_test(id int, v1 int, v2 int, v3 int, v4 int, index k(v1,v2,v3,v4))")
-	tk.MustExec("create materialized view log on base_test(v1, v2) purge next date_add(now(), interval 1 hour)")
-	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v1'").
-		Check(testkit.Rows(""))
-	tk.MustQuery("select column_key from information_schema.columns where table_schema='test' and table_name='$mlog$base_test' and column_name='v2'").
-		Check(testkit.Rows(""))
-}
-
-func TestCreateMaterializedViewColumnFlags(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table base_mv_flags(id bigint not null auto_increment primary key, g1 int not null, v1 bigint not null, key idx_g1_id(g1, id))")
-	tk.MustExec("create materialized view log on base_mv_flags(id, g1, v1) purge next date_add(now(), interval 1 hour)")
-	tk.MustExec("create materialized view mv_flags (g1, cnt, s_v1, min_id, max_id) as select g1, count(1), sum(v1), min(id), max(id) from base_mv_flags group by g1")
-	for _, col := range []string{"min_id", "max_id"} {
-		tk.MustQuery(fmt.Sprintf("select column_key from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='%s'", col)).Check(testkit.Rows(""))
-		tk.MustQuery(fmt.Sprintf("select extra from information_schema.columns where table_schema='test' and table_name='mv_flags' and column_name='%s'", col)).Check(testkit.Rows(""))
-	}
-}
-
-func TestMaterializedViewCommentLength(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_mv_comment_len (id bigint not null primary key, g1 int not null, v1 bigint not null, key idx_g1(g1))")
-	tk.MustExec("create materialized view log on t_mv_comment_len (id, g1, v1)")
-
-	maxTableCommentLength := ddl.MaxCommentLength * 2
-	commentMaxLen := strings.Repeat("y", maxTableCommentLength)
-	commentTooLong := strings.Repeat("y", maxTableCommentLength+1)
-	createMVSQL := func(name, comment string) string {
-		return fmt.Sprintf("create materialized view %s (g1, cnt) comment = '%s' refresh fast as select g1, count(1) from t_mv_comment_len group by g1", name, comment)
-	}
-	errTooLongComment := func(name string) string {
-		return fmt.Sprintf("Comment for table '%s' is too long (max = %d)", name, maxTableCommentLength)
-	}
-
-	tk.MustExec("set @@sql_mode='STRICT_TRANS_TABLES'")
-	tk.MustExec(createMVSQL("mv_comment_max", commentMaxLen))
-	err := tk.ExecToErr(createMVSQL("mv_comment_too_long", commentTooLong))
-	require.ErrorContains(t, err, errTooLongComment("mv_comment_too_long"))
-
-	tk.MustExec("set @@sql_mode=''")
-	tk.MustExec(createMVSQL("mv_comment_truncated", commentTooLong))
-	tk.MustQuery("show warnings").Check(testkit.RowsWithSep("|", "Warning|1628|"+errTooLongComment("mv_comment_truncated")))
-	tk.MustQuery("select length(table_comment) from information_schema.tables where table_schema = 'test' and table_name = 'mv_comment_truncated'").Check(testkit.Rows(strconv.Itoa(maxTableCommentLength)))
-}
-
-func TestCreateMaterializedViewRefreshExprTypeValidation(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t (a int not null, b int not null)")
-	tk.MustExec("insert into t values (1, 10), (1, 5), (2, 7)")
-	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
-
-	err := tk.ExecToErr("create materialized view mv_bad_next (a, s, cnt) refresh fast next 300 as select a, sum(b), count(1) from t group by a")
-	require.ErrorContains(t, err, "REFRESH NEXT expression must return DATETIME/TIMESTAMP")
-	err = tk.ExecToErr("create materialized view mv_bad_start (a, s, cnt) refresh fast start with 1 next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
-	require.ErrorContains(t, err, "REFRESH START WITH expression must return DATETIME/TIMESTAMP")
-	tk.MustExec("create materialized view mv_ok (a, s, cnt) refresh fast start with now() next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
 }
 
 func TestCreateMaterializedViewRejectsUnsupportedSelectClauses(t *testing.T) {
@@ -1038,36 +767,6 @@ func TestCreateMaterializedViewBuildReadTSQueryTypeAlignment(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, expected, rows[0].GetUint64(0))
-}
-
-func TestCreateMaterializedViewLogRejectsDuplicateColumns(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_dup (id bigint not null primary key, g1 int not null)")
-
-	err := tk.ExecToErr("create materialized view log on t_dup (id, id)")
-	require.ErrorContains(t, err, "Duplicate column name")
-}
-
-func TestCreateMaterializedViewLogNameLengthByRune(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	maxBaseNameLen := mysql.MaxTableNameLength - len([]rune(model.MaterializedViewLogTableNamePrefix))
-	maxName := strings.Repeat("表", maxBaseNameLen)
-	maxMLogName := model.MaterializedViewLogTableName(ast.NewCIStr(maxName)).O
-	require.Equal(t, mysql.MaxTableNameLength, len([]rune(maxMLogName)))
-	tk.MustExec(fmt.Sprintf("create table `%s` (a int)", maxName))
-	tk.MustExec(fmt.Sprintf("create materialized view log on `%s` (a)", maxName))
-	tk.MustQuery(fmt.Sprintf("select count(*) from information_schema.tables where table_schema='test' and table_name='%s'", maxMLogName)).Check(testkit.Rows("1"))
-
-	tooLongName := strings.Repeat("表", maxBaseNameLen+1)
-	require.Equal(t, maxMLogName, model.MaterializedViewLogTableName(ast.NewCIStr(tooLongName)).O)
-	tk.MustExec(fmt.Sprintf("create table `%s` (a int)", tooLongName))
-	err := tk.ExecToErr(fmt.Sprintf("create materialized view log on `%s` (a)", tooLongName))
-	require.ErrorContains(t, err, "already exists")
 }
 
 func TestCreateMaterializedViewSuccessRefreshInfoVisibilityBeforeCommit(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_create_test.go
+++ b/pkg/executor/test/ddl/materialized_view_create_test.go
@@ -77,6 +77,7 @@ func TestCreateMaterializedViewAndLog(t *testing.T) {
 	require.Contains(t, baseTable.Meta().MaterializedViewBase.MViewIDs, mviewTable.Meta().ID)
 	require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
 	require.Equal(t, baseTable.Meta().ID, mlogTable.Meta().MaterializedViewLog.BaseTableID)
+	require.Equal(t, []int64{mviewTable.Meta().ID}, mlogTable.Meta().MaterializedViewLog.DependentMViewIDs)
 	require.NotNil(t, mviewTable.Meta().MaterializedView)
 	require.Equal(t, model.MViewInitBuildReady, mviewTable.Meta().MaterializedView.GetInitBuildState())
 	require.Equal(t, 9, mviewTable.Meta().MaterializedView.DefinitionDivPrecisionIncrement)

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -165,6 +168,170 @@ func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {
 	tk.MustExec("drop materialized view log on t_drop_mlog_purge_state")
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
 		Check(testkit.Rows("0"))
+}
+
+func TestDropMaterializedViewRefreshInfoFailureRollsBackMetadata(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_mv_atomic (a int)")
+	tk.MustExec("create materialized view log on t_drop_mv_atomic (a)")
+	tk.MustExec("create materialized view mv_drop_atomic (a, cnt) as select a, count(1) from t_drop_mv_atomic group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("mv_drop_atomic"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+
+	const cleanupErrFP = "github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshInfoErr"
+	require.NoError(t, failpoint.Enable(cleanupErrFP, `1*return("mock refresh info delete error")`))
+	defer func() { require.NoError(t, failpoint.Disable(cleanupErrFP)) }()
+
+	retryStarted := make(chan struct{})
+	allowRetry := make(chan struct{})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		if job.Type == model.ActionDropTable && job.TableID == mvID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
+			select {
+			case <-retryStarted:
+			default:
+				close(retryStarted)
+			}
+			<-allowRetry
+		}
+	})
+
+	tkInspect := newMViewTestKit(t, store)
+	tkInspect.MustExec("use test")
+	dropErrCh := make(chan error, 1)
+	go func() { dropErrCh <- tk.ExecToErr("drop materialized view mv_drop_atomic") }()
+
+	select {
+	case <-retryStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for DROP MATERIALIZED VIEW retry")
+	}
+	tkInspect.MustQuery("show tables like 'mv_drop_atomic'").Check(testkit.Rows("mv_drop_atomic"))
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+
+	require.NoError(t, failpoint.Disable(cleanupErrFP))
+	close(allowRetry)
+	require.NoError(t, <-dropErrCh)
+}
+
+func TestDropMaterializedViewLogPurgeInfoFailureRollsBackMetadata(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_mlog_atomic (a int)")
+	tk.MustExec("create materialized view log on t_drop_mlog_atomic (a)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), model.MaterializedViewLogTableName(ast.NewCIStr("t_drop_mlog_atomic")))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	const cleanupErrFP = "github.com/pingcap/tidb/pkg/ddl/mockDeleteMaterializedViewLogPurgeInfoErr"
+	require.NoError(t, failpoint.Enable(cleanupErrFP, `1*return("mock purge info delete error")`))
+	defer func() { require.NoError(t, failpoint.Disable(cleanupErrFP)) }()
+
+	retryStarted := make(chan struct{})
+	allowRetry := make(chan struct{})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		if job.Type == model.ActionDropTable && job.TableID == mlogID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
+			select {
+			case <-retryStarted:
+			default:
+				close(retryStarted)
+			}
+			<-allowRetry
+		}
+	})
+
+	tkInspect := newMViewTestKit(t, store)
+	tkInspect.MustExec("use test")
+	dropErrCh := make(chan error, 1)
+	go func() { dropErrCh <- tk.ExecToErr("drop materialized view log on t_drop_mlog_atomic") }()
+
+	select {
+	case <-retryStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for DROP MATERIALIZED VIEW LOG retry")
+	}
+	tkInspect.MustQuery("show tables like '$mlog$t_drop_mlog_atomic'").Check(testkit.Rows("$mlog$t_drop_mlog_atomic"))
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("1"))
+
+	require.NoError(t, failpoint.Disable(cleanupErrFP))
+	close(allowRetry)
+	require.NoError(t, <-dropErrCh)
+}
+
+func TestDropDatabaseMViewInfoFailureRollsBackMetadata(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+
+	const dbName = "mv_drop_db_atomic"
+	tk.MustExec("create database " + dbName)
+	tk.MustExec("use " + dbName)
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create materialized view log on t (a)")
+	tk.MustExec("create materialized view mv (a, cnt) as select a, count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	dbInfo, ok := is.SchemaByName(ast.NewCIStr(dbName))
+	require.True(t, ok)
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("mv"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	mlogID := mlogTable.Meta().ID
+
+	const cleanupErrFP = "github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshInfoErr"
+	require.NoError(t, failpoint.Enable(cleanupErrFP, `1*return("mock refresh info delete error")`))
+	defer func() { require.NoError(t, failpoint.Disable(cleanupErrFP)) }()
+
+	retryStarted := make(chan struct{})
+	allowRetry := make(chan struct{})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		if job.Type == model.ActionDropSchema && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
+			select {
+			case <-retryStarted:
+			default:
+				close(retryStarted)
+			}
+			<-allowRetry
+		}
+	})
+
+	tkInspect := newMViewTestKit(t, store)
+	dropErrCh := make(chan error, 1)
+	go func() { dropErrCh <- tk.ExecToErr("drop database " + dbName) }()
+
+	select {
+	case <-retryStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for DROP DATABASE retry")
+	}
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("1"))
+	require.NoError(t, kv.RunInNewTxn(context.Background(), store, false, func(_ context.Context, txn kv.Transaction) error {
+		persistedDBInfo, err := meta.NewReader(txn).GetDatabase(dbInfo.ID)
+		require.NoError(t, err)
+		require.NotNil(t, persistedDBInfo)
+		return nil
+	}))
+
+	require.NoError(t, failpoint.Disable(cleanupErrFP))
+	close(allowRetry)
+	require.NoError(t, <-dropErrCh)
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tkInspect.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("0"))
+	require.NoError(t, kv.RunInNewTxn(context.Background(), store, false, func(_ context.Context, txn kv.Transaction) error {
+		persistedDBInfo, err := meta.NewReader(txn).GetDatabase(dbInfo.ID)
+		require.NoError(t, err)
+		require.Nil(t, persistedDBInfo)
+		return nil
+	}))
 }
 
 func TestDropMaterializedViewAndDatabaseCleanMViewState(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -17,6 +17,7 @@ package ddl_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +49,8 @@ func TestDropMaterializedViewIfExists(t *testing.T) {
 
 	err = tk.ExecToErr("drop materialized view if exists t_drop_if_exists")
 	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
+	err = tk.ExecToErr("drop materialized view log if exists on mv_drop_if_exists")
+	require.ErrorContains(t, err, "is not BASE TABLE")
 
 	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
 	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
@@ -92,6 +96,14 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	tk.MustExec("create materialized view log on t_drop_recheck (a, b) purge next date_add(now(), interval 1 hour)")
 
 	const pauseDropFailpoint = "github.com/pingcap/tidb/pkg/ddl/pauseDropMaterializedViewLogAfterCheck"
+	const afterCheckDropFailpoint = "github.com/pingcap/tidb/pkg/ddl/afterCheckDropMaterializedViewLog"
+	dropCheckDoneCh := make(chan struct{})
+	var dropCheckDoneOnce sync.Once
+	testfailpoint.EnableCall(t, afterCheckDropFailpoint, func() {
+		dropCheckDoneOnce.Do(func() {
+			close(dropCheckDoneCh)
+		})
+	})
 	require.NoError(t, failpoint.Enable(pauseDropFailpoint, "pause"))
 	enabled := true
 	defer func() {
@@ -107,7 +119,11 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 		dropErrCh <- tkDrop.ExecToErr("drop materialized view log on t_drop_recheck")
 	}()
 
-	time.Sleep(500 * time.Millisecond)
+	select {
+	case <-dropCheckDoneCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for DROP MATERIALIZED VIEW LOG precheck")
+	}
 	tk.MustExec("create materialized view mv_drop_dep (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_drop_recheck group by a")
 
 	require.NoError(t, failpoint.Disable(pauseDropFailpoint))
@@ -316,11 +332,41 @@ func TestDropMaterializedViewLogPrivilege(t *testing.T) {
 	tkSelect := newMViewTestKit(t, store)
 	require.NoError(t, tkSelect.Session().Auth(&auth.UserIdentity{Username: "u_drop_mlog_select", Hostname: "%"}, nil, nil, nil))
 	err := tkSelect.ExecToErr("drop materialized view log on test.t_drop_mlog_priv")
-	require.ErrorContains(t, err, "DROP command denied")
+	require.ErrorContains(t, err, "DROP MATERIALIZED VIEW LOG command denied")
+	require.ErrorContains(t, err, "for table 't_drop_mlog_priv'")
 
 	tkDrop := newMViewTestKit(t, store)
 	require.NoError(t, tkDrop.Session().Auth(&auth.UserIdentity{Username: "u_drop_mlog_ok", Hostname: "%"}, nil, nil, nil))
 	tkDrop.MustExec("drop materialized view log on test.t_drop_mlog_priv")
+}
+
+func TestDropMaterializedViewPrivilege(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_mv_priv (a int)")
+	tk.MustExec("create materialized view log on t_drop_mv_priv (a)")
+	tk.MustExec("create materialized view mv_drop_priv (a) as select a from t_drop_mv_priv")
+
+	tk.MustExec("create user 'u_drop_mv_select'@'%'")
+	tk.MustExec("create user 'u_drop_mv_ok'@'%'")
+	t.Cleanup(func() {
+		tk.MustExec("drop user 'u_drop_mv_select'@'%'")
+		tk.MustExec("drop user 'u_drop_mv_ok'@'%'")
+	})
+	tk.MustExec("grant select on test.mv_drop_priv to 'u_drop_mv_select'@'%'")
+	tk.MustExec("grant drop on test.mv_drop_priv to 'u_drop_mv_ok'@'%'")
+
+	tkSelect := newMViewTestKit(t, store)
+	require.NoError(t, tkSelect.Session().Auth(&auth.UserIdentity{Username: "u_drop_mv_select", Hostname: "%"}, nil, nil, nil))
+	err := tkSelect.ExecToErr("drop materialized view test.mv_drop_priv")
+	require.ErrorContains(t, err, "DROP command denied")
+
+	tkDrop := newMViewTestKit(t, store)
+	require.NoError(t, tkDrop.Session().Auth(&auth.UserIdentity{Username: "u_drop_mv_ok", Hostname: "%"}, nil, nil, nil))
+	tkDrop.MustExec("drop materialized view test.mv_drop_priv")
+	tk.MustExec("drop materialized view log on test.t_drop_mv_priv")
+	tk.MustExec("drop table test.t_drop_mv_priv")
 }
 
 func TestDropMaterializedViewLogBeforeBaseTable(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -434,7 +434,7 @@ func TestDropMaterializedViewPrivilege(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t_drop_mv_priv (a int)")
 	tk.MustExec("create materialized view log on t_drop_mv_priv (a)")
-	tk.MustExec("create materialized view mv_drop_priv (a) as select a from t_drop_mv_priv")
+	tk.MustExec("create materialized view mv_drop_priv (a, cnt) as select a, count(1) from t_drop_mv_priv group by a")
 
 	tk.MustExec("create user 'u_drop_mv_select'@'%'")
 	tk.MustExec("create user 'u_drop_mv_ok'@'%'")

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropMaterializedViewIfExists(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop materialized view if exists missing_mv")
+	tk.MustExec("drop materialized view if exists missing_schema.missing_mv")
+
+	err := tk.ExecToErr("drop materialized view log if exists on missing_base")
+	require.ErrorContains(t, err, "Table 'test.missing_base' doesn't exist")
+	err = tk.ExecToErr("drop materialized view log if exists on missing_schema.missing_base")
+	require.ErrorContains(t, err, "Table 'missing_schema.missing_base' doesn't exist")
+
+	tk.MustExec("create table t_drop_if_exists (a int not null)")
+	tk.MustExec("create table t_no_mlog_drop_if_exists (a int not null)")
+	tk.MustExec("create materialized view log on t_drop_if_exists (a)")
+	tk.MustExec("create materialized view mv_drop_if_exists (a, cnt) as select a, count(1) from t_drop_if_exists group by a")
+
+	err = tk.ExecToErr("drop materialized view if exists t_drop_if_exists")
+	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
+
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
+
+	tk.MustExec("create view v_drop_if_exists as select * from t_drop_if_exists")
+	err = tk.ExecToErr("drop materialized view log if exists on v_drop_if_exists")
+	require.ErrorContains(t, err, "is not BASE TABLE")
+
+	tk.MustExec("drop materialized view log if exists on t_no_mlog_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
+}
+
+func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_recheck (a int not null, b int not null)")
+	tk.MustExec("insert into t_drop_recheck values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t_drop_recheck (a, b) purge next date_add(now(), interval 1 hour)")
+
+	const pauseDropFailpoint = "github.com/pingcap/tidb/pkg/ddl/pauseDropMaterializedViewLogAfterCheck"
+	require.NoError(t, failpoint.Enable(pauseDropFailpoint, "pause"))
+	enabled := true
+	defer func() {
+		if enabled {
+			require.NoError(t, failpoint.Disable(pauseDropFailpoint))
+		}
+	}()
+
+	dropErrCh := make(chan error, 1)
+	go func() {
+		tkDrop := newMViewTestKit(t, store)
+		tkDrop.MustExec("use test")
+		dropErrCh <- tkDrop.ExecToErr("drop materialized view log on t_drop_recheck")
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+	tk.MustExec("create materialized view mv_drop_dep (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_drop_recheck group by a")
+
+	require.NoError(t, failpoint.Disable(pauseDropFailpoint))
+	enabled = false
+
+	err := <-dropErrCh
+	require.ErrorContains(t, err, "dependent materialized views exist")
+	tk.MustQuery("show tables like '$mlog$t_drop_recheck'").Check(testkit.Rows("$mlog$t_drop_recheck"))
+
+	tk.MustExec("drop materialized view mv_drop_dep")
+	tk.MustExec("drop materialized view log on t_drop_recheck")
+
+	is := dom.InfoSchema()
+	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t_drop_recheck"))
+	require.NoError(t, err)
+	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
+}
+
+func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_drop_mlog_purge_state (a int)")
+	tk.MustExec("create materialized view log on t_drop_mlog_purge_state (a)")
+
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t_drop_mlog_purge_state"))
+	require.NoError(t, err)
+	mlogID := mlogTable.Meta().ID
+
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("drop materialized view log on t_drop_mlog_purge_state")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
+		Check(testkit.Rows("0"))
+}
+
+func TestDropMaterializedViewAndDatabaseCleanMViewState(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+
+	const dbName = "mv_drop_cleanup"
+	tk.MustExec("drop database if exists " + dbName)
+	tk.MustExec("create database " + dbName)
+	tk.MustExec("use " + dbName)
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("mv"))
+	require.NoError(t, err)
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	mlogID := mlogTable.Meta().ID
+
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MVIEW_SCHEMA, MVIEW_NAME, ALERT_LEVEL, LAST_SUCCESS_SNAPSHOT_TIME, UPDATE_TIME) values (%d, '%s', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID, dbName,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+
+	tk.MustExec("drop materialized view mv")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tk.MustExec("drop materialized view log on t")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("0"))
+
+	tk.MustExec("create materialized view log on t (a, b)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+	is = dom.InfoSchema()
+	mvTable, err = is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("mv"))
+	require.NoError(t, err)
+	mlogTable, err = is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("$mlog$t"))
+	require.NoError(t, err)
+	mvID = mvTable.Meta().ID
+	mlogID = mlogTable.Meta().ID
+	tk.MustExec("drop database " + dbName)
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("0"))
+}
+
+func TestDropMaterializedViewCleansRefreshAlert(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_alert_cleanup (a int not null, b int not null)")
+	tk.MustExec("insert into t_drop_alert_cleanup values (1, 10), (1, 5), (2, 7)")
+	tk.MustExec("create materialized view log on t_drop_alert_cleanup (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_drop_alert_cleanup (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_drop_alert_cleanup group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("mv_drop_alert_cleanup"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MVIEW_SCHEMA, MVIEW_NAME, ALERT_LEVEL, LAST_SUCCESS_SNAPSHOT_TIME, UPDATE_TIME) values (%d, 'test', 'mv_drop_alert_cleanup', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	tk.MustExec("drop materialized view mv_drop_alert_cleanup")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustExec("drop materialized view log on t_drop_alert_cleanup")
+}
+
+func TestDropDatabaseIgnoresRefreshAlertDeleteFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+
+	const dbName = "mv_drop_db_alert_delete_fail"
+	tk.MustExec("drop database if exists " + dbName)
+	tk.MustExec("create database " + dbName)
+	tk.MustExec("use " + dbName)
+	tk.MustExec("create table t (a int not null, b int not null)")
+	tk.MustExec("insert into t values (1, 10), (2, 20)")
+	tk.MustExec("create materialized view log on t (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr(dbName), ast.NewCIStr("mv"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MVIEW_SCHEMA, MVIEW_NAME, ALERT_LEVEL, LAST_SUCCESS_SNAPSHOT_TIME, UPDATE_TIME) values (%d, '%s', 'mv', 'overdue', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+		dbName,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+
+	const fp = "github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr"
+	require.NoError(t, failpoint.Enable(fp, `return("mock drop schema alert delete error")`))
+	defer func() { require.NoError(t, failpoint.Disable(fp)) }()
+
+	tk.MustExec("drop database " + dbName)
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).
+		Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).
+		Check(testkit.Rows("1"))
+}
+
+func TestDropMaterializedViewIgnoresRefreshAlertDeleteFailure(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_alert (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_drop_alert (a, b) purge next date_add(now(), interval 1 hour)")
+	tk.MustExec("create materialized view mv_drop_alert (a, s, cnt) refresh fast next date_add(now(), interval 1 hour) as select a, sum(b), count(1) from t_drop_alert group by a")
+
+	is := dom.InfoSchema()
+	mvTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("mv_drop_alert"))
+	require.NoError(t, err)
+	mvID := mvTable.Meta().ID
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MVIEW_SCHEMA, MVIEW_NAME, ALERT_LEVEL, LAST_SUCCESS_SNAPSHOT_TIME, UPDATE_TIME) values (%d, 'test', 'mv_drop_alert', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID,
+	))
+
+	const fp = "github.com/pingcap/tidb/pkg/ddl/mockDeleteCreateMaterializedViewRefreshAlertErr"
+	require.NoError(t, failpoint.Enable(fp, `return("mock drop table alert delete error")`))
+	defer func() { require.NoError(t, failpoint.Disable(fp)) }()
+	tk.MustExec("drop materialized view mv_drop_alert")
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+	tk.MustExec("drop materialized view log on t_drop_alert")
+}
+
+func TestDropMaterializedViewLogPrivilege(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_mlog_priv (a int)")
+	tk.MustExec("create materialized view log on t_drop_mlog_priv (a)")
+	tk.MustExec("create user 'u_drop_mlog_select'@'%'")
+	tk.MustExec("create user 'u_drop_mlog_ok'@'%'")
+	defer tk.MustExec("drop user 'u_drop_mlog_select'@'%'")
+	defer tk.MustExec("drop user 'u_drop_mlog_ok'@'%'")
+	tk.MustExec("grant select on test.t_drop_mlog_priv to 'u_drop_mlog_select'@'%'")
+	tk.MustExec("grant drop on test.`$mlog$t_drop_mlog_priv` to 'u_drop_mlog_ok'@'%'")
+
+	tkSelect := newMViewTestKit(t, store)
+	require.NoError(t, tkSelect.Session().Auth(&auth.UserIdentity{Username: "u_drop_mlog_select", Hostname: "%"}, nil, nil, nil))
+	err := tkSelect.ExecToErr("drop materialized view log on test.t_drop_mlog_priv")
+	require.ErrorContains(t, err, "DROP command denied")
+
+	tkDrop := newMViewTestKit(t, store)
+	require.NoError(t, tkDrop.Session().Auth(&auth.UserIdentity{Username: "u_drop_mlog_ok", Hostname: "%"}, nil, nil, nil))
+	tkDrop.MustExec("drop materialized view log on test.t_drop_mlog_priv")
+}
+
+func TestDropMaterializedViewLogBeforeBaseTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_drop_seq (a int)")
+	tk.MustExec("create materialized view log on t_drop_seq (a)")
+	tk.MustExec("drop materialized view log on t_drop_seq")
+	tk.MustExec("drop table if exists t_drop_seq")
+}

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -118,9 +118,13 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	tk.MustQuery("show tables like '$mlog$t_drop_recheck'").Check(testkit.Rows("$mlog$t_drop_recheck"))
 
 	tk.MustExec("drop materialized view mv_drop_dep")
+	is := dom.InfoSchema()
+	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t_drop_recheck"))
+	require.NoError(t, err)
+	require.Empty(t, mlogTable.Meta().MaterializedViewLog.DependentMViewIDs)
 	tk.MustExec("drop materialized view log on t_drop_recheck")
 
-	is := dom.InfoSchema()
+	is = dom.InfoSchema()
 	baseTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t_drop_recheck"))
 	require.NoError(t, err)
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -32,64 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDropMaterializedViewIfExists(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec("drop materialized view if exists missing_mv")
-	tk.MustExec("drop materialized view if exists missing_schema.missing_mv")
-
-	err := tk.ExecToErr("drop materialized view log if exists on missing_base")
-	require.ErrorContains(t, err, "Table 'test.missing_base' doesn't exist")
-	err = tk.ExecToErr("drop materialized view log if exists on missing_schema.missing_base")
-	require.ErrorContains(t, err, "Table 'missing_schema.missing_base' doesn't exist")
-
-	tk.MustExec("create table t_drop_if_exists (a int not null)")
-	tk.MustExec("create table t_no_mlog_drop_if_exists (a int not null)")
-	tk.MustExec("create materialized view log on t_drop_if_exists (a)")
-	tk.MustExec("create materialized view mv_drop_if_exists (a, cnt) as select a, count(1) from t_drop_if_exists group by a")
-
-	err = tk.ExecToErr("drop materialized view if exists t_drop_if_exists")
-	require.ErrorContains(t, err, "is not MATERIALIZED VIEW")
-	err = tk.ExecToErr("drop materialized view log if exists on mv_drop_if_exists")
-	require.ErrorContains(t, err, "is not BASE TABLE")
-
-	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
-	tk.MustExec("drop materialized view if exists mv_drop_if_exists")
-
-	tk.MustExec("create view v_drop_if_exists as select * from t_drop_if_exists")
-	err = tk.ExecToErr("drop materialized view log if exists on v_drop_if_exists")
-	require.ErrorContains(t, err, "is not BASE TABLE")
-
-	tk.MustExec("drop materialized view log if exists on t_no_mlog_drop_if_exists")
-	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
-	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
-}
-
-func TestDropTableMaterializedViewConstraints(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t_drop_constraints (a int not null, b int not null)")
-	tk.MustExec("create materialized view log on t_drop_constraints (a, b)")
-	tk.MustExec("create materialized view mv_drop_constraints (a, s, cnt) as select a, sum(b), count(1) from t_drop_constraints group by a")
-
-	err := tk.ExecToErr("drop table mv_drop_constraints")
-	require.ErrorContains(t, err, "DROP TABLE on materialized view table")
-	err = tk.ExecToErr("drop table `$mlog$t_drop_constraints`")
-	require.ErrorContains(t, err, "DROP TABLE on materialized view log table")
-	err = tk.ExecToErr("drop table t_drop_constraints")
-	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
-
-	tk.MustExec("drop materialized view mv_drop_constraints")
-	err = tk.ExecToErr("drop table t_drop_constraints")
-	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view log")
-
-	tk.MustExec("drop materialized view log on t_drop_constraints")
-	tk.MustExec("drop table t_drop_constraints")
-}
-
 func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := newMViewTestKit(t, store)
@@ -149,27 +91,6 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
-func TestDropMaterializedViewLogRemovesPurgeState(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec("create table t_drop_mlog_purge_state (a int)")
-	tk.MustExec("create materialized view log on t_drop_mlog_purge_state (a)")
-
-	is := dom.InfoSchema()
-	mlogTable, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("$mlog$t_drop_mlog_purge_state"))
-	require.NoError(t, err)
-	mlogID := mlogTable.Meta().ID
-
-	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
-		Check(testkit.Rows("1"))
-
-	tk.MustExec("drop materialized view log on t_drop_mlog_purge_state")
-	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where MLOG_ID = %d", mlogID)).
-		Check(testkit.Rows("0"))
-}
-
 func TestDropMaterializedViewRefreshInfoFailureRollsBackMetadata(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := newMViewTestKit(t, store)
@@ -190,7 +111,7 @@ func TestDropMaterializedViewRefreshInfoFailureRollsBackMetadata(t *testing.T) {
 	retryStarted := make(chan struct{})
 	allowRetry := make(chan struct{})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
-		if job.Type == model.ActionDropTable && job.TableID == mvID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
+		if job.Type == model.ActionDropMaterializedView && job.TableID == mvID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
 			select {
 			case <-retryStarted:
 			default:
@@ -237,7 +158,7 @@ func TestDropMaterializedViewLogPurgeInfoFailureRollsBackMetadata(t *testing.T) 
 	retryStarted := make(chan struct{})
 	allowRetry := make(chan struct{})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
-		if job.Type == model.ActionDropTable && job.TableID == mlogID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
+		if job.Type == model.ActionDropMaterializedViewLog && job.TableID == mlogID && job.SchemaState == model.StateDeleteOnly && job.ErrorCount > 0 {
 			select {
 			case <-retryStarted:
 			default:
@@ -534,15 +455,4 @@ func TestDropMaterializedViewPrivilege(t *testing.T) {
 	tkDrop.MustExec("drop materialized view test.mv_drop_priv")
 	tk.MustExec("drop materialized view log on test.t_drop_mv_priv")
 	tk.MustExec("drop table test.t_drop_mv_priv")
-}
-
-func TestDropMaterializedViewLogBeforeBaseTable(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := newMViewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec("create table t_drop_seq (a int)")
-	tk.MustExec("create materialized view log on t_drop_seq (a)")
-	tk.MustExec("drop materialized view log on t_drop_seq")
-	tk.MustExec("drop table if exists t_drop_seq")
 }

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -60,6 +60,29 @@ func TestDropMaterializedViewIfExists(t *testing.T) {
 	tk.MustExec("drop materialized view log if exists on t_drop_if_exists")
 }
 
+func TestDropTableMaterializedViewConstraints(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := newMViewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t_drop_constraints (a int not null, b int not null)")
+	tk.MustExec("create materialized view log on t_drop_constraints (a, b)")
+	tk.MustExec("create materialized view mv_drop_constraints (a, s, cnt) as select a, sum(b), count(1) from t_drop_constraints group by a")
+
+	err := tk.ExecToErr("drop table mv_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on materialized view table")
+	err = tk.ExecToErr("drop table `$mlog$t_drop_constraints`")
+	require.ErrorContains(t, err, "DROP TABLE on materialized view log table")
+	err = tk.ExecToErr("drop table t_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view dependencies")
+
+	tk.MustExec("drop materialized view mv_drop_constraints")
+	err = tk.ExecToErr("drop table t_drop_constraints")
+	require.ErrorContains(t, err, "DROP TABLE on base table with materialized view log")
+
+	tk.MustExec("drop materialized view log on t_drop_constraints")
+	tk.MustExec("drop table t_drop_constraints")
+}
+
 func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := newMViewTestKit(t, store)
@@ -168,9 +191,19 @@ func TestDropMaterializedViewAndDatabaseCleanMViewState(t *testing.T) {
 	require.NoError(t, err)
 	mvID = mvTable.Meta().ID
 	mlogID = mlogTable.Meta().ID
+	tk.MustExec(fmt.Sprintf(
+		"insert into mysql.tidb_mview_refresh_alert (MVIEW_ID, MVIEW_SCHEMA, MVIEW_NAME, ALERT_LEVEL, LAST_SUCCESS_SNAPSHOT_TIME, UPDATE_TIME) values (%d, '%s', 'mv', 'warning', UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+		mvID, dbName,
+	))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("1"))
 	tk.MustExec("drop database " + dbName)
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_info where mview_id = %d", mvID)).Check(testkit.Rows("0"))
+	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mview_refresh_alert where mview_id = %d", mvID)).Check(testkit.Rows("0"))
 	tk.MustQuery(fmt.Sprintf("select count(*) from mysql.tidb_mlog_purge_info where mlog_id = %d", mlogID)).Check(testkit.Rows("0"))
+	_, ok := dom.InfoSchema().SchemaByName(ast.NewCIStr(dbName))
+	require.False(t, ok)
 }
 
 func TestDropMaterializedViewCleansRefreshAlert(t *testing.T) {

--- a/pkg/executor/test/ddl/materialized_view_drop_test.go
+++ b/pkg/executor/test/ddl/materialized_view_drop_test.go
@@ -91,6 +91,120 @@ func TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView(t *t
 	require.True(t, baseTable.Meta().MaterializedViewBase == nil || (baseTable.Meta().MaterializedViewBase.MLogID == 0 && len(baseTable.Meta().MaterializedViewBase.MViewIDs) == 0))
 }
 
+func TestDropOrTruncateTableRecheckMaterializedViewConstraints(t *testing.T) {
+	tests := []struct {
+		name                string
+		ddl                 string
+		op                  string
+		afterCheckFailpoint string
+	}{
+		{
+			name:                "drop table",
+			ddl:                 "drop table t_drop_or_truncate_mlog_recheck",
+			op:                  "DROP TABLE",
+			afterCheckFailpoint: "github.com/pingcap/tidb/pkg/ddl/afterCheckDropTableMaterializedViewConstraints",
+		},
+		{
+			name:                "truncate table",
+			ddl:                 "truncate table t_drop_or_truncate_mlog_recheck",
+			op:                  "TRUNCATE TABLE",
+			afterCheckFailpoint: "github.com/pingcap/tidb/pkg/ddl/afterCheckTruncateTableMaterializedViewConstraints",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, dom := testkit.CreateMockStoreAndDomain(t)
+			tk := newMViewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec("create table t_drop_or_truncate_mlog_recheck (a int)")
+
+			const baseTableName = "t_drop_or_truncate_mlog_recheck"
+			baseTable, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(baseTableName))
+			require.NoError(t, err)
+			baseTableID := baseTable.Meta().ID
+			mlogTableName := model.MaterializedViewLogTableName(ast.NewCIStr(baseTableName))
+
+			createStartedCh := make(chan struct{})
+			allowCreateCh := make(chan struct{})
+			var createStartedOnce sync.Once
+			var allowCreateOnce sync.Once
+			allowCreate := func() {
+				allowCreateOnce.Do(func() {
+					close(allowCreateCh)
+				})
+			}
+			t.Cleanup(allowCreate)
+			testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+				if job.Type != model.ActionCreateMaterializedViewLog || job.TableName != mlogTableName.L {
+					return
+				}
+				createStartedOnce.Do(func() {
+					close(createStartedCh)
+				})
+				<-allowCreateCh
+			})
+
+			createErrCh := make(chan error, 1)
+			go func() {
+				tkCreate := newMViewTestKit(t, store)
+				tkCreate.MustExec("use test")
+				createErrCh <- tkCreate.ExecToErr("create materialized view log on t_drop_or_truncate_mlog_recheck (a)")
+			}()
+			select {
+			case <-createStartedCh:
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for CREATE MATERIALIZED VIEW LOG worker")
+			}
+
+			entryCheckDoneCh := make(chan struct{})
+			var entryCheckDoneOnce sync.Once
+			testfailpoint.EnableCall(t, tt.afterCheckFailpoint, func(tableID int64) {
+				if tableID == baseTableID {
+					entryCheckDoneOnce.Do(func() {
+						close(entryCheckDoneCh)
+					})
+				}
+			})
+			ddlErrCh := make(chan error, 1)
+			go func() {
+				tkDDL := newMViewTestKit(t, store)
+				tkDDL.MustExec("use test")
+				ddlErrCh <- tkDDL.ExecToErr(tt.ddl)
+			}()
+			select {
+			case <-entryCheckDoneCh:
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for DDL materialized view constraint precheck")
+			}
+
+			allowCreate()
+			select {
+			case err := <-createErrCh:
+				require.NoError(t, err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for CREATE MATERIALIZED VIEW LOG")
+			}
+			select {
+			case err := <-ddlErrCh:
+				require.ErrorContains(t, err, tt.op+" on base table with materialized view log")
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for DDL job")
+			}
+
+			is := dom.InfoSchema()
+			baseTable, err = is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(baseTableName))
+			require.NoError(t, err)
+			require.Equal(t, baseTableID, baseTable.Meta().ID)
+			require.NotNil(t, baseTable.Meta().MaterializedViewBase)
+			mlogTable, ok := is.TableByID(context.Background(), baseTable.Meta().MaterializedViewBase.MLogID)
+			require.True(t, ok)
+			require.NotNil(t, mlogTable.Meta().MaterializedViewLog)
+			require.Equal(t, baseTableID, mlogTable.Meta().MaterializedViewLog.BaseTableID)
+		})
+	}
+}
+
 func TestDropMaterializedViewRefreshInfoFailureRollsBackMetadata(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := newMViewTestKit(t, store)

--- a/pkg/infoschema/BUILD.bazel
+++ b/pkg/infoschema/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
     timeout = "short",
     srcs = [
         "bench_test.go",
+        "builder_mview_test.go",
         "builder_test.go",
         "infoschema_nokit_test.go",
         "infoschema_test.go",
@@ -99,7 +100,7 @@ go_test(
     ],
     embed = [":infoschema"],
     flaky = True,
-    shard_count = 40,
+    shard_count = 41,
     deps = [
         "//pkg/ddl/placement",
         "//pkg/domain",

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -96,7 +96,8 @@ func (b *Builder) ApplyDiff(m meta.Reader, diff *model.SchemaDiff) ([]int64, err
 		return applyMaskingPolicyChange(b, m, diff)
 	case model.ActionTruncateTablePartition, model.ActionTruncateTable:
 		return applyTruncateTableOrPartition(b, m, diff)
-	case model.ActionDropTable, model.ActionDropTablePartition:
+	case model.ActionDropTable, model.ActionDropTablePartition,
+		model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		return applyDropTableOrPartition(b, m, diff)
 	case model.ActionRecoverTable:
 		return applyRecoverTable(b, m, diff)
@@ -290,28 +291,30 @@ func applyDropTableOrPartition(b *Builder, m meta.Reader, diff *model.SchemaDiff
 
 	// bundle ops
 	b.markTableBundleShouldUpdate(diff.TableID)
+	if diff.Type == model.ActionDropTable || diff.Type == model.ActionDropTablePartition {
+		for _, opt := range diff.AffectedOpts {
+			b.deleteBundle(b.infoSchema, opt.OldTableID)
+		}
+		return tblIDs, nil
+	}
+
+	// Materialized view drops update related table metadata in the same DDL
+	// transaction. These entries must be reloaded rather than treated as bundle
+	// IDs like the legacy DROP TABLE path does.
 	for _, opt := range diff.AffectedOpts {
-		// When SchemaID is 0, it comes from buildPlacementAffects and only indicates
-		// physical IDs (e.g. partition IDs) for placement bundle operations.
 		if opt.SchemaID == 0 && opt.OldSchemaID == 0 {
 			b.deleteBundle(b.infoSchema, opt.OldTableID)
 			continue
 		}
-
-		// Otherwise, it indicates an extra table updated in the same DDL transaction.
-		// Drop-table diffs don't apply affected opts by default, so reload the table
-		// metadata explicitly.
-		affectedDiff := &model.SchemaDiff{
-			// Use a non-drop action type so that applyTableUpdate treats it as a normal
-			// table update (reload from meta) instead of a drop.
-			Type:        model.ActionModifyTableComment,
+		reloadDiff := &model.SchemaDiff{
+			Type:        model.ActionCreateTable,
 			Version:     diff.Version,
 			SchemaID:    opt.SchemaID,
 			TableID:     opt.TableID,
 			OldSchemaID: opt.OldSchemaID,
 			OldTableID:  opt.OldTableID,
 		}
-		affectedIDs, err := applyTableUpdate(b, m, affectedDiff)
+		affectedIDs, err := applyTableUpdate(b, m, reloadDiff)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -518,7 +521,8 @@ func (b *Builder) getTableIDs(m meta.Reader, diff *model.SchemaDiff) (oldTableID
 		// Since the cluster-index feature also has similar problem, we chose to prevent DDL execution during the upgrade process to avoid this issue.
 		oldTableID = diff.OldTableID
 		newTableID = diff.TableID
-	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
+	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence,
+		model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		oldTableID = diff.TableID
 		// directly return if this action is initiated by refreshMeta DDL (only used by BR). In the BR case, we don't
 		// care about ON DELETE/UPDATE CASCADE so doesn't need to go through the below logic. The most important
@@ -561,7 +565,7 @@ func (b *Builder) updateBundleForTableUpdate(diff *model.SchemaDiff, newTableID,
 		} else if tableIDIsValid(oldTableID) {
 			b.deleteBundle(b.infoSchema, oldTableID)
 		}
-	case model.ActionDropTable:
+	case model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		b.deleteBundle(b.infoSchema, oldTableID)
 	case model.ActionTruncateTable:
 		b.deleteBundle(b.infoSchema, oldTableID)
@@ -659,7 +663,7 @@ func needRefreshMaskingPoliciesForTableDiff(tp model.ActionType) bool {
 	case model.ActionCreateMaskingPolicy,
 		model.ActionAlterMaskingPolicy,
 		model.ActionDropMaskingPolicy,
-		model.ActionDropTable,
+		model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog,
 		model.ActionDropColumn,
 		model.ActionModifyColumn,
 		model.ActionRenameTable,

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -291,7 +291,32 @@ func applyDropTableOrPartition(b *Builder, m meta.Reader, diff *model.SchemaDiff
 	// bundle ops
 	b.markTableBundleShouldUpdate(diff.TableID)
 	for _, opt := range diff.AffectedOpts {
-		b.deleteBundle(b.infoSchema, opt.OldTableID)
+		// When SchemaID is 0, it comes from buildPlacementAffects and only indicates
+		// physical IDs (e.g. partition IDs) for placement bundle operations.
+		if opt.SchemaID == 0 && opt.OldSchemaID == 0 {
+			b.deleteBundle(b.infoSchema, opt.OldTableID)
+			continue
+		}
+
+		// Otherwise, it indicates an extra table updated in the same DDL transaction.
+		// Drop-table diffs don't apply affected opts by default, so reload the table
+		// metadata explicitly.
+		affectedDiff := &model.SchemaDiff{
+			// Use a non-drop action type so that applyTableUpdate treats it as a normal
+			// table update (reload from meta) instead of a drop.
+			Type:        model.ActionModifyTableComment,
+			Version:     diff.Version,
+			SchemaID:    opt.SchemaID,
+			TableID:     opt.TableID,
+			OldSchemaID: opt.OldSchemaID,
+			OldTableID:  opt.OldTableID,
+		}
+		affectedIDs, err := applyTableUpdate(b, m, affectedDiff)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		tblIDs = append(tblIDs, affectedIDs...)
+		b.markTableBundleShouldUpdate(opt.TableID)
 	}
 	return tblIDs, nil
 }

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -306,8 +306,12 @@ func applyDropTableOrPartition(b *Builder, m meta.Reader, diff *model.SchemaDiff
 			b.deleteBundle(b.infoSchema, opt.OldTableID)
 			continue
 		}
+		// Use a non-drop action type so that applyTableUpdate reloads the related
+		// table metadata from the same transaction instead of removing the table.
+		// ActionModifyTableComment is intentionally used here because this is a
+		// metadata reload.
 		reloadDiff := &model.SchemaDiff{
-			Type:        model.ActionCreateTable,
+			Type:        model.ActionModifyTableComment,
 			Version:     diff.Version,
 			SchemaID:    opt.SchemaID,
 			TableID:     opt.TableID,

--- a/pkg/infoschema/builder_mview_test.go
+++ b/pkg/infoschema/builder_mview_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoschema_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/infoschema/internal"
+	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/autoid"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDropMaterializedViewDiff(t *testing.T) {
+	for _, useV2 := range []bool{false, true} {
+		name := "infoschema-v1"
+		if useV2 {
+			name = "infoschema-v2"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Run("materialized view", func(t *testing.T) {
+				testApplyDropMaterializedViewDiff(t, useV2)
+			})
+			t.Run("materialized view log", func(t *testing.T) {
+				testApplyDropMaterializedViewLogDiff(t, useV2)
+			})
+		})
+	}
+}
+
+func testApplyDropMaterializedViewDiff(t *testing.T, useV2 bool) {
+	re := internal.CreateAutoIDRequirement(t)
+	t.Cleanup(func() {
+		require.NoError(t, re.Store().Close())
+	})
+
+	dbInfo, policy, baseTable, mlogTable, mviewTable := setupMaterializedViewInfoSchema(t, re, true)
+	baseAfterDrop := baseTable.Clone()
+	baseAfterDrop.MaterializedViewBase.MViewIDs = nil
+	mlogAfterDrop := mlogTable.Clone()
+	mlogAfterDrop.MaterializedViewLog.DependentMViewIDs = nil
+	internal.UpdateTable(t, re.Store(), dbInfo, baseAfterDrop)
+	internal.UpdateTable(t, re.Store(), dbInfo, mlogAfterDrop)
+	internal.DropTable(t, re.Store(), dbInfo, mviewTable.ID, mviewTable.Name.O)
+
+	is := applyMaterializedViewDropDiff(t, re, useV2, dbInfo.ID, policy, []*model.TableInfo{baseTable, mlogTable, mviewTable}, &model.SchemaDiff{
+		Type:     model.ActionDropMaterializedView,
+		SchemaID: dbInfo.ID,
+		TableID:  mviewTable.ID,
+		Version:  2,
+		AffectedOpts: []*model.AffectedOption{
+			materializedViewAffectedOption(dbInfo.ID, baseTable.ID),
+			materializedViewAffectedOption(dbInfo.ID, mlogTable.ID),
+		},
+	})
+
+	_, exists := is.TableByID(context.Background(), mviewTable.ID)
+	require.False(t, exists)
+	base, exists := is.TableByID(context.Background(), baseTable.ID)
+	require.True(t, exists)
+	require.Equal(t, mlogTable.ID, base.Meta().MaterializedViewBase.MLogID)
+	require.Empty(t, base.Meta().MaterializedViewBase.MViewIDs)
+	mlog, exists := is.TableByID(context.Background(), mlogTable.ID)
+	require.True(t, exists)
+	require.Empty(t, mlog.Meta().MaterializedViewLog.DependentMViewIDs)
+	_, exists = is.PlacementBundleByPhysicalTableID(baseTable.ID)
+	require.True(t, exists)
+}
+
+func testApplyDropMaterializedViewLogDiff(t *testing.T, useV2 bool) {
+	re := internal.CreateAutoIDRequirement(t)
+	t.Cleanup(func() {
+		require.NoError(t, re.Store().Close())
+	})
+
+	dbInfo, policy, baseTable, mlogTable, _ := setupMaterializedViewInfoSchema(t, re, false)
+	baseAfterDrop := baseTable.Clone()
+	baseAfterDrop.MaterializedViewBase = nil
+	internal.UpdateTable(t, re.Store(), dbInfo, baseAfterDrop)
+	internal.DropTable(t, re.Store(), dbInfo, mlogTable.ID, mlogTable.Name.O)
+
+	is := applyMaterializedViewDropDiff(t, re, useV2, dbInfo.ID, policy, []*model.TableInfo{baseTable, mlogTable}, &model.SchemaDiff{
+		Type:     model.ActionDropMaterializedViewLog,
+		SchemaID: dbInfo.ID,
+		TableID:  mlogTable.ID,
+		Version:  2,
+		AffectedOpts: []*model.AffectedOption{
+			materializedViewAffectedOption(dbInfo.ID, baseTable.ID),
+		},
+	})
+
+	_, exists := is.TableByID(context.Background(), mlogTable.ID)
+	require.False(t, exists)
+	base, exists := is.TableByID(context.Background(), baseTable.ID)
+	require.True(t, exists)
+	require.Nil(t, base.Meta().MaterializedViewBase)
+	_, exists = is.PlacementBundleByPhysicalTableID(baseTable.ID)
+	require.True(t, exists)
+}
+
+func setupMaterializedViewInfoSchema(
+	t *testing.T,
+	re autoid.Requirement,
+	withMaterializedView bool,
+) (*model.DBInfo, *model.PolicyInfo, *model.TableInfo, *model.TableInfo, *model.TableInfo) {
+	dbInfo := internal.MockDBInfo(t, re.Store(), "test")
+	policy := internal.MockPolicyInfo(t, re.Store(), "p")
+	policy.State = model.StatePublic
+	policy.PlacementSettings = &model.PlacementSettings{PrimaryRegion: "r1", Regions: "r1,r2"}
+	baseTable := internal.MockTableInfo(t, re.Store(), "base")
+	mlogTable := internal.MockTableInfo(t, re.Store(), "$mlog$base")
+	baseTable.DBID = dbInfo.ID
+	mlogTable.DBID = dbInfo.ID
+	baseTable.PlacementPolicyRef = &model.PolicyRefInfo{ID: policy.ID, Name: policy.Name}
+	baseTable.MaterializedViewBase = &model.MaterializedViewBaseInfo{MLogID: mlogTable.ID}
+	mlogTable.MaterializedViewLog = &model.MaterializedViewLogInfo{BaseTableID: baseTable.ID}
+
+	tables := []*model.TableInfo{baseTable, mlogTable}
+	var mviewTable *model.TableInfo
+	if withMaterializedView {
+		mviewTable = internal.MockTableInfo(t, re.Store(), "mv")
+		mviewTable.DBID = dbInfo.ID
+		mviewTable.MaterializedView = &model.MaterializedViewInfo{BaseTableIDs: []int64{baseTable.ID}}
+		baseTable.MaterializedViewBase.MViewIDs = []int64{mviewTable.ID}
+		mlogTable.MaterializedViewLog.DependentMViewIDs = []int64{mviewTable.ID}
+		tables = append(tables, mviewTable)
+	}
+	dbInfo.Deprecated.Tables = tables
+	internal.AddDB(t, re.Store(), dbInfo)
+	for _, tbl := range tables {
+		internal.AddTable(t, re.Store(), dbInfo.ID, tbl)
+	}
+
+	return dbInfo, policy, baseTable, mlogTable, mviewTable
+}
+
+func applyMaterializedViewDropDiff(
+	t *testing.T,
+	re autoid.Requirement,
+	useV2 bool,
+	dbID int64,
+	policy *model.PolicyInfo,
+	tables []*model.TableInfo,
+	diff *model.SchemaDiff,
+) infoschema.InfoSchema {
+	schemaCacheSize := uint64(0)
+	if useV2 {
+		schemaCacheSize = 1
+	}
+	data := infoschema.NewData()
+	dbInfo := &model.DBInfo{ID: dbID, Name: ast.NewCIStr("test"), State: model.StatePublic}
+	dbInfo.Deprecated.Tables = tables
+	builder := infoschema.NewBuilder(re, schemaCacheSize, nil, data, useV2)
+	require.NoError(t, builder.InitWithDBInfos([]*model.DBInfo{dbInfo}, []*model.PolicyInfo{policy}, nil, nil, 1))
+	oldInfoSchema := builder.Build(math.MaxUint64)
+
+	txn, err := re.Store().Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, txn.Rollback())
+	})
+	builder = infoschema.NewBuilder(re, schemaCacheSize, nil, data, useV2)
+	require.NoError(t, builder.InitWithOldInfoSchema(oldInfoSchema))
+	_, err = builder.ApplyDiff(meta.NewMutator(txn), diff)
+	require.NoError(t, err)
+	return builder.Build(math.MaxUint64)
+}
+
+func materializedViewAffectedOption(schemaID, tableID int64) *model.AffectedOption {
+	return &model.AffectedOption{
+		SchemaID:    schemaID,
+		OldSchemaID: schemaID,
+		TableID:     tableID,
+		OldTableID:  tableID,
+	}
+}

--- a/pkg/meta/model/bdr.go
+++ b/pkg/meta/model/bdr.go
@@ -62,6 +62,8 @@ var BDRActionMap = map[DDLBDRType][]ActionType{
 	UnsafeDDL: {
 		ActionDropSchema,
 		ActionDropTable,
+		ActionDropMaterializedView,
+		ActionDropMaterializedViewLog,
 		ActionDropColumn,
 		ActionAddForeignKey,
 		ActionDropForeignKey,

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -127,6 +127,8 @@ const (
 	ActionAlterTableSetRegionSplitPolicy        ActionType = 84
 	ActionCreateMaterializedViewLog             ActionType = 85
 	ActionCreateMaterializedView                ActionType = 86
+	ActionDropMaterializedViewLog               ActionType = 87
+	ActionDropMaterializedView                  ActionType = 88
 
 	// range [200, 256) is reserved for a downstream fork
 )
@@ -214,6 +216,8 @@ var ActionMap = map[ActionType]string{
 	ActionAlterTableSetRegionSplitPolicy:        "alter table set region split policy",
 	ActionCreateMaterializedViewLog:             "create materialized view log",
 	ActionCreateMaterializedView:                "create materialized view",
+	ActionDropMaterializedViewLog:               "drop materialized view log",
+	ActionDropMaterializedView:                  "drop materialized view",
 
 	// `ActionAlterTableAlterPartition` is removed and will never be used.
 	// Just left a tombstone here for compatibility.
@@ -887,6 +891,7 @@ func (job *Job) IsRollbackable() bool {
 	case ActionAddTablePartition:
 		return job.SchemaState == StateNone || job.SchemaState == StateReplicaOnly
 	case ActionDropColumn, ActionDropSchema, ActionDropTable, ActionDropSequence,
+		ActionDropMaterializedView, ActionDropMaterializedViewLog,
 		ActionDropForeignKey, ActionDropTablePartition:
 		return job.SchemaState == StatePublic
 	case ActionTruncateTablePartition:

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -311,10 +311,10 @@ func GetBatchCreateTableArgs(job *Job) (*BatchCreateTableArgs, error) {
 	return getOrDecodeArgs[*BatchCreateTableArgs](&BatchCreateTableArgs{}, job)
 }
 
-// DropTableArgs is the arguments for drop table/view/sequence job.
+// DropTableArgs is the arguments for table-like object, view, and sequence drop jobs.
 // when dropping multiple objects, each object will have a separate job
 type DropTableArgs struct {
-	// below fields are only for drop table.
+	// The following fields are only for DROP TABLE and materialized view drop jobs.
 	// when dropping multiple tables, the Identifiers is the same, but each drop-table
 	// runs in a separate job.
 	Identifiers []ast.Ident `json:"identifiers,omitempty"`
@@ -327,8 +327,9 @@ type DropTableArgs struct {
 }
 
 func (a *DropTableArgs) getArgsV1(job *Job) []any {
-	// only drop-table job has in args, drop view/sequence job has no args.
-	if job.Type == ActionDropTable {
+	// Only table-like drop jobs have submission arguments in V1.
+	switch job.Type {
+	case ActionDropTable, ActionDropMaterializedView, ActionDropMaterializedViewLog:
 		return []any{a.Identifiers, a.FKCheck}
 	}
 	return nil
@@ -339,7 +340,8 @@ func (a *DropTableArgs) getFinishedArgsV1(*Job) []any {
 }
 
 func (a *DropTableArgs) decodeV1(job *Job) error {
-	if job.Type == ActionDropTable {
+	switch job.Type {
+	case ActionDropTable, ActionDropMaterializedView, ActionDropMaterializedViewLog:
 		return job.decodeArgs(&a.Identifiers, &a.FKCheck)
 	}
 	return nil

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -225,12 +225,14 @@ func TestDropTableArgs(t *testing.T) {
 		},
 		FKCheck: true,
 	}
-	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
-		j2 := &Job{}
-		require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, ActionDropTable)))
-		args, err := GetDropTableArgs(j2)
-		require.NoError(t, err)
-		require.EqualValues(t, inArgs, args)
+	for _, tp := range []ActionType{ActionDropTable, ActionDropMaterializedView, ActionDropMaterializedViewLog} {
+		for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+			j2 := &Job{}
+			require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, tp)))
+			args, err := GetDropTableArgs(j2)
+			require.NoError(t, err)
+			require.EqualValues(t, inArgs, args)
+		}
 	}
 	for _, tp := range []ActionType{ActionDropView, ActionDropSequence} {
 		for _, v := range []JobVersion{JobVersion1, JobVersion2} {
@@ -253,12 +255,14 @@ func TestFinishedDropTableArgs(t *testing.T) {
 		OldPartitionIDs: []int64{1, 2},
 		OldRuleIDs:      []string{"schema/test/a/par1", "schema/test/a/par2"},
 	}
-	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
-		j2 := &Job{}
-		require.NoError(t, j2.Decode(getFinishedJobBytes(t, inArgs, v, ActionDropTable)))
-		args, err := GetFinishedDropTableArgs(j2)
-		require.NoError(t, err)
-		require.EqualValues(t, inArgs, args)
+	for _, tp := range []ActionType{ActionDropTable, ActionDropMaterializedView, ActionDropMaterializedViewLog} {
+		for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+			j2 := &Job{}
+			require.NoError(t, j2.Decode(getFinishedJobBytes(t, inArgs, v, tp)))
+			args, err := GetFinishedDropTableArgs(j2)
+			require.NoError(t, err)
+			require.EqualValues(t, inArgs, args)
+		}
 	}
 }
 

--- a/pkg/meta/model/job_test.go
+++ b/pkg/meta/model/job_test.go
@@ -358,6 +358,8 @@ func TestString(t *testing.T) {
 		{ActionDropSchema, "drop schema"},
 		{ActionCreateTable, "create table"},
 		{ActionDropTable, "drop table"},
+		{ActionDropMaterializedView, "drop materialized view"},
+		{ActionDropMaterializedViewLog, "drop materialized view log"},
 		{ActionAddIndex, "add index"},
 		{ActionDropIndex, "drop index"},
 		{ActionAddColumn, "add column"},

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -911,6 +911,7 @@ func (i *MaterializedViewInfo) GetInitBuildState() MViewInitBuildState {
 // MaterializedViewLogInfo is stored in TableInfo for a materialized view log table.
 type MaterializedViewLogInfo struct {
 	BaseTableID              int64            `json:"base_table_id"`
+	DependentMViewIDs        []int64          `json:"dependent_mview_ids,omitempty"`
 	Columns                  []ast.CIStr      `json:"columns"`
 	PurgeMethod              string           `json:"purge_method,omitempty"`
 	PurgeStartWith           string           `json:"purge_start_with,omitempty"`
@@ -946,6 +947,7 @@ func (i *MaterializedViewLogInfo) Clone() *MaterializedViewLogInfo {
 	}
 	clone := &MaterializedViewLogInfo{
 		BaseTableID:           i.BaseTableID,
+		DependentMViewIDs:     append([]int64(nil), i.DependentMViewIDs...),
 		Columns:               append([]ast.CIStr(nil), i.Columns...),
 		PurgeMethod:           i.PurgeMethod,
 		PurgeStartWith:        i.PurgeStartWith,

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5676,6 +5676,19 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 				b.ctx.GetSessionVars().User.AuthHostname, v.ViewName.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.CreateViewPriv, dbName, v.ViewName.Name.L, "", authErr)
+	case *ast.DropMaterializedViewStmt:
+		dbName := v.ViewName.Schema.L
+		if dbName == "" {
+			dbName = b.ctx.GetSessionVars().CurrentDB
+		}
+		if dbName == "" {
+			return nil, plannererrors.ErrNoDB
+		}
+		if b.ctx.GetSessionVars().User != nil {
+			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DROP", b.ctx.GetSessionVars().User.AuthUsername,
+				b.ctx.GetSessionVars().User.AuthHostname, v.ViewName.Name.L)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DropPriv, dbName, v.ViewName.Name.L, "", authErr)
 	case *ast.CreateMaterializedViewLogStmt:
 		dbName := v.Table.Schema.L
 		if dbName == "" {
@@ -5692,6 +5705,20 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.CreateViewPriv, dbName, mlogName.L, "", createAuthErr)
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, v.Table.Name.L, "", selectAuthErr)
+	case *ast.DropMaterializedViewLogStmt:
+		dbName := v.Table.Schema.L
+		if dbName == "" {
+			dbName = b.ctx.GetSessionVars().CurrentDB
+		}
+		if dbName == "" {
+			return nil, plannererrors.ErrNoDB
+		}
+		mlogName := b.materializedViewLogNameForBaseTable(ctx, dbName, v.Table.Name)
+		if b.ctx.GetSessionVars().User != nil {
+			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DROP", b.ctx.GetSessionVars().User.AuthUsername,
+				b.ctx.GetSessionVars().User.AuthHostname, mlogName.L)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DropPriv, dbName, mlogName.L, "", authErr)
 	case *ast.OptimizeTableStmt:
 		return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStack("OPTIMIZE TABLE is not supported")
 	}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5715,8 +5715,8 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (base.Plan
 		}
 		mlogName := b.materializedViewLogNameForBaseTable(ctx, dbName, v.Table.Name)
 		if b.ctx.GetSessionVars().User != nil {
-			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DROP", b.ctx.GetSessionVars().User.AuthUsername,
-				b.ctx.GetSessionVars().User.AuthHostname, mlogName.L)
+			authErr = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("DROP MATERIALIZED VIEW LOG", b.ctx.GetSessionVars().User.AuthUsername,
+				b.ctx.GetSessionVars().User.AuthHostname, v.Table.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DropPriv, dbName, mlogName.L, "", authErr)
 	case *ast.OptimizeTableStmt:

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -300,6 +300,11 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		p.flag |= inCreateOrDropTable
 	case *ast.CreateMaterializedViewLogStmt:
 		p.stmtTp = TypeCreate
+	case *ast.DropMaterializedViewStmt:
+		p.stmtTp = TypeDrop
+		p.flag |= inCreateOrDropTable
+	case *ast.DropMaterializedViewLogStmt:
+		p.stmtTp = TypeDrop
 	case *ast.DropTableStmt:
 		p.flag |= inCreateOrDropTable
 		p.stmtTp = TypeDrop
@@ -646,7 +651,7 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 		p.flag &= ^inCreateOrDropTable
 	case *ast.CreateMaterializedViewStmt:
 		p.flag &= ^inCreateOrDropTable
-	case *ast.DropTableStmt, *ast.AlterTableStmt, *ast.RenameTableStmt:
+	case *ast.DropMaterializedViewStmt, *ast.DropTableStmt, *ast.AlterTableStmt, *ast.RenameTableStmt:
 		p.flag &= ^inCreateOrDropTable
 	case *driver.ParamMarkerExpr:
 		if p.flag&inPrepare == 0 {

--- a/pkg/store/gcworker/gc_worker.go
+++ b/pkg/store/gcworker/gc_worker.go
@@ -1691,6 +1691,24 @@ func doGCPlacementRules(se sessionapi.Session, _ uint64,
 					State:   model.JobStateRollbackDone,
 					TableID: tableID,
 				}
+			} else if strings.HasPrefix(x, "drop-mview:") || strings.HasPrefix(x, "drop-mlog:") {
+				prefix := "drop-mview:"
+				jobType := model.ActionDropMaterializedView
+				if strings.HasPrefix(x, "drop-mlog:") {
+					prefix = "drop-mlog:"
+					jobType = model.ActionDropMaterializedViewLog
+				}
+				tableID, convErr := strconv.ParseInt(strings.TrimPrefix(x, prefix), 10, 64)
+				if convErr != nil {
+					return
+				}
+				mockJ = &model.Job{
+					Version: model.GetJobVerInUse(),
+					ID:      dr.JobID,
+					Type:    jobType,
+					TableID: tableID,
+				}
+				mockJ.FillFinishedArgs(&model.DropTableArgs{})
 			}
 		default:
 			return
@@ -1721,7 +1739,7 @@ func doGCPlacementRules(se sessionapi.Session, _ uint64,
 	// Notify PD to drop the placement rules of partition-ids and table-id, even if there may be no placement rules.
 	var physicalTableIDs []int64
 	switch historyJob.Type {
-	case model.ActionDropTable:
+	case model.ActionDropTable, model.ActionDropMaterializedView, model.ActionDropMaterializedViewLog:
 		var args *model.DropTableArgs
 		args, err = model.GetFinishedDropTableArgs(historyJob)
 		if err != nil {
@@ -1822,7 +1840,9 @@ func (w *GCWorker) doGCLabelRules(dr util.DelRangeTask) (err error) {
 		}
 	}
 
-	if historyJob.Type == model.ActionDropTable {
+	if historyJob.Type == model.ActionDropTable ||
+		historyJob.Type == model.ActionDropMaterializedView ||
+		historyJob.Type == model.ActionDropMaterializedViewLog {
 		var (
 			args  *model.DropTableArgs
 			rules map[string]*label.Rule

--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -2402,8 +2402,11 @@ func TestCalcDeleteRangeConcurrency(t *testing.T) {
 func TestGCPlacementRulesForCreateMaterializedViewRollback(t *testing.T) {
 	s := createGCWorkerSuite(t)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC", `return("create-mv-rollback:20")`))
+	historyJobFailpointEnabled := true
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC"))
+		if historyJobFailpointEnabled {
+			require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC"))
+		}
 	}()
 
 	var gcPlacementRuleCache sync.Map
@@ -2427,4 +2430,38 @@ func TestGCPlacementRulesForCreateMaterializedViewRollback(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.True(t, got.IsEmpty())
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC"))
+	historyJobFailpointEnabled = false
+
+	for _, test := range []struct {
+		name      string
+		failpoint string
+		tableID   int64
+	}{
+		{name: "drop materialized view", failpoint: "drop-mview:20", tableID: 20},
+		{name: "drop materialized view log", failpoint: "drop-mlog:30", tableID: 30},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC", `return("`+test.failpoint+`")`))
+			defer func() {
+				require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/gcworker/mockHistoryJobForGC"))
+			}()
+
+			bundleID := fmt.Sprintf("TiDB_DDL_%d", test.tableID)
+			bundle, err := placement.NewBundleFromOptions(&model.PlacementSettings{PrimaryRegion: "r1", Regions: "r1, r2"})
+			require.NoError(t, err)
+			bundle.ID = bundleID
+			require.NoError(t, infosync.PutRuleBundles(context.Background(), []*placement.Bundle{bundle}))
+
+			var cache sync.Map
+			dr := util.DelRangeTask{JobID: 1, ElementID: test.tableID}
+			require.NoError(t, doGCPlacementRules(createSession(s.store), 1, dr, &cache))
+			_, ok := cache.Load(test.tableID)
+			require.True(t, ok)
+			got, err := infosync.GetRuleBundle(context.Background(), bundleID)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.True(t, got.IsEmpty())
+		})
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref pingcap/tidb#18023

Problem Summary:

Port the DROP MATERIALIZED VIEW and DROP MATERIALIZED VIEW LOG DDL support to `master` as the second part of the materialized view DDL port.

### What changed and how does it work?

- Add `DROP MATERIALIZED VIEW` and `DROP MATERIALIZED VIEW LOG` execution support, including `IF EXISTS` and object type validation.
- Reuse the regular drop-table DDL job machinery while adding materialized-view and materialized-view-log dependency checks.
- Record the IDs of dependent materialized views in each materialized view log when an MV is created, and remove the corresponding ID when that MV is dropped or rolled back.
- Check the MLog's direct dependent materialized views when deciding whether `DROP MATERIALIZED VIEW LOG` is allowed, instead of inferring the dependency from all MVs on the base table.
- Remove reverse metadata and materialized-view maintenance metadata when related objects are dropped.
- Add schema tracker, planner/preprocessor, infoschema, and DROP DATABASE support for materialized view metadata.
- Port focused executor tests for DROP MATERIALIZED VIEW and DROP MATERIALIZED VIEW LOG, including verification of MLog dependency metadata cleanup.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```bash
make lint
./tools/check/failpoint-go-test.sh pkg/executor/test/ddl \
  -run '^(TestCreateMaterializedViewAndLog|TestDropMaterializedViewIfExists|TestDropTableMaterializedViewConstraints|TestDropMaterializedViewLogRecheckWithConcurrentCreateMaterializedView|TestDropMaterializedViewAndDatabaseCleanMViewState)$' \
  -count=1
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support dropping materialized views and materialized view logs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dropping materialized views and materialized view logs.
  * Added `IF EXISTS` handling, including missing databases.
  * Added privilege checks for both drop operations.

* **Bug Fixes**
  * Prevents dropping logs with dependent materialized views.
  * Prevents dropping related tables when dependencies or logs exist.
  * Cleans up refresh, alert, and purge metadata during drops.
  * Rolls back changes when required cleanup fails.
  * Handles missing base tables and alert-cleanup failures safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
