### PR TITLE
executor: shortcut selection when a correlated-only filter is false

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -393,6 +393,7 @@ go_test(
         "resource_tag_test.go",
         "revoke_test.go",
         "sample_test.go",
+        "select_internal_test.go",
         "select_into_test.go",
         "select_test.go",
         "set_test.go",

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2256,8 +2256,8 @@ func (b *executorBuilder) buildSelection(v *physicalop.PhysicalSelection) exec.E
 	e := &SelectionExec{
 		selectionExecutorContext: newSelectionExecutorContext(b.sctx),
 		BaseExecutorV2:           exec.NewBaseExecutorV2(b.sctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
-		filters:                  v.Conditions,
 	}
+	e.initFilters(v.Conditions)
 	return e
 }
 
@@ -4947,8 +4947,8 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoinInternal(ctx context.
 		exec := &SelectionExec{
 			selectionExecutorContext: newSelectionExecutorContext(builder.sctx),
 			BaseExecutorV2:           exec.NewBaseExecutorV2(builder.sctx.GetSessionVars(), v.Schema(), v.ID(), childExec),
-			filters:                  v.Conditions,
 		}
+		exec.initFilters(v.Conditions)
 		err = exec.open(ctx)
 		return exec, err
 	case *physicalop.PhysicalHashAgg:

--- a/pkg/executor/detach.go
+++ b/pkg/executor/detach.go
@@ -166,6 +166,11 @@ func (e *SelectionExec) Detach() (exec.Executor, bool) {
 			return nil, false
 		}
 	}
+	for _, expr := range e.rowIndependentFilters {
+		if !expression.GetOptionalEvalPropsForExpr(expr).IsEmpty() {
+			return nil, false
+		}
+	}
 
 	//nolint:constructor
 	newExec := new(SelectionExec)

--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"runtime/pprof"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -702,7 +703,44 @@ type SelectionExec struct {
 	inputRow    chunk.Row
 	childResult *chunk.Chunk
 
+	// rowIndependentFilters holds the filters that reference no column of the input
+	// rows, only constants and correlated columns, whose values are all fixed before
+	// this executor runs. They evaluate to the same result for every input row, so
+	// they are checked only once per Open; if any of them is false or null, Next
+	// returns an empty result without reading the child at all. The values of the
+	// correlated columns may change between two Opens (e.g. for each outer row of an
+	// Apply), so the check is redone after each Open.
+	rowIndependentFilters []expression.Expression
+	// rowIndependentChecked and rowIndependentFalse are the runtime states of
+	// rowIndependentFilters, reset on each Open.
+	rowIndependentChecked bool
+	rowIndependentFalse   bool
+
 	memTracker *memory.Tracker
+}
+
+// initFilters splits conditions into row-independent filters and normal filters,
+// initializing e.rowIndependentFilters and e.filters.
+func (e *SelectionExec) initFilters(conditions []expression.Expression) {
+	if !slices.ContainsFunc(conditions, isRowIndependentFilter) {
+		e.filters = conditions
+		return
+	}
+	for _, cond := range conditions {
+		if isRowIndependentFilter(cond) {
+			e.rowIndependentFilters = append(e.rowIndependentFilters, cond)
+		} else {
+			e.filters = append(e.filters, cond)
+		}
+	}
+}
+
+// isRowIndependentFilter reports whether cond evaluates to the same result for
+// every input row during one execution: it references no column of the input
+// rows (only correlated columns, whose values are bound before this executor
+// runs, and constants) and contains no unfoldable function such as rand().
+func isRowIndependentFilter(cond expression.Expression) bool {
+	return cond.IsCorrelated() && len(expression.ExtractColumns(cond)) == 0 && expression.IsImmutableFunc(cond)
 }
 
 // Open implements the Executor Open interface.
@@ -733,6 +771,8 @@ func (e *SelectionExec) open(context.Context) error {
 	}
 	e.inputIter = chunk.NewIterator4Chunk(e.childResult)
 	e.inputRow = e.inputIter.End()
+	e.rowIndependentChecked = false
+	e.rowIndependentFalse = false
 	return nil
 }
 
@@ -749,6 +789,20 @@ func (e *SelectionExec) Close() error {
 // Next implements the Executor Next interface.
 func (e *SelectionExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.GrowAndReset(e.MaxChunkSize())
+
+	if len(e.rowIndependentFilters) > 0 && !e.rowIndependentChecked {
+		selected, _, err := expression.EvalBool(e.evalCtx, e.rowIndependentFilters, chunk.Row{})
+		if err != nil {
+			return err
+		}
+		e.rowIndependentChecked = true
+		e.rowIndependentFalse = !selected
+	}
+	// The row-independent filters filter out all rows, so there is no need to read
+	// the child at all.
+	if e.rowIndependentFalse {
+		return nil
+	}
 
 	if !e.batched {
 		return e.unBatchedNext(ctx, req)

--- a/pkg/executor/select_internal_test.go
+++ b/pkg/executor/select_internal_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectionInitFiltersClassification(t *testing.T) {
+	sctx := defaultCtx()
+	ds := newRequiredRowsDataSource(sctx, 0, nil)
+	corVal := types.NewDatum(int64(0))
+	corCol := &expression.CorrelatedColumn{
+		Column: expression.Column{UniqueID: 100, Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)},
+		Data:   &corVal,
+	}
+	one := &expression.Constant{Value: types.NewDatum(int64(1)), RetType: types.NewFieldType(mysql.TypeLonglong)}
+	buildFunc := func(funcName string, args ...expression.Expression) expression.Expression {
+		f, err := expression.NewFunction(sctx.GetExprCtx(), funcName, types.NewFieldType(byte(types.ETInt)), args...)
+		require.NoError(t, err)
+		return f
+	}
+	corConstFilter := buildFunc(ast.GT, corCol, one)
+	columnFilter := buildFunc(ast.GT, ds.Schema().Columns[1], one)
+	corColumnFilter := buildFunc(ast.GT, ds.Schema().Columns[1], corCol)
+	randFn, err := expression.NewFunction(sctx.GetExprCtx(), ast.Rand, types.NewFieldType(mysql.TypeDouble))
+	require.NoError(t, err)
+	corUnfoldableFilter := buildFunc(ast.GT, corCol, randFn)
+
+	e := new(SelectionExec)
+	e.initFilters([]expression.Expression{corConstFilter, columnFilter, corColumnFilter, corUnfoldableFilter})
+	require.Equal(t, []expression.Expression{corConstFilter}, e.rowIndependentFilters)
+	require.Equal(t, []expression.Expression{columnFilter, corColumnFilter, corUnfoldableFilter}, e.filters)
+
+	// No row-independent filter: the condition slice is kept as-is.
+	e = new(SelectionExec)
+	conds := []expression.Expression{columnFilter, corColumnFilter}
+	e.initFilters(conds)
+	require.Nil(t, e.rowIndependentFilters)
+	require.Equal(t, conds, e.filters)
+}
+
+func TestSelectionRowIndependentFilterShortcut(t *testing.T) {
+	sctx := defaultCtx()
+	ctx := context.Background()
+	totalRows := 20
+	ds := newRequiredRowsDataSource(sctx, totalRows, nil)
+
+	corVal := types.NewDatum(int64(0))
+	corCol := &expression.CorrelatedColumn{
+		Column: expression.Column{UniqueID: 100, Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)},
+		Data:   &corVal,
+	}
+	one := &expression.Constant{Value: types.NewDatum(int64(1)), RetType: types.NewFieldType(mysql.TypeLonglong)}
+	// filter: corCol > 1, which references no column of the input rows.
+	filter, err := expression.NewFunction(sctx.GetExprCtx(), ast.GT, types.NewFieldType(byte(types.ETInt)), corCol, one)
+	require.NoError(t, err)
+
+	e := &SelectionExec{
+		selectionExecutorContext: newSelectionExecutorContext(sctx),
+		BaseExecutorV2:           exec.NewBaseExecutorV2(sctx.GetSessionVars(), ds.Schema(), 0, ds),
+	}
+	e.initFilters([]expression.Expression{filter})
+	require.Len(t, e.rowIndependentFilters, 1)
+	require.Empty(t, e.filters)
+
+	fetchAll := func() int {
+		chk := exec.NewFirstChunk(e)
+		fetched := 0
+		for {
+			require.NoError(t, e.Next(ctx, chk))
+			if chk.NumRows() == 0 {
+				return fetched
+			}
+			fetched += chk.NumRows()
+		}
+	}
+
+	// The filter evaluates to false, so the child should never be read.
+	corVal = types.NewDatum(int64(0))
+	require.NoError(t, e.Open(ctx))
+	require.Equal(t, 0, fetchAll())
+	require.Equal(t, 0, ds.numNextCalled)
+	require.NoError(t, e.Close())
+
+	// Reopening rechecks the filter (like Apply does for each outer row): now it
+	// evaluates to true and all child rows pass through.
+	corVal = types.NewDatum(int64(2))
+	require.NoError(t, e.Open(ctx))
+	require.Equal(t, totalRows, fetchAll())
+	require.Positive(t, ds.numNextCalled)
+	require.NoError(t, e.Close())
+
+	// A null filter result also shortcuts the execution after reopening.
+	numNextCalled := ds.numNextCalled
+	corVal = types.NewDatum(nil)
+	require.NoError(t, e.Open(ctx))
+	require.Equal(t, 0, fetchAll())
+	require.Equal(t, numNextCalled, ds.numNextCalled)
+	require.NoError(t, e.Close())
+}

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -2666,3 +2666,33 @@ func TestIssue52984(t *testing.T) {
 		tk.MustQuery("select p, o, v, sum(v) over w as 'sum' from t window w as (partition by p order by o rows between 0 preceding and 0 following) limit 10;")
 	}
 }
+
+func TestSelectionWithRowIndependentCorrelatedFilter(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int, b int)")
+	tk.MustExec("create table t2(a int, b int)")
+	tk.MustExec("insert into t1 values (0, 10), (1, 11), (2, 12), (null, 13)")
+	tk.MustExec("insert into t2 values (0, 100), (1, 101), (2, 102)")
+	// Keep `>` out of the coprocessor so that the correlated filter stays in a
+	// TiDB-side Selection under Apply, which checks it once per outer row instead
+	// of for every inner row.
+	tk.MustExec("insert into mysql.expr_pushdown_blacklist values('>', 'tikv,tiflash', 'for test')")
+	tk.MustExec("admin reload expr_pushdown_blacklist")
+	defer func() {
+		tk.MustExec("delete from mysql.expr_pushdown_blacklist where name = '>'")
+		tk.MustExec("admin reload expr_pushdown_blacklist")
+	}()
+
+	query := "select t1.a, (select /*+ no_decorrelate() */ sum(t2.b) from t2 where t1.a > 1) from t1 order by t1.a"
+	foundRootSelection := false
+	for _, row := range tk.MustQuery("explain format='brief' " + query).Rows() {
+		id, task, info := row[0].(string), row[2].(string), row[4].(string)
+		if strings.Contains(id, "Selection") && strings.Contains(task, "root") && strings.Contains(info, "gt(test.t1.a, 1)") {
+			foundRootSelection = true
+		}
+	}
+	require.True(t, foundRootSelection)
+	tk.MustQuery(query).Check(testkit.Rows("<nil> <nil>", "0 <nil>", "1 <nil>", "2 303"))
+}


### PR DESCRIPTION

What problem does this PR solve?

Issue Number: close #12723

Problem Summary:

For a Selection inside the inner side of Apply, filters that reference only correlated columns and constants evaluate to the same result for every input row of one execution, but they were still evaluated per row and the child was always fully read. When such a filter is false, the whole child read is wasted work for that outer row.

What changed and how does it work?

Split such row-independent filters out of SelectionExec.filters at build time (initFilters), and check them once in the first Next call after each Open. If any of them evaluates to false or null, Next returns an empty result immediately without reading the child at all. The check is redone after each Open because Apply rebinds the correlated column values for every outer row.

A filter is classified as row-independent only when all of the following hold:

- it contains a correlated column (IsCorrelated),
- it references no column of the input rows (ExtractColumns is empty),
- it contains no unfoldable function such as rand() (IsImmutableFunc), so evaluating it once is semantically equivalent to evaluating it per row.

When all remaining filters are row-independent and true, the empty filter list passes all child rows through unchanged, matching the previous behavior. SelectionExec.Detach also checks the new filter slice for optional eval properties.

Note this only applies to Selections executed on the TiDB side (e.g. above root-only operators or blocklisted expressions); predicates pushed to the coprocessor are unaffected.

Check List

Tests

- [x] Unit test
- [x] Integration test