### PR TITLE
expression:  fix inconsistent JSON evaluation in boolean contexts

### DIFF
--- a/pkg/executor/select_test.go
+++ b/pkg/executor/select_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -67,4 +68,16 @@ func TestImportIntoShouldHaveSameFlagsAsInsert(t *testing.T) {
 			require.EqualValues(t, insertTypeCtx.Flags(), importTypeCtx.Flags())
 		})
 	}
+}
+
+func TestJSONBooleanContext(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (j json)")
+	tk.MustExec("insert into t values ('[1384012953742982754,2947325532971048317]'), ('[1150596447037189411,2407534394954758420]')")
+
+	const predicate = "j <=> '[1150596447037189411,2407534394954758420]'"
+	tk.MustQuery("select j from (select j from t limit 1000) x where " + predicate).Check(testkit.Rows())
+	tk.MustQuery("select j from (select j from t limit 1000) x where case when (j or not j or j is null) then " + predicate + " else 1 end").Check(testkit.Rows())
 }

--- a/pkg/executor/select_test.go
+++ b/pkg/executor/select_test.go
@@ -74,10 +74,16 @@ func TestJSONBooleanContext(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("create table t (j json)")
-	tk.MustExec("insert into t values ('[1384012953742982754,2947325532971048317]'), ('[1150596447037189411,2407534394954758420]')")
+	tk.MustExec("create table json_source (j json, join_key tinyint)")
+	tk.MustExec("create table string_source (join_key varchar(10))")
+	tk.MustExec("insert into json_source values ('[1384012953742982754,2947325532971048317,4925217513105514339,7040190206842180156,1351707314467911462]', 7)")
+	tk.MustExec("insert into string_source values ('7a')")
 
 	const predicate = "j <=> '[1150596447037189411,2407534394954758420]'"
-	tk.MustQuery("select j from (select j from t limit 1000) x where " + predicate).Check(testkit.Rows())
-	tk.MustQuery("select j from (select j from t limit 1000) x where case when (j or not j or j is null) then " + predicate + " else 1 end").Check(testkit.Rows())
+	const joinPredicate = "s.join_key = t.join_key"
+	const caseJoin = "select s.j from json_source s join string_source t on ((" + joinPredicate + " or not " + joinPredicate + " or " + joinPredicate + " is null) and " + joinPredicate + ") limit 1000"
+	tk.MustQuery("select j from (" + caseJoin + ") x where case when (j or not j or j is null) then " + predicate + " else 1 end").Check(testkit.Rows())
+	tk.MustQuery("show count(*) warnings").Check(testkit.Rows("7"))
+	tk.MustQuery("select j from (select s.j from json_source s join string_source t on " + joinPredicate + " limit 1000) x where " + predicate).Check(testkit.Rows())
+	tk.MustQuery("show count(*) warnings").Check(testkit.Rows("4"))
 }

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -483,7 +483,7 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 	}
 
 	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
-	if argTp == types.ETTimestamp || argTp == types.ETDatetime || argTp == types.ETDuration || argTp == types.ETJson || argTp == types.ETString {
+	if argTp == types.ETTimestamp || argTp == types.ETDatetime || argTp == types.ETDuration || argTp == types.ETString {
 		argTp = types.ETReal
 	}
 
@@ -518,6 +518,9 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_IntIsTrue)
 			}
+		case types.ETJson:
+			ctx.GetEvalCtx().AppendWarning(errJSONInBooleanContext)
+			sig = &builtinJSONIsTrueSig{bf, c.keepNull}
 		case types.ETVectorFloat32:
 			sig = &builtinVectorFloat32IsTrueSig{bf, c.keepNull}
 			// if c.keepNull {
@@ -551,6 +554,9 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 			} else {
 				sig.setPbCode(tipb.ScalarFuncSig_IntIsFalse)
 			}
+		case types.ETJson:
+			ctx.GetEvalCtx().AppendWarning(errJSONInBooleanContext)
+			sig = &builtinJSONIsFalseSig{bf}
 		case types.ETVectorFloat32:
 			sig = &builtinVectorFloat32IsFalseSig{bf, c.keepNull}
 			// if c.keepNull {
@@ -647,6 +653,35 @@ func (b *builtinIntIsTrueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 		return 0, true, nil
 	}
 	if isNull || input == 0 {
+		return 0, false, nil
+	}
+	return 1, false, nil
+}
+
+type builtinJSONIsTrueSig struct {
+	baseBuiltinFunc
+	keepNull bool
+
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinJSONIsTrueSig) Clone() builtinFunc {
+	newSig := &builtinJSONIsTrueSig{keepNull: b.keepNull}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinJSONIsTrueSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
+	input, isNull, err := b.args[0].EvalJSON(ctx, row)
+	if err != nil {
+		return 0, true, err
+	}
+	if b.keepNull && isNull {
+		return 0, true, nil
+	}
+	if isNull || input.IsZero() {
 		return 0, false, nil
 	}
 	return 1, false, nil
@@ -759,6 +794,31 @@ func (b *builtinIntIsFalseSig) evalInt(ctx EvalContext, row chunk.Row) (int64, b
 		return 0, true, nil
 	}
 	if isNull || input != 0 {
+		return 0, false, nil
+	}
+	return 1, false, nil
+}
+
+type builtinJSONIsFalseSig struct {
+	baseBuiltinFunc
+
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinJSONIsFalseSig) Clone() builtinFunc {
+	newSig := &builtinJSONIsFalseSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinJSONIsFalseSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
+	input, isNull, err := b.args[0].EvalJSON(ctx, row)
+	if err != nil {
+		return 0, true, err
+	}
+	if isNull || !input.IsZero() {
 		return 0, false, nil
 	}
 	return 1, false, nil

--- a/pkg/expression/builtin_op_test.go
+++ b/pkg/expression/builtin_op_test.go
@@ -618,6 +618,26 @@ func TestIsTrueOrFalse(t *testing.T) {
 			isTrue:  0,
 			isFalse: 1,
 		},
+		{
+			args:    []any{types.CreateBinaryJSON(int64(0))},
+			isTrue:  0,
+			isFalse: 1,
+		},
+		{
+			args:    []any{types.CreateBinaryJSON(int64(1))},
+			isTrue:  1,
+			isFalse: 0,
+		},
+		{
+			args:    []any{types.CreateBinaryJSON([]any{int64(1), int64(2)})},
+			isTrue:  1,
+			isFalse: 0,
+		},
+		{
+			args:    []any{types.CreateBinaryJSON(map[string]any{"key": int64(0)})},
+			isTrue:  1,
+			isFalse: 0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -639,6 +659,17 @@ func TestIsTrueOrFalse(t *testing.T) {
 		require.NoError(t, err)
 		testutil.DatumEqual(t, types.NewDatum(tc.isFalse), isFalse)
 	}
+
+	jsonNull := &Constant{Value: types.NewDatum(nil), RetType: types.NewFieldType(mysql.TypeJSON)}
+	isTrueWithNullSig, err := funcs[ast.IsTruthWithNull].getFunction(ctx, []Expression{jsonNull})
+	require.NoError(t, err)
+	require.True(t, isTrueWithNullSig.SafeToShareAcrossSession())
+	clonedJSONSig, ok := isTrueWithNullSig.Clone().(*builtinJSONIsTrueSig)
+	require.True(t, ok)
+	require.True(t, clonedJSONSig.keepNull)
+	isTrueWithNull, err := evalBuiltinFunc(isTrueWithNullSig, ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindNull, isTrueWithNull.Kind())
 }
 
 func TestLogicXor(t *testing.T) {

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -800,6 +800,61 @@ func (b *builtinIntIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	return nil
 }
 
+func (b *builtinJSONIsTrueSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinJSONIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := range numRows {
+		isNull := buf.IsNull(i)
+		if b.keepNull && isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		if !isNull && !buf.GetJSON(i).IsZero() {
+			i64s[i] = 1
+		}
+	}
+	return nil
+}
+
+func (b *builtinJSONIsFalseSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinJSONIsFalseSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := range numRows {
+		if !buf.IsNull(i) && buf.GetJSON(i).IsZero() {
+			i64s[i] = 1
+		}
+	}
+	return nil
+}
+
 func (b *builtinDurationIsNullSig) vectorized() bool {
 	return true
 }

--- a/pkg/expression/builtin_op_vec_test.go
+++ b/pkg/expression/builtin_op_vec_test.go
@@ -157,6 +157,36 @@ func makeBinaryLogicOpDataGeners() []dataGenerator {
 
 func TestVectorizedBuiltinOpFunc(t *testing.T) {
 	testVectorizedBuiltinFunc(t, vecBuiltinOpCases)
+
+	jsonValues := []any{
+		types.CreateBinaryJSON(int64(0)),
+		types.CreateBinaryJSON(int64(1)),
+		types.CreateBinaryJSON([]any{int64(1), int64(2)}),
+		types.CreateBinaryJSON(map[string]any{"key": int64(0)}),
+		nil,
+	}
+	for _, funcName := range []string{ast.IsTruthWithoutNull, ast.IsTruthWithNull, ast.IsFalsity} {
+		ctx := createContext(t)
+		baseFunc, _, input, result := genVecBuiltinFuncBenchCase(ctx, funcName, vecExprBenchCase{
+			retEvalType:   types.ETInt,
+			childrenTypes: []types.EvalType{types.ETJson},
+			geners:        []dataGenerator{makeGivenValsOrDefaultGener(jsonValues, types.ETJson)},
+			chunkSize:     len(jsonValues),
+		})
+		require.Equal(t, uint16(1), ctx.GetSessionVars().StmtCtx.WarningCount())
+		ctx.GetSessionVars().StmtCtx.SetWarnings(nil)
+
+		require.NoError(t, baseFunc.vecEvalInt(ctx, input, result))
+		for i := range input.NumRows() {
+			scalar, isNull, err := baseFunc.evalInt(ctx, input.GetRow(i))
+			require.NoError(t, err)
+			require.Equal(t, result.IsNull(i), isNull)
+			if !isNull {
+				require.Equal(t, result.GetInt64(i), scalar)
+			}
+		}
+		require.Equal(t, uint16(0), ctx.GetSessionVars().StmtCtx.WarningCount())
+	}
 }
 
 func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {

--- a/pkg/expression/builtin_threadsafe_generated.go
+++ b/pkg/expression/builtin_threadsafe_generated.go
@@ -1400,6 +1400,16 @@ func (s *builtinJSONInsertSig) SafeToShareAcrossSession() bool {
 }
 
 // SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
+func (s *builtinJSONIsFalseSig) SafeToShareAcrossSession() bool {
+	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
+}
+
+// SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
+func (s *builtinJSONIsTrueSig) SafeToShareAcrossSession() bool {
+	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
+}
+
+// SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
 func (s *builtinJSONKeys2ArgsSig) SafeToShareAcrossSession() bool {
 	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
 }

--- a/pkg/expression/generator/builtin_threadsafe.go
+++ b/pkg/expression/generator/builtin_threadsafe.go
@@ -39,6 +39,7 @@ var (
 		"builtinRealIsTrueSig":     {},
 		"builtinDecimalIsTrueSig":  {},
 		"builtinIntIsTrueSig":      {},
+		"builtinJSONIsTrueSig":     {},
 		"builtinRealIsFalseSig":    {},
 		"builtinDecimalIsFalseSig": {},
 		"builtinIntIsFalseSig":     {},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61209

Problem Summary:

TiDB previously used inconsistent rules when evaluating JSON values in Boolean contexts.

For positive truth tests such as `IS TRUE`, TiDB classified JSON expressions as `ETReal` and converted their values to `REAL` before determining whether they were true or false. However, unary `NOT` already evaluated JSON values using the native `BinaryJSON.IsZero()` semantics.

These two evaluation paths can produce different truth values for non-scalar JSON values such as arrays and objects. For example, the following three-valued Boolean expression should always be true:

  ```sql
  j OR NOT j OR j IS NULL
  ```

For every row:

  - A non-NULL true value satisfies `j`.
  - A non-NULL false value satisfies `NOT j`.
  - A NULL value satisfies `j IS NULL`.

Before this change, a JSON array could be treated as false after conversion to `REAL`, while `NOT` treated the same array as non-zero according to native JSON semantics. Consequently, both `j` and `NOT j` could evaluate to false for the same non-NULL value.

In the query reported in #61209, this inconsistency caused the `WHEN` condition of a `CASE` expression to evaluate incorrectly. TiDB then selected the `ELSE 1` branch and returned rows that should have been filtered out.


### What changed and how does it work?

This PR makes all JSON truth tests use native JSON Boolean semantics consistently.

#### 1. Keep JSON values in the JSON evaluation domain

`isTrueOrFalseFunctionClass.getFunction` no longer converts `ETJson` to `ETReal`.

Instead, JSON arguments are dispatched to dedicated JSON implementations:

  - `builtinJSONIsTrueSig` for `IS TRUE` and the internal true-with-NULL variant.
  - `builtinJSONIsFalseSig` for `IS FALSE`.

Timestamp, datetime, duration, and string values continue to use the existing `REAL` conversion path. Therefore, the change is limited to JSON expressions.

#### 2. Use `BinaryJSON.IsZero()` for scalar truth evaluation

The new scalar implementations evaluate the argument with `EvalJSON()` and determine its truth value using `BinaryJSON.IsZero()`.

The behavior is:

  - A non-NULL JSON zero value is false.
  - A non-NULL JSON non-zero value is true.
  - `IS TRUE` without NULL preservation treats SQL `NULL` as false.
  - The internal true-with-NULL variant preserves SQL `NULL`.
  - `IS FALSE` returns true only for a non-NULL JSON zero value.

This is consistent with the existing JSON implementation of unary `NOT`.

#### 3. Preserve NULL behavior with one immutable signature

Both true variants share `builtinJSONIsTrueSig`. Its immutable `keepNull` field controls whether SQL `NULL` is returned as NULL or converted to false.

The `Clone()` implementation explicitly copies `keepNull`, ensuring that cloned expressions retain the same NULL behavior.

`builtinJSONIsFalseSig` does not need such a field because TiDB does not register a false-with-NULL variant.

#### 4. Add native vectorized JSON evaluation

This PR adds vectorized implementations for both JSON truth signatures.

The vectorized path:

  1. Evaluates the input column with `VecEvalJSON()`.
  2. Reuses a temporary JSON column from the buffer allocator.
  3. Applies `BinaryJSON.IsZero()` to each non-NULL value.
  4. Preserves NULLs only when `keepNull` is enabled.
  5. Produces the same value and NULL result as scalar evaluation.

This avoids falling back to row-by-row scalar execution for vectorized expressions.

#### 5. Preserve the existing warning behavior

Using a JSON value in a Boolean context continues to append `errJSONInBooleanContext`.

The warning is generated once while the function is constructed. Scalar and vectorized evaluation do not generate additional warnings.

The tests explicitly verify both the construction-time warning and the absence of duplicate evaluation-time warnings.

#### 6. Keep the new evaluation at the TiDB root

The new JSON truth signatures do not assign a TiPB scalar-function code.

Therefore, JSON truth evaluation remains in TiDB instead of being pushed down to TiKV or TiFlash. This keeps the change within the TiDB expression layer and avoids introducing an unsupported storage-engine expression signature.

#### 7. Update generated cross-session safety metadata

The new signatures contain only immutable execution state and cloned base-function state.

The thread-safety generator is updated to recognize `builtinJSONIsTrueSig`, and `builtin_threadsafe_generated.go` is regenerated so both JSON signatures implement `SafeToShareAcrossSession()`.




### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that queries might return incorrect results when JSON values are evaluated in Boolean contexts such as `OR`, `NOT`, `IS TRUE`, or `IS FALSE` [#61209](https://github.com/pingcap/tidb/issues/61209)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `IS TRUE` and `IS FALSE` handling for JSON values, including numbers, arrays, objects, and `NULL`.
  * JSON values now produce appropriate boolean results without unintended type coercion.
  * Preserved expected warnings and `NULL` behavior in boolean contexts, including joined queries and conditional expressions.
  * Ensured batch evaluation produces results consistent with scalar evaluation across supported JSON values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->