### PR TITLE
planner: preserve volatile GROUP BY alias values

### DIFF
--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -7,10 +7,11 @@ go_test(
         "main_test.go",
         "panicrisk_tier2_test.go",
         "planner_issue_test.go",
+        "volatile_group_by_projection_test.go",
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/errno",
         "//pkg/parser",

--- a/pkg/planner/core/issuetest/volatile_group_by_projection_test.go
+++ b/pkg/planner/core/issuetest/volatile_group_by_projection_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 PingCAP, Inc.
 //
-// Licensed under the Apache License, Version 2.0.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package issuetest
 
@@ -20,14 +30,19 @@ func TestVolatileGroupByProjection(t *testing.T) {
 	tk.MustExec("CREATE TABLE t (a INT, b INT, c INT, d INT)")
 	tk.MustExec("INSERT INTO t VALUES (1,1,1,10), (2,1,2,2), (3,1,1,10), (4,1,2,2)")
 
-	const query = "SELECT b * FLOOR(2 * RAND(177)) AS e, COUNT(d) AS cnt FROM t GROUP BY e ORDER BY e, cnt"
-	tk.MustQuery(query).Check(testkit.Rows("0 3", "1 1"))
+	queries := []string{
+		"SELECT b * FLOOR(2 * RAND(177)) AS e, COUNT(d) AS cnt FROM t GROUP BY e ORDER BY e, cnt",
+		"SELECT b * FLOOR(2 * RAND(177)) AS e, COUNT(d) AS cnt FROM t GROUP BY 1 ORDER BY e, cnt",
+	}
+	for _, query := range queries {
+		tk.MustQuery(query).Check(testkit.Rows("0 3", "1 1"))
 
-	plan := tk.MustQuery("EXPLAIN FORMAT='brief' " + query).String()
-	lowerPlan := strings.ToLower(plan)
-	randPos := strings.Index(lowerPlan, "rand(177)")
-	hashAggPos := strings.Index(plan, "HashAgg")
-	if count := strings.Count(lowerPlan, "rand(177)"); count != 1 || hashAggPos < 0 || randPos < hashAggPos {
-		t.Fatalf("expected RAND(177) to be evaluated once below HashAgg, found plan:\n%s", plan)
+		plan := tk.MustQuery("EXPLAIN FORMAT='brief' " + query).String()
+		lowerPlan := strings.ToLower(plan)
+		randPos := strings.Index(lowerPlan, "rand(177)")
+		hashAggPos := strings.Index(plan, "HashAgg")
+		if count := strings.Count(lowerPlan, "rand(177)"); count != 1 || hashAggPos < 0 || randPos < hashAggPos {
+			t.Fatalf("expected RAND(177) to be evaluated once below HashAgg for %s, found plan:\n%s", query, plan)
+		}
 	}
 }

--- a/pkg/planner/core/issuetest/volatile_group_by_projection_test.go
+++ b/pkg/planner/core/issuetest/volatile_group_by_projection_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package issuetest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestVolatileGroupByProjection(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("SET @@session.tidb_allow_mpp = 0")
+	tk.MustExec("SET @@session.tidb_enable_cascades_planner = 0")
+	tk.MustExec("CREATE TABLE t (a INT, b INT, c INT, d INT)")
+	tk.MustExec("INSERT INTO t VALUES (1,1,1,10), (2,1,2,2), (3,1,1,10), (4,1,2,2)")
+
+	const query = "SELECT b * FLOOR(2 * RAND(177)) AS e, COUNT(d) AS cnt FROM t GROUP BY e ORDER BY e, cnt"
+	tk.MustQuery(query).Check(testkit.Rows("0 3", "1 1"))
+
+	plan := tk.MustQuery("EXPLAIN FORMAT='brief' " + query).String()
+	lowerPlan := strings.ToLower(plan)
+	randPos := strings.Index(lowerPlan, "rand(177)")
+	hashAggPos := strings.Index(plan, "HashAgg")
+	if count := strings.Count(lowerPlan, "rand(177)"); count != 1 || hashAggPos < 0 || randPos < hashAggPos {
+		t.Fatalf("expected RAND(177) to be evaluated once below HashAgg, found plan:\n%s", plan)
+	}
+}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3435,7 +3435,7 @@ func (g *gbyResolver) Enter(inNode ast.Node) (ast.Node, bool) {
 			}
 		}
 		return n, true
-	case *driver.ValueExpr, *ast.ColumnNameExpr, *ast.ParenthesesExpr, *ast.ColumnName:
+	case *driver.ValueExpr, *ast.ColumnNameExpr, *ast.ParenthesesExpr, *ast.ColumnName, *ast.PositionExpr:
 	default:
 		g.inExpr = true
 	}
@@ -3498,6 +3498,9 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			}
 			g.err = plannererrors.ErrWrongGroupField.GenWithStackByArgs(fieldName)
 			return inNode, false
+		}
+		if !g.inExpr {
+			g.selectFieldIdx = pos - 1
 		}
 		return ret, true
 	case *ast.ValuesExpr:

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -1803,7 +1803,7 @@ func (b *PlanBuilder) implicitProjectGroupingSetCols(projSchema *expression.Sche
 
 // buildProjection returns a Projection plan and non-aux columns length.
 func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int,
-	windowMapper map[*ast.WindowFuncExpr]int, considerWindow bool, expandGenerateColumn bool) (base.LogicalPlan, []expression.Expression, int, error) {
+	windowMapper map[*ast.WindowFuncExpr]int, considerWindow bool, expandGenerateColumn bool, mutableGbyAliasCols map[int]*expression.Column) (base.LogicalPlan, []expression.Expression, int, error) {
 	err := b.preprocessUserVarTypes(ctx, p, fields, mapper)
 	if err != nil {
 		return nil, nil, 0, err
@@ -1842,15 +1842,22 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 			newNames = append(newNames, name)
 			continue
 		}
-		newExpr, np, err := b.rewriteWithPreprocess(ctx, field.Expr, p, mapper, windowMapper, true, nil)
-		if err != nil {
-			return nil, nil, 0, err
-		}
+		var newExpr expression.Expression
+		if col, ok := mutableGbyAliasCols[i]; ok {
+			newExpr = p.Schema().RetrieveColumn(col)
+		} else {
+			var np base.LogicalPlan
+			newExpr, np, err = b.rewriteWithPreprocess(ctx, field.Expr, p, mapper, windowMapper, true, nil)
+			if err != nil {
+				return nil, nil, 0, err
+			}
+			p = np
 
-		// for case: select a+1, b, sum(b), grouping(a) from t group by a, b with rollup.
-		// the column inside aggregate (only sum(b) here) should be resolved to original source column,
-		// while for others, just use expanded columns if exists: a'+ 1, b', group(gid)
-		newExpr = b.replaceGroupingFunc(newExpr)
+			// for case: select a+1, b, sum(b), grouping(a) from t group by a, b with rollup.
+			// the column inside aggregate (only sum(b) here) should be resolved to original source column,
+			// while for others, just use expanded columns if exists: a'+ 1, b', group(gid)
+			newExpr = b.replaceGroupingFunc(newExpr)
+		}
 
 		// For window functions in the order by clause, we will append an field for it.
 		// We need rewrite the window mapper here so order by clause could find the added field.
@@ -1860,7 +1867,6 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p base.LogicalPlan, f
 			}
 		}
 
-		p = np
 		proj.Exprs = append(proj.Exprs, newExpr)
 
 		col, name, err := b.buildProjectionField(ctx, p, field, newExpr)
@@ -3410,6 +3416,8 @@ type gbyResolver struct {
 	skipAggMap map[*ast.AggregateFuncExpr]*expression.CorrelatedColumn
 
 	exprDepth int // exprDepth is the depth of current expression in expression tree.
+	// selectFieldIdx is set when the entire GROUP BY item resolves to a SELECT alias.
+	selectFieldIdx int
 }
 
 func (g *gbyResolver) Enter(inNode ast.Node) (ast.Node, bool) {
@@ -3459,6 +3467,9 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 				} else {
 					if isParam, ok := ret.(*driver.ParamMarkerExpr); ok {
 						isParam.UseAsValueInGbyByClause = true
+					}
+					if !g.inExpr {
+						g.selectFieldIdx = index
 					}
 					return ret, true
 				}
@@ -4063,9 +4074,10 @@ func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldNa
 // The returned `[]ast.Node` may differ from the original `gby.Items` in the group by clause for params. For params, the
 // `gby.Items[].Expr` will not be overwritten. However, the resolved expression is still needed for further processing, so
 // it's returned out.
-func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) ([]ast.ExprNode, error) {
+func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) ([]ast.ExprNode, []int, error) {
 	b.curClause = groupByClause
 	exprs := make([]ast.ExprNode, 0, len(gby.Items))
+	aliasFieldIdx := make([]int, 0, len(gby.Items))
 	schema := p.Schema()
 	names := p.OutputNames()
 	// findJoinFullSchema walks through transparent wrappers (LogicalSelection)
@@ -4076,27 +4088,30 @@ func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause
 		names = fullNames
 	}
 	resolver := &gbyResolver{
-		ctx:        b.ctx,
-		fields:     fields,
-		schema:     schema,
-		names:      names,
-		skipAggMap: b.correlatedAggMapper,
+		ctx:            b.ctx,
+		fields:         fields,
+		schema:         schema,
+		names:          names,
+		skipAggMap:     b.correlatedAggMapper,
+		selectFieldIdx: -1,
 	}
 	for _, item := range gby.Items {
 		resolver.inExpr = false
 		resolver.exprDepth = 0
 		resolver.isParam = false
+		resolver.selectFieldIdx = -1
 		retExpr, _ := item.Expr.Accept(resolver)
 		if resolver.err != nil {
-			return exprs, errors.Trace(resolver.err)
+			return exprs, aliasFieldIdx, errors.Trace(resolver.err)
 		}
 		if !resolver.isParam {
 			item.Expr = retExpr.(ast.ExprNode)
 		}
 
 		exprs = append(exprs, retExpr.(ast.ExprNode))
+		aliasFieldIdx = append(aliasFieldIdx, resolver.selectFieldIdx)
 	}
-	return exprs, nil
+	return exprs, aliasFieldIdx, nil
 }
 
 func (b *PlanBuilder) rewriteGbyExprs(ctx context.Context, p base.LogicalPlan, gby *ast.GroupByClause, items []ast.ExprNode) (base.LogicalPlan, []expression.Expression, bool, error) {
@@ -4112,6 +4127,44 @@ func (b *PlanBuilder) rewriteGbyExprs(ctx context.Context, p base.LogicalPlan, g
 		p = np
 	}
 	return p, exprs, gby.Rollup, nil
+}
+
+// materializeMutableGbyAliases makes a mutable SELECT expression referenced by a top-level
+// GROUP BY alias a child column of the aggregation. The aggregation then groups by and preserves
+// the same evaluated value instead of letting the SELECT projection evaluate the expression again.
+func (b *PlanBuilder) materializeMutableGbyAliases(p base.LogicalPlan, gbyItems []expression.Expression, aliasFieldIdx []int) (base.LogicalPlan, []expression.Expression, map[int]*expression.Column) {
+	var proj *logicalop.LogicalProjection
+	var newGbyItems []expression.Expression
+	materializedCols := make(map[int]*expression.Column)
+	for i, fieldIdx := range aliasFieldIdx {
+		if fieldIdx < 0 || !expression.IsMutableEffectsExpr(gbyItems[i]) {
+			continue
+		}
+		if newGbyItems == nil {
+			newGbyItems = append([]expression.Expression(nil), gbyItems...)
+			proj = logicalop.LogicalProjection{Exprs: expression.Column2Exprs(p.Schema().Columns)}.Init(b.ctx, b.getSelectOffset())
+			proj.SetSchema(p.Schema().Clone())
+			proj.SetOutputNames(append(types.NameSlice(nil), p.OutputNames()...))
+			proj.SetChildren(p)
+		}
+		if col, ok := materializedCols[fieldIdx]; ok {
+			newGbyItems[i] = col
+			continue
+		}
+		col := &expression.Column{
+			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
+			RetType:  gbyItems[i].GetType(b.ctx.GetExprCtx().GetEvalCtx()).Clone(),
+		}
+		proj.Exprs = append(proj.Exprs, gbyItems[i])
+		proj.Schema().Append(col)
+		proj.SetOutputNames(append(proj.OutputNames(), types.EmptyName))
+		newGbyItems[i] = col
+		materializedCols[fieldIdx] = col
+	}
+	if proj == nil {
+		return p, gbyItems, nil
+	}
+	return proj, newGbyItems, materializedCols
 }
 
 func (*PlanBuilder) unfoldWildStar(p base.LogicalPlan, selectFields []*ast.SelectField) (resultList []*ast.SelectField, err error) {
@@ -4328,6 +4381,8 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		windowAggMap                  map[*ast.AggregateFuncExpr]int
 		correlatedAggMap              map[*ast.AggregateFuncExpr]int
 		gbyCols                       []expression.Expression
+		gbyAliasFieldIdx              []int
+		mutableGbyAliasCols           map[int]*expression.Column
 		projExprs                     []expression.Expression
 		rollup                        bool
 	)
@@ -4396,7 +4451,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 
 	var gbyExprs []ast.ExprNode
 	if sel.GroupBy != nil {
-		gbyExprs, err = b.resolveGbyExprs(p, sel.GroupBy, sel.Fields.Fields)
+		gbyExprs, gbyAliasFieldIdx, err = b.resolveGbyExprs(p, sel.GroupBy, sel.Fields.Fields)
 		if err != nil {
 			return nil, err
 		}
@@ -4544,6 +4599,8 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			p, gbyCols, mutableGbyAliasCols = b.materializeMutableGbyAliases(p, gbyCols, gbyAliasFieldIdx)
 		}
 		var aggIndexMap map[int]int
 		p, aggIndexMap, err = b.buildAggregation(ctx, p, aggFuncs, gbyCols, correlatedAggMap)
@@ -4558,7 +4615,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	var oldLen int
 	// According to https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html,
 	// we can only process window functions after having clause, so `considerWindow` is false now.
-	p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, totalMap, nil, false, sel.OrderBy != nil)
+	p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, totalMap, nil, false, sel.OrderBy != nil, mutableGbyAliasCols)
 	if err != nil {
 		return nil, err
 	}
@@ -4596,7 +4653,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		// In such case plan `p` is not changed, so we don't have to build another projection.
 		if hasWindowFuncField {
 			// Now we build the window function fields.
-			p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, windowAggMap, windowMapper, true, false)
+			p, projExprs, oldLen, err = b.buildProjection(ctx, p, sel.Fields.Fields, windowAggMap, windowMapper, true, false, nil)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36386

Problem Summary:

TiDB can display duplicate grouping keys when a `GROUP BY` item references a SELECT expression containing a volatile function through either its alias or ordinal position, such as `SELECT b * FLOOR(2 * RAND()) AS e, COUNT(d) FROM t GROUP BY e`. The aggregation evaluates the expression once to build its groups, but the final projection evaluates the same expression again, so the displayed key can differ from the value used by `HashAgg` and multiple groups can be shown with the same key. Reproducing the issue with `RAND(177)` makes the behavior deterministic: the correct groups are `(0, 3)` and `(1, 1)`, while the existing plan returns `(0, 1)` and `(0, 3)`. `EXPLAIN` shows `RAND(177)` in both the projection below `HashAgg` and the projection above it, which localizes the problem to independent rewrites of the GROUP BY reference and its SELECT field.

### What changed and how does it work?

Track when a top-level GROUP BY item resolves to a SELECT field through either an alias or a validated ordinal position. If the resolved expression has mutable effects, materialize it once in a projection below the aggregation, replace the grouping expression with the generated column, and make the final SELECT projection read the same column instead of rebuilding the volatile expression. Reuse one materialized column when the same SELECT field is referenced more than once, and leave deterministic expressions, nested alias references, window processing, and rollup on their existing paths. Add deterministic seeded-RAND regression coverage for both alias and ordinal GROUP BY references that checks the expected group counts and verifies that the plan contains a single RAND evaluation below `HashAgg`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that grouping by a SELECT alias or ordinal position containing a volatile function might display duplicate or incorrect group keys because the expression is evaluated more than once #36386
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed grouped queries using volatile expressions, such as `RAND()`, through named or ordinal `GROUP BY` references.
  - Ensured these expressions are materialized once and consistently reused for grouping and displayed results.
  - Corrected grouped query behavior for both alias-based and positional grouping syntax.
  - Added coverage verifying query results and execution plans for volatile grouped projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->