### PR TITLE
ddl: reject orphan child rows when referenced key contains NULL

### DIFF
--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -686,38 +686,31 @@ func checkForeignKeyConstrain(
 	}()
 
 	var buf strings.Builder
-	buf.WriteString("select 1 from %n.%n where ")
-	paramsList := make([]any, 0, 4+len(fkInfo.Cols)*2)
+	buf.WriteString("select 1 from %n.%n as c where ")
+	paramsList := make([]any, 0, 4+len(fkInfo.Cols)*3)
 	paramsList = append(paramsList, schema, table)
 	for i, col := range fkInfo.Cols {
 		if i == 0 {
-			buf.WriteString("%n is not null")
+			buf.WriteString("c.%n is not null")
 			paramsList = append(paramsList, col.L)
 		} else {
-			buf.WriteString(" and %n is not null")
+			buf.WriteString(" and c.%n is not null")
 			paramsList = append(paramsList, col.L)
 		}
 	}
-	buf.WriteString(" and (")
-	for i, col := range fkInfo.Cols {
-		if i == 0 {
-			buf.WriteString("%n")
-		} else {
-			buf.WriteString(",%n")
-		}
-		paramsList = append(paramsList, col.L)
-	}
-	buf.WriteString(") not in (select ")
-	for i, col := range fkInfo.RefCols {
-		if i == 0 {
-			buf.WriteString("%n")
-		} else {
-			buf.WriteString(",%n")
-		}
-		paramsList = append(paramsList, col.L)
-	}
-	buf.WriteString(" from %n.%n ) limit 1")
+	// Use a correlated NOT EXISTS anti-join instead of NOT IN. If the referenced
+	// key contains NULL, NOT IN can evaluate to UNKNOWN for an orphan child row,
+	// so the child row would not be reported as a constraint violation.
+	buf.WriteString(" and not exists (select 1 from %n.%n as r where ")
 	paramsList = append(paramsList, fkInfo.RefSchema.L, fkInfo.RefTable.L)
+	for i, refCol := range fkInfo.RefCols {
+		if i > 0 {
+			buf.WriteString(" and ")
+		}
+		buf.WriteString("r.%n = c.%n")
+		paramsList = append(paramsList, refCol.L, fkInfo.Cols[i].L)
+	}
+	buf.WriteString(") limit 1")
 	rows, _, err := sctx.GetRestrictedSQLExecutor().ExecRestrictedSQL(
 		ctx,
 		[]sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession},

--- a/pkg/ddl/tests/fk/foreign_key_test.go
+++ b/pkg/ddl/tests/fk/foreign_key_test.go
@@ -1217,6 +1217,34 @@ func TestAddForeignKey(t *testing.T) {
 	tk.MustExec("insert into t1 values (1, 10);")
 	tk.MustExec("insert into t2 values (1, 10);")
 	tk.MustGetDBError("insert into t2 values (2, 20)", plannererrors.ErrNoReferencedRow2)
+
+	// Test adding a foreign key rejects orphan child rows even when the
+	// referenced key contains NULL values.
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int key, business_key int, unique key uk_business_key(business_key));")
+	tk.MustExec("create table t2 (id int key, parent_key int, index idx_parent_key(parent_key));")
+	tk.MustExec("insert into t1 values (1, 1), (2, null);")
+	tk.MustExec("insert into t2 values (1, 1), (2, 2);")
+	tk.MustGetErrCode("alter table t2 add constraint fk_parent foreign key (parent_key) references t1(business_key)", 1452)
+	tbl2Info = getTableInfo(t, dom, "test", "t2")
+	require.Equal(t, 0, len(tbl2Info.ForeignKeys))
+
+	// Control: a NULL child key is exempt, and every non-NULL child key has a match.
+	tk.MustExec("delete from t2 where parent_key = 2;")
+	tk.MustExec("insert into t2 values (2, null);")
+	tk.MustExec("alter table t2 add constraint fk_parent foreign key (parent_key) references t1(business_key)")
+	tbl2Info = getTableInfo(t, dom, "test", "t2")
+	require.Equal(t, 1, len(tbl2Info.ForeignKeys))
+
+	// Test the composite-key case with a NULL component in the referenced key.
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int key, a int, b int, unique key uk_ab(a, b));")
+	tk.MustExec("create table t2 (id int key, x int, y int, index idx_xy(x, y));")
+	tk.MustExec("insert into t1 values (1, 1, 1), (2, 2, null);")
+	tk.MustExec("insert into t2 values (1, 1, 1), (2, 2, 2);")
+	tk.MustGetErrCode("alter table t2 add constraint fk_xy foreign key (x, y) references t1(a, b)", 1452)
+	tbl2Info = getTableInfo(t, dom, "test", "t2")
+	require.Equal(t, 0, len(tbl2Info.ForeignKeys))
 }
 
 func TestAlterTableAddForeignKeyError(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #70102

Problem Summary:

`checkForeignKeyConstrain` validated existing child rows with `child_tuple NOT IN (SELECT referenced_tuple ...)`. If the referenced key contains NULL, SQL three-valued logic makes the `NOT IN` predicate UNKNOWN for an orphan child row. As a result, `ALTER TABLE ... ADD FOREIGN KEY` could succeed and publish a constraint while a historical orphan row remained.

### What changed and how does it work?

Replace the `NOT IN` predicate with a correlated `NOT EXISTS` anti-join. Aliases are used for both the child and referenced tables so the generated SQL also works for self-referencing foreign keys. The query still exempts child rows that contain a NULL foreign-key column. An orphan child row is now reported even when the referenced key contains NULL, so the existing error 1452 path is used.

Added regression coverage in `TestAddForeignKey` for a nullable referenced key and a composite referenced key containing NULL. The new assertions fail before this fix and pass after it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that `ADD FOREIGN KEY` could publish a constraint while historical orphan child rows remained when the referenced key contains NULL
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved foreign-key validation for referenced keys containing `NULL` values.
  - Correctly identifies orphan rows for both single-column and composite foreign keys.
  - Preserves valid behavior for child rows with `NULL` foreign-key values.
  - Failed foreign-key additions no longer leave behind foreign-key metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->