### PR TITLE
expression: preserve year-zero calendar arithmetic

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -358,6 +358,7 @@ go_test(
         "cluster_table_test.go",
         "compact_table_test.go",
         "copr_cache_test.go",
+        "date_sub_extreme_month_test.go",
         "delete_test.go",
         "detach_integration_test.go",
         "detach_test.go",

--- a/pkg/executor/date_sub_extreme_month_test.go
+++ b/pkg/executor/date_sub_extreme_month_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package executor_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestDateSubExtremeMonth(t *testing.T) {
+	for _, vectorized := range []string{"OFF", "ON"} {
+		t.Run(vectorized, func(t *testing.T) {
+			store := testkit.CreateMockStore(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("USE test")
+			tk.MustExec("SET @@session.tidb_allow_mpp = 0")
+			tk.MustExec("SET @@session.tidb_enable_vectorized_expression = " + vectorized)
+			tk.MustExec("CREATE TABLE lrr_test (col1 DATETIME)")
+			tk.MustExec("INSERT INTO lrr_test VALUES ('0001-01-01 00:00:00')")
+
+			tk.MustQuery("SELECT col1, DATE_SUB(col1, INTERVAL 10 MONTH) FROM lrr_test").Check(testkit.Rows(
+				"0001-01-01 00:00:00 0000-03-01 00:00:00",
+			))
+			tk.MustQuery("SELECT DATE_SUB(col1, INTERVAL 1 YEAR) FROM lrr_test").Check(testkit.Rows(
+				"0000-01-01 00:00:00",
+			))
+			tk.MustQuery("SELECT DATE_ADD(col1, INTERVAL -2 HOUR) FROM lrr_test").Check(testkit.Rows(
+				"0000-00-00 22:00:00",
+			))
+		})
+	}
+}

--- a/pkg/executor/date_sub_extreme_month_test.go
+++ b/pkg/executor/date_sub_extreme_month_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package executor_test
 
@@ -29,6 +39,9 @@ func TestDateSubExtremeMonth(t *testing.T) {
 			))
 			tk.MustQuery("SELECT DATE_ADD(col1, INTERVAL -2 HOUR) FROM lrr_test").Check(testkit.Rows(
 				"0000-00-00 22:00:00",
+			))
+			tk.MustQuery("SELECT DATE_ADD(col1, INTERVAL -10 MONTH) FROM lrr_test").Check(testkit.Rows(
+				"0000-03-01 00:00:00",
 			))
 		})
 	}

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -3203,6 +3203,10 @@ func (du *baseDateArithmetical) addDate(ctx EvalContext, date types.Time, year, 
 
 	// fix https://github.com/pingcap/tidb/issues/11329
 	if goTime.Year() == 0 {
+		if year != 0 || month != 0 {
+			date.SetCoreTime(types.FromGoTime(goTime))
+			return date, false, nil
+		}
 		hour, minute, second := goTime.Clock()
 		date.SetCoreTime(types.FromDate(0, 0, 0, hour, minute, second, goTime.Nanosecond()/1000))
 		return date, false, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56863

Problem Summary:

TiDB might lose valid month and day components when `DATE_ADD()` or `DATE_SUB()` with a `YEAR` or `MONTH` interval produces a date in year zero. 

For example:

  ```sql
  CREATE TABLE lrr_test (
      col1 DATETIME DEFAULT NULL
  );

  INSERT INTO lrr_test VALUES ('0001-01-01 00:00:00');

  SELECT col1, DATE_SUB(col1, INTERVAL 10 MONTH)
  FROM lrr_test;
  ```

The expected result, which is also returned by MySQL, is:

  ```text
  0001-01-01 00:00:00  0000-03-01 00:00:00
  ```

Before this change, TiDB returned:

  ```text
  0001-01-01 00:00:00  0000-00-00 00:00:00
  ```

The calendar calculation itself produced the correct normalized date, `0000-03-01 00:00:00`. However, the post-processing logic in `baseDateArithmetical.addDate` handled every result whose Go year was zero in the same way.

That compatibility path reconstructed the result with year, month, and day all set to zero while preserving only its clock components. It is required for existing time-only underflow behavior, but it also discarded valid calendar components produced by `YEAR` and `MONTH` arithmetic.


### What changed and how does it work?

This PR distinguishes year-zero results produced by calendar arithmetic from year-zero results produced by day or time arithmetic.        

After the date calculation, when the normalized result has year zero:

  - If the interval has a non-zero `YEAR` or `MONTH` component, TiDB now converts the complete calculated `time.Time` value back to a TiDB temporal value. This preserves the calculated month, day, time, and microsecond components.
  - Otherwise, TiDB retains the existing compatibility path that constructs an all-zero year/month/day value while preserving the clock components.

Conceptually, the new behavior is:

  ```go
  if goTime.Year() == 0 {
      if year != 0 || month != 0 {
          date.SetCoreTime(types.FromGoTime(goTime))
          return date, false, nil
      }

      // Keep the existing behavior for day and time arithmetic.
  }
  ```

This fixes calendar operations such as:

  ```sql
  DATE_SUB('0001-01-01 00:00:00', INTERVAL 10 MONTH)
  -- 0000-03-01 00:00:00

  DATE_SUB('0001-01-01 00:00:00', INTERVAL 1 YEAR)
  -- 0000-01-01 00:00:00
  ```
At the same time, the existing time-underflow behavior remains unchanged:

  ```sql
  DATE_ADD('0001-01-01 00:00:00', INTERVAL -2 HOUR)
  -- 0000-00-00 22:00:00
  ```

The fix is implemented in the shared `baseDateArithmetical.addDate` path, so scalar and vectorized execution use the same corrected behavior.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `DATE_ADD()` or `DATE_SUB()` might return an incorrect all-zero date when a `YEAR` or `MONTH` interval produces a valid date in year zero (#56863)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date arithmetic near the earliest supported dates.
  * Improved `DATE_SUB` and `DATE_ADD` results for year- and month-based intervals at lower date boundaries, including calculations involving negative intervals.

* **Tests**
  * Added coverage for extreme-month date calculations near the minimum supported date.
  * Verified behavior with vectorized expression evaluation both enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->