### PR TITLE
ingestor: fix race when disabling store write limiter

### DIFF
--- a/pkg/ingestor/ingestctrl/localhelper.go
+++ b/pkg/ingestor/ingestctrl/localhelper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	sst "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/lightning/metric"
@@ -173,6 +174,7 @@ type storeWriteLimiter struct {
 	rwm      sync.RWMutex
 	limiters map[uint64]*rate.Limiter
 	// limit and burst can only be non-negative, 0 means no rate limiting.
+	// Updates to both fields are published while holding rwm.
 	limit atomic.Int64
 	burst atomic.Int64
 }
@@ -225,6 +227,7 @@ func (s *storeWriteLimiter) getLimiter(storeID uint64) *rate.Limiter {
 	if s.limit.Load() == 0 {
 		return nil
 	}
+	failpoint.InjectCall("beforeStoreWriteLimiterLock")
 	s.rwm.RLock()
 	limiter, ok := s.limiters[storeID]
 	s.rwm.RUnlock()
@@ -233,9 +236,14 @@ func (s *storeWriteLimiter) getLimiter(storeID uint64) *rate.Limiter {
 	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
+	// The limit may have been disabled while getLimiter was waiting for the write lock.
+	limit := s.limit.Load()
+	if limit == 0 {
+		return nil
+	}
 	limiter, ok = s.limiters[storeID]
 	if !ok {
-		limiter = rate.NewLimiter(rate.Limit(s.limit.Load()), int(s.burst.Load()))
+		limiter = rate.NewLimiter(rate.Limit(limit), int(s.burst.Load()))
 		s.limiters[storeID] = limiter
 	}
 	return limiter
@@ -247,18 +255,21 @@ func (s *storeWriteLimiter) UpdateLimit(newLimit int) {
 		return
 	}
 
+	s.rwm.Lock()
+	defer s.rwm.Unlock()
+	if s.limit.Load() == limit {
+		return
+	}
 	s.limit.Store(limit)
 	s.burst.Store(burst)
 	// Update all existing limiters with the new limit and burst values.
-	s.rwm.Lock()
-	defer s.rwm.Unlock()
-	if s.limit.Load() == 0 {
+	if limit == 0 {
 		s.limiters = make(map[uint64]*rate.Limiter)
 		return
 	}
 	for _, limiter := range s.limiters {
-		limiter.SetLimit(rate.Limit(s.limit.Load()))
-		limiter.SetBurst(int(s.burst.Load()))
+		limiter.SetLimit(rate.Limit(limit))
+		limiter.SetBurst(int(burst))
 	}
 }
 

--- a/pkg/ingestor/ingestctrl/localhelper.go
+++ b/pkg/ingestor/ingestctrl/localhelper.go
@@ -227,13 +227,13 @@ func (s *storeWriteLimiter) getLimiter(storeID uint64) *rate.Limiter {
 	if s.limit.Load() == 0 {
 		return nil
 	}
-	failpoint.InjectCall("beforeStoreWriteLimiterLock")
 	s.rwm.RLock()
 	limiter, ok := s.limiters[storeID]
 	s.rwm.RUnlock()
 	if ok {
 		return limiter
 	}
+	failpoint.InjectCall("beforeStoreWriteLimiterLock")
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
 	// The limit may have been disabled while getLimiter was waiting for the write lock.

--- a/pkg/ingestor/ingestctrl/localhelper_test.go
+++ b/pkg/ingestor/ingestctrl/localhelper_test.go
@@ -345,6 +345,8 @@ func TestStoreWriteLimiter(t *testing.T) {
 	}
 	wg.Wait()
 
+	// Regression test for getLimiter's double-check: disabling the limit while it waits
+	// for the write lock must not return or register a limiter.
 	t.Run("disable while creating limiter", func(t *testing.T) {
 		limiter := newStoreWriteLimiter(100)
 		beforeLock := make(chan struct{})

--- a/pkg/ingestor/ingestctrl/localhelper_test.go
+++ b/pkg/ingestor/ingestctrl/localhelper_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/br/pkg/restore/split"
 	"github.com/pingcap/tidb/pkg/store/pdtypes"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/stretchr/testify/require"
 	tikvclient "github.com/tikv/client-go/v2/tikv"
@@ -343,6 +344,50 @@ func TestStoreWriteLimiter(t *testing.T) {
 		}(uint64(i))
 	}
 	wg.Wait()
+
+	t.Run("disable while creating limiter", func(t *testing.T) {
+		limiter := newStoreWriteLimiter(100)
+		beforeLock := make(chan struct{})
+		continueGetLimiter := make(chan struct{})
+		t.Cleanup(func() {
+			select {
+			case <-continueGetLimiter:
+			default:
+				close(continueGetLimiter)
+			}
+		})
+		testfailpoint.EnableCall(t,
+			"github.com/pingcap/tidb/pkg/ingestor/ingestctrl/beforeStoreWriteLimiterLock",
+			func() {
+				close(beforeLock)
+				<-continueGetLimiter
+			},
+		)
+
+		getLimiterDone := make(chan bool, 1)
+		go func() {
+			getLimiterDone <- limiter.getLimiter(1) == nil
+		}()
+
+		select {
+		case <-beforeLock:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for getLimiter to reach the failpoint")
+		}
+		limiter.UpdateLimit(0)
+		close(continueGetLimiter)
+
+		select {
+		case disabled := <-getLimiterDone:
+			require.True(t, disabled, "getLimiter returned a limiter after rate limiting was disabled")
+		case <-time.After(time.Second):
+			t.Fatal("getLimiter did not return after rate limiting was disabled")
+		}
+
+		limiter.rwm.RLock()
+		defer limiter.rwm.RUnlock()
+		require.Empty(t, limiter.limiters)
+	})
 }
 
 func TestTuneStoreWriteLimiter(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70940

Problem Summary:

Disabling the store write-rate limit can race with the creation of a per-store limiter. A caller can pass the initial positive-limit check, then construct a limiter after the configured limit and burst have become zero. `WaitN` can subsequently spin without making progress, consuming CPU and preventing the import from completing.

### What changed and how does it work?

- Publish the limit, burst, and per-store limiter map update while holding the same write lock.
- Recheck whether rate limiting was disabled immediately after acquiring the write lock and before looking up or creating a limiter.
- Add a deterministic failpoint-based regression test for the positive-to-zero interleaving.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test commands:

```bash
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/ingestor/ingestctrl -run 'Test(StoreWriteLimiter|TuneStoreWriteLimiter)$' -race -count=1
make lint
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a race that could make DDL or import workers spin indefinitely after store write rate limiting is disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when store write rate limiting is enabled, updated, or disabled during concurrent operations.
  - Ensured newly created and existing limiters use the latest configured limits and burst values.
  - Prevented stale limiters from being created after rate limiting is disabled.
  - Improved consistency when rate-limit configuration changes while limiter creation is in progress.

- **Tests**
  - Added coverage for concurrent rate-limit updates, disabling, and limiter creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->