### PR TITLE
expression: fold unmatched CASE to NULL

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -793,3 +793,16 @@ func TestIssue60926(t *testing.T) {
 	tk.MustQuery("select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
 	require.True(t, join.IsChildCloseCalledForTest.Load())
 }
+
+func TestIssue57284(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@session.tidb_allow_mpp = 0")
+	tk.MustExec("drop table if exists t0")
+	tk.MustExec("create table t0 (c0 int)")
+
+	tk.MustQuery("select * from t0 right join (select bit_or(1970) from t0) as sub0 on true").Check(testkit.Rows("<nil> 0"))
+	tk.MustQuery("select case 1 when null then true end").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("select * from t0 right join (select bit_or(1970) from t0) as sub0 on true where case 1 when null then true end").Check(testkit.Rows())
+}

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -156,7 +156,10 @@ func caseWhenHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool) 
 		}
 		return foldedExpr, isDeferredConst
 	}
-	return &Constant{Value: types.Datum{}, RetType: expr.RetType.Clone()}, isDeferredConst
+	if isDeferredConst {
+		return expr, true
+	}
+	return &Constant{Value: types.Datum{}, RetType: expr.RetType.Clone()}, false
 }
 
 func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -156,7 +156,7 @@ func caseWhenHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool) 
 		}
 		return foldedExpr, isDeferredConst
 	}
-	return expr, isDeferredConst
+	return &Constant{Value: types.Datum{}, RetType: expr.RetType.Clone()}, isDeferredConst
 }
 
 func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -271,6 +271,38 @@ func TestConstantFolding(t *testing.T) {
 	}
 }
 
+func TestConstantFoldingCaseWithoutElse(t *testing.T) {
+	ctx := mock.NewContext().GetExprCtx()
+	tests := []struct {
+		name string
+		expr Expression
+	}{
+		{
+			name: "false condition",
+			expr: newFunction(ctx, ast.Case, newLonglong(0), newLonglong(1)),
+		},
+		{
+			name: "null condition",
+			expr: newFunction(ctx, ast.Case, NewNull(), newString("unreachable", "utf8mb4_bin")),
+		},
+		{
+			name: "multiple unmatched conditions",
+			expr: newFunction(ctx, ast.Case, newLonglong(0), newLonglong(1), NewNull(), newLonglong(2)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedType := tt.expr.GetType(ctx.GetEvalCtx()).Clone()
+			folded := FoldConstant(ctx, tt.expr)
+			constant, ok := folded.(*Constant)
+			require.True(t, ok)
+			require.True(t, constant.Value.IsNull())
+			require.Equal(t, expectedType, constant.RetType)
+		})
+	}
+}
+
 func TestConstantFoldingCharsetConvert(t *testing.T) {
 	ctx := mock.NewContext()
 	tests := []struct {

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -301,6 +301,27 @@ func TestConstantFoldingCaseWithoutElse(t *testing.T) {
 			require.Equal(t, expectedType, constant.RetType)
 		})
 	}
+
+	t.Run("deferred condition", func(t *testing.T) {
+		sctx := mock.NewContext()
+		ctx := sctx.GetExprCtx()
+		sctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(0))
+		condition := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
+		caseExpr := newFunction(ctx, ast.Case, condition, newLonglong(1))
+
+		folded := FoldConstant(ctx, caseExpr)
+		require.Same(t, caseExpr, folded)
+		_, isNull, err := folded.EvalInt(ctx.GetEvalCtx(), chunk.Row{})
+		require.NoError(t, err)
+		require.True(t, isNull)
+
+		sctx.GetSessionVars().PlanCacheParams.Reset()
+		sctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(1))
+		value, isNull, err := folded.EvalInt(ctx.GetEvalCtx(), chunk.Row{})
+		require.NoError(t, err)
+		require.False(t, isNull)
+		require.Equal(t, int64(1), value)
+	})
 }
 
 func TestConstantFoldingCharsetConvert(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57284

Problem Summary:

TiDB might return an unexpected row when an unmatched `CASE` expression without an `ELSE` clause is used as a filter above a `RIGHT JOIN` containing a global aggregate.                                                                               

For example:

  ```sql
  CREATE TABLE t0 (c0 INT);

  SELECT *
  FROM t0
  RIGHT JOIN (
      SELECT BIT_OR(1970) FROM t0
  ) AS sub0
  ON TRUE
  WHERE CASE 1 WHEN NULL THEN TRUE END;
  ```

The expression:

  ```sql
  CASE 1 WHEN NULL THEN TRUE END
  ```

has no matching `WHEN` branch and no explicit `ELSE` branch. According to SQL semantics, the omitted `ELSE` is equivalent to `ELSE NULL`, so the expression evaluates to `NULL`. When it is used as a `WHERE` predicate, the query should return no rows.

Before this change, TiDB incorrectly returned:

  ```text
  NULL  0
  ```

This result was also inconsistent with MySQL.

The problem originated in the constant-folding implementation for `CASE` expressions. After proving that every `WHEN` condition was constant and evaluated to either `FALSE` or `NULL`, `caseWhenHandler` returned the original `ScalarFunction` when there was no explicit `ELSE` branch.

As a result, the expression remained in scalar-function form instead of being represented as a constant `NULL`. During predicate pushdown, the row-independent scalar expression could be pushed below the global aggregation without being retained as a post-aggregation filter. Filtering the aggregate input does not suppress the single row produced by a global aggregate over an empty input, so `BIT_OR` produced `0` and the `RIGHT JOIN` returned the unexpected row.



### What changed and how does it work?

This PR makes constant folding honor the implicit `ELSE NULL` semantics of a `CASE` expression without an explicit `ELSE` clause.                                               

When `caseWhenHandler` reaches its final no-`ELSE` path, all of the following have already been established:

  - Every `WHEN` condition can be folded to a constant.
  - None of the conditions evaluates to `TRUE`.
  - The `CASE` expression has no explicit `ELSE` argument.

In this situation, the handler now returns a typed `NULL` constant:

  ```go
  &Constant{
      Value:   types.Datum{},
      RetType: expr.RetType.Clone(),
  }
  ```

The change preserves the original deferred-constant state through the existing `isDeferredConst` return value.

Cloning the original return type ensures that the folded `NULL` retains the type metadata of the original `CASE` expression without sharing mutable type state.

The fix is intentionally placed in the expression constant-folding layer instead of adding a special case to aggregation or join predicate pushdown. This keeps the planner behavior consistent for every expression that has already been represented correctly as a constant.

The existing behavior remains unchanged when:

  - A `WHEN` condition is not constant.
  - A `WHEN` condition evaluates to `TRUE`.
  - The `CASE` expression has an explicit `ELSE` branch.
  - A matched result expression cannot be folded.
  - The expression contains a deferred constant or parameter marker.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that queries might return unexpected rows when an unmatched `CASE` expression without an `ELSE` clause is used as a filter above a `RIGHT JOIN` containing an aggregate (#57284)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected constant folding for `CASE` expressions without an `ELSE` clause, preserving deferred conditions and parameter markers while returning the expected `NULL` result and type when appropriate.
  * Improved query correctness for combinations of right joins, aggregate subqueries, conditional expressions, and filters.

* **Tests**
  * Added regression coverage for constant-folding and query behavior.
  * Adjusted test sharding to improve test suite distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->