### PR TITLE
planner: make RU V3 weights configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -394,9 +394,9 @@ type ErrorMessageExtension struct {
 	Regexp *regexp.Regexp `toml:"-" json:"-"`
 }
 
-// RUV2Config is the configuration for RU v2 weight calculation.
-// The default values are experimentally fitted so they stay stable under the
-// same workload while remaining numerically aligned with RU v1.
+// RUV2Config configures legacy RU v2 and statement RU v3 weight calculation.
+// Legacy RU v2 defaults are experimentally fitted to remain aligned with RU v1.
+// Statement RU v3 reuses this config section while replacing the legacy model.
 type RUV2Config struct {
 	// RUScale is the scale factor used to convert RU v2 float values into scaled integer values.
 	// It is intentionally chosen to match legacy RU values for compatibility.
@@ -425,9 +425,23 @@ type RUV2Config struct {
 	WriteKeys               float64 `toml:"write-keys" json:"write-keys"`
 	SessionParserTotal      float64 `toml:"session-parser-total" json:"session-parser-total"`
 	TxnCnt                  float64 `toml:"txn-cnt" json:"txn-cnt"`
+
+	// Statement weights convert RU v3 raw work units to RU. They must be finite
+	// and non-negative; zero disables the corresponding charge. Their defaults
+	// are uncalibrated internal placeholders, not billing values.
+	StatementCPUWork              float64 `toml:"statement-cpu-work" json:"statement-cpu-work"`
+	StatementScanBytes            float64 `toml:"statement-scan-bytes" json:"statement-scan-bytes"`
+	StatementNetBytes             float64 `toml:"statement-net-bytes" json:"statement-net-bytes"`
+	StatementFrontendCompileBytes float64 `toml:"statement-frontend-compile-bytes" json:"statement-frontend-compile-bytes"`
+	StatementHashStateRows        float64 `toml:"statement-hash-state-rows" json:"statement-hash-state-rows"`
+	StatementJoinOutputRows       float64 `toml:"statement-join-output-rows" json:"statement-join-output-rows"`
+	StatementWriteStatement       float64 `toml:"statement-write-statement" json:"statement-write-statement"`
+	StatementOperatorNum          float64 `toml:"statement-operator-num" json:"statement-operator-num"`
+	StatementWriteKeys            float64 `toml:"statement-write-keys" json:"statement-write-keys"`
+	StatementWriteBytes           float64 `toml:"statement-write-bytes" json:"statement-write-bytes"`
 }
 
-// DefaultRUV2Config returns the default RU v2 configuration.
+// DefaultRUV2Config returns the default legacy RU v2 and statement RU v3 configuration.
 func DefaultRUV2Config() RUV2Config {
 	return RUV2Config{
 		RUScale: 2.01,
@@ -444,7 +458,41 @@ func DefaultRUV2Config() RUV2Config {
 		WriteKeys:               0.330760861554226,
 		SessionParserTotal:      0.19230499,
 		TxnCnt:                  0.03013709,
+
+		StatementCPUWork:              1.0,
+		StatementScanBytes:            1.0,
+		StatementNetBytes:             1.0,
+		StatementFrontendCompileBytes: 1.0,
+		StatementHashStateRows:        1.0,
+		StatementJoinOutputRows:       1.0,
+		StatementWriteStatement:       1.0,
+		StatementOperatorNum:          1.0,
+		StatementWriteKeys:            1.0,
+		StatementWriteBytes:           1.0,
 	}
+}
+
+func (c *RUV2Config) validStatementWeights() error {
+	for _, weight := range []struct {
+		name  string
+		value float64
+	}{
+		{"statement-cpu-work", c.StatementCPUWork},
+		{"statement-scan-bytes", c.StatementScanBytes},
+		{"statement-net-bytes", c.StatementNetBytes},
+		{"statement-frontend-compile-bytes", c.StatementFrontendCompileBytes},
+		{"statement-hash-state-rows", c.StatementHashStateRows},
+		{"statement-join-output-rows", c.StatementJoinOutputRows},
+		{"statement-write-statement", c.StatementWriteStatement},
+		{"statement-operator-num", c.StatementOperatorNum},
+		{"statement-write-keys", c.StatementWriteKeys},
+		{"statement-write-bytes", c.StatementWriteBytes},
+	} {
+		if weight.value < 0 || math.IsNaN(weight.value) || math.IsInf(weight.value, 0) {
+			return fmt.Errorf("ru-v2.%s must be finite and non-negative, got %v", weight.name, weight.value)
+		}
+	}
+	return nil
 }
 
 // CSE is the config collection for the cloud storage engine.
@@ -1728,6 +1776,9 @@ func prepareErrorMessageExtensions(extensions []ErrorMessageExtension, ignoreInv
 func (c *Config) Valid() error {
 	if err := naming.CheckKeyspaceName(c.KeyspaceName); err != nil {
 		return errors.Annotate(err, "invalid keyspace name")
+	}
+	if err := c.RUV2.validStatementWeights(); err != nil {
+		return err
 	}
 	if c.Log.EnableErrorStack == c.Log.DisableErrorStack && c.Log.EnableErrorStack != nbUnset {
 		logutil.BgLogger().Warn(fmt.Sprintf("\"enable-error-stack\" (%v) conflicts \"disable-error-stack\" (%v). \"disable-error-stack\" is deprecated, please use \"enable-error-stack\" instead. disable-error-stack is ignored.", c.Log.EnableErrorStack, c.Log.DisableErrorStack))

--- a/pkg/executor/statement_ru_result.go
+++ b/pkg/executor/statement_ru_result.go
@@ -18,6 +18,7 @@ import (
 	"math"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -26,6 +27,28 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/resourcegroup/ruv3"
 )
+
+// currentStatementRUWeights reads the loaded config rather than capturing
+// package-initialization defaults. RU v3 shares the ru-v2 config section while
+// replacing the legacy model; its statement weights are not dynamically reloadable.
+func currentStatementRUWeights() ruv3.StmtWeights {
+	weights := config.DefaultRUV2Config()
+	if cfg := config.GetGlobalConfig(); cfg != nil {
+		weights = cfg.RUV2
+	}
+	return ruv3.StmtWeights{
+		CPUWork:             weights.StatementCPUWork,
+		ScanByte:            weights.StatementScanBytes,
+		NetByte:             weights.StatementNetBytes,
+		FrontendCompileByte: weights.StatementFrontendCompileBytes,
+		HashStateRow:        weights.StatementHashStateRows,
+		JoinOutputRow:       weights.StatementJoinOutputRows,
+		WriteStatement:      weights.StatementWriteStatement,
+		OperatorNum:         weights.StatementOperatorNum,
+		WriteKey:            weights.StatementWriteKeys,
+		WriteByte:           weights.StatementWriteBytes,
+	}
+}
 
 // The current producers cannot prove that all successful or canceled remote
 // work contributed execution details. ResultOnly therefore publishes a
@@ -224,7 +247,7 @@ func classifyStatementRUScanEvidence(totalKeys, processedKeys, processedBytes in
 }
 
 func (calculator statementRUCalculator) finalize() (statementRUFinalizedSnapshot, bool) {
-	result, ok := ruv3.Calculate(calculator.units, ruv3.DefaultWeights())
+	result, ok := ruv3.Calculate(calculator.units, currentStatementRUWeights())
 	if !ok {
 		return statementRUFinalizedSnapshot{}, false
 	}
@@ -279,7 +302,7 @@ func publishStatementRUMetricsSafely(finalized statementRUFinalizedSnapshot) {
 		sqlType = metrics.LblSQLTypeWrite
 	}
 	metrics.RUV3BySQLType.WithLabelValues(sqlType).Add(totalRU)
-	weights := ruv3.DefaultWeights()
+	weights := currentStatementRUWeights()
 	metrics.RUV3ByEngine.WithLabelValues(metrics.LblEngineTiKV).Add(
 		weights.ScanByte*finalized.units.ScanBytes +
 			weights.NetByte*finalized.units.NetBytes +

--- a/pkg/executor/statement_ru_result_test.go
+++ b/pkg/executor/statement_ru_result_test.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
@@ -350,6 +351,26 @@ func TestStatementRUPublisherIsolation(t *testing.T) {
 			publishStatementRUCalibrationSafely(fixture.stmt, statementRUCalibrationSnapshot{State: statementRUCalibrationComplete})
 		})
 	})
+}
+
+func TestStatementRUUsesConfig(t *testing.T) {
+	t.Cleanup(config.RestoreFunc())
+	config.UpdateGlobal(func(cfg *config.Config) {
+		cfg.RUV2.StatementCPUWork = 2
+		cfg.RUV2.StatementScanBytes = 3
+	})
+
+	calculator := statementRUCalculator{units: ruv3.StmtUnits{CPUWork: 5, ScanBytes: 7}}
+	finalized, ok := calculator.finalize()
+	require.True(t, ok)
+	require.Equal(t, float64(31), finalized.result.TotalRU) // 2*5 + 3*7
+
+	config.UpdateGlobal(func(cfg *config.Config) {
+		cfg.RUV2.StatementCPUWork = 0
+	})
+	finalized, ok = calculator.finalize()
+	require.True(t, ok)
+	require.Equal(t, float64(21), finalized.result.TotalRU) // 0*5 + 3*7
 }
 
 func TestStatementRUResultValueContracts(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #70747

Problem Summary: planner: make RU V3 weights configurable

### What changed and how does it work?


RU v3 uses hardcoded statement weights, preventing the model from being tuned through server configuration. Reuse the existing RUV2Config as RU v3 is intended to replace the legacy RU v2 implementation.

- Add ten statement-* weights under [ru-v2], defaulting to 1.0 to preserve current RU v3 results.
- Use configured weights for statement RU, EXPLAIN operator RU, and TiKV engine metrics.
- Reject negative, NaN, and infinite weights. Allow zero to disable individual charges.
- Preserve existing RU v2 fields and defaults. Dynamic reload is not supported.
- Add TestStatementRUUsesConfig to cover non-default and zero weights, with global configuration restored after the test.

Validation: gofmt and git diff --check only. Tests, builds, lint, and make bazel_prepare were not run locally.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable workload weights for statement resource-unit calculations.
  - Statement workload categories support independent weighting for CPU, scanning, networking, compilation, joins, writes, and related operations.
  - Defaults preserve existing weighting behavior.
  - Configuration documentation now covers both legacy and statement resource-unit formats.

- **Bug Fixes**
  - Invalid weights, including negative, NaN, or infinite values, are rejected during configuration validation.
  - Statement resource-unit results and metrics now consistently use configured weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->