### PR TITLE
sessionctx: update slow log test for statement RU

### DIFF
--- a/pkg/sessionctx/variable/tests/BUILD.bazel
+++ b/pkg/sessionctx/variable/tests/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "variable_test.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/config/deploymode",
@@ -35,7 +35,6 @@ go_test(
         "//pkg/util/memory",
         "//pkg/util/mock",
         "//pkg/util/tls",
-        "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -460,53 +459,47 @@ func TestSlowLogFormat(t *testing.T) {
 	compareSlowLogItems(t, logItems, actual)
 }
 
-func TestSlowLogFormatIncludesTiFlashRUInRUV2Metrics(t *testing.T) {
+func TestSlowLogFormatIncludesStatementRU(t *testing.T) {
 	seVar := variable.NewSessionVars(nil)
 	logItems := &variable.SlowQueryLogItems{
-		SQL:         "select 1",
-		Digest:      "digest",
-		TimeTotal:   time.Second,
-		Succ:        true,
-		ExecDetail:  &execdetails.ExecDetails{},
-		UsedStats:   &stmtctx.UsedStatsInfo{},
-		RUDetails:   util.NewRUDetailsWith(0, 0, 0),
-		RUV2Metrics: execdetails.NewRUV2Metrics(),
+		SQL:        "select 1",
+		TimeTotal:  time.Second,
+		ExecDetail: &execdetails.ExecDetails{},
+		UsedStats:  &stmtctx.UsedStatsInfo{},
+		RUDetails:  util.NewRUDetailsWith(0, 0, 0),
 	}
-	logItems.RUDetails.AddTiKVRUV2(100)
-	logItems.RUDetails.UpdateTiFlash(&rmpb.Consumption{RRU: 20, WRU: 30})
 
-	logString := seVar.SlowLogFormat(logItems)
-	require.Contains(t, logString, "# Request_unit_v2: 150.00")
-	require.Contains(t, logString, "# Request_unit_v2_detail: total_ru:150.00, tidb_ru:0.00, tikv_ru:100.00, tiflash_ru:50.00")
+	logString := seVar.SlowLogFormat(logItems, 150)
+	require.Contains(t, logString, "# Request_unit_v2: 150.00\n# Request_unit_v2_detail: \n")
+}
 
-	t.Run("default session weights come from config defaults", func(t *testing.T) {
-		original := config.GetGlobalConfig()
-		t.Cleanup(func() {
-			if original != nil {
-				config.StoreGlobalConfig(original)
-			}
-		})
-
-		cfg := config.NewConfig()
-		cfg.RUV2 = config.DefaultRUV2Config()
-		config.StoreGlobalConfig(cfg)
-
-		require.Equal(t, execdetails.RUV2Weights{
-			RUScale:                 cfg.RUV2.RUScale,
-			ResultChunkCells:        cfg.RUV2.ResultChunkCells,
-			ExecutorL1:              cfg.RUV2.ExecutorL1,
-			ExecutorL2:              cfg.RUV2.ExecutorL2,
-			ExecutorL3:              cfg.RUV2.ExecutorL3,
-			ExecutorL5InsertRows:    cfg.RUV2.ExecutorL5InsertRows,
-			PlanCnt:                 cfg.RUV2.PlanCnt,
-			PlanDeriveStatsPaths:    cfg.RUV2.PlanDeriveStatsPaths,
-			ResourceManagerReadCnt:  cfg.RUV2.ResourceManagerReadCnt,
-			ResourceManagerWriteCnt: cfg.RUV2.ResourceManagerWriteCnt,
-			WriteKeys:               cfg.RUV2.WriteKeys,
-			SessionParserTotal:      cfg.RUV2.SessionParserTotal,
-			TxnCnt:                  cfg.RUV2.TxnCnt,
-		}, variable.NewSessionVars(nil).RUV2Weights())
+func TestNewSessionVarsUsesDefaultRUV2Weights(t *testing.T) {
+	original := config.GetGlobalConfig()
+	t.Cleanup(func() {
+		if original != nil {
+			config.StoreGlobalConfig(original)
+		}
 	})
+
+	cfg := config.NewConfig()
+	cfg.RUV2 = config.DefaultRUV2Config()
+	config.StoreGlobalConfig(cfg)
+
+	require.Equal(t, execdetails.RUV2Weights{
+		RUScale:                 cfg.RUV2.RUScale,
+		ResultChunkCells:        cfg.RUV2.ResultChunkCells,
+		ExecutorL1:              cfg.RUV2.ExecutorL1,
+		ExecutorL2:              cfg.RUV2.ExecutorL2,
+		ExecutorL3:              cfg.RUV2.ExecutorL3,
+		ExecutorL5InsertRows:    cfg.RUV2.ExecutorL5InsertRows,
+		PlanCnt:                 cfg.RUV2.PlanCnt,
+		PlanDeriveStatsPaths:    cfg.RUV2.PlanDeriveStatsPaths,
+		ResourceManagerReadCnt:  cfg.RUV2.ResourceManagerReadCnt,
+		ResourceManagerWriteCnt: cfg.RUV2.ResourceManagerWriteCnt,
+		WriteKeys:               cfg.RUV2.WriteKeys,
+		SessionParserTotal:      cfg.RUV2.SessionParserTotal,
+		TxnCnt:                  cfg.RUV2.TxnCnt,
+	}, variable.NewSessionVars(nil).RUV2Weights())
 }
 
 func compareSlowLogItems(t *testing.T, expected, actual *variable.SlowQueryLogItems) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70956

Problem Summary:

PR #70926 changed the slow-log writer to publish the statement RU V3 total through the legacy `Request_unit_v2` key and leave the legacy detail field empty. `TestSlowLogFormatIncludesTiFlashRUInRUV2Metrics` still used the retired RU V2 input and output contract, so `pull-unit-test-ddlv1` failed deterministically after #70926 merged.

### What changed and how does it work?

- Replace the stale TiFlash RU V2 formatter test with a statement RU test that passes an explicit total and verifies the current total and blank-detail output.
- Move the unrelated default RU V2 weight assertions into a focused top-level test.
- Regenerate Bazel metadata to remove the obsolete kvproto dependency and account for the additional top-level test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Validation:

```bash
make bazel_prepare
go test ./pkg/sessionctx/variable/tests -run '^(TestSlowLogFormatIncludesStatementRU|TestNewSessionVarsUsesDefaultRUV2Weights)$' -count=1 -tags=intest,deadlock
make lint
bazel test --test_filter='^(TestSlowLogFormatIncludesStatementRU|TestNewSessionVarsUsesDefaultRUV2Weights)$' --test_output=errors //pkg/sessionctx/variable/tests:tests_test
git diff --check upstream/master
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated session variable coverage to verify statement-level RU information in slow-log output.
  - Added validation that new sessions apply configured default RUV2 weights.
  - Adjusted test parallelization and removed obsolete resource-manager test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->