### PR TITLE
lightning: close Parquet row-count readers [v8.5.7]

### DIFF
--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -518,14 +518,16 @@ func ReadParquetFileRowCountByFile(
 	ctx context.Context,
 	store storage.ExternalStorage,
 	fileMeta SourceFileMeta,
-) (int64, error) {
+) (rowCount int64, err error) {
 	r, err := store.Open(ctx, fileMeta.Path, nil)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
 
 	defer func() {
-		_ = r.Close()
+		if closeErr := r.Close(); closeErr != nil && err == nil {
+			err = errors.Annotate(closeErr, "close parquet row-count reader")
+		}
 	}()
 
 	reader, err := file.NewParquetReader(&parquetFileWrapper{ReadSeekCloser: r})

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -524,6 +524,10 @@ func ReadParquetFileRowCountByFile(
 		return 0, errors.Trace(err)
 	}
 
+	defer func() {
+		_ = r.Close()
+	}()
+
 	reader, err := file.NewParquetReader(&parquetFileWrapper{ReadSeekCloser: r})
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -502,7 +502,8 @@ func TestBasicReadFile(t *testing.T) {
 // rowCountTrackingStorage tracks readers retained by metadata-only reads.
 type rowCountTrackingStorage struct {
 	storage.ExternalStorage
-	readers []*rowCountTrackingReader
+	readers  []*rowCountTrackingReader
+	closeErr error
 }
 
 func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *storage.ReaderOption) (storage.ExternalFileReader, error) {
@@ -510,19 +511,28 @@ func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *s
 	if err != nil {
 		return nil, err
 	}
-	reader := &rowCountTrackingReader{ExternalFileReader: r}
+	reader := &rowCountTrackingReader{ExternalFileReader: r, closeErr: s.closeErr}
 	s.readers = append(s.readers, reader)
 	return reader, nil
 }
 
 type rowCountTrackingReader struct {
 	storage.ExternalFileReader
-	closed bool
+	closed     bool
+	closeErr   error
+	closeCalls int
 }
 
 func (r *rowCountTrackingReader) Close() error {
+	r.closeCalls++
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	if err := r.ExternalFileReader.Close(); err != nil {
+		return err
+	}
 	r.closed = true
-	return r.ExternalFileReader.Close()
+	return nil
 }
 
 func TestReadParquetFileRowCountClosesReader(t *testing.T) {
@@ -561,4 +571,28 @@ func TestReadParquetFileRowCountClosesReader(t *testing.T) {
 			}
 		})
 	}
+	for _, name := range []string{"valid.parquet", "invalid.parquet"} {
+		t.Run(name+"/close-error", func(t *testing.T) {
+			store := &rowCountTrackingStorage{ExternalStorage: base, closeErr: io.ErrClosedPipe}
+			t.Cleanup(func() {
+				for _, reader := range store.readers {
+					_ = reader.ExternalFileReader.Close()
+				}
+			})
+			_, err := ReadParquetFileRowCountByFile(ctx, store, SourceFileMeta{Path: name})
+			require.Error(t, err)
+			require.Len(t, store.readers, 1)
+			require.Equal(t, 1, store.readers[0].closeCalls)
+			require.False(t, store.readers[0].closed)
+			if name == "valid.parquet" {
+				require.ErrorIs(t, err, io.ErrClosedPipe)
+				require.ErrorContains(t, err, "close parquet row-count reader")
+			} else {
+				_, metadataErr := ReadParquetFileRowCountByFile(ctx, base, SourceFileMeta{Path: name})
+				require.EqualError(t, err, metadataErr.Error())
+				require.NotErrorIs(t, err, io.ErrClosedPipe)
+			}
+		})
+	}
+
 }

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -498,3 +498,67 @@ func TestBasicReadFile(t *testing.T) {
 		require.Equal(t, string(generated[i]), reader.lastRow.Row[0].GetString())
 	}
 }
+
+// rowCountTrackingStorage tracks readers retained by metadata-only reads.
+type rowCountTrackingStorage struct {
+	storage.ExternalStorage
+	readers []*rowCountTrackingReader
+}
+
+func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *storage.ReaderOption) (storage.ExternalFileReader, error) {
+	r, err := s.ExternalStorage.Open(ctx, path, opts)
+	if err != nil {
+		return nil, err
+	}
+	reader := &rowCountTrackingReader{ExternalFileReader: r}
+	s.readers = append(s.readers, reader)
+	return reader, nil
+}
+
+type rowCountTrackingReader struct {
+	storage.ExternalFileReader
+	closed bool
+}
+
+func (r *rowCountTrackingReader) Close() error {
+	r.closed = true
+	return r.ExternalFileReader.Close()
+}
+
+func TestReadParquetFileRowCountClosesReader(t *testing.T) {
+	ctx := context.Background()
+	base, err := storage.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+	data, err := storage.NewLocalStorage("examples")
+	require.NoError(t, err)
+	valid, err := data.ReadFile(ctx, "test.parquet")
+	require.NoError(t, err)
+	require.NoError(t, base.WriteFile(ctx, "valid.parquet", valid))
+	require.NoError(t, base.WriteFile(ctx, "invalid.parquet", []byte("invalid parquet")))
+
+	for _, name := range []string{"valid.parquet", "invalid.parquet", "missing.parquet"} {
+		t.Run(name, func(t *testing.T) {
+			store := &rowCountTrackingStorage{ExternalStorage: base}
+			t.Cleanup(func() {
+				for _, reader := range store.readers {
+					if !reader.closed {
+						_ = reader.Close()
+					}
+				}
+			})
+			rows, err := ReadParquetFileRowCountByFile(ctx, store, SourceFileMeta{Path: name})
+			if name == "valid.parquet" {
+				require.NoError(t, err)
+				require.Positive(t, rows)
+			} else {
+				require.Error(t, err)
+			}
+			if name == "missing.parquet" {
+				require.Empty(t, store.readers)
+			} else {
+				require.Len(t, store.readers, 1)
+				require.True(t, store.readers[0].closed, "metadata reads must release the storage reader")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70929

Problem Summary:

On v8.5.7, Parquet row-count reads leave the underlying storage reader open. Repeated metadata reads can exhaust S3 HTTP connections and stall source loading.

### What changed and how does it work?

Defer closing the storage reader immediately after a successful Open, covering both successful metadata reads and Parquet reader construction failures. Return a contextual close error when metadata reading succeeded, while preserving an existing metadata error. Add regression coverage for valid, malformed, and missing files, close failures, and error precedence. This uses the same ownership approach already present in master.

The patch is based on the v8.5.7 tag and targets the dedicated v8.5.7 maintenance branch. It does not change connection limits or sampling concurrency.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation (Go 1.25.10):

- The new regression test failed without the fix for both valid and malformed files, then passed with the fix. The added close-failure case also failed before close errors were propagated and passed afterward.
- Targeted tests passed on both the v8.5.7 tag and the target maintenance branch, with failpoints enabled and disabled afterward:

```bash
tools/bin/failpoint-ctl enable pkg/lightning/mydump
go test -tags=intest,deadlock ./pkg/lightning/mydump -run "^(TestReadParquetFileRowCountClosesReader|TestParquetParser|TestParquetVariousTypes)$" -count=1
tools/bin/failpoint-ctl disable pkg/lightning/mydump
make lint
GOPROXY=https://proxy.golang.org,direct make bazel_prepare
```

Bazel preparation completed after retrying with the official Go module proxy; no metadata changes were needed for the target package. Unrelated baseline metadata drift was excluded.

No live S3 or full-cluster import test was run. Concurrent sampling behavior is outside this narrow resource-lifecycle fix.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a storage reader leak during Parquet row-count reads that could exhaust S3 HTTP connections and stall TiDB Lightning source loading.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Parquet row-count reliability by preserving file-reader close errors when no earlier metadata or read error is available.
  * Existing metadata and read errors continue to take precedence over close errors.

* **Tests**
  * Added coverage for close failures while processing valid and invalid Parquet files.
  * Added verification that readers are only marked closed after a successful close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
