### PR TITLE
expression: align float-to-date casts with MySQL

### DIFF
--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -5,10 +5,11 @@ go_test(
     timeout = "short",
     srcs = [
         "executor_issue_test.go",
+        "float_cast_date_grouping_test.go",
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/float_cast_date_grouping_test.go
+++ b/pkg/executor/test/issuetest/float_cast_date_grouping_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issuetest_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestFloatCastDateGrouping(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t")
+	tk.MustExec(`CREATE TABLE t (
+		c0 DECIMAL(10, 0) NOT NULL,
+		c1 FLOAT UNSIGNED ZEROFILL NOT NULL,
+		PRIMARY KEY (c0, c1)
+	)`)
+	tk.MustExec(`INSERT INTO t VALUES
+		(-2068985011, 0.75245386),
+		(-668435082, 0.19411194),
+		(-500731198, 0.39079505),
+		(0, 0),
+		(0, 0.9938275),
+		(12196703, 970789000),
+		(919009011, 0.28699672),
+		(1069380201, 0.2576304)`)
+
+	tk.MustQuery("SELECT CAST(c1 AS DATE) IS NULL FROM t ORDER BY c0, c1").Check(
+		testkit.Rows("1", "1", "1", "1", "1", "1", "1", "1"),
+	)
+	tk.MustQuery(`SELECT c0 FROM t
+		GROUP BY c0, CAST(c1 AS DATE), c0 OR ''
+		HAVING NOT c0`).Check(testkit.Rows("0"))
+}

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1476,8 +1476,12 @@ func (b *builtinCastRealAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (typ
 	if isNull || err != nil {
 		return types.ZeroTime, true, err
 	}
-	// MySQL compatibility: 0 should not be converted to null, see #11203
 	fv := strconv.FormatFloat(val, 'f', -1, 64)
+	if b.tp.GetType() == mysql.TypeDate && val > -1 && val < 1 {
+		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), fv)
+		return types.ZeroTime, true, handleInvalidTimeError(ctx, err)
+	}
+	// MySQL compatibility: 0 should not be converted to null, see #11203
 	if fv == "0" {
 		return types.ZeroTime, false, nil
 	}

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -588,6 +588,14 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 			continue
 		}
 		fv := strconv.FormatFloat(f64s[i], 'f', -1, 64)
+		if b.tp.GetType() == mysql.TypeDate && f64s[i] > -1 && f64s[i] < 1 {
+			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), fv)
+			if err = handleInvalidTimeError(ctx, err); err != nil {
+				return err
+			}
+			result.SetNull(i, true)
+			continue
+		}
 		if fv == "0" {
 			times[i] = types.ZeroTime
 			continue

--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -188,6 +188,37 @@ func TestVectorizedCastRealAsTime(t *testing.T) {
 	}
 }
 
+func TestCastRealAsDate(t *testing.T) {
+	col := &Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}
+	ctx := createContext(t)
+	baseFunc, err := newBaseBuiltinFunc(ctx, "", []Expression{col}, types.NewFieldType(mysql.TypeDate))
+	require.NoError(t, err)
+	cast := &builtinCastRealAsTimeSig{baseFunc}
+	require.True(t, cast.vectorized() && cast.isChildrenVectorized())
+
+	input := chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDouble)}, 4)
+	input.AppendFloat64(0, 0)
+	input.AppendFloat64(0, 0.19411194)
+	input.AppendFloat64(0, 0.9938275)
+	input.AppendFloat64(0, 20240101)
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeDate), input.NumRows())
+	require.NoError(t, cast.vecEvalTime(ctx, input, result))
+
+	for i := range input.NumRows() {
+		res, isNull, err := cast.evalTime(ctx, input.GetRow(i))
+		require.NoError(t, err)
+		if i < 3 {
+			require.True(t, result.IsNull(i))
+			require.True(t, isNull)
+			continue
+		}
+		require.False(t, result.IsNull(i))
+		require.False(t, isNull)
+		require.Equal(t, "2024-01-01", result.GetTime(i).String())
+		require.Equal(t, "2024-01-01", res.String())
+	}
+}
+
 func getTime(year int, month int, day int, hour int, minute int, second int) *types.Time {
 	retTime := types.NewTime(types.FromDate(year, month, day, hour, minute, second, 0), mysql.TypeDatetime, types.DefaultFsp)
 	return &retTime

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -184,6 +184,11 @@ func scalarExprSupportedByTiDB(ctx EvalContext, function *ScalarFunction) bool {
 
 // supported functions tracked by https://github.com/tikv/tikv/issues/5751
 func scalarExprSupportedByTiKV(ctx EvalContext, sf *ScalarFunction) bool {
+	// TiKV's REAL-to-DATE conversion does not match TiDB for zero and fractional values.
+	if sf.FuncName.L == ast.Cast && sf.Function.PbCode() == tipb.ScalarFuncSig_CastRealAsTime &&
+		sf.RetType.GetType() == mysql.TypeDate {
+		return false
+	}
 	switch sf.FuncName.L {
 	case
 		// op functions.

--- a/pkg/expression/scalar_function_test.go
+++ b/pkg/expression/scalar_function_test.go
@@ -258,3 +258,20 @@ func TestForbidUnixTimestampPushdown(t *testing.T) {
 	}
 	require.False(t, scalarExprSupportedByTiKV(ctx, sf))
 }
+
+func TestForbidRealToDatePushdown(t *testing.T) {
+	ctx := mock.NewContext()
+	realColumn := &Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}
+
+	dateExpr, err := NewFunction(ctx, ast.Cast, types.NewFieldType(mysql.TypeDate), realColumn)
+	require.NoError(t, err)
+	dateCast := dateExpr.(*ScalarFunction)
+	require.Equal(t, tipb.ScalarFuncSig_CastRealAsTime, dateCast.Function.PbCode())
+	require.False(t, scalarExprSupportedByTiKV(ctx, dateCast))
+
+	datetimeExpr, err := NewFunction(ctx, ast.Cast, types.NewFieldType(mysql.TypeDatetime), realColumn)
+	require.NoError(t, err)
+	datetimeCast := datetimeExpr.(*ScalarFunction)
+	require.Equal(t, tipb.ScalarFuncSig_CastRealAsTime, datetimeCast.Function.PbCode())
+	require.True(t, scalarExprSupportedByTiKV(ctx, datetimeCast))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52934

Problem Summary:

TiDB can return duplicate rows for a `GROUP BY` that contains `CAST(float_column AS DATE)`, and the result can change depending on whether aggregation and the cast are executed by TiDB or pushed down to TiKV. In the reported data set, MySQL treats every FLOAT-to-DATE conversion as invalid and returns NULL, while TiDB and TiKV produce different combinations of NULL and zero dates, causing logically identical values to become different grouping keys. Reproducing the query showed the wrong two-row result when the execution plan pushed the FLOAT-to-DATE cast into a TiKV HashAgg. Checking the casts directly then narrowed the TiDB-side mismatch to zero and fractional REAL values between `-1` and `1`, and tracing pushdown capability showed that the same `CastRealAsTime` signature is accepted by TiKV even though its DATE semantics do not match TiDB or MySQL.

### What changed and how does it work?

For a REAL-to-DATE cast, treat values strictly between `-1` and `1` as invalid DATE values in both scalar and vectorized evaluation and route the error through the existing invalid-time handler so non-strict evaluation returns NULL with the expected warning. Keep the existing zero-time compatibility behavior for DATETIME casts and preserve valid date-like numeric inputs. Disable TiKV pushdown only when `CastRealAsTime` returns DATE, while retaining pushdown for DATETIME, so the same DATE conversion semantics are used regardless of the aggregation plan. Add regression coverage for scalar and vectorized DATE casts, the DATE-versus-DATETIME pushdown boundary, all eight values from the reported fixture, and the final grouping result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that casting FLOAT values to DATE might return inconsistent results between TiDB and TiKV and cause incorrect `GROUP BY` results #52934
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected conversions from fractional real-number values to `DATE`, which now return `NULL` with a truncation warning instead of being silently converted.
  * Ensured real-to-date conversions produce consistent results across standard and vectorized evaluation.
  * Prevented incompatible real-to-date conversions from being pushed down, preserving consistent query results.
* **Tests**
  * Added regression coverage for date casting and grouping scenarios involving real-number values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->