### PR TITLE
ingestor: prevent range splitter panic during shutdown

### DIFF
--- a/pkg/ingestor/simplesst/BUILD.bazel
+++ b/pkg/ingestor/simplesst/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
     ],
     embed = [":simplesst"],
     flaky = True,
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/ingestor/engineapi",

--- a/pkg/ingestor/simplesst/iter.go
+++ b/pkg/ingestor/simplesst/iter.go
@@ -677,7 +677,9 @@ func newMergePropBaseIter(
 				rd, err := NewStatsReader(ctx, exStorage, path, 250*1024)
 				select {
 				case <-closeCh:
-					_ = rd.Close()
+					if rd != nil {
+						_ = rd.Close()
+					}
 					return
 				case asyncTask <- readerAndError{r: &statReaderProxy{p: path, r: rd}, err: err}:
 				}

--- a/pkg/ingestor/simplesst/iter_test.go
+++ b/pkg/ingestor/simplesst/iter_test.go
@@ -632,6 +632,26 @@ func (s *slowOpenStorage) Open(
 	return s.MemStorage.Open(ctx, filePath, o)
 }
 
+type asyncFailStorage struct {
+	*objstore.MemStorage
+	failingPaths map[string]struct{}
+	openStarted  chan struct{}
+	continueOpen chan struct{}
+}
+
+func (s *asyncFailStorage) Open(
+	ctx context.Context,
+	filePath string,
+	o *storeapi.ReaderOption,
+) (objectio.Reader, error) {
+	if _, ok := s.failingPaths[filePath]; ok {
+		s.openStarted <- struct{}{}
+		<-s.continueOpen
+		return nil, fmt.Errorf("injected open failure for %s", filePath)
+	}
+	return s.MemStorage.Open(ctx, filePath, o)
+}
+
 func TestMergePropBaseIter(t *testing.T) {
 	// this test should be finished around 1 second. However, due to CI is not
 	// stable, we don't check the time.
@@ -673,6 +693,56 @@ func TestMergePropBaseIter(t *testing.T) {
 	_, err = iter.next()
 	require.ErrorIs(t, err, io.EOF)
 	require.EqualValues(t, fileNum, store.openCnt.Load())
+}
+
+func TestMergePropBaseIterCloseWithAsyncOpenError(t *testing.T) {
+	const readerLimit = 32
+	const fileNum = readerLimit * 2
+
+	ctx := context.Background()
+	memStore := objstore.NewMemStorage()
+	failingPaths := make(map[string]struct{}, readerLimit)
+	filenames := make([]string, fileNum)
+	for i := range filenames {
+		filename := fmt.Sprintf("/test%06d", i)
+		filenames[i] = filename
+		if i >= readerLimit {
+			failingPaths[filename] = struct{}{}
+			continue
+		}
+
+		writer, err := memStore.Create(ctx, filename, nil)
+		require.NoError(t, err)
+		buf := encodeMultiProps(nil, []*RangeProperty{{FirstKey: []byte{byte(i)}}})
+		_, err = writer.Write(ctx, buf)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close(ctx))
+	}
+
+	store := &asyncFailStorage{
+		MemStorage:   memStore,
+		failingPaths: failingPaths,
+		openStarted:  make(chan struct{}, readerLimit),
+		continueOpen: make(chan struct{}),
+	}
+	multiStat := MultipleFilesStat{MaxOverlappingNum: readerLimit - 1}
+	for _, filename := range filenames {
+		multiStat.Filenames = append(multiStat.Filenames, [2]string{"", filename})
+	}
+
+	iter, err := newMergePropBaseIter(ctx, multiStat, store)
+	require.NoError(t, err)
+	for range readerLimit {
+		<-store.openStarted
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- iter.close()
+	}()
+	<-iter.closeCh
+	close(store.continueOpen)
+	require.NoError(t, <-closeDone)
 }
 
 func TestEmptyBaseReader4LimitSizeMergeIter(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70939

Problem Summary:

`newMergePropBaseIter` asynchronously pre-opens range-statistics readers. If `NewStatsReader` returns `(nil, err)` while the iterator is being closed, the asynchronous worker can select the shutdown branch and call `Close` on the nil reader. Because the worker is a raw goroutine, the resulting nil-pointer panic can terminate the TiDB process.

### What changed and how does it work?

- Check that the asynchronously opened stats reader is non-nil before closing it during shutdown.
- Add a regression test that blocks asynchronous opens, starts iterator shutdown, and then makes all pending opens fail with `(nil, error)`.
- Regenerate the Bazel test metadata for the new top-level unit test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation commands:

```bash
./tools/check/failpoint-go-test.sh pkg/ingestor/simplesst -run '^(TestMergePropBaseIter|TestMergePropBaseIterCloseWithAsyncOpenError|TestCloseLimitSizeMergeIterHalfway)$' -count=1
./tools/check/failpoint-go-test.sh pkg/ingestor/simplesst -run '^TestMergePropBaseIterCloseWithAsyncOpenError$' -count=10 -race
make bazel_prepare
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential TiDB panic when an asynchronous range-statistics reader fails while an import task is shutting down.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause a crash when closing an iterator after an asynchronous reader-opening failure.
  * Improved cleanup behavior so iterators close cleanly without deadlocks when reader initialization fails.

* **Tests**
  * Added coverage for closing iterators during blocked and failed asynchronous reader openings.
  * Increased test sharding to improve test execution distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->