### PR TITLE
expression: compare temporal timestampadd as datetime

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1438,11 +1438,12 @@ func GetAccurateCmpType(ctx EvalContext, lhs, rhs Expression) types.EvalType {
 		cmpType = types.ETVectorFloat32
 	} else if (lhsEvalType.IsStringKind() && lhsFieldType.GetType() == mysql.TypeJSON) || (rhsEvalType.IsStringKind() && rhsFieldType.GetType() == mysql.TypeJSON) {
 		cmpType = types.ETJson
-	} else if cmpType == types.ETString && (types.IsTypeTime(lhsFieldType.GetType()) || types.IsTypeTime(rhsFieldType.GetType())) {
+	} else if cmpType == types.ETString && (types.IsTypeTime(lhsFieldType.GetType()) || types.IsTypeTime(rhsFieldType.GetType()) ||
+		isTemporalTimestampAdd(lhs) || isTemporalTimestampAdd(rhs)) {
 		// date[time] <cmp> date[time]
 		// string <cmp> date[time]
 		// compare as time
-		if lhsFieldType.GetType() == rhsFieldType.GetType() {
+		if lhsFieldType.GetType() == rhsFieldType.GetType() && types.IsTypeTime(lhsFieldType.GetType()) {
 			cmpType = lhsFieldType.EvalType()
 		} else {
 			cmpType = types.ETDatetime
@@ -1483,6 +1484,15 @@ func GetAccurateCmpType(ctx EvalContext, lhs, rhs Expression) types.EvalType {
 		}
 	}
 	return cmpType
+}
+
+func isTemporalTimestampAdd(expr Expression) bool {
+	scalarFunc, ok := expr.(*ScalarFunction)
+	if !ok {
+		return false
+	}
+	timestampAdd, ok := scalarFunc.Function.(*builtinTimestampAddSig)
+	return ok && timestampAdd.compareAsDatetime
 }
 
 // GetCmpFunction get the compare function according to two arguments.

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -77,6 +77,35 @@ func TestCompareFunctionWithRefine(t *testing.T) {
 	}
 }
 
+func TestTimestampAddComparisonType(t *testing.T) {
+	ctx := createContext(t)
+	tblInfo := newTestTableBuilder("").
+		add("d", mysql.TypeDate, 0).
+		add("dt", mysql.TypeDatetime, 0).
+		add("s", mysql.TypeVarchar, 0).
+		build()
+	rhs, err := ParseSimpleExpr(ctx, "'2021-02-01 00:00:00'", WithTableInfo("", tblInfo))
+	require.NoError(t, err)
+
+	tests := []struct {
+		exprStr string
+		cmpType types.EvalType
+	}{
+		{"timestampadd(month, 1, d)", types.ETDatetime},
+		{"timestampadd(month, 1, dt)", types.ETDatetime},
+		{"timestampadd(month, 1, s)", types.ETString},
+	}
+	for _, test := range tests {
+		t.Run(test.exprStr, func(t *testing.T) {
+			lhs, err := ParseSimpleExpr(ctx, test.exprStr, WithTableInfo("", tblInfo))
+			require.NoError(t, err)
+			require.Equal(t, mysql.TypeVarString, lhs.GetType(ctx).GetType())
+			require.Equal(t, test.cmpType, GetAccurateCmpType(ctx, lhs, rhs))
+			require.Equal(t, test.cmpType, GetAccurateCmpType(ctx, lhs.Clone(), rhs))
+		})
+	}
+}
+
 func TestCompare(t *testing.T) {
 	ctx := createContext(t)
 

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -6548,6 +6548,7 @@ func (c *timestampAddFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
+	compareAsDatetime := types.IsTypeTime(args[2].GetType(ctx.GetEvalCtx()).GetType())
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETString, types.ETReal, types.ETDatetime)
 	if err != nil {
 		return nil, err
@@ -6566,20 +6567,26 @@ func (c *timestampAddFunctionClass) getFunction(ctx BuildContext, args []Express
 	}
 
 	bf.tp.SetFlen(flen)
-	sig := &builtinTimestampAddSig{bf}
+	sig := &builtinTimestampAddSig{
+		baseBuiltinFunc:   bf,
+		compareAsDatetime: compareAsDatetime,
+	}
 	sig.setPbCode(tipb.ScalarFuncSig_TimestampAdd)
 	return sig, nil
 }
 
 type builtinTimestampAddSig struct {
 	baseBuiltinFunc
+	// compareAsDatetime records whether the third argument was temporal before
+	// its implicit cast. It is used only to select comparison coercion.
+	compareAsDatetime bool
 	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
 	// as this expression may be shared across sessions.
 	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
 }
 
 func (b *builtinTimestampAddSig) Clone() builtinFunc {
-	newSig := &builtinTimestampAddSig{}
+	newSig := &builtinTimestampAddSig{compareAsDatetime: b.compareAsDatetime}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
 	return newSig
 }

--- a/pkg/expression/distsql_builtin.go
+++ b/pkg/expression/distsql_builtin.go
@@ -880,7 +880,7 @@ func getSignatureByPB(ctx BuildContext, sigCode tipb.ScalarFuncSig, tp *tipb.Fie
 	case tipb.ScalarFuncSig_TimeToSec:
 		f = &builtinTimeToSecSig{base}
 	case tipb.ScalarFuncSig_TimestampAdd:
-		f = &builtinTimestampAddSig{base}
+		f = &builtinTimestampAddSig{baseBuiltinFunc: base}
 	case tipb.ScalarFuncSig_ToDays:
 		f = &builtinToDaysSig{base}
 	case tipb.ScalarFuncSig_ToSeconds:

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -4079,6 +4079,24 @@ func TestTimeBuiltin(t *testing.T) {
 	tk.MustExec("drop table t2")
 }
 
+func TestIssue56870(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (d date, dt datetime, s varchar(20))")
+	tk.MustExec("insert into t values ('2021-01-01', '2021-01-01 00:00:00', '2021-01-01')")
+
+	for _, vectorized := range []string{"on", "off"} {
+		tk.MustExec("set @@tidb_enable_vectorized_expression=" + vectorized)
+		tk.MustQuery("select d, timestampadd(month, 1, d) from t where timestampadd(month, 1, d) >= '2021-02-01 00:00:00'").
+			Check(testkit.Rows("2021-01-01 2021-02-01"))
+		tk.MustQuery("select dt from t where timestampadd(month, 1, dt) = '2021-02-01'").
+			Check(testkit.Rows("2021-01-01 00:00:00"))
+		tk.MustQuery("select timestampadd(month, 1, s) = '2021-02-01' from t").
+			Check(testkit.Rows("0"))
+	}
+}
+
 func TestSetVariables(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56870

Problem Summary:

TiDB might return incorrect results when comparing the result of `TIMESTAMPADD()` derived from a temporal value with an equivalent datetime literal.                                                          

For example:

  ```sql
  CREATE TABLE lrr_test (col1 DATE);
  INSERT INTO lrr_test VALUES ('2021-01-01');

  SELECT col1, TIMESTAMPADD(MONTH, 1, col1)
  FROM lrr_test
  WHERE TIMESTAMPADD(MONTH, 1, col1) >= '2021-02-01 00:00:00';
  ```

The expected result, which is also returned by MySQL, is:

  ```text
  2021-01-01  2021-02-01
  ```

Before this change, TiDB returned an empty result.

The problem occurred because `TIMESTAMPADD()` uses string return metadata in TiDB. Even when its third argument originated from a `DATE` or `DATETIME` value, comparison type inference treated the function result as a regular string.

Consequently, TiDB compared the following values lexicographically:

  ```text
  2021-02-01
  2021-02-01 00:00:00
  ```

The shorter string sorts before the longer string, so the `>=` predicate incorrectly evaluated to false even though both strings represent the same temporal value.

The issue did not occur when the comparison bound was written as `'2021-02-01'`, or when the original `DATE` column was compared directly with `'2021-01-01 00:00:00'`.


### What changed and how does it work?

This PR preserves the existing public string return metadata of `TIMESTAMPADD()` while selecting datetime comparison semantics when its original third argument is temporal.

During construction of `builtinTimestampAddSig`, the implementation records whether the original third argument is a temporal type before the argument is implicitly cast for function evaluation:

  ```go
  compareAsDatetime := types.IsTypeTime(args[2].GetType(ctx.GetEvalCtx()).GetType())
  ```

The value is stored in the immutable `compareAsDatetime` field of `builtinTimestampAddSig`.

A new helper, `isTemporalTimestampAdd`, identifies a `TIMESTAMPADD()` scalar function whose original third argument was temporal. `GetAccurateCmpType` uses this information when selecting the comparison type.

When either operand is such a `TIMESTAMPADD()` expression and the initially inferred comparison type is string, TiDB now selects `ETDatetime` comparison semantics. This causes values such as:

  ```text
  2021-02-01
  2021-02-01 00:00:00
  ```

to be parsed and compared as temporal values instead of raw strings.

The implementation also ensures that:

  - The `compareAsDatetime` flag is preserved when the expression is cloned.
  - Two expressions with string field metadata are not accidentally forced back to `ETString` merely because their field types are equal.
  - Protobuf-reconstructed `TIMESTAMPADD()` signatures continue to use the safe default value for the new field.
  - The return type of `TIMESTAMPADD()` remains `TypeVarString`, avoiding a broader return-type compatibility change.
  - The scalar and vectorized implementations of `TIMESTAMPADD()` remain unchanged.
  - Only comparison type selection is affected.
 
The datetime comparison behavior applies when the original third argument is a temporal type such as `DATE` or `DATETIME`.

When the third argument is a regular string column, the existing string comparison behavior is preserved. This negative-control case prevents the fix from changing all `TIMESTAMPADD()` comparisons indiscriminately.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that queries might return incorrect results when comparing a `TIMESTAMPADD()` result derived from a `DATE` or `DATETIME` value with an equivalent temporal literal (#56870)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed comparisons involving `TIMESTAMPADD` expressions so date and datetime values are compared using temporal semantics, including mixed string/time comparisons.
  - Ensured consistent comparison results across cloned expressions and vectorized expression settings.

- **Tests**
  - Added coverage for `TIMESTAMPADD` comparisons across date, datetime, and string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->