### PR TITLE
test: stabilize flaky TestTopSQLCatchRunningSQL

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -1183,9 +1183,11 @@ func TestTopSQLCatchRunningSQL(t *testing.T) {
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/topsql/mockHighLoadForEachPlan", `return(true)`))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/skipLoadSysVarCacheLoop", `return(true)`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/mockStmtSlow", "return(2000)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/topsql/mockHighLoadForEachPlan"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/skipLoadSysVarCacheLoop"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/session/mockStmtSlow"))
 	}()
 
 	mc := mockTopSQLTraceCPU.NewTopSQLCollector()
@@ -1195,42 +1197,34 @@ func TestTopSQLCatchRunningSQL(t *testing.T) {
 	sqlCPUCollector.Start()
 	defer sqlCPUCollector.Stop()
 
-	query := "select count(*) from t as t0 join t as t1 on t0.a != t1.a;"
-	needEnableTopSQL := int64(0)
+	query := "select /* sleep */ count(*) from t as t0 join t as t1 on t0.a != t1.a;"
+	queryStarted := make(chan struct{})
+	var notifyQueryStarted sync.Once
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			if atomic.LoadInt64(&needEnableTopSQL) == 1 {
-				time.Sleep(2 * time.Millisecond)
-				topsqlstate.EnableTopSQL()
-				atomic.StoreInt64(&needEnableTopSQL, 0)
-			}
-			time.Sleep(time.Millisecond)
-		}
-	}()
 	execFn := func(db *sql.DB) {
 		dbt := testkit.NewDBTestKit(t, db)
-		atomic.StoreInt64(&needEnableTopSQL, 1)
+		topsqlstate.DisableTopSQL()
+		notifyQueryStarted.Do(func() { close(queryStarted) })
 		mustQuery(t, dbt, query)
 		topsqlstate.DisableTopSQL()
 	}
 	check := func() {
-		require.NoError(t, ctx.Err())
+		select {
+		case <-queryStarted:
+		case <-ctx.Done():
+			require.NoError(t, ctx.Err())
+		}
+		require.Eventually(t, func() bool {
+			return processlistCountByInfo(t, dbt, "select /* sleep */ count(*) from t as t0 join t as t1%") > 0
+		}, 10*time.Second, 10*time.Millisecond)
+		require.False(t, topsqlstate.TopSQLEnabled())
+		topsqlstate.EnableTopSQL()
 		stats := mc.GetSQLStatsBySQLWithRetry(query, true)
 		require.Greaterf(t, len(stats), 0, query)
 	}
 	ts.TestCase(t, mc, execFn, check)
 	cancel()
-	wg.Wait()
 }
 
 func TestTopSQLCPUProfile(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/68448

Problem Summary:
Flaky test `TestTopSQLCatchRunningSQL` in `pkg/server/tests/commontest` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test raced query start and TopSQL enablement, allowing empty stats or stats from the wrong global start state.

#### Fix

The fix synchronizes on the actual running target query, proves TopSQL is disabled at that boundary, then enables TopSQL before asserting the same stats contract.

#### Verification

Spec:
- target: `pkg/server/tests/commontest :: TestTopSQLCatchRunningSQL`
- strategy: `tidb.go_flaky.default`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- execution surface: `WRAPPED_GO_TEST`
- wrapper: `./tools/check/failpoint-go-test.sh`
- build tags: `intest, deadlock`
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build_lint passed.

Gate checklist:
- timing_repro: SKIPPED
- target_flaky: PASS
- package_surface: SKIPPED
- build_lint: PASS

Commands:
- `./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -json -run '^TestTopSQLCatchRunningSQL$' -count=1`
- `make build && make lint`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

Fixes #68448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for monitoring running SQL queries by ensuring test queries remain active while their process-list entries are checked.
  * Updated Top SQL test setup and cleanup to provide more reliable, deterministic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->