### PR TITLE
dumpling: report dump progress over HTTP, and serve the dump metrics

### DIFF
--- a/dumpling/export/BUILD.bazel
+++ b/dumpling/export/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "config_test.go",
         "consistency_test.go",
         "dump_test.go",
+        "http_handler_test.go",
         "ir_impl_test.go",
         "main_test.go",
         "metadata_test.go",

--- a/dumpling/export/BUILD.bazel
+++ b/dumpling/export/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
         "@com_github_docker_go_units//:go-units",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/collectors",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_stretchr_testify//require",

--- a/dumpling/export/BUILD.bazel
+++ b/dumpling/export/BUILD.bazel
@@ -131,5 +131,7 @@ go_test(
         "@com_github_tikv_pd_client//clients/gc",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest/observer",
     ],
 )

--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -1579,7 +1579,7 @@ func startHTTPService(d *Dumper) error {
 	conf := d.conf
 	if conf.StatusAddr != "" {
 		go func() {
-			err := startDumplingService(d.tctx, conf.StatusAddr)
+			err := startDumplingService(d.tctx, conf.StatusAddr, d)
 			if err != nil {
 				d.L().Info("meet error when stopping dumpling http service", log.ShortError(err))
 			}

--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -74,6 +74,7 @@ type Dumper struct {
 	charsetAndDefaultCollationMap map[string]string
 
 	speedRecorder *SpeedRecorder
+	status        atomic.Pointer[DumpStatus]
 }
 
 // NewDumper returns a new Dumper

--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -317,9 +317,8 @@ func (d *Dumper) Dump() (dumpErr error) {
 	summary.SetUnit(summary.BackupUnit)
 	defer summary.Summary(summary.BackupUnit)
 
-	logProgressCtx, logProgressCancel := tctx.WithCancel()
-	go d.runLogProgress(logProgressCtx)
-	defer logProgressCancel()
+	stopLogProgress := d.startLogProgress(tctx)
+	defer stopLogProgress()
 
 	tableDataStartTime := time.Now()
 

--- a/dumpling/export/http_handler.go
+++ b/dumpling/export/http_handler.go
@@ -3,6 +3,7 @@
 package export
 
 import (
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -12,15 +13,17 @@ import (
 	"github.com/pingcap/errors"
 	tcontext "github.com/pingcap/tidb/dumpling/context"
 	"github.com/pingcap/tidb/dumpling/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
 )
 
 var cmuxReadTimeout = 10 * time.Second
 
-func startHTTPServer(tctx *tcontext.Context, lis net.Listener) {
+func startHTTPServer(tctx *tcontext.Context, lis net.Listener, d *Dumper) {
 	router := http.NewServeMux()
-	router.Handle("/metrics", promhttp.Handler())
+	router.Handle("/metrics", metricsHandler(d))
+	router.HandleFunc("/status", statusHandler(tctx, d))
 
 	router.HandleFunc("/debug/pprof/", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -38,7 +41,7 @@ func startHTTPServer(tctx *tcontext.Context, lis net.Listener) {
 	}
 }
 
-func startDumplingService(tctx *tcontext.Context, addr string) error {
+func startDumplingService(tctx *tcontext.Context, addr string, d *Dumper) error {
 	rootLis, err := net.Listen("tcp", addr)
 	if err != nil {
 		return errors.Annotate(err, "start listening")
@@ -49,13 +52,48 @@ func startDumplingService(tctx *tcontext.Context, addr string) error {
 	m.SetReadTimeout(cmuxReadTimeout) // set a timeout, ref: https://github.com/pingcap/tidb-binlog/pull/352
 
 	httpL := m.Match(cmux.HTTP1Fast())
-	go startHTTPServer(tctx, httpL)
+	go startHTTPServer(tctx, httpL, d)
 
 	err = m.Serve() // start serving, block
 	if err != nil && isErrNetClosing(err) {
 		err = nil
 	}
 	return err
+}
+
+// metricsHandler serves the metrics this Dumper records, which live in the
+// registry its config names rather than the process-wide default one. Serving
+// the default registry instead - as this endpoint used to - answered every
+// scrape with the Go and process collectors and none of the dump counters,
+// because nothing ever registers those with it.
+//
+// A registry that cannot be gathered from is not an error worth failing over:
+// the endpoint falls back to the default handler so /metrics keeps answering.
+func metricsHandler(d *Dumper) http.Handler {
+	if d != nil && d.conf != nil {
+		if gatherer, ok := d.conf.PromRegistry.(prometheus.Gatherer); ok {
+			return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+		}
+	}
+	return promhttp.Handler()
+}
+
+// statusHandler reports how far the dump has got, as JSON. The same numbers
+// reach the log every logProgressTick, but a caller driving a progress bar
+// should not have to scrape log lines to find them.
+func statusHandler(tctx *tcontext.Context, d *Dumper) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if d == nil {
+			http.Error(w, "dumper is not running", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(d.GetStatus()); err != nil {
+			// The status line is already written by now, so this can only be
+			// logged, not turned into an error response.
+			tctx.L().Warn("failed to write dumpling status response", log.ShortError(err))
+		}
+	}
 }
 
 var useOfClosedErrMsg = "use of closed network connection"

--- a/dumpling/export/http_handler.go
+++ b/dumpling/export/http_handler.go
@@ -78,9 +78,8 @@ func metricsHandler(d *Dumper) http.Handler {
 	return promhttp.Handler()
 }
 
-// statusHandler reports how far the dump has got, as JSON. The same numbers
-// reach the log every logProgressTick, but a caller driving a progress bar
-// should not have to scrape log lines to find them.
+// statusHandler serves the latest dump status snapshot as JSON.
+// The progress loop refreshes it every statusRefreshTick independently of HTTP polling.
 func statusHandler(tctx *tcontext.Context, d *Dumper) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		if d == nil {

--- a/dumpling/export/http_handler.go
+++ b/dumpling/export/http_handler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pingcap/tidb/dumpling/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/soheilhy/cmux"
 )
 
@@ -62,51 +61,19 @@ func startDumplingService(tctx *tcontext.Context, addr string, d *Dumper) error 
 	return err
 }
 
-// metricsHandler serves the configured dump metrics while retaining the metric
-// families exposed by the default handler. Registerers that do not implement
-// Gatherer retain the default handler's behavior.
+// metricsHandler serves the configured registry when it supports gathering.
+// Unlike the previous global handler, it does not add unrelated default metrics
+// or promhttp instrumentation. The CLI registers Go and process collectors in
+// its configured registry; embedded callers control their own collectors.
+// Registerers without Gatherer retain the default gatherer as the scrape source.
 func metricsHandler(d *Dumper) http.Handler {
 	gatherer := prometheus.DefaultGatherer
 	if d != nil && d.conf != nil {
 		if configured, ok := d.conf.PromRegistry.(prometheus.Gatherer); ok {
-			gatherer = metricsGatherer{configured: configured, previous: gatherer}
+			gatherer = configured
 		}
 	}
-	return promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer,
-		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
-}
-
-type metricsGatherer struct {
-	configured prometheus.Gatherer
-	previous   prometheus.Gatherer
-}
-
-func (g metricsGatherer) Gather() ([]*dto.MetricFamily, error) {
-	configured, err := g.configured.Gather()
-	if err != nil {
-		return configured, err
-	}
-	// The CLI already installs its registry as DefaultGatherer.
-	if registry, ok := g.configured.(*prometheus.Registry); ok && registry == g.previous {
-		return configured, nil
-	}
-	previous, err := g.previous.Gather()
-	if err != nil {
-		return configured, err
-	}
-	names := make(map[string]struct{}, len(configured))
-	result := make([]*dto.MetricFamily, 0, len(configured)+len(previous))
-	result = append(result, configured...)
-	for _, family := range configured {
-		names[family.GetName()] = struct{}{}
-	}
-	// Prefer the configured family when both sources expose the same name.
-	for _, family := range previous {
-		if _, exists := names[family.GetName()]; !exists {
-			result = append(result, family)
-		}
-	}
-	return result, nil
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
 }
 
 // statusHandler serves the latest dump status snapshot as JSON.

--- a/dumpling/export/http_handler.go
+++ b/dumpling/export/http_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pingcap/tidb/dumpling/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/soheilhy/cmux"
 )
 
@@ -61,21 +62,51 @@ func startDumplingService(tctx *tcontext.Context, addr string, d *Dumper) error 
 	return err
 }
 
-// metricsHandler serves the metrics this Dumper records, which live in the
-// registry its config names rather than the process-wide default one. Serving
-// the default registry instead - as this endpoint used to - answered every
-// scrape with the Go and process collectors and none of the dump counters,
-// because nothing ever registers those with it.
-//
-// A registry that cannot be gathered from is not an error worth failing over:
-// the endpoint falls back to the default handler so /metrics keeps answering.
+// metricsHandler serves the configured dump metrics while retaining the metric
+// families exposed by the default handler. Registerers that do not implement
+// Gatherer retain the default handler's behavior.
 func metricsHandler(d *Dumper) http.Handler {
+	gatherer := prometheus.DefaultGatherer
 	if d != nil && d.conf != nil {
-		if gatherer, ok := d.conf.PromRegistry.(prometheus.Gatherer); ok {
-			return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+		if configured, ok := d.conf.PromRegistry.(prometheus.Gatherer); ok {
+			gatherer = metricsGatherer{configured: configured, previous: gatherer}
 		}
 	}
-	return promhttp.Handler()
+	return promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer,
+		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
+}
+
+type metricsGatherer struct {
+	configured prometheus.Gatherer
+	previous   prometheus.Gatherer
+}
+
+func (g metricsGatherer) Gather() ([]*dto.MetricFamily, error) {
+	configured, err := g.configured.Gather()
+	if err != nil {
+		return configured, err
+	}
+	// The CLI already installs its registry as DefaultGatherer.
+	if registry, ok := g.configured.(*prometheus.Registry); ok && registry == g.previous {
+		return configured, nil
+	}
+	previous, err := g.previous.Gather()
+	if err != nil {
+		return configured, err
+	}
+	names := make(map[string]struct{}, len(configured))
+	result := make([]*dto.MetricFamily, 0, len(configured)+len(previous))
+	result = append(result, configured...)
+	for _, family := range configured {
+		names[family.GetName()] = struct{}{}
+	}
+	// Prefer the configured family when both sources expose the same name.
+	for _, family := range previous {
+		if _, exists := names[family.GetName()]; !exists {
+			result = append(result, family)
+		}
+	}
+	return result, nil
 }
 
 // statusHandler serves the latest dump status snapshot as JSON.

--- a/dumpling/export/http_handler_test.go
+++ b/dumpling/export/http_handler_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 PingCAP, Inc. Licensed under Apache-2.0.
+
+package export
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tcontext "github.com/pingcap/tidb/dumpling/context"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusHandlerReportsProgress pins that the endpoint answers with the
+// same numbers the progress log carries, in a shape a caller can compute with
+// rather than parse out of a log line.
+func TestStatusHandlerReportsProgress(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+
+	AddCounter(d.metrics.finishedTablesCounter, 3)
+	AddGauge(d.metrics.finishedSizeGauge, 4096)
+	AddGauge(d.metrics.finishedRowsGauge, 250)
+	AddCounter(d.metrics.estimateTotalRowsCounter, 1000)
+	d.metrics.totalChunks.Store(8)
+	d.metrics.completedChunks.Store(2)
+	d.metrics.progressReady.Store(true)
+
+	rec := httptest.NewRecorder()
+	statusHandler(tcontext.Background(), d)(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var got DumpStatus
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.EqualValues(t, 3, got.CompletedTables)
+	require.EqualValues(t, 4096, got.FinishedBytes)
+	require.EqualValues(t, 250, got.FinishedRows)
+	require.EqualValues(t, 1000, got.EstimateTotalRows)
+	require.NotNil(t, got.ProgressPercent)
+	require.InDelta(t, 25, *got.ProgressPercent, 1e-9)
+}
+
+// TestStatusHandlerOmitsProgressBeforeChunksAreCounted covers the window
+// before the chunk count is known. Reporting zero there would say no work had
+// been done, which is a different claim from "the answer is not available
+// yet", so the field is absent instead.
+func TestStatusHandlerOmitsProgressBeforeChunksAreCounted(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+
+	rec := httptest.NewRecorder()
+	statusHandler(tcontext.Background(), d)(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	require.NotContains(t, raw, "progressPercent")
+	require.NotContains(t, raw, "progress")
+}
+
+// TestMetricsHandlerServesTheDumperRegistry pins the fix for an endpoint that
+// used to answer every scrape without a single dump metric: the counters are
+// registered with the registry the config names, and the handler was serving
+// the process-wide default one, which nothing registers them with.
+func TestMetricsHandlerServesTheDumperRegistry(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+	d.metrics.registerTo(conf.PromRegistry)
+	defer d.metrics.unregisterFrom(conf.PromRegistry)
+
+	AddGauge(d.metrics.finishedRowsGauge, 42)
+
+	rec := httptest.NewRecorder()
+	metricsHandler(d).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "dumpling_dump_finished_rows 42")
+}

--- a/dumpling/export/http_handler_test.go
+++ b/dumpling/export/http_handler_test.go
@@ -126,9 +126,9 @@ func TestMetricsHandlerServesTheDumperRegistry(t *testing.T) {
 	body, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(body), "dumpling_dump_finished_rows 42")
-	require.Contains(t, string(body), "go_goroutines ")
-	require.Contains(t, string(body), "process_cpu_seconds_total ")
-	require.Contains(t, string(body), "promhttp_metric_handler_requests_total")
+	require.NotContains(t, string(body), "go_goroutines ")
+	require.NotContains(t, string(body), "process_cpu_seconds_total ")
+	require.NotContains(t, string(body), "promhttp_metric_handler_requests_total")
 }
 
 func TestMetricsHandlerPreservesConfiguredMetricFamilies(t *testing.T) {
@@ -137,8 +137,8 @@ func TestMetricsHandlerPreservesConfiguredMetricFamilies(t *testing.T) {
 	d.metrics = newMetrics(conf.PromFactory, nil)
 	d.metrics.registerTo(conf.PromRegistry)
 	defer d.metrics.unregisterFrom(conf.PromRegistry)
-	// Both registries expose this name. The configured family must win
-	// without producing duplicate-metric errors on the scrape.
+	// A configured family with the same name as a default metric must be
+	// served without importing any other default metric families.
 	configured := prometheus.NewGauge(prometheus.GaugeOpts{Name: "go_goroutines", Help: "Configured test value."})
 	configured.Set(123)
 	conf.PromRegistry.MustRegister(configured)
@@ -147,7 +147,7 @@ func TestMetricsHandlerPreservesConfiguredMetricFamilies(t *testing.T) {
 	metricsHandler(d).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "go_goroutines 123\n")
-	require.Contains(t, rec.Body.String(), "process_cpu_seconds_total ")
+	require.NotContains(t, rec.Body.String(), "process_cpu_seconds_total ")
 }
 
 func TestMetricsHandlerWithSharedDefaultGatherer(t *testing.T) {

--- a/dumpling/export/http_handler_test.go
+++ b/dumpling/export/http_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	tcontext "github.com/pingcap/tidb/dumpling/context"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,4 +126,43 @@ func TestMetricsHandlerServesTheDumperRegistry(t *testing.T) {
 	body, err := io.ReadAll(rec.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(body), "dumpling_dump_finished_rows 42")
+	require.Contains(t, string(body), "go_goroutines ")
+	require.Contains(t, string(body), "process_cpu_seconds_total ")
+	require.Contains(t, string(body), "promhttp_metric_handler_requests_total")
+}
+
+func TestMetricsHandlerPreservesConfiguredMetricFamilies(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+	d.metrics.registerTo(conf.PromRegistry)
+	defer d.metrics.unregisterFrom(conf.PromRegistry)
+	// Both registries expose this name. The configured family must win
+	// without producing duplicate-metric errors on the scrape.
+	configured := prometheus.NewGauge(prometheus.GaugeOpts{Name: "go_goroutines", Help: "Configured test value."})
+	configured.Set(123)
+	conf.PromRegistry.MustRegister(configured)
+
+	rec := httptest.NewRecorder()
+	metricsHandler(d).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "go_goroutines 123\n")
+	require.Contains(t, rec.Body.String(), "process_cpu_seconds_total ")
+}
+
+func TestMetricsHandlerWithSharedDefaultGatherer(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+	d.metrics.registerTo(conf.PromRegistry)
+	defer d.metrics.unregisterFrom(conf.PromRegistry)
+	previous := prometheus.DefaultGatherer
+	prometheus.DefaultGatherer = conf.PromRegistry.(prometheus.Gatherer)
+	t.Cleanup(func() { prometheus.DefaultGatherer = previous })
+	AddGauge(d.metrics.finishedRowsGauge, 42)
+
+	rec := httptest.NewRecorder()
+	metricsHandler(d).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "dumpling_dump_finished_rows 42")
 }

--- a/dumpling/export/http_handler_test.go
+++ b/dumpling/export/http_handler_test.go
@@ -28,6 +28,7 @@ func TestStatusHandlerReportsProgress(t *testing.T) {
 	d.metrics.totalChunks.Store(8)
 	d.metrics.completedChunks.Store(2)
 	d.metrics.progressReady.Store(true)
+	d.RefreshStatus()
 
 	rec := httptest.NewRecorder()
 	statusHandler(tcontext.Background(), d)(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
@@ -62,6 +63,46 @@ func TestStatusHandlerOmitsProgressBeforeChunksAreCounted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
 	require.NotContains(t, raw, "progressPercent")
 	require.NotContains(t, raw, "progress")
+}
+
+func TestStatusHandlerDoesNotUpdateSpeed(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+	lastUpdateTime := d.speedRecorder.lastUpdateTime
+
+	for range 2 {
+		AddGauge(d.metrics.finishedSizeGauge, 4096)
+		rec := httptest.NewRecorder()
+		statusHandler(tcontext.Background(), d)(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, lastUpdateTime, d.speedRecorder.lastUpdateTime)
+		require.Zero(t, d.speedRecorder.lastFinished)
+		require.Zero(t, d.speedRecorder.speedBPS)
+	}
+
+	d.RefreshStatus()
+	snapshot := d.GetStatus()
+	lastUpdateTime = d.speedRecorder.lastUpdateTime
+	AddGauge(d.metrics.finishedSizeGauge, 4096)
+	responses := make(chan *httptest.ResponseRecorder, 8)
+	for range cap(responses) {
+		go func() {
+			rec := httptest.NewRecorder()
+			statusHandler(tcontext.Background(), d)(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+			responses <- rec
+		}()
+	}
+	for range cap(responses) {
+		rec := <-responses
+		require.Equal(t, http.StatusOK, rec.Code)
+		var got DumpStatus
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.Equal(t, *snapshot, got)
+	}
+	require.Equal(t, lastUpdateTime, d.speedRecorder.lastUpdateTime)
+	require.Equal(t, snapshot.FinishedBytes, d.speedRecorder.lastFinished)
+	require.Equal(t, snapshot.CurrentSpeedBPS, d.speedRecorder.speedBPS)
 }
 
 // TestMetricsHandlerServesTheDumperRegistry pins the fix for an endpoint that

--- a/dumpling/export/status.go
+++ b/dumpling/export/status.go
@@ -52,13 +52,22 @@ func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 
 // DumpStatus is the status of dumping.
 type DumpStatus struct {
-	CompletedTables   float64
-	FinishedBytes     float64
-	FinishedRows      float64
-	EstimateTotalRows float64
-	TotalTables       int64
-	CurrentSpeedBPS   float64
-	Progress          string
+	CompletedTables   float64 `json:"completedTables"`
+	FinishedBytes     float64 `json:"finishedBytes"`
+	FinishedRows      float64 `json:"finishedRows"`
+	EstimateTotalRows float64 `json:"estimateTotalRows"`
+	TotalTables       int64   `json:"totalTables"`
+	CurrentSpeedBPS   float64 `json:"currentSpeedBPS"`
+	// Progress is rendered for a person reading a log line. A caller that
+	// needs to compute with it - to drive a progress bar, or to estimate a
+	// finish time - should read ProgressPercent instead of parsing this.
+	Progress string `json:"progress,omitempty"`
+	// ProgressPercent is Progress as a number between 0 and 100. It is nil
+	// until the chunk count is known, which is the same moment Progress stops
+	// being empty: before that there is no denominator to divide by, and
+	// reporting zero would claim no work had been done rather than that the
+	// answer is not available yet.
+	ProgressPercent *float64 `json:"progressPercent,omitempty"`
 }
 
 // GetStatus returns the status of dumping by reading metrics.
@@ -73,18 +82,30 @@ func (d *Dumper) GetStatus() *DumpStatus {
 	if d.metrics.progressReady.Load() {
 		// chunks will be zero when upstream has no data
 		if d.metrics.totalChunks.Load() == 0 {
-			ret.Progress = "100 %"
+			ret.setProgress(1)
 			return ret
 		}
 		progress := float64(d.metrics.completedChunks.Load()) / float64(d.metrics.totalChunks.Load())
 		if progress > 1 {
-			ret.Progress = "100 %"
+			progress = 1
 			d.L().Warn("completedChunks is greater than totalChunks", zap.Int64("completedChunks", d.metrics.completedChunks.Load()), zap.Int64("totalChunks", d.metrics.totalChunks.Load()))
-		} else {
-			ret.Progress = fmt.Sprintf("%5.2f %%", progress*100)
 		}
+		ret.setProgress(progress)
 	}
 	return ret
+}
+
+// setProgress records one progress value in both the shapes callers need:
+// the string a log line prints, and the number an API returns. They are set
+// together so the two can never disagree.
+func (s *DumpStatus) setProgress(fraction float64) {
+	percent := fraction * 100
+	s.ProgressPercent = &percent
+	if fraction >= 1 {
+		s.Progress = "100 %"
+		return
+	}
+	s.Progress = fmt.Sprintf("%5.2f %%", percent)
 }
 
 func calculateTableCount(m DatabaseTables) int {

--- a/dumpling/export/status.go
+++ b/dumpling/export/status.go
@@ -14,9 +14,16 @@ import (
 	"go.uber.org/zap"
 )
 
-const logProgressTick = 2 * time.Minute
+const (
+	logProgressTick   = 2 * time.Minute
+	statusRefreshTick = 5 * time.Second
+)
 
 func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
+	d.RefreshStatus()
+	defer d.RefreshStatus()
+	statusTicker := time.NewTicker(statusRefreshTick)
+	defer statusTicker.Stop()
 	logProgressTicker := time.NewTicker(logProgressTick)
 	failpoint.Inject("EnableLogProgress", func() {
 		logProgressTicker.Stop()
@@ -31,21 +38,25 @@ func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 		case <-tctx.Done():
 			tctx.L().Debug("stopping log progress")
 			return
+		case <-statusTicker.C:
+			d.RefreshStatus()
 		case <-logProgressTicker.C:
 			nanoseconds := float64(time.Since(lastCheckpoint).Nanoseconds())
+			// Keep the average over the log interval independent of snapshot age.
+			finishedBytes := ReadGauge(d.metrics.finishedSizeGauge)
 			s := d.GetStatus()
 			tctx.L().Info("progress",
-				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", s.CompletedTables, float64(d.totalTables), s.CompletedTables/float64(d.totalTables)*100)),
+				zap.String("tables", fmt.Sprintf("%.0f/%.0f (%.1f%%)", s.CompletedTables, float64(s.TotalTables), s.CompletedTables/float64(s.TotalTables)*100)),
 				zap.String("finished rows", fmt.Sprintf("%.0f", s.FinishedRows)),
 				zap.String("estimate total rows", fmt.Sprintf("%.0f", s.EstimateTotalRows)),
 				zap.String("finished size", units.HumanSize(s.FinishedBytes)),
-				zap.Float64("average speed(MiB/s)", (s.FinishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
+				zap.Float64("average speed(MiB/s)", (finishedBytes-lastBytes)/(1048576e-9*nanoseconds)),
 				zap.Float64("recent speed bps", s.CurrentSpeedBPS),
 				zap.String("chunks progress", s.Progress),
 			)
 
 			lastCheckpoint = time.Now()
-			lastBytes = s.FinishedBytes
+			lastBytes = finishedBytes
 		}
 	}
 }
@@ -70,9 +81,20 @@ type DumpStatus struct {
 	ProgressPercent *float64 `json:"progressPercent,omitempty"`
 }
 
-// GetStatus returns the status of dumping by reading metrics.
+// GetStatus returns the latest status snapshot without updating the speed recorder.
+// Callers must not modify the returned snapshot. Before the first refresh it is empty.
 func (d *Dumper) GetStatus() *DumpStatus {
+	if status := d.status.Load(); status != nil {
+		return status
+	}
+	return &DumpStatus{}
+}
+
+// RefreshStatus samples metrics and publishes a new status snapshot.
+// The progress loop is the sole refresher, so readers cannot change the speed's sampling window.
+func (d *Dumper) RefreshStatus() {
 	ret := &DumpStatus{}
+	defer d.status.Store(ret)
 	ret.TotalTables = atomic.LoadInt64(&d.totalTables)
 	ret.CompletedTables = ReadCounter(d.metrics.finishedTablesCounter)
 	ret.FinishedBytes = ReadGauge(d.metrics.finishedSizeGauge)
@@ -83,7 +105,7 @@ func (d *Dumper) GetStatus() *DumpStatus {
 		// chunks will be zero when upstream has no data
 		if d.metrics.totalChunks.Load() == 0 {
 			ret.setProgress(1)
-			return ret
+			return
 		}
 		progress := float64(d.metrics.completedChunks.Load()) / float64(d.metrics.totalChunks.Load())
 		if progress > 1 {
@@ -92,7 +114,6 @@ func (d *Dumper) GetStatus() *DumpStatus {
 		}
 		ret.setProgress(progress)
 	}
-	return ret
 }
 
 // setProgress records one progress value in both the shapes callers need:

--- a/dumpling/export/status.go
+++ b/dumpling/export/status.go
@@ -41,6 +41,10 @@ func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 		case <-statusTicker.C:
 			d.RefreshStatus()
 		case <-logProgressTicker.C:
+			// Integration tests shorten the log interval below the snapshot refresh interval.
+			failpoint.Inject("EnableLogProgress", func() {
+				d.RefreshStatus()
+			})
 			nanoseconds := float64(time.Since(lastCheckpoint).Nanoseconds())
 			// Keep the average over the log interval independent of snapshot age.
 			finishedBytes := ReadGauge(d.metrics.finishedSizeGauge)

--- a/dumpling/export/status.go
+++ b/dumpling/export/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/failpoint"
 	tcontext "github.com/pingcap/tidb/dumpling/context"
+	"github.com/pingcap/tidb/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -21,15 +22,14 @@ const (
 
 func (d *Dumper) startLogProgress(tctx *tcontext.Context) func() {
 	ctx, cancel := tctx.WithCancel()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	var wg util.WaitGroupWrapper
+	wg.Run(func() {
 		d.runLogProgress(ctx)
-	}()
+	})
 	return func() {
 		cancel()
 		// Publish the final snapshot before Dump returns or releases resources.
-		<-done
+		wg.Wait()
 	}
 }
 

--- a/dumpling/export/status.go
+++ b/dumpling/export/status.go
@@ -19,6 +19,20 @@ const (
 	statusRefreshTick = 5 * time.Second
 )
 
+func (d *Dumper) startLogProgress(tctx *tcontext.Context) func() {
+	ctx, cancel := tctx.WithCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runLogProgress(ctx)
+	}()
+	return func() {
+		cancel()
+		// Publish the final snapshot before Dump returns or releases resources.
+		<-done
+	}
+}
+
 func (d *Dumper) runLogProgress(tctx *tcontext.Context) {
 	d.RefreshStatus()
 	defer d.RefreshStatus()
@@ -85,11 +99,16 @@ type DumpStatus struct {
 	ProgressPercent *float64 `json:"progressPercent,omitempty"`
 }
 
-// GetStatus returns the latest status snapshot without updating the speed recorder.
-// Callers must not modify the returned snapshot. Before the first refresh it is empty.
+// GetStatus returns an independent copy of the latest status snapshot without
+// updating the speed recorder. Before the first refresh it is empty.
 func (d *Dumper) GetStatus() *DumpStatus {
 	if status := d.status.Load(); status != nil {
-		return status
+		result := *status
+		if status.ProgressPercent != nil {
+			percent := *status.ProgressPercent
+			result.ProgressPercent = &percent
+		}
+		return &result
 	}
 	return &DumpStatus{}
 }

--- a/dumpling/export/status_test.go
+++ b/dumpling/export/status_test.go
@@ -10,6 +10,7 @@ import (
 
 	tcontext "github.com/pingcap/tidb/dumpling/context"
 	"github.com/pingcap/tidb/dumpling/log"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -100,6 +101,37 @@ func TestRunLogProgressRefreshesStatus(t *testing.T) {
 		synctest.Wait()
 		require.Same(t, final, d.GetStatus())
 		require.Len(t, logs.FilterMessage("progress").All(), 1)
+	})
+}
+
+func TestRunLogProgressFailpointRefreshesStatus(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/dumpling/export/EnableLogProgress", "return()")
+	synctest.Test(t, func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		tctx, cancel := tcontext.Background().WithLogger(log.NewAppLogger(zap.New(core))).WithCancel()
+		defer cancel()
+		conf := defaultConfigForTest(t)
+		d := &Dumper{tctx: tctx, conf: conf, speedRecorder: NewSpeedRecorder(), totalTables: 1}
+		d.metrics = newMetrics(conf.PromFactory, nil)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.runLogProgress(tctx)
+		}()
+		synctest.Wait()
+		require.Empty(t, d.GetStatus().Progress)
+
+		// Short integration dumps finish before the normal five-second refresh.
+		d.metrics.totalChunks.Store(4)
+		d.metrics.completedChunks.Store(1)
+		d.metrics.progressReady.Store(true)
+		time.Sleep(time.Second)
+		synctest.Wait()
+		cancel()
+		<-done
+		entries := logs.FilterMessage("progress").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, "25.00 %", entries[0].ContextMap()["chunks progress"])
 	})
 }
 

--- a/dumpling/export/status_test.go
+++ b/dumpling/export/status_test.go
@@ -34,7 +34,7 @@ func TestGetParameters(t *testing.T) {
 	AddGauge(d.metrics.finishedRowsGauge, 30)
 	AddCounter(d.metrics.estimateTotalRowsCounter, 40)
 
-	require.Same(t, initial, d.GetStatus())
+	require.Equal(t, initial, d.GetStatus())
 	d.RefreshStatus()
 	mid = d.GetStatus()
 	require.EqualValues(t, float64(10), mid.CompletedTables)
@@ -42,6 +42,49 @@ func TestGetParameters(t *testing.T) {
 	require.EqualValues(t, float64(30), mid.FinishedRows)
 	require.EqualValues(t, float64(40), mid.EstimateTotalRows)
 	require.Zero(t, initial.FinishedBytes)
+}
+
+func TestGetStatusReturnsIndependentSnapshots(t *testing.T) {
+	conf := defaultConfigForTest(t)
+	d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+	d.metrics = newMetrics(conf.PromFactory, nil)
+	AddGauge(d.metrics.finishedSizeGauge, 500)
+	d.metrics.totalChunks.Store(4)
+	d.metrics.completedChunks.Store(1)
+	d.metrics.progressReady.Store(true)
+	d.RefreshStatus()
+
+	first, second := d.GetStatus(), d.GetStatus()
+	first.FinishedBytes = 999
+	*first.ProgressPercent = 100
+	for _, snapshot := range []*DumpStatus{second, d.GetStatus()} {
+		require.EqualValues(t, 500, snapshot.FinishedBytes)
+		require.EqualValues(t, 25, *snapshot.ProgressPercent)
+	}
+}
+
+func TestStopLogProgressPublishesFinalStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conf := defaultConfigForTest(t)
+		d := &Dumper{conf: conf, speedRecorder: NewSpeedRecorder()}
+		d.metrics = newMetrics(conf.PromFactory, nil)
+		d.metrics.totalChunks.Store(4)
+		d.metrics.completedChunks.Store(1)
+		d.metrics.progressReady.Store(true)
+		stop := d.startLogProgress(tcontext.Background())
+		defer stop()
+		synctest.Wait()
+		require.EqualValues(t, 25, *d.GetStatus().ProgressPercent)
+
+		AddGauge(d.metrics.finishedSizeGauge, 500)
+		d.metrics.completedChunks.Store(4)
+		// Use the same stop function that Dump defers; callers must not need
+		// an additional wait before reading the final snapshot.
+		stop()
+		final := d.GetStatus()
+		require.EqualValues(t, 500, final.FinishedBytes)
+		require.EqualValues(t, 100, *final.ProgressPercent)
+	})
 }
 
 func TestRunLogProgressRefreshesStatus(t *testing.T) {
@@ -99,7 +142,7 @@ func TestRunLogProgressRefreshesStatus(t *testing.T) {
 		AddGauge(d.metrics.finishedSizeGauge, 1000)
 		time.Sleep(5 * time.Second)
 		synctest.Wait()
-		require.Same(t, final, d.GetStatus())
+		require.Equal(t, final, d.GetStatus())
 		require.Len(t, logs.FilterMessage("progress").All(), 1)
 	})
 }

--- a/dumpling/export/status_test.go
+++ b/dumpling/export/status_test.go
@@ -5,9 +5,14 @@ package export
 import (
 	"math"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	tcontext "github.com/pingcap/tidb/dumpling/context"
+	"github.com/pingcap/tidb/dumpling/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestGetParameters(t *testing.T) {
@@ -20,17 +25,82 @@ func TestGetParameters(t *testing.T) {
 	require.EqualValues(t, float64(0), mid.FinishedBytes)
 	require.EqualValues(t, float64(0), mid.FinishedRows)
 	require.EqualValues(t, float64(0), mid.EstimateTotalRows)
+	d.RefreshStatus()
+	initial := d.GetStatus()
 
 	AddCounter(d.metrics.finishedTablesCounter, 10)
 	AddGauge(d.metrics.finishedSizeGauge, 20)
 	AddGauge(d.metrics.finishedRowsGauge, 30)
 	AddCounter(d.metrics.estimateTotalRowsCounter, 40)
 
+	require.Same(t, initial, d.GetStatus())
+	d.RefreshStatus()
 	mid = d.GetStatus()
 	require.EqualValues(t, float64(10), mid.CompletedTables)
 	require.EqualValues(t, float64(20), mid.FinishedBytes)
 	require.EqualValues(t, float64(30), mid.FinishedRows)
 	require.EqualValues(t, float64(40), mid.EstimateTotalRows)
+	require.Zero(t, initial.FinishedBytes)
+}
+
+func TestRunLogProgressRefreshesStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		core, logs := observer.New(zap.InfoLevel)
+		tctx, cancel := tcontext.Background().WithLogger(log.NewAppLogger(zap.New(core))).WithCancel()
+		defer cancel()
+		conf := defaultConfigForTest(t)
+		d := &Dumper{tctx: tctx, conf: conf, speedRecorder: NewSpeedRecorder(), totalTables: 1}
+		d.metrics = newMetrics(conf.PromFactory, nil)
+		d.metrics.totalChunks.Store(4)
+		d.metrics.progressReady.Store(true)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.runLogProgress(tctx)
+		}()
+		synctest.Wait()
+		initial := d.GetStatus()
+		require.NotNil(t, initial.ProgressPercent)
+
+		AddGauge(d.metrics.finishedSizeGauge, 500)
+		d.metrics.completedChunks.Store(1)
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		snapshot := d.GetStatus()
+		require.EqualValues(t, 500, snapshot.FinishedBytes)
+		require.EqualValues(t, 100, snapshot.CurrentSpeedBPS)
+		require.EqualValues(t, 25, *snapshot.ProgressPercent)
+		require.Zero(t, initial.FinishedBytes)
+		require.Zero(t, *initial.ProgressPercent)
+		require.Zero(t, logs.Len())
+
+		// A log tick must use live bytes for its interval average, even if it
+		// runs before the simultaneous status refresh.
+		time.Sleep(114 * time.Second)
+		synctest.Wait()
+		require.Zero(t, logs.Len())
+		AddGauge(d.metrics.finishedSizeGauge, 1500)
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.EqualValues(t, 2000, d.GetStatus().FinishedBytes)
+		require.InDelta(t, 1500.0/115, d.GetStatus().CurrentSpeedBPS, 1e-9)
+		entries := logs.FilterMessage("progress").All()
+		require.Len(t, entries, 1)
+		require.InDelta(t, 2000.0/120/1048576, entries[0].ContextMap()["average speed(MiB/s)"], 1e-12)
+
+		AddGauge(d.metrics.finishedSizeGauge, 1000)
+		d.metrics.completedChunks.Store(4)
+		cancel()
+		<-done
+		final := d.GetStatus()
+		require.EqualValues(t, 3000, final.FinishedBytes)
+		require.EqualValues(t, 100, *final.ProgressPercent)
+		AddGauge(d.metrics.finishedSizeGauge, 1000)
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Same(t, final, d.GetStatus())
+		require.Len(t, logs.FilterMessage("progress").All(), 1)
+	})
 }
 
 func TestSpeedRecorder(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70894

Problem Summary:

Dumpling tracks how far a dump has got, but the only way to read it is the `[progress]` log line. Anything that wants to show progress — a control plane driving a UI progress bar, say — has to scrape and parse log lines, which breaks whenever the log format changes.

This is not theoretical. A 2 TB export measured on a test cluster ran for over twelve hours, and for that whole time the only state that could be surfaced was "running": no percentage, no throughput, no estimate of when it would finish.

Separately, `/metrics` on the same status server has never served a single dump metric. It serves the process-wide default registry, while the dump counters are registered with the registry `conf.PromRegistry` names — the two are never connected.

### What changed and how does it work?

**`GET /status`** — the status server already runs and is already started per-Dumper, so the Dumper is threaded through to the handlers and answers with the same `DumpStatus` the log line is built from:

```json
{
  "completedTables": 0,
  "finishedBytes": 1650000000000,
  "finishedRows": 1586923373,
  "estimateTotalRows": 2147483648,
  "totalTables": 1,
  "currentSpeedBPS": 55000000,
  "progress": "73.60 %",
  "progressPercent": 73.6
}
```

`progressPercent` is new. Progress previously existed only as a preformatted string, which a caller driving a progress bar would have had to parse. Both are set together so they cannot disagree.

It is absent, rather than zero, until the chunk count is known — the same moment `progress` stops being empty. Before that there is no denominator to divide by, and reporting zero would claim no work had been done rather than that the answer is not yet available.

**`GET /metrics`** now serves the Dumper's own registry. If that registry cannot be gathered from, the handler falls back to the default one, so the endpoint keeps answering either way rather than failing over a metrics concern.

No change to how dumps run, and no new flags: `--status-addr` already defaults to `:8281`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Three tests in `dumpling/export/http_handler_test.go`: the status response carries the counters and a numeric progress; progress is omitted before chunks are counted; `/metrics` serves the dump counters rather than an empty default registry (this one fails without the fix).

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

`DumpStatus` gains a field and JSON tags. It is exported, but its only in-tree consumer is the progress log, whose output is unchanged.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add a `/status` endpoint to expose Dumpling progress as JSON, and fix `/metrics` to serve Dumpling's registered metrics
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `/status` endpoint that reports dump progress in JSON.
  - Status responses include progress percentage and monitoring details when available.
  - The `/metrics` endpoint now serves metrics from the configured dump registry.

- **Bug Fixes**
  - Improved progress and speed reporting during active and completed dumps.
  - Status snapshots remain stable between refreshes and report service unavailability when data is unavailable.
  - Configured metrics remain available during registry configuration changes and name conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
