### PR TITLE
ddl: allow explicit region split options when split-table is disabled

### DIFF
--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -960,6 +960,10 @@ func TestCreateTableWithBR(t *testing.T) {
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/handleAutoIncID", func() {
 		count++
 	})
+	preSplitCount := 0
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/preSplitAndScatter", func(string) {
+		preSplitCount++
+	})
 
 	tblInfo := &model.TableInfo{
 		ID:   42043,
@@ -973,8 +977,10 @@ func TestCreateTableWithBR(t *testing.T) {
 				FieldType: *types.NewFieldType(mysql.TypeLonglong),
 			},
 		},
-		State:     model.StatePublic,
-		AutoIncID: 1000,
+		State:           model.StatePublic,
+		AutoIncID:       1000,
+		ShardRowIDBits:  2,
+		PreSplitRegions: 2,
 	}
 
 	involvingRef := []model.InvolvingSchemaInfo{{
@@ -993,6 +999,20 @@ func TestCreateTableWithBR(t *testing.T) {
 
 	// For BR execution, rebase should be called twice. And this won't affect the rebase result.
 	require.Equal(t, 2, count)
+	require.Zero(t, preSplitCount)
 	rs := tk.MustQuery("show table test.t1 next_row_id").Rows()
 	require.Equal(t, "1000", rs[0][3])
+
+	preSplitCount = 0
+	batchTableInfos := make([]*model.TableInfo, 2)
+	for i := range batchTableInfos {
+		batchTableInfos[i] = tblInfo.Clone()
+		batchTableInfos[i].ID = int64(42044 + i)
+		batchTableInfos[i].Name = ast.NewCIStr(fmt.Sprintf("batch_t%d", i))
+	}
+	se.SetValue(sessionctx.QueryString, "skip")
+	require.NoError(t, dom.DDLExecutor().BatchCreateTableWithInfo(
+		se, ast.NewCIStr("test"), batchTableInfos,
+		ddl.WithOnExist(ddl.OnExistError), ddl.WithIDAllocated(true)))
+	require.Zero(t, preSplitCount)
 }

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -171,9 +171,9 @@ const (
 )
 
 var (
-	// EnableSplitTableRegion is a flag to decide whether to split a new region for
-	// a newly created table. It takes effect only if the Storage supports split
-	// region.
+	// EnableSplitTableRegion controls whether to split a new Region for a newly
+	// created table without explicit split options. It takes effect only if the
+	// Storage supports splitting Regions.
 	EnableSplitTableRegion = uint32(0)
 )
 

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -172,8 +172,8 @@ const (
 
 var (
 	// EnableSplitTableRegion controls whether to split a new Region for a newly
-	// created table without pre-split configuration. It takes effect only if the
-	// Storage supports splitting Regions.
+	// created table without pre-split configuration or Region split policies. It
+	// takes effect only if the Storage supports splitting Regions.
 	EnableSplitTableRegion = uint32(0)
 )
 

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -172,7 +172,7 @@ const (
 
 var (
 	// EnableSplitTableRegion controls whether to split a new Region for a newly
-	// created table without explicit split options. It takes effect only if the
+	// created table without pre-split configuration. It takes effect only if the
 	// Storage supports splitting Regions.
 	EnableSplitTableRegion = uint32(0)
 )

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1440,10 +1440,10 @@ func preSplitAndScatter(ctx sessionctx.Context, store kv.Storage, tbInfo *model.
 		return
 	}
 	sp, ok := store.(kv.SplittableStore)
-	explicitSplit := tbInfo.PreSplitRegions > 0 || hasSplitPolicies(tbInfo)
-	// split-table controls implicit table-boundary splitting. Explicit split
-	// options should take effect regardless of that configuration.
-	if !ok || (atomic.LoadUint32(&EnableSplitTableRegion) == 0 && !explicitSplit) {
+	hasRegionSplitConfig := tbInfo.PreSplitRegions > 0 || hasSplitPolicies(tbInfo)
+	// split-table controls only implicit table-boundary splitting. PRE_SPLIT_REGIONS,
+	// tidb_pre_split_regions, and Region split policies take precedence.
+	if !ok || (atomic.LoadUint32(&EnableSplitTableRegion) == 0 && !hasRegionSplitConfig) {
 		return
 	}
 	var preSplit func()

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1440,7 +1440,10 @@ func preSplitAndScatter(ctx sessionctx.Context, store kv.Storage, tbInfo *model.
 		return
 	}
 	sp, ok := store.(kv.SplittableStore)
-	if !ok || atomic.LoadUint32(&EnableSplitTableRegion) == 0 {
+	explicitSplit := tbInfo.PreSplitRegions > 0 || hasSplitPolicies(tbInfo)
+	// split-table controls implicit table-boundary splitting. Explicit split
+	// options should take effect regardless of that configuration.
+	if !ok || (atomic.LoadUint32(&EnableSplitTableRegion) == 0 && !explicitSplit) {
 		return
 	}
 	var preSplit func()

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1271,12 +1271,14 @@ func (e *executor) createTableWithInfoPost(
 	schemaID int64,
 	scatterScope string,
 ) error {
-	preSplitAndScatterTable(ctx, e.store, tbInfo, scatterScope)
 	if e.startMode == BR {
+		// BR applies its own split strategy while restoring table data.
 		if err := handleAutoIncID(e.getAutoIDRequirement(), schemaID, tbInfo); err != nil {
 			return errors.Trace(err)
 		}
+		return nil
 	}
+	preSplitAndScatterTable(ctx, e.store, tbInfo, scatterScope)
 	return nil
 }
 
@@ -1440,7 +1442,7 @@ func preSplitAndScatter(ctx sessionctx.Context, store kv.Storage, tbInfo *model.
 		return
 	}
 	sp, ok := store.(kv.SplittableStore)
-	hasRegionSplitConfig := tbInfo.PreSplitRegions > 0 || hasSplitPolicies(tbInfo)
+	hasRegionSplitConfig := hasExplicitRegionSplitConfig(tbInfo)
 	// split-table controls only implicit table-boundary splitting. PRE_SPLIT_REGIONS,
 	// tidb_pre_split_regions, and Region split policies take precedence.
 	if !ok || (atomic.LoadUint32(&EnableSplitTableRegion) == 0 && !hasRegionSplitConfig) {

--- a/pkg/ddl/split_region.go
+++ b/pkg/ddl/split_region.go
@@ -57,7 +57,7 @@ func splitPartitionTableRegion(ctx sessionctx.Context, store kv.SplittableStore,
 			regionIDs = append(regionIDs,
 				applySplitPoliciesForTable(ctxWithTimeout, ctx, store, tbInfo, def.ID)...)
 		}
-	} else if shardingBits(tbInfo) > 0 && tbInfo.PreSplitRegions > 0 {
+	} else if hasExplicitRegionSplitConfig(tbInfo) {
 		regionIDs = make([]uint64, 0, len(parts)*(len(tbInfo.Indices)+1))
 		scatter, tableID := getScatterConfig(scatterScope, tbInfo.ID)
 		// Try to split global index region here.
@@ -84,7 +84,7 @@ func splitTableRegion(ctx sessionctx.Context, store kv.SplittableStore, tbInfo *
 	var regionIDs []uint64
 	if hasSplitPolicies(tbInfo) {
 		regionIDs = applySplitPoliciesForTable(ctxWithTimeout, ctx, store, tbInfo, tbInfo.ID)
-	} else if shardingBits(tbInfo) > 0 && tbInfo.PreSplitRegions > 0 {
+	} else if hasExplicitRegionSplitConfig(tbInfo) {
 		regionIDs = preSplitPhysicalTableByShardRowID(ctxWithTimeout, store, tbInfo, tbInfo.ID, scatterScope)
 	} else {
 		regionIDs = append(regionIDs, SplitRecordRegion(ctxWithTimeout, store, tbInfo.ID, tbInfo.ID, scatterScope))
@@ -231,6 +231,10 @@ func hasSplitPolicies(tbInfo *model.TableInfo) bool {
 		}
 	}
 	return false
+}
+
+func hasExplicitRegionSplitConfig(tbInfo *model.TableInfo) bool {
+	return hasSplitPolicies(tbInfo) || (shardingBits(tbInfo) > 0 && tbInfo.PreSplitRegions > 0)
 }
 
 func applySplitPoliciesForTable(ctx context.Context, sctx sessionctx.Context, store kv.SplittableStore, tbInfo *model.TableInfo, physicalTableID int64) []uint64 {

--- a/pkg/ddl/table_split_test.go
+++ b/pkg/ddl/table_split_test.go
@@ -71,16 +71,37 @@ func TestTableSplit(t *testing.T) {
 	require.Len(t, re.Rows(), 1)
 
 	// Explicit split options should take effect even when automatic table splitting is disabled.
-	tk.MustExec(`create table t_pre_split_disabled (
+	tk.MustExec(`create table t_pre_split_with_split_table_disabled (
 		a bigint
 	) shard_row_id_bits = 2 pre_split_regions = 2`)
-	re = tk.MustQuery("show table t_pre_split_disabled regions")
+	re = tk.MustQuery("show table t_pre_split_with_split_table_disabled regions")
 	require.Len(t, re.Rows(), 4)
 
-	tk.MustExec(`create table t_split_policy_disabled (
+	tk.MustExec(`create table t_split_policy_with_split_table_disabled (
 		a bigint primary key
 	) split between (0) and (10000) regions 4`)
-	re = tk.MustQuery("show table t_split_policy_disabled regions")
+	re = tk.MustQuery("show table t_split_policy_with_split_table_disabled regions")
+	require.Len(t, re.Rows(), 4)
+
+	tk.MustExec("create table t_alter_split_policy_with_split_table_disabled (a bigint primary key)")
+	re = tk.MustQuery("show table t_alter_split_policy_with_split_table_disabled regions")
+	require.Len(t, re.Rows(), 1)
+	tk.MustExec("alter table t_alter_split_policy_with_split_table_disabled split between (0) and (10000) regions 4")
+	re = tk.MustQuery("show table t_alter_split_policy_with_split_table_disabled regions")
+	require.Len(t, re.Rows(), 4)
+	tk.MustExec("truncate table t_alter_split_policy_with_split_table_disabled")
+	re = tk.MustQuery("show table t_alter_split_policy_with_split_table_disabled regions")
+	require.Len(t, re.Rows(), 4)
+
+	tk.MustExec(`create table t_add_partition_with_split_table_disabled (
+		a bigint primary key
+	) partition by range(a) (
+		partition p0 values less than (100),
+		partition p1 values less than (200)
+	) split between (0) and (10000) regions 4`)
+	tk.MustExec(`alter table t_add_partition_with_split_table_disabled
+		add partition (partition p2 values less than (300))`)
+	re = tk.MustQuery("show table t_add_partition_with_split_table_disabled partition (p2) regions")
 	require.Len(t, re.Rows(), 4)
 
 	infoSchema := dom.InfoSchema()

--- a/pkg/ddl/table_split_test.go
+++ b/pkg/ddl/table_split_test.go
@@ -65,6 +65,24 @@ func TestTableSplit(t *testing.T) {
 	)`)
 	defer dom.Close()
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
+
+	tk.MustExec("create table t_implicit_split_disabled (a bigint)")
+	re := tk.MustQuery("show table t_implicit_split_disabled regions")
+	require.Len(t, re.Rows(), 1)
+
+	// Explicit split options should take effect even when automatic table splitting is disabled.
+	tk.MustExec(`create table t_pre_split_disabled (
+		a bigint
+	) shard_row_id_bits = 2 pre_split_regions = 2`)
+	re = tk.MustQuery("show table t_pre_split_disabled regions")
+	require.Len(t, re.Rows(), 4)
+
+	tk.MustExec(`create table t_split_policy_disabled (
+		a bigint primary key
+	) split between (0) and (10000) regions 4`)
+	re = tk.MustQuery("show table t_split_policy_disabled regions")
+	require.Len(t, re.Rows(), 4)
+
 	infoSchema := dom.InfoSchema()
 	require.NotNil(t, infoSchema)
 	tbl, err := infoSchema.TableByName(context.Background(), ast.NewCIStr("mysql"), ast.NewCIStr("tidb"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70918

Problem Summary:

When `split-table` is disabled, CREATE TABLE returns from the common pre-split path before honoring explicit `PRE_SPLIT_REGIONS` or Region split policies. This leaves explicitly configured tables unsplit.

refer https://github.com/tidbcloud/tidb-cse/pull/2682 for how it's changed in that repo

### What changed and how does it work?

Treat `PRE_SPLIT_REGIONS` and table/index Region split policies as explicit split requests. They now bypass the `split-table` gate, while ordinary tables still remain unsplit when the setting is disabled. Unsupported stores and temporary tables retain their existing behavior.

The regression test covers all three cases with embedded UniStore: no explicit option, `PRE_SPLIT_REGIONS`, and `SPLIT BETWEEN ... REGIONS`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```sh
./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestTableSplit$' -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Honor explicit `PRE_SPLIT_REGIONS` and Region split policies when `split-table` is disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that disabling automatic table-region splitting affects only tables without explicit split configuration.
  * Documented that explicit settings, including pre-split regions and split policies, continue to take effect when automatic splitting is disabled.

* **Bug Fixes**
  * Prevented unnecessary region pre-splitting during BR-backed table creation and restoration.

* **Tests**
  * Added coverage for explicit table and partition region splitting, including behavior after truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->