### PR TITLE
expression: support right shift for binary strings

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -158,6 +158,7 @@ go_test(
     timeout = "moderate",
     srcs = [
         "bench_test.go",
+        "binary_right_shift_blob_test.go",
         "builtin_arithmetic_test.go",
         "builtin_arithmetic_vec_test.go",
         "builtin_cast_bench_test.go",

--- a/pkg/expression/binary_right_shift_blob_test.go
+++ b/pkg/expression/binary_right_shift_blob_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package expression_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestBinaryRightShiftBlob(t *testing.T) {
+	for _, vectorized := range []string{"off", "on"} {
+		t.Run(vectorized, func(t *testing.T) {
+			store := testkit.CreateMockStore(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec("create table shift_source(id int primary key, b blob, vb varbinary(2), fixed binary(2), text_value varchar(4), shift_count int)")
+			tk.MustExec("insert into shift_source values (1, 0xC2A0, 0xC2A0, 0xC2A0, '16', 4), (2, NULL, NULL, NULL, NULL, 4)")
+			tk.MustExec("create table t2(a blob)")
+			tk.MustExec("create table t3(a blob)")
+			tk.MustExec("insert into t2 values (0xC2A0)")
+			tk.MustExec("insert into t3 values (0xC2)")
+			tk.MustExec("set @@tidb_enable_vectorized_expression=" + vectorized)
+
+			tk.MustQuery("select hex(b >> shift_count), hex(b >> 8), hex(b >> 16), length(b >> shift_count), hex(vb >> shift_count), hex(fixed >> shift_count) from shift_source where id = 1").Check(
+				testkit.Rows("0C2A 00C2 0000 2 0C2A 0C2A"),
+			)
+			tk.MustQuery("select hex(b >> shift_count), hex(vb >> shift_count), hex(fixed >> shift_count) from shift_source where id = 2").Check(
+				testkit.Rows("<nil> <nil> <nil>"),
+			)
+			tk.MustQuery("select hex(t2.a), hex(t3.a) from t2, t3 where (t2.a >> 4) = t3.a").Check(testkit.Rows())
+			tk.MustQuery("select 123 >> 2, 0xC2A0 >> 4, text_value >> 2 from shift_source where id = 1").Check(
+				testkit.Rows("30 3114 4"),
+			)
+		})
+	}
+}

--- a/pkg/expression/binary_right_shift_blob_test.go
+++ b/pkg/expression/binary_right_shift_blob_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package expression_test
 
@@ -30,7 +40,13 @@ func TestBinaryRightShiftBlob(t *testing.T) {
 			tk.MustQuery("select hex(b >> shift_count), hex(vb >> shift_count), hex(fixed >> shift_count) from shift_source where id = 2").Check(
 				testkit.Rows("<nil> <nil> <nil>"),
 			)
-			tk.MustQuery("select hex(t2.a), hex(t3.a) from t2, t3 where (t2.a >> 4) = t3.a").Check(testkit.Rows())
+			for _, query := range []string{
+				"select hex(t2.a), hex(t3.a) from t2, t3 where (t2.a >> 4) = t3.a",
+				"select hex(t2.a), hex(t3.a) from t2, t3 where (t2.a >> 8) = t3.a",
+			} {
+				tk.MustQuery(query).Check(testkit.Rows())
+				tk.MustQuery("show warnings").Check(testkit.Rows())
+			}
 			tk.MustQuery("select 123 >> 2, 0xC2A0 >> 4, text_value >> 2 from shift_source where id = 1").Check(
 				testkit.Rows("30 3114 4"),
 			)

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -425,6 +425,16 @@ func (c *rightShiftFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
+	argType := args[0].GetType(ctx.GetEvalCtx())
+	if types.IsBinaryStr(argType) && !IsBinaryLiteral(args[0]) {
+		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETString, types.ETInt)
+		if err != nil {
+			return nil, err
+		}
+		bf.tp.SetFlen(argType.GetFlen())
+		SetBinFlagOrBinStr(argType, bf.tp)
+		return &builtinRightShiftBinarySig{baseBuiltinFunc: bf}, nil
+	}
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt, types.ETInt)
 	if err != nil {
 		return nil, err
@@ -459,6 +469,53 @@ func (b *builtinRightShiftSig) evalInt(ctx EvalContext, row chunk.Row) (int64, b
 		return 0, isNull, err
 	}
 	return int64(uint64(arg0) >> uint64(arg1)), false, nil
+}
+
+type builtinRightShiftBinarySig struct {
+	baseBuiltinFunc
+
+	// NOTE: Any new fields added here must be thread-safe or immutable during execution,
+	// as this expression may be shared across sessions.
+	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
+}
+
+func (b *builtinRightShiftBinarySig) Clone() builtinFunc {
+	newSig := &builtinRightShiftBinarySig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
+func (b *builtinRightShiftBinarySig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
+	arg0, isNull, err := b.args[0].EvalString(ctx, row)
+	if isNull || err != nil {
+		return "", isNull, err
+	}
+	arg1, isNull, err := b.args[1].EvalInt(ctx, row)
+	if isNull || err != nil {
+		return "", isNull, err
+	}
+	return rightShiftBinaryString(arg0, uint64(arg1)), false, nil
+}
+
+func rightShiftBinaryString(arg string, shift uint64) string {
+	if shift == 0 || len(arg) == 0 {
+		return arg
+	}
+
+	result := make([]byte, len(arg))
+	byteShift := shift / 8
+	if byteShift >= uint64(len(arg)) {
+		return string(result)
+	}
+	bitShift := shift % 8
+	for i := int(byteShift); i < len(arg); i++ {
+		src := i - int(byteShift)
+		result[i] = arg[src] >> bitShift
+		if bitShift != 0 && src > 0 {
+			result[i] |= arg[src-1] << (8 - bitShift)
+		}
+	}
+	return string(result)
 }
 
 type isTrueOrFalseFunctionClass struct {

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -708,6 +708,42 @@ func (b *builtinRightShiftSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	return nil
 }
 
+func (*builtinRightShiftBinarySig) vectorized() bool {
+	return true
+}
+
+func (b *builtinRightShiftBinarySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
+	arg0, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(arg0)
+	if err := b.args[0].VecEvalString(ctx, input, arg0); err != nil {
+		return err
+	}
+
+	arg1, err := b.bufAllocator.get()
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(arg1)
+	if err := b.args[1].VecEvalInt(ctx, input, arg1); err != nil {
+		return err
+	}
+
+	n := input.NumRows()
+	result.ReserveString(n)
+	shifts := arg1.Int64s()
+	for i := range n {
+		if arg0.IsNull(i) || arg1.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(rightShiftBinaryString(arg0.GetString(i), uint64(shifts[i])))
+	}
+	return nil
+}
+
 func (b *builtinRealIsTrueSig) vectorized() bool {
 	return true
 }

--- a/pkg/expression/builtin_threadsafe_generated.go
+++ b/pkg/expression/builtin_threadsafe_generated.go
@@ -2000,6 +2000,11 @@ func (s *builtinReverseUTF8Sig) SafeToShareAcrossSession() bool {
 }
 
 // SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
+func (s *builtinRightShiftBinarySig) SafeToShareAcrossSession() bool {
+	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
+}
+
+// SafeToShareAcrossSession implements BuiltinFunc.SafeToShareAcrossSession.
 func (s *builtinRightShiftSig) SafeToShareAcrossSession() bool {
 	return safeToShareAcrossSession(&s.safeToShareAcrossSessionFlag, s.args)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53943

Problem Summary:

TiDB currently evaluates the right-shift operator with the integer signature for all operands. When the left operand is a nonliteral binary string such as a BLOB, TiDB implicitly converts its bytes to BIGINT before shifting. This conversion can truncate the value to 0, so a comparison such as `(t2.a >> 4) = t3.a` can incorrectly match rows and emit truncation warnings, while MySQL shifts the binary value directly. The execution plan exposes the unexpected BLOB-to-BIGINT cast, and tracing the expression construction leads to `rightShiftFunctionClass.getFunction`, which always selects the `(ETInt, ETInt) -> ETInt` signature.

### What changed and how does it work?

Add a binary-string right-shift signature for nonliteral binary string operands while preserving the existing integer path for numbers, binary literals, and nonbinary strings. The new implementation shifts the byte sequence with zero fill, preserves the original binary length and type flags, returns an all-zero value when the shift count is at least the bit width, and supports both scalar and vectorized evaluation with NULL propagation. Add regression coverage for BLOB, VARBINARY, and BINARY operands, 4-bit, 8-bit, and 16-bit shifts, length and leading-zero preservation, NULL values, the reported join comparison, and unchanged integer, hexadecimal literal, and VARCHAR behavior in both vectorized modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that right-shifting a BLOB, BINARY, or VARBINARY value might return an incorrect result because TiDB converts the value to an integer before shifting #53943
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary right-shift operations now support blob, varbinary, fixed binary, numeric, and text values.
  * Results preserve expected hexadecimal formatting, lengths, and NULL behavior.
  * Support is available in both vectorized and non-vectorized execution modes.
  * Empty results are handled correctly without generating warnings.

* **Tests**
  * Added coverage for binary right-shift behavior across supported data types, operand combinations, and execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->