### PR TITLE
ddl: fix clustered global indexes after partition exchange

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -92,9 +92,10 @@ const (
 )
 
 var (
-	jobV2FirstVer        = *semver.New("8.4.0")
-	globalIdxV1FirstVer  = *semver.New("8.5.6")
-	detectJobVerInterval = 10 * time.Second
+	jobV2FirstVer                = *semver.New("8.4.0")
+	globalIdxV1FirstVer          = *semver.New("8.5.6")
+	clusteredGlobalIdxV1FirstVer = *semver.New("8.5.8")
+	detectJobVerInterval         = 10 * time.Second
 )
 
 // StartMode is an enum type for the start mode of the DDL.
@@ -984,6 +985,7 @@ func (d *ddl) detectAndUpdateJobVersion() {
 			model.SetJobVerInUse(model.JobVersion2)
 		}
 		model.SetGlobalIndexV1Supported(true)
+		model.SetClusteredGlobalIndexV1Supported(true)
 		return
 	}
 
@@ -992,13 +994,15 @@ func (d *ddl) detectAndUpdateJobVersion() {
 		logutil.DDLLogger().Warn("detect job version failed", zap.String("err", err.Error()))
 	}
 
-	if model.GetJobVerInUse() == model.JobVersion2 && model.GetGlobalIndexV1Supported() {
+	if model.GetJobVerInUse() == model.JobVersion2 && model.GetGlobalIndexV1Supported() &&
+		model.GetClusteredGlobalIndexV1Supported() {
 		return
 	}
 
-	logutil.DDLLogger().Info("job version in use is not v2 or global index v1 not supported, maybe in upgrade, start detecting",
+	logutil.DDLLogger().Info("job version in use is not v2 or a global index v1 variant is not supported, maybe in upgrade, start detecting",
 		zap.Stringer("current", model.GetJobVerInUse()),
-		zap.Bool("globalIndexV1Supported", model.GetGlobalIndexV1Supported()))
+		zap.Bool("globalIndexV1Supported", model.GetGlobalIndexV1Supported()),
+		zap.Bool("clusteredGlobalIndexV1Supported", model.GetClusteredGlobalIndexV1Supported()))
 	d.wg.RunWithLog(func() {
 		ticker := time.NewTicker(detectJobVerInterval)
 		defer ticker.Stop()
@@ -1013,8 +1017,9 @@ func (d *ddl) detectAndUpdateJobVersion() {
 				logutil.SampleLogger().Warn("detect job version failed", zap.String("err", err.Error()))
 			}
 			failpoint.InjectCall("afterDetectAndUpdateJobVersionOnce")
-			if model.GetJobVerInUse() == model.JobVersion2 && model.GetGlobalIndexV1Supported() {
-				logutil.DDLLogger().Info("job version in use is v2 and global index v1 supported now, stop detecting")
+			if model.GetJobVerInUse() == model.JobVersion2 && model.GetGlobalIndexV1Supported() &&
+				model.GetClusteredGlobalIndexV1Supported() {
+				logutil.DDLLogger().Info("job version in use is v2 and all global index v1 variants are supported now, stop detecting")
 				return
 			}
 		}
@@ -1023,7 +1028,8 @@ func (d *ddl) detectAndUpdateJobVersion() {
 
 // when all TiDB instances have version >= 8.4.0, we can use job version 2, otherwise
 // we should use job version 1 to keep compatibility.
-// Also checks whether all instances support global index V1 key format (>= 8.5.6).
+// Also checks whether all instances support global index V1 key format (>= 8.5.6)
+// and its clustered-table variant (>= 8.5.8).
 func (d *ddl) detectAndUpdateJobVersionOnce() error {
 	infos, err := infosync.GetAllServerInfo(d.ctx)
 	if err != nil {
@@ -1031,6 +1037,7 @@ func (d *ddl) detectAndUpdateJobVersionOnce() error {
 	}
 	allSupportV2 := true
 	allSupportGlobalIdxV1 := true
+	allSupportClusteredGlobalIdxV1 := true
 	for _, info := range infos {
 		// we don't store TiDB version directly, but concatenated with a MySQL version,
 		// separated by mysql.VersionSeparator.
@@ -1039,6 +1046,7 @@ func (d *ddl) detectAndUpdateJobVersionOnce() error {
 		if idx < 0 {
 			allSupportV2 = false
 			allSupportGlobalIdxV1 = false
+			allSupportClusteredGlobalIdxV1 = false
 			// see https://github.com/pingcap/tidb/issues/31823
 			logutil.SampleLogger().Warn("unknown server version, might be changed directly in config",
 				zap.String("version", tidbVer))
@@ -1050,6 +1058,7 @@ func (d *ddl) detectAndUpdateJobVersionOnce() error {
 		if err2 != nil {
 			allSupportV2 = false
 			allSupportGlobalIdxV1 = false
+			allSupportClusteredGlobalIdxV1 = false
 			logutil.SampleLogger().Warn("parse server version failed", zap.String("version", info.Version),
 				zap.String("err", err2.Error()))
 			break
@@ -1063,7 +1072,10 @@ func (d *ddl) detectAndUpdateJobVersionOnce() error {
 		if ver.LessThan(globalIdxV1FirstVer) {
 			allSupportGlobalIdxV1 = false
 		}
-		if !allSupportV2 && !allSupportGlobalIdxV1 {
+		if ver.LessThan(clusteredGlobalIdxV1FirstVer) {
+			allSupportClusteredGlobalIdxV1 = false
+		}
+		if !allSupportV2 && !allSupportGlobalIdxV1 && !allSupportClusteredGlobalIdxV1 {
 			break
 		}
 	}
@@ -1082,6 +1094,12 @@ func (d *ddl) detectAndUpdateJobVersionOnce() error {
 			zap.Bool("old", model.GetGlobalIndexV1Supported()),
 			zap.Bool("new", allSupportGlobalIdxV1))
 		model.SetGlobalIndexV1Supported(allSupportGlobalIdxV1)
+	}
+	if model.GetClusteredGlobalIndexV1Supported() != allSupportClusteredGlobalIdxV1 {
+		logutil.DDLLogger().Info("change clustered global index V1 support",
+			zap.Bool("old", model.GetClusteredGlobalIndexV1Supported()),
+			zap.Bool("new", allSupportClusteredGlobalIdxV1))
+		model.SetClusteredGlobalIndexV1Supported(allSupportClusteredGlobalIdxV1)
 	}
 	return nil
 }

--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -511,12 +511,14 @@ func TestDetectAndUpdateJobVersion(t *testing.T) {
 	reset := func() {
 		model.SetJobVerInUse(model.JobVersion1)
 		model.SetGlobalIndexV1Supported(false)
+		model.SetClusteredGlobalIndexV1Supported(false)
 	}
 	t.Cleanup(reset)
 	// other ut in the same address space might change it
 	reset()
 	require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 	require.False(t, model.GetGlobalIndexV1Supported())
+	require.False(t, model.GetClusteredGlobalIndexV1Supported())
 
 	t.Run("in ut", func(t *testing.T) {
 		reset()
@@ -527,6 +529,7 @@ func TestDetectAndUpdateJobVersion(t *testing.T) {
 			require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 		}
 		require.True(t, model.GetGlobalIndexV1Supported())
+		require.True(t, model.GetClusteredGlobalIndexV1Supported())
 	})
 
 	d.etcdCli = &clientv3.Client{}
@@ -544,13 +547,24 @@ func TestDetectAndUpdateJobVersion(t *testing.T) {
 		testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/serverinfo/mockGetAllServerInfo", inTerms)
 	}
 
-	t.Run("all support v2 and global index v1", func(t *testing.T) {
+	t.Run("all support v2 and global index v1 but not clustered global index v1", func(t *testing.T) {
 		reset()
-		mockGetAllServerInfo(t, "8.0.11-TiDB-v8.5.6-alpha-228-g650888fea7-dirty",
-			"8.0.11-TiDB-v9.0.0", "8.0.11-TiDB-8.5.6-beta")
+		mockGetAllServerInfo(t, "8.0.11-TiDB-v8.5.7-alpha-228-g650888fea7-dirty",
+			"8.0.11-TiDB-v9.0.0", "8.0.11-TiDB-8.5.8-beta")
 		d.detectAndUpdateJobVersionOnce()
 		require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 		require.True(t, model.GetGlobalIndexV1Supported())
+		require.False(t, model.GetClusteredGlobalIndexV1Supported())
+	})
+
+	t.Run("all support clustered global index v1", func(t *testing.T) {
+		reset()
+		mockGetAllServerInfo(t, "8.0.11-TiDB-v8.5.8-alpha-228-g650888fea7-dirty",
+			"8.0.11-TiDB-v9.0.0", "8.0.11-TiDB-8.5.8-beta")
+		d.detectAndUpdateJobVersionOnce()
+		require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
+		require.True(t, model.GetGlobalIndexV1Supported())
+		require.True(t, model.GetClusteredGlobalIndexV1Supported())
 	})
 
 	t.Run("all support v2 but not global index v1", func(t *testing.T) {
@@ -559,6 +573,7 @@ func TestDetectAndUpdateJobVersion(t *testing.T) {
 		d.detectAndUpdateJobVersionOnce()
 		require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 		require.False(t, model.GetGlobalIndexV1Supported())
+		require.False(t, model.GetClusteredGlobalIndexV1Supported())
 	})
 
 	t.Run("v1 first, later all support v2 and global index v1", func(t *testing.T) {
@@ -576,41 +591,54 @@ func TestDetectAndUpdateJobVersion(t *testing.T) {
 			if iterateCnt == 1 {
 				require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// user set version explicitly in config
 				mockGetAllServerInfo(t, "9.0.0-xxx")
 			} else if iterateCnt == 2 {
 				require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// invalid version
 				mockGetAllServerInfo(t, "xxx")
 			} else if iterateCnt == 3 {
 				require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// less than 8.4.0
 				mockGetAllServerInfo(t, "8.0.11-TiDB-8.3.0")
 			} else if iterateCnt == 4 {
 				require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// upgrade case
 				mockGetAllServerInfo(t, "8.0.11-TiDB-v8.3.0", "8.0.11-TiDB-v8.3.0", "8.0.11-TiDB-v8.4.0")
 			} else if iterateCnt == 5 {
 				require.Equal(t, model.JobVersion1, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// all support job v2 but not global index v1
 				mockGetAllServerInfo(t, "8.0.11-TiDB-v8.4.0", "8.0.11-TiDB-v8.4.0", "8.0.11-TiDB-v8.4.0")
 			} else if iterateCnt == 6 {
 				require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 				require.False(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
 				// upgrade to version supporting global index v1
 				mockGetAllServerInfo(t, "8.0.11-TiDB-v8.5.6", "8.0.11-TiDB-v8.5.6", "8.0.11-TiDB-v8.5.6")
+			} else if iterateCnt == 7 {
+				require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
+				require.True(t, model.GetGlobalIndexV1Supported())
+				require.False(t, model.GetClusteredGlobalIndexV1Supported())
+				// upgrade to version supporting clustered global index v1
+				mockGetAllServerInfo(t, "8.0.11-TiDB-v8.5.8", "8.0.11-TiDB-v8.5.8", "8.0.11-TiDB-v8.5.8")
 			} else {
 				require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 				require.True(t, model.GetGlobalIndexV1Supported())
+				require.True(t, model.GetClusteredGlobalIndexV1Supported())
 			}
 		})
 		d.detectAndUpdateJobVersion()
 		d.wg.Wait()
-		require.EqualValues(t, 7, iterateCnt)
+		require.EqualValues(t, 8, iterateCnt)
 	})
 }
 
@@ -618,14 +646,28 @@ func TestSetGlobalIndexVersionFlag(t *testing.T) {
 	tblInfo := &model.TableInfo{} // non-clustered (zero value)
 	idxInfo := &model.IndexInfo{Global: true, Unique: false}
 
+	originGlobalIdxV1 := model.GetGlobalIndexV1Supported()
+	originClusteredGlobalIdxV1 := model.GetClusteredGlobalIndexV1Supported()
 	model.SetGlobalIndexV1Supported(false)
-	t.Cleanup(func() { model.SetGlobalIndexV1Supported(false) })
+	model.SetClusteredGlobalIndexV1Supported(false)
+	t.Cleanup(func() {
+		model.SetGlobalIndexV1Supported(originGlobalIdxV1)
+		model.SetClusteredGlobalIndexV1Supported(originClusteredGlobalIdxV1)
+	})
 
 	setGlobalIndexVersion(tblInfo, idxInfo)
 	require.Equal(t, uint8(0), idxInfo.GlobalIndexVersion)
 
 	model.SetGlobalIndexV1Supported(true)
 	setGlobalIndexVersion(tblInfo, idxInfo)
+	require.Equal(t, model.GlobalIndexVersionV1, idxInfo.GlobalIndexVersion)
+
+	clusteredTblInfo := &model.TableInfo{PKIsHandle: true}
+	setGlobalIndexVersion(clusteredTblInfo, idxInfo)
+	require.Equal(t, model.GlobalIndexVersionLegacy, idxInfo.GlobalIndexVersion)
+
+	model.SetClusteredGlobalIndexV1Supported(true)
+	setGlobalIndexVersion(clusteredTblInfo, idxInfo)
 	require.Equal(t, model.GlobalIndexVersionV1, idxInfo.GlobalIndexVersion)
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -347,35 +347,39 @@ func getIndexColumnLength(col *model.ColumnInfo, colLen int, columnarIndexType m
 }
 
 // Set global index version for new global indexes.
-// Version 1 is needed for non-clustered tables to prevent collisions after
-// EXCHANGE PARTITION due to duplicate _tidb_rowid values.
+// Version 1 is needed to prevent collisions after EXCHANGE PARTITION when
+// different partitions contain duplicate handles.
 // For non-unique indexes, the handle is always encoded in the key.
 // For unique indexes with NULL values, the handle is also encoded in the key
 // (since NULL != NULL, multiple NULLs are allowed).
 // In both cases, we need the partition ID in the key to distinguish rows
-// from different partitions that may have the same _tidb_rowid.
-// Clustered tables don't have this issue and use version 0.
+// from different partitions that may have the same handle.
 func setGlobalIndexVersion(tblInfo *model.TableInfo, idxInfo *model.IndexInfo) {
 	idxInfo.GlobalIndexVersion = 0
-	if !model.GetGlobalIndexV1Supported() {
+	if !idxInfo.Global {
 		return
 	}
-	if idxInfo.Global && !tblInfo.HasClusteredIndex() {
-		needPartitionInKey := !idxInfo.Unique
-		if !needPartitionInKey {
-			nullCols := getNullColInfos(tblInfo, idxInfo.Columns)
-			if len(nullCols) > 0 {
-				needPartitionInKey = true
+	supported := model.GetGlobalIndexV1Supported()
+	if tblInfo.HasClusteredIndex() {
+		supported = model.GetClusteredGlobalIndexV1Supported()
+	}
+	if !supported {
+		return
+	}
+	needPartitionInKey := !idxInfo.Unique
+	if !needPartitionInKey {
+		nullCols := getNullColInfos(tblInfo, idxInfo.Columns)
+		if len(nullCols) > 0 {
+			needPartitionInKey = true
+		}
+	}
+	if needPartitionInKey {
+		idxInfo.GlobalIndexVersion = model.GlobalIndexVersionV1
+		failpoint.Inject("SetGlobalIndexVersion", func(val failpoint.Value) {
+			if valInt, ok := val.(int); ok {
+				idxInfo.GlobalIndexVersion = uint8(valInt)
 			}
-		}
-		if needPartitionInKey {
-			idxInfo.GlobalIndexVersion = model.GlobalIndexVersionV1
-			failpoint.Inject("SetGlobalIndexVersion", func(val failpoint.Value) {
-				if valInt, ok := val.(int); ok {
-					idxInfo.GlobalIndexVersion = uint8(valInt)
-				}
-			})
-		}
+		})
 	}
 }
 
@@ -2496,6 +2500,7 @@ type baseIndexWorker struct {
 
 type addIndexTxnWorker struct {
 	baseIndexWorker
+	physicalID int64
 
 	// The following attributes are used to reduce memory allocation.
 	idxKeyBufs         [][]byte
@@ -2534,6 +2539,7 @@ func newAddIndexTxnWorker(
 	rowDecoder := decoder.NewRowDecoder(t, t.WritableCols(), decodeColMap)
 
 	return &addIndexTxnWorker{
+		physicalID: t.GetPhysicalID(),
 		baseIndexWorker: baseIndexWorker{
 			backfillCtx: bfCtx,
 			indexes:     allIndexes,
@@ -2665,8 +2671,8 @@ func (w *baseIndexWorker) fetchRowColVals(txn kv.Transaction, taskRange reorgBac
 				actualHandle := handle
 				// For global indexes V1+ on partitioned tables, we need to wrap the handle
 				// with the partition ID to create a PartitionHandle.
-				// This is critical for non-clustered tables after EXCHANGE PARTITION,
-				// where duplicate _tidb_rowid values exist across partitions.
+				// This is critical after EXCHANGE PARTITION, where duplicate handles
+				// can exist across partitions.
 				// Legacy indexes (version 0) don't use PartitionHandle in the key.
 				if index.Meta().Global && index.Meta().GlobalIndexVersion >= model.GlobalIndexVersionV1 {
 					actualHandle = kv.NewPartitionHandle(taskRange.physicalTable.GetPhysicalID(), handle)
@@ -2714,6 +2720,11 @@ func (w *addIndexTxnWorker) checkHandleExists(idxInfo *model.IndexInfo, key kv.K
 	h, err := tablecodec.DecodeIndexHandle(key, value, idxColLen)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if idxInfo.Global {
+		if _, ok := handle.(kv.PartitionHandle); !ok {
+			handle = kv.NewPartitionHandle(w.physicalID, handle)
+		}
 	}
 	hasBeenBackFilled := h.Equal(handle)
 	if hasBeenBackFilled {

--- a/pkg/ddl/integration_test.go
+++ b/pkg/ddl/integration_test.go
@@ -257,12 +257,15 @@ func TestJobVersionAndGlobalIndexV1SupportForNextGen(t *testing.T) {
 
 	originJobVer := model.GetJobVerInUse()
 	originGlobalIdxV1 := model.GetGlobalIndexV1Supported()
+	originClusteredGlobalIdxV1 := model.GetClusteredGlobalIndexV1Supported()
 	t.Cleanup(func() {
 		model.SetJobVerInUse(originJobVer)
 		model.SetGlobalIndexV1Supported(originGlobalIdxV1)
+		model.SetClusteredGlobalIndexV1Supported(originClusteredGlobalIdxV1)
 	})
 	require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 	require.True(t, model.GetGlobalIndexV1Supported())
+	require.True(t, model.GetClusteredGlobalIndexV1Supported())
 
 	serverInfos := map[string]*serverinfo.ServerInfo{
 		"node0": {
@@ -310,7 +313,8 @@ func TestJobVersionAndGlobalIndexV1SupportForNextGen(t *testing.T) {
 	require.NoError(t, newDDL.Stop())
 
 	// The only meaningful assert in this test. It makes sure that the JobVersion is 2
-	// and the global index v1 is always supported for next-gen cluster.
+	// and both global index v1 variants are always supported for next-gen cluster.
 	require.Equal(t, model.JobVersion2, model.GetJobVerInUse())
 	require.True(t, model.GetGlobalIndexV1Supported())
+	require.True(t, model.GetClusteredGlobalIndexV1Supported())
 }

--- a/pkg/ddl/tests/partition/global_index_version_test.go
+++ b/pkg/ddl/tests/partition/global_index_version_test.go
@@ -105,7 +105,8 @@ func TestGlobalIndexVersion0(t *testing.T) {
 	require.Equal(t, model.GlobalIndexVersionLegacy, globalIdx.GlobalIndexVersion,
 		"Global index should have version %d", model.GlobalIndexVersionLegacy)
 
-	// Create a non-global index and unique global index and verify they have version 0
+	// Create a local index and a nullable unique global index and verify their
+	// respective versions.
 	tk.MustExec("CREATE INDEX idx_a ON tp(a)")
 	tk.MustExec(`CREATE UNIQUE INDEX idx_ab ON tp(a,b) GLOBAL`)
 
@@ -137,7 +138,8 @@ func TestGlobalIndexVersion0(t *testing.T) {
 	require.Equal(t, model.GlobalIndexVersionV1, globalIdx.GlobalIndexVersion,
 		"Global index should have version %d", model.GlobalIndexVersionV1)
 
-	// Verify that clustered tables get V0 global indexes
+	// Verify that clustered tables get V1 global indexes after the separate
+	// clustered-table capability gate is enabled.
 	tk.MustExec(`CREATE TABLE tpc (
 		a INT,
 		b INT,
@@ -161,8 +163,8 @@ func TestGlobalIndexVersion0(t *testing.T) {
 	}
 	require.NotNil(t, globalIdx, "Global index idx_b not found")
 	require.True(t, globalIdx.Global, "Index should be global")
-	require.Equal(t, model.GlobalIndexVersionLegacy, globalIdx.GlobalIndexVersion,
-		"Global index should have version %d", model.GlobalIndexVersionLegacy)
+	require.Equal(t, model.GlobalIndexVersionV1, globalIdx.GlobalIndexVersion,
+		"Global index should have version %d", model.GlobalIndexVersionV1)
 }
 
 // TestGlobalIndexVersion1 tests that global indexes are created with version V1.
@@ -268,6 +270,73 @@ func TestGlobalIndexVersionConstants(t *testing.T) {
 	require.Equal(t, uint8(0), model.GlobalIndexVersionLegacy)
 	require.Equal(t, uint8(1), model.GlobalIndexVersionV1)
 	require.Equal(t, uint8(2), model.GlobalIndexVersionV2)
+}
+
+func TestIssue70932ClusteredGlobalIndexes(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("USE test")
+	tk.MustExec("SET @@tidb_enable_exchange_partition = 1")
+	tk.MustExec("SET GLOBAL tidb_enable_dist_task = 0")
+	tk.MustExec("SET GLOBAL tidb_ddl_enable_fast_reorg = 0")
+	t.Cleanup(func() {
+		tk.MustExec("SET GLOBAL tidb_enable_dist_task = 1")
+		tk.MustExec("SET GLOBAL tidb_ddl_enable_fast_reorg = 1")
+	})
+	originClusteredGlobalIdxV1 := model.GetClusteredGlobalIndexV1Supported()
+	t.Cleanup(func() {
+		model.SetClusteredGlobalIndexV1Supported(originClusteredGlobalIdxV1)
+	})
+
+	tk.MustExec(`CREATE TABLE t (
+		a INT,
+		b INT,
+		c VARCHAR(20) NOT NULL,
+		PRIMARY KEY (a, b) CLUSTERED
+	) PARTITION BY RANGE (b) (
+		PARTITION p0 VALUES LESS THAN (10),
+		PARTITION p1 VALUES LESS THAN MAXVALUE
+	)`)
+	tk.MustExec("INSERT INTO t VALUES (1, 1, 'x')")
+	tk.MustExec("CREATE TABLE tx LIKE t")
+	tk.MustExec("ALTER TABLE tx REMOVE PARTITIONING")
+	tk.MustExec("INSERT INTO tx VALUES (1, 1, 'x')")
+	tk.MustExec("ALTER TABLE t EXCHANGE PARTITION p1 WITH TABLE tx WITHOUT VALIDATION")
+
+	model.SetClusteredGlobalIndexV1Supported(false)
+	tk.MustContainErrMsg("ALTER TABLE t ADD UNIQUE KEY ug(c) GLOBAL", "Duplicate entry")
+
+	model.SetClusteredGlobalIndexV1Supported(true)
+	// A unique index whose columns are all NOT NULL remains legacy even after
+	// the clustered V1 gate opens. Its duplicate check must still use the full
+	// (partition ID, handle) identity.
+	tk.MustContainErrMsg("ALTER TABLE t ADD UNIQUE KEY ug(c) GLOBAL", "Duplicate entry")
+
+	tk.MustExec("ALTER TABLE t ADD INDEX idx_c(c) GLOBAL")
+	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx_c)").Check(testkit.Rows("2"))
+	tk.MustQuery("SELECT COUNT(*) FROM t IGNORE INDEX(idx_c)").Check(testkit.Rows("2"))
+	tk.MustExec("ADMIN CHECK TABLE t")
+
+	tk.MustExec("ALTER TABLE t DROP INDEX idx_c")
+	tk.MustExec("SET GLOBAL tidb_ddl_enable_fast_reorg = 1")
+	tk.MustExec("ALTER TABLE t ADD INDEX idx_c_fast(c) GLOBAL")
+	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(idx_c_fast)").Check(testkit.Rows("2"))
+	tk.MustQuery("SELECT COUNT(*) FROM t IGNORE INDEX(idx_c_fast)").Check(testkit.Rows("2"))
+	tk.MustExec("ADMIN CHECK TABLE t")
+
+	tk.MustExec("ALTER TABLE t ADD COLUMN d INT")
+	tk.MustExec("ALTER TABLE t ADD UNIQUE KEY ug_d(d) GLOBAL")
+	tk.MustQuery("SELECT COUNT(*) FROM t USE INDEX(ug_d)").Check(testkit.Rows("2"))
+	tk.MustExec("ADMIN CHECK TABLE t")
+
+	dom := domain.GetDomain(tk.Session())
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	for _, indexName := range []string{"idx_c_fast", "ug_d"} {
+		idx := tbl.Meta().FindIndexByName(indexName)
+		require.NotNil(t, idx)
+		require.Equal(t, model.GlobalIndexVersionV1, idx.GlobalIndexVersion)
+	}
 }
 
 // TestGlobalIndexTruncateAndDropPartition verifies that TRUNCATE PARTITION and

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -49,17 +49,15 @@ const (
 
 	// GlobalIndexVersion constants define the key format versions for global indexes.
 	// GlobalIndexVersionLegacy is the legacy format (version 0) where partition ID is not in the key.
-	// This format has a bug with duplicate handles after EXCHANGE PARTITION on non-clustered tables.
+	// This format can collide when EXCHANGE PARTITION leaves duplicate handles across partitions.
 	// See https://github.com/pingcap/tidb/issues/65289
 	GlobalIndexVersionLegacy uint8 = 0
 	// GlobalIndexVersionV1 is the current format (version 1) where partition ID is encoded in the key
-	// for global indexes on non-clustered tables to prevent key collisions
-	// after EXCHANGE PARTITION.
+	// for global indexes to prevent key collisions after EXCHANGE PARTITION.
 	// Applies to non-unique indexes (handle always in key) and unique indexes with nullable
 	// columns (handle in key when any indexed value is NULL, since NULL != NULL).
 	// For unique global indexes where all columns are NOT NULL, version 0 is used since
 	// uniqueness alone prevents collisions.
-	// For clustered tables, common handles already include partition-specific data.
 	// Notice that for V1 the partition id is still in the value part as well,
 	// for decreasing the risk of issues changing the read code path for various index reads.
 	GlobalIndexVersionV1 uint8 = 1
@@ -74,6 +72,11 @@ const (
 // being created during rolling upgrades where old nodes cannot handle V1 format.
 var globalIndexV1Supported atomic.Bool
 
+// clusteredGlobalIndexV1Supported tracks whether all TiDB nodes in the cluster support
+// GlobalIndexVersionV1 key encoding for clustered tables. Clustered-table support has
+// its own gate because it was introduced after V1 support for non-clustered tables.
+var clusteredGlobalIndexV1Supported atomic.Bool
+
 // SetGlobalIndexV1Supported sets whether GlobalIndexVersionV1 is supported
 // by all nodes in the cluster.
 func SetGlobalIndexV1Supported(supported bool) {
@@ -84,6 +87,18 @@ func SetGlobalIndexV1Supported(supported bool) {
 // by all nodes in the cluster.
 func GetGlobalIndexV1Supported() bool {
 	return globalIndexV1Supported.Load()
+}
+
+// SetClusteredGlobalIndexV1Supported sets whether GlobalIndexVersionV1 for clustered
+// tables is supported by all nodes in the cluster.
+func SetClusteredGlobalIndexV1Supported(supported bool) {
+	clusteredGlobalIndexV1Supported.Store(supported)
+}
+
+// GetClusteredGlobalIndexV1Supported returns whether GlobalIndexVersionV1 for
+// clustered tables is supported by all nodes in the cluster.
+func GetClusteredGlobalIndexV1Supported() bool {
+	return clusteredGlobalIndexV1Supported.Load()
 }
 
 // GenUniqueChangingIndexName generates a unique index name for the changing index.
@@ -571,9 +586,10 @@ func FindIndexColumnByName(indexCols []*IndexColumn, nameL string) (int, *IndexC
 func init() {
 	if kerneltype.IsNextGen() {
 		// For now, we don't need to detect job version and global index v1 support for NextGen
-		// as they are always V2 and support global index v1.
+		// as they are always V2 and support both global index v1 variants.
 		// To keep align with the logic of `JobVersion`, we set it in the init function of model
 		// package. The `JobVersion` is set in the init function of `job.go`.
 		SetGlobalIndexV1Supported(true)
+		SetClusteredGlobalIndexV1Supported(true)
 	}
 }

--- a/pkg/meta/model/index_test.go
+++ b/pkg/meta/model/index_test.go
@@ -101,5 +101,6 @@ func TestIsIndexPrefixCovered(t *testing.T) {
 func TestGlobalIndexV1SupportedForNextGen(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		require.True(t, GetGlobalIndexV1Supported())
+		require.True(t, GetClusteredGlobalIndexV1Supported())
 	}
 }

--- a/pkg/tablecodec/BUILD.bazel
+++ b/pkg/tablecodec/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":tablecodec"],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/kv",
         "//pkg/meta/model",

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -68,7 +68,7 @@ const (
 	CommonHandleFlag byte = 127
 	// PartitionIDFlag is the flag used to decode the partition ID.
 	// Used in both global index values and global index keys (for V1+ non-unique indexes).
-	// In keys: PartitionIDFlag + partition_id (8 bytes) + inner_handle_encoded (IntHandle)
+	// In keys: PartitionIDFlag + partition_id (8 bytes) + encoded inner handle
 	// In values: PartitionIDFlag + partition_id (8 bytes)
 	PartitionIDFlag byte = 126
 	// IndexVersionFlag is the flag used to decode the index's version info.
@@ -1260,12 +1260,9 @@ func GenIndexKey(enc codec.Encoder, loc *time.Location, tblInfo *model.TableInfo
 	if !distinct && h != nil {
 		// For PartitionHandle on global indexes V1+, we must encode BOTH partition ID and inner handle
 		// in the key to prevent collisions when different partitions have duplicate handles.
-		// This is critical after EXCHANGE PARTITION, which can create duplicate _tidb_rowid values.
+		// This is critical after EXCHANGE PARTITION, which can create duplicate handles.
 		// Only use the new format for version >= V1. Legacy indexes (version 0) use the old format.
 		if idxInfo.GlobalIndexVersion >= model.GlobalIndexVersionV1 {
-			if tblInfo.HasClusteredIndex() {
-				return nil, false, errors.New("clustered index is not supported in GlobalIndexVersionV1+")
-			}
 			ph, ok := h.(kv.PartitionHandle)
 			if !ok {
 				return nil, false, errors.New("handle is not a PartitionHandle in GlobalIndexVersionV1+")
@@ -1970,8 +1967,9 @@ func decodeIndexKvForClusteredIndexVersion1(useNewCollate bool, key, value []byt
 		// In unique common handle index.
 		handle, err = kv.NewCommonHandle(segs.CommonHandle)
 	} else {
-		// In non-unique index, decode handle in keySuffix.
-		handle, err = kv.NewCommonHandle(keySuffix)
+		// In non-unique index, decode the handle, including a possible partition ID,
+		// from keySuffix.
+		handle, err = decodeHandleInIndexKey(keySuffix)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/tablecodec/tablecodec_test.go
+++ b/pkg/tablecodec/tablecodec_test.go
@@ -986,3 +986,92 @@ func TestUniqueGlobalIndexKeyWithNullValues(t *testing.T) {
 			"legacy (v0) global index key should NOT contain partition ID flag")
 	}
 }
+
+func TestClusteredGlobalIndexV1HandleInKey(t *testing.T) {
+	const (
+		tableID     int64 = 100
+		partitionID int64 = 42
+	)
+
+	commonHandleBytes, err := codec.EncodeKey(time.UTC, nil, types.NewIntDatum(7), types.NewStringDatum("pk"))
+	require.NoError(t, err)
+	commonHandle, err := kv.NewCommonHandle(commonHandleBytes)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name    string
+		handle  kv.Handle
+		tblInfo *model.TableInfo
+	}{
+		{
+			name:   "int handle",
+			handle: kv.IntHandle(99),
+			tblInfo: &model.TableInfo{
+				ID: tableID, PKIsHandle: true,
+				Columns: []*model.ColumnInfo{{ID: 1, Name: ast.NewCIStr("c"), FieldType: *types.NewFieldType(mysql.TypeLong)}},
+			},
+		},
+		{
+			name:   "common handle",
+			handle: commonHandle,
+			tblInfo: &model.TableInfo{
+				ID: tableID, IsCommonHandle: true, CommonHandleVersion: 1,
+				Columns: []*model.ColumnInfo{{ID: 1, Name: ast.NewCIStr("c"), FieldType: *types.NewFieldType(mysql.TypeLong)}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			idxInfo := &model.IndexInfo{
+				ID: 1, Name: ast.NewCIStr("idx_c"), Global: true,
+				GlobalIndexVersion: model.GlobalIndexVersionV1,
+				Columns:            []*model.IndexColumn{{Name: ast.NewCIStr("c"), Offset: 0, Length: types.UnspecifiedLength}},
+			}
+			indexedValues := []types.Datum{types.NewIntDatum(123)}
+			partitionHandle := kv.NewPartitionHandle(partitionID, testCase.handle)
+
+			key, distinct, err := GenIndexKey(defaultCodecEncoder(), time.UTC, testCase.tblInfo, idxInfo,
+				tableID, indexedValues, partitionHandle, nil)
+			require.NoError(t, err)
+			require.False(t, distinct)
+
+			expectedSuffix := []byte{PartitionIDFlag}
+			expectedSuffix = codec.EncodeInt(expectedSuffix, partitionID)
+			if testCase.handle.IsInt() {
+				expectedSuffix = append(expectedSuffix, codec.IntHandleFlag)
+				expectedSuffix = codec.EncodeInt(expectedSuffix, testCase.handle.IntValue())
+			} else {
+				expectedSuffix = append(expectedSuffix, testCase.handle.Encoded()...)
+			}
+			require.Equal(t, expectedSuffix, key[len(key)-len(expectedSuffix):])
+
+			value, err := GenIndexValuePortal(false, time.UTC, testCase.tblInfo, idxInfo, false, false, false,
+				indexedValues, testCase.handle, partitionID, nil, nil)
+			require.NoError(t, err)
+			decodedHandle, err := DecodeIndexHandle(key, value, len(idxInfo.Columns))
+			require.NoError(t, err)
+			decodedPartitionHandle, ok := decodedHandle.(kv.PartitionHandle)
+			require.True(t, ok)
+			require.Equal(t, partitionID, decodedPartitionHandle.PartitionID)
+			require.True(t, decodedPartitionHandle.Handle.Equal(testCase.handle))
+
+			if !testCase.handle.IsInt() {
+				columns := []rowcodec.ColInfo{
+					{ID: 1, Ft: types.NewFieldType(mysql.TypeLong)},
+					{ID: 2, Ft: types.NewFieldType(mysql.TypeLong)},
+					{ID: 3, Ft: types.NewFieldType(mysql.TypeVarchar)},
+					{ID: model.ExtraPhysTblID, Ft: types.NewFieldType(mysql.TypeLonglong)},
+				}
+				decodedValues, err := DecodeIndexKV(key, value, len(idxInfo.Columns), HandleDefault, columns)
+				require.NoError(t, err)
+				require.Len(t, decodedValues, 4)
+				require.Equal(t, testCase.handle.EncodedCol(0), decodedValues[1])
+				require.Equal(t, testCase.handle.EncodedCol(1), decodedValues[2])
+				partitionIDBytes, err := codec.EncodeValue(time.UTC, nil, types.NewIntDatum(partitionID))
+				require.NoError(t, err)
+				require.Equal(t, partitionIDBytes, decodedValues[3])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue Number: close #70932

Problem Summary:

`EXCHANGE PARTITION ... WITHOUT VALIDATION` can leave equal clustered primary-key handles in different physical partitions.

When a unique global index is added through the legacy transactional backfill path, the duplicate check compares the decoded partition handle of an existing index entry with the inner handle of the current row. It can therefore mistake two rows from different partitions for the same row, skip one entry, and publish an incomplete index.

Non-unique global indexes and nullable unique global-index entries have a related key-collision problem. Their keys contain the indexed values and row handle, but clustered tables were excluded from `GlobalIndexVersionV1`, so the physical partition ID was not available to distinguish equal handles from different partitions. Index scans can then return fewer rows than table scans, and `ADMIN CHECK TABLE` reports error 8223.

### What changed and how does it work?

- Extend the `GlobalIndexVersionV1` key format introduced by #65380 to clustered partitioned tables. Every non-distinct global-index entry is encoded as `<indexed-values><PartitionIDFlag><partition-ID><encoded-inner-handle>`, supporting both `IntHandle` and `CommonHandle`.
- Decode the partition-aware CommonHandle suffix through the existing partition-handle decoder instead of treating `PartitionIDFlag` as part of the CommonHandle.
- Make the legacy global unique-index duplicate check normalize both the existing and current row identities to `PartitionHandle`, so it always compares the complete `(partitionID, handle)` pair.
- Add an independent clustered-global-index V1 capability gate. New clustered V1 global indexes are created only after every TiDB node is at least v8.5.8. The existing v8.5.6 gate for non-clustered V1 global indexes is unchanged.
- Add regression coverage for legacy and fast-reorg add-index paths, nullable unique global indexes, exact IntHandle/CommonHandle key encoding, the v8.5.7/v8.5.8 version boundary, and `ADMIN CHECK TABLE` consistency.

For V1 non-distinct entries, the key grows by 9 bytes: one byte for `PartitionIDFlag` and eight bytes for the partition ID.

Compatibility note: distributed CommonHandle index scans require a companion TiKV decoder change to strip the partition-ID prefix before decoding the CommonHandle. This TiDB change must not be shipped without the corresponding TiKV change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `./tools/check/failpoint-go-test.sh pkg/tablecodec -run '^(TestDecodeIndexHandleWithPartitionIDInKeyAndValue|TestUniqueGlobalIndexKeyWithNullValues|TestClusteredGlobalIndexV1HandleInKey)$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ddl -run '^(TestDetectAndUpdateJobVersion|TestSetGlobalIndexVersionFlag)$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/ddl/tests/partition -run '^(TestGlobalIndexVersion0|TestGlobalIndexVersion1|TestIssue70932ClusteredGlobalIndexes)$' -count=1`
  - `./tools/check/failpoint-go-test.sh pkg/meta/model -run '^TestGlobalIndexV1SupportedForNextGen$' -count=1`
  - `make lint`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue where adding a global index to a clustered partitioned table after `EXCHANGE PARTITION ... WITHOUT VALIDATION` could create an incomplete index and cause `ADMIN CHECK TABLE` to report an inconsistency.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clustered tables can now use the Global Index V1 format when all database instances support it.
  - Global indexes preserve partition and row-handle information for clustered tables, including integer and common handles.

- **Bug Fixes**
  - Improved duplicate detection for unique global indexes across partitions, including partition exchange scenarios.
  - Added compatibility checks to prevent unsupported instances from using the clustered Global Index V1 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->