### PR TITLE
planner: fix cast order for quantified comparisons

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -933,7 +933,19 @@ func (er *expressionRewriter) handleOtherComparableSubq(planCtx *exprRewriterPla
 	if useMin {
 		funcName = ast.AggFuncMin
 	}
-	funcMaxOrMin, err := aggregation.NewAggFuncDesc(planCtx.builder.ctx.GetExprCtx(), funcName, []expression.Expression{rexpr}, false)
+	cmpLExpr, aggArg := lexpr, rexpr
+	evalCtx := er.sctx.GetEvalCtx()
+	// MAX/MIN must order values in the comparison domain; casting its result is too late when coercion can change ordering.
+	if expression.GetAccurateCmpType(evalCtx, lexpr, rexpr) != rexpr.GetType(evalCtx).EvalType() {
+		cmpExpr, err := expression.NewFunctionBase(er.sctx, cmpFunc, types.NewFieldType(mysql.TypeTiny), lexpr, rexpr)
+		if err != nil {
+			er.err = err
+			return
+		}
+		cmpArgs := cmpExpr.(*expression.ScalarFunction).GetArgs()
+		cmpLExpr, aggArg = cmpArgs[0], cmpArgs[1]
+	}
+	funcMaxOrMin, err := aggregation.NewAggFuncDesc(planCtx.builder.ctx.GetExprCtx(), funcName, []expression.Expression{aggArg}, false)
 	if err != nil {
 		er.err = err
 		return
@@ -944,14 +956,14 @@ func (er *expressionRewriter) handleOtherComparableSubq(planCtx *exprRewriterPla
 		UniqueID: planCtx.builder.ctx.GetSessionVars().AllocPlanColumnID(),
 		RetType:  funcMaxOrMin.RetTp,
 	}
-	colMaxOrMin.SetCoercibility(rexpr.Coercibility())
+	colMaxOrMin.SetCoercibility(aggArg.Coercibility())
 	schema := expression.NewSchema(colMaxOrMin)
 
 	plan4Agg.SetOutputNames(append(plan4Agg.OutputNames(), types.EmptyName))
 	plan4Agg.SetSchema(schema)
 	plan4Agg.AggFuncs = []*aggregation.AggFuncDesc{funcMaxOrMin}
 
-	cond := expression.NewFunctionInternal(er.sctx, cmpFunc, types.NewFieldType(mysql.TypeTiny), lexpr, colMaxOrMin)
+	cond := expression.NewFunctionInternal(er.sctx, cmpFunc, types.NewFieldType(mysql.TypeTiny), cmpLExpr, colMaxOrMin)
 	er.buildQuantifierPlan(planCtx, plan4Agg, cond, lexpr, rexpr, all, markNoDecorrelate)
 }
 

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -4,13 +4,14 @@ go_test(
     name = "issuetest_test",
     timeout = "moderate",
     srcs = [
+        "any_comparison_cast_rewrite_test.go",
         "main_test.go",
         "panicrisk_tier2_test.go",
         "planner_issue_test.go",
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/any_comparison_cast_rewrite_test.go
+++ b/pkg/planner/core/issuetest/any_comparison_cast_rewrite_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issuetest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnyComparisonCastRewrite(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table lhs (v double)")
+	tk.MustExec("create table rhs (v char(20))")
+	tk.MustExec("insert into lhs values (0.0001), (0), (2), (-1)")
+	tk.MustExec("insert into rhs values ('1'), ('3'), (' '), ('w')")
+
+	maxQuery := "select v from lhs where (-v) <= any (select v from rhs) order by v"
+	tk.MustQuery(maxQuery).Check(testkit.Rows("-1", "0", "0.0001", "2"))
+	maxPlan := fmt.Sprint(tk.MustQuery("explain format='brief' " + maxQuery).Rows())
+	require.Contains(t, maxPlan, "max(cast(test.rhs.v, double BINARY))")
+
+	tk.MustExec("truncate table lhs")
+	tk.MustExec("truncate table rhs")
+	tk.MustExec("insert into lhs values (1), (2), (5), (10)")
+	tk.MustExec("insert into rhs values ('2'), ('10')")
+
+	minQuery := "select v from lhs where v >= any (select v from rhs) order by v"
+	tk.MustQuery(minQuery).Check(testkit.Rows("2", "5", "10"))
+	minPlan := fmt.Sprint(tk.MustQuery("explain format='brief' " + minQuery).Rows())
+	require.Contains(t, minPlan, "min(cast(test.rhs.v, double BINARY))")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50785

Problem Summary:

TiDB can return incorrect results for quantified comparisons such as `<= ANY` when the left and right operands require implicit type conversion. A minimized case comparing DOUBLE values with CHAR values misses the `-1` row even though an equivalent pairwise comparison includes it. Inspecting the execution plan showed that the planner rewrites `x <= ANY(subquery)` to `x <= MAX(subquery)`, computes `MAX` in the original string domain, and only casts the aggregate result to DOUBLE for the final comparison. This changes semantics because type conversion can change ordering: the string maximum `'w'` converts to 0, while converting each input to DOUBLE before aggregation produces the correct numeric maximum. The same ordering issue applies to the corresponding `MIN` rewrite.

### What changed and how does it work?

When the accurate comparison type differs from the right operand's evaluation type, build the comparison expression first and reuse its coerced arguments. Feed the coerced right argument into `MAX` or `MIN`, use the coerced left argument in the final comparison, and propagate coercibility from the actual aggregate argument. This makes the aggregate order values in the comparison domain while preserving the existing optimized MAX/MIN plan and leaving comparisons with already compatible types unchanged. Add regression coverage for both `<= ANY` through `MAX` and `>= ANY` through `MIN`, including result checks and plan assertions that the cast is applied inside the aggregate.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that quantified comparisons such as `<= ANY` and `>= ANY` might return incorrect results when the two sides require implicit type conversion #50785
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparisons involving `ANY` subqueries when the compared values use different data types.
  * Ensured `MAX` and `MIN` comparisons apply the appropriate type conversion, producing more accurate query results and execution plans.

* **Tests**
  * Added coverage for `ANY` comparisons between numeric and character values, including boundary comparison operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->