### PR TITLE
executor: fix IndexMerge union truncating at 1024 rows with ORDER BY and LIMIT

### DIFF
--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -1075,15 +1075,19 @@ func (w *indexMergeProcessWorker) NewHandleHeap(taskMap map[int][]*indexMergeTab
 	}
 
 	requiredCnt := uint64(0)
+	initSize := uint64(0)
 	if w.indexMerge.pushedLimit != nil {
-		// Pre-allocate up to 1024 to avoid oom
-		requiredCnt = min(1024, w.indexMerge.pushedLimit.Count+w.indexMerge.pushedLimit.Offset)
+		// requiredCnt is the logical retention bound of the heap. Since it brings
+		// the heap size down to the real limit+offset, it must not be capped here.
+		requiredCnt = w.indexMerge.pushedLimit.Count + w.indexMerge.pushedLimit.Offset
+		// Pre-allocate at most 1024 slots to avoid OOM on a huge limit value.
+		initSize = min(1024, requiredCnt)
 	}
 	return &handleHeap{
 		requiredCnt: requiredCnt,
 		tracker:     memTracker,
 		taskMap:     taskMap,
-		idx:         make([]rowIdx, 0, requiredCnt),
+		idx:         make([]rowIdx, 0, initSize),
 		compareFunc: compareFuncs,
 		byItems:     w.indexMerge.byItems,
 	}

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -1153,7 +1153,7 @@ func (w *indexMergeProcessWorker) fetchLoopUnionWithOrderBy(ctx context.Context,
 			if _, ok := distinctHandles.Get(h); !ok {
 				distinctHandles.Set(h, true)
 				heap.Push(taskHeap, rowIdx{task.partialPlanID, len(taskMap[task.partialPlanID]) - 1, i})
-				if int(taskHeap.requiredCnt) != 0 && taskHeap.Len() > int(taskHeap.requiredCnt) {
+				if taskHeap.requiredCnt != 0 && uint64(taskHeap.Len()) > taskHeap.requiredCnt {
 					top := heap.Pop(taskHeap).(rowIdx)
 					if top.partialID == task.partialPlanID && top.taskID == len(taskMap[task.partialPlanID])-1 && top.rowID == i {
 						uselessMap[task.partialPlanID] = struct{}{}

--- a/pkg/executor/test/indexmergereadtest/BUILD.bazel
+++ b/pkg/executor/test/indexmergereadtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
+++ b/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
@@ -924,5 +924,9 @@ func TestIssues70910(t *testing.T) {
 	tk.MustNotHavePlan(query, "TopN")
 	// Issue #70910: the pushed-down limit must not be truncated to 1024 rows by
 	// the index merge union worker heap. The full 2000 rows must be returned.
-	require.Equal(t, 2000, len(tk.MustQuery(query).Rows()))
+rows := tk.MustQuery(query).Rows()
+	require.Equal(t, 2000, len(rows))
+	for i, row := range rows {
+		require.Equal(t, fmt.Sprintf("%d", i), fmt.Sprintf("%v", row[2]))
+	}
 }

--- a/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
+++ b/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
@@ -904,3 +904,25 @@ func TestIssues46005(t *testing.T) {
 
 	tk.MustQuery("select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where a = 1 or b = 1 order by c limit 1025")
 }
+
+func TestIssues70910(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t(a int, b int, c int, index idx1(a, c), index idx2(b, c))")
+	for rowID := 0; rowID < 3000; rowID += 500 {
+		vals := make([]string, 0, 500)
+		for i := rowID; i < rowID+500; i++ {
+			vals = append(vals, fmt.Sprintf("(1, 1, %d)", i))
+		}
+		tk.MustExec("insert into t(a,b,c) values " + strings.Join(vals, ","))
+	}
+
+	query := "select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where a = 1 or b = 1 order by c limit 2000"
+	tk.MustHavePlan(query, "IndexMerge")
+	tk.MustNotHavePlan(query, "TopN")
+	// Issue #70910: the pushed-down limit must not be truncated to 1024 rows by
+	// the index merge union worker heap. The full 2000 rows must be returned.
+	require.Equal(t, 2000, len(tk.MustQuery(query).Rows()))
+}

--- a/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
+++ b/pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
@@ -924,7 +924,7 @@ func TestIssues70910(t *testing.T) {
 	tk.MustNotHavePlan(query, "TopN")
 	// Issue #70910: the pushed-down limit must not be truncated to 1024 rows by
 	// the index merge union worker heap. The full 2000 rows must be returned.
-rows := tk.MustQuery(query).Rows()
+	rows := tk.MustQuery(query).Rows()
 	require.Equal(t, 2000, len(rows))
 	for i, row := range rows {
 		require.Equal(t, fmt.Sprintf("%d", i), fmt.Sprintf("%v", row[2]))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #70910

Problem Summary:
When IndexMerge union executes with ORDER BY and a pushed-down LIMIT, `requiredCnt` in `NewHandleHeap` was bounded by `min(1024, Count+Offset)` to avoid OOM during pre-allocation. However, `fetchLoopUnionWithOrderBy` also uses `requiredCnt` as the heap's logical retention limit, popping and discarding handles once the heap exceeds this value. Consequently, queries requesting more than 1024 rows silently truncate at 1024 rows.

### What is changed and how it works?

- Decoupled initial slice allocation from the heap retention bound in `NewHandleHeap`.
- `requiredCnt` now retains the full logical threshold (`Count + Offset`).
- Initial slice allocation is capped at `min(1024, requiredCnt)`.
- Added regression test `TestIssues70910` in `pkg/executor/test/indexmergereadtest/index_merge_reader_test.go`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- No side effects

### Release note

<!--
Please add a release note. If your change does not require a release note, write "None".
-->
```release-note
Fix an issue where IndexMerge union with ORDER BY and a pushed-down LIMIT returns at most 1024 rows.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IndexMerge queries with large `LIMIT` and `OFFSET` values being incorrectly truncated.
  * Ensured ordered results return the full requested number of rows when using IndexMerge without TopN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->