### PR TITLE
expression: handle unsigned length arguments in RIGHT

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -212,6 +212,7 @@ go_test(
         "helper_test.go",
         "inference_helper_test.go",
         "main_test.go",
+        "right_unsigned_length_test.go",
         "scalar_function_test.go",
         "schema_test.go",
         "simple_rewriter_test.go",

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -572,6 +572,20 @@ type builtinRightSig struct {
 	// If a field does not meet these requirements, set SafeToShareAcrossSession to false.
 }
 
+// normalizeRightLength treats a negative unsigned ETInt payload as a value above MaxInt64.
+func normalizeRightLength(strLength int, right int64, unsigned bool) int {
+	if right < 0 {
+		if unsigned {
+			return strLength
+		}
+		return 0
+	}
+	if right > int64(strLength) {
+		return strLength
+	}
+	return int(right)
+}
+
 func (b *builtinRightSig) Clone() builtinFunc {
 	newSig := &builtinRightSig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
@@ -589,12 +603,8 @@ func (b *builtinRightSig) evalString(ctx EvalContext, row chunk.Row) (string, bo
 	if isNull || err != nil {
 		return "", true, err
 	}
-	strLength, rightLength := len(str), int(right)
-	if rightLength > strLength {
-		rightLength = strLength
-	} else if rightLength < 0 {
-		rightLength = 0
-	}
+	strLength := len(str)
+	rightLength := normalizeRightLength(strLength, right, mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()))
 	return str[strLength-rightLength:], false, nil
 }
 
@@ -624,12 +634,8 @@ func (b *builtinRightUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (string
 		return "", true, err
 	}
 	runes := []rune(str)
-	strLength, rightLength := len(runes), int(right)
-	if rightLength > strLength {
-		rightLength = strLength
-	} else if rightLength < 0 {
-		rightLength = 0
-	}
+	strLength := len(runes)
+	rightLength := normalizeRightLength(strLength, right, mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()))
 	return string(runes[strLength-rightLength:]), false, nil
 }
 

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -256,6 +256,7 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 
 	result.ReserveString(n)
 	nums := buf2.Int64s()
+	unsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 	for i := range n {
 		if buf.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
@@ -264,12 +265,8 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 
 		str := buf.GetString(i)
 		runes := []rune(str)
-		strLength, rightLength := len(runes), int(nums[i])
-		if rightLength > strLength {
-			rightLength = strLength
-		} else if rightLength < 0 {
-			rightLength = 0
-		}
+		strLength := len(runes)
+		rightLength := normalizeRightLength(strLength, nums[i], unsigned)
 
 		result.AppendString(string(runes[strLength-rightLength:]))
 	}
@@ -2799,18 +2796,15 @@ func (b *builtinRightSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	}
 	right := buf2.Int64s()
 	result.ReserveString(n)
+	unsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 	for i := range n {
 		if buf.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		str, rightLength := buf.GetString(i), int(right[i])
+		str := buf.GetString(i)
 		strLength := len(str)
-		if rightLength > strLength {
-			rightLength = strLength
-		} else if rightLength < 0 {
-			rightLength = 0
-		}
+		rightLength := normalizeRightLength(strLength, right[i], unsigned)
 		result.AppendString(str[strLength-rightLength:])
 	}
 	return nil

--- a/pkg/expression/right_unsigned_length_test.go
+++ b/pkg/expression/right_unsigned_length_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package expression
+
+import (
+	"math"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRightUnsignedLength(t *testing.T) {
+	ctx := createContext(t)
+	utf8Input := primitiveValsToConstants(ctx, []any{"你好"})[0]
+	binaryInput := &Constant{
+		Value: types.NewStringDatum("abc"),
+		RetType: types.NewFieldTypeBuilder().
+			SetType(mysql.TypeString).
+			SetFlag(mysql.BinaryFlag).
+			SetCharset(charset.CharsetBin).
+			SetCollate(charset.CollationBin).
+			BuildP(),
+	}
+	unsignedLength := primitiveValsToConstants(ctx, []any{uint64(math.MaxUint64)})[0]
+	signedLength := primitiveValsToConstants(ctx, []any{int64(-1)})[0]
+
+	testCases := []struct {
+		name     string
+		str      Expression
+		length   Expression
+		expected string
+		binary   bool
+	}{
+		{name: "utf8/unsigned", str: utf8Input, length: unsignedLength, expected: "你好"},
+		{name: "binary/unsigned", str: binaryInput, length: unsignedLength, expected: "abc", binary: true},
+		{name: "utf8/signed_negative", str: utf8Input, length: signedLength, expected: ""},
+		{name: "binary/signed_negative", str: binaryInput, length: signedLength, expected: "", binary: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, vectorized := range []bool{false, true} {
+				mode := "scalar"
+				if vectorized {
+					mode = "vectorized"
+				}
+				t.Run(mode, func(t *testing.T) {
+					expr, err := NewFunctionBase(
+						ctx,
+						ast.Right,
+						types.NewFieldType(mysql.TypeVarString),
+						testCase.str,
+						testCase.length,
+					)
+					require.NoError(t, err)
+					f := expr.(*ScalarFunction).Function
+					if testCase.binary {
+						require.IsType(t, &builtinRightSig{}, f)
+					} else {
+						require.IsType(t, &builtinRightUTF8Sig{}, f)
+					}
+
+					if !vectorized {
+						actual, isNull, err := expr.EvalString(ctx, chunk.Row{})
+						require.NoError(t, err)
+						require.False(t, isNull)
+						require.Equal(t, testCase.expected, actual)
+						return
+					}
+
+					input := chunk.NewChunkWithCapacity(nil, 1)
+					input.SetNumVirtualRows(1)
+					require.True(t, expr.Vectorized())
+					result := chunk.NewColumn(expr.GetType(ctx.GetEvalCtx()), 1)
+					require.NoError(t, expr.VecEvalString(ctx, input, result))
+					require.False(t, result.IsNull(0))
+					require.Equal(t, testCase.expected, result.GetString(0))
+				})
+			}
+		})
+	}
+}

--- a/pkg/expression/right_unsigned_length_test.go
+++ b/pkg/expression/right_unsigned_length_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package expression
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53894

Problem Summary:

TiDB returns an empty string for `RIGHT(str, CAST(-1 AS UNSIGNED))`, while the unsigned length is `18446744073709551615` and should therefore return the whole input string. This also makes TiDB and TiFlash return different results for the same expression. Reducing the reported query to a local `RIGHT('abcd', CAST(-1 AS UNSIGNED))` call showed that the plan preserves the unsigned value and that the expression is evaluated by TiDB rather than pushed down. Tracing the scalar and vectorized implementations then showed that the unsigned ETInt value is carried in an `int64`, so a value above `MaxInt64` has a negative payload. The existing code checks only whether that payload is negative and clamps the requested length to 0 without considering the argument's unsigned type flag. The same normalization logic is duplicated in both UTF-8 and binary string implementations.

### What changed and how does it work?

Add a shared length normalization helper that checks the unsigned flag of the second argument. A negative payload from an unsigned ETInt represents a value above `MaxInt64`, so it is clamped to the input length, while a genuinely signed negative value continues to produce an empty string and ordinary positive lengths retain the existing bounds handling. Use the helper in the UTF-8 and binary implementations for both scalar and vectorized evaluation. Add regression coverage for `MaxUint64` and signed `-1` length arguments across UTF-8 and binary strings in both execution modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `RIGHT()` returns an empty string instead of the whole input when its length argument is an unsigned integer greater than `MaxInt64` #53894
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the `RIGHT()` function’s handling of very large unsigned length values.
  - These values now return the full input string instead of an empty result.
  - Applied the correction consistently to standard and vectorized evaluation for UTF-8 and binary strings.
  - Added coverage for unsigned maximum lengths and negative signed lengths to help ensure consistent behavior across supported input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->