### PR TITLE
executor, session: support MemTable/Lock RU and close results on commit failure

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -293,12 +293,30 @@ func (a *recordSet) Finish() error {
 }
 
 func (a *recordSet) Close() error {
+	return a.close(nil)
+}
+
+func (a *recordSet) close(lastErr error) error {
 	err := a.Finish()
 	if err != nil {
 		logutil.BgLogger().Error("close recordSet error", zap.Error(err))
 	}
-	a.stmt.CloseRecordSet(a.txnStartTS, errors.Join(a.lastErrs...))
+	a.stmt.CloseRecordSet(a.txnStartTS, errors.Join(errors.Join(a.lastErrs...), lastErr))
 	return err
+}
+
+// CloseRecordSetWithError closes an executor-owned record set and passes the
+// execution error to statement completion, including slow logs and RU accounting.
+func CloseRecordSetWithError(rs sqlexec.RecordSet, lastErr error) error {
+	switch rs := rs.(type) {
+	case *recordSet:
+		return rs.close(lastErr)
+	case *chunkRowRecordSet:
+		rs.execStmt.CloseRecordSet(rs.execStmt.Ctx.GetSessionVars().TxnCtx.StartTS, lastErr)
+		return nil
+	default:
+		return rs.Close()
+	}
 }
 
 // OnFetchReturned implements commandLifeCycle#OnFetchReturned
@@ -1907,6 +1925,7 @@ func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
 
 // CloseRecordSet will finish the execution of current statement and do some record work
 func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) {
+	failpoint.InjectCall("observeCloseRecordSetForTest", a, &lastErr)
 	a.FinishExecuteStmt(txnStartTS, lastErr, false)
 	a.logAudit()
 	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()

--- a/pkg/executor/statement_ru_plan_walk.go
+++ b/pkg/executor/statement_ru_plan_walk.go
@@ -752,6 +752,17 @@ func calculateStatementRUPlanChildFirst(
 		if !addStatementRUCPUWork(calculator, float64(children[0].outputRows)) {
 			return statementRUOperatorResult{state: statementRUOperatorInvalid}
 		}
+	case *physicalop.PhysicalMemTable:
+		// Memory-table access has no modeled self units. Its observed output
+		// still supplies input rows to parent operators.
+		if !operator.IsRoot || len(children) != 0 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
+	case *physicalop.PhysicalLock:
+		// Lock has no modeled self units; the child retains its read work.
+		if !operator.IsRoot || len(children) != 1 {
+			return statementRUOperatorResult{state: statementRUOperatorUnsupported}
+		}
 	case *physicalop.PhysicalTableDual:
 		// TableDual has zero modeled self RU. Runtime evidence, rather than the
 		// optimizer estimate, distinguishes its actual zero/one output for a

--- a/pkg/executor/statement_ru_plan_walk_integration_test.go
+++ b/pkg/executor/statement_ru_plan_walk_integration_test.go
@@ -488,6 +488,7 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 			wantJoinOutput bool
 			wantRootAndCop bool
 		}{
+			{name: "MemTable", query: "select concat(table_name, '') from information_schema.tables where table_schema = 'test' and table_name = 't'", rows: testkit.Rows("t"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalMemTable], wantPublish: true, wantCPUWork: true},
 			{name: "Selection", query: "select * from t ignore index (idx_b) where b > 10", rows: testkit.Rows("2 20 200", "3 30 300"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSelection], sortRows: true, wantPublish: true, wantCPUWork: true},
 			{name: "Sort", query: "select * from t ignore index (idx_b) order by b desc", rows: testkit.Rows("3 30 300", "2 20 200", "1 10 100"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalSort], wantPublish: true, wantCPUWork: true},
 			{name: "TopN", query: "select * from t ignore index (idx_b) order by b desc limit 2", rows: testkit.Rows("3 30 300", "2 20 200"), expectOperator: isStatementRUPlanType[*physicalop.PhysicalTopN], wantPublish: true, wantCPUWork: true},
@@ -524,7 +525,8 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 				calibrationMu.Lock()
 				calibration = calibrationObservation{}
 				calibrationMu.Unlock()
-				result := tk.MustQuery(tc.query)
+				// Execute once: MustQuery replays information_schema queries to test extractors.
+				result := tk.MustQueryWithContext(context.Background(), tc.query)
 				if tc.sortRows {
 					result = result.Sort()
 				}
@@ -602,6 +604,65 @@ func TestStatementRUResultSetTerminalOutcomes(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("Lock supports RU explain without changing statement eligibility", func(t *testing.T) {
+		store := testkit.CreateMockStore(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("create table lock_ru(a int primary key, b int)")
+		tk.MustExec("insert into lock_ru values (1, 10), (2, 20)")
+		for _, mode := range []string{"optimistic", "pessimistic"} {
+			t.Run(mode, func(t *testing.T) {
+				tk.MustExec("begin " + mode)
+				defer tk.MustExec("rollback")
+				rows := tk.MustQuery("explain analyze format='ru' select * from lock_ru where a >= 1 for update").Rows()
+				require.NotEmpty(t, rows)
+				require.Contains(t, rows[0][0], "SelectLock")
+				for _, row := range rows {
+					require.NotEmpty(t, row[3], "missing RU for Lock tree: %v", rows)
+				}
+			})
+		}
+	})
+
+	t.Run("explain analyze commit failure closes record set", func(t *testing.T) {
+		store := testkit.CreateMockStore(t)
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("use test")
+		tk.MustExec("create table commit_failure(a int primary key, b int)")
+		tk.MustExec("insert into commit_failure values (1, 10)")
+		tk.MustExec("set tidb_retry_limit = 0")
+		var observation *statementRUObservation
+		testfailpoint.EnableCall(t, statementRUOwnerInstallFailpoint, func(stmt *executor.ExecStmt) {
+			if stmt.Ctx == tk.Session() {
+				observation = observeInstalledStatementRUOwner(stmt)
+			}
+		})
+		var closeCount int
+		var terminalErr error
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/observeCloseRecordSetForTest", func(stmt *executor.ExecStmt, err *error) {
+			if stmt.Ctx == tk.Session() {
+				closeCount++
+				terminalErr = *err
+			}
+		})
+		t.Run("injected commit error", func(t *testing.T) {
+			testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/session/mockCommitError8942", "return(true)")
+			rs, err := tk.Exec("explain analyze update commit_failure set b = b + 1 where a = 1")
+			require.Error(t, err)
+			require.Nil(t, rs)
+			require.Equal(t, 1, closeCount)
+			require.EqualError(t, terminalErr, err.Error())
+			require.NotNil(t, observation)
+			// EXPLAIN ANALYZE DML has no production RU owner under current policy.
+			require.Nil(t, observation.owner)
+			vars := tk.Session().GetSessionVars()
+			require.Nil(t, vars.StmtCtx.CTEStorageMap)
+			require.Nil(t, vars.MemTracker.SearchTrackerWithoutLock(vars.StmtCtx.MemTracker.Label()))
+			require.Nil(t, vars.DiskTracker.SearchTrackerWithoutLock(vars.StmtCtx.DiskTracker.Label()))
+		})
+		tk.MustQuery("select b from commit_failure where a = 1").Check(testkit.Rows("10"))
 	})
 
 	t.Run("post-compile panic consumes owner", func(t *testing.T) {

--- a/pkg/executor/statement_ru_plan_walk_test.go
+++ b/pkg/executor/statement_ru_plan_walk_test.go
@@ -160,6 +160,26 @@ func (observation *StatementRUOwnerObservationForTest) RecordedSuccessForTest() 
 }
 
 func TestStatementRUCalculationTraversal(t *testing.T) {
+	t.Run("MemTable and Lock preserve child work", func(t *testing.T) {
+		ctx := mock.NewContext()
+		memTable := physicalop.PhysicalMemTable{}.Init(ctx, &property.StatsInfo{}, 0)
+		projection := physicalop.PhysicalProjection{Exprs: []expression.Expression{&expression.Column{}}}.Init(ctx, &property.StatsInfo{}, 0)
+		lock := physicalop.PhysicalLock{}.Init(ctx, &property.StatsInfo{}, nil)
+		projection.SetChildren(memTable)
+		lock.SetChildren(projection)
+		tree := plannercore.FlattenPhysicalPlan(lock, false).Main
+		for _, rows := range []int{0, 3} {
+			coll := execdetails.NewRuntimeStatsColl(nil)
+			for _, operator := range tree {
+				coll.GetBasicRuntimeStats(operator.Origin.ID(), true).Record(0, rows)
+			}
+			calculator := &statementRUCalculator{}
+			result := calculateStatementRUPlanChildFirst(tree, 0, coll, calculator, 10, statementRURawUnits{}, nil)
+			require.Equal(t, statementRUOperatorComplete, result.state)
+			require.EqualValues(t, rows, result.outputRows)
+			require.Equal(t, statementRURawUnits{CPUWork: float64(rows), OperatorNum: 3}, calculator.units)
+		}
+	})
 	t.Run("DML requires typed processed work", func(t *testing.T) {
 		ctx := mock.NewContext()
 		plan := physicalop.Insert{}.Init(ctx)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3118,6 +3118,11 @@ func runStmt(ctx context.Context, se *session, s sqlexec.Statement) (rs sqlexec.
 			if !sessVars.InTxn() {
 				se.StmtCommit(ctx)
 				if err := se.CommitTxn(ctx); err != nil {
+					s.(*executor.ExecStmt).RecordStatementRUFinalOutcome(false)
+					if closeErr := executor.CloseRecordSetWithError(rs, err); closeErr != nil {
+						logutil.Logger(ctx).Error("close EXPLAIN ANALYZE DML record set after commit error failed",
+							zap.Error(closeErr), zap.NamedError("commitError", err))
+					}
 					return nil, err
 				}
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70445

Problem Summary:

Statement RU calculation rejects MemTable and Lock nodes instead of preserving their descendants' modeled work. Separately, when autocommit fails after EXPLAIN ANALYZE DML has created a record set, the session returns the error without closing that record set or completing statement cleanup.

### What changed and how does it work?

- Handle root MemTable and Lock nodes with zero modeled self units, retaining output-row evidence and descendant work.
- Close the executor-owned record set with the original commit error before returning it. Reuse executor/CTE cleanup and statement completion, and record any close error separately.
- Extend existing tests for zero/nonzero input rows, MemTable publication, Lock RU EXPLAIN in optimistic and pessimistic transactions, and commit-failure close count, error forwarding, tracker detachment, and rollback.

Existing production RU eligibility remains unchanged: SELECT FOR UPDATE and EXPLAIN ANALYZE DML do not acquire a production RU owner. Lock compatibility is exercised through EXPLAIN ANALYZE FORMAT='ru'.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Ready validation passed:

```sh
make bazel_prepare
make lint
./tools/check/failpoint-go-test.sh pkg/executor -run 'TestStatementRU(CalculationTraversal|ResultSetTerminalOutcomes)$' -count=1
./tools/check/failpoint-go-test.sh pkg/session -run 'Test(RUV2MetricsIsolatedPerStatementInExplicitTxn|ScalarSubqueryRegistryTxnReplay)$' -count=1
(cd tests/integrationtest && ./run-tests.sh -t executor/explain)
git diff --check
```

Regression checks failed before the fix and passed afterward. The SQL integration suite passed 120 cases using a race-enabled server. Failpoints were disabled after package tests. Independent maintainability and quality reviews found no actionable issues. RealTiKV and performance benchmarks were not run.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support MemTable and Lock nodes in statement RU calculation and close EXPLAIN ANALYZE DML result sets when autocommit fails.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved RU calculation for memory-table access and row-lock operations, preserving work from child operators.
  * `EXPLAIN ANALYZE` now reports RU details for `FOR UPDATE` queries in both optimistic and pessimistic modes.

* **Bug Fixes**
  * Improved handling of commit failures during `EXPLAIN ANALYZE` DML statements, ensuring resources are closed and execution outcomes are recorded correctly.
  * Added coverage for information schema queries and related RU calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->