### PR TITLE
ddl: keep original NOT NULL when rolling back failed MODIFY COLUMN

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -75,6 +75,20 @@ func isColumnCommentOnlyChange(oldCol, newCol *model.ColumnInfo) bool {
 	return reflect.DeepEqual(oldClone, newClone)
 }
 
+// clearModifyColumnTempFlags removes in-progress modify-column markers from col.
+// NotNullFlag is only cleared when this job was converting NULL to NOT NULL;
+// otherwise rollback would drop an original NOT NULL constraint.
+func clearModifyColumnTempFlags(col, newCol *model.ColumnInfo) {
+	if !hasModifyFlag(col) {
+		return
+	}
+	col.DelFlag(mysql.PreventNullInsertFlag)
+	if isNullToNotNullChange(col, newCol) {
+		col.DelFlag(mysql.NotNullFlag)
+	}
+	col.ChangingFieldType = nil
+}
+
 func isIntegerChange(from, to *model.ColumnInfo) bool {
 	return mysql.IsIntegerType(from.GetType()) && mysql.IsIntegerType(to.GetType())
 }
@@ -402,12 +416,7 @@ func rollbackModifyColumnJob(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	newCol, oldCol *model.ColumnInfo) (ver int64, err error) {
 	if oldCol.ID == newCol.ID {
-		// Clean the flag info in oldCol.
-		if hasModifyFlag(tblInfo.Columns[oldCol.Offset]) {
-			tblInfo.Columns[oldCol.Offset].DelFlag(mysql.PreventNullInsertFlag)
-			tblInfo.Columns[oldCol.Offset].DelFlag(mysql.NotNullFlag)
-			tblInfo.Columns[oldCol.Offset].ChangingFieldType = nil
-		}
+		clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], newCol)
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -424,12 +433,7 @@ func rollbackModifyColumnJob(
 func rollbackModifyColumnJobWithReorg(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	oldCol *model.ColumnInfo, args *model.ModifyColumnArgs) (ver int64, err error) {
-	// Clean the flag info in oldCol.
-	if hasModifyFlag(tblInfo.Columns[oldCol.Offset]) {
-		tblInfo.Columns[oldCol.Offset].DelFlag(mysql.PreventNullInsertFlag)
-		tblInfo.Columns[oldCol.Offset].DelFlag(mysql.NotNullFlag)
-		tblInfo.Columns[oldCol.Offset].ChangingFieldType = nil
-	}
+	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], args.Column)
 
 	var changingIdxIDs []int64
 	if args.ChangingColumn != nil {
@@ -454,12 +458,7 @@ func rollbackModifyColumnJobWithReorg(
 func rollbackModifyColumnJobWithIndexReorg(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	oldCol *model.ColumnInfo, args *model.ModifyColumnArgs) (ver int64, err error) {
-	// Clean the flag info in oldCol.
-	if hasModifyFlag(tblInfo.Columns[oldCol.Offset]) {
-		tblInfo.Columns[oldCol.Offset].DelFlag(mysql.PreventNullInsertFlag)
-		tblInfo.Columns[oldCol.Offset].DelFlag(mysql.NotNullFlag)
-		tblInfo.Columns[oldCol.Offset].ChangingFieldType = nil
-	}
+	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], args.Column)
 
 	allIdxs := buildRelatedIndexInfos(tblInfo, oldCol.ID)
 	changingIdxInfos := make([]*model.IndexInfo, 0, len(allIdxs)/2)

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -76,16 +76,11 @@ func isColumnCommentOnlyChange(oldCol, newCol *model.ColumnInfo) bool {
 }
 
 // clearModifyColumnTempFlags removes in-progress modify-column markers from col.
-// NotNullFlag is only cleared when this job was converting NULL to NOT NULL;
-// otherwise rollback would drop an original NOT NULL constraint.
-func clearModifyColumnTempFlags(col, newCol *model.ColumnInfo) {
+func clearModifyColumnTempFlags(col *model.ColumnInfo) {
 	if !hasModifyFlag(col) {
 		return
 	}
 	col.DelFlag(mysql.PreventNullInsertFlag)
-	if isNullToNotNullChange(col, newCol) {
-		col.DelFlag(mysql.NotNullFlag)
-	}
 	col.ChangingFieldType = nil
 }
 
@@ -416,7 +411,7 @@ func rollbackModifyColumnJob(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	newCol, oldCol *model.ColumnInfo) (ver int64, err error) {
 	if oldCol.ID == newCol.ID {
-		clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], newCol)
+		clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset])
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -433,7 +428,7 @@ func rollbackModifyColumnJob(
 func rollbackModifyColumnJobWithReorg(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	oldCol *model.ColumnInfo, args *model.ModifyColumnArgs) (ver int64, err error) {
-	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], args.Column)
+	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset])
 
 	var changingIdxIDs []int64
 	if args.ChangingColumn != nil {
@@ -458,7 +453,7 @@ func rollbackModifyColumnJobWithReorg(
 func rollbackModifyColumnJobWithIndexReorg(
 	jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job,
 	oldCol *model.ColumnInfo, args *model.ModifyColumnArgs) (ver int64, err error) {
-	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset], args.Column)
+	clearModifyColumnTempFlags(tblInfo.Columns[oldCol.Offset])
 
 	allIdxs := buildRelatedIndexInfos(tblInfo, oldCol.ID)
 	changingIdxInfos := make([]*model.IndexInfo, 0, len(allIdxs)/2)
@@ -1509,7 +1504,9 @@ func (w *worker) doModifyColumnIndexReorg(
 
 	switch job.SchemaState {
 	case model.StateNone:
-		oldCol.AddFlag(mysql.PreventNullInsertFlag)
+		if isNullToNotNullChange(oldCol, args.Column) {
+			oldCol.AddFlag(mysql.PreventNullInsertFlag)
+		}
 		oldCol.ChangingFieldType = &args.Column.FieldType
 		// none -> delete only
 		updateObjectState(nil, changingIdxInfos, model.StateDeleteOnly)

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -742,6 +742,47 @@ func TestModifyColumnRollbackKeepsOriginalNotNull(t *testing.T) {
 	})
 }
 
+func TestModifyColumnIndexReorgAllowsNull(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key, c char(20) collate utf8mb4_bin, index idx(c))")
+	tk.MustExec("insert into t values (1, 'a')")
+	tbl := external.GetTableByName(t, tk, "test", "t")
+
+	var gotTp byte
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/getModifyColumnType", func(tp byte) {
+		gotTp = tp
+	})
+
+	var once sync.Once
+	var insertErr error
+	var preventNullInsert bool
+	var checked bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		if job.TableID != tbl.Meta().ID ||
+			job.Type != model.ActionModifyColumn ||
+			job.SchemaState != model.StateDeleteOnly {
+			return
+		}
+		once.Do(func() {
+			checked = true
+			tk2 := testkit.NewTestKit(t, store)
+			col := external.GetModifyColumn(t, tk2, "test", "t", "c", false)
+			preventNullInsert = mysql.HasPreventNullInsertFlag(col.GetFlag())
+			insertErr = tk2.ExecToErr("insert into test.t values (2, null)")
+		})
+	})
+
+	tk.MustExec("alter table t modify column c varchar(10) collate utf8mb4_bin")
+	require.Equal(t, model.ModifyTypeIndexReorg, gotTp)
+	require.True(t, checked)
+	require.False(t, preventNullInsert)
+	require.NoError(t, insertErr)
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("1 a", "2 <nil>"))
+	tk.MustExec("admin check table t")
+}
+
 func TestGetModifyColumnType(t *testing.T) {
 	type testCase struct {
 		beforeType string

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -683,6 +683,65 @@ func TestModifyColumnWithSkipReorg(t *testing.T) {
 	require.Equal(t, model.ModifyTypeNoReorgWithCheck, gotTp)
 }
 
+// TestModifyColumnRollbackKeepsOriginalNotNull covers issue #70787:
+// a failed MODIFY COLUMN must not drop an original NOT NULL constraint on rollback.
+func TestModifyColumnRollbackKeepsOriginalNotNull(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set session sql_mode = 'STRICT_TRANS_TABLES'")
+
+	assertNotNullPreserved := func(t *testing.T, colName string) {
+		t.Helper()
+		col := external.GetModifyColumn(t, tk, "test", "t", colName, false)
+		require.True(t, mysql.HasNotNullFlag(col.GetFlag()))
+		require.False(t, mysql.HasPreventNullInsertFlag(col.GetFlag()))
+		require.Nil(t, col.ChangingFieldType)
+		require.EqualError(t, tk.ExecToErr(fmt.Sprintf("insert into t (id, %s) values (100, null)", colName)),
+			fmt.Sprintf("[table:1048]Column '%s' cannot be null", colName))
+	}
+
+	t.Run("NoReorgWithCheck", func(t *testing.T) {
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (id int primary key, c int not null)")
+		tk.MustExec("insert into t values (1, 1000), (2, 2000)")
+		err := tk.ExecToErr("alter table t modify column c tinyint not null")
+		require.ErrorContains(t, err, "Data truncated for column 'c'")
+		col := external.GetModifyColumn(t, tk, "test", "t", "c", false)
+		require.Equal(t, mysql.TypeLong, col.GetType())
+		assertNotNullPreserved(t, "c")
+	})
+
+	t.Run("NullToNotNull", func(t *testing.T) {
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (id int primary key, c int)")
+		tk.MustExec("insert into t values (1, 1)")
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeDoModifyColumnSkipReorgCheck", func() {
+			tk2 := testkit.NewTestKit(t, store)
+			tk2.MustExec("insert into test.t values (2, null)")
+		})
+		err := tk.ExecToErr("alter table t modify column c tinyint not null")
+		require.EqualError(t, err, "[ddl:1138]Invalid use of NULL value")
+		col := external.GetModifyColumn(t, tk, "test", "t", "c", false)
+		require.Equal(t, mysql.TypeLong, col.GetType())
+		require.False(t, mysql.HasNotNullFlag(col.GetFlag()))
+		require.False(t, mysql.HasPreventNullInsertFlag(col.GetFlag()))
+		require.Nil(t, col.ChangingFieldType)
+		tk.MustExec("insert into t values (3, null)")
+	})
+
+	t.Run("IndexReorg", func(t *testing.T) {
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (id int primary key, c char(20) collate utf8mb4_bin not null, index idx(c))")
+		tk.MustExec("insert into t values (1, 'abcdefghijklmnop')")
+		err := tk.ExecToErr("alter table t modify column c varchar(10) collate utf8mb4_bin not null")
+		require.ErrorContains(t, err, "Data truncated for column 'c'")
+		col := external.GetModifyColumn(t, tk, "test", "t", "c", false)
+		require.Equal(t, mysql.TypeString, col.GetType())
+		assertNotNullPreserved(t, "c")
+	})
+}
+
 func TestGetModifyColumnType(t *testing.T) {
 	type testCase struct {
 		beforeType string


### PR DESCRIPTION
Issue Number: close #70787

Problem Summary:

A failed `MODIFY COLUMN` that is rolled back can drop the original `NOT NULL` constraint.

For example, `INT NOT NULL` -> `TINYINT NOT NULL` fails because existing values do not fit in `TINYINT`. After rollback the column is still `INT`, but it becomes nullable, so `INSERT ... NULL` succeeds.

This is a regression from #63465. That change treats `ChangingFieldType` as an in-progress modify marker, but rollback still cleared `NotNullFlag` whenever any modify marker was present. A type-only change therefore removed the original constraint even though nullability was never being changed.

### What changed and how does it work?

Rollback now restores only temporary modify-column markers:

- Always clear `PreventNullInsertFlag` and `ChangingFieldType`.
- Clear `NotNullFlag` only when the job was converting `NULL` to `NOT NULL`.

The three rollback paths share `clearModifyColumnTempFlags()`.

`TestModifyColumnRollbackKeepsOriginalNotNull` covers:

- `ModifyTypeNoReorgWithCheck`: `INT NOT NULL` -> `TINYINT NOT NULL` with out-of-range data
- `NULL` -> `NOT NULL` that fails after the job starts, so the column stays nullable
- `ModifyTypeIndexReorg`: a failing indexed `CHAR` -> `VARCHAR` change keeps `NOT NULL`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Validation performed:

- `./tools/check/failpoint-go-test.sh pkg/ddl -run '^TestModifyColumnRollbackKeepsOriginalNotNull$' -count=1`
- `make bazel_prepare`
- `make lint`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that a failed `MODIFY COLUMN` statement might drop the original `NOT NULL` constraint after rollback
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Column changes now account for dependencies between base tables and materialized views, applying compatible updates and rejecting unsupported modifications.

* **Bug Fixes**
  * Failed column modifications preserve existing `NOT NULL` constraints during rollback.
  * Nullable columns continue accepting `NULL` values during index reorganization.
  * Rollback behavior is improved for type changes, concurrent inserts, and index reorganization failures.

* **Tests**
  * Added coverage for constraint preservation, nullable inserts, materialized view dependencies, and restored column behavior after failed modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->