### PR TITLE
executor: add plan-change inspection rule to detect SQL plan changes …

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -379,6 +379,7 @@ go_test(
         "infoschema_reader_test.go",
         "insert_test.go",
         "inspection_result_internal_test.go",
+        "inspection_result_plan_change_test.go",
         "inspection_result_test.go",
         "inspection_summary_test.go",
         "join_pkg_test.go",

--- a/pkg/executor/inspection_result.go
+++ b/pkg/executor/inspection_result.go
@@ -95,6 +95,9 @@ type (
 
 	// thresholdCheckInspection is used to check some threshold value, like CPU usage, leader count change.
 	thresholdCheckInspection struct{ inspectionName }
+
+	// planChangeInspection is used to check whether SQL plan changed and execution slowed down notably.
+	planChangeInspection struct{ inspectionName }
 )
 
 var inspectionRules = []inspectionRule{
@@ -103,6 +106,7 @@ var inspectionRules = []inspectionRule{
 	&nodeLoadInspection{inspectionName: "node-load"},
 	&criticalErrorInspection{inspectionName: "critical-error"},
 	&thresholdCheckInspection{inspectionName: "threshold-check"},
+	&planChangeInspection{inspectionName: "plan-change"},
 }
 
 type inspectionResultRetriever struct {
@@ -1250,6 +1254,130 @@ func (thresholdCheckInspection) inspectForLeaderDrop(ctx context.Context, sctx s
 			}
 			lastValue = v
 		}
+	}
+	return results
+}
+
+const (
+	planChangeSlowThreshold = 2.0
+	planChangeResultLimit   = 3
+)
+
+func (planChangeInspection) inspect(ctx context.Context, sctx sessionctx.Context, filter inspectionFilter) []inspectionResult {
+	from := filter.timeRange.From.Format(plannerutil.MetricTableTimeFormat)
+	to := filter.timeRange.To.Format(plannerutil.MetricTableTimeFormat)
+
+	// cluster_statements_summary and cluster_statements_summary_history only contain recent data.
+	// Try them first, then fall back to cluster_slow_query for older time ranges.
+	results := inspectPlanChangeFromStmtSummary(ctx, sctx, filter, infoschema.ClusterTableStatementsSummary, from, to)
+	if len(results) > 0 {
+		return results
+	}
+	results = inspectPlanChangeFromStmtSummary(ctx, sctx, filter, infoschema.ClusterTableStatementsSummaryHistory, from, to)
+	if len(results) > 0 {
+		return results
+	}
+	return inspectPlanChangeFromSlowQuery(ctx, sctx, filter, from, to)
+}
+
+func inspectPlanChangeFromStmtSummary(ctx context.Context, sctx sessionctx.Context, filter inspectionFilter, tableName, from, to string) []inspectionResult {
+	exec := sctx.GetRestrictedSQLExecutor()
+	sql := fmt.Sprintf("select digest, plan_digest, avg_latency, query_sample_text from information_schema.%s where summary_begin_time <= '%s' and summary_end_time >= '%s'", tableName, to, from)
+	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, sql)
+	if err != nil {
+		sctx.GetSessionVars().StmtCtx.AppendWarning(fmt.Errorf("check plan change from %s failed: %v", tableName, err))
+		return nil
+	}
+	return buildPlanChangeResults(filter, rows, "avg_latency")
+}
+
+func inspectPlanChangeFromSlowQuery(ctx context.Context, sctx sessionctx.Context, filter inspectionFilter, from, to string) []inspectionResult {
+	exec := sctx.GetRestrictedSQLExecutor()
+	sql := fmt.Sprintf("select digest, plan_digest, avg(query_time) as avg_query_time, min(query) from information_schema.cluster_slow_query where time >= '%s' and time <= '%s' group by digest, plan_digest", from, to)
+	rows, _, err := exec.ExecRestrictedSQL(ctx, nil, sql)
+	if err != nil {
+		sctx.GetSessionVars().StmtCtx.AppendWarning(fmt.Errorf("check plan change from cluster_slow_query failed: %v", err))
+		return nil
+	}
+	return buildPlanChangeResults(filter, rows, "query_time")
+}
+
+type planChangePlanInfo struct {
+	planDigest string
+	latency    float64
+	queryText  string
+}
+
+func buildPlanChangeResults(filter inspectionFilter, rows []chunk.Row, latencyCol string) []inspectionResult {
+	digestToPlans := make(map[string][]planChangePlanInfo)
+	for _, row := range rows {
+		if row.Len() < 4 {
+			continue
+		}
+		digest := row.GetString(0)
+		planDigest := row.GetString(1)
+		var latency float64
+		switch latencyCol {
+		case "avg_latency":
+			latency = float64(row.GetUint64(2))
+		case "query_time":
+			latency = row.GetFloat64(2)
+		}
+		queryText := row.GetString(3)
+		digestToPlans[digest] = append(digestToPlans[digest], planChangePlanInfo{planDigest: planDigest, latency: latency, queryText: queryText})
+	}
+
+	var results []inspectionResult
+	for digest, plans := range digestToPlans {
+		if len(plans) < 2 {
+			continue
+		}
+		if !filter.enable(digest) {
+			continue
+		}
+		minLatency := plans[0].latency
+		maxLatency := plans[0].latency
+		var queryText string
+		for _, p := range plans {
+			if p.latency < minLatency {
+				minLatency = p.latency
+			}
+			if p.latency > maxLatency {
+				maxLatency = p.latency
+				queryText = p.queryText
+			}
+		}
+		if minLatency <= 0 {
+			continue
+		}
+		ratio := maxLatency / minLatency
+		if ratio < planChangeSlowThreshold {
+			continue
+		}
+		detail := fmt.Sprintf("the plan of sql '%s' changed, execution time slow down %.2fx; possible causes: inaccurate statistics, consider running ANALYZE TABLE or using SQL plan binding", queryText, ratio)
+		if len(detail) > 256 {
+			detail = detail[:256]
+		}
+		results = append(results, inspectionResult{
+			tp:       "tidb",
+			item:     digest,
+			actual:   fmt.Sprintf("%.2f", ratio),
+			expected: "< 2.00",
+			severity: "warning",
+			detail:   detail,
+			degree:   ratio,
+		})
+	}
+
+	// Sort by degree descending and item ascending, then limit the result count.
+	slices.SortFunc(results, func(i, j inspectionResult) int {
+		if c := cmp.Compare(j.degree, i.degree); c != 0 {
+			return c
+		}
+		return cmp.Compare(i.item, j.item)
+	})
+	if len(results) > planChangeResultLimit {
+		results = results[:planChangeResultLimit]
 	}
 	return results
 }

--- a/pkg/executor/inspection_result_plan_change_test.go
+++ b/pkg/executor/inspection_result_plan_change_test.go
@@ -1,0 +1,174 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/pingcap/tidb/pkg/util/set"
+	"github.com/stretchr/testify/require"
+)
+
+type planChangeFakeRestrictedSQLExecutor struct {
+	stmtRows     []chunk.Row
+	histRows     []chunk.Row
+	slowRows     []chunk.Row
+	resultFields []*resolve.ResultField
+}
+
+func (e *planChangeFakeRestrictedSQLExecutor) ParseWithParams(_ context.Context, _ string, _ ...any) (ast.StmtNode, error) {
+	return nil, nil
+}
+
+func (e *planChangeFakeRestrictedSQLExecutor) ExecRestrictedStmt(_ context.Context, _ ast.StmtNode, _ ...sqlexec.OptionFuncAlias) ([]chunk.Row, []*resolve.ResultField, error) {
+	return nil, nil, nil
+}
+
+func (e *planChangeFakeRestrictedSQLExecutor) ExecRestrictedSQL(_ context.Context, _ []sqlexec.OptionFuncAlias, sql string, _ ...any) ([]chunk.Row, []*resolve.ResultField, error) {
+	sqlLower := strings.ToLower(sql)
+	switch {
+	case strings.Contains(sqlLower, "cluster_statements_summary_history"):
+		return e.histRows, e.resultFields, nil
+	case strings.Contains(sqlLower, "cluster_statements_summary"):
+		return e.stmtRows, e.resultFields, nil
+	case strings.Contains(sqlLower, "cluster_slow_query"):
+		return e.slowRows, e.resultFields, nil
+	}
+	return nil, nil, nil
+}
+
+type planChangeFakeSession struct {
+	*mock.Context
+	exec sqlexec.RestrictedSQLExecutor
+}
+
+func (s *planChangeFakeSession) GetRestrictedSQLExecutor() sqlexec.RestrictedSQLExecutor {
+	return s.exec
+}
+
+func makePlanChangeStmtSummaryRow(digest, planDigest string, latency uint64, query string) chunk.Row {
+	return chunk.MutRowFromDatums([]types.Datum{
+		types.NewStringDatum(digest),
+		types.NewStringDatum(planDigest),
+		types.NewUintDatum(latency),
+		types.NewStringDatum(query),
+	}).ToRow()
+}
+
+func makePlanChangeSlowQueryRow(digest, planDigest string, latency float64, query string) chunk.Row {
+	return chunk.MutRowFromDatums([]types.Datum{
+		types.NewStringDatum(digest),
+		types.NewStringDatum(planDigest),
+		types.NewFloat64Datum(latency),
+		types.NewStringDatum(query),
+	}).ToRow()
+}
+
+func newPlanChangeFakeSession(t *testing.T) *planChangeFakeSession {
+	t.Helper()
+	ctx := mock.NewContext()
+	return &planChangeFakeSession{Context: ctx}
+}
+
+func newPlanChangeTimeFilter() inspectionFilter {
+	from := time.Date(2020, 2, 14, 5, 10, 0, 0, time.UTC)
+	to := time.Date(2020, 2, 14, 5, 25, 0, 0, time.UTC)
+	return inspectionFilter{timeRange: plannerutil.QueryTimeRange{From: from, To: to}}
+}
+
+func TestPlanChangeInspectionFromStmtSummary(t *testing.T) {
+	sctx := newPlanChangeFakeSession(t)
+	sctx.exec = &planChangeFakeRestrictedSQLExecutor{
+	stmtRows: []chunk.Row{
+		makePlanChangeStmtSummaryRow("digest1", "plan1", 1e9, "SELECT * FROM t1"),
+		makePlanChangeStmtSummaryRow("digest1", "plan2", 3e9, "SELECT * FROM t1"),
+		makePlanChangeStmtSummaryRow("digest2", "plan3", 5e8, "SELECT * FROM t2"),
+		makePlanChangeStmtSummaryRow("digest3", "plan4", 2e9, "SELECT * FROM t3"),
+		makePlanChangeStmtSummaryRow("digest3", "plan5", 3e9, "SELECT * FROM t3"),
+	},
+	}
+
+	results := planChangeInspection{}.inspect(context.Background(), sctx, newPlanChangeTimeFilter())
+	require.Equal(t, uint16(0), sctx.GetSessionVars().StmtCtx.WarningCount())
+	require.Len(t, results, 1)
+	require.Equal(t, "digest1", results[0].item)
+	require.Equal(t, "3.00", results[0].actual)
+	require.Equal(t, "tidb", results[0].tp)
+	require.Equal(t, "warning", results[0].severity)
+	require.Equal(t, "< 2.00", results[0].expected)
+}
+
+func TestPlanChangeInspectionFromSlowQuery(t *testing.T) {
+	sctx := newPlanChangeFakeSession(t)
+	sctx.exec = &planChangeFakeRestrictedSQLExecutor{
+	slowRows: []chunk.Row{
+		makePlanChangeSlowQueryRow("digest1", "plan1", 1.0, "SELECT * FROM t1"),
+		makePlanChangeSlowQueryRow("digest1", "plan2", 3.0, "SELECT * FROM t1"),
+		makePlanChangeSlowQueryRow("digest2", "plan3", 0.5, "SELECT * FROM t2"),
+		makePlanChangeSlowQueryRow("digest3", "plan4", 2.0, "SELECT * FROM t3"),
+		makePlanChangeSlowQueryRow("digest3", "plan5", 3.0, "SELECT * FROM t3"),
+	},
+	}
+
+	results := planChangeInspection{}.inspect(context.Background(), sctx, newPlanChangeTimeFilter())
+	require.Equal(t, uint16(0), sctx.GetSessionVars().StmtCtx.WarningCount())
+	require.Len(t, results, 1)
+	require.Equal(t, "digest1", results[0].item)
+	require.Equal(t, "3.00", results[0].actual)
+}
+
+func TestPlanChangeInspectionItemFilter(t *testing.T) {
+	sctx := newPlanChangeFakeSession(t)
+	sctx.exec = &planChangeFakeRestrictedSQLExecutor{
+		stmtRows: []chunk.Row{
+			makePlanChangeStmtSummaryRow("digest1", "plan1", 1e9, "SELECT * FROM t1"),
+			makePlanChangeStmtSummaryRow("digest1", "plan2", 3e9, "SELECT * FROM t1"),
+			makePlanChangeStmtSummaryRow("digest2", "plan3", 1e9, "SELECT * FROM t2"),
+			makePlanChangeStmtSummaryRow("digest2", "plan4", 5e9, "SELECT * FROM t2"),
+		},
+	}
+
+	filter := inspectionFilter{
+		set:       set.NewStringSet("digest2"),
+		timeRange: newPlanChangeTimeFilter().timeRange,
+	}
+	results := planChangeInspection{}.inspect(context.Background(), sctx, filter)
+	require.Len(t, results, 1)
+	require.Equal(t, "digest2", results[0].item)
+	require.Equal(t, "5.00", results[0].actual)
+}
+
+func TestPlanChangeInspectionNoResult(t *testing.T) {
+	sctx := newPlanChangeFakeSession(t)
+	sctx.exec = &planChangeFakeRestrictedSQLExecutor{}
+
+	results := planChangeInspection{}.inspect(context.Background(), sctx, newPlanChangeTimeFilter())
+	require.Equal(t, uint16(0), sctx.GetSessionVars().StmtCtx.WarningCount())
+	require.Empty(t, results)
+}
+
+var _ sessionctx.Context = (*planChangeFakeSession)(nil)
+var _ sqlexec.RestrictedSQLExecutor = (*planChangeFakeRestrictedSQLExecutor)(nil)

--- a/tests/integrationtest/r/executor/inspection_common.result
+++ b/tests/integrationtest/r/executor/inspection_common.result
@@ -1,9 +1,9 @@
 select count(*) from information_schema.inspection_rules;
 count(*)
-15
+16
 select count(*) from information_schema.inspection_rules where type='inspection';
 count(*)
-5
+6
 select count(*) from information_schema.inspection_rules where type='summary';
 count(*)
 10


### PR DESCRIPTION
executor: add plan-change inspection rule to detect SQL plan changes and slowdowns

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #17928, ref #14892

Problem Summary:

`information_schema.inspection_result` today covers configuration drift, version consistency, node load, critical errors and threshold checks, but nothing that points at SQL plan regressions. When the optimizer picks a different plan for the same statement and latency degrades as a result, users have to find it by hand — joining `cluster_statements_summary`, `cluster_statements_summary_history` or `cluster_slow_query` and comparing latency per `plan_digest` themselves. These tables expose enough metrics to spot the problem, but too many to spot it quickly.

### What changed and how does it work?

Adds a `plan-change` inspection rule that reports SQL digests whose slowest plan is at least `2.0x` slower than their fastest plan within the inspection time range.

**Rule registration** (`pkg/executor/inspection_result.go`)

- New `planChangeInspection` type, registered in `inspectionRules` as `"plan-change"`, so it runs as part of `select * from information_schema.inspection_result`.
- Two constants govern the behavior: `planChangeSlowThreshold = 2.0` (minimum slowdown ratio to report) and `planChangeResultLimit = 3` (maximum findings, so the output stays actionable).

**Data sources**

The statement summary tables only retain recent data, so `inspect` tries three sources in order and returns as soon as one yields results:

1. `information_schema.cluster_statements_summary`
2. `information_schema.cluster_statements_summary_history`
3. `information_schema.cluster_slow_query`

- `inspectPlanChangeFromStmtSummary` reads `digest, plan_digest, avg_latency, query_sample_text`, bounded by `summary_begin_time <= <to> and summary_end_time >= <from>`.
- `inspectPlanChangeFromSlowQuery` reads `digest, plan_digest, avg(query_time), min(query)` bounded by `time >= <from> and time <= <to>`, grouped by `digest, plan_digest`.

Both bounds come from the inspection time range, which honors the `/*+ time_range(...) */` hint. If a query fails, the rule appends a statement warning and returns no results for that source rather than failing the whole inspection.

**Detection** (`buildPlanChangeResults`)

Rows are grouped by SQL digest. A digest is skipped when it has fewer than two rows (nothing to compare), when it is excluded by the item filter (`filter.enable(digest)`), or when the minimum latency is non-positive (guards the ratio against divide-by-zero). Otherwise the ratio of maximum to minimum latency is compared against the threshold, and the sample query text of the slowest plan is carried into the detail message.

Each finding becomes an `inspection_result` row:

| column | value |
| --- | --- |
| `rule` | `plan-change` |
| `item` | the SQL digest |
| `type` | `tidb` |
| `value` | slowdown ratio, e.g. `3.00` |
| `reference` | `< 2.00` |
| `severity` | `warning` |
| `details` | the plan changed, how much it slowed down, and advice to run `ANALYZE TABLE` or use SQL plan binding |

The detail string is truncated to 256 characters so a long sample query cannot dominate the output. Results are sorted by slowdown ratio descending (ties broken by digest ascending, for deterministic output) and truncated to the top 3.

**Tests** (`pkg/executor/inspection_result_plan_change_test.go`, new)

Unit tests drive the rule through a fake `RestrictedSQLExecutor`, so they are deterministic and need no cluster tables or network: `TestPlanChangeInspectionFromStmtSummary`, `TestPlanChangeInspectionFromSlowQuery`, `TestPlanChangeInspectionItemFilter` and `TestPlanChangeInspectionNoResult` cover detection from each source, item-level filtering, and the no-finding path.

**Metadata**

- `pkg/executor/BUILD.bazel`: new test file added to test `srcs`.
- `tests/integrationtest/r/executor/inspection_common.result`: rule counts updated for the added rule — total `15` -> `16`, `type='inspection'` `5` -> `6` (`type='summary'` unchanged at `10`).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add the `plan-change` inspection rule to `information_schema.inspection_result`, which reports SQL statements whose execution plan changed and whose execution slowed down by 2x or more, together with advice on collecting statistics or using SQL plan binding.
```