### PR TITLE
br/pkg/streamhelper: stabilize flaky tests

### DIFF
--- a/br/pkg/streamhelper/subscription_test.go
+++ b/br/pkg/streamhelper/subscription_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/br/pkg/streamhelper"
 	"github.com/pingcap/tidb/br/pkg/streamhelper/spans"
@@ -32,6 +33,33 @@ func installSubscribeSupportForRandomN(c *fakeCluster, n int) {
 	}
 }
 
+func waitEvents(t *testing.T, sub *streamhelper.FlushSubscriber, expected int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(sub.Events()) >= expected
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+// collectCheckpointSpans drains the subscription events until the observed
+// spans cover the checkpoint. Waiting for the events to be delivered avoids the
+// race where the subscription has not pushed all events yet when the test
+// drains the channel (see pingcap/tidb#52791, #67839).
+func collectCheckpointSpans(t *testing.T, sub *streamhelper.FlushSubscriber, checkpoint uint64) *spans.ValueSortedFull {
+	t.Helper()
+	observed := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case event := <-sub.Events():
+				observed.Merge(event)
+			default:
+				return observed.MinValue() >= checkpoint
+			}
+		}
+	}, 3*time.Second, 100*time.Millisecond)
+	return observed
+}
+
 func TestSubBasic(t *testing.T) {
 	req := require.New(t)
 	ctx := context.Background()
@@ -47,11 +75,8 @@ func TestSubBasic(t *testing.T) {
 	}
 	sub.HandleErrors(ctx)
 	req.NoError(sub.PendingErrors())
+	s := collectCheckpointSpans(t, sub, cp)
 	sub.Drop()
-	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
-	for k := range sub.Events() {
-		s.Merge(k)
-	}
 	defer func() {
 		if t.Failed() {
 			fmt.Println(c)
@@ -59,7 +84,7 @@ func TestSubBasic(t *testing.T) {
 		}
 	}()
 
-	req.Equal(cp, s.MinValue(), "%d vs %d", cp, s.MinValue())
+	req.GreaterOrEqual(s.MinValue(), cp, "s.MinValue() = %d, cp = %d", s.MinValue(), cp)
 }
 
 func TestNormalError(t *testing.T) {
@@ -81,11 +106,8 @@ func TestNormalError(t *testing.T) {
 		cp = c.advanceCheckpoints()
 		c.flushAll()
 	}
+	s := collectCheckpointSpans(t, sub, cp)
 	sub.Drop()
-	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
-	for k := range sub.Events() {
-		s.Merge(k)
-	}
 	req.Equal(cp, s.MinValue(), "%d vs %d", cp, s.MinValue())
 }
 
@@ -155,11 +177,8 @@ func TestStoreRemoved(t *testing.T) {
 	sub.HandleErrors(ctx)
 	req.NoError(sub.PendingErrors())
 
+	s := collectCheckpointSpans(t, sub, cp)
 	sub.Drop()
-	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
-	for k := range sub.Events() {
-		s.Merge(k)
-	}
 
 	defer func() {
 		if t.Failed() {
@@ -168,12 +187,13 @@ func TestStoreRemoved(t *testing.T) {
 		}
 	}()
 
-	req.Equal(cp, s.MinValue(), "cp = %d, s = %d", cp, s.MinValue())
+	req.GreaterOrEqual(s.MinValue(), cp, "s.MinValue() = %d, cp = %d", s.MinValue(), cp)
 }
 
 func TestSomeOfStoreUnsupported(t *testing.T) {
 	req := require.New(t)
 	ctx := context.Background()
+	const flushRounds = 10
 	c := createFakeCluster(t, 4, true)
 	c.splitAndScatter("0001", "0002", "0003", "0008", "0009", "0010", "0100", "0956", "1000")
 
@@ -181,13 +201,28 @@ func TestSomeOfStoreUnsupported(t *testing.T) {
 	installSubscribeSupportForRandomN(c, 3)
 	req.NoError(sub.UpdateStoreTopology(ctx))
 
+	supportedStores := make(map[uint64]struct{})
+	for _, store := range c.stores {
+		if store.supportsSub {
+			supportedStores[store.id] = struct{}{}
+		}
+	}
+	expectedEventsPerFlush := 0
+	for _, region := range c.regions {
+		if _, ok := supportedStores[region.leader]; ok {
+			expectedEventsPerFlush++
+		}
+	}
+
 	var cp uint64
-	for i := 0; i < 10; i++ {
+	for i := 0; i < flushRounds; i++ {
 		cp = c.advanceCheckpoints()
 		c.flushAll()
 	}
 	s := spans.Sorted(spans.NewFullWith(spans.Full(), 1))
 	m := new(sync.Mutex)
+
+	waitEvents(t, sub, expectedEventsPerFlush*flushRounds)
 	sub.Drop()
 	for k := range sub.Events() {
 		s.Merge(k)


### PR DESCRIPTION
### What problem does this PR solve?

Manual backport to `release-7.1` of the `br/pkg/streamhelper` flaky-test stabilization that already landed on master.

On release-7.1 these tests drain `sub.Events()` right after `sub.Drop()` without waiting for the subscription to finish delivering events, so `s.MinValue()` can be greater than the latest checkpoint and the assertion fails. This is flaky on the release-7.1 CI (observed in `ghpr_unit_test`): `TestSubBasic` (`subscription_test.go:62`) and `TestStoreRemoved` (`subscription_test.go:171`).

Backported from master:

- #67954 `br/pkg/streamhelper: stabilize flaky TestStoreRemoved`
- #69264 `test: stabilize flaky TestSomeOfStoreUnsupported`
- #67859 `br/pkg/streamhelper: stabilize flaky TestSubBasic`
- #70054 `test: stabilize flaky TestNormalError`

Issue Number: ref #52791, ref #52792, ref #67839, ref #67741

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved subscription test reliability by waiting for events to be delivered before collecting results.
  * Updated checkpoint assertions to accommodate values that meet or exceed the expected checkpoint.
  * Added coverage for event counts across supported stores during flush operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->