### PR TITLE
pkg/util/execdetails: fix panic in Percentile when formatted concurre…

### DIFF
--- a/pkg/util/execdetails/BUILD.bazel
+++ b/pkg/util/execdetails/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/kv",
         "//pkg/metrics",
+        "//pkg/util/logutil",
         "@com_github_influxdata_tdigest//:tdigest",
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_pingcap_kvproto//pkg/resource_manager",
@@ -30,6 +31,8 @@ go_test(
     srcs = [
         "execdetails_test.go",
         "main_test.go",
+        "util_bench_test.go",
+        "util_test.go",
     ],
     embed = [":execdetails"],
     flaky = True,

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -347,7 +347,7 @@ func TestCopRuntimeStats(t *testing.T) {
 		"scan_detail: {total_process_keys: 10, total_process_keys_size: 10, total_keys: 15, rocksdb: {delete_skipped_count: 5, key_skipped_count: 1, block: {cache_hit_count: 10, read_count: 20, read_byte: 100 Bytes}}}"
 	require.Equal(t, expected, cop.String())
 
-	require.NotNil(t, cop.stats)
+	require.NotNil(t, &cop.stats)
 	require.Equal(t, "time:3ns, loops:3", cop.stats.String())
 	require.Equal(t, "tikv_task:{proc max:4ns, min:3ns, avg: 3ns, p80:4ns, p95:4ns, iters:7, tasks:2}", stats.GetCopStats(aggID).String())
 
@@ -618,7 +618,7 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 	cop := stats.GetCopStats(tableScanID)
 	require.Equal(t, "tiflash_task:{proc max:2ns, min:1ns, avg: 1ns, p80:2ns, p95:2ns, iters:3, tasks:2, threads:2}, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_network: {inner_zone_send_bytes: 11000, inter_zone_send_bytes: 22000, inner_zone_receive_bytes: 33000, inter_zone_receive_bytes: 44000}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", cop.String())
 
-	copStats := cop.stats
+	copStats := &cop.stats
 	require.NotNil(t, copStats)
 
 	require.Equal(t, "time:3ns, loops:3, threads:2, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_network: {inner_zone_send_bytes: 11000, inter_zone_send_bytes: 22000, inner_zone_receive_bytes: 33000, inter_zone_receive_bytes: 44000}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", copStats.String())

--- a/pkg/util/execdetails/runtime_stats.go
+++ b/pkg/util/execdetails/runtime_stats.go
@@ -93,7 +93,7 @@ type basicCopRuntimeStats struct {
 func (e *basicCopRuntimeStats) String() string {
 	buf := bytes.NewBuffer(make([]byte, 0, 16))
 	buf.WriteString("time:")
-	buf.WriteString(FormatDuration(time.Duration(e.procTimes.sumVal)))
+	buf.WriteString(FormatDuration(time.Duration(e.procTimes.Sum())))
 	buf.WriteString(", loops:")
 	buf.WriteString(strconv.Itoa(int(e.loop)))
 	if e.tiflashStats != nil {
@@ -116,11 +116,11 @@ func (e *basicCopRuntimeStats) String() string {
 // Clone implements the RuntimeStats interface.
 func (e *basicCopRuntimeStats) Clone() RuntimeStats {
 	stats := &basicCopRuntimeStats{
-		loop:      e.loop,
-		rows:      e.rows,
-		threads:   e.threads,
-		procTimes: e.procTimes,
+		loop:    e.loop,
+		rows:    e.rows,
+		threads: e.threads,
 	}
+	stats.procTimes.MergePercentile(&e.procTimes)
 	if e.tiflashStats != nil {
 		stats.tiflashStats = &TiflashStats{
 			scanContext:    e.tiflashStats.scanContext.Clone(),
@@ -220,14 +220,14 @@ func (crs *CopRuntimeStats) GetActRows() int64 {
 
 // GetTasks return total tasks of CopRuntimeStats
 func (crs *CopRuntimeStats) GetTasks() int32 {
-	return int32(crs.stats.procTimes.size)
+	return int32(crs.stats.procTimes.Size())
 }
 
 var zeroTimeDetail = util.TimeDetail{}
 
 func (crs *CopRuntimeStats) String() string {
-	procTimes := crs.stats.procTimes
-	totalTasks := procTimes.size
+	procTimes := &crs.stats.procTimes
+	totalTasks := procTimes.Size()
 	isTiFlashCop := crs.storeType == kv.TiFlash
 	buf := bytes.NewBuffer(make([]byte, 0, 16))
 	{

--- a/pkg/util/execdetails/util.go
+++ b/pkg/util/execdetails/util.go
@@ -19,11 +19,15 @@ import (
 	"context"
 	"math"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/influxdata/tdigest"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
 )
 
 // ContextWithInitializedExecDetails returns a context with initialized stmt execution, execution and resource usage details.
@@ -153,6 +157,7 @@ func (d DurationWithAddr) GetFloat64() float64 { return float64(d.D) }
 
 // Percentile is a struct to calculate the percentile of a series of values.
 type Percentile[valueType canGetFloat64] struct {
+	mu       sync.Mutex
 	values   []valueType
 	size     int
 	isSorted bool
@@ -165,6 +170,12 @@ type Percentile[valueType canGetFloat64] struct {
 
 // Add adds a value to calculate the percentile.
 func (p *Percentile[valueType]) Add(value valueType) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.addLocked(value)
+}
+
+func (p *Percentile[valueType]) addLocked(value valueType) {
 	p.isSorted = false
 	p.sumVal += value.GetFloat64()
 	p.size++
@@ -172,10 +183,10 @@ func (p *Percentile[valueType]) Add(value valueType) {
 		p.minVal = value
 		p.maxVal = value
 	} else {
-		if value.GetFloat64() < p.minVal.GetFloat64() {
+		if cmp.Compare(value.GetFloat64(), p.minVal.GetFloat64()) < 0 {
 			p.minVal = value
 		}
-		if value.GetFloat64() > p.maxVal.GetFloat64() {
+		if cmp.Compare(value.GetFloat64(), p.maxVal.GetFloat64()) > 0 {
 			p.maxVal = value
 		}
 	}
@@ -194,7 +205,22 @@ func (p *Percentile[valueType]) Add(value valueType) {
 }
 
 // GetPercentile returns the percentile `f` of the values.
-func (p *Percentile[valueType]) GetPercentile(f float64) float64 {
+func (p *Percentile[valueType]) GetPercentile(f float64) (result float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	defer func() {
+		if r := recover(); r != nil {
+			logutil.BgLogger().Warn("recovered panic in Percentile.GetPercentile",
+				zap.Any("recover", r),
+				zap.Stack("stack"))
+			result = math.NaN()
+		}
+	}()
+	if p.size == 0 {
+		// No samples yet. Return 0 rather than math.NaN() to prevent
+		// time.Duration(math.NaN()) from evaluating to -9223372036854775808.
+		return 0
+	}
 	if p.dt == nil {
 		if !p.isSorted {
 			p.isSorted = true
@@ -209,24 +235,54 @@ func (p *Percentile[valueType]) GetPercentile(f float64) float64 {
 
 // GetMax returns the max value.
 func (p *Percentile[valueType]) GetMax() valueType {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.maxVal
 }
 
 // GetMin returns the min value.
 func (p *Percentile[valueType]) GetMin() valueType {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.minVal
 }
 
 // MergePercentile merges two Percentile.
 func (p *Percentile[valueType]) MergePercentile(p2 *Percentile[valueType]) {
+	if p == p2 {
+		return
+	}
+	if uintptr(unsafe.Pointer(p)) < uintptr(unsafe.Pointer(p2)) {
+		p.mu.Lock()
+		p2.mu.Lock()
+	} else {
+		p2.mu.Lock()
+		p.mu.Lock()
+	}
+	defer p.mu.Unlock()
+	defer p2.mu.Unlock()
+
 	p.isSorted = false
 	if p2.dt == nil {
 		for _, v := range p2.values {
-			p.Add(v)
+			p.addLocked(v)
 		}
 		return
 	}
 	p.sumVal += p2.sumVal
+	if p2.size > 0 {
+		if p.size == 0 {
+			p.minVal = p2.minVal
+			p.maxVal = p2.maxVal
+		} else {
+			if cmp.Compare(p2.minVal.GetFloat64(), p.minVal.GetFloat64()) < 0 {
+				p.minVal = p2.minVal
+			}
+			if cmp.Compare(p2.maxVal.GetFloat64(), p.maxVal.GetFloat64()) > 0 {
+				p.maxVal = p2.maxVal
+			}
+		}
+	}
 	p.size += p2.size
 	if p.dt == nil {
 		p.dt = tdigest.New()
@@ -240,11 +296,15 @@ func (p *Percentile[valueType]) MergePercentile(p2 *Percentile[valueType]) {
 
 // Size returns the size of the values.
 func (p *Percentile[valueType]) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.size
 }
 
 // Sum returns the sum of the values.
 func (p *Percentile[valueType]) Sum() float64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.sumVal
 }
 

--- a/pkg/util/execdetails/util_bench_test.go
+++ b/pkg/util/execdetails/util_bench_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execdetails
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkPercentileAdd(b *testing.B) {
+	b.ReportAllocs()
+	var p Percentile[Duration]
+	for i := 0; i < b.N; i++ {
+		p.Add(Duration(time.Duration(i) * time.Microsecond))
+	}
+}
+
+func BenchmarkPercentileGetPercentile(b *testing.B) {
+	b.ReportAllocs()
+	var p Percentile[Duration]
+	// Pre-populate with 2000 samples (forces TDigest path)
+	for i := 0; i < 2000; i++ {
+		p.Add(Duration(time.Duration(i) * time.Microsecond))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.GetPercentile(0.95)
+	}
+}
+
+func BenchmarkPercentileAddContended(b *testing.B) {
+	b.ReportAllocs()
+	var p Percentile[Duration]
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			p.Add(Duration(time.Duration(i) * time.Microsecond))
+			i++
+		}
+	})
+}

--- a/pkg/util/execdetails/util_test.go
+++ b/pkg/util/execdetails/util_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execdetails
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercentileConcurrentAddAndGetPercentile(t *testing.T) {
+	var p Percentile[Duration]
+
+	// Preload past the slice->TDigest switchover so readers immediately
+	// exercise tdigest.Quantile concurrently with writers still calling
+	// tdigest.Add — this is the path that panicked in #70655.
+	const preloadSamples = 1500
+	for i := 0; i < preloadSamples; i++ {
+		p.Add(Duration(time.Duration(i) * time.Microsecond))
+	}
+	require.NotNil(t, p.dt, "expected TDigest path to already be active")
+
+	const totalSamples = 3000
+	const numWriters = 4
+	const numReaders = 4
+	samplesPerWriter := totalSamples / numWriters
+
+	var wg sync.WaitGroup
+
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := 0; i < samplesPerWriter; i++ {
+				p.Add(Duration(time.Duration(preloadSamples+writerID*samplesPerWriter+i) * time.Microsecond))
+			}
+		}(w)
+	}
+
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				val := p.GetPercentile(0.95)
+				require.False(t, math.IsNaN(val), "GetPercentile returned NaN")
+				require.False(t, math.IsInf(val, 0), "GetPercentile returned Inf")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	val := p.GetPercentile(0.95)
+	require.False(t, math.IsNaN(val), "final GetPercentile returned NaN")
+	require.False(t, math.IsInf(val, 0), "final GetPercentile returned Inf")
+}


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: closes #70655 

Problem Summary:

`execdetails.Percentile` has no synchronization. Once a query produces more than 1,000 Cop tasks, `Percentile` switches internally from a sorted slice to `influxdata/tdigest`. A background writer calling `Add()` can race with a reader calling `GetPercentile()`, corrupting internal state and causing a panic (`index out of range`) in either the TDigest quantile path or the slice-indexing path during the slice→TDigest transition. This panic kills the client's query.

### What changed and how does it work?

- **pkg/util/execdetails/util.go**
  - Added `sync.Mutex` to `Percentile` to synchronize all access
  - Extracted `addLocked()` for internal use
  - Updated `MergePercentile` to use `unsafe.Pointer` for safe symmetric lock ordering
  - Properly merged `maxVal` and `minVal`
  - Added empty‑state guards to `GetPercentile`

- **pkg/util/execdetails/runtime_stats.go**
  - Updated `Clone()` to perform a proper deep copy via `MergePercentile(&e.procTimes)`
  - Switched `procTimes` accesses to pointer references to respect the new mutex

- **pkg/util/execdetails/execdetails_test.go**
  - Changed `cop.stats` assertions to use pointers (`&cop.stats`) to avoid `go vet` copylocks warnings

- **pkg/util/execdetails/util_bench_test.go**
  - Added benchmarks for `Percentile` concurrent paths

- **pkg/util/execdetails/util_test.go**
  - Added regression test `TestPercentileConcurrentAddAndGetPercentile` to verify TDigest concurrency safety
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [[Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html)](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of runtime statistics when percentile data is collected and queried concurrently.
  * Prevented invalid percentile results during high-volume or simultaneous statistics processing.
  * Improved percentile aggregation to preserve accurate minimum and maximum values.
  * Improved handling of empty or incomplete percentile data to avoid unexpected failures.
* **Tests**
  * Added coverage for concurrent percentile calculations and high-volume runtime statistics workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->