### PR TITLE
ingestor: wait for global-sort buffers before resizing

### DIFF
--- a/pkg/ingestor/globalsort/engine.go
+++ b/pkg/ingestor/globalsort/engine.go
@@ -464,6 +464,7 @@ func (e *Engine) updateActiveIngestDataFlags() {
 		}
 	}
 	e.activeIngestDataFlags = res
+	failpoint.InjectCall("afterUpdateActiveIngestDataFlags")
 }
 
 // handleConcurrencyChange handles the concurrency change for this engine. If
@@ -778,7 +779,9 @@ type MemoryIngestData struct {
 	kvs []simplesst.KVPair
 	ts  uint64
 
-	memBuf          []*membuf.Buffer
+	memBuf         []*membuf.Buffer
+	releaseStarted atomic.Bool
+	// released is published after all release work has completed.
 	released        *atomic.Bool
 	refCnt          *atomic.Int64
 	importedKVSize  *atomic.Int64
@@ -900,7 +903,7 @@ func (m *MemoryIngestData) GetTS() uint64 {
 func (m *MemoryIngestData) IncRef() {
 	m.refCnt.Inc()
 	// Make sure data is not released.
-	intest.Assert(!m.released.Load(), "data shouldn't be released when IncRef")
+	intest.Assert(!m.releaseStarted.Load(), "data shouldn't be released when IncRef")
 }
 
 // DecRef implements IngestData.DecRef.
@@ -911,7 +914,7 @@ func (m *MemoryIngestData) DecRef() {
 }
 
 func (m *MemoryIngestData) release() {
-	if !m.released.CAS(false, true) {
+	if !m.releaseStarted.CAS(false, true) {
 		return
 	}
 	m.kvs = nil
@@ -922,6 +925,7 @@ func (m *MemoryIngestData) release() {
 	if m.onRelease != nil {
 		m.onRelease()
 	}
+	m.released.Store(true)
 }
 
 // Finish implements IngestData.Finish.

--- a/pkg/ingestor/globalsort/engine.go
+++ b/pkg/ingestor/globalsort/engine.go
@@ -489,7 +489,11 @@ func (e *Engine) handleConcurrencyChange(ctx context.Context, currBatchSize int)
 	startTime := time.Now()
 	logger.Info("waiting ingest data batch size change")
 
-	tick := time.NewTicker(time.Second)
+	tickInterval := time.Second
+	failpoint.Inject("fastHandleConcurrencyChangeTicker", func() {
+		tickInterval = 10 * time.Millisecond
+	})
+	tick := time.NewTicker(tickInterval)
 	defer func() {
 		tick.Stop()
 	}()
@@ -902,8 +906,8 @@ func (m *MemoryIngestData) GetTS() uint64 {
 // IncRef implements IngestData.IncRef.
 func (m *MemoryIngestData) IncRef() {
 	m.refCnt.Inc()
-	// Make sure data is not released.
-	intest.Assert(!m.releaseStarted.Load(), "data shouldn't be released when IncRef")
+	// Make sure data release has not started.
+	intest.Assert(!m.releaseStarted.Load(), "data release shouldn't have started when IncRef")
 }
 
 // DecRef implements IngestData.DecRef.

--- a/pkg/ingestor/globalsort/engine.go
+++ b/pkg/ingestor/globalsort/engine.go
@@ -783,8 +783,7 @@ type MemoryIngestData struct {
 	kvs []simplesst.KVPair
 	ts  uint64
 
-	memBuf         []*membuf.Buffer
-	releaseStarted atomic.Bool
+	memBuf []*membuf.Buffer
 	// released is published after all release work has completed.
 	released        *atomic.Bool
 	refCnt          *atomic.Int64
@@ -906,8 +905,8 @@ func (m *MemoryIngestData) GetTS() uint64 {
 // IncRef implements IngestData.IncRef.
 func (m *MemoryIngestData) IncRef() {
 	m.refCnt.Inc()
-	// Make sure data release has not started.
-	intest.Assert(!m.releaseStarted.Load(), "data release shouldn't have started when IncRef")
+	// Make sure data is not released.
+	intest.Assert(!m.released.Load(), "data shouldn't be released when IncRef")
 }
 
 // DecRef implements IngestData.DecRef.
@@ -918,9 +917,6 @@ func (m *MemoryIngestData) DecRef() {
 }
 
 func (m *MemoryIngestData) release() {
-	if !m.releaseStarted.CAS(false, true) {
-		return
-	}
 	m.kvs = nil
 	for _, b := range m.memBuf {
 		b.Destroy()

--- a/pkg/ingestor/globalsort/engine_test.go
+++ b/pkg/ingestor/globalsort/engine_test.go
@@ -661,6 +661,7 @@ func TestChangeEngineConcurrency(t *testing.T) {
 		})
 
 		data := resizeEngine.buildIngestData(nil, []*membuf.Buffer{buf})
+		require.False(t, data.released.Load())
 		data.IncRef()
 		resizeEngine.activeIngestDataFlags = append(resizeEngine.activeIngestDataFlags, data.released)
 		onRelease := data.onRelease
@@ -691,6 +692,7 @@ func TestChangeEngineConcurrency(t *testing.T) {
 			data.DecRef()
 		}()
 		<-allocator.firstFreeStarted
+		require.False(t, data.released.Load())
 
 		resizeDoneCh := make(chan int, 1)
 		resizeStartedAt := time.Now()
@@ -710,6 +712,7 @@ func TestChangeEngineConcurrency(t *testing.T) {
 			"engine treated data as released before its release callback completed")
 		close(continueReleaseCallbackCh)
 		releasePanic := <-releaseResultCh
+		require.True(t, data.released.Load())
 
 		continueAfterCheckCh <- struct{}{}
 		<-flagsCheckedCh
@@ -718,7 +721,6 @@ func TestChangeEngineConcurrency(t *testing.T) {
 		continueAfterCheckCh <- struct{}{}
 		newBatchSize := <-resizeDoneCh
 
-		data.release()
 		require.Less(t, time.Since(resizeStartedAt), time.Second,
 			"test should not wait for the production resize ticker")
 		require.Equal(t, 2, newBatchSize)

--- a/pkg/ingestor/globalsort/engine_test.go
+++ b/pkg/ingestor/globalsort/engine_test.go
@@ -633,6 +633,10 @@ func TestChangeEngineConcurrency(t *testing.T) {
 	})
 
 	t.Run("wait for memory buffers to be released", func(t *testing.T) {
+		testfailpoint.Enable(t,
+			"github.com/pingcap/tidb/pkg/ingestor/globalsort/fastHandleConcurrencyChangeTicker",
+			"return(true)")
+
 		allocator := &blockingReleaseAllocator{
 			firstFreeStarted: make(chan struct{}),
 			continueFree:     make(chan struct{}),
@@ -689,50 +693,34 @@ func TestChangeEngineConcurrency(t *testing.T) {
 		<-allocator.firstFreeStarted
 
 		resizeDoneCh := make(chan int, 1)
+		resizeStartedAt := time.Now()
 		go func() {
 			resizeDoneCh <- resizeEngine.handleConcurrencyChange(context.Background(), 1)
 		}()
 
 		<-flagsCheckedCh
-		buffersStillActive := len(resizeEngine.activeIngestDataFlags) == 1
+		require.Len(t, resizeEngine.activeIngestDataFlags, 1,
+			"engine treated data as released before its buffers were returned")
+		close(allocator.continueFree)
+		<-releaseCallbackStartedCh
 
-		var releasePanic any
-		var newBatchSize int
-		callbackStillActive := false
-		releaseRemovedAfterCallback := false
-		if buffersStillActive {
-			close(allocator.continueFree)
-			<-releaseCallbackStartedCh
+		continueAfterCheckCh <- struct{}{}
+		<-flagsCheckedCh
+		require.Len(t, resizeEngine.activeIngestDataFlags, 1,
+			"engine treated data as released before its release callback completed")
+		close(continueReleaseCallbackCh)
+		releasePanic := <-releaseResultCh
 
-			continueAfterCheckCh <- struct{}{}
-			<-flagsCheckedCh
-			callbackStillActive = len(resizeEngine.activeIngestDataFlags) == 1
-
-			if callbackStillActive {
-				close(continueReleaseCallbackCh)
-				releasePanic = <-releaseResultCh
-				continueAfterCheckCh <- struct{}{}
-				<-flagsCheckedCh
-				releaseRemovedAfterCallback = len(resizeEngine.activeIngestDataFlags) == 0
-				continueAfterCheckCh <- struct{}{}
-				newBatchSize = <-resizeDoneCh
-			} else {
-				continueAfterCheckCh <- struct{}{}
-				newBatchSize = <-resizeDoneCh
-				close(continueReleaseCallbackCh)
-				releasePanic = <-releaseResultCh
-			}
-		} else {
-			continueAfterCheckCh <- struct{}{}
-			newBatchSize = <-resizeDoneCh
-			close(allocator.continueFree)
-			releasePanic = <-releaseResultCh
-		}
+		continueAfterCheckCh <- struct{}{}
+		<-flagsCheckedCh
+		require.Empty(t, resizeEngine.activeIngestDataFlags,
+			"engine did not observe the completed release")
+		continueAfterCheckCh <- struct{}{}
+		newBatchSize := <-resizeDoneCh
 
 		data.release()
-		require.True(t, buffersStillActive, "engine treated data as released before its buffers were returned")
-		require.True(t, callbackStillActive, "engine treated data as released before its release callback completed")
-		require.True(t, releaseRemovedAfterCallback, "engine did not observe the completed release")
+		require.Less(t, time.Since(resizeStartedAt), time.Second,
+			"test should not wait for the production resize ticker")
 		require.Equal(t, 2, newBatchSize)
 		require.Nil(t, releasePanic)
 		require.EqualValues(t, 2, allocator.freeCount.Load())

--- a/pkg/ingestor/globalsort/engine_test.go
+++ b/pkg/ingestor/globalsort/engine_test.go
@@ -538,6 +538,23 @@ type dummyWorker struct{}
 func (w *dummyWorker) Tune(int32, bool) {
 }
 
+type blockingReleaseAllocator struct {
+	firstFreeStarted chan struct{}
+	continueFree     chan struct{}
+	freeCount        atomic.Int32
+}
+
+func (a *blockingReleaseAllocator) Alloc(n int) []byte {
+	return make([]byte, n)
+}
+
+func (a *blockingReleaseAllocator) Free(_ []byte) {
+	if a.freeCount.Inc() == 1 {
+		close(a.firstFreeStarted)
+		<-a.continueFree
+	}
+}
+
 func TestChangeEngineConcurrency(t *testing.T) {
 	var (
 		outCh     chan engineapi.DataAndRanges
@@ -613,5 +630,113 @@ func TestChangeEngineConcurrency(t *testing.T) {
 		}, 3*time.Second, 10*time.Millisecond)
 		require.NoError(t, e.UpdateResource(context.Background(), 8, 1024))
 		require.NoError(t, eg.Wait())
+	})
+
+	t.Run("wait for memory buffers to be released", func(t *testing.T) {
+		allocator := &blockingReleaseAllocator{
+			firstFreeStarted: make(chan struct{}),
+			continueFree:     make(chan struct{}),
+		}
+		bufPool := membuf.NewPool(
+			membuf.WithBlockNum(0),
+			membuf.WithBlockSize(1),
+			membuf.WithAllocator(allocator),
+		)
+		buf := bufPool.NewBuffer()
+		buf.AllocBytes(1)
+		buf.AllocBytes(1)
+
+		resizeEngine := &Engine{
+			smallBlockBufPool: bufPool,
+			workerConcurrency: *atomic.NewInt32(2),
+			readyCh:           make(chan struct{}, 1),
+			memLimit:          2,
+		}
+		t.Cleanup(func() {
+			require.NoError(t, resizeEngine.Close())
+		})
+
+		data := resizeEngine.buildIngestData(nil, []*membuf.Buffer{buf})
+		data.IncRef()
+		resizeEngine.activeIngestDataFlags = append(resizeEngine.activeIngestDataFlags, data.released)
+		onRelease := data.onRelease
+		releaseCallbackStartedCh := make(chan struct{})
+		continueReleaseCallbackCh := make(chan struct{})
+		var releaseCallbackCount atomic.Int32
+		data.onRelease = func() {
+			releaseCallbackCount.Inc()
+			close(releaseCallbackStartedCh)
+			<-continueReleaseCallbackCh
+			onRelease()
+		}
+
+		flagsCheckedCh := make(chan struct{})
+		continueAfterCheckCh := make(chan struct{})
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/globalsort/afterUpdateActiveIngestDataFlags",
+			func() {
+				flagsCheckedCh <- struct{}{}
+				<-continueAfterCheckCh
+			})
+
+		releaseResultCh := make(chan any, 1)
+		go func() {
+			defer func() {
+				releaseResultCh <- recover()
+			}()
+			data.DecRef()
+		}()
+		<-allocator.firstFreeStarted
+
+		resizeDoneCh := make(chan int, 1)
+		go func() {
+			resizeDoneCh <- resizeEngine.handleConcurrencyChange(context.Background(), 1)
+		}()
+
+		<-flagsCheckedCh
+		buffersStillActive := len(resizeEngine.activeIngestDataFlags) == 1
+
+		var releasePanic any
+		var newBatchSize int
+		callbackStillActive := false
+		releaseRemovedAfterCallback := false
+		if buffersStillActive {
+			close(allocator.continueFree)
+			<-releaseCallbackStartedCh
+
+			continueAfterCheckCh <- struct{}{}
+			<-flagsCheckedCh
+			callbackStillActive = len(resizeEngine.activeIngestDataFlags) == 1
+
+			if callbackStillActive {
+				close(continueReleaseCallbackCh)
+				releasePanic = <-releaseResultCh
+				continueAfterCheckCh <- struct{}{}
+				<-flagsCheckedCh
+				releaseRemovedAfterCallback = len(resizeEngine.activeIngestDataFlags) == 0
+				continueAfterCheckCh <- struct{}{}
+				newBatchSize = <-resizeDoneCh
+			} else {
+				continueAfterCheckCh <- struct{}{}
+				newBatchSize = <-resizeDoneCh
+				close(continueReleaseCallbackCh)
+				releasePanic = <-releaseResultCh
+			}
+		} else {
+			continueAfterCheckCh <- struct{}{}
+			newBatchSize = <-resizeDoneCh
+			close(allocator.continueFree)
+			releasePanic = <-releaseResultCh
+		}
+
+		data.release()
+		require.True(t, buffersStillActive, "engine treated data as released before its buffers were returned")
+		require.True(t, callbackStillActive, "engine treated data as released before its release callback completed")
+		require.True(t, releaseRemovedAfterCallback, "engine did not observe the completed release")
+		require.Equal(t, 2, newBatchSize)
+		require.Nil(t, releasePanic)
+		require.EqualValues(t, 2, allocator.freeCount.Load())
+		require.EqualValues(t, 1, releaseCallbackCount.Load())
+		require.Zero(t, resizeEngine.inFlightDataCount.Load())
 	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70938

Problem Summary:

When the last reference to a global-sort `MemoryIngestData` batch was released, the batch published its `released` flag before returning its memory buffers. A concurrent resource resize could observe that flag and reset the engine's memory pools while `Buffer.Destroy()` was still returning blocks, causing a `send on closed channel` panic.

### What changed and how does it work?

- Make the existing `released` flag represent completed release work: destroy all memory buffers, run the release callback, and only then publish `released=true`.
- Keep each batch in `activeIngestDataFlags` until release completes, preventing `Engine.Reset()` from destroying its old memory pools too early.
- Add a deterministic real-buffer regression test that pauses buffer destruction and the release callback at explicit failpoint boundaries, then verifies resize waits for both and release side effects occur exactly once.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -run 'Test(ChangeEngineConcurrency|LoadRangeBatchDataReleasesReadersWhileWaitingForDownstream)$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ingestor/globalsort -race -run 'TestChangeEngineConcurrency/wait_for_memory_buffers_to_be_released$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a potential panic when resizing global-sort resources while ingest buffers are being released.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordination during ingest engine resizing so active buffers remain tracked until release completes.
  - Ensured release status is updated only after buffer cleanup finishes.
  - Prevented processing state and batch-size updates from occurring before in-progress buffer cleanup completes.

- **Tests**
  - Expanded concurrency coverage for resizing while ingest buffers and release callbacks remain active.
  - Added timing checks to verify resizing completes promptly after cleanup is finalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
