### PR TITLE
expression: verify DNF predicates beyond hash codes

### DIFF
--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "integration_test_test",
     timeout = "short",
     srcs = [
+        "dnf_common_condition_extraction_collation_hash_collision_test.go",
         "integration_test.go",
         "main_test.go",
     ],

--- a/pkg/expression/integration_test/dnf_common_condition_extraction_collation_hash_collision_test.go
+++ b/pkg/expression/integration_test/dnf_common_condition_extraction_collation_hash_collision_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package integration_test
 
@@ -25,5 +35,36 @@ func TestDnfCommonConditionExtractionCollationHashCollision(t *testing.T) {
 		{"2"},
 		{"3"},
 	})
+	tk.MustExec("TRUNCATE TABLE t1")
+	tk.MustExec("INSERT INTO t1 VALUES (1,'A',1),(2,'a',1),(3,'A',2),(4,'a',2)")
+	tk.MustExec("DELETE t1 FROM t1 JOIN t2 ON t1.id = t2.id AND ((c = 'A' COLLATE utf8mb4_general_ci AND t1.b = 1) OR (c = 'A' COLLATE utf8mb4_bin AND t1.b = 2))")
+	tk.MustQuery("SELECT id FROM t1 ORDER BY id").Check(testkit.Rows("4"))
+}
 
+func TestRemoveDupExprsCollationHashCollision(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t_remove_dup")
+	tk.MustExec("CREATE TABLE t_remove_dup(id INT PRIMARY KEY, c VARCHAR(10) COLLATE utf8mb4_general_ci)")
+	tk.MustExec("INSERT INTO t_remove_dup VALUES (1,'A'),(2,'a')")
+	tk.MustQuery("SELECT id FROM t_remove_dup WHERE c = 'A' COLLATE utf8mb4_general_ci AND c = 'A' COLLATE utf8mb4_bin ORDER BY id").Check(testkit.Rows("1"))
+	tk.MustExec("TRUNCATE TABLE t_remove_dup")
+	tk.MustExec("INSERT INTO t_remove_dup VALUES (1,'A'),(2,'a')")
+	tk.MustExec("DELETE FROM t_remove_dup WHERE c = 'A' COLLATE utf8mb4_general_ci AND c = 'A' COLLATE utf8mb4_bin")
+	tk.MustQuery("SELECT id FROM t_remove_dup ORDER BY id").Check(testkit.Rows("2"))
+}
+
+func TestIndexMergeCollationHashCollision(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t_hash")
+	tk.MustExec("CREATE TABLE t_hash(id INT PRIMARY KEY, c VARCHAR(10) COLLATE utf8mb4_general_ci, j JSON, k INT, INDEX idx_mv(c, (CAST(j->'$.a' AS SIGNED ARRAY))), INDEX idx_k(k))")
+	tk.MustExec(`INSERT INTO t_hash VALUES (1,'A','{"a":[1]}',1),(2,'a','{"a":[1]}',1),(3,'B','{"a":[1]}',1),(4,'A','{"a":[2]}',1),(5,'a','{"a":[2]}',1)`)
+	tk.MustQuery("SELECT /*+ USE_INDEX_MERGE(t_hash, idx_mv, idx_k) */ id FROM t_hash WHERE c = 'A' COLLATE utf8mb4_general_ci AND c = 'A' COLLATE utf8mb4_bin AND 1 MEMBER OF (j->'$.a') AND k = 1 ORDER BY id").Check(testkit.Rows("1"))
+	tk.MustExec("TRUNCATE TABLE t_hash")
+	tk.MustExec(`INSERT INTO t_hash VALUES (1,'A','{"a":[1]}',1),(2,'a','{"a":[1]}',1),(3,'B','{"a":[1]}',1),(4,'A','{"a":[2]}',1),(5,'a','{"a":[2]}',1)`)
+	tk.MustExec("DELETE /*+ USE_INDEX_MERGE(t_hash, idx_mv, idx_k) */ FROM t_hash WHERE c = 'A' COLLATE utf8mb4_general_ci AND c = 'A' COLLATE utf8mb4_bin AND 1 MEMBER OF (j->'$.a') AND k = 1")
+	tk.MustQuery("SELECT id FROM t_hash ORDER BY id").Check(testkit.Rows("2", "3", "4", "5"))
 }

--- a/pkg/expression/integration_test/dnf_common_condition_extraction_collation_hash_collision_test.go
+++ b/pkg/expression/integration_test/dnf_common_condition_extraction_collation_hash_collision_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestDnfCommonConditionExtractionCollationHashCollision(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t1")
+	tk.MustExec("DROP TABLE IF EXISTS t2")
+	tk.MustExec("CREATE TABLE t1(id INT PRIMARY KEY, c VARCHAR(10) COLLATE utf8mb4_general_ci, b INT)")
+	tk.MustExec("CREATE TABLE t2(id INT PRIMARY KEY, x INT)")
+	tk.MustExec("INSERT INTO t1 VALUES (1,'A',1),(2,'a',1),(3,'A',2),(4,'a',2)")
+	tk.MustExec("INSERT INTO t2 VALUES (1,1),(2,1),(3,2),(4,2)")
+	tk.MustQuery("SELECT t1.id\nFROM t1 JOIN t2\n  ON t1.id = t2.id\n AND ((c = 'A' COLLATE utf8mb4_general_ci AND t1.b = 1)\n   OR (c = 'A' COLLATE utf8mb4_bin AND t1.b = 2))\nORDER BY t1.id;").Check([][]any{
+		{"1"},
+		{"2"},
+		{"3"},
+	})
+
+}

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1586,15 +1586,67 @@ func RemoveDupExprs(exprs []Expression) []Expression {
 	if len(exprs) <= 1 {
 		return exprs
 	}
-	exists := make(map[string]struct{}, len(exprs))
+	exists := make(map[string][]Expression, len(exprs))
 	return slices.DeleteFunc(exprs, func(expr Expression) bool {
-		key := string(expr.HashCode())
-		if _, ok := exists[key]; !ok || IsMutableEffectsExpr(expr) {
-			exists[key] = struct{}{}
+		if IsMutableEffectsExpr(expr) {
 			return false
 		}
-		return true
+		key := string(expr.HashCode())
+		for _, existing := range exists[key] {
+			if HashCodeEqual(expr, existing) {
+				return true
+			}
+		}
+		exists[key] = append(exists[key], expr)
+		return false
 	})
+}
+
+// HashCodeEqual checks whether two expressions have the same legacy hash-code identity.
+// HashCode omits field types, so compare the semantic type tree to distinguish expressions
+// whose values are encoded identically but whose collations or other type properties differ.
+func HashCodeEqual(lhs, rhs Expression) bool {
+	if !bytes.Equal(lhs.HashCode(), rhs.HashCode()) {
+		return false
+	}
+	if lhs.Equals(rhs) {
+		return true
+	}
+	return hashCodeTypeEqual(lhs, rhs)
+}
+
+func hashCodeTypeEqual(lhs, rhs Expression) bool {
+	switch left := lhs.(type) {
+	case *ScalarFunction:
+		right, ok := rhs.(*ScalarFunction)
+		if !ok || !fieldTypeEqual(left.RetType, right.RetType) || len(left.GetArgs()) != len(right.GetArgs()) {
+			return false
+		}
+		for i, arg := range left.GetArgs() {
+			if !HashCodeEqual(arg, right.GetArgs()[i]) {
+				return false
+			}
+		}
+		return true
+	case *Constant:
+		right, ok := rhs.(*Constant)
+		return ok && fieldTypeEqual(left.RetType, right.RetType)
+	case *Column:
+		right, ok := rhs.(*Column)
+		return ok && fieldTypeEqual(left.RetType, right.RetType)
+	case *CorrelatedColumn:
+		right, ok := rhs.(*CorrelatedColumn)
+		return ok && fieldTypeEqual(left.RetType, right.RetType)
+	default:
+		return false
+	}
+}
+
+func fieldTypeEqual(lhs, rhs *types.FieldType) bool {
+	if lhs == nil || rhs == nil {
+		return lhs == rhs
+	}
+	return lhs.Equal(rhs)
 }
 
 // GetUint64FromConstant gets a uint64 from constant expression.

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1231,6 +1231,11 @@ func extractFiltersFromDNF(ctx BuildContext, dnfFunc *ScalarFunction) ([]Express
 				codeMap[string(code)] = 1
 				hashcode2Expr[string(code)] = cnfItem
 			} else if _, ok := codeMap[string(code)]; ok {
+				// HashCode is a lossy digest (for example, Constant.HashCode
+				// does not encode the collation), so verify structural equality.
+				if !cnfItem.Equals(hashcode2Expr[string(code)]) {
+					continue
+				}
 				// We need this check because there may be the case like `select * from t, t1 where (t.a=t1.a and t.a=t1.a) or (something).
 				// We should make sure that the two `t.a=t1.a` contributes only once.
 				// TODO: do this out of this function.
@@ -1257,8 +1262,8 @@ func extractFiltersFromDNF(ctx BuildContext, dnfFunc *ScalarFunction) ([]Express
 		newCNFItems := make([]Expression, 0, len(cnfItems))
 		for _, cnfItem := range cnfItems {
 			code := cnfItem.HashCode()
-			_, ok := hashcode2Expr[string(code)]
-			if !ok {
+			extracted, ok := hashcode2Expr[string(code)]
+			if !ok || !cnfItem.Equals(extracted) {
 				newCNFItems = append(newCNFItems, cnfItem)
 			}
 		}

--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"cmp"
-	"maps"
 	"slices"
 	"strings"
 
@@ -262,7 +261,48 @@ func accessPathsForConds(
 	return newPath
 }
 
-func generateNormalIndexPartialPath4And(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap map[string]expression.Expression) []*util.AccessPath {
+type expressionHashSet map[string][]expression.Expression
+
+func (s expressionHashSet) contains(expr expression.Expression) bool {
+	for _, existing := range s[string(expr.HashCode())] {
+		if expression.HashCodeEqual(expr, existing) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s expressionHashSet) add(expr expression.Expression) bool {
+	if s.contains(expr) {
+		return false
+	}
+	key := string(expr.HashCode())
+	s[key] = append(s[key], expr)
+	return true
+}
+
+func sameExpressionMultiset(lhs, rhs []expression.Expression) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	matched := make([]bool, len(rhs))
+	for _, left := range lhs {
+		found := false
+		for i, right := range rhs {
+			if !matched[i] && expression.HashCodeEqual(left, right) {
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func generateNormalIndexPartialPath4And(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap expressionHashSet) []*util.AccessPath {
 	if res := generateANDIndexMerge4NormalIndex(ds, normalPathCnt, usedAccessMap); res != nil {
 		return res.PartialIndexPaths
 	}
@@ -270,7 +310,7 @@ func generateNormalIndexPartialPath4And(ds *logicalop.DataSource, normalPathCnt 
 }
 
 // generateANDIndexMerge4NormalIndex generates IndexMerge paths for `AND` (a.k.a. intersection type IndexMerge)
-func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap map[string]expression.Expression) *util.AccessPath {
+func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt int, usedAccessMap expressionHashSet) *util.AccessPath {
 	// For now, we only consider intersection type IndexMerge when the index names are specified in the hints.
 	if !indexMergeHintsHasSpecifiedIdx(ds) {
 		return nil
@@ -305,7 +345,7 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 			// since idx2's access cond has already been covered by idx1.
 			containRelation := true
 			for _, access := range originalPath.AccessConds {
-				if _, ok := usedAccessMap[string(access.HashCode())]; !ok {
+				if !usedAccessMap.contains(access) {
 					// some condition is not covered in previous mv index partial path, use it!
 					containRelation = false
 					break
@@ -316,9 +356,7 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 			}
 			// for this picked normal index, mark its access conds.
 			for _, access := range originalPath.AccessConds {
-				if _, ok := usedAccessMap[string(access.HashCode())]; !ok {
-					usedAccessMap[string(access.HashCode())] = access
-				}
+				usedAccessMap.add(access)
 			}
 		}
 		newPath := originalPath.Clone()
@@ -335,7 +373,7 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 	// 2. Collect filters that can't be covered by the partial paths and deduplicate them.
 	finalFilters := make([]expression.Expression, 0)
 	partialFilters := make([]expression.Expression, 0, len(partialPaths))
-	hashCodeSet := make(map[string]struct{})
+	coveredFilterSet := make(expressionHashSet)
 	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
 	for _, path := range partialPaths {
 		// Classify filters into coveredConds and notCoveredConds.
@@ -355,19 +393,17 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 		// TableFilters can't be covered by partial path.
 		notCoveredConds = append(notCoveredConds, path.TableFilters...)
 
-		// Record covered filters in hashCodeSet.
+		// Record covered filters in coveredFilterSet.
 		// Note that we only record filters that not appear in the notCoveredConds. It's possible that a filter appear
 		// in both coveredConds and notCoveredConds (e.g. because of prefix index). So we need this extra check to
 		// avoid wrong deduplication.
-		notCoveredHashCodeSet := make(map[string]struct{})
+		notCoveredFilterSet := make(expressionHashSet)
 		for _, cond := range notCoveredConds {
-			hashCode := string(cond.HashCode())
-			notCoveredHashCodeSet[hashCode] = struct{}{}
+			notCoveredFilterSet.add(cond)
 		}
 		for _, cond := range coveredConds {
-			hashCode := string(cond.HashCode())
-			if _, ok := notCoveredHashCodeSet[hashCode]; !ok {
-				hashCodeSet[hashCode] = struct{}{}
+			if !notCoveredFilterSet.contains(cond) {
+				coveredFilterSet.add(cond)
 			}
 		}
 
@@ -378,10 +414,8 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 	// Remove covered filters from finalFilters and deduplicate finalFilters.
 	dedupedFinalFilters := make([]expression.Expression, 0, len(finalFilters))
 	for _, cond := range finalFilters {
-		hashCode := string(cond.HashCode())
-		if _, ok := hashCodeSet[hashCode]; !ok {
+		if coveredFilterSet.add(cond) {
 			dedupedFinalFilters = append(dedupedFinalFilters, cond)
-			hashCodeSet[hashCode] = struct{}{}
 		}
 	}
 
@@ -407,7 +441,7 @@ func generateANDIndexMerge4NormalIndex(ds *logicalop.DataSource, normalPathCnt i
 }
 
 // generateMVIndexMergePartialPaths4And try to find mv index merge partial path from a collection of cnf conditions.
-func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCnt int, indexMergeConds []expression.Expression, histColl *statistics.HistColl) ([]*util.AccessPath, map[string]expression.Expression, error) {
+func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCnt int, indexMergeConds []expression.Expression, histColl *statistics.HistColl) ([]*util.AccessPath, expressionHashSet, error) {
 	// step1: collect all mv index paths
 	possibleMVIndexPaths := make([]*util.AccessPath, 0, len(ds.PossibleAccessPaths))
 	for idx := range normalPathCnt {
@@ -421,16 +455,17 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 	}
 	// step2: mapping index merge conditions into possible mv index path
 	mvAndPartialPath := make([]*util.AccessPath, 0, len(possibleMVIndexPaths))
-	usedAccessCondsMap := make(map[string]expression.Expression, len(indexMergeConds))
+	usedAccessCondsMap := make(expressionHashSet, len(indexMergeConds))
 	// fill the possible indexMergeConds down to possible index merge paths. If two index merge path
 	// share same accessFilters, pick the one with minimum countAfterAccess.
 	type record struct {
 		originOffset     int
 		paths            []*util.AccessPath
 		countAfterAccess float64
+		accessFilters    []expression.Expression
 	}
 	// mm is a map here used for de-duplicate partial paths which is derived from **same** accessFilters, not necessary to keep them both.
-	mm := make(map[string]*record, 0)
+	mm := make(map[string][]*record)
 	for idx := range possibleMVIndexPaths {
 		idxCols, ok := PrepareIdxColsAndUnwrapArrayType(
 			ds.Table.Meta(),
@@ -447,8 +482,10 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 		}
 		// record the all hashcodes before accessFilters is mutated.
 		allHashCodes := make([]string, 0, len(accessFilters)+len(mvFilterMutations)-1)
+		allAccessFilters := make([]expression.Expression, 0, len(accessFilters)+len(mvFilterMutations)-1)
 		for _, accessF := range accessFilters {
 			allHashCodes = append(allHashCodes, string(accessF.HashCode()))
+			allAccessFilters = append(allAccessFilters, accessF)
 		}
 		for i, mvF := range mvFilterMutations {
 			if i == 0 {
@@ -456,6 +493,7 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 				continue
 			}
 			allHashCodes = append(allHashCodes, string(mvF.HashCode()))
+			allAccessFilters = append(allAccessFilters, mvF)
 		}
 		// in traveling of these mv index conditions, we can only use one of them to build index merge path, just fetch it out first.
 		// build index merge partial path for every mutation combination access filters.
@@ -480,7 +518,7 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 			//		And(path1, path2, And(path3, path4)) => And(path1, path2, path3, path4, merge(table-action like filter)
 			if len(partialPaths) == 1 || isIntersection {
 				for _, accessF := range accessFilters {
-					usedAccessCondsMap[string(accessF.HashCode())] = accessF
+					usedAccessCondsMap.add(accessF)
 				}
 				partialPaths4ThisMvIndex = append(partialPaths4ThisMvIndex, partialPaths...)
 			}
@@ -489,18 +527,33 @@ func generateMVIndexMergePartialPaths4And(ds *logicalop.DataSource, normalPathCn
 		slices.Sort(allHashCodes)
 		allHashCodesKey := strings.Join(allHashCodes, "")
 		countAfterAccess := float64(histColl.RealtimeCount) * cardinality.CalcTotalSelectivityForMVIdxPath(histColl, partialPaths4ThisMvIndex, true)
-		if rec, ok := mm[allHashCodesKey]; !ok {
-			// compute the count after access from those intersection partial paths, for this mv index usage.
-			mm[allHashCodesKey] = &record{idx, partialPaths4ThisMvIndex, countAfterAccess}
-		} else {
-			// pick the minimum countAfterAccess's paths.
-			if rec.countAfterAccess > countAfterAccess {
-				mm[allHashCodesKey] = &record{idx, partialPaths4ThisMvIndex, countAfterAccess}
+		newRecord := &record{
+			originOffset:     idx,
+			paths:            partialPaths4ThisMvIndex,
+			countAfterAccess: countAfterAccess,
+			accessFilters:    allAccessFilters,
+		}
+		records := mm[allHashCodesKey]
+		matchedRecord := -1
+		for i, rec := range records {
+			if sameExpressionMultiset(rec.accessFilters, allAccessFilters) {
+				matchedRecord = i
+				break
 			}
+		}
+		if matchedRecord == -1 {
+			// Compute the count after access from those intersection partial paths for this MV index usage.
+			mm[allHashCodesKey] = append(records, newRecord)
+		} else if records[matchedRecord].countAfterAccess > countAfterAccess {
+			// Pick the paths with the minimum countAfterAccess among identical access filters.
+			records[matchedRecord] = newRecord
 		}
 	}
 	// after all mv index is traversed, pick those remained paths which has already been de-duplicated for its accessFilters.
-	recordsCollection := slices.Collect(maps.Values(mm))
+	var recordsCollection []*record
+	for _, records := range mm {
+		recordsCollection = append(recordsCollection, records...)
+	}
 	// according origin offset to stable the partial paths order. (golang map is not order stable)
 	slices.SortFunc(recordsCollection, func(a, b *record) int {
 		return cmp.Compare(a.originOffset, b.originOffset)
@@ -685,19 +738,19 @@ func generateANDIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt
 	// collect the remained CNF conditions
 	var remainedCNFs []expression.Expression
 	for _, CNFItem := range indexMergeConds {
-		if _, ok := usedAccessMap[string(CNFItem.HashCode())]; !ok {
+		if !usedAccessMap.contains(CNFItem) {
 			remainedCNFs = append(remainedCNFs, CNFItem)
 		}
 	}
 
-	condInIdxFilter := make(map[string]struct{}, len(remainedCNFs))
+	condInIdxFilter := make(expressionHashSet, len(remainedCNFs))
 	// try to derive index filters for each path
 	for _, path := range combinedPartialPaths {
 		idxFilters, _ := splitIndexFilterConditions(ds, remainedCNFs, path.FullIdxCols, path.FullIdxColLens)
 		idxFilters = util.CloneExprs(idxFilters)
 		path.IndexFilters = append(path.IndexFilters, idxFilters...)
 		for _, idxFilter := range idxFilters {
-			condInIdxFilter[string(idxFilter.HashCode())] = struct{}{}
+			condInIdxFilter.add(idxFilter)
 		}
 	}
 
@@ -706,7 +759,7 @@ func generateANDIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt
 	// the table filters.
 	var tableFilters []expression.Expression
 	for _, CNFItem := range remainedCNFs {
-		if _, ok := condInIdxFilter[string(CNFItem.HashCode())]; !ok {
+		if !condInIdxFilter.contains(CNFItem) {
 			tableFilters = append(tableFilters, CNFItem)
 		}
 	}

--- a/pkg/planner/core/util_test.go
+++ b/pkg/planner/core/util_test.go
@@ -20,9 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +38,60 @@ var (
 	_ ast.InPlaceVisitor = (*AggregateFuncExtractor)(nil)
 	_ ast.InPlaceVisitor = (*WindowFuncExtractor)(nil)
 )
+
+func TestExpressionHashSetHandlesHashCollisions(t *testing.T) {
+	newConstant := func(collation string) *expression.Constant {
+		return &expression.Constant{
+			Value: types.NewStringDatum("A"),
+			RetType: types.NewFieldTypeBuilder().
+				SetType(mysql.TypeVarString).
+				SetCharset(charset.CharsetUTF8MB4).
+				SetCollate(collation).
+				BuildP(),
+		}
+	}
+
+	caseInsensitive := newConstant("utf8mb4_general_ci")
+	binary := newConstant(charset.CollationUTF8MB4)
+	require.Equal(t, caseInsensitive.HashCode(), binary.HashCode())
+	require.False(t, caseInsensitive.Equals(binary))
+	require.False(t, expression.HashCodeEqual(caseInsensitive, binary))
+
+	set := make(expressionHashSet)
+	require.True(t, set.add(caseInsensitive))
+	require.False(t, set.add(caseInsensitive.Clone()))
+	require.True(t, set.add(binary))
+	require.True(t, set.contains(caseInsensitive))
+	require.True(t, set.contains(binary))
+	require.Len(t, set, 1)
+
+	firstColumn := &expression.Column{
+		UniqueID: 1,
+		Index:    0,
+		OrigName: "first",
+		RetType:  types.NewFieldType(mysql.TypeLonglong),
+	}
+	secondColumn := &expression.Column{
+		UniqueID: 1,
+		Index:    1,
+		OrigName: "second",
+		RetType:  types.NewFieldType(mysql.TypeLonglong),
+	}
+	require.Equal(t, firstColumn.HashCode(), secondColumn.HashCode())
+	require.False(t, firstColumn.Equals(secondColumn))
+	require.True(t, expression.HashCodeEqual(firstColumn, secondColumn))
+	require.True(t, set.add(firstColumn))
+	require.False(t, set.add(secondColumn))
+
+	require.True(t, sameExpressionMultiset(
+		[]expression.Expression{caseInsensitive, binary},
+		[]expression.Expression{binary, caseInsensitive},
+	))
+	require.False(t, sameExpressionMultiset(
+		[]expression.Expression{caseInsensitive},
+		[]expression.Expression{binary},
+	))
+}
 
 func tableNamesAsStr(tableNames []*ast.TableName) string {
 	names := []string{}


### PR DESCRIPTION
Expression hash codes do not encode all semantic properties, including collation, so distinct predicates can collide during common-condition extraction. Verify structural equality before counting or removing extracted predicates, and cover the collation collision regression.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70645

Problem Summary:

DNF common-condition extraction used `Expression.HashCode()` as proof that predicates were equivalent. However, the hash does not encode every semantic property, including collation.

As a result, predicates such as case-insensitive and binary-collation comparisons could share the same hash. TiDB could then incorrectly extract or remove a collation-distinct predicate, causing wrong query results.

In the regression case, TiDB returned rows `[1, 2, 3, 4]` instead of the expected `[1, 2, 3]`.

### What changed and how does it work?

Keep using `HashCode()` for efficient predicate lookup, but verify matches with `Expression.Equals()` before:

  1. Counting a predicate as a common DNF condition.
  2. Removing an extracted predicate from individual DNF branches.

This prevents hash collisions from being treated as semantic equality while preserving the existing common-condition extraction behavior for genuinely equivalent predicates.

A regression test covering mixed `utf8mb4_general_ci` and `utf8mb4_bin` predicates has also been added.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `SELECT` statements might return extra rows and `DELETE` statements might delete unintended rows when `OR` conditions compare strings using different collations [#70645](https://github.com/pingcap/tidb/issues/70645)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query condition handling for expressions that differ by collation.
  * Prevented incorrect filter extraction and expression deduplication when distinct conditions produce the same internal hash.
  * Improved the accuracy of JOIN, SELECT, and DELETE results involving mixed collations, JSON predicates, and index-merge plans.

* **Tests**
  * Added integration coverage for collation-related condition handling in JOIN, SELECT, and DELETE queries.
  * Added coverage for hash-collision scenarios across query planning and expression processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->