### PR TITLE
*: migrate non-replacing AST visitors to in-place traversal part 3

### DIFF
--- a/pkg/bindinfo/binding_plan_generation.go
+++ b/pkg/bindinfo/binding_plan_generation.go
@@ -673,16 +673,16 @@ type selectOffsetAssigner struct {
 	offset int
 }
 
-func (a *selectOffsetAssigner) Enter(in ast.Node) (node ast.Node, skipChildren bool) {
+func (a *selectOffsetAssigner) Enter(in ast.Node) (skipChildren bool) {
 	if sel, ok := in.(*ast.SelectStmt); ok {
 		a.offset++
 		sel.QueryBlockOffset = a.offset
 	}
-	return in, false
+	return false
 }
 
-func (*selectOffsetAssigner) Leave(in ast.Node) (node ast.Node, ok bool) {
-	return in, true
+func (*selectOffsetAssigner) Leave(ast.Node) (ok bool) {
+	return true
 }
 
 type subqueryOffsetExtractor struct {
@@ -781,7 +781,7 @@ func extractNoDecorrelateQBs(node ast.StmtNode) []ast.CIStr {
 	}
 
 	assigner := &selectOffsetAssigner{}
-	selStmt.Accept(assigner)
+	ast.Walk(selStmt, assigner)
 
 	extractor := &subqueryOffsetExtractor{offsets: make(map[int]struct{})}
 	ast.Walk(selStmt, extractor)

--- a/pkg/ddl/masking_policy.go
+++ b/pkg/ddl/masking_policy.go
@@ -696,20 +696,20 @@ type renameMaskingExprVisitor struct {
 	newCol ast.CIStr
 }
 
-func (v *renameMaskingExprVisitor) Enter(in ast.Node) (ast.Node, bool) {
+func (v *renameMaskingExprVisitor) Enter(in ast.Node) bool {
 	colExpr, ok := in.(*ast.ColumnNameExpr)
 	if !ok {
-		return in, false
+		return false
 	}
 	if colExpr.Name.Name.L != v.oldCol.L {
-		return in, false
+		return false
 	}
 	colExpr.Name.Name = v.newCol
-	return in, false
+	return false
 }
 
-func (*renameMaskingExprVisitor) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (*renameMaskingExprVisitor) Leave(ast.Node) bool {
+	return true
 }
 
 func rewriteMaskingPolicyExprColumnName(expr string, oldCol, newCol ast.CIStr) (string, error) {
@@ -725,13 +725,9 @@ func rewriteMaskingPolicyExprColumnName(expr string, oldCol, newCol ast.CIStr) (
 	if !ok || selectStmt.Fields == nil || len(selectStmt.Fields.Fields) != 1 {
 		return "", errors.New("invalid masking policy expression")
 	}
-	out, ok := selectStmt.Fields.Fields[0].Expr.Accept(&renameMaskingExprVisitor{oldCol: oldCol, newCol: newCol})
-	if !ok {
+	outExpr := selectStmt.Fields.Fields[0].Expr
+	if !ast.Walk(outExpr, &renameMaskingExprVisitor{oldCol: oldCol, newCol: newCol}) {
 		return "", errors.New("failed to rewrite masking policy expression")
-	}
-	outExpr, ok := out.(ast.ExprNode)
-	if !ok {
-		return "", errors.New("invalid rewritten masking policy expression")
 	}
 	return restoreMaskingExpression(outExpr)
 }

--- a/pkg/ddl/materialized_view.go
+++ b/pkg/ddl/materialized_view.go
@@ -1105,7 +1105,7 @@ func resolveMViewColumnName(col *ast.ColumnName, baseTableName *ast.TableName, f
 
 func collectColumnNamesInExpr(expr ast.ExprNode) []*ast.ColumnName {
 	collector := &columnNameCollector{cols: make([]*ast.ColumnName, 0, 8)}
-	expr.Accept(collector)
+	ast.Walk(expr, collector)
 	return collector.cols
 }
 
@@ -1113,14 +1113,14 @@ type columnNameCollector struct {
 	cols []*ast.ColumnName
 }
 
-func (c *columnNameCollector) Enter(n ast.Node) (ast.Node, bool) {
+func (c *columnNameCollector) Enter(n ast.Node) bool {
 	if x, ok := n.(*ast.ColumnNameExpr); ok {
 		c.cols = append(c.cols, x.Name)
 	}
-	return n, false
+	return false
 }
 
-func (*columnNameCollector) Leave(n ast.Node) (ast.Node, bool) { return n, true }
+func (*columnNameCollector) Leave(ast.Node) bool { return true }
 
 func isCountStarOrOne(arg ast.ExprNode) bool {
 	v, ok := arg.(*driver.ValueExpr)
@@ -1156,26 +1156,26 @@ func normalizeMVDefinitionHintDBNames(node ast.Node, defaultDB ast.CIStr) {
 	if node == nil || defaultDB.L == "" {
 		return
 	}
-	_, _ = node.Accept(&mvDefinitionHintDBNameNormalizer{defaultDB: defaultDB})
+	ast.Walk(node, &mvDefinitionHintDBNameNormalizer{defaultDB: defaultDB})
 }
 
 type mvDefinitionHintDBNameNormalizer struct {
 	defaultDB ast.CIStr
 }
 
-func (v *mvDefinitionHintDBNameNormalizer) Enter(node ast.Node) (ast.Node, bool) {
+func (v *mvDefinitionHintDBNameNormalizer) Enter(node ast.Node) bool {
 	hint, ok := node.(*ast.TableOptimizerHint)
 	if !ok {
-		return node, false
+		return false
 	}
 	for i := range hint.Tables {
 		if hint.Tables[i].DBName.L == "" {
 			hint.Tables[i].DBName = v.defaultDB
 		}
 	}
-	return hint, true
+	return true
 }
 
-func (*mvDefinitionHintDBNameNormalizer) Leave(node ast.Node) (ast.Node, bool) {
-	return node, true
+func (*mvDefinitionHintDBNameNormalizer) Leave(ast.Node) bool {
+	return true
 }

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -58,7 +58,7 @@ func TestDDLVisitorCover(t *testing.T) {
 
 	for _, v := range stmts {
 		ce.reset()
-		v.node.Accept(checkVisitor{})
+		Walk(v.node, checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
 		Walk(v.node, visitor1{})

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -61,7 +61,7 @@ func TestDDLVisitorCover(t *testing.T) {
 		v.node.Accept(checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
-		v.node.Accept(visitor1{})
+		Walk(v.node, visitor1{})
 	}
 }
 

--- a/pkg/parser/ast/dml_test.go
+++ b/pkg/parser/ast/dml_test.go
@@ -67,7 +67,7 @@ func TestDMLVisitorCover(t *testing.T) {
 
 	for _, v := range stmts {
 		ce.reset()
-		v.node.Accept(checkVisitor{})
+		Walk(v.node, checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
 		Walk(v.node, visitor1{})

--- a/pkg/parser/ast/dml_test.go
+++ b/pkg/parser/ast/dml_test.go
@@ -70,7 +70,7 @@ func TestDMLVisitorCover(t *testing.T) {
 		v.node.Accept(checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
-		v.node.Accept(visitor1{})
+		Walk(v.node, visitor1{})
 	}
 }
 

--- a/pkg/parser/ast/expressions.go
+++ b/pkg/parser/ast/expressions.go
@@ -1696,7 +1696,7 @@ func (e *exprCleaner) BeginRestore() {
 	e.restore = true
 }
 
-func (e *exprCleaner) Enter(n Node) (node Node, skipChildren bool) {
+func (e *exprCleaner) Enter(n Node) bool {
 	if e.restore {
 		n.SetOriginTextPosition(e.oldTextPos[0])
 		e.oldTextPos = e.oldTextPos[1:]
@@ -1704,7 +1704,7 @@ func (e *exprCleaner) Enter(n Node) (node Node, skipChildren bool) {
 			f.FnName.O = e.oldOriginFuncName[0]
 			e.oldOriginFuncName = e.oldOriginFuncName[1:]
 		}
-		return n, false
+		return false
 	}
 	e.oldTextPos = append(e.oldTextPos, n.OriginTextPosition())
 	n.SetOriginTextPosition(0)
@@ -1712,23 +1712,23 @@ func (e *exprCleaner) Enter(n Node) (node Node, skipChildren bool) {
 		e.oldOriginFuncName = append(e.oldOriginFuncName, f.FnName.O)
 		f.FnName.O = f.FnName.L
 	}
-	return n, false
+	return false
 }
 
-func (e *exprCleaner) Leave(n Node) (node Node, ok bool) {
-	return n, true
+func (e *exprCleaner) Leave(Node) bool {
+	return true
 }
 
 // ExpressionDeepEqual compares the equivalence of two expressions.
 func ExpressionDeepEqual(a ExprNode, b ExprNode) bool {
 	cleanerA := &exprCleaner{}
 	cleanerB := &exprCleaner{}
-	a.Accept(cleanerA)
-	b.Accept(cleanerB)
+	Walk(a, cleanerA)
+	Walk(b, cleanerB)
 	result := reflect.DeepEqual(a, b)
 	cleanerA.BeginRestore()
 	cleanerB.BeginRestore()
-	a.Accept(cleanerA)
-	b.Accept(cleanerB)
+	Walk(a, cleanerA)
+	Walk(b, cleanerB)
 	return result
 }

--- a/pkg/parser/ast/expressions_test.go
+++ b/pkg/parser/ast/expressions_test.go
@@ -101,7 +101,7 @@ func TestExpresionsVisitorCover(t *testing.T) {
 		v.node.Accept(checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
-		v.node.Accept(visitor1{})
+		Walk(v.node, visitor1{})
 	}
 }
 

--- a/pkg/parser/ast/expressions_test.go
+++ b/pkg/parser/ast/expressions_test.go
@@ -24,19 +24,19 @@ import (
 
 type checkVisitor struct{}
 
-func (v checkVisitor) Enter(in Node) (Node, bool) {
+func (v checkVisitor) Enter(in Node) bool {
 	if e, ok := in.(*checkExpr); ok {
 		e.enterCnt++
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-func (v checkVisitor) Leave(in Node) (Node, bool) {
+func (v checkVisitor) Leave(in Node) bool {
 	if e, ok := in.(*checkExpr); ok {
 		e.leaveCnt++
 	}
-	return in, true
+	return true
 }
 
 type checkExpr struct {
@@ -98,7 +98,7 @@ func TestExpresionsVisitorCover(t *testing.T) {
 
 	for _, v := range stmts {
 		ce.reset()
-		v.node.Accept(checkVisitor{})
+		Walk(v.node, checkVisitor{})
 		require.Equal(t, v.expectedEnterCnt, ce.enterCnt)
 		require.Equal(t, v.expectedLeaveCnt, ce.leaveCnt)
 		Walk(v.node, visitor1{})

--- a/pkg/parser/ast/flag.go
+++ b/pkg/parser/ast/flag.go
@@ -25,17 +25,17 @@ func HasWindowFlag(expr ExprNode) bool {
 // SetFlag sets flag for expression.
 func SetFlag(n Node) {
 	var setter flagSetter
-	n.Accept(&setter)
+	Walk(n, &setter)
 }
 
 type flagSetter struct {
 }
 
-func (f *flagSetter) Enter(in Node) (Node, bool) {
-	return in, false
+func (f *flagSetter) Enter(Node) bool {
+	return false
 }
 
-func (f *flagSetter) Leave(in Node) (Node, bool) {
+func (f *flagSetter) Leave(in Node) bool {
 	if x, ok := in.(ParamMarkerExpr); ok {
 		x.SetFlag(FlagHasParamMarker)
 	}
@@ -92,7 +92,7 @@ func (f *flagSetter) Leave(in Node) (Node, bool) {
 		}
 	}
 
-	return in, true
+	return true
 }
 
 func (f *flagSetter) caseExpr(x *CaseExpr) {

--- a/pkg/parser/ast/functions_test.go
+++ b/pkg/parser/ast/functions_test.go
@@ -35,8 +35,8 @@ func TestFunctionsVisitorCover(t *testing.T) {
 	}
 
 	for _, stmt := range stmts {
-		stmt.Accept(visitor{})
-		stmt.Accept(visitor1{})
+		Walk(stmt, visitor{})
+		Walk(stmt, visitor1{})
 	}
 }
 

--- a/pkg/parser/ast/misc_test.go
+++ b/pkg/parser/ast/misc_test.go
@@ -26,20 +26,20 @@ import (
 
 type visitor struct{}
 
-func (v visitor) Enter(in ast.Node) (ast.Node, bool) {
-	return in, false
+func (visitor) Enter(ast.Node) bool {
+	return false
 }
 
-func (v visitor) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (visitor) Leave(ast.Node) bool {
+	return true
 }
 
 type visitor1 struct {
 	visitor
 }
 
-func (visitor1) Enter(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (visitor1) Enter(ast.Node) bool {
+	return true
 }
 
 func TestMiscVisitorCover(t *testing.T) {
@@ -84,8 +84,8 @@ func TestMiscVisitorCover(t *testing.T) {
 	}
 
 	for _, v := range stmts {
-		v.Accept(visitor{})
-		v.Accept(visitor1{})
+		ast.Walk(v, visitor{})
+		ast.Walk(v, visitor1{})
 	}
 }
 
@@ -109,8 +109,8 @@ constraint foreign key (jobabbr) references ffxi_jobtype (jobabbr) on delete cas
 	stmts, _, err := parse.Parse(sql, "", "")
 	require.NoError(t, err)
 	for _, stmt := range stmts {
-		stmt.Accept(visitor{})
-		stmt.Accept(visitor1{})
+		ast.Walk(stmt, visitor{})
+		ast.Walk(stmt, visitor1{})
 	}
 }
 
@@ -129,8 +129,8 @@ import into t from '/file.csv'`
 	stmts, _, err := p.Parse(sql, "", "")
 	require.NoError(t, err)
 	for _, stmt := range stmts {
-		stmt.Accept(visitor{})
-		stmt.Accept(visitor1{})
+		ast.Walk(stmt, visitor{})
+		ast.Walk(stmt, visitor1{})
 	}
 }
 

--- a/pkg/parser/ast/procedure_test.go
+++ b/pkg/parser/ast/procedure_test.go
@@ -28,8 +28,8 @@ func TestProcedureVisitorCover(t *testing.T) {
 		&ast.ProcedureDecl{},
 	}
 	for _, v := range stmts {
-		v.Accept(visitor{})
-		v.Accept(visitor1{})
+		ast.Walk(v, visitor{})
+		ast.Walk(v, visitor1{})
 	}
 	stmts2 := []ast.StmtNode{
 		&ast.ProcedureBlock{},
@@ -37,8 +37,8 @@ func TestProcedureVisitorCover(t *testing.T) {
 		&ast.DropProcedureStmt{},
 	}
 	for _, v := range stmts2 {
-		v.Accept(visitor{})
-		v.Accept(visitor1{})
+		ast.Walk(v, visitor{})
+		ast.Walk(v, visitor1{})
 	}
 }
 func TestProcedure(t *testing.T) {
@@ -134,8 +134,8 @@ func TestProcedureVisitor(t *testing.T) {
 		stmts, _, err := parse.Parse(sql, "", "")
 		require.NoError(t, err)
 		for _, stmt := range stmts {
-			stmt.Accept(visitor{})
-			stmt.Accept(visitor1{})
+			ast.Walk(stmt, visitor{})
+			ast.Walk(stmt, visitor1{})
 		}
 	}
 }

--- a/pkg/parser/ast/util_test.go
+++ b/pkg/parser/ast/util_test.go
@@ -121,7 +121,7 @@ func TestUnionReadOnly(t *testing.T) {
 // For test only.
 func CleanNodeText(node Node) {
 	var cleaner nodeTextCleaner
-	node.Accept(&cleaner)
+	Walk(node, &cleaner)
 }
 
 // nodeTextCleaner clean the text of a node and it's child node.
@@ -129,8 +129,8 @@ func CleanNodeText(node Node) {
 type nodeTextCleaner struct {
 }
 
-// Enter implements Visitor interface.
-func (checker *nodeTextCleaner) Enter(in Node) (out Node, skipChildren bool) {
+// Enter implements InPlaceVisitor interface.
+func (checker *nodeTextCleaner) Enter(in Node) bool {
 	in.SetText(nil, "")
 	in.SetOriginTextPosition(0)
 	if v, ok := in.(ValueExpr); ok && v != nil {
@@ -170,12 +170,12 @@ func (checker *nodeTextCleaner) Enter(in Node) (out Node, skipChildren bool) {
 	case *ColumnDef:
 		node.Tp.CleanElemIsBinaryLit()
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *nodeTextCleaner) Leave(in Node) (out Node, ok bool) {
-	return in, true
+// Leave implements InPlaceVisitor interface.
+func (checker *nodeTextCleaner) Leave(in Node) bool {
+	return true
 }
 
 type NodeRestoreTestCase struct {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7477,7 +7477,7 @@ func TestSignedInt64OutOfRange(t *testing.T) {
 // For test only.
 func CleanNodeText(node ast.Node) {
 	var cleaner nodeTextCleaner
-	node.Accept(&cleaner)
+	ast.Walk(node, &cleaner)
 }
 
 // nodeTextCleaner clean the text of a node and it's child node.
@@ -7491,19 +7491,19 @@ func cleanPartition(n ast.Node) {
 		if p.Interval != nil {
 			p.Interval.SetText(nil, "")
 			p.Interval.SetOriginTextPosition(0)
-			p.Interval.IntervalExpr.Expr.Accept(&tmpCleaner)
+			ast.Walk(p.Interval.IntervalExpr.Expr, &tmpCleaner)
 			if p.Interval.FirstRangeEnd != nil {
-				(*p.Interval.FirstRangeEnd).Accept(&tmpCleaner)
+				ast.Walk(*p.Interval.FirstRangeEnd, &tmpCleaner)
 			}
 			if p.Interval.LastRangeEnd != nil {
-				(*p.Interval.LastRangeEnd).Accept(&tmpCleaner)
+				ast.Walk(*p.Interval.LastRangeEnd, &tmpCleaner)
 			}
 		}
 	}
 }
 
-// Enter implements Visitor interface.
-func (checker *nodeTextCleaner) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+// Enter implements ast.InPlaceVisitor interface.
+func (checker *nodeTextCleaner) Enter(in ast.Node) bool {
 	in.SetText(nil, "")
 	in.SetOriginTextPosition(0)
 	if v, ok := in.(ast.ValueExpr); ok && v != nil {
@@ -7587,12 +7587,12 @@ func (checker *nodeTextCleaner) Enter(in ast.Node) (out ast.Node, skipChildren b
 	case *ast.PartitionOptions:
 		cleanPartition(node)
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (checker *nodeTextCleaner) Leave(in ast.Node) (out ast.Node, ok bool) {
-	return in, true
+// Leave implements ast.InPlaceVisitor interface.
+func (checker *nodeTextCleaner) Leave(in ast.Node) bool {
+	return true
 }
 
 // For BRIE

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5771,18 +5771,18 @@ type subqueryChecker struct {
 	t    *testing.T
 }
 
-// Enter implements ast.Visitor interface.
-func (sc *subqueryChecker) Enter(inNode ast.Node) (outNode ast.Node, skipChildren bool) {
+// Enter implements ast.InPlaceVisitor interface.
+func (sc *subqueryChecker) Enter(inNode ast.Node) bool {
 	if expr, ok := inNode.(*ast.SubqueryExpr); ok {
 		require.Equal(sc.t, sc.text, expr.Query.Text())
-		return inNode, true
+		return true
 	}
-	return inNode, false
+	return false
 }
 
-// Leave implements ast.Visitor interface.
-func (sc *subqueryChecker) Leave(inNode ast.Node) (node ast.Node, ok bool) {
-	return inNode, true
+// Leave implements ast.InPlaceVisitor interface.
+func (*subqueryChecker) Leave(ast.Node) bool {
+	return true
 }
 
 func TestSubquery(t *testing.T) {
@@ -5830,7 +5830,7 @@ func TestSubquery(t *testing.T) {
 	for _, tbl := range tests {
 		stmt, err := p.ParseOneStmt(tbl.input, "", "")
 		require.NoError(t, err)
-		stmt.Accept(&subqueryChecker{
+		ast.Walk(stmt, &subqueryChecker{
 			text: tbl.text,
 			t:    t,
 		})
@@ -7184,8 +7184,8 @@ type windowFrameBoundChecker struct {
 	t      *testing.T
 }
 
-// Enter implements ast.Visitor interface.
-func (wfc *windowFrameBoundChecker) Enter(inNode ast.Node) (outNode ast.Node, skipChildren bool) {
+// Enter implements ast.InPlaceVisitor interface.
+func (wfc *windowFrameBoundChecker) Enter(inNode ast.Node) bool {
 	if _, ok := inNode.(*ast.FrameBound); ok {
 		wfc.fb = inNode.(*ast.FrameBound)
 		if wfc.fb.Unit != ast.TimeUnitInvalid {
@@ -7193,11 +7193,11 @@ func (wfc *windowFrameBoundChecker) Enter(inNode ast.Node) (outNode ast.Node, sk
 			require.False(wfc.t, ok)
 		}
 	}
-	return inNode, false
+	return false
 }
 
-// Leave implements ast.Visitor interface.
-func (wfc *windowFrameBoundChecker) Leave(inNode ast.Node) (node ast.Node, ok bool) {
+// Leave implements ast.InPlaceVisitor interface.
+func (wfc *windowFrameBoundChecker) Leave(inNode ast.Node) bool {
 	if _, ok := inNode.(*ast.FrameBound); ok {
 		wfc.fb = nil
 	}
@@ -7207,7 +7207,7 @@ func (wfc *windowFrameBoundChecker) Leave(inNode ast.Node) (node ast.Node, ok bo
 		}
 		wfc.unit = wfc.fb.Unit
 	}
-	return inNode, true
+	return true
 }
 
 // For issue #51
@@ -7228,7 +7228,7 @@ func TestVisitFrameBound(t *testing.T) {
 		stmt, err := p.ParseOneStmt(tbl.s, "", "")
 		require.NoError(t, err)
 		checker := windowFrameBoundChecker{t: t}
-		stmt.Accept(&checker)
+		ast.Walk(stmt, &checker)
 		require.Equal(t, tbl.exprRc, checker.exprRc)
 		require.Equal(t, tbl.unit, checker.unit)
 	}
@@ -8089,14 +8089,14 @@ func TestGBKEncoding(t *testing.T) {
 	stmt, _, err := p.ParseSQL(sql)
 	require.NoError(t, err)
 	checker := &gbkEncodingChecker{}
-	_, _ = stmt[0].Accept(checker)
+	ast.Walk(stmt[0], checker)
 	require.NotEqual(t, "测试表", checker.tblName)
 	require.NotEqual(t, "测试列", checker.colName)
 
 	gbkOpt := parser.CharsetClient("gbk")
 	stmt, _, err = p.ParseSQL(sql, gbkOpt)
 	require.NoError(t, err)
-	_, _ = stmt[0].Accept(checker)
+	ast.Walk(stmt[0], checker)
 	require.Equal(t, "测试表", checker.tblName)
 	require.Equal(t, "测试列", checker.colName)
 	require.Equal(t, "GBK测试用例", checker.expr)
@@ -8137,14 +8137,14 @@ func TestGB18030Encoding(t *testing.T) {
 	stmt, _, err := p.ParseSQL(sql)
 	require.NoError(t, err)
 	checker := &gbkEncodingChecker{}
-	_, _ = stmt[0].Accept(checker)
+	ast.Walk(stmt[0], checker)
 	require.NotEqual(t, "测试表", checker.tblName)
 	require.NotEqual(t, "测试列", checker.colName)
 
 	gb18030Opt := parser.CharsetClient("gb18030")
 	stmt, _, err = p.ParseSQL(sql, gb18030Opt)
 	require.NoError(t, err)
-	_, _ = stmt[0].Accept(checker)
+	ast.Walk(stmt[0], checker)
 	require.Equal(t, "测试表", checker.tblName)
 	require.Equal(t, "测试列", checker.colName)
 	require.Equal(t, "GB18030测试用例", checker.expr)
@@ -8181,26 +8181,26 @@ type gbkEncodingChecker struct {
 	expr    string
 }
 
-func (g *gbkEncodingChecker) Enter(n ast.Node) (node ast.Node, skipChildren bool) {
+func (g *gbkEncodingChecker) Enter(n ast.Node) bool {
 	if tn, ok := n.(*ast.TableName); ok {
 		g.tblName = tn.Name.O
-		return n, false
+		return false
 	}
 	if cn, ok := n.(*ast.ColumnName); ok {
 		g.colName = cn.Name.O
-		return n, false
+		return false
 	}
 	if c, ok := n.(*ast.ColumnOption); ok {
 		if ve, ok := c.Expr.(ast.ValueExpr); ok {
 			g.expr = ve.GetString()
-			return n, false
+			return false
 		}
 	}
-	return n, false
+	return false
 }
 
-func (g *gbkEncodingChecker) Leave(n ast.Node) (node ast.Node, ok bool) {
-	return n, true
+func (*gbkEncodingChecker) Leave(ast.Node) bool {
+	return true
 }
 
 func TestInsertStatementMemoryAllocation(t *testing.T) {

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -305,7 +305,7 @@ func rewriteExprNode(rewriter *expressionRewriter, exprNode ast.ExprNode, asScal
 			planCtx.plan.SetOutputNames(names)
 		}()
 	}
-	exprNode.Accept(rewriter)
+	ast.Walk(exprNode, rewriter)
 	if rewriter.err != nil {
 		return nil, nil, errors.Trace(rewriter.err)
 	}
@@ -526,16 +526,17 @@ func (er *expressionRewriter) requirePlanCtx(inNode ast.Node, detail string) (ct
 	return
 }
 
-// Enter implements Visitor interface.
-func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
+// Enter implements InPlaceVisitor interface.
+func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 	er.astNodeStack = append(er.astNodeStack, inNode)
-	enterWithPlanCtx := func(fn func(*exprRewriterPlanCtx) (ast.Node, bool)) (ast.Node, bool) {
+	enterWithPlanCtx := func(fn func(*exprRewriterPlanCtx) (ast.Node, bool)) bool {
 		planCtx, err := er.requirePlanCtx(inNode, "")
 		if err != nil {
 			er.err = err
-			return inNode, true
+			return true
 		}
-		return fn(planCtx)
+		_, skipChildren := fn(planCtx)
+		return skipChildren
 	}
 
 	switch v := inNode.(type) {
@@ -569,7 +570,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 		if planCtx := er.planCtx; planCtx != nil {
 			if index, ok := planCtx.builder.colMapper[v]; ok {
 				er.ctxStackAppend(er.schema.Columns[index], er.names[index])
-				return inNode, true
+				return true
 			}
 		}
 	case *ast.CompareSubqueryExpr:
@@ -590,7 +591,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			// IN-list operands are scalar expression children. A nested IN-subquery on the left
 			// must therefore append its boolean result for this parent IN expression.
 			er.asScalar = true
-			return inNode, false
+			return false
 		}
 		// For 10 in ((select * from t)), the parser won't set v.Sel.
 		// So we must process this case here.
@@ -607,7 +608,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			default:
 				// Expect its left and right child to be a scalar value.
 				er.asScalar = true
-				return inNode, false
+				return false
 			}
 		}
 	case *ast.SubqueryExpr:
@@ -678,7 +679,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 	default:
 		er.asScalar = true
 	}
-	return inNode, false
+	return false
 }
 
 // canTreatInSubqueryAsExistsForFilter reports whether the IN subquery is in a WHERE/HAVING boolean chain
@@ -821,7 +822,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 	defer resetCTECheckForSubQuery(ci)
 	asScalar := er.asScalar
 	er.asScalar = true
-	v.L.Accept(er)
+	ast.Walk(v.L, er)
 	if er.err != nil {
 		return v, true
 	}
@@ -1282,7 +1283,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 	defer resetCTECheckForSubQuery(ci)
 	asScalar := er.asScalar
 	er.asScalar = true
-	v.Expr.Accept(er)
+	ast.Walk(v.Expr, er)
 	if er.err != nil {
 		return v, true
 	}
@@ -1663,15 +1664,15 @@ func (er *expressionRewriter) adjustUTF8MB4Collation(tp *types.FieldType) {
 	}
 }
 
-// Leave implements Visitor interface.
-func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok bool) {
+// Leave implements InPlaceVisitor interface.
+func (er *expressionRewriter) Leave(originInNode ast.Node) bool {
 	defer func() {
 		if len(er.astNodeStack) > 0 {
 			er.astNodeStack = er.astNodeStack[:len(er.astNodeStack)-1]
 		}
 	}()
 	if er.err != nil {
-		return retNode, false
+		return false
 	}
 	var inNode = originInNode
 	if er.preprocess != nil {
@@ -1704,7 +1705,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		initConstantRepertoire(er.sctx.GetEvalCtx(), value)
 		er.adjustUTF8MB4Collation(retType)
 		if er.err != nil {
-			return retNode, false
+			return false
 		}
 		er.ctxStackAppend(value, types.EmptyName)
 	case *driver.ParamMarkerExpr:
@@ -1756,25 +1757,25 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 	case *ast.FuncCastExpr:
 		if v.Tp.IsArray() && !er.allowBuildCastArray {
 			er.err = expression.ErrNotSupportedYet.GenWithStackByArgs("Use of CAST( .. AS .. ARRAY) outside of functional index in CREATE(non-SELECT)/ALTER TABLE or in general expressions")
-			return retNode, false
+			return false
 		}
 		arg := er.ctxStack[len(er.ctxStack)-1]
 		er.err = expression.CheckArgsNotMultiColumnRow(arg)
 		if er.err != nil {
-			return retNode, false
+			return false
 		}
 
 		// check the decimal precision of "CAST(AS TIME)".
 		er.err = er.checkTimePrecision(v.Tp)
 		if er.err != nil {
-			return retNode, false
+			return false
 		}
 
 		targetTp := v.Tp.DeepCopy()
 		castFunction, err := expression.BuildCastFunctionWithCheck(er.sctx, arg, targetTp, false, v.ExplicitCharSet)
 		if err != nil {
 			er.err = err
-			return retNode, false
+			return false
 		}
 		if v.Tp.EvalType() == types.ETString {
 			castFunction.SetCoercibility(expression.CoercibilityImplicit)
@@ -1796,7 +1797,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		jsonSumFunction, err := expression.BuildJSONSumCrc32FunctionWithCheck(er.sctx, arg, targetTp)
 		if err != nil {
 			er.err = err
-			return retNode, false
+			return false
 		}
 
 		jsonSumFunction.SetCoercibility(expression.CoercibilityNumeric)
@@ -1891,13 +1892,13 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		er.matchAgainstToExpression(v)
 	default:
 		er.err = errors.Errorf("UnknownType: %T", v)
-		return retNode, false
+		return false
 	}
 
 	if er.err != nil {
-		return retNode, false
+		return false
 	}
-	return originInNode, true
+	return true
 }
 
 // newFunctionWithInit chooses which expression.NewFunctionImpl() will be used.

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1894,10 +1894,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) bool {
 		return false
 	}
 
-	if er.err != nil {
-		return false
-	}
-	return true
+	return er.err == nil
 }
 
 // newFunctionWithInit chooses which expression.NewFunctionImpl() will be used.

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -529,19 +529,18 @@ func (er *expressionRewriter) requirePlanCtx(inNode ast.Node, detail string) (ct
 // Enter implements InPlaceVisitor interface.
 func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 	er.astNodeStack = append(er.astNodeStack, inNode)
-	enterWithPlanCtx := func(fn func(*exprRewriterPlanCtx) (ast.Node, bool)) bool {
+	enterWithPlanCtx := func(fn func(*exprRewriterPlanCtx) bool) bool {
 		planCtx, err := er.requirePlanCtx(inNode, "")
 		if err != nil {
 			er.err = err
 			return true
 		}
-		_, skipChildren := fn(planCtx)
-		return skipChildren
+		return fn(planCtx)
 	}
 
 	switch v := inNode.(type) {
 	case *ast.AggregateFuncExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			index, ok := -1, false
 			if planCtx.aggrMap != nil {
 				index, ok = planCtx.aggrMap[v]
@@ -556,15 +555,15 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 					// index >= 0 indicates this is a regular aggregate column
 					er.ctxStackAppend(er.schema.Columns[index], er.names[index])
 				}
-				return inNode, true
+				return true
 			}
 			// replace correlated aggregate in sub-query with its corresponding correlated column
 			if col, ok := planCtx.builder.correlatedAggMapper[v]; ok {
 				er.ctxStackAppend(col, types.EmptyName)
-				return inNode, true
+				return true
 			}
 			er.err = plannererrors.ErrInvalidGroupFuncUse
-			return inNode, true
+			return true
 		})
 	case *ast.ColumnNameExpr:
 		if planCtx := er.planCtx; planCtx != nil {
@@ -574,16 +573,16 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 			}
 		}
 	case *ast.CompareSubqueryExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			return er.handleCompareSubquery(er.ctx, planCtx, v)
 		})
 	case *ast.ExistsSubqueryExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			return er.handleExistSubquery(er.ctx, planCtx, v)
 		})
 	case *ast.PatternInExpr:
 		if v.Sel != nil {
-			return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+			return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 				return er.handleInSubquery(er.ctx, planCtx, v)
 			})
 		}
@@ -600,7 +599,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 			switch y := x.(type) {
 			case *ast.SubqueryExpr:
 				v.Sel = y
-				return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+				return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 					return er.handleInSubquery(er.ctx, planCtx, v)
 				})
 			case *ast.ParenthesesExpr:
@@ -612,12 +611,12 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 			}
 		}
 	case *ast.SubqueryExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			return er.handleScalarSubquery(er.ctx, planCtx, v)
 		})
 	case *ast.ParenthesesExpr:
 	case *ast.ValuesExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			schema, names := er.schema, er.names
 			// NOTE: "er.insertPlan != nil" means that we are rewriting the
 			// expressions inside the assignment of "INSERT" statement. we have to
@@ -629,18 +628,18 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 			idx, err := expression.FindFieldName(names, v.Column.Name)
 			if err != nil {
 				er.err = err
-				return inNode, false
+				return false
 			}
 			if idx < 0 {
 				er.err = plannererrors.ErrUnknownColumn.GenWithStackByArgs(v.Column.Name.OrigColName(), "field list")
-				return inNode, false
+				return false
 			}
 			col := schema.Columns[idx]
 			er.ctxStackAppend(expression.NewValuesFunc(er.sctx, col.Index, col.RetType), types.EmptyName)
-			return inNode, true
+			return true
 		})
 	case *ast.WindowFuncExpr:
-		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) (ast.Node, bool) {
+		return enterWithPlanCtx(func(planCtx *exprRewriterPlanCtx) bool {
 			intest.AssertNotNil(planCtx)
 			index, ok := -1, false
 			if planCtx.windowMap != nil {
@@ -648,10 +647,10 @@ func (er *expressionRewriter) Enter(inNode ast.Node) bool {
 			}
 			if !ok {
 				er.err = plannererrors.ErrWindowInvalidWindowFuncUse.GenWithStackByArgs(strings.ToLower(v.Name))
-				return inNode, true
+				return true
 			}
 			er.ctxStackAppend(er.schema.Columns[index], er.names[index])
-			return inNode, true
+			return true
 		})
 	case *ast.FuncCallExpr:
 		er.asScalar = true
@@ -815,7 +814,7 @@ func (er *expressionRewriter) buildSemiApplyFromEqualSubq(np base.LogicalPlan, p
 	planCtx.plan, er.err = planCtx.builder.buildSemiApply(planCtx.plan, np, []expression.Expression{condition}, er.asScalar, not, false, markNoDecorrelate)
 }
 
-func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.CompareSubqueryExpr) (ast.Node, bool) {
+func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.CompareSubqueryExpr) bool {
 	intest.AssertNotNil(planCtx)
 	b := planCtx.builder
 	ci := b.prepareCTECheckForSubQuery()
@@ -824,19 +823,19 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 	er.asScalar = true
 	ast.Walk(v.L, er)
 	if er.err != nil {
-		return v, true
+		return true
 	}
 	lexpr := er.ctxStack[len(er.ctxStack)-1]
 	er.asScalar = asScalar
 	subq, ok := v.R.(*ast.SubqueryExpr)
 	if !ok {
 		er.err = errors.Errorf("Unknown compare type %T", v.R)
-		return v, true
+		return true
 	}
 	np, hintFlags, err := er.buildSubquery(ctx, planCtx, subq, handlingCompareSubquery)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	corCols := coreusage.ExtractCorColumnsBySchema4LogicalPlan(np, planCtx.plan.Schema())
 	noDecorrelate := isNoDecorrelate(planCtx, corCols, hintFlags, handlingCompareSubquery)
@@ -845,12 +844,12 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 	canMultiCol := (!v.All && v.Op == opcode.EQ) || (v.All && v.Op == opcode.NE)
 	if !canMultiCol && (expression.GetRowLen(lexpr) != 1 || np.Schema().Len() != 1) {
 		er.err = expression.ErrOperandColumns.GenWithStackByArgs(1)
-		return v, true
+		return true
 	}
 	lLen := expression.GetRowLen(lexpr)
 	if lLen != np.Schema().Len() {
 		er.err = expression.ErrOperandColumns.GenWithStackByArgs(lLen)
-		return v, true
+		return true
 	}
 	var rexpr expression.Expression
 	if np.Schema().Len() == 1 {
@@ -862,7 +861,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 		}
 		rexpr, er.err = er.newFunction(ast.RowFunc, args[0].GetType(er.sctx.GetEvalCtx()), args...)
 		if er.err != nil {
-			return v, true
+			return true
 		}
 	}
 
@@ -871,7 +870,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 	v.Op.Format(opString)
 	_, er.err = expression.CheckAndDeriveCollationFromExprs(er.sctx, opString.String(), types.ETInt, lexpr, rexpr)
 	if er.err != nil {
-		return v, true
+		return true
 	}
 
 	switch v.Op {
@@ -885,7 +884,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 				er.asScalar = true
 				er.buildSemiApplyFromEqualSubq(np, planCtx, lexpr, rexpr, false, noDecorrelate)
 				if er.err != nil {
-					return v, true
+					return true
 				}
 			}
 		} else if v.Op == opcode.NE {
@@ -894,7 +893,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 				er.asScalar = true
 				er.buildSemiApplyFromEqualSubq(np, planCtx, lexpr, rexpr, true, noDecorrelate)
 				if er.err != nil {
-					return v, true
+					return true
 				}
 			} else {
 				er.handleNEAny(planCtx, lexpr, rexpr, np, noDecorrelate)
@@ -902,7 +901,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 		} else {
 			// TODO: Support this in future.
 			er.err = errors.New("We don't support <=> all or <=> any now")
-			return v, true
+			return true
 		}
 	default:
 		// When < all or > any , the agg function should use min.
@@ -915,7 +914,7 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, planCtx
 		col := planCtx.plan.Schema().Columns[planCtx.plan.Schema().Len()-1]
 		er.ctxStackAppend(col, planCtx.plan.OutputNames()[planCtx.plan.Schema().Len()-1])
 	}
-	return v, true
+	return true
 }
 
 // handleOtherComparableSubq handles the queries like < any, < max, etc. For example, if the query is t.id < any (select s.id from s),
@@ -1129,7 +1128,7 @@ func (er *expressionRewriter) handleEQAll(planCtx *exprRewriterPlanCtx, lexpr, r
 	er.buildQuantifierPlan(planCtx, plan4Agg, cond, lexpr, rexpr, true, markNoDecorrelate)
 }
 
-func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.ExistsSubqueryExpr) (ast.Node, bool) {
+func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.ExistsSubqueryExpr) bool {
 	intest.AssertNotNil(planCtx)
 	b := planCtx.builder
 	ci := b.prepareCTECheckForSubQuery()
@@ -1137,12 +1136,12 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 	subq, ok := v.Sel.(*ast.SubqueryExpr)
 	if !ok {
 		er.err = errors.Errorf("Unknown exists type %T", v.Sel)
-		return v, true
+		return true
 	}
 	np, hintFlags, err := er.buildSubquery(ctx, planCtx, subq, handlingExistsSubquery)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	// Add LIMIT 1 when noDecorrelate is true for EXISTS subqueries to enable early exit
 	corCols := coreusage.ExtractCorColumnsBySchema4LogicalPlan(np, planCtx.plan.Schema())
@@ -1168,7 +1167,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 			np, err = planCtx.builder.buildLimit(np, limitClause, np.QueryBlockOffset())
 			if err != nil {
 				er.err = err
-				return v, true
+				return true
 			}
 		}
 	}
@@ -1184,7 +1183,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 	if b.disableSubQueryPreprocessing || len(coreusage.ExtractCorrelatedCols4LogicalPlan(np)) > 0 || hasCTEConsumerInSubPlan(np) {
 		planCtx.plan, er.err = b.buildSemiApply(planCtx.plan, np, nil, er.asScalar, v.Not, semiJoinRewrite, noDecorrelate)
 		if er.err != nil || !er.asScalar {
-			return v, true
+			return true
 		}
 		er.ctxStackAppend(planCtx.plan.Schema().Columns[planCtx.plan.Schema().Len()-1], planCtx.plan.OutputNames()[planCtx.plan.Schema().Len()-1])
 	} else {
@@ -1195,7 +1194,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 		b.ctx.GetSessionVars().StmtCtx.StmtHints.ForceNthPlan = nthPlanBackup
 		if err != nil {
 			er.err = err
-			return v, true
+			return true
 		}
 		if b.ctx.GetSessionVars().StmtCtx.InExplainStmt && !b.ctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt && b.ctx.GetSessionVars().ExplainNonEvaledSubQuery {
 			newColID := b.ctx.GetSessionVars().AllocPlanColumnID()
@@ -1216,13 +1215,13 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 				notWrapped, err := expression.NewFunction(b.ctx.GetExprCtx(), ast.UnaryNot, types.NewFieldType(mysql.TypeTiny), scalarSubQ)
 				if err != nil {
 					er.err = err
-					return v, true
+					return true
 				}
 				er.ctxStackAppend(notWrapped, types.EmptyName)
-				return v, true
+				return true
 			}
 			er.ctxStackAppend(scalarSubQ, types.EmptyName)
-			return v, true
+			return true
 		}
 		// register the subquery plan but continue with normal execution
 		subqueryCtx := ScalarSubqueryEvalCtx{
@@ -1242,7 +1241,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 		row, err := EvalSubqueryFirstRow(ctx, physicalPlan, b.is, b.ctx)
 		if err != nil {
 			er.err = err
-			return v, true
+			return true
 		}
 		if (row != nil && !v.Not) || (row == nil && v.Not) {
 			er.ctxStackAppend(expression.NewSignedOne(), types.EmptyName)
@@ -1250,7 +1249,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, planCtx *
 			er.ctxStackAppend(expression.NewSignedZero(), types.EmptyName)
 		}
 	}
-	return v, true
+	return true
 }
 
 // popExistsSubPlan will remove the useless plan in exist's child.
@@ -1277,7 +1276,7 @@ out:
 	return p
 }
 
-func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.PatternInExpr) (ast.Node, bool) {
+func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.PatternInExpr) bool {
 	intest.AssertNotNil(planCtx)
 	ci := planCtx.builder.prepareCTECheckForSubQuery()
 	defer resetCTECheckForSubQuery(ci)
@@ -1285,23 +1284,23 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 	er.asScalar = true
 	ast.Walk(v.Expr, er)
 	if er.err != nil {
-		return v, true
+		return true
 	}
 	lexpr := er.ctxStack[len(er.ctxStack)-1]
 	subq, ok := v.Sel.(*ast.SubqueryExpr)
 	if !ok {
 		er.err = errors.Errorf("Unknown compare type %T", v.Sel)
-		return v, true
+		return true
 	}
 	np, hintFlags, err := er.buildSubquery(ctx, planCtx, subq, handlingInSubquery)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	lLen := expression.GetRowLen(lexpr)
 	if lLen != np.Schema().Len() {
 		er.err = expression.ErrOperandColumns.GenWithStackByArgs(lLen)
-		return v, true
+		return true
 	}
 	var rexpr expression.Expression
 	markInOperand := v.Not || (asScalar && !er.canTreatInSubqueryAsExistsForFilter(planCtx))
@@ -1343,13 +1342,13 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		}
 		rexpr, er.err = er.newFunction(ast.RowFunc, args[0].GetType(er.sctx.GetEvalCtx()), args...)
 		if er.err != nil {
-			return v, true
+			return true
 		}
 	}
 	checkCondition, err := er.constructBinaryOpFunction(lexpr, rexpr, ast.EQ)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 
 	// If the leftKey and the rightKey have different collations, don't convert the sub-query to an inner-join
@@ -1433,7 +1432,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 						joinCondition, err = er.constructBinaryOpFunction(lexpr, projCol, ast.EQ)
 						if err != nil {
 							er.err = err
-							return v, true
+							return true
 						}
 					}
 				}
@@ -1443,7 +1442,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		agg, err := planCtx.builder.buildDistinct(distinctChild, distinctLen)
 		if err != nil {
 			er.err = err
-			return v, true
+			return true
 		}
 		// Build inner join above the aggregation.
 		join := logicalop.LogicalJoin{JoinType: base.InnerJoin}.Init(planCtx.builder.ctx, planCtx.builder.getSelectOffset())
@@ -1467,7 +1466,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		semiRewrite := hintFlags&hint.HintFlagSemiJoinRewrite > 0
 		planCtx.plan, er.err = planCtx.builder.buildSemiApply(planCtx.plan, np, expression.SplitCNFItems(checkCondition), asScalar, v.Not, semiRewrite, noDecorrelate)
 		if er.err != nil {
-			return v, true
+			return true
 		}
 		// When EnableCorrelateSubquery is ON (set by the correlate alternative round)
 		// and the subquery is non-correlated, mark the join so that CorrelateSolver
@@ -1487,7 +1486,7 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		col := planCtx.plan.Schema().Columns[planCtx.plan.Schema().Len()-1]
 		er.ctxStackAppend(col, planCtx.plan.OutputNames()[planCtx.plan.Schema().Len()-1])
 	}
-	return v, true
+	return true
 }
 
 func isNoDecorrelate(planCtx *exprRewriterPlanCtx, corCols []*expression.CorrelatedColumn, hintFlags uint64, sCtx subQueryCtx) bool {
@@ -1520,14 +1519,14 @@ func isNoDecorrelate(planCtx *exprRewriterPlanCtx, corCols []*expression.Correla
 	return noDecorrelate
 }
 
-func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.SubqueryExpr) (ast.Node, bool) {
+func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx *exprRewriterPlanCtx, v *ast.SubqueryExpr) bool {
 	intest.AssertNotNil(planCtx)
 	ci := planCtx.builder.prepareCTECheckForSubQuery()
 	defer resetCTECheckForSubQuery(ci)
 	np, hintFlags, err := er.buildSubquery(ctx, planCtx, v, handlingScalarSubquery)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	np = planCtx.builder.buildMaxOneRow(np)
 	correlatedColumn := coreusage.ExtractCorColumnsBySchema4LogicalPlan(np, planCtx.plan.Schema())
@@ -1543,13 +1542,13 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 			expr, err1 := er.newFunction(ast.RowFunc, newCols[0].GetType(er.sctx.GetEvalCtx()), newCols...)
 			if err1 != nil {
 				er.err = err1
-				return v, true
+				return true
 			}
 			er.ctxStackAppend(expr, types.EmptyName)
 		} else {
 			er.ctxStackAppend(planCtx.plan.Schema().Columns[planCtx.plan.Schema().Len()-1], planCtx.plan.OutputNames()[planCtx.plan.Schema().Len()-1])
 		}
-		return v, true
+		return true
 	}
 	// We don't want nth_plan hint to affect separately executed subqueries here, so disable nth_plan temporarily.
 	nthPlanBackup := planCtx.builder.ctx.GetSessionVars().StmtCtx.StmtHints.ForceNthPlan
@@ -1558,7 +1557,7 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 	planCtx.builder.ctx.GetSessionVars().StmtCtx.StmtHints.ForceNthPlan = nthPlanBackup
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	if planCtx.builder.ctx.GetSessionVars().StmtCtx.InExplainStmt && !planCtx.builder.ctx.GetSessionVars().StmtCtx.InExplainAnalyzeStmt && planCtx.builder.ctx.GetSessionVars().ExplainNonEvaledSubQuery {
 		subqueryCtx := ScalarSubqueryEvalCtx{
@@ -1588,11 +1587,11 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 			rowFunc, err := er.newFunction(ast.RowFunc, newScalarSubQueryExprs[0].GetType(er.sctx.GetEvalCtx()), newScalarSubQueryExprs...)
 			if err != nil {
 				er.err = err
-				return v, true
+				return true
 			}
 			er.ctxStack = append(er.ctxStack, rowFunc)
 		}
-		return v, true
+		return true
 	}
 
 	// register the subquery plan but continue with normal execution
@@ -1612,7 +1611,7 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 	row, err := EvalSubqueryFirstRow(ctx, physicalPlan, planCtx.builder.is, planCtx.builder.ctx)
 	if err != nil {
 		er.err = err
-		return v, true
+		return true
 	}
 	newCols := make([]expression.Expression, 0, np.Schema().Len())
 	for i, data := range row {
@@ -1629,13 +1628,13 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, planCtx 
 		expr, err := er.newFunction(ast.RowFunc, newCols[0].GetType(er.sctx.GetEvalCtx()), newCols...)
 		if err != nil {
 			er.err = err
-			return v, true
+			return true
 		}
 		er.ctxStackAppend(expr, types.EmptyName)
 	} else {
 		er.ctxStackAppend(newCols[0], types.EmptyName)
 	}
-	return v, true
+	return true
 }
 
 func hasCTEConsumerInSubPlan(p base.LogicalPlan) bool {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -1658,20 +1658,20 @@ type userVarTypeProcessor struct {
 	err     error
 }
 
-func (p *userVarTypeProcessor) Enter(in ast.Node) (ast.Node, bool) {
+func (p *userVarTypeProcessor) Enter(in ast.Node) bool {
 	v, ok := in.(*ast.VariableExpr)
 	if !ok {
-		return in, false
+		return false
 	}
 	if v.IsSystem || v.Value == nil {
-		return in, true
+		return true
 	}
 	_, p.plan, p.err = p.builder.rewrite(p.ctx, v, p.plan, p.mapper, true)
-	return in, true
+	return true
 }
 
-func (p *userVarTypeProcessor) Leave(in ast.Node) (ast.Node, bool) {
-	return in, p.err == nil
+func (p *userVarTypeProcessor) Leave(ast.Node) bool {
+	return p.err == nil
 }
 
 func (b *PlanBuilder) preprocessUserVarTypes(ctx context.Context, p base.LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int) error {
@@ -1684,7 +1684,7 @@ func (b *PlanBuilder) preprocessUserVarTypes(ctx context.Context, p base.Logical
 		mapper:  aggMapper,
 	}
 	for _, field := range fields {
-		field.Expr.Accept(&processor)
+		ast.Walk(field.Expr, &processor)
 		if processor.err != nil {
 			return processor.err
 		}
@@ -3169,8 +3169,8 @@ type correlatedAggregateResolver struct {
 	noDecorrelate bool
 }
 
-// Enter implements Visitor interface.
-func (r *correlatedAggregateResolver) Enter(n ast.Node) (ast.Node, bool) {
+// Enter implements InPlaceVisitor interface.
+func (r *correlatedAggregateResolver) Enter(n ast.Node) bool {
 	if v, ok := n.(*ast.SelectStmt); ok {
 		if r.outerPlan != nil {
 			outerSchema := r.outerPlan.Schema()
@@ -3179,9 +3179,9 @@ func (r *correlatedAggregateResolver) Enter(n ast.Node) (ast.Node, bool) {
 			r.b.outerBlockExpand = append(r.b.outerBlockExpand, r.b.currentBlockExpand)
 		}
 		r.err = r.resolveSelect(v)
-		return n, true
+		return true
 	}
-	return n, false
+	return false
 }
 
 // resolveSelect finds and collects correlated aggregates within the SELECT stmt.
@@ -3273,7 +3273,7 @@ func (r *correlatedAggregateResolver) collectFromTableRefs(from *ast.TableRefsCl
 		ctx: r.ctx,
 		b:   r.b,
 	}
-	_, ok := from.TableRefs.Accept(subResolver)
+	ok := ast.Walk(from.TableRefs, subResolver)
 	if !ok {
 		return subResolver.err
 	}
@@ -3324,8 +3324,8 @@ func (r *correlatedAggregateResolver) collectFromWhere(p base.LogicalPlan, where
 	return nil
 }
 
-// Leave implements Visitor interface.
-func (r *correlatedAggregateResolver) Leave(n ast.Node) (ast.Node, bool) {
+// Leave implements InPlaceVisitor interface.
+func (r *correlatedAggregateResolver) Leave(n ast.Node) bool {
 	if _, ok := n.(*ast.SelectStmt); ok {
 		if r.outerPlan != nil {
 			r.b.outerSchemas = r.b.outerSchemas[0 : len(r.b.outerSchemas)-1]
@@ -3334,7 +3334,7 @@ func (r *correlatedAggregateResolver) Leave(n ast.Node) (ast.Node, bool) {
 			r.b.outerBlockExpand = r.b.outerBlockExpand[0 : len(r.b.outerBlockExpand)-1]
 		}
 	}
-	return n, r.err == nil
+	return r.err == nil
 }
 
 // resolveCorrelatedAggregates finds and collects all correlated aggregates which should be evaluated
@@ -3348,14 +3348,14 @@ func (b *PlanBuilder) resolveCorrelatedAggregates(ctx context.Context, sel *ast.
 	}
 	correlatedAggList := make([]*ast.AggregateFuncExpr, 0)
 	for _, field := range sel.Fields.Fields {
-		_, ok := field.Expr.Accept(resolver)
+		ok := ast.Walk(field.Expr, resolver)
 		if !ok {
 			return nil, resolver.err
 		}
 		correlatedAggList = append(correlatedAggList, resolver.correlatedAggFuncs...)
 	}
 	if sel.Having != nil {
-		_, ok := sel.Having.Expr.Accept(resolver)
+		ok := ast.Walk(sel.Having.Expr, resolver)
 		if !ok {
 			return nil, resolver.err
 		}
@@ -3363,7 +3363,7 @@ func (b *PlanBuilder) resolveCorrelatedAggregates(ctx context.Context, sel *ast.
 	}
 	if sel.OrderBy != nil {
 		for _, item := range sel.OrderBy.Items {
-			_, ok := item.Expr.Accept(resolver)
+			ok := ast.Walk(item.Expr, resolver)
 			if !ok {
 				return nil, resolver.err
 			}
@@ -5589,7 +5589,7 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName ast.CI
 	}()
 
 	hintProcessor := h.NewQBHintHandler(b.ctx.GetSessionVars().StmtCtx)
-	selectNode.Accept(hintProcessor)
+	ast.Walk(selectNode, hintProcessor)
 	currentQbNameMap4View := make(map[string][]ast.HintTable)
 	currentQbHints4View := make(map[string][]*ast.TableOptimizerHint)
 	currentQbHints := make(map[int][]*ast.TableOptimizerHint)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -256,7 +256,7 @@ type preprocessor struct {
 	resolveCtx *resolve.Context
 }
 
-func (p *preprocessor) Enter(in ast.Node) (skipChildren bool) {
+func (p *preprocessor) Enter(in ast.Node) bool {
 	switch node := in.(type) {
 	case *ast.AdminStmt:
 		p.checkAdminCheckTableGrammar(node)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -636,7 +636,7 @@ func (p *preprocessor) checkBindGrammar(originNode, hintedNode ast.StmtNode, def
 	}
 }
 
-func (p *preprocessor) Leave(in ast.Node) (proceed bool) {
+func (p *preprocessor) Leave(in ast.Node) bool {
 	switch x := in.(type) {
 	case *ast.CreateTableStmt:
 		p.flag &= ^inCreateOrDropTable
@@ -651,7 +651,7 @@ func (p *preprocessor) Leave(in ast.Node) (proceed bool) {
 	case *driver.ParamMarkerExpr:
 		if p.flag&inPrepare == 0 {
 			p.err = parser.ErrSyntax.GenWithStack("syntax error, unexpected '?'")
-			return
+			return false
 		}
 	case *ast.ExplainStmt:
 		if _, ok := x.Stmt.(*ast.ShowStmt); ok {

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -145,7 +145,7 @@ func Preprocess(ctx context.Context, sctx sessionctx.Context, node *resolve.Node
 	if v.PreprocessorReturn == nil {
 		v.PreprocessorReturn = &PreprocessorReturn{}
 	}
-	node.Node.Accept(&v)
+	ast.Walk(node.Node, &v)
 	// InfoSchema must be non-nil after preprocessing
 	v.ensureInfoSchema()
 	sctx.GetPlanCtx().SetReadonlyUserVarMap(v.varsReadonly)
@@ -225,7 +225,7 @@ func (pw *preprocessWith) UpdateCTEConsumerCount(tableName string) {
 	}
 }
 
-// preprocessor is an ast.Visitor that preprocess
+// preprocessor is an ast.InPlaceVisitor that preprocesses
 // ast Nodes parsed from parser.
 type preprocessor struct {
 	ctx    context.Context
@@ -256,7 +256,7 @@ type preprocessor struct {
 	resolveCtx *resolve.Context
 }
 
-func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+func (p *preprocessor) Enter(in ast.Node) (skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.AdminStmt:
 		p.checkAdminCheckTableGrammar(node)
@@ -268,7 +268,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 			p.preprocessWith.cteStack = append(p.preprocessWith.cteStack, node.With.CTEs)
 		}
 		p.checkSelectNoopFuncs(node)
-		// SelectStmt.Accept visits FROM before LockInfo, so one per-SELECT context can collect FROM
+		// ast.Walk visits FROM before LockInfo, so one per-SELECT context can collect FROM
 		// table refs during traversal and later bind LockInfo targets without re-walking the FROM tree.
 		p.pushLockSelectCtx(node)
 	case *ast.SetOprStmt:
@@ -342,7 +342,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		p.checkSetOprSelectList(node)
 	case *ast.DeleteTableList:
 		p.stmtTp = TypeDelete
-		return in, true
+		return true
 	case *ast.Join:
 		p.checkNonUniqTableAlias(node)
 	case *ast.CreateBindingStmt:
@@ -353,7 +353,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 			EraseLastSemicolon(node.HintedNode)
 			p.checkBindGrammar(node.OriginNode, node.HintedNode, p.sctx.GetSessionVars().CurrentDB)
 		}
-		return in, true
+		return true
 	case *ast.DropBindingStmt:
 		p.stmtTp = TypeDrop
 		if node.OriginNode != nil {
@@ -363,22 +363,22 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 				p.checkBindGrammar(node.OriginNode, node.HintedNode, p.sctx.GetSessionVars().CurrentDB)
 			}
 		}
-		return in, true
+		return true
 	case *ast.RecoverTableStmt:
 		// The specified table in recover table statement maybe already been dropped.
 		// So skip check table name here, otherwise, recover table [table_name] syntax will return
 		// table not exists error. But recover table statement is use to recover the dropped table. So skip children here.
-		return in, true
+		return true
 	case *ast.FlashBackTableStmt:
 		if len(node.NewName) > 0 {
 			p.checkFlashbackTableGrammar(node)
 		}
-		return in, true
+		return true
 	case *ast.FlashBackDatabaseStmt:
 		if len(node.NewName) > 0 {
 			p.checkFlashbackDatabaseGrammar(node)
 		}
-		return in, true
+		return true
 	case *ast.RepairTableStmt:
 		p.stmtTp = TypeRepair
 		// The RepairTable should consist of the logic for creating tables and renaming tables.
@@ -477,7 +477,7 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	default:
 		p.flag &= ^parentIsJoin
 	}
-	return in, p.err != nil
+	return p.err != nil
 }
 
 // EraseLastSemicolon removes last semicolon of sql.
@@ -627,8 +627,8 @@ func (p *preprocessor) checkBindGrammar(originNode, hintedNode ast.StmtNode, def
 		})
 	}
 	aliasChecker := &aliasChecker{}
-	originNode.Accept(aliasChecker)
-	hintedNode.Accept(aliasChecker)
+	ast.Walk(originNode, aliasChecker)
+	ast.Walk(hintedNode, aliasChecker)
 	originSQL, _ := bindinfo.NormalizeStmtForBinding(originNode, defaultDB, false)
 	hintedSQL, _ := bindinfo.NormalizeStmtForBinding(hintedNode, defaultDB, false)
 	if originSQL != hintedSQL {
@@ -636,7 +636,7 @@ func (p *preprocessor) checkBindGrammar(originNode, hintedNode ast.StmtNode, def
 	}
 }
 
-func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
+func (p *preprocessor) Leave(in ast.Node) (proceed bool) {
 	switch x := in.(type) {
 	case *ast.CreateTableStmt:
 		p.flag &= ^inCreateOrDropTable
@@ -755,7 +755,7 @@ func (p *preprocessor) Leave(in ast.Node) (out ast.Node, ok bool) {
 		}
 	}
 
-	return in, p.err == nil
+	return p.err == nil
 }
 
 func checkAutoIncrementOp(colDef *ast.ColumnDef, index int) (bool, error) {
@@ -2361,7 +2361,7 @@ func (p *preprocessor) skipLockMDL() bool {
 //	   so we have to set `tt1` as alias by aliasChecker.
 type aliasChecker struct{}
 
-func (*aliasChecker) Enter(in ast.Node) (ast.Node, bool) {
+func (*aliasChecker) Enter(in ast.Node) bool {
 	if deleteStmt, ok := in.(*ast.DeleteStmt); ok {
 		// 1. check the tableRefs of deleteStmt to find the alias
 		var aliases []*ast.CIStr
@@ -2388,9 +2388,9 @@ func (*aliasChecker) Enter(in ast.Node) (ast.Node, bool) {
 				}
 			}
 		}
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
 func getTableRefsAlias(tableRefs ast.ResultSetNode) *ast.CIStr {
@@ -2405,6 +2405,6 @@ func getTableRefsAlias(tableRefs ast.ResultSetNode) *ast.CIStr {
 	return nil
 }
 
-func (*aliasChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+func (*aliasChecker) Leave(ast.Node) bool {
+	return true
 }

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -778,7 +778,7 @@ func optimize(ctx context.Context, sctx planctx.PlanContext, node *resolve.NodeW
 	// Build the logical plan from the raw AST. The hint processor only keeps
 	// AST-derived metadata; per-build state is allocated inside PlanBuilder.
 	hintProcessor := hint.NewQBHintHandler(sctx.GetSessionVars().StmtCtx)
-	node.Node.Accept(hintProcessor)
+	ast.Walk(node.Node, hintProcessor)
 
 	// build multi logical plan from raw AST.
 	var (

--- a/pkg/util/hint/hint_processor.go
+++ b/pkg/util/hint/hint_processor.go
@@ -260,7 +260,7 @@ type hintProcessor struct {
 	blockCounter int
 }
 
-func (hp *hintProcessor) Enter(in ast.Node) (ast.Node, bool) {
+func (hp *hintProcessor) Enter(in ast.Node) (skipChildren bool) {
 	switch v := in.(type) {
 	case *ast.SelectStmt, *ast.UpdateStmt, *ast.DeleteStmt:
 		if hp.bindHint2Ast {
@@ -277,7 +277,7 @@ func (hp *hintProcessor) Enter(in ast.Node) (ast.Node, bool) {
 	case *ast.TableName:
 		// Insert cases.
 		if hp.blockCounter == 0 {
-			return in, false
+			return false
 		}
 		if hp.bindHint2Ast {
 			if hp.indexCounter < len(hp.indexHints) {
@@ -290,28 +290,28 @@ func (hp *hintProcessor) Enter(in ast.Node) (ast.Node, bool) {
 			hp.indexHints = append(hp.indexHints, v.IndexHints)
 		}
 	}
-	return in, false
+	return false
 }
 
-func (hp *hintProcessor) Leave(in ast.Node) (ast.Node, bool) {
+func (hp *hintProcessor) Leave(in ast.Node) (proceed bool) {
 	switch in.(type) {
 	case *ast.SelectStmt, *ast.UpdateStmt, *ast.DeleteStmt:
 		hp.blockCounter--
 	}
-	return in, true
+	return true
 }
 
 // CollectHint collects hints for a statement.
 func CollectHint(in ast.StmtNode) *HintsSet {
 	hp := hintProcessor{HintsSet: &HintsSet{tableHints: make([][]*ast.TableOptimizerHint, 0, 4), indexHints: make([][]*ast.IndexHint, 0, 4)}}
-	in.Accept(&hp)
+	ast.Walk(in, &hp)
 	return hp.HintsSet
 }
 
 // BindHint will add hints for stmt according to the hints in `hintsSet`.
 func BindHint(stmt ast.StmtNode, hintsSet *HintsSet) ast.StmtNode {
 	hp := hintProcessor{HintsSet: hintsSet, bindHint2Ast: true}
-	stmt.Accept(&hp)
+	ast.Walk(stmt, &hp)
 	return stmt
 }
 
@@ -328,7 +328,7 @@ func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*Hints
 	}
 	hs := CollectHint(stmtNodes[0])
 	processor := NewQBHintHandler(nil)
-	stmtNodes[0].Accept(processor)
+	ast.Walk(stmtNodes[0], processor)
 	topNodeType := nodeType4Stmt(stmtNodes[0])
 	for i, tblHints := range hs.tableHints {
 		newHints := make([]*ast.TableOptimizerHint, 0, len(tblHints))

--- a/pkg/util/hint/hint_query_block.go
+++ b/pkg/util/hint/hint_query_block.go
@@ -79,8 +79,8 @@ func (p *QBHintHandler) MaxSelectStmtOffset() int {
 	return p.selectStmtOffset
 }
 
-// Enter implements Visitor interface.
-func (p *QBHintHandler) Enter(in ast.Node) (ast.Node, bool) {
+// Enter implements ast.InPlaceVisitor.
+func (p *QBHintHandler) Enter(in ast.Node) (skipChildren bool) {
 	switch node := in.(type) {
 	case *ast.UpdateStmt:
 		p.checkQueryBlockHints(node.TableHints, 0)
@@ -93,16 +93,16 @@ func (p *QBHintHandler) Enter(in ast.Node) (ast.Node, bool) {
 		node.TableHints = p.handleViewHints(node.TableHints, node.QueryBlockOffset)
 		p.checkQueryBlockHints(node.TableHints, node.QueryBlockOffset)
 	case *ast.ExplainStmt:
-		return in, true
+		return true
 	case *ast.CreateBindingStmt:
-		return in, true
+		return true
 	}
-	return in, false
+	return false
 }
 
-// Leave implements Visitor interface.
-func (*QBHintHandler) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+// Leave implements ast.InPlaceVisitor.
+func (*QBHintHandler) Leave(ast.Node) (proceed bool) {
+	return true
 }
 
 const hintQBName = "qb_name"

--- a/pkg/util/hint/hint_query_block.go
+++ b/pkg/util/hint/hint_query_block.go
@@ -80,7 +80,7 @@ func (p *QBHintHandler) MaxSelectStmtOffset() int {
 }
 
 // Enter implements ast.InPlaceVisitor.
-func (p *QBHintHandler) Enter(in ast.Node) (skipChildren bool) {
+func (p *QBHintHandler) Enter(in ast.Node) bool {
 	switch node := in.(type) {
 	case *ast.UpdateStmt:
 		p.checkQueryBlockHints(node.TableHints, 0)
@@ -101,7 +101,7 @@ func (p *QBHintHandler) Enter(in ast.Node) (skipChildren bool) {
 }
 
 // Leave implements ast.InPlaceVisitor.
-func (*QBHintHandler) Leave(ast.Node) (proceed bool) {
+func (*QBHintHandler) Leave(ast.Node) bool {
 	return true
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70622

Problem Summary:

The replacement-capable `ast.Visitor` API publishes returned child nodes back
into their parent AST. Thirteen production visitors still used this API even
though they always returned the original node and never needed replacement.
Most of these visitors intentionally mutate the visited AST or maintain
visitor-owned state, but the traversal framework's replacement checks and
child writebacks are still unnecessary.

This is a follow-up to #70678, which migrated the previous batch of read-only
visitors to `ast.InPlaceVisitor` and `ast.Walk`.

### What changed and how does it work?

This is part 3 of the non-replacing visitor migration. It converts thirteen
production visitors and their traversal sites from `ast.Visitor`/`Node.Accept`
to `ast.InPlaceVisitor`/`ast.Walk`:

- Parser AST: `exprCleaner` and `flagSetter`.
- DDL: `columnNameCollector`, `mvDefinitionHintDBNameNormalizer`, and
  `renameMaskingExprVisitor`.
- Binding and hints: `selectOffsetAssigner`, `QBHintHandler`, and
  `hintProcessor`.
- Planner: `preprocessor`, `aliasChecker`, `expressionRewriter`,
  `userVarTypeProcessor`, and `correlatedAggregateResolver`.

`columnNameCollector` remains read-only with respect to the AST. The other
twelve visitors retain their intentional AST or traversal-state mutations.
The migration preserves traversal order, child-pruning and early-stop
decisions, stored-error handling, nested expression walks, query-block
counters, AST stacks, and temporary field restoration. Parser test visitors
that exercise the same non-replacing traversal contract are migrated as well.

The exported `QBHintHandler.Enter` and `QBHintHandler.Leave` signatures now
implement `ast.InPlaceVisitor` rather than `ast.Visitor`. SQL behavior is
unchanged, but Go code that directly calls those methods or requires
`*QBHintHandler` as an `ast.Visitor` must migrate to `ast.InPlaceVisitor`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Commands:

```text
make bazel_prepare
make parser
make parser_yacc
make parser_fmt
make parser_unit_test
./tools/check/failpoint-go-test.sh pkg/parser/ast -run '^(TestFlag|TestWalk)$' -count=1
./tools/check/failpoint-go-test.sh pkg/ddl -run '^(TestNormalizeMVDefinitionHintDBNames|TestMaskingPolicyRenameColumn)$' -count=1
./tools/check/failpoint-go-test.sh pkg/bindinfo -run '^(TestExplainExploreNoDecorrelateHint|TestHintsSetID|TestPreparedStmt)$' -count=1
./tools/check/failpoint-go-test.sh pkg/planner/core -run '^(TestValidator|TestPreprocessCTE|TestPreprocessDeleteFromWithAlias|TestBuildExpression|TestRewriterPool|TestSubquery|TestTopNPushDown|TestResolvingCorrelatedAggregate|TestIndexJoinHintInSubquery|TestValidate|TestSelectView)$' -count=1
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/hint -run '^(TestAllViewHintType|TestQBHintHandlerDuplicateObjects)$' -count=1
make lint
git diff --check upstream/master...HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The exported `QBHintHandler` now implements `ast.InPlaceVisitor` instead of `ast.Visitor`; SQL behavior is unchanged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized syntax-tree traversal across parsing, planning, DDL, masking policies, hints, and expression processing.
  - Updated traversal visitors to use the current in-place API for more consistent processing.
  - Preserved existing query rewriting, hint handling, masking behavior, and expression processing.

- **Tests**
  - Updated parser and syntax-tree coverage to use the standardized traversal mechanism.
  - Preserved existing visitor behavior and validation expectations across supported statement types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->