### PR TITLE
expression: honor decimal result scale in string casts

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -358,6 +358,7 @@ go_test(
         "cluster_table_test.go",
         "compact_table_test.go",
         "copr_cache_test.go",
+        "decimal_div_runtime_precision_test.go",
         "delete_test.go",
         "detach_integration_test.go",
         "detach_test.go",

--- a/pkg/executor/decimal_div_runtime_precision_test.go
+++ b/pkg/executor/decimal_div_runtime_precision_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package executor_test
 

--- a/pkg/executor/decimal_div_runtime_precision_test.go
+++ b/pkg/executor/decimal_div_runtime_precision_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package executor_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestDecimalDivRuntimePrecision(t *testing.T) {
+	for _, vectorized := range []string{"OFF", "ON"} {
+		t.Run(vectorized, func(t *testing.T) {
+			store := testkit.CreateMockStore(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("USE test")
+			tk.MustExec("SET @@session.tidb_allow_mpp = 0")
+			tk.MustExec("SET @@session.tidb_enable_vectorized_expression = " + vectorized)
+			tk.MustExec("CREATE TABLE t (id INT, num DECIMAL)")
+			tk.MustExec("INSERT INTO t VALUES (1, 100)")
+
+			tk.MustQuery("SELECT CAST(CAST('1.2300' AS DECIMAL(10,4)) AS CHAR)").Check(testkit.Rows("1.2300"))
+			tk.MustQuery("SELECT /*+ READ_FROM_STORAGE(TIKV[t]) */ LENGTH(SUM(num) / 10) FROM t GROUP BY id").Check(testkit.Rows("7"))
+			tk.MustQuery("SELECT /*+ READ_FROM_STORAGE(TIKV[t]) */ CAST(SUM(num) / 10 AS CHAR) FROM t GROUP BY id").Check(testkit.Rows("10.0000"))
+		})
+	}
+}

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1613,7 +1613,7 @@ func (b *builtinCastDecimalAsStringSig) evalString(ctx EvalContext, row chunk.Ro
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, typeCtx(ctx), false)
+	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, typeCtx(ctx), false)
 	if err != nil {
 		return res, false, err
 	}

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -262,7 +262,7 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx EvalContext, input *ch
 			result.AppendNull()
 			continue
 		}
-		res, e := types.ProduceStrWithSpecifiedTp(string(v.ToString()), b.tp, tc, false)
+		res, e := types.ProduceStrWithSpecifiedTp(v.String(), b.tp, tc, false)
 		if e != nil {
 			return e
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55294

Problem Summary:

TiDB might expose internal decimal guard digits when implicitly or explicitly casting a decimal expression to a string. This can produce inconsistent results between TiKV and TiFlash even though the decimal expression has the same declared result type.

For example:

  ```sql
  CREATE TABLE t (
      id INT,
      num DECIMAL
  );

  INSERT INTO t VALUES (1, 100);

  SELECT /*+ READ_FROM_STORAGE(TIKV[t]) */
         LENGTH(SUM(num) / 10)
  FROM t
  GROUP BY id;

  SELECT /*+ READ_FROM_STORAGE(TIFLASH[t]) */
         LENGTH(SUM(num) / 10)
  FROM t
  GROUP BY id;
  ```

Before this change, the TiKV query returned:

  ```text
  12
  ```

TiFlash returned:

  ```text
  7
  ```

The compile-time result type of `SUM(num) / 10` is `DECIMAL(37,4)`, so its string representation should be:

  ```text
  10.0000
  ```

whose length is `7`.

During TiDB runtime evaluation, decimal division retains additional fractional digits for calculation precision. The internal value could therefore be rendered as:

  ```text
  10.000000000
  ```

whose length is `12`.

An explicit cast to the declared decimal type was a possible workaround:

  ```sql
  CAST(SUM(num) / 10 AS DECIMAL(37,4))
  ```

However, users should not need an additional cast merely to make string conversion honor the expression's declared result scale.

### What changed and how does it work?

TiDB's `MyDecimal` representation maintains two distinct fractional-scale values:                                                

  - `digitsFrac` records the number of fractional digits retained internally. Decimal arithmetic can use additional guard digits here to preserve calculation precision.
  - `resultFrac` records the semantic scale that should be presented as the expression result.

The scalar and vectorized decimal-to-string cast implementations previously called:

  ```go
  val.ToString()
  ```

`ToString()` renders the internal decimal using `digitsFrac`, which can expose guard digits that are not part of the declared result.

This PR changes both cast paths to call:

  ```go
  val.String()
  ```

`MyDecimal.String()`:

  1. Copies the decimal value.
  2. Rounds the copy to `resultFrac` using the existing decimal rounding behavior.
  3. Renders the rounded copy as a string.

Because the operation uses a copy, the original decimal value and its internal guard digits are not modified. Internal arithmetic precision therefore remains unchanged.

The resulting string is still passed through `ProduceStrWithSpecifiedTp`, so the existing target string type, length, charset, collation, and error handling continue to apply.

The fix covers both implementations of `builtinCastDecimalAsStringSig`:

  - Scalar evaluation in `builtin_cast.go`
  - Vectorized evaluation in `builtin_cast_vec.go`

This change does not modify:

  - Decimal division or aggregation
  - The compile-time decimal type
  - The internal decimal precision used during calculation
  - TiKV or TiFlash pushdown behavior
  - Non-decimal cast implementations

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that casting a decimal expression to a string might expose internal guard digits instead of honoring the result scale, causing inconsistent results between TiKV and TiFlash (#55294)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal-to-string conversion consistency across standard and vectorized execution paths.
  * Preserved decimal string representations when converting decimal values to text.

* **Tests**
  * Included runtime-precision decimal division coverage in the test suite for both vectorized and non-vectorized execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->