### PR TITLE
lightning: close Parquet row-count readers [release-8.5]

### DIFF
--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -518,14 +518,16 @@ func ReadParquetFileRowCountByFile(
 	ctx context.Context,
 	store storage.ExternalStorage,
 	fileMeta SourceFileMeta,
-) (int64, error) {
+) (rowCount int64, err error) {
 	r, err := store.Open(ctx, fileMeta.Path, nil)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
 
 	defer func() {
-		_ = r.Close()
+		if closeErr := r.Close(); closeErr != nil && err == nil {
+			err = errors.Annotate(closeErr, "close parquet row-count reader")
+		}
 	}()
 
 	reader, err := file.NewParquetReader(&parquetFileWrapper{ReadSeekCloser: r})

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -524,6 +524,10 @@ func ReadParquetFileRowCountByFile(
 		return 0, errors.Trace(err)
 	}
 
+	defer func() {
+		_ = r.Close()
+	}()
+
 	reader, err := file.NewParquetReader(&parquetFileWrapper{ReadSeekCloser: r})
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -582,7 +582,8 @@ func TestBasicReadFile(t *testing.T) {
 // rowCountTrackingStorage tracks readers retained by metadata-only reads.
 type rowCountTrackingStorage struct {
 	storage.ExternalStorage
-	readers []*rowCountTrackingReader
+	readers  []*rowCountTrackingReader
+	closeErr error
 }
 
 func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *storage.ReaderOption) (storage.ExternalFileReader, error) {
@@ -590,19 +591,28 @@ func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *s
 	if err != nil {
 		return nil, err
 	}
-	reader := &rowCountTrackingReader{ExternalFileReader: r}
+	reader := &rowCountTrackingReader{ExternalFileReader: r, closeErr: s.closeErr}
 	s.readers = append(s.readers, reader)
 	return reader, nil
 }
 
 type rowCountTrackingReader struct {
 	storage.ExternalFileReader
-	closed bool
+	closed     bool
+	closeErr   error
+	closeCalls int
 }
 
 func (r *rowCountTrackingReader) Close() error {
+	r.closeCalls++
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	if err := r.ExternalFileReader.Close(); err != nil {
+		return err
+	}
 	r.closed = true
-	return r.ExternalFileReader.Close()
+	return nil
 }
 
 func TestReadParquetFileRowCountClosesReader(t *testing.T) {
@@ -641,4 +651,28 @@ func TestReadParquetFileRowCountClosesReader(t *testing.T) {
 			}
 		})
 	}
+	for _, name := range []string{"valid.parquet", "invalid.parquet"} {
+		t.Run(name+"/close-error", func(t *testing.T) {
+			store := &rowCountTrackingStorage{ExternalStorage: base, closeErr: io.ErrClosedPipe}
+			t.Cleanup(func() {
+				for _, reader := range store.readers {
+					_ = reader.ExternalFileReader.Close()
+				}
+			})
+			_, err := ReadParquetFileRowCountByFile(ctx, store, SourceFileMeta{Path: name})
+			require.Error(t, err)
+			require.Len(t, store.readers, 1)
+			require.Equal(t, 1, store.readers[0].closeCalls)
+			require.False(t, store.readers[0].closed)
+			if name == "valid.parquet" {
+				require.ErrorIs(t, err, io.ErrClosedPipe)
+				require.ErrorContains(t, err, "close parquet row-count reader")
+			} else {
+				_, metadataErr := ReadParquetFileRowCountByFile(ctx, base, SourceFileMeta{Path: name})
+				require.EqualError(t, err, metadataErr.Error())
+				require.NotErrorIs(t, err, io.ErrClosedPipe)
+			}
+		})
+	}
+
 }

--- a/pkg/lightning/mydump/parquet_parser_test.go
+++ b/pkg/lightning/mydump/parquet_parser_test.go
@@ -578,3 +578,67 @@ func TestBasicReadFile(t *testing.T) {
 		require.Equal(t, string(generated[i]), reader.lastRow.Row[0].GetString())
 	}
 }
+
+// rowCountTrackingStorage tracks readers retained by metadata-only reads.
+type rowCountTrackingStorage struct {
+	storage.ExternalStorage
+	readers []*rowCountTrackingReader
+}
+
+func (s *rowCountTrackingStorage) Open(ctx context.Context, path string, opts *storage.ReaderOption) (storage.ExternalFileReader, error) {
+	r, err := s.ExternalStorage.Open(ctx, path, opts)
+	if err != nil {
+		return nil, err
+	}
+	reader := &rowCountTrackingReader{ExternalFileReader: r}
+	s.readers = append(s.readers, reader)
+	return reader, nil
+}
+
+type rowCountTrackingReader struct {
+	storage.ExternalFileReader
+	closed bool
+}
+
+func (r *rowCountTrackingReader) Close() error {
+	r.closed = true
+	return r.ExternalFileReader.Close()
+}
+
+func TestReadParquetFileRowCountClosesReader(t *testing.T) {
+	ctx := context.Background()
+	base, err := storage.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+	data, err := storage.NewLocalStorage("examples")
+	require.NoError(t, err)
+	valid, err := data.ReadFile(ctx, "test.parquet")
+	require.NoError(t, err)
+	require.NoError(t, base.WriteFile(ctx, "valid.parquet", valid))
+	require.NoError(t, base.WriteFile(ctx, "invalid.parquet", []byte("invalid parquet")))
+
+	for _, name := range []string{"valid.parquet", "invalid.parquet", "missing.parquet"} {
+		t.Run(name, func(t *testing.T) {
+			store := &rowCountTrackingStorage{ExternalStorage: base}
+			t.Cleanup(func() {
+				for _, reader := range store.readers {
+					if !reader.closed {
+						_ = reader.Close()
+					}
+				}
+			})
+			rows, err := ReadParquetFileRowCountByFile(ctx, store, SourceFileMeta{Path: name})
+			if name == "valid.parquet" {
+				require.NoError(t, err)
+				require.Positive(t, rows)
+			} else {
+				require.Error(t, err)
+			}
+			if name == "missing.parquet" {
+				require.Empty(t, store.readers)
+			} else {
+				require.Len(t, store.readers, 1)
+				require.True(t, store.readers[0].closed, "metadata reads must release the storage reader")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70929

Problem Summary:

Parquet row-count reads leave their underlying storage reader open. Repeated metadata reads can exhaust S3 HTTP connections and stall Lightning source loading.

### What changed and how does it work?

Port #70930 to `release-8.5`. Close the storage reader on every return path after a successful Open, including Parquet reader construction errors. Return contextual close errors only when there is no earlier metadata error. Add regression coverage for valid, malformed, and missing files, close failures, and error precedence.

The patch is identical to #70930 and does not alter connection limits, sampling concurrency, or SQL semantics.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation:

- On the v8.5.7 source branch, regression tests failed before the reader-close fix and before close-error propagation, then passed after each fix.
- Targeted regression and existing Parquet tests pass with failpoints enabled and disabled afterward.

```bash
tools/bin/failpoint-ctl enable pkg/lightning/mydump
go test -tags=intest,deadlock ./pkg/lightning/mydump -run "^(TestReadParquetFileRowCountClosesReader|TestParquetParser|TestParquetVariousTypes)$" -count=1
tools/bin/failpoint-ctl disable pkg/lightning/mydump
make lint
GOPROXY=https://proxy.golang.org,direct make bazel_prepare
```

No live S3 or full-cluster import test was run. This patch addresses the reader leak; other concurrent sampling resource usage is outside its scope.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a storage reader leak during Parquet row-count reads that could exhaust S3 HTTP connections and stall TiDB Lightning source loading.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Parquet file readers are properly closed after row-count checks.
  * Close errors are now reported when no earlier error occurs.
  * Preserved correct behavior for valid, invalid, and missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->