### PR TITLE
types: preserve significant words in decimal multiplication

### DIFF
--- a/pkg/types/mydecimal.go
+++ b/pkg/types/mydecimal.go
@@ -2088,13 +2088,24 @@ func DecimalMul(from1, from2, to *MyDecimal) error {
 			wordsFrac2 = 0
 		} else {
 			tmp2 -= wordsFracTo
-			tmp1 = tmp2 >> 1
-			if wordsFrac1 <= wordsFrac2 {
-				wordsFrac1 -= tmp1
-				wordsFrac2 -= tmp2 - tmp1
-			} else {
-				wordsFrac2 -= tmp1
-				wordsFrac1 -= tmp2 - tmp1
+			// Discard whole trailing zero words before significant fractional words.
+			for tmp2 > 0 && wordsFrac1 > 0 && from1.wordBuf[idx1+wordsFrac1-1] == 0 {
+				wordsFrac1--
+				tmp2--
+			}
+			for tmp2 > 0 && wordsFrac2 > 0 && from2.wordBuf[idx2+wordsFrac2-1] == 0 {
+				wordsFrac2--
+				tmp2--
+			}
+			if tmp2 > 0 {
+				tmp1 = tmp2 >> 1
+				if wordsFrac1 <= wordsFrac2 {
+					wordsFrac1 -= tmp1
+					wordsFrac2 -= tmp2 - tmp1
+				} else {
+					wordsFrac2 -= tmp1
+					wordsFrac1 -= tmp2 - tmp1
+				}
 			}
 		}
 	}

--- a/pkg/types/mydecimal_test.go
+++ b/pkg/types/mydecimal_test.go
@@ -702,6 +702,31 @@ func TestMulMyDecimal(t *testing.T) {
 	}
 }
 
+func TestMulMyDecimalTrailingZeroPrecision(t *testing.T) {
+	tests := []struct {
+		factor string
+		mulErr error
+	}{
+		{"41.18903250000", ErrTruncated},
+		{"41.1890325000", nil},
+	}
+
+	for _, tt := range tests {
+		var left, factor, right, partial MyDecimal
+		require.NoError(t, left.FromString([]byte("119.00000000")))
+		require.NoError(t, factor.FromString([]byte(tt.factor)))
+		require.NoError(t, right.FromString([]byte("0.1402072262804424940061410765110833812375")))
+		require.NoError(t, DecimalMul(&left, &factor, &partial))
+
+		for _, operands := range [][2]*MyDecimal{{&partial, &right}, {&right, &partial}} {
+			var product, rounded MyDecimal
+			require.Equal(t, tt.mulErr, DecimalMul(operands[0], operands[1], &product))
+			require.NoError(t, product.Round(&rounded, 2, ModeHalfUp))
+			require.Equal(t, "687.23", string(rounded.ToString()))
+		}
+	}
+}
+
 func TestDivModMyDecimal(t *testing.T) {
 	type tcase struct {
 		a      string


### PR DESCRIPTION
When a decimal product exceeds the fixed word buffer, discard redundant trailing zero fractional words before significant words. Add coverage for equivalent decimal literals that previously rounded differently.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59504

Problem Summary:

TiDB can return different rounded results for numerically equivalent high-precision decimal expressions when one operand contains an additional trailing zero. 

For example, these two expressions differ only in the scale of the second operand:

  ```sql
  SELECT ROUND(
      119.00000000 *
      41.18903250000 *
      0.1402072262804424940061410765110833812375,
      2
  );

  SELECT ROUND(
      119.00000000 *
      41.1890325000 *
      0.1402072262804424940061410765110833812375,
      2
  );
  ```

Before this change, TiDB returned:

  - `687.22` for `41.18903250000`
  - `687.23` for `41.1890325000`

The two decimal literals represent the same numeric value, so their redundant trailing zeros should not affect the result. MySQL 8.0 returns `687.23` for both expressions.

`MyDecimal` stores decimal digits in a fixed-size buffer of nine words, with each word containing nine decimal digits. When the result of `DecimalMul` requires more fractional words than the buffer can hold, the existing implementation reduces the number of fractional words participating in the multiplication.

Previously, the required reduction was distributed between the two operands based only on their fractional word counts. This could retain a fractional word containing only trailing zeros from one operand while discarding a significant fractional word from the other operand. As a result, redundant trailing zeros could reduce the effective multiplication precision and change the final rounded value.

### What changed and how does it work?

This PR changes the fractional truncation handling in `DecimalMul`:

1. When the product exceeds the fixed `MyDecimal` word-buffer capacity, inspect the least-significant fractional words of both operands.
2. Exclude complete trailing fractional words whose value is zero before excluding any significant words.
3. Reduce the number of words still needing truncation for every zero word excluded.
4. If additional words must still be removed, apply the existing balanced truncation logic to the remaining significant fractional words.

The change only adjusts local word ranges used by the multiplication. It does not modify the input decimal values.

This preserves more significant digits while keeping the existing result-scale and error behavior. In particular, the long-scale test case still returns `ErrTruncated`, but its retained digits now produce the correct rounded result.

The additional scans run only when decimal multiplication has already entered the fractional truncation path. They are bounded by the fixed nine-word `MyDecimal` buffer, so no material performance impact is expected for ordinary decimal multiplication.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
- `make bazel_prepare` passed without producing generated metadata changes.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that multiplying high-precision DECIMAL values might return different rounded results for numerically equivalent operands that differ only in trailing zeros (#59504)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decimal multiplication precision when inputs contain trailing fractional zeros.
  - Corrected truncation behavior when multiplication results exceed available precision.
  - Ensured consistent results regardless of operand order and rounding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->