### PR TITLE
server, session: restore short DML disconnect checks

### DIFF
--- a/pkg/server/internal/util/BUILD.bazel
+++ b/pkg/server/internal/util/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "util",
     srcs = [
         "buffered_read_conn.go",
+        "socket_probe_other.go",
+        "socket_probe_unix.go",
         "util.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/server/internal/util",
@@ -17,9 +19,15 @@ go_library(
 go_test(
     name = "util_test",
     timeout = "short",
-    srcs = ["util_test.go"],
+    srcs = [
+        "buffered_read_conn_test.go",
+        "util_test.go",
+    ],
     embed = [":util"],
     flaky = True,
-    shard_count = 3,
-    deps = ["@com_github_stretchr_testify//require"],
+    shard_count = 10,
+    deps = [
+        "@com_github_blacktear23_go_proxyprotocol//:go-proxyprotocol",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/server/internal/util/buffered_read_conn.go
+++ b/pkg/server/internal/util/buffered_read_conn.go
@@ -16,8 +16,9 @@ package util
 
 import (
 	"bufio"
-	"io"
+	"crypto/tls"
 	"net"
+	"reflect"
 	"sync"
 	"time"
 )
@@ -25,22 +26,70 @@ import (
 // DefaultReaderSize is the default size of bufio.Reader.
 const DefaultReaderSize = 16 * 1024
 
+type socketProbeState int
+
+const (
+	socketUnknown socketProbeState = iota - 1
+	socketClosed
+	socketIdle
+	socketReadable
+)
+
 // BufferedReadConn is a net.Conn compatible structure that reads from bufio.Reader.
 type BufferedReadConn struct {
 	net.Conn
 	rb *bufio.Reader
-	// `mu` is for `IsAlive()` function.
-	// We use this to ensure that `SetReadDeadline` is not called concurrently.
+	// IsAlive calls can come from different execution checkpoints. Serialize
+	// their buffer access, socket probes and fallback deadline changes.
 	mu *sync.Mutex
+	// Wrapped connections must still run their reader to check buffered TLS
+	// records and protocol errors, even when the underlying socket is idle.
+	probe          func() socketProbeState
+	rawConn        net.Conn
+	probeNeedsRead bool
 }
 
 // NewBufferedReadConn creates a BufferedReadConn.
 func NewBufferedReadConn(conn net.Conn) *BufferedReadConn {
+	rawConn, needsRead := connectionProbeSource(conn)
 	return &BufferedReadConn{
-		mu:   &sync.Mutex{},
-		Conn: conn,
-		rb:   bufio.NewReaderSize(conn, DefaultReaderSize),
+		mu:             &sync.Mutex{},
+		Conn:           conn,
+		rb:             bufio.NewReaderSize(conn, DefaultReaderSize),
+		probe:          newConnectionAliveProbe(rawConn),
+		rawConn:        rawConn,
+		probeNeedsRead: needsRead,
 	}
+}
+
+// connectionProbeSource resolves only known wrappers, once at construction.
+// Unknown wrappers retain the timed Read-based probe; their buffers are opaque.
+func connectionProbeSource(conn net.Conn) (net.Conn, bool) {
+	switch c := conn.(type) {
+	case *BufferedReadConn:
+		return c.rawConn, true
+	case *tls.Conn:
+		raw, _ := connectionProbeSource(c.NetConn())
+		return raw, true
+	}
+	// go-proxyprotocol exposes its underlying connection as an exported Conn
+	// field, but the wrapper type is unexported and has no accessor. This is
+	// also how the server obtains Unix peer credentials through that wrapper.
+	// Keep this guarded and off the hot path; a changed wrapper falls back.
+	v := reflect.ValueOf(conn)
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
+		v = v.Elem()
+		if v.Kind() == reflect.Struct && v.Type().PkgPath() == "github.com/blacktear23/go-proxyprotocol" {
+			field := v.FieldByName("Conn")
+			if field.IsValid() && field.CanInterface() {
+				if inner, ok := field.Interface().(net.Conn); ok {
+					raw, _ := connectionProbeSource(inner)
+					return raw, true
+				}
+			}
+		}
+	}
+	return conn, false
 }
 
 // Read reads data from the connection.
@@ -54,13 +103,34 @@ func (conn BufferedReadConn) Peek(n int) ([]byte, error) {
 }
 
 // IsAlive detects the connection is alive or not.
-// return value < 0, means unknow
+// return value < 0, means unknown
 // return value = 0, means not alive
 // return value = 1, means still alive
 func (conn BufferedReadConn) IsAlive() int {
 	if conn.mu.TryLock() {
 		defer conn.mu.Unlock()
-		err := conn.SetReadDeadline(time.Now().Add(30 * time.Microsecond))
+		if conn.rb.Buffered() > 0 {
+			return 1
+		}
+		idle := false
+		if conn.probe != nil {
+			state := conn.probe()
+			if !conn.probeNeedsRead && state != socketUnknown {
+				if state == socketClosed {
+					return 0
+				}
+				return 1
+			}
+			idle = state == socketIdle
+		}
+		// An idle socket has no pending bytes or EOF. Peek must still drain
+		// wrapper buffers (notably TLS close_notify), but need not wait for
+		// future network traffic. An expired deadline avoids a timer.
+		deadline := time.Unix(1, 0)
+		if !idle {
+			deadline = time.Now().Add(30 * time.Microsecond)
+		}
+		err := conn.SetReadDeadline(deadline)
 		if err != nil {
 			return -1
 		}
@@ -74,11 +144,15 @@ func (conn BufferedReadConn) IsAlive() int {
 		// the liveness check might be inaccurate - this won't impact the
 		// actual connection state or its operations.
 		_, err = conn.Peek(1)
-		if err == io.EOF {
-			return 0
-		} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		if err == nil {
 			return 1
 		}
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return 1
+		}
+		// EOF, reset and TLS protocol errors all prevent the client from
+		// receiving the statement result. Timeouts are the healthy case above.
+		return 0
 	}
 	return -1
 }

--- a/pkg/server/internal/util/buffered_read_conn_test.go
+++ b/pkg/server/internal/util/buffered_read_conn_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blacktear23/go-proxyprotocol"
+	"github.com/stretchr/testify/require"
+)
+
+func newAliveTestConn(t testing.TB, transport string) (*BufferedReadConn, net.Conn) {
+	t.Helper()
+	network, address := "tcp", "127.0.0.1:0"
+	if transport == "unix" {
+		network, address = "unix", filepath.Join(t.TempDir(), "s")
+	}
+	listener, err := net.Listen(network, address)
+	require.NoError(t, err)
+	if transport == "proxy" || transport == "tls-proxy" {
+		listener, err = proxyprotocol.NewLazyListener(listener, "*", 1, false)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	client, err := net.Dial(network, listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	server, err := listener.Accept()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = server.Close() })
+	if transport == "proxy" || transport == "tls-proxy" {
+		_, err = io.WriteString(client, "PROXY TCP4 127.0.0.1 127.0.0.1 12345 4000\r\nx")
+		require.NoError(t, err)
+		buf := make([]byte, 1)
+		_, err = io.ReadFull(server, buf)
+		require.NoError(t, err)
+		require.Equal(t, "x", string(buf))
+	}
+	if transport == "tls" || transport == "tls-proxy" {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		cert := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
+		require.NoError(t, err)
+		// Match the server's TLS-over-BufferedReadConn layering.
+		tlsServer := tls.Server(NewBufferedReadConn(server), &tls.Config{
+			Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		})
+		tlsClient := tls.Client(client, &tls.Config{InsecureSkipVerify: true})
+		require.NoError(t, server.SetDeadline(time.Now().Add(5*time.Second)))
+		require.NoError(t, client.SetDeadline(time.Now().Add(5*time.Second)))
+		done := make(chan error, 1)
+		go func() { done <- tlsServer.Handshake() }()
+		require.NoError(t, tlsClient.Handshake())
+		require.NoError(t, <-done)
+		require.NoError(t, server.SetDeadline(time.Time{}))
+		require.NoError(t, client.SetDeadline(time.Time{}))
+		server, client = tlsServer, tlsClient
+	}
+	if transport == "opaque" {
+		server = &opaqueBufferedConn{Conn: server, reader: bufio.NewReader(server)}
+	}
+	return NewBufferedReadConn(server), client
+}
+
+// Unknown wrappers must never be bypassed just because they embed a net.Conn.
+type opaqueBufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *opaqueBufferedConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func TestBufferedReadConnLiveness(t *testing.T) {
+	for _, transport := range []string{"tcp", "unix", "tls", "proxy", "tls-proxy", "opaque"} {
+		t.Run(transport, func(t *testing.T) {
+			server, client := newAliveTestConn(t, transport)
+			for range 10 {
+				require.NotZero(t, server.IsAlive())
+			}
+			// A health check must not consume data or poison subsequent TLS reads.
+			_, err := io.WriteString(client, "request")
+			require.NoError(t, err)
+			require.NotZero(t, server.IsAlive())
+			buf, err := server.Peek(7)
+			require.NoError(t, err)
+			require.Equal(t, "request", string(buf))
+			require.NoError(t, client.Close())
+			// Honor data already buffered above the underlying socket's EOF.
+			require.NotZero(t, server.IsAlive())
+			buf = make([]byte, 7)
+			_, err = io.ReadFull(server, buf)
+			require.NoError(t, err)
+			require.Equal(t, "request", string(buf))
+			require.Eventually(t, func() bool { return server.IsAlive() == 0 }, time.Second, time.Millisecond)
+		})
+	}
+}
+
+func TestBufferedReadConnReset(t *testing.T) {
+	server, client := newAliveTestConn(t, "tcp")
+	require.NoError(t, client.(*net.TCPConn).SetLinger(0))
+	require.NoError(t, client.Close())
+	require.Eventually(t, func() bool { return server.IsAlive() == 0 }, time.Second, time.Millisecond)
+}
+
+func TestBufferedReadConnTLSCloseNotify(t *testing.T) {
+	for _, transport := range []string{"tls", "tls-proxy"} {
+		for _, buffered := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/buffered=%t", transport, buffered), func(t *testing.T) {
+				server, client := newAliveTestConn(t, transport)
+				// CloseWrite sends close_notify without closing the TCP connection.
+				require.NoError(t, client.(*tls.Conn).CloseWrite())
+				if buffered {
+					// The TCP socket can be idle while the close record is already
+					// buffered below TLS. Its reader still has to process the record.
+					inner := server.Conn.(*tls.Conn).NetConn().(*BufferedReadConn)
+					_, err := inner.Peek(1)
+					require.NoError(t, err)
+				}
+				require.Eventually(t, func() bool { return server.IsAlive() == 0 }, time.Second, time.Millisecond)
+			})
+		}
+	}
+}
+
+func TestBufferedReadConnTLSBufferedPlaintext(t *testing.T) {
+	server, client := newAliveTestConn(t, "tls")
+	_, err := io.WriteString(client, "request")
+	require.NoError(t, err)
+	buf := make([]byte, 1)
+	_, err = io.ReadFull(server.Conn, buf)
+	require.NoError(t, err)
+	require.Equal(t, "r", string(buf))
+	// The remaining plaintext lives inside tls.Conn, not on the TCP socket.
+	require.NotZero(t, server.IsAlive())
+	buf = make([]byte, 6)
+	_, err = io.ReadFull(server, buf)
+	require.NoError(t, err)
+	require.Equal(t, "equest", string(buf))
+}
+
+func TestBufferedReadConnConcurrentProbes(t *testing.T) {
+	server, _ := newAliveTestConn(t, "tcp")
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 100 {
+				require.NotZero(t, server.IsAlive())
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func TestBufferedReadConnProbeAllocations(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("nonblocking probes are only implemented on Linux and macOS")
+	}
+	server, _ := newAliveTestConn(t, "tcp")
+	var alive int
+	allocations := testing.AllocsPerRun(100, func() { alive = server.IsAlive() })
+	require.Equal(t, 1, alive)
+	require.Zero(t, allocations)
+}
+
+func TestBufferedReadConnProbePreservesDeadline(t *testing.T) {
+	server, client := newAliveTestConn(t, "tcp")
+	if server.probe == nil {
+		t.Skip("nonblocking socket probe unavailable")
+	}
+	require.NoError(t, server.SetReadDeadline(time.Unix(1, 0)))
+	require.Equal(t, 1, server.IsAlive())
+	_, err := client.Write([]byte("x"))
+	require.NoError(t, err)
+	// A raw healthy probe must not clear a deadline belonging to its caller.
+	_, err = server.Read(make([]byte, 1))
+	require.Error(t, err)
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	require.True(t, netErr.Timeout())
+}
+
+func BenchmarkBufferedReadConnIsAlive(b *testing.B) {
+	for _, transport := range []string{"tcp", "unix", "tls", "proxy", "tls-proxy"} {
+		b.Run(transport, func(b *testing.B) {
+			server, _ := newAliveTestConn(b, transport)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if server.IsAlive() == 0 {
+					b.Fatal("healthy connection reported disconnected")
+				}
+			}
+		})
+	}
+}

--- a/pkg/server/internal/util/socket_probe_other.go
+++ b/pkg/server/internal/util/socket_probe_other.go
@@ -1,0 +1,23 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux && !darwin
+
+package util
+
+import "net"
+
+func newConnectionAliveProbe(net.Conn) func() socketProbeState {
+	return nil
+}

--- a/pkg/server/internal/util/socket_probe_unix.go
+++ b/pkg/server/internal/util/socket_probe_unix.go
@@ -1,0 +1,82 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || darwin
+
+package util
+
+import (
+	"net"
+	"syscall"
+)
+
+// socketProbe is owned by one BufferedReadConn and used under its IsAlive mutex.
+// Cache the callback and buffer once per connection to avoid hot-path allocation.
+type socketProbe struct {
+	raw      syscall.RawConn
+	callback func(uintptr)
+	buf      [1]byte
+	state    socketProbeState
+}
+
+func newConnectionAliveProbe(conn net.Conn) func() socketProbeState {
+	var socket syscall.Conn
+	switch c := conn.(type) {
+	case *net.TCPConn:
+		socket = c
+	case *net.UnixConn:
+		if c.LocalAddr().Network() != "unix" {
+			return nil
+		}
+		socket = c
+	default:
+		// The caller resolves known wrappers while preserving their reader.
+		// Arbitrary syscall.Conn implementations may have their own buffers.
+		return nil
+	}
+	raw, err := socket.SyscallConn()
+	if err != nil {
+		return nil
+	}
+	probe := &socketProbe{raw: raw}
+	probe.callback = probe.peek
+	return probe.check
+}
+
+func (p *socketProbe) check() socketProbeState {
+	p.state = socketUnknown
+	// Control keeps the descriptor valid only for the duration of the callback.
+	// MSG_DONTWAIT avoids waiting in the runtime poller or changing socket flags.
+	if err := p.raw.Control(p.callback); err != nil {
+		return socketUnknown
+	}
+	return p.state
+}
+
+func (p *socketProbe) peek(fd uintptr) {
+	n, _, err := syscall.Recvfrom(int(fd), p.buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+	switch {
+	case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
+		p.state = socketIdle
+	case err == nil && n > 0:
+		// Distinguish readable data from an idle socket so wrapped readers
+		// get a chance to decode complete TLS records or protocol errors.
+		p.state = socketReadable
+	case err == nil && n == 0, err == syscall.ECONNRESET, err == syscall.ENOTCONN:
+		p.state = socketClosed
+	default:
+		// Unexpected errors (including EINTR) use the protocol-aware fallback.
+		p.state = socketUnknown
+	}
+}

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3507,6 +3507,109 @@ func TestIssue57531(t *testing.T) {
 	}
 }
 
+func TestClientDisconnectBeforeAutocommit(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	for _, protocol := range []string{"query", "prepared", "execute"} {
+		for _, statement := range []struct {
+			name string
+			sql  string
+			rows string
+		}{
+			{"insert", "insert into disconnect_short values (3, 30), (4, 40)", "1 10\n2 20\n3 30\n4 40"},
+			{"update", "update disconnect_short set v = v + 1", "1 11\n2 21"},
+			{"delete", "delete from disconnect_short", ""},
+		} {
+			for _, disconnect := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/disconnect=%t", protocol, statement.name, disconnect), func(t *testing.T) {
+					ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+						dbt.MustExec("drop table if exists disconnect_short")
+						dbt.MustExec("create table disconnect_short (id int primary key, v int)")
+						dbt.MustExec("insert into disconnect_short values (1, 10), (2, 20)")
+						conn, err := dbt.GetDB().Conn(context.Background())
+						require.NoError(t, err)
+						defer conn.Close()
+						var connID uint64
+						require.NoError(t, conn.QueryRowContext(context.Background(), "select connection_id()").Scan(&connID))
+						netConn := getRawNetConn(t, conn)
+						execSQL := statement.sql
+						var prepared *sql.Stmt
+						if protocol == "prepared" {
+							prepared, err = conn.PrepareContext(context.Background(), execSQL)
+							require.NoError(t, err)
+							defer prepared.Close()
+						} else if protocol == "execute" {
+							_, err = conn.ExecContext(context.Background(), "prepare short_dml from '"+execSQL+"'")
+							require.NoError(t, err)
+							execSQL = "execute short_dml"
+						}
+
+						paused := make(chan *variable.SessionVars, 1)
+						resume := make(chan struct{})
+						var resumeOnce sync.Once
+						release := func() { resumeOnce.Do(func() { close(resume) }) }
+						defer release()
+						testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/session/beforeCheckConnectionAlive", func(vars *variable.SessionVars) {
+							if vars.ConnectionID == connID {
+								paused <- vars
+								<-resume
+								// Isolate the precommit check from both scheduler delays and
+								// the shorter periodic SQLKiller interval in intest builds.
+								vars.StartTime = time.Now()
+							}
+						})
+						done := make(chan error, 1)
+						go func() {
+							var execErr error
+							if prepared != nil {
+								_, execErr = prepared.ExecContext(context.Background())
+							} else {
+								_, execErr = conn.ExecContext(context.Background(), execSQL)
+							}
+							done <- execErr
+						}()
+						var vars *variable.SessionVars
+						select {
+						case vars = <-paused:
+						case <-time.After(10 * time.Second):
+							t.Fatal("DML did not reach the precommit checkpoint")
+						}
+						if disconnect {
+							require.NoError(t, netConn.Close())
+							alive := vars.SQLKiller.IsConnectionAlive.Load()
+							require.NotNil(t, alive)
+							// Observe the socket shutdown without setting a kill signal.
+							require.Eventually(t, func() bool { return !(*alive)() }, 5*time.Second, time.Millisecond)
+						}
+						release()
+						select {
+						case execErr := <-done:
+							if disconnect {
+								require.Error(t, execErr)
+							} else {
+								require.NoError(t, execErr)
+							}
+						case <-time.After(10 * time.Second):
+							t.Fatal("DML did not finish")
+						}
+						expected := statement.rows
+						if disconnect {
+							// The client can report EOF before the server finishes. Wait
+							// for session cleanup before asserting the committed data.
+							require.Eventually(t, func() bool {
+								var count int
+								err := dbt.GetDB().QueryRow("select count(*) from information_schema.processlist where id = ?", connID).Scan(&count)
+								return err == nil && count == 0
+							}, 5*time.Second, time.Millisecond)
+							expected = "1 10\n2 20"
+						}
+						ts.CheckRows(t, dbt.MustQuery("select * from disconnect_short order by id"), expected)
+					})
+				})
+			}
+		}
+	}
+}
+
 func TestClientDisconnectKillsAutocommitInsert(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
 

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -240,6 +240,7 @@ func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.St
 			failpoint.Return(errors.New("occur an error after finishStmt"))
 		}
 	})
+	failpoint.InjectCall("beforeCheckConnectionAlive", sessVars)
 	readOnly := sql.IsReadOnly(sessVars)
 	if !readOnly && meetsErr == nil && shouldCheckConnectionAliveBeforeCommit(sessVars, sql) {
 		sessVars.SQLKiller.CheckConnectionAlive()
@@ -294,16 +295,10 @@ func isLoadDataLocal(sql sqlexec.Statement) bool {
 	return false
 }
 
-// Avoid probing the socket on fast OLTP DML. This matches SQLKiller's normal
-// connection-alive throttle, while still covering long statements that reach
-// the disconnect-before-commit race without hitting another checkpoint.
-const minConnectionAliveCheckBeforeCommitDuration = time.Second
-
+// The final check must not share the execution-time throttle: even a short DML
+// can finish after its client has disconnected without hitting another check.
 func shouldCheckConnectionAliveBeforeCommit(sessVars *variable.SessionVars, sql sqlexec.Statement) bool {
 	if !sessVars.IsAutocommit() || sessVars.InTxn() {
-		return false
-	}
-	if !sessVars.StartTime.IsZero() && time.Since(sessVars.StartTime) < minConnectionAliveCheckBeforeCommitDuration {
 		return false
 	}
 	stmt, err := resolvePreparedStmt(sql.GetStmtNode(), sessVars)

--- a/pkg/session/tidb_test.go
+++ b/pkg/session/tidb_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
@@ -26,14 +27,17 @@ import (
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
+	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	session_metrics "github.com/pingcap/tidb/pkg/session/metrics"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
@@ -51,6 +55,36 @@ import (
 
 type recordingObserver struct {
 	count int
+}
+
+func TestShouldCheckConnectionAliveBeforeCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		node ast.StmtNode
+		want bool
+	}{
+		{"insert", &ast.InsertStmt{}, true},
+		{"update", &ast.UpdateStmt{}, true},
+		{"delete", &ast.DeleteStmt{}, true},
+		{"select", &ast.SelectStmt{}, false},
+		{"commit", &ast.CommitStmt{}, false},
+		{"rollback", &ast.RollbackStmt{}, false},
+		{"ddl", &ast.CreateTableStmt{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := variable.NewSessionVars(nil)
+			stmt := &executor.ExecStmt{StmtNode: tc.node}
+			for _, start := range []time.Time{{}, time.Now(), time.Now().Add(-2 * time.Second)} {
+				vars.StartTime = start
+				require.Equal(t, tc.want, shouldCheckConnectionAliveBeforeCommit(vars, stmt), "start=%v", start)
+			}
+			vars.SetStatusFlag(mysql.ServerStatusInTrans, true)
+			require.False(t, shouldCheckConnectionAliveBeforeCommit(vars, stmt))
+			vars.SetStatusFlag(mysql.ServerStatusInTrans, false)
+			vars.SetStatusFlag(mysql.ServerStatusAutocommit, false)
+			require.False(t, shouldCheckConnectionAliveBeforeCommit(vars, stmt))
+		})
+	}
 }
 
 func (o *recordingObserver) Observe(float64) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #69910

Problem Summary:

The final connection-alive check skips autocommit DML that has run for less than one second. Execution-time checks are also throttled, so a short INSERT, UPDATE, or DELETE can commit after the client has disconnected during execution without observing that disconnection.

Simply removing this exemption would put the existing deadline-based socket probe on every eligible short-DML commit path. On the local macOS benchmark, that probe costs about 40 microseconds per healthy connection check.

### What changed and how does it work?

- Remove the statement-duration exemption from the final check. Preserve the existing autocommit, explicit-transaction, statement-type, and prepared-statement handling. Keep execution-time SQLKiller throttling; do not restore a per-statement monitor goroutine.
- Add a nonblocking `MSG_PEEK | MSG_DONTWAIT` probe for concrete TCP and Unix stream connections on Linux/macOS. Cache the callback and buffer per connection, serialize probes with the existing mutex, and use `RawConn.Control` for descriptor lifetime. Do not consume protocol bytes, change socket blocking flags, or retain a raw descriptor outside the callback.
- Preserve protocol-aware reads for TLS, PROXY protocol, and buffered wrappers. When the underlying socket is idle, an already-expired deadline allows the reader to inspect buffered data or TLS `close_notify` without waiting. Readable/uncertain sockets and unsupported platforms/wrappers retain the timed reader fallback. Known wrappers are resolved once during construction; guarded reflection for go-proxyprotocol's exported `Conn` field stays off the hot path.
- Add deterministic precommit regression tests and socket-level tests covering unread data, reset/EOF, TLS shutdown including buffered close records, TLS/PROXY combinations, unknown wrappers, concurrent probes, allocations, and deadline preservation. Regenerate Bazel metadata.

This restores detection of disconnects observable at the final precommit check. It does not guarantee that a transaction never commits after any client disconnection: a disconnect after the check, or loss of the response after the commit decision, can still leave the client with an unknown outcome.

The separate pessimistic rollback cleanup fix in https://github.com/tikv/client-go/pull/2061 is not included; this PR does not change `go.mod` or `go.sum`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Regression evidence:

- Before the fix, the new session test fails for short INSERT/UPDATE/DELETE, and disconnected DML commits in the new protocol test. Connected controls pass.
- After the fix, all 18 protocol cases pass: query/binary prepared/text EXECUTE, INSERT/UPDATE/DELETE, and connected/disconnected controls. The protocol test pauses immediately before the final check, observes socket shutdown without setting a kill signal, and waits for server session cleanup before asserting the committed rows. Resetting the statement start time at the checkpoint makes the short-DML regression deterministic despite scheduling delays and `intest` polling.
- The final protocol regression plus existing long-DML, explicit-transaction, and result-set cancellation tests passed three repetitions. Socket race tests passed 20 repetitions. Existing TLS and undetermined-result rollback tests also passed.

Local validation commands, using Go 1.25.12 on macOS/arm64 (the failpoint wrapper enables `intest,deadlock` by default and disables instrumentation on exit):

```bash
export GOPROXY=https://proxy.golang.org,direct
export GOTOOLCHAIN=go1.25.12
make bazel_prepare
./tools/check/failpoint-go-test.sh pkg/session -run '^TestShouldCheckConnectionAliveBeforeCommit$' -count=1
./tools/check/failpoint-go-test.sh pkg/server/tests/commontest -run '^(TestClientDisconnectBeforeAutocommit|TestClientDisconnectKillsAutocommitInsert|TestClientDisconnectKillsExplicitTxn|TestIssue57531)$' -count=3
./tools/check/failpoint-go-test.sh pkg/server/tests/tls -run '^(TestTLSBasic|TestErrorNoRollback)$' -count=1
go test -race ./pkg/server/internal/util -run '^TestBufferedReadConn' -count=20
go test -race ./pkg/server/internal/util -count=1
go test ./pkg/server/internal/util -run '^$' -bench BenchmarkBufferedReadConn -benchmem -benchtime=500ms -count=5
make lint
GOFLAGS=-p=4 make server TARGET=../tidb-69910-fixed
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -p=4 -c -o ../69910-util-linux.test ./pkg/server/internal/util
git diff --check
```

All commands above completed successfully. Linux was cross-compiled, not executed. `make bazel_prepare` exited 0 and generated the metadata, but its update-repos step reported the existing unsupported local parser-module replacement; no `DEPS.bzl` change resulted. macOS race linking emitted an `LC_DYSYMTAB` warning.

Additional non-passing diagnostic: running the new protocol test with `-tags=deadlock` (without `intest`) passes its SQL assertions but fails TestMain's final goleak check on `memory.(*MemArbitrator).asyncRun.func1`. The unrelated existing `TestWarningForParseError` reproduces the same shutdown failure with those tags. Neither command is counted as passing; no leak suppression or unrelated memory-subsystem change is included.

Manual real-TiKV verification: 36/36 cases passed using the production TiDB binary built from this patch (no `intest`, race, or failpoint instrumentation) with PD/TiKV v8.5.7. Steps:

1. Start a disposable TiUP playground using the new TiDB binary and `[security] auto-tls = true`.
2. Create `test.disconnect_69910(id INT PRIMARY KEY, v INT)` with rows `(1,10),(2,20)`.
3. Run each statement below from a separate `mysql` process, both with `--ssl-mode=DISABLED` and `--ssl-mode=REQUIRED`. Confirm that TLS actually negotiates a nonempty cipher.
   ```sql
   INSERT INTO test.disconnect_69910 VALUES (3,SLEEP(0.3)),(4,40);
   UPDATE test.disconnect_69910 SET v=v+1+SLEEP(0.3);
   DELETE FROM test.disconnect_69910 WHERE SLEEP(0.3)=0;
   ```
4. For disconnected cases, observe the writer's connection ID and statement in `information_schema.processlist`, then SIGKILL only that mysql process. Wait until its server session disappears before reading the table. Each statement must preserve the two original rows.
5. Reset the table and repeat without disconnecting. INSERT must add both rows, UPDATE must produce `(1,11),(2,21)`, and DELETE must leave no rows.
6. Repeat the TCP/TLS, three-statement, connected/disconnected matrix three times. All 36 cases passed. Stop the disposable playground and clean up its data afterward.

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

The performance boxes are checked conservatively: short statements previously skipped the probe entirely, whereas this change adds a probe and cached per-connection state. They do not represent a measured cluster-QPS regression. No cluster-level zero-regression claim is made.

Healthy `IsAlive` microbenchmark on Apple M4 Pro, macOS/arm64, Go 1.25.12 (baseline: three 300ms runs; patched: five 500ms runs):

| Transport | Baseline time/probe | Patched time/probe | Patched allocations/probe |
| --- | ---: | ---: | ---: |
| TCP | 38.98–40.67 us | 0.275–0.280 us | 0 B, 0 allocations |
| Unix stream | 40.98–41.39 us | 0.265–0.273 us | 0 B, 0 allocations |
| TLS | 40.58–41.03 us | 0.443–0.446 us | 104 B, 2 allocations |
| PROXY | 40.52–41.29 us | 0.391–0.400 us | 80 B, 1 allocation |
| TLS+PROXY | Not measured in the same baseline batch | 0.443–0.459 us | 104 B, 2 allocations |

These numbers compare one probe, not SQL throughput. Linux sysbench/QPS/P99 comparisons remain to be performed; wrapped readers still allocate, and unsupported transports retain the timed fallback. A release-8.5 backport has not been validated by this PR.

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where short autocommit INSERT, UPDATE, or DELETE statements could commit after a client disconnect during execution because the final connection-alive check was skipped.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of client disconnects across TCP, Unix socket, TLS, and proxy connections.
  - Prevents qualifying autocommit data changes from being committed when the client disconnects before completion.
  - More reliably distinguishes active, idle, closed, and reset connections.
  - Preserves buffered data and read deadlines while checking connection status.
  - Connection checks now occur consistently for applicable autocommit statements, improving transaction safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->