### PR TITLE
test: stabilize flaky TestTTLClusteredPKScanPlannerContracts/unsigned_integer_handle

### DIFF
--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -101,6 +101,7 @@ go_test(
         "//pkg/ttl/client",
         "//pkg/ttl/metrics",
         "//pkg/ttl/session",
+        "//pkg/ttl/sqlbuilder",
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/chunk",

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -47,6 +48,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/client"
 	"github.com/pingcap/tidb/pkg/ttl/metrics"
 	"github.com/pingcap/tidb/pkg/ttl/session"
+	"github.com/pingcap/tidb/pkg/ttl/sqlbuilder"
 	"github.com/pingcap/tidb/pkg/ttl/ttlworker"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/skip"
@@ -360,6 +362,59 @@ func TestTTLAutoAnalyze(t *testing.T) {
 	tk.MustExec("flush stats_delta *.*")
 	require.NoError(t, h.Update(context.Background(), is))
 	require.True(t, h.HandleAutoAnalyze())
+}
+
+func TestTTLClusteredPKScanPlannerContracts(t *testing.T) {
+	originLiteInitStats := config.GetGlobalConfig().Performance.LiteInitStats
+	config.GetGlobalConfig().Performance.LiteInitStats = true
+	defer func() {
+		config.GetGlobalConfig().Performance.LiteInitStats = originLiteInitStats
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	waitAndStopTTLManager(t, dom)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	h := dom.StatsHandle()
+	h.SetLease(time.Millisecond)
+	defer h.SetLease(0)
+
+	t.Run("unsigned_integer_handle", func(t *testing.T) {
+		runTTLScanPlannerContract(t, tk, dom, "ttl_pk_plan_1",
+			"create table ttl_pk_plan_1 (k bigint unsigned primary key clustered, expired_at datetime not null) TTL=`expired_at` + interval 1 day")
+		runTTLScanPlannerContract(t, tk, dom, "ttl_pk_fallback_2",
+			"create table ttl_pk_fallback_2 (id bigint unsigned primary key clustered, expired_at datetime not null, index idx_ttl(expired_at)) TTL=`expired_at` + interval 1 day")
+	})
+}
+
+func runTTLScanPlannerContract(t *testing.T, tk *testkit.TestKit, dom *domain.Domain, tableName string, createTableSQL string) {
+	tk.MustExec(createTableSQL)
+	tk.MustExec(fmt.Sprintf("insert into %s values (1, '2000-01-01'), (2, '2000-01-02'), (3, '2000-01-03')", tableName))
+	tk.MustExec(fmt.Sprintf("analyze table %s with 2 topn, 2 buckets", tableName))
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(tableName))
+	require.NoError(t, err)
+	ttlTbl, err := cache.NewPhysicalTable(ast.NewCIStr("test"), tbl.Meta(), ast.NewCIStr(""))
+	require.NoError(t, err)
+
+	h := dom.StatsHandle()
+	h.Clear()
+	require.NoError(t, h.InitStatsLite(context.Background(), is))
+
+	tk.MustExec("set @@tidb_stats_load_sync_wait = 60000")
+	generator, err := sqlbuilder.NewScanQueryGenerator(ttlTbl, time.Unix(0, 0), nil, nil)
+	require.NoError(t, err)
+	scanSQL, err := generator.NextSQL(nil, 128)
+	require.NoError(t, err)
+
+	plan := tk.MustQuery("explain format = 'brief' " + scanSQL).Rows()
+	planText := fmt.Sprint(plan)
+	require.Contains(t, planText, "TableFullScan")
+	require.Contains(t, planText, "keep order:true")
+	require.NotContains(t, planText, "IndexLookUp")
+	require.NotContains(t, planText, "IndexReader")
 }
 
 func TestTriggerTTLJob(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70869

Problem Summary:
Flaky test `TestTTLClusteredPKScanPlannerContracts/unsigned_integer_handle` in `pkg/ttl/ttlworker` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Unsafe test harness SQL reentry at a stats-load boundary could race session statement reset while checking TTL scan planning.

#### Fix

The final test preserves the planner assertions while avoiding the reentrant timing hook that produced the race.

#### Verification

Spec:
- target: `pkg/ttl/ttlworker :: TestTTLClusteredPKScanPlannerContracts/unsigned_integer_handle`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `GO_TEST_WITH_TAGS`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_raw passed.
build passed.

Gate checklist:
- timing_race_repro: SKIPPED
- target_raw: PASS
- package_failpoint_advisory: SKIPPED
- build: PASS

Commands:
- `go test -json -tags=intest,deadlock ./pkg/ttl/ttlworker -run '^TestTTLClusteredPKScanPlannerContracts/unsigned_integer_handle$' -count=1`
- `make build`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #70869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added planner-contract coverage for TTL scans on clustered tables, including scenarios with and without expiration indexes.
  * Verified that generated scan plans use ordered full-table scans and avoid index-based lookup operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->