### PR TITLE
statistics: fix stats cache dropping sync-loaded column stats

### DIFF
--- a/pkg/statistics/handle/cache/BUILD.bazel
+++ b/pkg/statistics/handle/cache/BUILD.bazel
@@ -45,9 +45,10 @@ go_test(
     ],
     embed = [":cache"],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
+        "//pkg/meta/model",
         "//pkg/statistics",
         "//pkg/statistics/handle/cache/internal",
         "//pkg/statistics/handle/cache/internal/testutil",

--- a/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
+++ b/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     embed = [":lfu"],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//pkg/statistics",
         "//pkg/statistics/handle/cache/internal/testutil",

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -16,6 +16,7 @@ package lfu
 
 import (
 	"math/rand/v2"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -43,6 +44,11 @@ type LFU struct {
 	cost         atomic.Int64
 	closed       atomic.Bool
 	closeOnce    sync.Once
+	// waiting counts the WaitForAsyncUpdates calls that are inside Ristretto. Ristretto's Close
+	// stops the background goroutine that serves Wait before it marks the cache closed, so a wait
+	// that is queued at that moment never returns. Close therefore lets in-flight waits finish
+	// before it stops Ristretto, and waits that start afterwards see closed and return at once.
+	waiting atomic.Int64
 }
 
 // NewLFU creates a new LFU cache.
@@ -251,7 +257,20 @@ func (s *LFU) SetCapacity(maxCost int64) {
 
 // WaitForAsyncUpdates blocks until all buffered writes have been applied. This ensures a call to
 // Put is visible to future calls to Get.
+//
+// It returns without that guarantee only when the cache is being closed concurrently.
 func (s *LFU) WaitForAsyncUpdates() {
+	// Callers that arrive after Close started must not touch the counter, otherwise a steady
+	// stream of them could keep Close spinning. The second check, after the increment, is the
+	// one that pairs with the store in Close.
+	if s.closed.Load() {
+		return
+	}
+	s.waiting.Add(1)
+	defer s.waiting.Add(-1)
+	if s.closed.Load() {
+		return
+	}
 	s.cache.Wait()
 }
 
@@ -263,6 +282,11 @@ func (s *LFU) metrics() *ristretto.Metrics {
 func (s *LFU) Close() {
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
+		// See the comment on waiting. A wait in flight finishes as soon as the still running
+		// background goroutine reaches its sentinel.
+		for s.waiting.Load() > 0 {
+			runtime.Gosched()
+		}
 		s.Clear()
 		s.cache.Close()
 		s.cache.Wait()

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -17,6 +17,7 @@ package lfu
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -313,4 +314,31 @@ func TestMemoryControlWithUpdate(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return int64(0) == lfu.Cost()
 	}, 5*time.Second, 100*time.Millisecond)
+}
+
+// TestCloseDuringWait closes the cache while another goroutine keeps waiting for buffered writes
+// to be applied, which happens when the stats cache is replaced (for example at the end of
+// InitStats) while sync stats loading is running. The wait must not hang.
+func TestCloseDuringWait(t *testing.T) {
+	for range 300 {
+		lfu, err := NewLFU(100000000)
+		require.NoError(t, err)
+		lfu.Put(1, testutil.NewMockStatisticsTable(1, 1, true, false, false))
+		var stop atomic.Bool
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for !stop.Load() {
+				lfu.WaitForAsyncUpdates()
+			}
+		}()
+		time.Sleep(time.Duration(rand.Intn(200)) * time.Microsecond)
+		lfu.Close()
+		stop.Store(true)
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("WaitForAsyncUpdates hangs when the cache is closed concurrently")
+		}
+	}
 }

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -17,8 +17,11 @@ package cache
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal"
+	"github.com/pingcap/tidb/pkg/statistics/handle/cache/internal/testutil"
 	handle_metrics "github.com/pingcap/tidb/pkg/statistics/handle/metrics"
 	promtestutils "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -199,4 +202,38 @@ func (*mockStatsCacheInner) TriggerEvict() {
 
 func (*mockStatsCacheInner) WaitForAsyncUpdates() {
 	panic("not implemented")
+}
+
+// TestUpdateDropsPendingTableUpdate records the current behavior of the LFU cache: a table which is
+// updated right after it was added is dropped, and Get keeps returning the first table, because
+// Ristretto admits new keys asynchronously and rejects a Put of the same key that arrives before
+// the admission finishes. This is the pattern of sync stats loading: the loaded column is written
+// back to a table that the stats cache Update just added.
+func TestUpdateDropsPendingTableUpdate(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.EnableStatsCacheMemQuota = true
+	})
+	sc, err := NewStatsCache()
+	require.NoError(t, err)
+	defer sc.Close()
+
+	const tableID = int64(1)
+	added := testutil.NewMockStatisticsTable(1, 1, true, false, false)
+	added.PhysicalID = tableID
+	sc.Update([]*statistics.Table{added}, nil, false)
+	// Simulate sync loading that writes the loaded column back immediately.
+	updated := added.CopyAs(statistics.ColumnMapWritable)
+	updated.SetCol(2, &statistics.Column{
+		Info:              &model.ColumnInfo{ID: 2},
+		StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
+	})
+	sc.Update([]*statistics.Table{updated}, nil, false)
+	sc.WaitForAsyncUpdates()
+
+	got, ok := sc.Get(tableID)
+	require.True(t, ok)
+	require.Same(t, added, got)
+	require.Nil(t, got.GetCol(2))
 }

--- a/pkg/statistics/handle/cache/statscache_test.go
+++ b/pkg/statistics/handle/cache/statscache_test.go
@@ -204,12 +204,11 @@ func (*mockStatsCacheInner) WaitForAsyncUpdates() {
 	panic("not implemented")
 }
 
-// TestUpdateDropsPendingTableUpdate records the current behavior of the LFU cache: a table which is
-// updated right after it was added is dropped, and Get keeps returning the first table, because
-// Ristretto admits new keys asynchronously and rejects a Put of the same key that arrives before
-// the admission finishes. This is the pattern of sync stats loading: the loaded column is written
-// back to a table that the stats cache Update just added.
-func TestUpdateDropsPendingTableUpdate(t *testing.T) {
+// TestUpdateOverwritesPendingTable makes sure that a table which is updated right after it was
+// added to the cache is the one returned by Get, even though the LFU admits new keys asynchronously.
+// This is the pattern of sync stats loading: the loaded column is written back to a table that the
+// stats cache Update just added.
+func TestUpdateOverwritesPendingTable(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
@@ -234,6 +233,6 @@ func TestUpdateDropsPendingTableUpdate(t *testing.T) {
 
 	got, ok := sc.Get(tableID)
 	require.True(t, ok)
-	require.Same(t, added, got)
-	require.Nil(t, got.GetCol(2))
+	require.Same(t, updated, got)
+	require.NotNil(t, got.GetCol(2))
 }

--- a/pkg/statistics/handle/cache/statscacheinner.go
+++ b/pkg/statistics/handle/cache/statscacheinner.go
@@ -175,6 +175,11 @@ func (sc *StatsCache) Update(tables []*statistics.Table, deletedIDs []int64, ski
 		metrics.DelCounter.Inc()
 		sc.c.Del(id)
 	}
+	// LFU/Ristretto admits a non-resident key asynchronously, and it rejects a later Put of the
+	// same key that arrives before the admission finishes, which keeps the stale table resident.
+	// Callers such as sync stats loading read-modify-write a table right after it is added here,
+	// so make the writes above visible before returning to prevent losing those updates.
+	sc.c.WaitForAsyncUpdates()
 
 	if !skipMoveForwardStatsCache {
 		// update the maxTblStatsVer


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/70964, ref https://github.com/pingcap/tidb/issues/69695

Problem Summary:

A column or index that sync stats loading just wrote back can silently vanish from the stats cache when the table was added to the cache moments before. The optimizer then uses pseudo stats for that column. This is what makes `TestPlanStatsLoad` flaky (#69695); the test-only stabilization is in #69982, this PR fixes the cache.

### What changed and how does it work?

**Root cause**

The LFU stats cache is backed by Ristretto, which admits a new key asynchronously. If the same key is `Put` again before that admission finishes, Ristretto rejects the second value as a duplicate and keeps the first one, and `LFU.Get` returns what Ristretto holds. So the second `Put` is silently lost.

Sync stats loading does `Get -> copy -> Put` for every requested column, right after `StatsCache.Update` inserted a fresh table. When two columns of one table are loaded by two workers and the admission of the fresh table lands between their `Put`s, one loaded column disappears. No error is reported, and the plan sees a table without that column.

**Fix**

`StatsCache.Update` now waits for Ristretto to apply its writes before returning, so a later `Put` of the same table takes the synchronous in-place update path. Bootstrap already drains the same way between its load phases (#67971); the runtime write path did not.

Waiting must not hang when the cache is closed concurrently, which happens when `InitStats` replaces the cache while the sync load workers are already running: Ristretto's `Close` stops the goroutine that serves `Wait` before it marks the cache closed, so a wait queued at that moment never returns. `LFU` now counts in-flight waits with an atomic, and `Close` lets them finish before it stops Ristretto; waits that start afterwards see the closed flag and return at once. `Put`, `Get` and `Del` are untouched, so there is no lock on the write or read path.

**Commits**

1. Add a cache test that records the current behavior (`Get` returns the first table).
2. Apply the fix and flip the test to the fixed behavior, together with the close gate and `TestCloseDuringWait`, which closes the cache under a `Wait` loop 300 times and hangs on the first round without the gate.

**How it was reproduced and verified**

- Cache level: `Put(k, t0); Put(k, t1); WaitForAsyncUpdates(); Get(k)` returned `t0` in 1998 of 2000 iterations.
- End to end: with a local copy of ristretto that sleeps a random 0-3ms at the top of the `setBuf` branch of `processItems`, `TestPlanStatsLoad` failed in 5 of 30 runs with the same assertions as CI. With the fix it passed 30 of 30 runs under the same delay.
- The new cache test fails 5 of 5 runs without the fix and passes 20 of 20 runs with it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test: see the reproduction above. Commands run locally:

```
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/statistics/handle/cache -count=1
./tools/check/failpoint-go-test.sh pkg/statistics/handle/syncload -count=1
./tools/check/failpoint-go-test.sh pkg/planner/core/casetest/planstats -count=1
./tools/check/failpoint-go-test.sh pkg/statistics/handle -count=1
./tools/check/failpoint-go-test.sh pkg/statistics/handle/handletest/initstats -count=1
./tools/check/failpoint-go-test.sh pkg/statistics/handle/handletest -count=1
go test -race ./pkg/statistics/handle/cache/internal/lfu -tags=intest,deadlock
make lint
```

`TestInitStatsLite` in `pkg/statistics/handle/handletest` fails in a whole-package local run on the base commit too and passes alone; the process-global async load queue leaks between tests there. CI runs one test per shard for that package, so it is not affected.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that column or index statistics loaded synchronously for a query could be dropped from the statistics cache when the table had just been added to the cache, which made the optimizer use pseudo statistics for that column or index
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache shutdown handling to prevent waits from hanging when the cache closes.
  * Ensured cache updates are visible to subsequent reads before update operations return.
  * Fixed cases where recently updated table statistics could be overwritten or lost during asynchronous processing.

* **Tests**
  * Added coverage for concurrent cache closure and pending table updates.
  * Adjusted test sharding for improved test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->