### PR TITLE
txn: add multi-key shared-lock upgrade tests

### DIFF
--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -406,6 +406,119 @@ func TestSharedLockUpgrade(t *testing.T) {
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
+	t.Run("upgrade_multiple_shared_locks_in_one_statement", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+		enableSharedLockUpgrade(tk)
+		prepareSharedLockUpgradeTables(tk, "")
+		tk.MustExec("insert into parent values (3, 0), (4, 0), (5, 0), (6, 0), (7, 0), (8, 0), (9, 0), (10, 0)")
+
+		tk.MustExec("begin pessimistic")
+		tk.MustExec("insert into child values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10)")
+		tk.MustExec("update parent set v = v + 1 where id between 1 and 10")
+		tk.MustExec("commit")
+
+		tk.MustQuery("select * from parent order by id").Check(testkit.Rows(
+			"1 1", "2 1", "3 1", "4 1", "5 1", "6 1", "7 1", "8 1", "9 1", "10 1",
+		))
+		tk.MustQuery("select * from child order by id").Check(testkit.Rows(
+			"1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "10 10",
+		))
+		tk.MustExec("admin check table parent")
+		tk.MustExec("admin check table child")
+	})
+
+	t.Run("upgrade_multiple_shared_locks_in_separate_statements", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+		enableSharedLockUpgrade(tk)
+		prepareSharedLockUpgradeTables(tk, "")
+		tk.MustExec("insert into parent values (3, 0), (4, 0), (5, 0), (6, 0), (7, 0), (8, 0), (9, 0), (10, 0)")
+
+		tk.MustExec("begin pessimistic")
+		tk.MustExec("insert into child values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10)")
+		for id := 1; id <= 10; id++ {
+			tk.MustExec(fmt.Sprintf("update parent set v = v + 1 where id = %d", id))
+		}
+		tk.MustExec("commit")
+
+		tk.MustQuery("select * from parent order by id").Check(testkit.Rows(
+			"1 1", "2 1", "3 1", "4 1", "5 1", "6 1", "7 1", "8 1", "9 1", "10 1",
+		))
+		tk.MustQuery("select * from child order by id").Check(testkit.Rows(
+			"1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "10 10",
+		))
+		tk.MustExec("admin check table parent")
+		tk.MustExec("admin check table child")
+	})
+
+	t.Run("upgrade_multiple_shared_locks_waits_for_shared_holder", func(t *testing.T) {
+		testCases := []struct {
+			name              string
+			releaseSQL        string
+			expectedChildRows [][]any
+		}{
+			{
+				name:       "holder_commits",
+				releaseSQL: "commit",
+				expectedChildRows: testkit.Rows(
+					"1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "10 10", "11 5",
+				),
+			},
+			{
+				name:       "holder_rolls_back",
+				releaseSQL: "rollback",
+				expectedChildRows: testkit.Rows(
+					"1 1", "2 2", "3 3", "4 4", "5 5", "6 6", "7 7", "8 8", "9 9", "10 10",
+				),
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				upgrader := testkit.NewTestKit(t, store)
+				holder := testkit.NewTestKit(t, store)
+				for _, tk := range []*testkit.TestKit{upgrader, holder} {
+					tk.MustExec("use test")
+					tk.MustExec("set @@tidb_foreign_key_check_in_shared_lock = ON")
+				}
+				enableSharedLockUpgrade(upgrader, holder)
+				prepareSharedLockUpgradeTables(upgrader, "")
+				upgrader.MustExec("insert into parent values (3, 0), (4, 0), (5, 0), (6, 0), (7, 0), (8, 0), (9, 0), (10, 0)")
+				parentTableID := external.GetTableByName(t, upgrader, "test", "parent").Meta().ID
+				blockedKey := tablecodec.EncodeRowKeyWithHandle(parentTableID, kv.IntHandle(5))
+
+				holder.MustExec("begin pessimistic")
+				holder.MustExec("insert into child values (11, 5)")
+
+				upgrader.MustExec("begin pessimistic")
+				upgraderTxn, err := upgrader.Session().Txn(false)
+				require.NoError(t, err)
+				upgrader.MustExec("insert into child values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10)")
+
+				upgradeDone := make(chan error, 1)
+				go func() {
+					upgradeDone <- upgrader.ExecToErr("update parent set v = v + 1 where id between 1 and 10")
+				}()
+
+				requireTxnLockAcquiring(t, upgrader)
+				requireStorageLockWait(t, store, upgraderTxn.StartTS(), blockedKey)
+				holder.MustExec(testCase.releaseSQL)
+				require.NoError(t, <-upgradeDone)
+				upgrader.MustExec("commit")
+
+				upgrader.MustQuery("select * from parent order by id").Check(testkit.Rows(
+					"1 1", "2 1", "3 1", "4 1", "5 1", "6 1", "7 1", "8 1", "9 1", "10 1",
+				))
+				upgrader.MustQuery("select * from child order by id").Check(testCase.expectedChildRows)
+				upgrader.MustExec("admin check table parent")
+				upgrader.MustExec("admin check table child")
+			})
+		}
+	})
+
 	t.Run("shared_lock_upgrade_waits_for_last_holder", func(t *testing.T) {
 		tk1 := testkit.NewTestKit(t, store)
 		tk2 := testkit.NewTestKit(t, store)

--- a/tests/realtikvtest/txntest/shared_lock_test.go
+++ b/tests/realtikvtest/txntest/shared_lock_test.go
@@ -506,7 +506,13 @@ func TestSharedLockUpgrade(t *testing.T) {
 				requireTxnLockAcquiring(t, upgrader)
 				requireStorageLockWait(t, store, upgraderTxn.StartTS(), blockedKey)
 				holder.MustExec(testCase.releaseSQL)
-				require.NoError(t, <-upgradeDone)
+				var upgradeErr error
+				select {
+				case upgradeErr = <-upgradeDone:
+				case <-time.After(10 * time.Second):
+					require.FailNow(t, "shared lock upgrader did not resume after holder release")
+				}
+				require.NoError(t, upgradeErr)
 				upgrader.MustExec("commit")
 
 				upgrader.MustQuery("select * from parent order by id").Check(testkit.Rows(


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #68815

Problem Summary:

The shared-lock upgrade acceptance tests only covered upgrading a single parent-row lock. They did not verify that one transaction can upgrade multiple shared locks, or that a multi-key upgrade waits for another shared-lock holder and resumes correctly after the holder releases its lock.

### What changed and how does it work?

- Add a next-gen RealTiKV case that upgrades 10 shared locks in one statement.
- Add a case that upgrades the same number of locks through separate statements in one transaction.
- Add commit and rollback variants where an external transaction holds a shared lock on the middle key. Verify that the multi-key update is blocked on that key, resumes after the holder finishes, commits successfully, and leaves consistent parent and child tables.
- Explicitly enable both foreign-key shared-lock checking and shared-lock upgrade in every new case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

- `GOTOOLCHAIN=go1.25.12 tests/realtikvtest/scripts/next-gen/run-with-container-minio.sh tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh bash -lc 'make failpoint-enable && go test -run "^TestSharedLockUpgrade$" -count=1 -timeout 5m -tags=intest,nextgen ./tests/realtikvtest/txntest -args -with-real-tikv'`
- `GOTOOLCHAIN=go1.25.12 make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for upgrading multiple shared locks within a single statement.
  * Added coverage for shared-lock upgrades across separate statements.
  * Added scenarios verifying upgrade blocking when another transaction holds a shared lock.
  * Added validation for commit and rollback outcomes, including row results and storage consistency.
  * Added a timeout to prevent blocked upgrade tests from waiting indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->