### PR TITLE
ddl: record global-sort backfill index KV size

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -47,6 +47,8 @@ const (
 
 // BackfillTaskSummary is the execution summary of a backfill task.
 type BackfillTaskSummary struct {
+	// IndexKVSize is currently collected only for global-sort backfills and is
+	// primarily used for NextGen resource accounting.
 	IndexKVSize uint64 `json:"index_kv_size"`
 }
 

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -45,6 +45,11 @@ const (
 	BackfillTaskMetaVersion1
 )
 
+// BackfillTaskSummary is the execution summary of a backfill task.
+type BackfillTaskSummary struct {
+	IndexKVSize uint64 `json:"index_kv_size"`
+}
+
 // BackfillTaskMeta is the dist task meta for backfilling index.
 type BackfillTaskMeta struct {
 	Job model.Job `json:"job"`
@@ -57,6 +62,8 @@ type BackfillTaskMeta struct {
 	CloudStorageURI string `json:"cloud_storage_uri"`
 	EstimateRowSize int    `json:"estimate_row_size"`
 	MergeTempIndex  bool   `json:"merge_temp_index"`
+
+	Summary *BackfillTaskSummary `json:"summary,omitempty"`
 
 	Version int `json:"version,omitempty"`
 }

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -169,22 +169,23 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 		return metaBytes, nil
 	case proto.BackfillStepWriteAndIngest:
 		if sch.GlobalSort {
-			failpoint.Inject("mockWriteIngest", func() {
-				m := &BackfillSubTaskMeta{
-					MetaGroups: []*globalsort.SortedKVMeta{},
-				}
-				metaBytes, _ := m.Marshal()
-				metaArr := make([][]byte, 0, 16)
-				metaArr = append(metaArr, metaBytes)
-				failpoint.Return(metaArr, nil)
-			})
-			return generateGlobalSortIngestPlan(
+			metas, totalKVSize, err := generateGlobalSortIngestPlan(
 				ctx,
 				store.(kv.StorageWithPD),
 				taskHandle,
 				task,
 				backfillMeta.CloudStorageURI,
 				logger)
+			if err != nil {
+				return nil, err
+			}
+			backfillMeta.Summary = &BackfillTaskSummary{IndexKVSize: totalKVSize}
+			newTaskMeta, err := json.Marshal(&backfillMeta)
+			if err != nil {
+				return nil, err
+			}
+			task.Meta = newTaskMeta
+			return metas, nil
 		}
 		return nil, nil
 	case proto.BackfillStepMergeTempIndex:
@@ -455,14 +456,14 @@ func generateGlobalSortIngestPlan(
 	task *proto.Task,
 	cloudStorageURI string,
 	logger *zap.Logger,
-) ([][]byte, error) {
+) ([][]byte, uint64, error) {
 	var (
 		kvMetaGroups []*globalsort.SortedKVMeta
 		eleIDs       []int64
 	)
 	objStore, err := handle.NewObjStore(ctx, cloudStorageURI)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer func() {
 		objStore.Close()
@@ -483,7 +484,7 @@ func generateGlobalSortIngestPlan(
 			}
 		})
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if hasSubtasks {
 			break
@@ -491,19 +492,35 @@ func generateGlobalSortIngestPlan(
 		// If there is no subtask for merge sort step,
 		// it means the merge sort step is skipped.
 	}
-
-	instanceIDs, err := scheduler.GetLiveExecIDs(ctx)
-	if err != nil {
-		return nil, err
-	}
-	iCnt := int64(len(instanceIDs))
-	metaArr := make([]*BackfillSubTaskMeta, 0, 16)
+	totalKVSize := uint64(0)
 	for i, g := range kvMetaGroups {
 		if g == nil {
 			logger.Error("meet empty kv group when getting subtask summary",
 				zap.Int64("taskID", task.ID))
-			return nil, errors.Errorf("subtask kv group %d is empty", i)
+			return nil, totalKVSize, errors.Errorf("subtask kv group %d is empty", i)
 		}
+		totalKVSize += g.TotalKVSize
+	}
+	failpoint.Inject("mockGlobalSortIngestPlanErr", func() {
+		failpoint.Return(nil, totalKVSize, errors.New("mock global-sort ingest planning error"))
+	})
+	failpoint.Inject("mockWriteIngest", func() {
+		m := &BackfillSubTaskMeta{
+			MetaGroups: []*globalsort.SortedKVMeta{},
+		}
+		metaBytes, _ := m.Marshal()
+		metaArr := make([][]byte, 0, 16)
+		metaArr = append(metaArr, metaBytes)
+		failpoint.Return(metaArr, totalKVSize, nil)
+	})
+
+	instanceIDs, err := scheduler.GetLiveExecIDs(ctx)
+	if err != nil {
+		return nil, totalKVSize, err
+	}
+	iCnt := int64(len(instanceIDs))
+	metaArr := make([]*BackfillSubTaskMeta, 0, 16)
+	for i, g := range kvMetaGroups {
 		eleID := int64(0)
 		// in case the subtask metadata is written by an old version of TiDB.
 		if i < len(eleIDs) {
@@ -511,7 +528,7 @@ func generateGlobalSortIngestPlan(
 		}
 		newMeta, err := splitSubtaskMetaForOneKVMetaGroup(ctx, store, g, eleID, cloudStorageURI, iCnt, logger)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, totalKVSize, errors.Trace(err)
 		}
 		metaArr = append(metaArr, newMeta...)
 	}
@@ -522,18 +539,18 @@ func generateGlobalSortIngestPlan(
 			proto.Step2Str(proto.Backfill, proto.BackfillStepWriteAndIngest),
 			i+1,
 		)); err != nil {
-			return nil, err
+			return nil, totalKVSize, err
 		}
 	}
 	metas := make([][]byte, 0, len(metaArr))
 	for _, m := range metaArr {
 		metaBytes, err := m.Marshal()
 		if err != nil {
-			return nil, err
+			return nil, totalKVSize, err
 		}
 		metas = append(metas, metaBytes)
 	}
-	return metas, nil
+	return metas, totalKVSize, nil
 }
 
 func allocNewTS(ctx context.Context, store kv.StorageWithPD) (uint64, error) {

--- a/pkg/ddl/backfilling_dist_scheduler_test.go
+++ b/pkg/ddl/backfilling_dist_scheduler_test.go
@@ -92,6 +92,13 @@ func TestBackfillingSchedulerLocalMode(t *testing.T) {
 	metas, err := sch.OnNextSubtasksBatch(ctx, nil, task, execIDs, task.Step)
 	require.NoError(t, err)
 	require.Equal(t, len(tblInfo.Partition.Definitions), len(metas))
+	var taskMetaView struct {
+		Summary *struct {
+			IndexKVSize uint64 `json:"index_kv_size"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(task.Meta, &taskMetaView))
+	require.Nil(t, taskMetaView.Summary)
 	for i, par := range tblInfo.Partition.Definitions {
 		var subTask ddl.BackfillSubTaskMeta
 		require.NoError(t, json.Unmarshal(metas[i], &subTask))
@@ -274,29 +281,74 @@ func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
 
 	// update meta, same as import into.
 	sortStepMeta := &ddl.BackfillSubTaskMeta{
-		MetaGroups: []*globalsort.SortedKVMeta{{
-			StartKey:    []byte("ta"),
-			EndKey:      []byte("tc"),
-			TotalKVSize: 12,
-			MultipleFilesStats: []simplesst.MultipleFilesStat{
-				{
-					Filenames: [][2]string{
-						{"gs://sort-bucket/data/1", "gs://sort-bucket/data/1.stat"},
+		EleIDs: []int64{10, 20},
+		MetaGroups: []*globalsort.SortedKVMeta{
+			{
+				StartKey:    []byte("ta"),
+				EndKey:      []byte("tc"),
+				TotalKVSize: 12,
+				MultipleFilesStats: []simplesst.MultipleFilesStat{
+					{
+						Filenames: [][2]string{
+							{"gs://sort-bucket/data/1", "gs://sort-bucket/data/1.stat"},
+						},
 					},
 				},
 			},
-		}},
+			{
+				StartKey:    []byte("td"),
+				EndKey:      []byte("tf"),
+				TotalKVSize: 30,
+				MultipleFilesStats: []simplesst.MultipleFilesStat{
+					{
+						Filenames: [][2]string{
+							{"gs://sort-bucket/data/2", "gs://sort-bucket/data/2.stat"},
+						},
+					},
+				},
+			},
+		},
 	}
 	sortStepMetaBytes, err := json.Marshal(sortStepMeta)
 	require.NoError(t, err)
 	for _, s := range gotSubtasks {
 		require.NoError(t, mgr.FinishSubtask(ctx, s.ExecID, s.ID, sortStepMetaBytes))
 	}
+
+	// Write-and-ingest planning can be retried out of sequence. A failed attempt
+	// must not mutate the task meta, while a retry records the read-index total.
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockWriteIngest", "return(true)")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockGlobalSortIngestPlanErr", "1*return()")
+	originalTaskMeta := append([]byte(nil), task.Meta...)
+	var taskMetaView struct {
+		EleIDs          []int64 `json:"ele_ids"`
+		CloudStorageURI string  `json:"cloud_storage_uri"`
+		Summary         *struct {
+			IndexKVSize uint64 `json:"index_kv_size"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(originalTaskMeta, &taskMetaView))
+	originalEleIDs := append([]int64(nil), taskMetaView.EleIDs...)
+	originalCloudStorageURI := taskMetaView.CloudStorageURI
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, proto.BackfillStepWriteAndIngest)
+	require.EqualError(t, err, "mock global-sort ingest planning error")
+	require.Empty(t, subtaskMetas)
+	require.Equal(t, originalTaskMeta, task.Meta)
+
+	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, proto.BackfillStepWriteAndIngest)
+	require.NoError(t, err)
+	require.Len(t, subtaskMetas, 1)
+	require.NoError(t, json.Unmarshal(task.Meta, &taskMetaView))
+	require.Equal(t, originalEleIDs, taskMetaView.EleIDs)
+	require.Equal(t, originalCloudStorageURI, taskMetaView.CloudStorageURI)
+	require.NotNil(t, taskMetaView.Summary)
+	require.Equal(t, uint64(42), taskMetaView.Summary.IndexKVSize)
+
 	// 2. to merge-sort stage.
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/forceMergeSort", `return()`)
 	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
-	require.Len(t, subtaskMetas, 1)
+	require.Len(t, subtaskMetas, 2)
 	nextStep = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.BackfillStepMergeSort, nextStep)
 
@@ -310,30 +362,37 @@ func TestBackfillingSchedulerGlobalSortMode(t *testing.T) {
 	task.Step = nextStep
 	gotSubtasks, err = mgr.GetSubtasksWithHistory(ctx, taskID, task.Step)
 	require.NoError(t, err)
-	mergeSortStepMeta := &ddl.BackfillSubTaskMeta{
-		MetaGroups: []*globalsort.SortedKVMeta{{
-			StartKey:    []byte("ta"),
-			EndKey:      []byte("tc"),
-			TotalKVSize: 12,
-			MultipleFilesStats: []simplesst.MultipleFilesStat{
-				{
-					Filenames: [][2]string{
-						{"gs://sort-bucket/data/1", "gs://sort-bucket/data/1.stat"},
+	require.Len(t, gotSubtasks, 2)
+	mergeTotals := []uint64{17, 23}
+	for i, s := range gotSubtasks {
+		mergeSortStepMeta := &ddl.BackfillSubTaskMeta{
+			EleIDs: []int64{int64((i + 1) * 10)},
+			MetaGroups: []*globalsort.SortedKVMeta{{
+				StartKey:    []byte("ta"),
+				EndKey:      []byte("tc"),
+				TotalKVSize: mergeTotals[i],
+				MultipleFilesStats: []simplesst.MultipleFilesStat{
+					{
+						Filenames: [][2]string{
+							{fmt.Sprintf("gs://sort-bucket/merged/%d", i), fmt.Sprintf("gs://sort-bucket/merged/%d.stat", i)},
+						},
 					},
 				},
-			},
-		}},
-	}
-	mergeSortStepMetaBytes, err := json.Marshal(mergeSortStepMeta)
-	require.NoError(t, err)
-	for _, s := range gotSubtasks {
+			}},
+		}
+		mergeSortStepMetaBytes, err := json.Marshal(mergeSortStepMeta)
+		require.NoError(t, err)
 		require.NoError(t, mgr.FinishSubtask(ctx, s.ExecID, s.ID, mergeSortStepMetaBytes))
 	}
 	// 3. to write&ingest stage.
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockWriteIngest", "return(true)")
 	subtaskMetas, err = ext.OnNextSubtasksBatch(ctx, sch, task, execIDs, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
+	require.NoError(t, json.Unmarshal(task.Meta, &taskMetaView))
+	require.Equal(t, originalEleIDs, taskMetaView.EleIDs)
+	require.Equal(t, originalCloudStorageURI, taskMetaView.CloudStorageURI)
+	require.NotNil(t, taskMetaView.Summary)
+	require.Equal(t, uint64(40), taskMetaView.Summary.IndexKVSize)
 	task.Step = ext.GetNextStep(&task.TaskBase)
 	require.Equal(t, proto.BackfillStepWriteAndIngest, task.Step)
 	// 4. to done stage.
@@ -469,10 +528,30 @@ func TestBackfillTaskMetaVersion(t *testing.T) {
 	// Test the default version.
 	meta := &ddl.BackfillTaskMeta{}
 	require.Equal(t, ddl.BackfillTaskMetaVersion0, meta.Version)
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+	var zeroMetaView struct {
+		Summary json.RawMessage `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(metaBytes, &zeroMetaView))
+	require.Nil(t, zeroMetaView.Summary)
 
 	// Test the new version.
 	meta = &ddl.BackfillTaskMeta{
 		Version: ddl.BackfillTaskMetaVersion1,
 	}
 	require.Equal(t, ddl.BackfillTaskMetaVersion1, meta.Version)
+
+	// Optional fields are decode-compatible without a task-meta version bump.
+	require.NoError(t, json.Unmarshal([]byte(`{"summary":{"index_kv_size":0}}`), meta))
+	metaBytes, err = json.Marshal(meta)
+	require.NoError(t, err)
+	var summaryMetaView struct {
+		Summary map[string]json.RawMessage `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(metaBytes, &summaryMetaView))
+	require.NotNil(t, summaryMetaView.Summary)
+	indexKVSize, ok := summaryMetaView.Summary["index_kv_size"]
+	require.True(t, ok)
+	require.JSONEq(t, "0", string(indexKVSize))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70961

Problem Summary:

DDL RU accounting needs the generated index KV size for successful distributed ADD INDEX tasks. Global-sort backfill already produces an exact task-wide total in sorted-KV metadata, but `BackfillTaskMeta` did not retain it.

### What changed and how does it work?

- Add an optional `BackfillTaskMeta` summary containing `index_kv_size`.
- Sum the canonical `SortedKVMeta.TotalKVSize` values while planning the global-sort write-and-ingest step, preferring merge-sort metadata and falling back to read-index metadata.
- Persist the summary only after planning succeeds, and overwrite it deterministically when planning is retried.
- Add unit coverage for global-sort aggregation, local-mode omission, fallback behavior, retries, and planning failures.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backfill task summaries now report the total index key-value size.
  - Backfill metadata preserves summary information when serialized and restored.

- **Bug Fixes**
  - Improved validation when global-sort planning encounters empty key-value groups.
  - Failed planning retries no longer alter task metadata.
  - Successful retries now record the calculated index size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->