### PR TITLE
dumpling: read password from MYSQL_PWD environment variable

### DIFF
--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -94,6 +95,10 @@ const (
 
 	// FlagHelp represents the help flag
 	FlagHelp = "help"
+
+	// envMySQLPwd is the environment variable the MySQL client reads the password
+	// from. Dumpling only consults it when the password flag is absent.
+	envMySQLPwd = "MYSQL_PWD"
 )
 
 // CSVDialect is the dialect of the CSV output for compatible with different import target
@@ -355,7 +360,7 @@ func (*Config) DefineFlags(flags *pflag.FlagSet) {
 	flags.StringP(flagHost, "h", "127.0.0.1", "The host to connect to")
 	flags.StringP(flagUser, "u", "root", "Username with privileges to run the dump")
 	flags.IntP(flagPort, "P", 4000, "TCP/IP port to connect to")
-	flags.StringP(flagPassword, "p", "", "User password")
+	flags.StringP(flagPassword, "p", "", "User password, read from the MYSQL_PWD environment variable if this flag is not set")
 	flags.Bool(flagAllowCleartextPasswords, false, "Allow passwords to be sent in cleartext (warning: don't use without TLS)")
 	flags.IntP(flagThreads, "t", 4, "Number of goroutines to use, default 4")
 	flags.StringP(flagFilesize, "F", "", "The approximate size of output file")
@@ -445,6 +450,11 @@ func (conf *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	conf.Password, err = flags.GetString(flagPassword)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	// Follow the MySQL client precedence: the flag always wins, and MYSQL_PWD is
+	// only used when no password flag is given.
+	if !flags.Changed(flagPassword) {
+		conf.Password = os.Getenv(envMySQLPwd)
 	}
 	conf.AllowCleartextPasswords, err = flags.GetBool(flagAllowCleartextPasswords)
 	if err != nil {

--- a/dumpling/export/config_test.go
+++ b/dumpling/export/config_test.go
@@ -391,6 +391,34 @@ func TestOutputFilenameTemplateWithRowsValidation(t *testing.T) {
 	})
 }
 
+func TestParsePassword(t *testing.T) {
+	t.Run("read from MYSQL_PWD when the flag is not set", func(t *testing.T) {
+		t.Setenv(envMySQLPwd, "pwd-from-env")
+		conf := parseConfigFromArgsForTest(t)
+		require.Equal(t, "pwd-from-env", conf.Password)
+	})
+
+	t.Run("flag takes precedence over MYSQL_PWD", func(t *testing.T) {
+		t.Setenv(envMySQLPwd, "pwd-from-env")
+		conf := parseConfigFromArgsForTest(t, "--password", "pwd-from-flag")
+		require.Equal(t, "pwd-from-flag", conf.Password)
+	})
+
+	t.Run("empty flag takes precedence over MYSQL_PWD", func(t *testing.T) {
+		t.Setenv(envMySQLPwd, "pwd-from-env")
+		conf := parseConfigFromArgsForTest(t, "--password", "")
+		require.Equal(t, "", conf.Password)
+	})
+
+	t.Run("no password when neither is set", func(t *testing.T) {
+		// t.Setenv restores the original value on cleanup, so unset it afterwards.
+		t.Setenv(envMySQLPwd, "pwd-from-env")
+		require.NoError(t, os.Unsetenv(envMySQLPwd))
+		conf := parseConfigFromArgsForTest(t)
+		require.Equal(t, "", conf.Password)
+	})
+}
+
 func parseConfigFromArgsForTest(t *testing.T, args ...string) *Config {
 	t.Helper()
 	conf, err := parseConfigFromArgsForTestWithErr(t, args...)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70907

Problem Summary:

- Dumpling reads the password only from `--password`, so the secret must sit on the command line, where `ps`, shell history and CI logs can expose it.
- `mysql` and `mysqldump` fall back to the `MYSQL_PWD` environment variable when no password option is given, but dumpling does not.

### What changed and how does it work?

- `ParseFromFlags` now reads `MYSQL_PWD` when the `--password` flag is absent. The flag always wins, so current users see no change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
s-mitani % ./bin/dumpling --help 2>&1 | grep '\-\-password'
  -p, --password string                   User password, read from the MYSQL_PWD environment variable if this flag is not set

# Confirmed that the password is read from the environment variable.
s-mitani % MYSQL_PWD=my_password ./bin/dumpling -P 4000 -B test -o /tmp/dump-out 2>&1 | tail -n3
[2026/09/05 15:53:28.432 +09:00] [INFO] [dispatcher.go:149] ["[tso] exit tso dispatcher"]
[2026/09/05 15:53:28.432 +09:00] [INFO] [main.go:82] ["dump data successfully, dumpling will exit now"]
[2026/09/05 15:53:28.432 +09:00] [INFO] [service_discovery.go:562] ["[pd] exit member loop due to context canceled"]

# Confirmed that the --password option can still be used.
s-mitani % ./bin/dumpling -p my_password -P 4000 -B test -o /tmp/dump-out 2>&1 | tail -n3
[2026/09/05 15:53:37.377 +09:00] [INFO] [main.go:82] ["dump data successfully, dumpling will exit now"]
[2026/09/05 15:53:37.377 +09:00] [INFO] [router_service_discovery.go:315] ["[router service] exit health check member loop"]
[2026/09/05 15:53:37.377 +09:00] [INFO] [router_service_discovery.go:273] ["[router service] exit check member loop"]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
dumpling: support reading the password from the `MYSQL_PWD` environment variable when `--password` is not set
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dumpling can now read the MySQL password from the `MYSQL_PWD` environment variable when no password is provided through the command line.
  - An explicitly provided `--password` value, including an empty value, takes precedence over `MYSQL_PWD`.

- **Documentation**
  - Updated the password option help text to explain the environment-variable behavior and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->