### PR TITLE
ddl: persist vector index kind

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -518,6 +518,7 @@ func buildVectorInfoWithCheck(indexPartSpecifications []*ast.IndexPartSpecificat
 	idxPart.Length = types.UnspecifiedLength
 
 	return &model.VectorIndexInfo{
+		Kind:           model.VectorIndexKindHNSW,
 		Dimension:      uint64(colInfo.FieldType.GetFlen()),
 		DistanceMetric: distanceMetric,
 	}, exprStr, nil

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -1400,6 +1400,7 @@ func TestCreateTableWithVectorIndex(t *testing.T) {
 		indexes := tbl.Meta().Indices
 		require.Equal(t, 2, len(indexes))
 		require.Equal(t, ast.IndexTypeVector, indexes[0].Tp)
+		require.Equal(t, model.VectorIndexKindHNSW, indexes[0].VectorInfo.Kind)
 		require.Equal(t, model.DistanceMetricCosine, indexes[0].VectorInfo.DistanceMetric)
 		require.Equal(t, "vector_index", tbl.Meta().Indices[0].Name.O)
 		require.Equal(t, "vector_index_2", tbl.Meta().Indices[1].Name.O)
@@ -1600,6 +1601,7 @@ func TestAddVectorIndexSimple(t *testing.T) {
 	indexes = tbl.Meta().Indices
 	require.Equal(t, 1, len(indexes))
 	require.Equal(t, ast.IndexTypeVector, indexes[0].Tp)
+	require.Equal(t, model.VectorIndexKindHNSW, indexes[0].VectorInfo.Kind)
 	require.Equal(t, model.DistanceMetricCosine, indexes[0].VectorInfo.DistanceMetric)
 	// test row count
 	jobs, err := getJobsBySQL(tk.Session(), "tidb_ddl_history", "order by job_id desc limit 1")
@@ -1664,6 +1666,7 @@ func TestAddVectorIndexSimple(t *testing.T) {
 	indexes = tbl.Meta().Indices
 	require.Equal(t, 1, len(indexes))
 	require.Equal(t, ast.IndexTypeVector, indexes[0].Tp)
+	require.Equal(t, model.VectorIndexKindHNSW, indexes[0].VectorInfo.Kind)
 	require.Equal(t, model.DistanceMetricCosine, indexes[0].VectorInfo.DistanceMetric)
 	tk.MustQuery("select * from t;").Check(testkit.Rows("1 [1,2.1,3.3]"))
 	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -34,6 +34,7 @@ type DistanceMetric string
 
 // Note: tipb.VectorDistanceMetric's enum names must be aligned with these constant values.
 const (
+	// DistanceMetricL2 is L2 distance.
 	DistanceMetricL2 DistanceMetric = "L2"
 	// DistanceMetricCosine is cosine distance.
 	DistanceMetricCosine DistanceMetric = "COSINE"
@@ -66,6 +67,14 @@ const (
 	// GlobalIndexVersionV2 is the next, not yet implemented format (version 2) where partition ID
 	// is encoded in the key ONLY!
 	GlobalIndexVersionV2 uint8 = 2
+)
+
+// VectorIndexKind is the kind of vector index.
+type VectorIndexKind string
+
+const (
+	// VectorIndexKindHNSW is HNSW index.
+	VectorIndexKindHNSW VectorIndexKind = "HNSW"
 )
 
 // globalIndexV1Supported tracks whether all TiDB nodes in the cluster support
@@ -117,6 +126,8 @@ var IndexableDistanceMetricToFnName = map[DistanceMetric]string{
 
 // VectorIndexInfo is the information of vector index of a column.
 type VectorIndexInfo struct {
+	// Kind is the kind of vector index. Currently only HNSW is supported.
+	Kind VectorIndexKind `json:"kind"`
 	// Dimension is the dimension of the vector.
 	Dimension uint64 `json:"dimension"`
 	// DistanceMetric is the distance metric used by the index.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70969 

Problem Summary:
Add kind field to VectorIndex schema.

### What changed and how does it work?

Pick https://github.com/tidbcloud/tidb-cse/pull/1928

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector index metadata now identifies the index kind as HNSW.
  * Added support for exposing the vector index kind in index information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->