### PR TITLE
br: deprecate pitr support batch kv files

### DIFF
--- a/br/pkg/restore/log_client/BUILD.bazel
+++ b/br/pkg/restore/log_client/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "//br/pkg/utils",
         "//br/pkg/utils/consts",
         "//br/pkg/utils/iter",
-        "//br/pkg/version",
         "//pkg/ddl/util",
         "//pkg/domain",
         "//pkg/infoschema",

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -60,7 +60,6 @@ import (
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/br/pkg/utils/consts"
 	"github.com/pingcap/tidb/br/pkg/utils/iter"
-	"github.com/pingcap/tidb/br/pkg/version"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -979,37 +978,6 @@ func ApplyKVFilesWithBatchMethod(
 	return nil
 }
 
-func ApplyKVFilesWithSingleMethod(
-	ctx context.Context,
-	files LogIter,
-	applyFunc func(file []*LogDataFileInfo, kvCount int64, size uint64),
-	applyWg *sync.WaitGroup,
-) error {
-	deleteKVFiles := make([]*LogDataFileInfo, 0)
-
-	for r := files.TryNext(ctx); !r.Finished; r = files.TryNext(ctx) {
-		if r.Err != nil {
-			return r.Err
-		}
-
-		f := r.Item
-		if f.GetType() == backuppb.FileType_Delete {
-			deleteKVFiles = append(deleteKVFiles, f)
-			continue
-		}
-		applyFunc([]*LogDataFileInfo{f}, f.GetNumberOfEntries(), f.GetLength())
-	}
-
-	applyWg.Wait()
-	log.Info("restore delete files", zap.Int("count", len(deleteKVFiles)))
-	for _, file := range deleteKVFiles {
-		f := file
-		applyFunc([]*LogDataFileInfo{f}, f.GetNumberOfEntries(), f.GetLength())
-	}
-
-	return nil
-}
-
 func (rc *LogClient) RestoreKVFiles(
 	ctx context.Context,
 	rules map[int64]*restoreutils.RewriteRules,
@@ -1022,11 +990,10 @@ func (rc *LogClient) RestoreKVFiles(
 	masterKeys []*encryptionpb.MasterKey,
 ) error {
 	var (
-		err          error
-		fileCount    = 0
-		start        = time.Now()
-		supportBatch = version.CheckPITRSupportBatchKVFiles()
-		skipFile     = 0
+		err       error
+		fileCount = 0
+		start     = time.Now()
+		skipFile  = 0
 	)
 	defer func() {
 		if err == nil {
@@ -1111,17 +1078,13 @@ func (rc *LogClient) RestoreKVFiles(
 				}()
 
 				return rc.logRestoreManager.fileImporter.ImportKVFiles(ectx, files, rule, rc.shiftStartTS, rc.startTS, rc.restoreTS,
-					supportBatch, cipherInfo, masterKeys)
+					cipherInfo, masterKeys)
 			})
 		}
 	}
 
 	rc.logRestoreManager.workerPool.ApplyOnErrorGroup(eg, func() error {
-		if supportBatch {
-			err = ApplyKVFilesWithBatchMethod(ectx, logIter, int(pitrBatchCount), uint64(pitrBatchSize), applyFunc, &applyWg)
-		} else {
-			err = ApplyKVFilesWithSingleMethod(ectx, logIter, applyFunc, &applyWg)
-		}
+		err = ApplyKVFilesWithBatchMethod(ectx, logIter, int(pitrBatchCount), uint64(pitrBatchSize), applyFunc, &applyWg)
 		return errors.Trace(err)
 	})
 

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -881,59 +881,6 @@ func toLogDataFileInfoIter(logIter iter.TryNextor[*backuppb.DataFileInfo]) logcl
 	})
 }
 
-func TestApplyKVFilesWithSingelMethod(t *testing.T) {
-	var (
-		totalKVCount int64  = 0
-		totalSize    uint64 = 0
-		logs                = make([]string, 0)
-	)
-	ds := []*backuppb.DataFileInfo{
-		{
-			Path:            "log3",
-			NumberOfEntries: 5,
-			Length:          100,
-			Cf:              consts.WriteCF,
-			Type:            backuppb.FileType_Delete,
-		},
-		{
-			Path:            "log1",
-			NumberOfEntries: 5,
-			Length:          100,
-			Cf:              consts.DefaultCF,
-			Type:            backuppb.FileType_Put,
-		}, {
-			Path:            "log2",
-			NumberOfEntries: 5,
-			Length:          100,
-			Cf:              consts.WriteCF,
-			Type:            backuppb.FileType_Put,
-		},
-	}
-	var applyWg sync.WaitGroup
-	applyFunc := func(
-		files []*logclient.LogDataFileInfo,
-		kvCount int64,
-		size uint64,
-	) {
-		totalKVCount += kvCount
-		totalSize += size
-		for _, f := range files {
-			logs = append(logs, f.GetPath())
-		}
-	}
-
-	logclient.ApplyKVFilesWithSingleMethod(
-		context.TODO(),
-		toLogDataFileInfoIter(iter.FromSlice(ds)),
-		applyFunc,
-		&applyWg,
-	)
-
-	require.Equal(t, totalKVCount, int64(15))
-	require.Equal(t, totalSize, uint64(300))
-	require.Equal(t, logs, []string{"log1", "log2", "log3"})
-}
-
 func TestApplyKVFilesWithBatchMethod1(t *testing.T) {
 	var (
 		runCount            = 0
@@ -1341,17 +1288,6 @@ func TestApplyKVFilesWithBatchMethod5(t *testing.T) {
 		toLogDataFileInfoIter(iter.FromSlice(ds)),
 		2,
 		1500,
-		applyFunc,
-		&applyWg,
-	)
-
-	applyWg.Wait()
-	require.Equal(t, backuppb.FileType_Delete, types[len(types)-1])
-
-	types = make([]backuppb.FileType, 0)
-	logclient.ApplyKVFilesWithSingleMethod(
-		context.TODO(),
-		toLogDataFileInfoIter(iter.FromSlice(ds)),
 		applyFunc,
 		&applyWg,
 	)

--- a/br/pkg/restore/log_client/import.go
+++ b/br/pkg/restore/log_client/import.go
@@ -103,7 +103,6 @@ func (importer *LogFileImporter) ImportKVFiles(
 	shiftStartTS uint64,
 	startTS uint64,
 	restoreTS uint64,
-	supportBatch bool,
 	cipherInfo *backuppb.CipherInfo,
 	masterKeys []*encryptionpb.MasterKey,
 ) error {
@@ -114,10 +113,6 @@ func (importer *LogFileImporter) ImportKVFiles(
 		err      error
 	)
 
-	if !supportBatch && len(files) > 1 {
-		return errors.Annotatef(berrors.ErrInvalidArgument,
-			"do not support batch apply, file count: %v > 1", len(files))
-	}
 	log.Debug("import kv files", zap.Int("batch file count", len(files)))
 
 	for i, f := range files {
@@ -161,8 +156,7 @@ func (importer *LogFileImporter) ImportKVFiles(
 		if len(subfiles) == 0 {
 			return RPCResultOK()
 		}
-		return importer.importKVFileForRegion(ctx, subfiles, rule, shiftStartTS, startTS, restoreTS, r, supportBatch,
-			cipherInfo, masterKeys)
+		return importer.importKVFileForRegion(ctx, subfiles, rule, shiftStartTS, startTS, restoreTS, r, cipherInfo, masterKeys)
 	})
 	metrics.KVApplyBatchRegions.Observe(float64(numRegions))
 	return errors.Trace(err)
@@ -203,12 +197,11 @@ func (importer *LogFileImporter) importKVFileForRegion(
 	startTS uint64,
 	restoreTS uint64,
 	info *split.RegionInfo,
-	supportBatch bool,
 	cipherInfo *backuppb.CipherInfo,
 	masterKeys []*encryptionpb.MasterKey,
 ) RPCResult {
 	// Try to download file.
-	result := importer.downloadAndApplyKVFile(ctx, files, rule, info, shiftStartTS, startTS, restoreTS, supportBatch, cipherInfo, masterKeys)
+	result := importer.downloadAndApplyKVFile(ctx, files, rule, info, shiftStartTS, startTS, restoreTS, cipherInfo, masterKeys)
 	if !result.OK() {
 		errDownload := result.Err
 		for _, e := range multierr.Errors(errDownload) {
@@ -237,7 +230,6 @@ func (importer *LogFileImporter) downloadAndApplyKVFile(
 	shiftStartTS uint64,
 	startTS uint64,
 	restoreTS uint64,
-	supportBatch bool,
 	cipherInfo *backuppb.CipherInfo,
 	masterKeys []*encryptionpb.MasterKey) RPCResult {
 	leader := regionInfo.Leader
@@ -292,27 +284,14 @@ func (importer *LogFileImporter) downloadAndApplyKVFile(
 		Peer:        leader,
 	}
 
-	var req *import_sstpb.ApplyRequest
-	if supportBatch {
-		req = &import_sstpb.ApplyRequest{
-			Metas:          metas,
-			StorageBackend: importer.backend,
-			RewriteRules:   rewriteRules,
-			Context:        reqCtx,
-			StorageCacheId: importer.cacheKey,
-			CipherInfo:     cipherInfo,
-			MasterKeys:     masterKeys,
-		}
-	} else {
-		req = &import_sstpb.ApplyRequest{
-			Meta:           metas[0],
-			StorageBackend: importer.backend,
-			RewriteRule:    *rewriteRules[0],
-			Context:        reqCtx,
-			StorageCacheId: importer.cacheKey,
-			CipherInfo:     cipherInfo,
-			MasterKeys:     masterKeys,
-		}
+	req := &import_sstpb.ApplyRequest{
+		Metas:          metas,
+		StorageBackend: importer.backend,
+		RewriteRules:   rewriteRules,
+		Context:        reqCtx,
+		StorageCacheId: importer.cacheKey,
+		CipherInfo:     cipherInfo,
+		MasterKeys:     masterKeys,
 	}
 
 	log.Debug("applying kv file", logutil.Leader(leader))

--- a/br/pkg/restore/log_client/import_test.go
+++ b/br/pkg/restore/log_client/import_test.go
@@ -32,39 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestImportKVFiles(t *testing.T) {
-	var (
-		importer            = logclient.LogFileImporter{}
-		ctx                 = context.Background()
-		shiftStartTS uint64 = 100
-		startTS      uint64 = 200
-		restoreTS    uint64 = 300
-	)
-
-	err := importer.ImportKVFiles(
-		ctx,
-		[]*logclient.LogDataFileInfo{
-			{
-				DataFileInfo: &backuppb.DataFileInfo{
-					Path: "log3",
-				},
-			},
-			{
-				DataFileInfo: &backuppb.DataFileInfo{
-					Path: "log1",
-				},
-			},
-		},
-		nil,
-		shiftStartTS,
-		startTS,
-		restoreTS,
-		false,
-		nil, nil,
-	)
-	require.True(t, berrors.ErrInvalidArgument.Equal(err))
-}
-
 func TestFilterFilesByRegion(t *testing.T) {
 	files := []*logclient.LogDataFileInfo{
 		{
@@ -269,9 +236,6 @@ func TestFileImporter(t *testing.T) {
 	require.NoError(t, err)
 
 	rewriteRules, encodeKeyFiles := prepareData()
-	err = importer.ImportKVFiles(ctx, encodeKeyFiles, rewriteRules, 1, 1, 1, true, nil, nil)
-	require.NoError(t, err)
-
-	err = importer.ImportKVFiles(ctx, encodeKeyFiles, rewriteRules, 1, 1, 1, false, nil, nil)
+	err = importer.ImportKVFiles(ctx, encodeKeyFiles, rewriteRules, 1, 1, 1, nil, nil)
 	require.NoError(t, err)
 }

--- a/br/pkg/version/version.go
+++ b/br/pkg/version/version.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	minTiKVVersion          = semver.New("3.1.0-beta.2")
+	minTiKVPiTRVersion      = semver.New("6.5.0")
 	incompatibleTiKVMajor3  = semver.New("3.1.0")
 	incompatibleTiKVMajor4  = semver.New("4.0.0-rc.1")
 	compatibleTiFlashMajor3 = semver.New("3.1.0")
@@ -36,8 +37,6 @@ var (
 	versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}")
 
 	checkpointSupportError error = nil
-	// pitrSupportBatchKVFiles specifies whether TiKV-server supports batch PITR.
-	pitrSupportBatchKVFiles bool = false
 
 	// Once TableInfoVersion updated. BR need to check compatibility with
 	// new TableInfoVersion. both snapshot restore and pitr need to be checked.
@@ -142,28 +141,16 @@ func CheckVersionForBRPiTR(s *metapb.Store, tikvVersion *semver.Version) error {
 		return errors.Annotatef(berrors.ErrVersionMismatch, "%s: invalid version, please recompile using `git fetch origin --tags && make build`", err)
 	}
 
-	// tikvVersion should at least 6.1.0
-	if tikvVersion.Major < 6 || (tikvVersion.Major == 6 && tikvVersion.Minor == 0) {
-		return errors.Annotatef(berrors.ErrVersionMismatch, "TiKV node %s version %s is too low when use PiTR, please update tikv's version to at least v6.1.0(v6.2.0+ recommanded)",
-			s.Address, tikvVersion)
-	}
-	// If tikv version < 6.5, PITR do not support restoring batch kv files.
-	if tikvVersion.Major < 6 || (tikvVersion.Major == 6 && tikvVersion.Minor < 5) {
-		pitrSupportBatchKVFiles = false
-	} else {
-		pitrSupportBatchKVFiles = true
+	// TiKV must support batch ApplyKVFile requests for PiTR restore.
+	if tikvVersion.Compare(*minTiKVPiTRVersion) < 0 {
+		return errors.Annotatef(berrors.ErrVersionMismatch, "TiKV node %s version %s is too low when use PiTR, please update tikv's version to at least v%s",
+			s.Address, tikvVersion, minTiKVPiTRVersion)
 	}
 
 	// The versions of BR and TiKV should be the same when use BR 6.1.0
 	if BRVersion.Major == 6 && BRVersion.Minor == 1 {
 		if tikvVersion.Major != 6 || tikvVersion.Minor != 1 {
 			return errors.Annotatef(berrors.ErrVersionMismatch, "TiKV node %s version %s and BR %s version mismatch when use PiTR v6.1.0, please use the same version of BR",
-				s.Address, tikvVersion, build.ReleaseVersion)
-		}
-	} else {
-		// If BRVersion > v6.1.0, the version of TiKV should be at least v6.2.0
-		if tikvVersion.Major == 6 && tikvVersion.Minor <= 1 {
-			return errors.Annotatef(berrors.ErrVersionMismatch, "TiKV node %s version %s and BR %s version mismatch when use PiTR v6.2.0+, please use the tikv with version v6.2.0+",
 				s.Address, tikvVersion, build.ReleaseVersion)
 		}
 	}
@@ -344,10 +331,6 @@ func FetchVersion(ctx context.Context, db dbutil.QueryExecutor) (string, error) 
 
 func CheckCheckpointSupport() error {
 	return checkpointSupportError
-}
-
-func CheckPITRSupportBatchKVFiles() bool {
-	return pitrSupportBatchKVFiles
 }
 
 type ServerType int

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -78,16 +78,7 @@ func TestCheckClusterVersion(t *testing.T) {
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
 		require.Error(t, err)
-		require.Regexp(t, `^TiKV .* version mismatch when use PiTR v6.2.0\+, please `, err.Error())
-	}
-
-	{
-		// Default value of `pitrSupportBatchKVFiles` should be `false`.
-		build.ReleaseVersion = "v6.5.0"
-		mock.getAllStores = func() []*metapb.Store {
-			return []*metapb.Store{{Version: `v6.2.0`}}
-		}
-		require.Equal(t, CheckPITRSupportBatchKVFiles(), false)
+		require.Regexp(t, `^TiKV .* is too low when use PiTR, please `, err.Error())
 	}
 
 	{
@@ -96,30 +87,27 @@ func TestCheckClusterVersion(t *testing.T) {
 			return []*metapb.Store{{Version: `v6.2.0`}}
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
-		require.NoError(t, err)
-		require.Equal(t, CheckPITRSupportBatchKVFiles(), false)
+		require.Error(t, err)
+		require.Regexp(t, `^TiKV .* is too low when use PiTR, please `, err.Error())
 	}
 
 	{
-		pitrSupportBatchKVFiles = true
 		build.ReleaseVersion = "v6.2.0"
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: `v6.4.0`}}
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
-		require.NoError(t, err)
-		require.Equal(t, CheckPITRSupportBatchKVFiles(), false)
+		require.Error(t, err)
+		require.Regexp(t, `^TiKV .* is too low when use PiTR, please `, err.Error())
 	}
 
 	{
-		pitrSupportBatchKVFiles = true
 		build.ReleaseVersion = "v6.2.0"
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: `v6.5.0`}}
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
 		require.NoError(t, err)
-		require.Equal(t, CheckPITRSupportBatchKVFiles(), true)
 	}
 
 	{
@@ -138,13 +126,24 @@ func TestCheckClusterVersion(t *testing.T) {
 			return []*metapb.Store{{Version: `v6.1.0`}}
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Regexp(t, `^TiKV .* is too low when use PiTR, please `, err.Error())
 	}
 
 	{
 		build.ReleaseVersion = "v6.1.0"
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: `v6.2.0`}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
+		require.Error(t, err)
+		require.Regexp(t, `^TiKV .* is too low when use PiTR, please `, err.Error())
+	}
+
+	{
+		build.ReleaseVersion = "v6.1.0"
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: `v6.5.0`}}
 		}
 		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBRPiTR)
 		require.Error(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #69015

Problem Summary:
if the parameter `--check-requirements=false` is set, the `supportBatch` will be false in default so that it only sends one log file to TiKV once.
### What changed and how does it work?
deprecate the `supportBatch`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * PiTR restores now consistently use batch KV-file restoration.
  * PiTR restore compatibility now requires TiKV version 6.5.0 or later; older versions are no longer supported.
  * Region pre-splitting is no longer treated as complete during PiTR restores, allowing the fallback per-batch splitting process to run.
  * Restore operations now use up to nine RocksDB background jobs by default, improving restore throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->