### PR TITLE
expression: prefer earlier time in UNIX_TIMESTAMP DST overlap

### DIFF
--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -4463,6 +4463,26 @@ func goTimeToMysqlUnixTimestamp(t time.Time, decimal int) (*types.MyDecimal, err
 	return dec, err
 }
 
+// adjustUnixTimestampForDSTOverlap makes UNIX_TIMESTAMP prefer the earlier
+// occurrence of an ambiguous wall time during a backward offset transition.
+func adjustUnixTimestampForDSTOverlap(val types.Time, t time.Time) time.Time {
+	zoneStart, _ := t.ZoneBounds()
+	if zoneStart.IsZero() {
+		return t
+	}
+	_, currentOffset := t.Zone()
+	_, previousOffset := zoneStart.Add(-time.Nanosecond).Zone()
+	if previousOffset <= currentOffset {
+		return t
+	}
+
+	earlier := t.Add(time.Duration(currentOffset-previousOffset) * time.Second)
+	if types.FromGoTime(earlier) == val.CoreTime() {
+		return earlier
+	}
+	return t
+}
+
 type builtinUnixTimestampCurrentSig struct {
 	baseBuiltinFunc
 	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
@@ -4524,6 +4544,7 @@ func (b *builtinUnixTimestampIntSig) evalInt(ctx EvalContext, row chunk.Row) (in
 	if err != nil {
 		return 0, false, nil
 	}
+	t = adjustUnixTimestampForDSTOverlap(val, t)
 	dec, err := goTimeToMysqlUnixTimestamp(t, 1)
 	if err != nil {
 		return 0, true, err
@@ -4560,6 +4581,7 @@ func (b *builtinUnixTimestampDecSig) evalDecimal(ctx EvalContext, row chunk.Row)
 	if err != nil {
 		return new(types.MyDecimal), false, nil
 	}
+	t = adjustUnixTimestampForDSTOverlap(val, t)
 	result, err := goTimeToMysqlUnixTimestamp(t, b.tp.GetDecimal())
 	return result, err != nil, err
 }

--- a/pkg/expression/builtin_time_test.go
+++ b/pkg/expression/builtin_time_test.go
@@ -2272,6 +2272,60 @@ func TestUnixTimestamp(t *testing.T) {
 	}
 }
 
+func TestAdjustUnixTimestampForDSTOverlap(t *testing.T) {
+	tests := []struct {
+		name     string
+		zone     string
+		value    types.CoreTime
+		expected int64
+	}{
+		{
+			name:     "one hour overlap",
+			zone:     "Europe/Vilnius",
+			value:    types.FromDate(2020, 10, 25, 3, 45, 0, 0),
+			expected: 1603586700,
+		},
+		{
+			name:     "different transition hour",
+			zone:     "Europe/Amsterdam",
+			value:    types.FromDate(2020, 10, 25, 2, 35, 0, 0),
+			expected: 1603586100,
+		},
+		{
+			name:     "thirty minute overlap",
+			zone:     "Australia/Lord_Howe",
+			value:    types.FromDate(2020, 4, 5, 1, 45, 0, 0),
+			expected: 1586011500,
+		},
+		{
+			name:     "outside overlap",
+			zone:     "Europe/Vilnius",
+			value:    types.FromDate(2020, 6, 29, 3, 45, 0, 0),
+			expected: 1593391500,
+		},
+		{
+			name:     "fixed offset",
+			zone:     "UTC",
+			value:    types.FromDate(2020, 6, 29, 3, 45, 0, 0),
+			expected: 1593402300,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loc, err := time.LoadLocation(tt.zone)
+			require.NoError(t, err)
+			val := types.NewTime(tt.value, mysql.TypeDatetime, 0)
+			got, err := val.GoTime(loc)
+			require.NoError(t, err)
+
+			got = adjustUnixTimestampForDSTOverlap(val, got)
+			require.Equal(t, tt.expected, got.Unix())
+			require.Equal(t, val.CoreTime(), types.FromGoTime(got))
+		})
+	}
+}
+
 func TestDateArithFuncs(t *testing.T) {
 	ctx := createContext(t)
 	date := []string{"2016-12-31", "2017-01-01"}

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -1640,6 +1640,7 @@ func (b *builtinUnixTimestampDecSig) vecEvalDecimal(ctx EvalContext, input *chun
 				ts[i] = *new(types.MyDecimal)
 				continue
 			}
+			t = adjustUnixTimestampForDSTOverlap(timeBuf.GetTime(i), t)
 			tmp, err := goTimeToMysqlUnixTimestamp(t, b.tp.GetDecimal())
 			if err != nil {
 				return err
@@ -2351,6 +2352,7 @@ func (b *builtinUnixTimestampIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 				i64s[i] = 0
 				continue
 			}
+			t = adjustUnixTimestampForDSTOverlap(buf.GetTime(i), t)
 			dec, err := goTimeToMysqlUnixTimestamp(t, 1)
 			if err != nil {
 				return err

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4079,6 +4079,23 @@ func TestTimeBuiltin(t *testing.T) {
 	tk.MustExec("drop table t2")
 }
 
+func TestUnixTimestampDSTOverlap(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set time_zone = 'Europe/Vilnius'")
+
+	tk.MustQuery("select unix_timestamp('2020-10-25 03:45:00'), unix_timestamp('2020-10-25 03:45:00.123456')").
+		Check(testkit.Rows("1603586700 1603586700.123456"))
+
+	tk.MustExec("create table t_dst_overlap(dt datetime, dt6 datetime(6))")
+	tk.MustExec("insert into t_dst_overlap values ('2020-10-25 03:45:00', '2020-10-25 03:45:00.123456'), ('2020-10-25 04:45:00', '2020-10-25 04:45:00.123456')")
+	tk.MustQuery("select unix_timestamp(dt), unix_timestamp(dt6) from t_dst_overlap order by dt").Check(testkit.Rows(
+		"1603586700 1603586700.123456",
+		"1603593900 1603593900.123456",
+	))
+}
+
 func TestSetVariables(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59340

Problem Summary:

During a daylight saving time fall-back transition, the same local wall time can correspond to two different Unix timestamps.

For example:

  ```sql
  SET time_zone = 'Europe/Vilnius';
  SELECT UNIX_TIMESTAMP('2020-10-25 03:45:00');
  ```

`2020-10-25 03:45:00` occurs twice in `Europe/Vilnius` because the UTC offset changes backward. Both timestamps can be converted back to the same local wall time, but MySQL deterministically selects the earlier occurrence.

Before this change, TiDB selected the later occurrence and returned:

  ```text
  1603590300
  ```

MySQL returns the earlier occurrence:

  ```text
  1603586700
  ```

This caused `UNIX_TIMESTAMP()` to produce a result inconsistent with MySQL for ambiguous local times during DST fall-back transitions.


### What changed and how does it work?

This PR makes `UNIX_TIMESTAMP()` prefer the earlier occurrence of an ambiguous local time during a backward UTC-offset transition.

The implementation:

  1. Uses `time.Time.ZoneBounds()` to find the beginning of the current timezone interval.
  2. Compares the current UTC offset with the offset immediately before that interval.
  3. Detects a fall-back transition only when the previous offset is greater than the current offset.
  4. Calculates the earlier candidate using the exact offset difference. This does not assume that every DST transition is one hour and therefore also supports zones such as `Australia/Lord_Howe`, which has a 30-minute overlap.
  5. Converts the candidate back to a TiDB wall time and applies the adjustment only when it exactly matches the original input. This prevents non-ambiguous times from being changed.


The adjustment is applied consistently to:

  - Scalar integer `UNIX_TIMESTAMP()` evaluation
  - Scalar decimal `UNIX_TIMESTAMP()` evaluation
  - Vectorized integer evaluation
  - Vectorized decimal evaluation

Fixed-offset zones, forward transitions, and local times outside a DST overlap retain their existing behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `UNIX_TIMESTAMP()` might return the later of two possible timestamps for an ambiguous local time during a daylight saving time fall-back transition, causing a result inconsistent with MySQL (#59340)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `UNIX_TIMESTAMP` results for ambiguous local times during daylight-saving-time transitions.
  * Ensured both whole-second and fractional-second timestamps consistently select the earlier occurrence of overlapping times.
  * Improved behavior across multiple time zones while preserving correct results for non-overlapping and fixed-offset times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->