### PR TITLE
expression: fix fractional YEAR comparison refinement

### DIFF
--- a/pkg/executor/select_test.go
+++ b/pkg/executor/select_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -66,5 +67,41 @@ func TestImportIntoShouldHaveSameFlagsAsInsert(t *testing.T) {
 			importTypeCtx := importCtx.GetSessionVars().StmtCtx.TypeCtx()
 			require.EqualValues(t, insertTypeCtx.Flags(), importTypeCtx.Flags())
 		})
+	}
+}
+
+func TestYearComparisonTiKV(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_allow_mpp = 0")
+	tk.MustExec("create table t0(c0 year not null, index i0(c0))")
+	tk.MustExec("insert into t0 values (1935), (1982)")
+	tk.MustQuery("select /*+ read_from_storage(tikv[t0]) */ c0 from t0 where 0.025 <= c0").
+		Sort().Check(testkit.Rows("1935", "1982"))
+
+	tk.MustExec("truncate table t0")
+	tk.MustExec("insert into t0 values (0), (1901), (1935), (1982), (2000), (2001), (2155)")
+	tests := []struct {
+		op       string
+		constant string
+	}{
+		{">=", "-0.025"},
+		{">=", "0.025"},
+		{">", "0.025"},
+		{"<=", "0.025"},
+		{"<", "0.025"},
+		{">=", "69.5"},
+		{"<=", "1935.5"},
+		{">", "1935.5"},
+		{">=", "2155.5"},
+		{">=", "2.5e-2"},
+		{"<=", "1935.25e0"},
+		{">=", "1935.000"},
+	}
+	for _, tt := range tests {
+		indexedSQL := fmt.Sprintf("select /*+ use_index(t0, i0) */ c0 from t0 where c0 %s %s order by c0", tt.op, tt.constant)
+		referenceSQL := fmt.Sprintf("select c0 from t0 where cast(c0 as decimal(10, 3)) %s %s order by c0", tt.op, tt.constant)
+		require.Equal(t, tk.MustQuery(referenceSQL).Rows(), tk.MustQuery(indexedSQL).Rows(), indexedSQL)
 	}
 }

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1609,6 +1609,22 @@ func RefineComparedConstant(ctx BuildContext, targetFieldType types.FieldType, c
 			SubqueryRefID: con.SubqueryRefID,
 		}, false
 	}
+	if targetFieldType.GetType() == mysql.TypeYear &&
+		(op == opcode.LT || op == opcode.LE || op == opcode.GT || op == opcode.GE) {
+		// Converting a rounded fractional value to YEAR can apply two-digit-year adjustment
+		// and move the comparison boundary, so keep fractional YEAR bounds numeric.
+		switch con.GetType(evalCtx).EvalType() {
+		case types.ETReal:
+			value := dt.GetFloat64()
+			if value != math.Trunc(value) {
+				return con, false
+			}
+		case types.ETDecimal:
+			if _, decimalErr := dt.GetMysqlDecimal().ToInt(); decimalErr == types.ErrTruncated {
+				return con, false
+			}
+		}
+	}
 	switch op {
 	case opcode.LT, opcode.GE:
 		resultExpr := NewFunctionInternal(ctx, ast.Ceil, types.NewFieldType(mysql.TypeUnspecified), con)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59001

Problem Summary:

TiDB might return incorrect results when an indexed `YEAR` column is compared with a fractional numeric constant using an inequality operator.                                                             

For example:

  ```sql
  CREATE TABLE t0 (
      c0 YEAR NOT NULL,
      INDEX i0(c0)
  );

  INSERT INTO t0 VALUES (1935), (1982);

  SELECT /*+ READ_FROM_STORAGE(tikv[t0]) */
         c0
  FROM t0
  WHERE 0.025 <= c0;
  ```

Both stored `YEAR` values are numerically greater than `0.025`, so the expected result is:

  ```text
  1935
  1982
  ```

Before this change, the TiKV query returned an empty result, while TiFlash returned both rows.

The incorrect result was caused by constant refinement for integer-like columns. For the normalized predicate `c0 >= 0.025`, the generic integer refinement logic performed the following conversions:

  1. Round the fractional lower bound up from `0.025` to `1`.
  2. Convert `1` to the target `YEAR` type.
  3. Apply the two-digit `YEAR` conversion rule and convert `1` to `2001`.
  4. Build the incorrect TiKV index range `[2001, +inf]`.

The resulting range excluded `1935` and `1982`, even though both values satisfy the original numeric predicate.


### What changed and how does it work?

This PR prevents genuinely fractional `REAL` and `DECIMAL` constants from being converted into `YEAR` range boundaries for inequality comparisons.

In `RefineComparedConstant`, when the target column is of the `YEAR` type and the comparison operator is `<`, `<=`, `>`, or `>=`, the implementation now determines whether the original numeric constant has a fractional part:

  - For a `REAL` constant, it compares the value with `math.Trunc(value)`.
  - For a `DECIMAL` constant, it uses `ToInt()` and checks whether the conversion reports `ErrTruncated`.

If the constant has a fractional part, the original numeric constant is preserved instead of passing through the generic `CEIL` or `FLOOR` integer-boundary refinement and subsequent `YEAR` conversion.

As a result, TiDB no longer derives an incorrect boundary such as `YEAR 2001` from the numeric constant `0.025`. The affected query falls back to an `IndexFullScan` with a pushed-down numeric `Selection`, which evaluates the original comparison semantics correctly.

The change is deliberately limited to:

  - `YEAR` columns
  - Inequality operators: `<`, `<=`, `>`, and `>=`
  - `REAL` or `DECIMAL` constants with a non-zero fractional part

The following behavior remains unchanged:

  - Equality and null-safe equality comparisons
  - Integer-valued constants such as `1935.000`
  - Comparisons against non-`YEAR` columns
  - Existing refinement for integral numeric boundaries
  - Existing overflow and underflow handling

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that TiKV queries might return incorrect results when an indexed `YEAR` column is compared with a fractional numeric constant using an inequality operator (#59001)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparisons involving indexed `YEAR` columns and fractional or decimal values.
  - Preserved precise comparison boundaries so two-digit year handling no longer shifts results unexpectedly.
  - Ensured queries produce consistent results when executed with the TiKV storage engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->