### PR TITLE
executor: fix output column order for HashJoin V1 right outer joins

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -370,6 +370,7 @@ go_test(
         "explain_unit_test.go",
         "explainfor_test.go",
         "grant_test.go",
+        "hash_join_v1_output_order_test.go",
         "historical_stats_test.go",
         "hot_regions_history_table_test.go",
         "import_into_test.go",

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2077,6 +2077,10 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 		colsFromChildren = colsFromChildren[:len(colsFromChildren)-1]
 	}
 	childrenUsedSchema := markChildrenUsedCols(colsFromChildren, v.Children()[0].Schema(), v.Children()[1].Schema())
+	var outputColumnOrder []int
+	if v.JoinType == base.RightOuterJoin {
+		outputColumnOrder = getHashJoinV1OutputColumnOrder(colsFromChildren, childrenUsedSchema, v.Children()[0].Schema().Len())
+	}
 	var fullJoinBuildJoinerJoinType, fullJoinProbeJoinerJoinType base.JoinType
 	var fullJoinBuildJoinerOuterIsRight, fullJoinProbeJoinerOuterIsRight bool
 	var fullJoinBuildJoinerDefaultValues, fullJoinProbeJoinerDefaultValues []types.Datum
@@ -2122,7 +2126,11 @@ func (b *executorBuilder) buildHashJoinFromChildExecs(leftExec, rightExec exec.E
 			// Keep Joiner as probe-mismatch joiner for shared non-full code paths.
 			worker.Joiner = worker.FullJoinProbeJoiner
 		} else {
-			worker.Joiner = join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin)
+			if outputColumnOrder == nil {
+				worker.Joiner = join.NewJoiner(b.sctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, isNAJoin)
+			} else {
+				worker.Joiner = join.NewRightOuterJoinerWithOutputColumnOrder(b.sctx, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, lhsTypes, rhsTypes, childrenUsedSchema, outputColumnOrder)
+			}
 		}
 		worker.WorkerID = i
 		e.ProbeWorkers[i] = worker
@@ -3495,6 +3503,22 @@ func markChildrenUsedCols(outputCols []*expression.Column, childSchemas ...*expr
 		prefixLen += childSchema.Len()
 	}
 	return
+}
+
+func getHashJoinV1OutputColumnOrder(outputCols []*expression.Column, childrenUsed [][]int, leftSchemaLen int) []int {
+	leftThenRightOrder := make([]int, 0, len(outputCols))
+	leftThenRightOrder = append(leftThenRightOrder, childrenUsed[0]...)
+	for _, idx := range childrenUsed[1] {
+		leftThenRightOrder = append(leftThenRightOrder, leftSchemaLen+idx)
+	}
+	outputColumnOrder := make([]int, 0, len(outputCols))
+	for _, col := range outputCols {
+		outputColumnOrder = append(outputColumnOrder, col.Index)
+	}
+	if slices.Equal(leftThenRightOrder, outputColumnOrder) {
+		return nil
+	}
+	return outputColumnOrder
 }
 
 func (*executorBuilder) corColInDistPlan(plans []base.PhysicalPlan) bool {

--- a/pkg/executor/hash_join_v1_output_order_test.go
+++ b/pkg/executor/hash_join_v1_output_order_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/executor/join"
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestNaturalRightJoinHashJoinV1OutputOrder(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	setupTK := testkit.NewTestKit(t, store)
+	setupTK.MustExec("use test")
+	setupTK.MustExec("CREATE TABLE t1(c0 SMALLINT)")
+	setupTK.MustExec("CREATE TABLE t4(c0 BIGINT DEFAULT 1383675574, c2 BLOB(55))")
+	setupTK.MustExec("INSERT IGNORE INTO t4 VALUES(NULL, '') ON DUPLICATE KEY UPDATE c0=t4.c2")
+	setupTK.MustExec("INSERT IGNORE INTO t4(c2) VALUES('MZ')")
+	setupTK.MustExec("DELETE FROM mysql.opt_rule_blacklist")
+	setupTK.MustExec("INSERT INTO mysql.opt_rule_blacklist VALUES('predicate_push_down'),('column_prune'),('projection_eliminate')")
+	setupTK.MustExec("ADMIN RELOAD opt_rule_blacklist")
+	t.Cleanup(func() {
+		setupTK.MustExec("DELETE FROM mysql.opt_rule_blacklist")
+		setupTK.MustExec("ADMIN RELOAD opt_rule_blacklist")
+	})
+
+	originalQuery := "SELECT t4.c2, t4.c0 FROM t1 NATURAL RIGHT JOIN t4 WHERE t4.c0"
+	explicitRightJoin := "SELECT t4.c2, t4.c0 FROM t1 RIGHT JOIN t4 ON t1.c0=t4.c0 WHERE t4.c0"
+	swappedLeftJoin := "SELECT t4.c2, t4.c0 FROM t4 LEFT JOIN t1 ON t4.c0=t1.c0 WHERE t4.c0"
+	expected := testkit.Rows("MZ 1383675574")
+	hashJoinVersions := []struct {
+		name string
+		sql  string
+	}{
+		{name: "legacy", sql: join.DisableHashJoinV2},
+		{name: "optimized", sql: join.EnableHashJoinV2},
+	}
+
+	for _, vectorized := range []string{"OFF", "ON"} {
+		for _, hashJoinVersion := range hashJoinVersions {
+			t.Run(vectorized+"/"+hashJoinVersion.name, func(t *testing.T) {
+				tk := testkit.NewTestKit(t, store)
+				tk.MustExec("use test")
+				tk.MustExec("SET @@tidb_enable_vectorized_expression=" + vectorized)
+				tk.MustExec(hashJoinVersion.sql)
+
+				tk.MustQuery("EXPLAIN FORMAT='brief' " + originalQuery).
+					CheckContain("CARTESIAN right outer join")
+				tk.MustQuery(originalQuery).Check(expected)
+				tk.MustQuery(explicitRightJoin).Check(expected)
+				tk.MustQuery(swappedLeftJoin).Check(expected)
+			})
+		}
+	}
+}

--- a/pkg/executor/join/joiner.go
+++ b/pkg/executor/join/joiner.go
@@ -210,6 +210,20 @@ func NewJoiner(ctx sessionctx.Context, joinType plannerbase.JoinType,
 	panic("unsupported join type in func NewJoiner()")
 }
 
+// NewRightOuterJoinerWithOutputColumnOrder creates a right outer joiner whose output follows
+// indexes in the merged left-right schema.
+func NewRightOuterJoinerWithOutputColumnOrder(ctx sessionctx.Context, outerIsRight bool,
+	defaultInner []types.Datum, filter []expression.Expression, lhsColTypes, rhsColTypes []*types.FieldType,
+	childrenUsed [][]int, outputColumnOrder []int) Joiner {
+	joiner := NewJoiner(ctx, plannerbase.RightOuterJoin, outerIsRight, defaultInner, filter, lhsColTypes, rhsColTypes, childrenUsed, false).(*rightOuterJoiner)
+	joiner.outputColumnOrder = slices.Clone(outputColumnOrder)
+	shallowRowType := make([]*types.FieldType, 0, len(lhsColTypes)+len(rhsColTypes))
+	shallowRowType = append(shallowRowType, lhsColTypes...)
+	shallowRowType = append(shallowRowType, rhsColTypes...)
+	joiner.shallowRow = chunk.MutRowFromTypes(shallowRowType)
+	return joiner
+}
+
 type outerRowStatusFlag byte
 
 const (
@@ -234,6 +248,10 @@ type baseJoiner struct {
 	// 1. every columns are used if lUsed/rUsed is nil.
 	// 2. no columns are used if lUsed/rUsed is not nil but the size of lUsed/rUsed is 0.
 	lUsed, rUsed []int
+
+	// outputColumnOrder is nil when the output follows the existing left-then-right layout.
+	// Otherwise, it contains output column indexes in the unpruned merged left-right row.
+	outputColumnOrder []int
 }
 
 func (j *baseJoiner) initDefaultInner(innerTypes []*types.FieldType, defaultInner []types.Datum) {
@@ -247,6 +265,12 @@ func (*baseJoiner) makeJoinRowToChunk(chk *chunk.Chunk, lhs, rhs chunk.Row, lUse
 	// Fix: https://github.com/pingcap/tidb/issues/5771
 	lWide := chk.AppendRowByColIdxs(lhs, lUsed)
 	chk.AppendPartialRowByColIdxs(lWide, rhs, rUsed)
+}
+
+func (j *baseJoiner) makeOutputJoinRowToChunk(chk *chunk.Chunk, lhs, rhs chunk.Row) {
+	j.shallowRow.ShallowCopyPartialRow(0, lhs)
+	j.shallowRow.ShallowCopyPartialRow(lhs.Len(), rhs)
+	chk.AppendRowByColIdxs(j.shallowRow.ToRow(), j.outputColumnOrder)
 }
 
 // makeShallowJoinRow shallow copies `inner` and `outer` into `shallowRow`.
@@ -268,6 +292,10 @@ func (j *baseJoiner) filter(input, output *chunk.Chunk, outerColLen int, lUsed, 
 	j.selected, err = expression.VectorizedFilter(j.ctx.GetExprCtx().GetEvalCtx(), j.ctx.GetSessionVars().EnableVectorizedExpression, j.conditions, chunk.NewIterator4Chunk(input), j.selected)
 	if err != nil {
 		return false, err
+	}
+	if len(j.outputColumnOrder) > 0 {
+		input = input.Prune(j.outputColumnOrder)
+		return chunk.CopySelectedJoinRowsDirect(input, j.selected, output)
 	}
 	// Batch copies selected rows to output chunk.
 	innerColOffset, outerColOffset := 0, input.NumCols()-outerColLen
@@ -317,7 +345,9 @@ func (j *baseJoiner) filterAndCheckOuterRowStatus(
 		}
 	}
 
-	if lUsed != nil || rUsed != nil {
+	if len(j.outputColumnOrder) > 0 {
+		input = input.Prune(j.outputColumnOrder)
+	} else if lUsed != nil || rUsed != nil {
 		lSize := innerColsLen
 		if !j.outerIsRight {
 			lSize = input.NumCols() - innerColsLen
@@ -348,6 +378,9 @@ func (j *baseJoiner) Clone() baseJoiner {
 	}
 	if j.chk != nil {
 		base.chk = j.chk.CopyConstruct()
+		if len(j.outputColumnOrder) > 0 {
+			base.shallowRow = j.shallowRow.Clone()
+		}
 	} else {
 		base.shallowRow = j.shallowRow.Clone()
 	}
@@ -356,6 +389,7 @@ func (j *baseJoiner) Clone() baseJoiner {
 	}
 	base.lUsed = slices.Clone(j.lUsed)
 	base.rUsed = slices.Clone(j.rUsed)
+	base.outputColumnOrder = slices.Clone(j.outputColumnOrder)
 	return base
 }
 
@@ -938,9 +972,16 @@ func (j *rightOuterJoiner) TryToMatchInners(outer chunk.Row, inners chunk.Iterat
 	}
 
 	numToAppend := chk.RequiredRows() - chk.NumRows()
-	for ; inners.Current() != inners.End() && numToAppend > 0; numToAppend-- {
-		j.makeJoinRowToChunk(chkForJoin, inners.Current(), outer, lUsed, rUsed)
-		inners.Next()
+	if len(j.conditions) == 0 && len(j.outputColumnOrder) > 0 {
+		for ; inners.Current() != inners.End() && numToAppend > 0; numToAppend-- {
+			j.makeOutputJoinRowToChunk(chkForJoin, inners.Current(), outer)
+			inners.Next()
+		}
+	} else {
+		for ; inners.Current() != inners.End() && numToAppend > 0; numToAppend-- {
+			j.makeJoinRowToChunk(chkForJoin, inners.Current(), outer, lUsed, rUsed)
+			inners.Next()
+		}
 	}
 	err = inners.Error()
 	if err != nil {
@@ -969,8 +1010,14 @@ func (j *rightOuterJoiner) TryToMatchOuters(outers chunk.Iterator, inner chunk.R
 	}
 
 	outer, numToAppend, cursor := outers.Current(), chk.RequiredRows()-chk.NumRows(), 0
-	for ; outer != outers.End() && cursor < numToAppend; outer, cursor = outers.Next(), cursor+1 {
-		j.makeJoinRowToChunk(chkForJoin, inner, outer, lUsed, rUsed)
+	if len(j.conditions) == 0 && len(j.outputColumnOrder) > 0 {
+		for ; outer != outers.End() && cursor < numToAppend; outer, cursor = outers.Next(), cursor+1 {
+			j.makeOutputJoinRowToChunk(chkForJoin, inner, outer)
+		}
+	} else {
+		for ; outer != outers.End() && cursor < numToAppend; outer, cursor = outers.Next(), cursor+1 {
+			j.makeJoinRowToChunk(chkForJoin, inner, outer, lUsed, rUsed)
+		}
 	}
 
 	outerRowStatus = outerRowStatus[:0]
@@ -985,6 +1032,10 @@ func (j *rightOuterJoiner) TryToMatchOuters(outers chunk.Iterator, inner chunk.R
 }
 
 func (j *rightOuterJoiner) OnMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
+	if len(j.outputColumnOrder) > 0 {
+		j.makeOutputJoinRowToChunk(chk, j.defaultInner, outer)
+		return
+	}
 	lWide := chk.AppendRowByColIdxs(j.defaultInner, j.lUsed)
 	chk.AppendPartialRowByColIdxs(lWide, outer, j.rUsed)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53900

Problem Summary:

TiDB can return an empty result for a `NATURAL RIGHT JOIN` that should return a row when predicate pushdown, column pruning, and projection elimination are disabled. Reproducing the reported query and comparing it with equivalent explicit `RIGHT JOIN` and swapped `LEFT JOIN` queries showed that only the natural join path failed. `EXPLAIN` keeps the natural equality in `OtherConditions` on a Cartesian right outer HashJoin, and changing it into a hash key makes the query pass only by switching the execution path. Inspecting HashJoin V1 further showed that `markChildrenUsedCols` records used columns separately for each child, so the joiner always writes the selected left columns before the selected right columns. A natural right join can require a different physical output order across the two children, leaving the produced chunk inconsistent with the output schema and causing upper operators to read the wrong columns.

### What changed and how does it work?

Detect right outer HashJoin V1 plans whose physical output order differs from the existing left-then-right layout and pass the required column order to the right outer joiner. The joiner continues to build the full left-then-right row when evaluating residual conditions, then applies the output permutation only when writing filtered, matched, and unmatched rows, while the existing identity-order path remains unchanged. The new state is also preserved when a joiner is cloned. Add regression coverage that keeps the reported Cartesian right outer join plan and verifies the original query together with equivalent explicit joins under vectorized expression evaluation both on and off and with both hash join settings.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `NATURAL RIGHT JOIN` might return incorrect results when predicate pushdown, column pruning, and projection elimination are disabled #53900
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected output column ordering for natural right joins when the join inputs use different column orders.
  * Ensured matched and unmatched rows follow the query’s requested schema consistently.
  * Verified consistent results across supported execution modes and hash join implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->