### PR TITLE
expression: fix incorrect CASE results in prepared statements

### DIFF
--- a/pkg/executor/prepared_test.go
+++ b/pkg/executor/prepared_test.go
@@ -162,6 +162,32 @@ func TestParameterPushDown(t *testing.T) {
 	}
 }
 
+func TestPreparedCaseFloatResult(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (c float)")
+	tk.MustExec("insert into t values (100000030)")
+	tk.MustExec("set @result = false")
+	tk.MustExec("prepare stmt from 'select c from t where c not like case when false then ? else c end'")
+	tk.MustQuery("execute stmt using @result").Check(testkit.Rows())
+	tk.MustExec("deallocate prepare stmt")
+
+	tk.MustExec("set @condition = true")
+	tk.MustExec("prepare control from 'select case when ? then 1 else 2 end'")
+	tk.MustQuery("execute control using @condition").Check(testkit.Rows("1"))
+	tk.MustExec("set @condition = false")
+	tk.MustQuery("execute control using @condition").Check(testkit.Rows("2"))
+	tk.MustExec("deallocate prepare control")
+
+	tk.MustExec("set @selected = 1")
+	tk.MustExec("prepare selected from 'select case when true then ? else 2 end'")
+	tk.MustQuery("execute selected using @selected").Check(testkit.Rows("1"))
+	tk.MustExec("set @selected = 3")
+	tk.MustQuery("execute selected using @selected").Check(testkit.Rows("3"))
+	tk.MustExec("deallocate prepare selected")
+}
+
 func TestPrepareStmtAfterIsolationReadChange(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -169,8 +169,24 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 			// we should not fold the extension function, because it may have a side effect.
 			return expr, false
 		}
-		if function := specialFoldHandler[x.FuncName.L]; function != nil && !MaybeOverOptimized4PlanCache(ctx, expr) {
-			return function(ctx, x)
+		if function := specialFoldHandler[x.FuncName.L]; function != nil {
+			canFold := true
+			if x.FuncName.L == ast.Case {
+				// A mutable result arm does not affect which CASE branch is selected.
+				// Only mutable WHEN conditions make branch elimination unsafe for plan cache.
+				args := x.GetArgs()
+				for i := 0; i < len(args)-1; i += 2 {
+					if MaybeOverOptimized4PlanCache(ctx, args[i]) {
+						canFold = false
+						break
+					}
+				}
+			} else {
+				canFold = !MaybeOverOptimized4PlanCache(ctx, expr)
+			}
+			if canFold {
+				return function(ctx, x)
+			}
 		}
 
 		args := x.GetArgs()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62717

Problem Summary:

In a prepared statement, a parameter marker in any result arm of a `CASE` expression caused TiDB to skip the special constant-folding logic, even when all `WHEN` conditions were static and the parameterized arm could not be selected.

As a result, the remaining `CASE` expression could apply unnecessary result-type conversion to the selected `FLOAT` value. This caused the prepared statement to return a different result from the equivalent non-prepared query.

### What changed and how does it work?

Apply the plan-cache safety check only to the `WHEN` conditions when performing special constant folding for a `CASE` expression.

A mutable result arm does not affect which branch is selected, so it should not prevent TiDB from eliminating branches selected by static conditions. Mutable `WHEN` conditions still disable branch elimination, and a selected parameterized result remains evaluated at execution time.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that a `CASE` expression might return an incorrect `FLOAT` value in a prepared statement when an unselected result branch contains a parameter marker [#62717](https://github.com/pingcap/tidb/issues/62717)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation of `CASE` expressions involving floating-point values and user variables.
  - Corrected constant handling for `CASE` expressions so variable-based result branches are evaluated reliably, including when queries use plan caching.

- **Tests**
  - Added coverage for `CASE` expressions in filtering, selected results, and conditional variable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->